### PR TITLE
changelogs: Reflow line lengths + yaml cleanups

### DIFF
--- a/.github/workflows/mobile_release.yml
+++ b/.github/workflows/mobile_release.yml
@@ -38,7 +38,12 @@ jobs:
           --linkopt=-fuse-ld=lld \
           //:android_dist
     - name: 'Tar artifacts'
-      run: tar -czvf envoy_android_aar_sources.tar.gz bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy.aar bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy-pom.xml bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy-sources.jar bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy-javadoc.jar
+      run: |
+        tar -czvf envoy_android_aar_sources.tar.gz \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy.aar \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy-pom.xml \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy-sources.jar \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy-javadoc.jar
       working-directory: mobile
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -4,14 +4,14 @@ on:
   - cron: '0 5 * * 1,2,3,4,5'
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read  # to fetch code (actions/checkout)
 
 jobs:
   pr_notifier:
     permissions:
-      contents: read # to fetch code (actions/checkout)
-      statuses: read # for pr_notifier.py
-      pull-requests: read # for pr_notifier.py
+      contents: read  # to fetch code (actions/checkout)
+      statuses: read  # for pr_notifier.py
+      pull-requests: read  # for pr_notifier.py
     name: PR Notifier
     runs-on: ubuntu-20.04
     if: github.repository == 'envoyproxy/envoy'

--- a/.yamllint
+++ b/.yamllint
@@ -6,11 +6,15 @@ rules:
     spaces: consistent
     indent-sequences: false
   line-length:
-    max: 200
-    level: warning
+    # This can be adjusted if there is a very good reason.
+    max: 140
+    level: error
+    allow-non-breakable-words: true
   truthy:
     allowed-values:
     - "yes"
     - "no"
     - "true"
     - "false"
+    # https://github.com/adrienverge/yamllint/issues/430
+    - "on"

--- a/changelogs/1.1.0.yaml
+++ b/changelogs/1.1.0.yaml
@@ -3,8 +3,7 @@ date: November 30, 2016
 changes:
 - area: config
   change: |
-    Switch from Jannson to RapidJSON for our JSON library (allowing for a configuration schema in
-    1.2.0).
+    Switch from Jannson to RapidJSON for our JSON library (allowing for a configuration schema in 1.2.0).
 - area: deps
   change: |
     Upgrade :ref:`recommended version <v1.5:install_requirements>` of various other libraries.
@@ -26,34 +25,33 @@ changes:
     HTTP/2 graceful connection draining (double GOAWAY).
 - area: dyanmodb
   change: |
-    DynamoDB filter :ref:`per shard statistics <v1.5:config_http_filters_dynamo>` (pre-release AWS
-    feature).
+    DynamoDB filter :ref:`per shard statistics <v1.5:config_http_filters_dynamo>` (pre-release AWS feature).
 - area: fault_injection
   change: |
     Initial release of the :ref:`fault injection HTTP filter <v1.5:config_http_filters_fault_injection>`.
 - area: rate_limit
   change: |
-    HTTP :ref:`rate limit filter <v1.5:config_http_filters_rate_limit>` enhancements (note that the
-    configuration for HTTP rate limiting is going to be overhauled in 1.2.0).
+    HTTP :ref:`rate limit filter <v1.5:config_http_filters_rate_limit>` enhancements (note that the configuration for HTTP
+    rate limiting is going to be overhauled in 1.2.0).
 - area: retry
   change: |
     Added :ref:`refused-stream retry policy <v1.5:config_http_filters_router_x-envoy-retry-on>`.
 - area: routing
   change: |
-    Multiple :ref:`priority queues <v1.5:arch_overview_http_routing_priority>` for upstream clusters
-    (configurable on a per route basis, with separate connection pools, circuit breakers, etc.).
+    Multiple :ref:`priority queues <v1.5:arch_overview_http_routing_priority>` for upstream clusters (configurable on a per
+    route basis, with separate connection pools, circuit breakers, etc.).
 - area: circuit_breaking
   change: |
     Added max connection circuit breaking to the :ref:`TCP proxy filter <v1.5:arch_overview_tcp_proxy>`.
 - area: options
   change: |
-    Added :ref:`CLI <v1.5:operations_cli>` options for setting the logging file flush interval as well
-    as the drain/shutdown time during hot restart.
+    Added :ref:`CLI <v1.5:operations_cli>` options for setting the logging file flush interval as well as the drain/shutdown
+    time during hot restart.
 - area: performance
   change: |
-    A very large number of performance enhancements for core HTTP/TCP proxy flows as well as a
-    few new configuration flags to allow disabling expensive features if they are not needed
-    (specifically request ID generation and dynamic response code stats).
+    A very large number of performance enhancements for core HTTP/TCP proxy flows as well as a few new configuration flags
+    to allow disabling expensive features if they are not needed (specifically request ID generation and dynamic response
+    code stats).
 - area: mongo
   change: |
     Support Mongo 3.2 in the :ref:`Mongo sniffing filter <v1.5:config_network_filters_mongo_proxy>`.

--- a/changelogs/1.10.0.yaml
+++ b/changelogs/1.10.0.yaml
@@ -6,14 +6,16 @@ changes:
     added a new flag for upstream retry count exceeded.
 - area: access log
   change: |
-    added a :ref:`gRPC filter <envoy_api_msg_config.filter.accesslog.v2.GrpcStatusFilter>` to allow filtering on gRPC status.
+    added a :ref:`gRPC filter <envoy_api_msg_config.filter.accesslog.v2.GrpcStatusFilter>` to allow filtering on gRPC
+    status.
 - area: access log
   change: |
     added a new flag for stream idle timeout.
 - area: access log
   change: |
-    added a new field for upstream transport failure reason in :ref:`file access logger <config_access_log_format_upstream_transport_failure_reason>` and
-    :ref:`gRPC access logger <envoy_api_field_data.accesslog.v2.AccessLogCommon.upstream_transport_failure_reason>` for HTTP access logs.
+    added a new field for upstream transport failure reason in :ref:`file access logger
+    <config_access_log_format_upstream_transport_failure_reason>` and :ref:`gRPC access logger
+    <envoy_api_field_data.accesslog.v2.AccessLogCommon.upstream_transport_failure_reason>` for HTTP access logs.
 - area: access log
   change: |
     added new fields for downstream x509 information (URI sans and subject) to file and gRPC access logger.
@@ -31,8 +33,8 @@ changes:
     releases are built with GCC-7 and linked with LLD.
 - area: build
   change: |
-    dev docker images :ref:`have been split <install_binaries>` from tagged images for easier
-    discoverability in Docker Hub. Additionally, we now build images for point releases.
+    dev docker images :ref:`have been split <install_binaries>` from tagged images for easier discoverability in Docker Hub.
+    Additionally, we now build images for point releases.
 - area: config
   change: |
     added support of using google.protobuf.Any in opaque configs for extensions.
@@ -53,13 +55,16 @@ changes:
     removed REST_LEGACY as a valid :ref:`ApiType <envoy_api_field_core.ApiConfigSource.api_type>`.
 - area: config
   change: |
-    finish cluster warming only when a named response i.e. ClusterLoadAssignment associated to the cluster being warmed comes in the EDS response. This is a behavioural change from the current implementation where warming of cluster completes on missing load assignments also.
+    finish cluster warming only when a named response i.e. ClusterLoadAssignment associated to the cluster being warmed
+    comes in the EDS response. This is a behavioural change from the current implementation where warming of cluster
+    completes on missing load assignments also.
 - area: config
   change: |
     use Envoy cpuset size to set the default number or worker threads if :option:`--cpuset-threads` is enabled.
 - area: config
   change: |
-    added support for :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>`. The timeout is disabled by default.
+    added support for :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>`. The timeout is
+    disabled by default.
 - area: cors
   change: |
     added :ref:`filter_enabled & shadow_enabled RuntimeFractionalPercent flags <cors-runtime>` to filter.
@@ -74,38 +79,39 @@ changes:
     migrated from v2alpha to v2 and improved docs.
 - area: ext_authz
   change: |
-    added a configurable option to make the gRPC service cross-compatible with V2Alpha. Note that this feature is already deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
+    added a configurable option to make the gRPC service cross-compatible with V2Alpha. Note that this feature is already
+    deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
 - area: ext_authz
   change: |
     migrated from v2alpha to v2 and improved the documentation.
 - area: ext_authz
   change: |
-    authorization request and response configuration has been separated into two distinct objects: :ref:`authorization request
-    <envoy_api_field_config.filter.http.ext_authz.v2.HttpService.authorization_request>` and :ref:`authorization response
-    <envoy_api_field_config.filter.http.ext_authz.v2.HttpService.authorization_response>`. In addition, :ref:`client headers
-    <envoy_api_field_config.filter.http.ext_authz.v2.AuthorizationResponse.allowed_client_headers>` and :ref:`upstream headers
-    <envoy_api_field_config.filter.http.ext_authz.v2.AuthorizationResponse.allowed_upstream_headers>` replaces the previous ``allowed_authorization_headers-`` object.
-    All the control header lists now support :ref:`string matcher <envoy_api_msg_type.matcher.StringMatcher>` instead of standard string.
+    authorization request and response configuration has been separated into two distinct objects: :ref:`authorization
+    request <envoy_api_field_config.filter.http.ext_authz.v2.HttpService.authorization_request>` and :ref:`authorization
+    response <envoy_api_field_config.filter.http.ext_authz.v2.HttpService.authorization_response>`. In addition,
+    :ref:`client headers <envoy_api_field_config.filter.http.ext_authz.v2.AuthorizationResponse.allowed_client_headers>` and
+    :ref:`upstream headers <envoy_api_field_config.filter.http.ext_authz.v2.AuthorizationResponse.allowed_upstream_headers>`
+    replaces the previous ``allowed_authorization_headers-`` object. All the control header lists now support :ref:`string
+    matcher <envoy_api_msg_type.matcher.StringMatcher>` instead of standard string.
 - area: fault
   change: |
-    added the :ref:`max_active_faults
-    <envoy_api_field_config.filter.http.fault.v2.HTTPFault.max_active_faults>` setting, as well as
-    :ref:`statistics <config_http_filters_fault_injection_stats>` for the number of active faults
-    and the number of faults the overflowed.
+    added the :ref:`max_active_faults <envoy_api_field_config.filter.http.fault.v2.HTTPFault.max_active_faults>` setting, as
+    well as :ref:`statistics <config_http_filters_fault_injection_stats>` for the number of active faults and the number of
+    faults the overflowed.
 - area: fault
   change: |
-    added :ref:`response rate limit
-    <envoy_api_field_config.filter.http.fault.v2.HTTPFault.response_rate_limit>` fault injection.
+    added :ref:`response rate limit <envoy_api_field_config.filter.http.fault.v2.HTTPFault.response_rate_limit>` fault
+    injection.
 - area: fault
   change: |
-    added :ref:`HTTP header fault configuration
-    <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
+    added :ref:`HTTP header fault configuration <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 - area: governance
   change: |
     extending Envoy deprecation policy from 1 release (0-3 months) to 2 releases (3-6 months).
 - area: health check
   change: |
-    expected response codes in http health checks are now :ref:`configurable <envoy_api_msg_core.HealthCheck.HttpHealthCheck>`.
+    expected response codes in http health checks are now :ref:`configurable
+    <envoy_api_msg_core.HealthCheck.HttpHealthCheck>`.
 - area: http
   change: |
     added new grpc_http1_reverse_bridge filter for converting gRPC requests into HTTP/1.1 requests.
@@ -114,31 +120,39 @@ changes:
     fixed a bug where Content-Length:0 was added to HTTP/1 204 responses.
 - area: http
   change: |
-    added :ref:`max request headers size <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_kb>`. The default behaviour is unchanged.
+    added :ref:`max request headers size
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.max_request_headers_kb>`. The
+    default behaviour is unchanged.
 - area: http
   change: |
     added modifyDecodingBuffer/modifyEncodingBuffer to allow modifying the buffered request/response data.
 - area: http
   change: |
-    added encodeComplete/decodeComplete. These are invoked at the end of the stream, after all data has been encoded/decoded respectively. Default implementation is a no-op.
+    added encodeComplete/decodeComplete. These are invoked at the end of the stream, after all data has been encoded/decoded
+    respectively. Default implementation is a no-op.
 - area: outlier_detection
   change: |
     added support for :ref:`outlier detection event protobuf-based logging <arch_overview_outlier_detection_logging>`.
 - area: mysql
   change: |
-    added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy <config_network_filters_mysql_proxy>` for more details.
+    added a MySQL proxy filter that is capable of parsing SQL queries over MySQL wire protocol. Refer to :ref:`MySQL proxy
+    <config_network_filters_mysql_proxy>` for more details.
 - area: performance
   change: |
-    new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments when starting Envoy).
+    new buffer implementation (disabled by default; to test it, add "--use-libevent-buffers 0" to the command-line arguments
+    when starting Envoy).
 - area: jwt_authn
   change: |
-    added :ref:`filter_state_rules <envoy_api_field_config.filter.http.jwt_authn.v2alpha.jwtauthentication.rules>` to allow specifying requirements from filterState by other filters.
+    added :ref:`filter_state_rules <envoy_api_field_config.filter.http.jwt_authn.v2alpha.jwtauthentication.rules>` to allow
+    specifying requirements from filterState by other filters.
 - area: ratelimit
   change: |
     removed deprecated rate limit configuration from bootstrap.
 - area: redis
   change: |
-    added :ref:`hashtagging <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a given key's upstream.
+    added :ref:`hashtagging
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_hashtagging>` to guarantee a
+    given key's upstream.
 - area: redis
   change: |
     added :ref:`latency stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
@@ -147,17 +161,20 @@ changes:
     added :ref:`success and error stats <config_network_filters_redis_proxy_per_command_stats>` for commands.
 - area: redis
   change: |
-    migrate hash function for host selection to `MurmurHash2 <https://sites.google.com/site/murmurhash>`_ from std::hash. MurmurHash2 is compatible with std::hash in GNU libstdc++ 3.4.20 or above. This is typically the case when compiled on Linux and not macOS.
+    migrate hash function for host selection to `MurmurHash2 <https://sites.google.com/site/murmurhash>`_ from std::hash.
+    MurmurHash2 is compatible with std::hash in GNU libstdc++ 3.4.20 or above. This is typically the case when compiled on
+    Linux and not macOS.
 - area: redis
   change: |
-    added :ref:`latency_in_micros <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.latency_in_micros>` to specify the redis commands stats time unit in microseconds.
+    added :ref:`latency_in_micros <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.latency_in_micros>` to
+    specify the redis commands stats time unit in microseconds.
 - area: router
   change: |
-    added ability to configure a :ref:`retry policy <envoy_api_msg_route.RetryPolicy>` at the
-    virtual host level.
+    added ability to configure a :ref:`retry policy <envoy_api_msg_route.RetryPolicy>` at the virtual host level.
 - area: router
   change: |
-    added reset reason to response body when upstream reset happens. After this change, the response body will be of the form ``upstream connect error or disconnect/reset before headers. reset reason:``.
+    added reset reason to response body when upstream reset happens. After this change, the response body will be of the
+    form ``upstream connect error or disconnect/reset before headers. reset reason:``.
 - area: router
   change: |
     added :ref:`rq_reset_after_downstream_response_started <config_http_filters_router_stats>` counter stat to router stats.
@@ -169,7 +186,8 @@ changes:
     removed deprecated route-action level headers_to_add/remove.
 - area: router
   change: |
-    made :ref:`max retries header <config_http_filters_router_x-envoy-max-retries>` take precedence over the number of retries in route and virtual host retry policies.
+    made :ref:`max retries header <config_http_filters_router_x-envoy-max-retries>` take precedence over the number of
+    retries in route and virtual host retry policies.
 - area: router
   change: |
     added support for prefix wildcards in :ref:`virtual host domains <envoy_api_field_route.VirtualHost.domains>`.
@@ -178,8 +196,7 @@ changes:
     added support for histograms in prometheus.
 - area: stats
   change: |
-    added usedonly flag to prometheus stats to only output metrics which have been
-    updated at least once.
+    added usedonly flag to prometheus stats to only output metrics which have been updated at least once.
 - area: stats
   change: |
     added gauges tracking remaining resources before circuit breakers open.
@@ -191,27 +208,34 @@ changes:
     enabled TLS 1.3 on the server-side (non-FIPS builds).
 - area: upstream
   change: |
-    add hash_function to specify the hash function for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` as either xxHash or `murmurHash2 <https://sites.google.com/site/murmurhash>`_. MurmurHash2 is compatible with std::hash in GNU libstdc++ 3.4.20 or above. This is typically the case when compiled on Linux and not macOS.
+    add hash_function to specify the hash function for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` as either
+    xxHash or `murmurHash2 <https://sites.google.com/site/murmurhash>`_. MurmurHash2 is compatible with std::hash in GNU
+    libstdc++ 3.4.20 or above. This is typically the case when compiled on Linux and not macOS.
 - area: upstream
   change: |
-    added :ref:`degraded health value <arch_overview_load_balancing_degraded>` which allows
-    routing to certain hosts only when there are insufficient healthy hosts available.
+    added :ref:`degraded health value <arch_overview_load_balancing_degraded>` which allows routing to certain hosts only
+    when there are insufficient healthy hosts available.
 - area: upstream
   change: |
-    add cluster factory to allow creating and registering :ref:`custom cluster type <arch_overview_service_discovery_types_custom>`.
+    add cluster factory to allow creating and registering :ref:`custom cluster type
+    <arch_overview_service_discovery_types_custom>`.
 - area: upstream
   change: |
-    added a :ref:`circuit breaker <arch_overview_circuit_break_cluster_maximum_connection_pools>` to limit the number of concurrent connection pools in use.
+    added a :ref:`circuit breaker <arch_overview_circuit_break_cluster_maximum_connection_pools>` to limit the number of
+    concurrent connection pools in use.
 - area: tracing
   change: |
-    added :ref:`verbose <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` to support logging annotations on spans.
+    added :ref:`verbose <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` to
+    support logging annotations on spans.
 - area: upstream
   change: |
-    added support for host weighting and :ref:`locality weighting <arch_overview_load_balancing_locality_weighted_lb>` in the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`, and added a :ref:`maximum_ring_size <envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>` config parameter to strictly bound the ring size.
+    added support for host weighting and :ref:`locality weighting <arch_overview_load_balancing_locality_weighted_lb>` in
+    the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`, and added a :ref:`maximum_ring_size
+    <envoy_api_field_Cluster.RingHashLbConfig.maximum_ring_size>` config parameter to strictly bound the ring size.
 - area: zookeeper
   change: |
-    added a ZooKeeper proxy filter that parses ZooKeeper messages (requests/responses/events).
-    Refer to :ref:`ZooKeeper proxy <config_network_filters_zookeeper_proxy>` for more details.
+    added a ZooKeeper proxy filter that parses ZooKeeper messages (requests/responses/events). Refer to :ref:`ZooKeeper
+    proxy <config_network_filters_zookeeper_proxy>` for more details.
 - area: upstream
   change: |
     added configuration option to select any host when the fallback policy fails.
@@ -222,15 +246,15 @@ changes:
 deprecated:
 - area: ext_authz
   change: |
-    Use of ``use_alpha`` in :ref:`Ext-Authz Authorization Service <envoy_api_file_envoy/service/auth/v2/external_auth.proto>` is deprecated. It should be used for a short time, and only when transitioning from alpha to V2 release version.
+    Use of ``use_alpha`` in :ref:`Ext-Authz Authorization Service
+    <envoy_api_file_envoy/service/auth/v2/external_auth.proto>` is deprecated. It should be used for a short time, and only
+    when transitioning from alpha to V2 release version.
 - area: cors
   change: |
-    Use of ``enabled`` in ``CorsPolicy``, found in
-    :ref:`route.proto <envoy_api_file_envoy/api/v2/route/route.proto>`.
-    Set the ``filter_enabled`` field instead.
+    Use of ``enabled`` in ``CorsPolicy``, found in :ref:`route.proto <envoy_api_file_envoy/api/v2/route/route.proto>`. Set
+    the ``filter_enabled`` field instead.
 - area: fault_delay
   change: |
-    Use of the ``type`` field in the ``FaultDelay`` message (found in
-    :ref:`fault.proto <envoy_api_file_envoy/config/filter/fault/v2/fault.proto>`)
-    has been deprecated. It was never used and setting it has no effect. It will be removed in the
-    following release.
+    Use of the ``type`` field in the ``FaultDelay`` message (found in :ref:`fault.proto
+    <envoy_api_file_envoy/config/filter/fault/v2/fault.proto>`) has been deprecated. It was never used and setting it has no
+    effect. It will be removed in the following release.

--- a/changelogs/1.11.0.yaml
+++ b/changelogs/1.11.0.yaml
@@ -9,29 +9,36 @@ changes:
     added a new field for route name to file and gRPC access logger.
 - area: access log
   change: |
-    added a new field for response code details in :ref:`file access logger <config_access_log_format_response_code_details>` and :ref:`gRPC access logger <envoy_api_field_data.accesslog.v2.HTTPResponseProperties.response_code_details>`.
+    added a new field for response code details in :ref:`file access logger
+    <config_access_log_format_response_code_details>` and :ref:`gRPC access logger
+    <envoy_api_field_data.accesslog.v2.HTTPResponseProperties.response_code_details>`.
 - area: access log
   change: |
-    added several new variables for exposing information about the downstream TLS connection to :ref:`file access logger <config_access_log_format_response_code_details>` and :ref:`gRPC access logger <envoy_api_field_data.accesslog.v2.AccessLogCommon.tls_properties>`.
+    added several new variables for exposing information about the downstream TLS connection to :ref:`file access logger
+    <config_access_log_format_response_code_details>` and :ref:`gRPC access logger
+    <envoy_api_field_data.accesslog.v2.AccessLogCommon.tls_properties>`.
 - area: access log
   change: |
     added a new flag for request rejected due to failed strict header check.
 - area: admin
   change: |
-    the administration interface now includes a :ref:`/ready endpoint <operations_admin_interface>` for easier readiness checks.
+    the administration interface now includes a :ref:`/ready endpoint <operations_admin_interface>` for easier readiness
+    checks.
 - area: admin
   change: |
-    extend :ref:`/runtime_modify endpoint <operations_admin_interface_runtime_modify>` to support parameters within the request body.
+    extend :ref:`/runtime_modify endpoint <operations_admin_interface_runtime_modify>` to support parameters within the
+    request body.
 - area: admin
   change: |
-    the :ref:`/listener endpoint <operations_admin_interface_listeners>` now returns :ref:`listeners.proto <envoy_api_msg_admin.v2alpha.Listeners>` which includes listener names and ports.
+    the :ref:`/listener endpoint <operations_admin_interface_listeners>` now returns :ref:`listeners.proto
+    <envoy_api_msg_admin.v2alpha.Listeners>` which includes listener names and ports.
 - area: admin
   change: |
     added host priority to :http:get:`/clusters` and :http:get:`/clusters?format=json` endpoint response.
 - area: admin
   change: |
-    the :ref:`/clusters endpoint <operations_admin_interface_clusters>` now shows hostname
-    for each host, useful for DNS based clusters.
+    the :ref:`/clusters endpoint <operations_admin_interface_clusters>` now shows hostname for each host, useful for DNS
+    based clusters.
 - area: api
   change: |
     track and report requests issued since last load report.
@@ -40,10 +47,12 @@ changes:
     releases are built with Clang and linked with LLD.
 - area: config
   change: |
-    added :ref:`stats_server_version_override <envoy_api_field_config.bootstrap.v2.bootstrap.stats_config>` in bootstrap, that can be used to override :ref:`server.version statistic <statistics>`.
+    added :ref:`stats_server_version_override <envoy_api_field_config.bootstrap.v2.bootstrap.stats_config>` in bootstrap,
+    that can be used to override :ref:`server.version statistic <statistics>`.
 - area: control-plane
   change: |
-    management servers can respond with HTTP 304 to indicate that config is up to date for Envoy proxies polling a :ref:`REST API Config Type <envoy_api_field_core.ApiConfigSource.api_type>`.
+    management servers can respond with HTTP 304 to indicate that config is up to date for Envoy proxies polling a
+    :ref:`REST API Config Type <envoy_api_field_core.ApiConfigSource.api_type>`.
 - area: csrf
   change: |
     added support for allowlisting additional source origins.
@@ -55,10 +64,13 @@ changes:
     support the :ref:`dubbo proxy filter <config_network_filters_dubbo_proxy>`.
 - area: dynamo_request_parser
   change: |
-    adding support for transactions. Adds check for new types of dynamodb operations (TransactWriteItems, TransactGetItems) and awareness for new types of dynamodb errors (IdempotentParameterMismatchException, TransactionCanceledException, TransactionInProgressException).
+    adding support for transactions. Adds check for new types of dynamodb operations (TransactWriteItems, TransactGetItems)
+    and awareness for new types of dynamodb errors (IdempotentParameterMismatchException, TransactionCanceledException,
+    TransactionInProgressException).
 - area: eds
   change: |
-    added support to specify max time for which endpoints can be used :ref:`gRPC filter <envoy_api_msg_ClusterLoadAssignment.Policy>`.
+    added support to specify max time for which endpoints can be used :ref:`gRPC filter
+    <envoy_api_msg_ClusterLoadAssignment.Policy>`.
 - area: eds
   change: |
     removed max limit for ``load_balancing_weight``.
@@ -67,7 +79,8 @@ changes:
     added :ref:`loop duration and poll delay statistics <operations_performance>`.
 - area: ext_authz
   change: |
-    added a ``x-envoy-auth-partial-body`` metadata header set to ``false|true`` indicating if there is a partial body sent in the authorization request message.
+    added a ``x-envoy-auth-partial-body`` metadata header set to ``false|true`` indicating if there is a partial body sent
+    in the authorization request message.
 - area: ext_authz
   change: |
     added configurable status code that allows customizing HTTP responses on filter check status errors.
@@ -80,10 +93,12 @@ changes:
     <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.auto_mapping>`.
 - area: health check
   change: |
-    added :ref:`initial jitter <envoy_api_field_core.HealthCheck.initial_jitter>` to add jitter to the first health check in order to prevent thundering herd on Envoy startup.
+    added :ref:`initial jitter <envoy_api_field_core.HealthCheck.initial_jitter>` to add jitter to the first health check in
+    order to prevent thundering herd on Envoy startup.
 - area: hot restart
   change: |
-    stats are no longer shared between hot restart parent/child via shared memory, but rather by RPC. Hot restart version incremented to 11.
+    stats are no longer shared between hot restart parent/child via shared memory, but rather by RPC. Hot restart version
+    incremented to 11.
 - area: http
   change: |
     added the ability to pass a URL encoded PEM encoded peer certificate chain in the
@@ -96,30 +111,35 @@ changes:
     fixed a crashing bug where gRPC local replies would cause segfaults when upstream access logging was on.
 - area: http
   change: |
-    mitigated a race condition with the :ref:`delayed_close_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` where it could trigger while actively flushing a pending write buffer for a downstream connection.
+    mitigated a race condition with the :ref:`delayed_close_timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` where it
+    could trigger while actively flushing a pending write buffer for a downstream connection.
 - area: http
   change: |
-    added support for :ref:`preserve_external_request_id <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.preserve_external_request_id>` that represents whether the x-request-id should not be reset on edge entry inside mesh.
+    added support for :ref:`preserve_external_request_id
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.preserve_external_request_id>`
+    that represents whether the x-request-id should not be reset on edge entry inside mesh.
 - area: http
   change: |
     changed ``sendLocalReply`` to send percent-encoded ``GrpcMessage``.
 - area: http
   change: |
-    added a :ref:`header_prefix <envoy_api_field_config.bootstrap.v2.Bootstrap.header_prefix>` configuration option to allow Envoy to send and process x-custom- prefixed headers rather than x-envoy.
+    added a :ref:`header_prefix <envoy_api_field_config.bootstrap.v2.Bootstrap.header_prefix>` configuration option to allow
+    Envoy to send and process x-custom- prefixed headers rather than x-envoy.
 - area: http
   change: |
     added :ref:`dynamic forward proxy <arch_overview_http_dynamic_forward_proxy>` support.
 - area: http
   change: |
-    tracking the active stream and dumping state in Envoy crash handlers. This can be disabled by building with ``--define disable_object_dump_on_signal_trace=disabled``.
+    tracking the active stream and dumping state in Envoy crash handlers. This can be disabled by building with ``--define
+    disable_object_dump_on_signal_trace=disabled``.
 - area: jwt_authn
   change: |
     make filter's parsing of JWT more flexible, allowing syntax like ``jwt=eyJhbGciOiJS...ZFnFIw,extra=7,realm=123``.
 - area: listener
   change: |
-    added :ref:`source IP <envoy_api_field_listener.FilterChainMatch.source_prefix_ranges>`
-    and :ref:`source port <envoy_api_field_listener.FilterChainMatch.source_ports>` filter
-    chain matching.
+    added :ref:`source IP <envoy_api_field_listener.FilterChainMatch.source_prefix_ranges>` and :ref:`source port
+    <envoy_api_field_listener.FilterChainMatch.source_ports>` filter chain matching.
 - area: lua
   change: |
     exposed functions to Lua to verify digital signature.
@@ -128,7 +148,9 @@ changes:
     added the :ref:`filter <config_http_filters_original_src>`.
 - area: outlier_detector
   change: |
-    added configuration :ref:`outlier_detection.split_external_local_origin_errors <envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>` to distinguish locally and externally generated errors. See :ref:`arch_overview_outlier_detection` for full details.
+    added configuration :ref:`outlier_detection.split_external_local_origin_errors
+    <envoy_api_field_cluster.OutlierDetection.split_external_local_origin_errors>` to distinguish locally and externally
+    generated errors. See :ref:`arch_overview_outlier_detection` for full details.
 - area: rbac
   change: |
     migrated from v2alpha to v2.
@@ -140,54 +162,67 @@ changes:
     automatically route commands using cluster slots for Redis cluster.
 - area: redis
   change: |
-    added :ref:`prefix routing <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.prefix_routes>` to enable routing commands based on their key's prefix to different upstream.
+    added :ref:`prefix routing <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.prefix_routes>` to enable
+    routing commands based on their key's prefix to different upstream.
 - area: redis
   change: |
-    added :ref:`request mirror policy <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.Route.request_mirror_policy>` to enable shadow traffic and/or dual writes.
+    added :ref:`request mirror policy
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.Route.request_mirror_policy>` to enable
+    shadow traffic and/or dual writes.
 - area: redis
   change: |
     add support for zpopmax and zpopmin commands.
 - area: redis
   change: |
-    added
-    :ref:`max_buffer_size_before_flush <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.max_buffer_size_before_flush>` to batch commands together until the encoder buffer hits a certain size, and
-    :ref:`buffer_flush_timeout <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.buffer_flush_timeout>` to control how quickly the buffer is flushed if it is not full.
+    added :ref:`max_buffer_size_before_flush
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.max_buffer_size_before_flush>` to
+    batch commands together until the encoder buffer hits a certain size, and :ref:`buffer_flush_timeout
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.buffer_flush_timeout>` to control how
+    quickly the buffer is flushed if it is not full.
 - area: redis
   change: |
-    added auth support :ref:`downstream_auth_password <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.downstream_auth_password>` for downstream client authentication, and :ref:`auth_password <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProtocolOptions.auth_password>` to configure authentication passwords for upstream server clusters.
+    added auth support :ref:`downstream_auth_password
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.downstream_auth_password>` for downstream client
+    authentication, and :ref:`auth_password
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProtocolOptions.auth_password>` to configure authentication
+    passwords for upstream server clusters.
 - area: retry
   change: |
     added a retry predicate that :ref:`rejects canary hosts. <envoy_api_field_route.RetryPolicy.retry_host_predicate>`.
 - area: router
   change: |
-    add support for configuring a :ref:`gRPC timeout offset <envoy_api_field_route.RouteAction.grpc_timeout_offset>` on incoming requests.
+    add support for configuring a :ref:`gRPC timeout offset <envoy_api_field_route.RouteAction.grpc_timeout_offset>` on
+    incoming requests.
 - area: router
   change: |
-    added ability to control retry back-off intervals via :ref:`retry policy <envoy_api_msg_route.RetryPolicy.RetryBackOff>`.
+    added ability to control retry back-off intervals via :ref:`retry policy
+    <envoy_api_msg_route.RetryPolicy.RetryBackOff>`.
 - area: router
   change: |
-    added ability to issue a hedged retry in response to a per try timeout via a :ref:`hedge policy <envoy_api_msg_route.HedgePolicy>`.
+    added ability to issue a hedged retry in response to a per try timeout via a :ref:`hedge policy
+    <envoy_api_msg_route.HedgePolicy>`.
 - area: router
   change: |
     added a route name field to each http route in route.Route list.
 - area: router
   change: |
-    added several new variables for exposing information about the downstream TLS connection via :ref:`header
-    formatters <config_http_conn_man_headers_custom_request_headers>`.
-- area: router
-  change: |
-    per try timeouts will no longer start before the downstream request has been received in full by the router.This ensures that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
-- area: router
-  change: |
-    added :ref:`RouteAction's auto_host_rewrite_header <envoy_api_field_route.RouteAction.auto_host_rewrite_header>` to allow upstream host header substitution with some other header's value.
-- area: router
-  change: |
-    added support for UPSTREAM_REMOTE_ADDRESS :ref:`header formatter
+    added several new variables for exposing information about the downstream TLS connection via :ref:`header formatters
     <config_http_conn_man_headers_custom_request_headers>`.
 - area: router
   change: |
-    add ability to reject a request that includes invalid values for
-    headers configured in :ref:`strict_check_headers <envoy_api_field_config.filter.http.router.v2.Router.strict_check_headers>`.
+    per try timeouts will no longer start before the downstream request has been received in full by the router.This ensures
+    that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
+- area: router
+  change: |
+    added :ref:`RouteAction's auto_host_rewrite_header <envoy_api_field_route.RouteAction.auto_host_rewrite_header>` to
+    allow upstream host header substitution with some other header's value.
+- area: router
+  change: |
+    added support for UPSTREAM_REMOTE_ADDRESS :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
+- area: router
+  change: |
+    add ability to reject a request that includes invalid values for headers configured in :ref:`strict_check_headers
+    <envoy_api_field_config.filter.http.router.v2.Router.strict_check_headers>`.
 - area: runtime
   change: |
     added support for :ref:`flexible layering configuration
@@ -204,8 +239,8 @@ changes:
     added :ref:`CSRF sandbox <install_sandboxes_csrf>`.
 - area: server
   change: |
-    ``--define manual_stamp=manual_stamp`` was added to allow server stamping outside of binary rules.
-    more info in the `bazel docs <https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#enabling-optional-features>`_.
+    ``--define manual_stamp=manual_stamp`` was added to allow server stamping outside of binary rules. more info in the
+    `bazel docs <https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#enabling-optional-features>`_.
 - area: server
   change: |
     added :ref:`server state <statistics>` statistic.
@@ -214,12 +249,12 @@ changes:
     added :ref:`initialization_time_ms <statistics>` statistic.
 - area: subset
   change: |
-    added :ref:`list_as_any <envoy_api_field_Cluster.LbSubsetConfig.list_as_any>` option to
-    the subset lb which allows matching metadata against any of the values in a list value
-    on the endpoints.
+    added :ref:`list_as_any <envoy_api_field_Cluster.LbSubsetConfig.list_as_any>` option to the subset lb which allows
+    matching metadata against any of the values in a list value on the endpoints.
 - area: tools
   change: |
-    added `proto <https://github.com/envoyproxy/envoy/blob/v1.11.0/test/tools/router_check/validation.proto>`_ support for :ref:`router check tool <install_tools_route_table_check_tool>` tests.
+    added `proto <https://github.com/envoyproxy/envoy/blob/v1.11.0/test/tools/router_check/validation.proto>`_ support for
+    :ref:`router check tool <install_tools_route_table_check_tool>` tests.
 - area: tracing
   change: |
     add trace sampling configuration to the route, to override the route level.
@@ -228,26 +263,26 @@ changes:
     added :ref:`upstream_cx_pool_overflow <config_cluster_manager_cluster_stats>` for the connection pool circuit breaker.
 - area: upstream
   change: |
-    an EDS management server can now force removal of a host that is still passing active
-    health checking by first marking the host as failed via EDS health check and subsequently removing
-    it in a future update. This is a mechanism to work around a race condition in which an EDS
-    implementation may remove a host before it has stopped passing active HC, thus causing the host
-    to become stranded until a future update.
+    an EDS management server can now force removal of a host that is still passing active health checking by first marking
+    the host as failed via EDS health check and subsequently removing it in a future update. This is a mechanism to work
+    around a race condition in which an EDS implementation may remove a host before it has stopped passing active HC, thus
+    causing the host to become stranded until a future update.
 - area: upstream
   change: |
-    added :ref:`an option <envoy_api_field_Cluster.CommonLbConfig.ignore_new_hosts_until_first_hc>`
-    that allows ignoring new hosts for the purpose of load balancing calculations until they have
-    been health checked for the first time.
+    added :ref:`an option <envoy_api_field_Cluster.CommonLbConfig.ignore_new_hosts_until_first_hc>` that allows ignoring new
+    hosts for the purpose of load balancing calculations until they have been health checked for the first time.
 - area: upstream
   change: |
-    added runtime error checking to prevent setting dns type to STRICT_DNS or LOGICAL_DNS when custom resolver name is specified.
+    added runtime error checking to prevent setting dns type to STRICT_DNS or LOGICAL_DNS when custom resolver name is
+    specified.
 - area: upstream
   change: |
-    added possibility to override fallback_policy per specific selector in :ref:`subset load balancer <arch_overview_load_balancer_subsets>`.
+    added possibility to override fallback_policy per specific selector in :ref:`subset load balancer
+    <arch_overview_load_balancer_subsets>`.
 - area: upstream
   change: |
-    the :ref:`logical DNS cluster <arch_overview_service_discovery_types_logical_dns>` now
-    displays the current resolved IP address in admin output instead of 0.0.0.0.
+    the :ref:`logical DNS cluster <arch_overview_service_discovery_types_logical_dns>` now displays the current resolved IP
+    address in admin output instead of 0.0.0.0.
 
 deprecated:
 - area: options
@@ -255,18 +290,25 @@ deprecated:
     The --max-stats and --max-obj-name-len flags no longer has any effect.
 - area: redis
   change: |
-    Use of :ref:`cluster <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.cluster>` in :ref:`redis_proxy.proto <envoy_api_file_envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto>` is deprecated. Set a :ref:`catch_all_route <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_route>` instead.
+    Use of :ref:`cluster <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.cluster>` in
+    :ref:`redis_proxy.proto <envoy_api_file_envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto>` is deprecated.
+    Set a :ref:`catch_all_route
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_route>` instead.
 - area: redis
   change: |
-    Use of :ref:`catch_all_cluster <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_cluster>` in :ref:`redis_proxy.proto <envoy_api_file_envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto>` is deprecated. Set a :ref:`catch_all_route <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_route>` instead.
+    Use of :ref:`catch_all_cluster
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_cluster>` in
+    :ref:`redis_proxy.proto <envoy_api_file_envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto>` is deprecated.
+    Set a :ref:`catch_all_route
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.catch_all_route>` instead.
 - area: router_check_tool
   change: |
-    Use of json based schema in router check tool tests. The tests should follow validation `schema <https://github.com/envoyproxy/envoy/blob/v1.11.0/test/tools/router_check/validation.proto>`_.
+    Use of json based schema in router check tool tests. The tests should follow validation `schema
+    <https://github.com/envoyproxy/envoy/blob/v1.11.0/test/tools/router_check/validation.proto>`_.
 - area: listener
   change: |
-    Use of the v1 style route configuration for the :ref:`TCP proxy filter <config_network_filters_tcp_proxy>`
-    is now fully replaced with listener :ref:`filter chain matching <envoy_api_msg_listener.FilterChainMatch>`.
-    Use this instead.
+    Use of the v1 style route configuration for the :ref:`TCP proxy filter <config_network_filters_tcp_proxy>` is now fully
+    replaced with listener :ref:`filter chain matching <envoy_api_msg_listener.FilterChainMatch>`. Use this instead.
 - area: config
   change: |
     Use of :ref:`runtime <envoy_api_field_config.bootstrap.v2.Bootstrap.runtime>` in :ref:`Bootstrap
@@ -274,8 +316,7 @@ deprecated:
     <envoy_api_field_config.bootstrap.v2.Bootstrap.layered_runtime>` instead.
 - area: config
   change: |
-    Specifying "deprecated_v1: true" in HTTP and network filter configuration to allow loading JSON
-    configuration is now deprecated and will be removed in a following release. Update any custom
-    filters to use protobuf configuration. A struct can be used for a mostly 1:1 conversion if needed.
-    The ``envoy.deprecated_features.v1_filter_json_config`` runtime key can be used to temporarily
-    enable this feature once the deprecation becomes fail by default.
+    Specifying "deprecated_v1: true" in HTTP and network filter configuration to allow loading JSON configuration is now
+    deprecated and will be removed in a following release. Update any custom filters to use protobuf configuration. A struct
+    can be used for a mostly 1:1 conversion if needed. The ``envoy.deprecated_features.v1_filter_json_config`` runtime key
+    can be used to temporarily enable this feature once the deprecation becomes fail by default.

--- a/changelogs/1.11.1.yaml
+++ b/changelogs/1.11.1.yaml
@@ -3,28 +3,63 @@ date: August 13, 2019
 changes:
 - area: http
   change: |
-    added mitigation of client initiated attacks that result in flooding of the downstream HTTP/2 connections. Those attacks can be logged at the "warning" level when the runtime feature ``http.connection_manager.log_flood_exception`` is enabled. The runtime setting defaults to disabled to avoid log spam when under attack.
+    added mitigation of client initiated attacks that result in flooding of the downstream HTTP/2 connections. Those attacks
+    can be logged at the "warning" level when the runtime feature ``http.connection_manager.log_flood_exception`` is
+    enabled. The runtime setting defaults to disabled to avoid log spam when under attack.
 - area: http
   change: |
-    added :ref:`inbound_empty_frames_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for tracking number of connections terminated for exceeding the limit on consecutive inbound frames with an empty payload and no end stream flag. The limit is configured by setting the :ref:`max_consecutive_inbound_frames_with_empty_payload config setting <envoy_api_field_core.Http2ProtocolOptions.max_consecutive_inbound_frames_with_empty_payload>`.
-    Runtime feature ``envoy.reloadable_features.http2_protocol_options.max_consecutive_inbound_frames_with_empty_payload`` overrides :ref:`max_consecutive_inbound_frames_with_empty_payload setting <envoy_api_field_core.Http2ProtocolOptions.max_consecutive_inbound_frames_with_empty_payload>`. Large override value (i.e. 2147483647) effectively disables mitigation of inbound frames with empty payload.
+    added :ref:`inbound_empty_frames_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats,
+    for tracking number of connections terminated for exceeding the limit on consecutive inbound frames with an empty
+    payload and no end stream flag. The limit is configured by setting the
+    :ref:`max_consecutive_inbound_frames_with_empty_payload config setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_consecutive_inbound_frames_with_empty_payload>`. Runtime feature
+    ``envoy.reloadable_features.http2_protocol_options.max_consecutive_inbound_frames_with_empty_payload`` overrides
+    :ref:`max_consecutive_inbound_frames_with_empty_payload setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_consecutive_inbound_frames_with_empty_payload>`. Large override value
+    (i.e. 2147483647) effectively disables mitigation of inbound frames with empty payload.
 - area: http
   change: |
-    added :ref:`inbound_priority_frames_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for tracking number of connections terminated for exceeding the limit on inbound PRIORITY frames. The limit is configured by setting the :ref:`max_inbound_priority_frames_per_stream config setting <envoy_api_field_core.Http2ProtocolOptions.max_inbound_priority_frames_per_stream>`.
-    Runtime feature ``envoy.reloadable_features.http2_protocol_options.max_inbound_priority_frames_per_stream`` overrides :ref:`max_inbound_priority_frames_per_stream setting <envoy_api_field_core.Http2ProtocolOptions.max_inbound_priority_frames_per_stream>`. Large override value effectively disables flood mitigation of inbound PRIORITY frames.
+    added :ref:`inbound_priority_frames_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec
+    stats, for tracking number of connections terminated for exceeding the limit on inbound PRIORITY frames. The limit is
+    configured by setting the :ref:`max_inbound_priority_frames_per_stream config setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_inbound_priority_frames_per_stream>`. Runtime feature
+    ``envoy.reloadable_features.http2_protocol_options.max_inbound_priority_frames_per_stream`` overrides
+    :ref:`max_inbound_priority_frames_per_stream setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_inbound_priority_frames_per_stream>`. Large override value effectively
+    disables flood mitigation of inbound PRIORITY frames.
 - area: http
   change: |
-    added :ref:`inbound_window_update_frames_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for tracking number of connections terminated for exceeding the limit on inbound WINDOW_UPDATE frames. The limit is configured by setting the :ref:`max_inbound_window_update_frames_per_data_frame_sent config setting <envoy_api_field_core.Http2ProtocolOptions.max_inbound_window_update_frames_per_data_frame_sent>`.
-    Runtime feature ``envoy.reloadable_features.http2_protocol_options.max_inbound_window_update_frames_per_data_frame_sent`` overrides :ref:`max_inbound_window_update_frames_per_data_frame_sent setting <envoy_api_field_core.Http2ProtocolOptions.max_inbound_window_update_frames_per_data_frame_sent>`. Large override value effectively disables flood mitigation of inbound WINDOW_UPDATE frames.
+    added :ref:`inbound_window_update_frames_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec
+    stats, for tracking number of connections terminated for exceeding the limit on inbound WINDOW_UPDATE frames. The limit
+    is configured by setting the :ref:`max_inbound_window_update_frames_per_data_frame_sent config setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_inbound_window_update_frames_per_data_frame_sent>`. Runtime feature
+    ``envoy.reloadable_features.http2_protocol_options.max_inbound_window_update_frames_per_data_frame_sent`` overrides
+    :ref:`max_inbound_window_update_frames_per_data_frame_sent setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_inbound_window_update_frames_per_data_frame_sent>`. Large override value
+    effectively disables flood mitigation of inbound WINDOW_UPDATE frames.
 - area: http
   change: |
-    added :ref:`outbound_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for tracking number of connections terminated for exceeding the outbound queue limit. The limit is configured by setting the :ref:`max_outbound_frames config setting <envoy_api_field_core.Http2ProtocolOptions.max_outbound_frames>`
-    Runtime feature ``envoy.reloadable_features.http2_protocol_options.max_outbound_frames`` overrides :ref:`max_outbound_frames config setting <envoy_api_field_core.Http2ProtocolOptions.max_outbound_frames>`. Large override value effectively disables flood mitigation of outbound frames of all types.
+    added :ref:`outbound_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for tracking
+    number of connections terminated for exceeding the outbound queue limit. The limit is configured by setting the
+    :ref:`max_outbound_frames config setting <envoy_api_field_core.Http2ProtocolOptions.max_outbound_frames>` Runtime
+    feature ``envoy.reloadable_features.http2_protocol_options.max_outbound_frames`` overrides :ref:`max_outbound_frames
+    config setting <envoy_api_field_core.Http2ProtocolOptions.max_outbound_frames>`. Large override value effectively
+    disables flood mitigation of outbound frames of all types.
 - area: http
   change: |
-    added :ref:`outbound_control_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for tracking number of connections terminated for exceeding the outbound queue limit for ``PING``, ``SETTINGS`` and ``RST_STREAM`` frames. The limit is configured by setting the :ref:`max_outbound_control_frames config setting <envoy_api_field_core.Http2ProtocolOptions.max_outbound_control_frames>`.
-    Runtime feature ``envoy.reloadable_features.http2_protocol_options.max_outbound_control_frames`` overrides :ref:`max_outbound_control_frames config setting <envoy_api_field_core.Http2ProtocolOptions.max_outbound_control_frames>`. Large override value effectively disables flood mitigation of outbound frames of types ``PING``, ``SETTINGS`` and ``RST_STREAM``.
+    added :ref:`outbound_control_flood <config_http_conn_man_stats_per_codec>` counter stat to the HTTP/2 codec stats, for
+    tracking number of connections terminated for exceeding the outbound queue limit for ``PING``, ``SETTINGS`` and
+    ``RST_STREAM`` frames. The limit is configured by setting the :ref:`max_outbound_control_frames config setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_outbound_control_frames>`. Runtime feature
+    ``envoy.reloadable_features.http2_protocol_options.max_outbound_control_frames`` overrides
+    :ref:`max_outbound_control_frames config setting
+    <envoy_api_field_core.Http2ProtocolOptions.max_outbound_control_frames>`. Large override value effectively disables
+    flood mitigation of outbound frames of types ``PING``, ``SETTINGS`` and ``RST_STREAM``.
 - area: http
   change: |
-    enabled strict validation of HTTP/2 messaging. Previous behavior can be restored using :ref:`stream_error_on_invalid_http_messaging config setting <envoy_api_field_core.Http2ProtocolOptions.stream_error_on_invalid_http_messaging>`.
-    Runtime feature ``envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging`` overrides :ref:`stream_error_on_invalid_http_messaging config setting <envoy_api_field_core.Http2ProtocolOptions.stream_error_on_invalid_http_messaging>`.
+    enabled strict validation of HTTP/2 messaging. Previous behavior can be restored using
+    :ref:`stream_error_on_invalid_http_messaging config setting
+    <envoy_api_field_core.Http2ProtocolOptions.stream_error_on_invalid_http_messaging>`. Runtime feature
+    ``envoy.reloadable_features.http2_protocol_options.stream_error_on_invalid_http_messaging`` overrides
+    :ref:`stream_error_on_invalid_http_messaging config setting
+    <envoy_api_field_core.Http2ProtocolOptions.stream_error_on_invalid_http_messaging>`.

--- a/changelogs/1.11.2.yaml
+++ b/changelogs/1.11.2.yaml
@@ -6,14 +6,19 @@ changes:
     fixed CVE-2019-15226 by adding a cached byte size in HeaderMap.
 - area: http
   change: |
-    added :ref:`max headers count <envoy_api_field_core.HttpProtocolOptions.max_headers_count>` for http connections. The default limit is 100.
+    added :ref:`max headers count <envoy_api_field_core.HttpProtocolOptions.max_headers_count>` for http connections. The
+    default limit is 100.
 - area: upstream
   change: |
-    runtime feature ``envoy.reloadable_features.max_response_headers_count`` overrides the default limit for upstream :ref:`max headers count <envoy_api_field_Cluster.common_http_protocol_options>`.
+    runtime feature ``envoy.reloadable_features.max_response_headers_count`` overrides the default limit for upstream
+    :ref:`max headers count <envoy_api_field_Cluster.common_http_protocol_options>`.
 - area: http
   change: |
-    added :ref:`common_http_protocol_options <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
-    Runtime feature ``envoy.reloadable_features.max_request_headers_count`` overrides the default limit for downstream :ref:`max headers count <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`.
+    added :ref:`common_http_protocol_options
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
+    Runtime feature ``envoy.reloadable_features.max_request_headers_count`` overrides the default limit for downstream
+    :ref:`max headers count
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`.
 - area: regex
   change: |
     backported safe regex matcher fix for CVE-2019-15225.
@@ -22,7 +27,7 @@ deprecated:
 - area: hcm
   change: |
     Use of :ref:`idle_timeout
-    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>`
-    is deprecated. Use :ref:`common_http_protocol_options
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>` is deprecated.
+    Use :ref:`common_http_protocol_options
     <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
     instead.

--- a/changelogs/1.12.0.yaml
+++ b/changelogs/1.12.0.yaml
@@ -3,37 +3,47 @@ date: October 31, 2019
 changes:
 - area: access log
   change: |
-    added a new flag for :ref:`downstream protocol error <envoy_api_field_data.accesslog.v2.ResponseFlags.downstream_protocol_error>`.
+    added a new flag for :ref:`downstream protocol error
+    <envoy_api_field_data.accesslog.v2.ResponseFlags.downstream_protocol_error>`.
 - area: access log
   change: |
-    added :ref:`buffering <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_size_bytes>` and :ref:`periodical flushing <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_flush_interval>` support to gRPC access logger. Defaults to 16KB buffer and flushing every 1 second.
+    added :ref:`buffering <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_size_bytes>` and
+    :ref:`periodical flushing <envoy_api_field_config.accesslog.v2.CommonGrpcAccessLogConfig.buffer_flush_interval>` support
+    to gRPC access logger. Defaults to 16KB buffer and flushing every 1 second.
 - area: access log
   change: |
-    added DOWNSTREAM_DIRECT_REMOTE_ADDRESS and DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT :ref:`access log formatters <config_access_log_format>` and gRPC access logger.
+    added DOWNSTREAM_DIRECT_REMOTE_ADDRESS and DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT :ref:`access log formatters
+    <config_access_log_format>` and gRPC access logger.
 - area: access log
   change: |
-    gRPC Access Log Service (ALS) support added for :ref:`TCP access logs <envoy_api_msg_config.accesslog.v2.TcpGrpcAccessLogConfig>`.
+    gRPC Access Log Service (ALS) support added for :ref:`TCP access logs
+    <envoy_api_msg_config.accesslog.v2.TcpGrpcAccessLogConfig>`.
 - area: access log
   change: |
-    reintroduced :ref:`filesystem <filesystem_stats>` stats and added the ``write_failed`` counter to track failed log writes.
+    reintroduced :ref:`filesystem <filesystem_stats>` stats and added the ``write_failed`` counter to track failed log
+    writes.
 - area: admin
   change: |
     added ability to configure listener :ref:`socket options <envoy_api_field_config.bootstrap.v2.Admin.socket_options>`.
 - area: admin
   change: |
-    added config dump support for Secret Discovery Service :ref:`SecretConfigDump <envoy_api_msg_admin.v2alpha.SecretsConfigDump>`.
+    added config dump support for Secret Discovery Service :ref:`SecretConfigDump
+    <envoy_api_msg_admin.v2alpha.SecretsConfigDump>`.
 - area: admin
   change: |
     added support for :ref:`draining <operations_admin_interface_drain>` listeners via admin interface.
 - area: admin
   change: |
-    added :http:get:`/stats/recentlookups`, :http:post:`/stats/recentlookups/clear`, :http:post:`/stats/recentlookups/disable`, and :http:post:`/stats/recentlookups/enable` endpoints.
+    added :http:get:`/stats/recentlookups`, :http:post:`/stats/recentlookups/clear`,
+    :http:post:`/stats/recentlookups/disable`, and :http:post:`/stats/recentlookups/enable` endpoints.
 - area: api
   change: |
-    added :ref:`set_node_on_first_message_only <envoy_api_field_core.ApiConfigSource.set_node_on_first_message_only>` option to omit the node identifier from the subsequent discovery requests on the same stream.
+    added :ref:`set_node_on_first_message_only <envoy_api_field_core.ApiConfigSource.set_node_on_first_message_only>` option
+    to omit the node identifier from the subsequent discovery requests on the same stream.
 - area: buffer filter
   change: |
-    now populates content-length header if not present. This behavior can be temporarily disabled using the runtime feature ``envoy.reloadable_features.buffer_filter_populate_content_length``.
+    now populates content-length header if not present. This behavior can be temporarily disabled using the runtime feature
+    ``envoy.reloadable_features.buffer_filter_populate_content_length``.
 - area: build
   change: |
     official released binary is now PIE so it can be run with ASLR.
@@ -42,42 +52,49 @@ changes:
     added support for :ref:`delta xDS <arch_overview_dynamic_config_delta>` (including ADS) delivery.
 - area: config
   change: |
-    enforcing that terminal filters (e.g. HttpConnectionManager for L4, router for L7) be the last in their respective filter chains.
+    enforcing that terminal filters (e.g. HttpConnectionManager for L4, router for L7) be the last in their respective
+    filter chains.
 - area: config
   change: |
     added access log :ref:`extension filter <envoy_api_field_config.filter.accesslog.v2.AccessLogFilter.extension_filter>`.
 - area: config
   change: |
-    added support for :option:`--reject-unknown-dynamic-fields`, providing independent control
-    over whether unknown fields are rejected in static and dynamic configuration. By default, unknown
-    fields in static configuration are rejected and are allowed in dynamic configuration. Warnings
-    are logged for the first use of any unknown field and these occurrences are counted in the
-    :ref:`server.static_unknown_fields <server_statistics>` and :ref:`server.dynamic_unknown_fields
+    added support for :option:`--reject-unknown-dynamic-fields`, providing independent control over whether unknown fields
+    are rejected in static and dynamic configuration. By default, unknown fields in static configuration are rejected and
+    are allowed in dynamic configuration. Warnings are logged for the first use of any unknown field and these occurrences
+    are counted in the :ref:`server.static_unknown_fields <server_statistics>` and :ref:`server.dynamic_unknown_fields
     <server_statistics>` statistics.
 - area: config
   change: |
     added async data access for local and remote data sources.
 - area: config
   change: |
-    changed the default value of :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>` from 0s to 15s. This is a change in behaviour in the sense that Envoy will move to the next initialization phase, even if the first config is not delivered in 15s. Refer to :ref:`initialization process <arch_overview_initialization>` for more details.
+    changed the default value of :ref:`initial_fetch_timeout <envoy_api_field_core.ConfigSource.initial_fetch_timeout>` from
+    0s to 15s. This is a change in behaviour in the sense that Envoy will move to the next initialization phase, even if the
+    first config is not delivered in 15s. Refer to :ref:`initialization process <arch_overview_initialization>` for more
+    details.
 - area: config
   change: |
     added stat :ref:`init_fetch_timeout <config_cluster_manager_cds>`.
 - area: config
   change: |
-    tls_context in Cluster and FilterChain are deprecated in favor of transport socket. See :ref:`deprecated documentation <deprecated>` for more information.
+    tls_context in Cluster and FilterChain are deprecated in favor of transport socket. See :ref:`deprecated documentation
+    <deprecated>` for more information.
 - area: csrf
   change: |
     added PATCH to supported methods.
 - area: dns
   change: |
-    added support for configuring :ref:`dns_failure_refresh_rate <envoy_api_field_Cluster.dns_failure_refresh_rate>` to set the DNS refresh rate during failures.
+    added support for configuring :ref:`dns_failure_refresh_rate <envoy_api_field_Cluster.dns_failure_refresh_rate>` to set
+    the DNS refresh rate during failures.
 - area: ext_authz
   change: |
-    added :ref:`configurable ability <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.metadata_context_namespaces>` to send dynamic metadata to the ``ext_authz`` service.
+    added :ref:`configurable ability <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.metadata_context_namespaces>`
+    to send dynamic metadata to the ``ext_authz`` service.
 - area: ext_authz
   change: |
-    added :ref:`filter_enabled RuntimeFractionalPercent flag <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.filter_enabled>` to filter.
+    added :ref:`filter_enabled RuntimeFractionalPercent flag
+    <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.filter_enabled>` to filter.
 - area: ext_authz
   change: |
     added tracing to the HTTP client.
@@ -86,74 +103,104 @@ changes:
     deprecated :ref:`cluster scope stats <config_http_filters_ext_authz_stats>` in favour of filter scope stats.
 - area: fault
   change: |
-    added overrides for default runtime keys in :ref:`HTTPFault <envoy_api_msg_config.filter.http.fault.v2.HTTPFault>` filter.
+    added overrides for default runtime keys in :ref:`HTTPFault <envoy_api_msg_config.filter.http.fault.v2.HTTPFault>`
+    filter.
 - area: grpc
   change: |
-    added :ref:`AWS IAM grpc credentials extension <envoy_api_file_envoy/config/grpc_credential/v2alpha/aws_iam.proto>` for AWS-managed xDS.
+    added :ref:`AWS IAM grpc credentials extension <envoy_api_file_envoy/config/grpc_credential/v2alpha/aws_iam.proto>` for
+    AWS-managed xDS.
 - area: grpc
   change: |
-    added :ref:`gRPC stats filter <config_http_filters_grpc_stats>` for collecting stats about gRPC calls and streaming message counts.
+    added :ref:`gRPC stats filter <config_http_filters_grpc_stats>` for collecting stats about gRPC calls and streaming
+    message counts.
 - area: grpc-json
   change: |
-    added support for :ref:`ignoring unknown query parameters <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.ignore_unknown_query_parameters>`.
+    added support for :ref:`ignoring unknown query parameters
+    <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.ignore_unknown_query_parameters>`.
 - area: grpc-json
   change: |
-    added support for :ref:`the grpc-status-details-bin header <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.convert_grpc_status>`.
+    added support for :ref:`the grpc-status-details-bin header
+    <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.convert_grpc_status>`.
 - area: header to metadata
   change: |
-    added :ref:`PROTOBUF_VALUE <envoy_api_enum_value_config.filter.http.header_to_metadata.v2.Config.ValueType.PROTOBUF_VALUE>` and :ref:`ValueEncode <envoy_api_enum_config.filter.http.header_to_metadata.v2.Config.ValueEncode>` to support protobuf Value and Base64 encoding.
+    added :ref:`PROTOBUF_VALUE
+    <envoy_api_enum_value_config.filter.http.header_to_metadata.v2.Config.ValueType.PROTOBUF_VALUE>` and :ref:`ValueEncode
+    <envoy_api_enum_config.filter.http.header_to_metadata.v2.Config.ValueEncode>` to support protobuf Value and Base64
+    encoding.
 - area: http
   change: |
-    added a default one hour idle timeout to upstream and downstream connections. HTTP connections with no streams and no activity will be closed after one hour unless the default idle_timeout is overridden. To disable upstream idle timeouts, set the :ref:`idle_timeout <envoy_api_field_core.HttpProtocolOptions.idle_timeout>` to zero in Cluster :ref:`http_protocol_options <envoy_api_field_Cluster.common_http_protocol_options>`. To disable downstream idle timeouts, either set :ref:`idle_timeout <envoy_api_field_core.HttpProtocolOptions.idle_timeout>` to zero in the HttpConnectionManager :ref:`common_http_protocol_options <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>` or set the deprecated :ref:`connection manager <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>` field to zero.
+    added a default one hour idle timeout to upstream and downstream connections. HTTP connections with no streams and no
+    activity will be closed after one hour unless the default idle_timeout is overridden. To disable upstream idle timeouts,
+    set the :ref:`idle_timeout <envoy_api_field_core.HttpProtocolOptions.idle_timeout>` to zero in Cluster
+    :ref:`http_protocol_options <envoy_api_field_Cluster.common_http_protocol_options>`. To disable downstream idle
+    timeouts, either set :ref:`idle_timeout <envoy_api_field_core.HttpProtocolOptions.idle_timeout>` to zero in the
+    HttpConnectionManager :ref:`common_http_protocol_options
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
+    or set the deprecated :ref:`connection manager
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>` field to zero.
 - area: http
   change: |
-    added the ability to format HTTP/1.1 header keys using :ref:`header_key_format <envoy_api_field_core.Http1ProtocolOptions.header_key_format>`.
+    added the ability to format HTTP/1.1 header keys using :ref:`header_key_format
+    <envoy_api_field_core.Http1ProtocolOptions.header_key_format>`.
 - area: http
   change: |
-    added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature ``envoy.reloadable_features.strict_header_validation``.
+    added the ability to reject HTTP/1.1 requests with invalid HTTP header values, using the runtime feature
+    ``envoy.reloadable_features.strict_header_validation``.
 - area: http
   change: |
-    changed Envoy to forward existing x-forwarded-proto from upstream trusted proxies. Guarded by ``envoy.reloadable_features.trusted_forwarded_proto`` which defaults true.
+    changed Envoy to forward existing x-forwarded-proto from upstream trusted proxies. Guarded by
+    ``envoy.reloadable_features.trusted_forwarded_proto`` which defaults true.
 - area: http
   change: |
-    added the ability to configure the behavior of the server response header, via the :ref:`server_header_transformation <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.server_header_transformation>` field.
+    added the ability to configure the behavior of the server response header, via the :ref:`server_header_transformation
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.server_header_transformation>`
+    field.
 - area: http
   change: |
-    added the ability to :ref:`merge adjacent slashes <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
+    added the ability to :ref:`merge adjacent slashes
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` in the path.
 - area: http
   change: |
-    :ref:`AUTO <envoy_api_enum_value_config.filter.network.http_connection_manager.v2.HttpConnectionManager.CodecType.AUTO>` codec protocol inference now requires the H2 magic bytes to be the first bytes transmitted by a downstream client.
+    :ref:`AUTO <envoy_api_enum_value_config.filter.network.http_connection_manager.v2.HttpConnectionManager.CodecType.AUTO>`
+    codec protocol inference now requires the H2 magic bytes to be the first bytes transmitted by a downstream client.
 - area: http
   change: |
     remove h2c upgrade headers for HTTP/1 as h2c upgrades are currently not supported.
 - area: http
   change: |
-    absolute URL support is now on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
+    absolute URL support is now on by default. The prior behavior can be reinstated by setting :ref:`allow_absolute_url
+    <envoy_api_field_core.Http1ProtocolOptions.allow_absolute_url>` to false.
 - area: http
   change: |
-    support :ref:`host rewrite <envoy_api_msg_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig>` in the dynamic forward proxy.
+    support :ref:`host rewrite <envoy_api_msg_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig>` in the
+    dynamic forward proxy.
 - area: http
   change: |
-    support :ref:`disabling the filter per route <envoy_api_msg_config.filter.http.grpc_http1_reverse_bridge.v2alpha1.FilterConfigPerRoute>` in the grpc http1 reverse bridge filter.
+    support :ref:`disabling the filter per route
+    <envoy_api_msg_config.filter.http.grpc_http1_reverse_bridge.v2alpha1.FilterConfigPerRoute>` in the grpc http1 reverse
+    bridge filter.
 - area: http
   change: |
-    added the ability to :ref:`configure max connection duration <envoy_api_field_core.HttpProtocolOptions.max_connection_duration>` for downstream connections.
+    added the ability to :ref:`configure max connection duration
+    <envoy_api_field_core.HttpProtocolOptions.max_connection_duration>` for downstream connections.
 - area: listeners
   change: |
-    added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to configure whether a listener will still create a connection when listener filters time out.
+    added :ref:`continue_on_listener_filters_timeout <envoy_api_field_Listener.continue_on_listener_filters_timeout>` to
+    configure whether a listener will still create a connection when listener filters time out.
 - area: listeners
   change: |
     added :ref:`HTTP inspector listener filter <config_listener_filters_http_inspector>`.
 - area: listeners
   change: |
-    added :ref:`connection balancer <envoy_api_field_Listener.connection_balance_config>`
-    configuration for TCP listeners.
+    added :ref:`connection balancer <envoy_api_field_Listener.connection_balance_config>` configuration for TCP listeners.
 - area: listeners
   change: |
-    listeners now close the listening socket as part of the draining stage as soon as workers stop accepting their connections.
+    listeners now close the listening socket as part of the draining stage as soon as workers stop accepting their
+    connections.
 - area: lua
   change: |
-    extended ``httpCall()`` and ``respond()`` APIs to accept headers with entry values that can be a string or table of strings.
+    extended ``httpCall()`` and ``respond()`` APIs to accept headers with entry values that can be a string or table of
+    strings.
 - area: lua
   change: |
     extended ``dynamicMetadata:set()`` to allow setting complex values.
@@ -162,22 +209,29 @@ changes:
     added support for flushing histogram buckets.
 - area: outlier_detector
   change: |
-    added :ref:`support for the grpc-status response header <arch_overview_outlier_detection_grpc>` by mapping it to HTTP status. Guarded by envoy.reloadable_features.outlier_detection_support_for_grpc_status which defaults to true.
+    added :ref:`support for the grpc-status response header <arch_overview_outlier_detection_grpc>` by mapping it to HTTP
+    status. Guarded by envoy.reloadable_features.outlier_detection_support_for_grpc_status which defaults to true.
 - area: performance
   change: |
-    new buffer implementation enabled by default (to disable add "--use-libevent-buffers 1" to the command-line arguments when starting Envoy).
+    new buffer implementation enabled by default (to disable add "--use-libevent-buffers 1" to the command-line arguments
+    when starting Envoy).
 - area: performance
   change: |
-    stats symbol table implementation (disabled by default; to test it, add "--use-fake-symbol-table 0" to the command-line arguments when starting Envoy).
+    stats symbol table implementation (disabled by default; to test it, add "--use-fake-symbol-table 0" to the command-line
+    arguments when starting Envoy).
 - area: rbac
   change: |
-    added support for DNS SAN as :ref:`principal_name <envoy_api_field_config.rbac.v2.Principal.Authenticated.principal_name>`.
+    added support for DNS SAN as :ref:`principal_name
+    <envoy_api_field_config.rbac.v2.Principal.Authenticated.principal_name>`.
 - area: redis
   change: |
-    added :ref:`enable_command_stats <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_command_stats>` to enable :ref:`per command statistics <arch_overview_redis_cluster_command_stats>` for upstream clusters.
+    added :ref:`enable_command_stats
+    <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.enable_command_stats>` to enable
+    :ref:`per command statistics <arch_overview_redis_cluster_command_stats>` for upstream clusters.
 - area: redis
   change: |
-    added :ref:`read_policy <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.read_policy>` to allow reading from redis replicas for Redis Cluster deployments.
+    added :ref:`read_policy <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.ConnPoolSettings.read_policy>`
+    to allow reading from redis replicas for Redis Cluster deployments.
 - area: redis
   change: |
     fixed a bug where the redis health checker ignored the upstream auth password.
@@ -186,10 +240,9 @@ changes:
     enable_hashtaging is always enabled when the upstream uses open source Redis cluster protocol.
 - area: regex
   change: |
-    introduced new :ref:`RegexMatcher <envoy_api_msg_type.matcher.RegexMatcher>` type that
-    provides a safe regex implementation for untrusted user input. This type is now used in all
-    configuration that processes user provided input. See :ref:`deprecated configuration details
-    <deprecated>` for more information.
+    introduced new :ref:`RegexMatcher <envoy_api_msg_type.matcher.RegexMatcher>` type that provides a safe regex
+    implementation for untrusted user input. This type is now used in all configuration that processes user provided input.
+    See :ref:`deprecated configuration details <deprecated>` for more information.
 - area: rbac
   change: |
     added conditions to the policy, see :ref:`condition <envoy_api_field_config.rbac.v2.Policy.condition>`.
@@ -201,25 +254,30 @@ changes:
     :ref:`scoped routing <arch_overview_http_routing_route_scope>` is supported.
 - area: router
   change: |
-    added new :ref:`retriable-headers <config_http_filters_router_x-envoy-retry-on>` retry policy. Retries can now be configured to trigger by arbitrary response header matching.
+    added new :ref:`retriable-headers <config_http_filters_router_x-envoy-retry-on>` retry policy. Retries can now be
+    configured to trigger by arbitrary response header matching.
 - area: router
   change: |
     added ability for most specific header mutations to take precedence, see :ref:`route configuration's most specific
     header mutations wins flag <envoy_api_field_RouteConfiguration.most_specific_header_mutations_wins>`.
 - area: router
   change: |
-    added :ref:`respect_expected_rq_timeout <envoy_api_field_config.filter.http.router.v2.Router.respect_expected_rq_timeout>` that instructs ingress Envoy to respect :ref:`config_http_filters_router_x-envoy-expected-rq-timeout-ms` header, populated by egress Envoy, when deriving timeout for upstream cluster.
+    added :ref:`respect_expected_rq_timeout
+    <envoy_api_field_config.filter.http.router.v2.Router.respect_expected_rq_timeout>` that instructs ingress Envoy to
+    respect :ref:`config_http_filters_router_x-envoy-expected-rq-timeout-ms` header, populated by egress Envoy, when
+    deriving timeout for upstream cluster.
 - area: router
   change: |
-    added new :ref:`retriable request headers <envoy_api_field_route.Route.per_request_buffer_limit_bytes>` to route configuration, to allow limiting buffering for retries and shadowing.
+    added new :ref:`retriable request headers <envoy_api_field_route.Route.per_request_buffer_limit_bytes>` to route
+    configuration, to allow limiting buffering for retries and shadowing.
 - area: router
   change: |
-    added new :ref:`retriable request headers <envoy_api_field_route.RetryPolicy.retriable_request_headers>` to retry policies. Retries can now be configured to only trigger on request header match.
+    added new :ref:`retriable request headers <envoy_api_field_route.RetryPolicy.retriable_request_headers>` to retry
+    policies. Retries can now be configured to only trigger on request header match.
 - area: router
   change: |
-    added the ability to match a route based on whether a TLS certificate has been
-    :ref:`presented <envoy_api_field_route.RouteMatch.TlsContextMatchOptions.presented>` by the
-    downstream connection.
+    added the ability to match a route based on whether a TLS certificate has been :ref:`presented
+    <envoy_api_field_route.RouteMatch.TlsContextMatchOptions.presented>` by the downstream connection.
 - area: router check tool
   change: |
     added coverage reporting & enforcement.
@@ -246,22 +304,23 @@ changes:
     allows for the ability to parse integers as double values and vice-versa.
 - area: sds
   change: |
-    added :ref:`session_ticket_keys_sds_secret_config <envoy_api_field_auth.DownstreamTlsContext.session_ticket_keys_sds_secret_config>` for loading TLS Session Ticket Encryption Keys using SDS API.
+    added :ref:`session_ticket_keys_sds_secret_config
+    <envoy_api_field_auth.DownstreamTlsContext.session_ticket_keys_sds_secret_config>` for loading TLS Session Ticket
+    Encryption Keys using SDS API.
 - area: server
   change: |
     added a post initialization lifecycle event, in addition to the existing startup and shutdown events.
 - area: server
   change: |
-    added :ref:`per-handler listener stats <config_listener_stats_per_handler>` and
-    :ref:`per-worker watchdog stats <operations_performance_watchdog>` to help diagnosing event
-    loop imbalance and general performance issues.
+    added :ref:`per-handler listener stats <config_listener_stats_per_handler>` and :ref:`per-worker watchdog stats
+    <operations_performance_watchdog>` to help diagnosing event loop imbalance and general performance issues.
 - area: stats
   change: |
     added unit support to histogram.
 - area: tcp_proxy
   change: |
-    the default :ref:`idle_timeout
-    <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.idle_timeout>` is now 1 hour.
+    the default :ref:`idle_timeout <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.idle_timeout>` is now 1
+    hour.
 - area: thrift_proxy
   change: |
     fixed crashing bug on invalid transport/protocol framing.
@@ -270,7 +329,8 @@ changes:
     added support for stripping service name from method when using the multiplexed protocol.
 - area: tls
   change: |
-    added verification of IP address SAN fields in certificates against configured SANs in the certificate validation context.
+    added verification of IP address SAN fields in certificates against configured SANs in the certificate validation
+    context.
 - area: tracing
   change: |
     added support to the Zipkin reporter for sending list of spans as Zipkin JSON v2 and protobuf message over HTTP.
@@ -280,13 +340,19 @@ changes:
     added tags for gRPC response status and message.
 - area: tracing
   change: |
-    added :ref:`max_path_tag_length <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` to support customizing the length of the request path included in the extracted `http.url <https://github.com/opentracing/specification/blob/master/semantic_conventions.md#standard-span-tags-and-log-fields>`_ tag.
+    added :ref:`max_path_tag_length
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` to support customizing
+    the length of the request path included in the extracted `http.url
+    <https://github.com/opentracing/specification/blob/master/semantic_conventions.md#standard-span-tags-and-log-fields>`_
+    tag.
 - area: upstream
   change: |
-    added :ref:`an option <envoy_api_field_Cluster.CommonLbConfig.close_connections_on_host_set_change>` that allows draining HTTP, TCP connection pools on cluster membership change.
+    added :ref:`an option <envoy_api_field_Cluster.CommonLbConfig.close_connections_on_host_set_change>` that allows
+    draining HTTP, TCP connection pools on cluster membership change.
 - area: upstream
   change: |
-    added :ref:`transport_socket_matches <envoy_api_field_Cluster.transport_socket_matches>`, support using different transport socket config when connecting to different upstream endpoints within a cluster.
+    added :ref:`transport_socket_matches <envoy_api_field_Cluster.transport_socket_matches>`, support using different
+    transport socket config when connecting to different upstream endpoints within a cluster.
 - area: upstream
   change: |
     added network filter chains to upstream connections, see :ref:`filters <envoy_api_field_Cluster.filters>`.
@@ -295,10 +361,12 @@ changes:
     added new :ref:`failure-percentage based outlier detection <arch_overview_outlier_detection_failure_percentage>` mode.
 - area: upstream
   change: |
-    uses p2c to select hosts for least-requests load balancers if all host weights are the same, even in cases where weights are not equal to 1.
+    uses p2c to select hosts for least-requests load balancers if all host weights are the same, even in cases where weights
+    are not equal to 1.
 - area: upstream
   change: |
-    added :ref:`fail_traffic_on_panic <envoy_api_field_Cluster.CommonLbConfig.ZoneAwareLbConfig.fail_traffic_on_panic>` to allow failing all requests to a cluster during panic state.
+    added :ref:`fail_traffic_on_panic <envoy_api_field_Cluster.CommonLbConfig.ZoneAwareLbConfig.fail_traffic_on_panic>` to
+    allow failing all requests to a cluster during panic state.
 - area: zookeeper
   change: |
     parses responses and emits latency stats.
@@ -306,72 +374,64 @@ changes:
 deprecated:
 - area: load_balancing
   change: |
-    The ``ORIGINAL_DST_LB`` :ref:`load balancing policy <envoy_api_field_Cluster.lb_policy>` is
-    deprecated, use CLUSTER_PROVIDED policy instead when configuring an :ref:`original destination
-    cluster <envoy_api_field_Cluster.type>`.
+    The ``ORIGINAL_DST_LB`` :ref:`load balancing policy <envoy_api_field_Cluster.lb_policy>` is deprecated, use
+    CLUSTER_PROVIDED policy instead when configuring an :ref:`original destination cluster <envoy_api_field_Cluster.type>`.
 - area: matching
   change: |
-    The ``regex`` field in :ref:`StringMatcher <envoy_api_msg_type.matcher.StringMatcher>` has been
-    deprecated in favor of the ``safe_regex`` field.
+    The ``regex`` field in :ref:`StringMatcher <envoy_api_msg_type.matcher.StringMatcher>` has been deprecated in favor of
+    the ``safe_regex`` field.
 - area: routing
   change: |
-    The ``regex`` field in :ref:`RouteMatch <envoy_api_msg_route.RouteMatch>` has been
-    deprecated in favor of the ``safe_regex`` field.
+    The ``regex`` field in :ref:`RouteMatch <envoy_api_msg_route.RouteMatch>` has been deprecated in favor of the
+    ``safe_regex`` field.
 - area: cors
   change: |
-    The ``allow_origin`` and ``allow_origin_regex`` fields in :ref:`CorsPolicy
-    <envoy_api_msg_route.CorsPolicy>` have been deprecated in favor of the
-    ``allow_origin_string_match`` field.
+    The ``allow_origin`` and ``allow_origin_regex`` fields in :ref:`CorsPolicy <envoy_api_msg_route.CorsPolicy>` have been
+    deprecated in favor of the ``allow_origin_string_match`` field.
 - area: cluster
   change: |
-    The ``pattern`` and ``method`` fields in :ref:`VirtualCluster <envoy_api_msg_route.VirtualCluster>`
-    have been deprecated in favor of the ``headers`` field.
+    The ``pattern`` and ``method`` fields in :ref:`VirtualCluster <envoy_api_msg_route.VirtualCluster>` have been deprecated
+    in favor of the ``headers`` field.
 - area: matching
   change: |
-    The ``regex_match`` field in :ref:`HeaderMatcher <envoy_api_msg_route.HeaderMatcher>` has been
-    deprecated in favor of the ``safe_regex_match`` field.
+    The ``regex_match`` field in :ref:`HeaderMatcher <envoy_api_msg_route.HeaderMatcher>` has been deprecated in favor of
+    the ``safe_regex_match`` field.
 - area: matching
   change: |
-    The ``value`` and ``regex`` fields in :ref:`QueryParameterMatcher
-    <envoy_api_msg_route.QueryParameterMatcher>` has been deprecated in favor of the ``string_match``
-    and ``present_match`` fields.
+    The ``value`` and ``regex`` fields in :ref:`QueryParameterMatcher <envoy_api_msg_route.QueryParameterMatcher>` has been
+    deprecated in favor of the ``string_match`` and ``present_match`` fields.
 - area: options
   change: |
-    The :option:`--allow-unknown-fields` command-line option,
-    use :option:`--allow-unknown-static-fields` instead.
+    The :option:`--allow-unknown-fields` command-line option, use :option:`--allow-unknown-static-fields` instead.
 - area: zipkin
   change: |
     The use of ``HTTP_JSON_V1`` :ref:`Zipkin collector endpoint version
-    <envoy_api_field_config.trace.v2.ZipkinConfig.collector_endpoint_version>` or not explicitly
-    specifying it is deprecated, use ``HTTP_JSON`` or ``HTTP_PROTO`` instead.
+    <envoy_api_field_config.trace.v2.ZipkinConfig.collector_endpoint_version>` or not explicitly specifying it is
+    deprecated, use ``HTTP_JSON`` or ``HTTP_PROTO`` instead.
 - area: listener
   change: |
     The ``operation_name`` field in :ref:`HTTP connection manager
-    <envoy_api_msg_config.filter.network.http_connection_manager.v2.HttpConnectionManager>`
-    has been deprecated in favor of the ``traffic_direction`` field in
-    :ref:`Listener <envoy_api_msg_Listener>`. The latter takes priority if
-    specified.
+    <envoy_api_msg_config.filter.network.http_connection_manager.v2.HttpConnectionManager>` has been deprecated in favor of
+    the ``traffic_direction`` field in :ref:`Listener <envoy_api_msg_Listener>`. The latter takes priority if specified.
 - area: tls
   change: |
-    The ``tls_context`` field in :ref:`Filter chain <envoy_api_field_listener.FilterChain.tls_context>` message
-    and :ref:`Cluster <envoy_api_field_Cluster.tls_context>` message have been deprecated in favor of
-    ``transport_socket`` with name ``envoy.transport_sockets.tls``. The latter takes priority if specified.
+    The ``tls_context`` field in :ref:`Filter chain <envoy_api_field_listener.FilterChain.tls_context>` message and
+    :ref:`Cluster <envoy_api_field_Cluster.tls_context>` message have been deprecated in favor of ``transport_socket`` with
+    name ``envoy.transport_sockets.tls``. The latter takes priority if specified.
 - area: health_check
   change: |
-    The ``use_http2`` field in
-    :ref:`HTTP health checker <envoy_api_msg_core.HealthCheck.HttpHealthCheck>` has been deprecated in
-    favor of the ``codec_client_type`` field.
+    The ``use_http2`` field in :ref:`HTTP health checker <envoy_api_msg_core.HealthCheck.HttpHealthCheck>` has been
+    deprecated in favor of the ``codec_client_type`` field.
 - area: grpc
   change: |
-    The use of :ref:`gRPC bridge filter <config_http_filters_grpc_bridge>` for
-    gRPC stats has been deprecated in favor of the dedicated :ref:`gRPC stats
-    filter <config_http_filters_grpc_stats>`.
+    The use of :ref:`gRPC bridge filter <config_http_filters_grpc_bridge>` for gRPC stats has been deprecated in favor of
+    the dedicated :ref:`gRPC stats filter <config_http_filters_grpc_stats>`.
 - area: ext_authz
   change: |
-    Ext_authz filter stats ``ok``, ``error``, ``denied``, ``failure_mode_allowed`` in
-    ``cluster.<route target cluster>.ext_authz.`` namespace is deprecated.
-    Use ``http.<stat_prefix>.ext_authz.`` namespace to access same counters instead.
+    Ext_authz filter stats ``ok``, ``error``, ``denied``, ``failure_mode_allowed`` in ``cluster.<route target
+    cluster>.ext_authz.`` namespace is deprecated. Use ``http.<stat_prefix>.ext_authz.`` namespace to access same counters
+    instead.
 - area: udpa
   change: |
-    Use of ``google.protobuf.Struct`` for extension opaque configs is deprecated. Use ``google.protobuf.Any`` instead or pack
-    ``udpa.type.v1.TypedStruct`` in ``google.protobuf.Any``.
+    Use of ``google.protobuf.Struct`` for extension opaque configs is deprecated. Use ``google.protobuf.Any`` instead or
+    pack ``udpa.type.v1.TypedStruct`` in ``google.protobuf.Any``.

--- a/changelogs/1.12.2.yaml
+++ b/changelogs/1.12.2.yaml
@@ -12,7 +12,8 @@ changes:
     trim LWS at the end of header keys, for correct HTTP/1.1 header parsing.
 - area: http
   change: |
-    added strict authority checking. This can be reversed temporarily by setting the runtime feature ``envoy.reloadable_features.strict_authority_validation`` to false.
+    added strict authority checking. This can be reversed temporarily by setting the runtime feature
+    ``envoy.reloadable_features.strict_authority_validation`` to false.
 - area: route config
   change: |
     fixed CVE-2019-18838 by checking for presence of host/path headers.

--- a/changelogs/1.12.3.yaml
+++ b/changelogs/1.12.3.yaml
@@ -6,13 +6,17 @@ changes:
     force copy when appending small slices to OwnedImpl buffer to avoid fragmentation.
 - area: http
   change: |
-    added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature ``envoy.reloadable_features.http1_flood_protection``.
+    added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature
+    ``envoy.reloadable_features.http1_flood_protection``.
 - area: listeners
   change: |
-    fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed by a client using only TLS 1.3.
+    fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed
+    by a client using only TLS 1.3.
 - area: rbac
   change: |
-    added :ref:`url_path <envoy_api_field_config.rbac.v2.Permission.url_path>` for matching URL path without the query and fragment string.
+    added :ref:`url_path <envoy_api_field_config.rbac.v2.Permission.url_path>` for matching URL path without the query and
+    fragment string.
 - area: sds
   change: |
-    fixed the SDS vulnerability that TLS validation context (e.g., subject alt name or hash) cannot be effectively validated in some cases.
+    fixed the SDS vulnerability that TLS validation context (e.g., subject alt name or hash) cannot be effectively validated
+    in some cases.

--- a/changelogs/1.12.4.yaml
+++ b/changelogs/1.12.4.yaml
@@ -3,7 +3,10 @@ date: June 8, 2020
 changes:
 - area: http
   change: |
-    added :ref:`headers_with_underscores_action setting <envoy_api_field_core.HttpProtocolOptions.headers_with_underscores_action>` to control how client requests with header names containing underscore characters are handled. The options are to allow such headers, reject request or drop headers. The default is to allow headers, preserving existing behavior.
+    added :ref:`headers_with_underscores_action setting
+    <envoy_api_field_core.HttpProtocolOptions.headers_with_underscores_action>` to control how client requests with header
+    names containing underscore characters are handled. The options are to allow such headers, reject request or drop
+    headers. The default is to allow headers, preserving existing behavior.
 - area: http
   change: |
     fixed CVE-2020-11080 by rejecting HTTP/2 SETTINGS frames with too many parameters.

--- a/changelogs/1.12.5.yaml
+++ b/changelogs/1.12.5.yaml
@@ -6,14 +6,19 @@ changes:
     fixed CVE-2020-12603 by avoiding fragmentation, and tracking of HTTP/2 data and control frames in the output buffer.
 - area: http
   change: |
-    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
-    to also defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a downstream client.
+    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>` to also
+    defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a
+    downstream client.
 - area: http
   change: |
-    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that exceed configured limits.
+    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that
+    exceed configured limits.
 - area: listener
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on
+    active/accepted connections.
 - area: overload management
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted
+    connections.

--- a/changelogs/1.12.6.yaml
+++ b/changelogs/1.12.6.yaml
@@ -3,4 +3,5 @@ date: July 7, 2020
 changes:
 - area: tls
   change: |
-    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.
+    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be
+    temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.

--- a/changelogs/1.13.0.yaml
+++ b/changelogs/1.13.0.yaml
@@ -9,7 +9,8 @@ changes:
     added the ability to filter :ref:`/config_dump <operations_admin_interface_config_dump>`.
 - area: access log
   change: |
-    added a :ref:`typed JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format with non-string values.
+    added a :ref:`typed JSON logging mode <config_access_log_format_dictionaries>` to output access logs in JSON format with
+    non-string values.
 - area: access log
   change: |
     fixed ``UPSTREAM_LOCAL_ADDRESS`` :ref:`access log formatters <config_access_log_format>` to work for http requests.
@@ -39,16 +40,21 @@ changes:
     added :ref:`aggregate cluster <arch_overview_aggregate_cluster>` that allows load balancing between clusters.
 - area: config
   change: |
-    all category names of internal envoy extensions are prefixed with the 'envoy.' prefix to follow the reverse DNS naming notation.
+    all category names of internal envoy extensions are prefixed with the 'envoy.' prefix to follow the reverse DNS naming
+    notation.
 - area: decompressor
   change: |
     remove decompressor hard assert failure and replace with an error flag.
 - area: ext_authz
   change: |
-    added :ref:`configurable ability <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to send the :ref:`certificate <envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the ``ext_authz`` service.
+    added :ref:`configurable ability <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.include_peer_certificate>` to
+    send the :ref:`certificate <envoy_api_field_service.auth.v2.AttributeContext.Peer.certificate>` to the ``ext_authz``
+    service.
 - area: fault
   change: |
-    fixed an issue where the http fault filter would repeatedly check the percentage of abort/delay when the ``x-envoy-downstream-service-cluster`` header was included in the request to ensure that the actual percentage of abort/delay matches the configuration of the filter.
+    fixed an issue where the http fault filter would repeatedly check the percentage of abort/delay when the ``x-envoy-
+    downstream-service-cluster`` header was included in the request to ensure that the actual percentage of abort/delay
+    matches the configuration of the filter.
 - area: health check
   change: |
     gRPC health checker sets the gRPC deadline to the configured timeout duration.
@@ -57,31 +63,42 @@ changes:
     added :ref:`TlsOptions <envoy_api_msg_core.HealthCheck.TlsOptions>` to allow TLS configuration overrides.
 - area: health check
   change: |
-    added :ref:`service_name_matcher <envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name_matcher>` to better compare the service name patterns for health check identity.
+    added :ref:`service_name_matcher <envoy_api_field_core.HealthCheck.HttpHealthCheck.service_name_matcher>` to better
+    compare the service name patterns for health check identity.
 - area: http
   change: |
-    added strict validation that ``CONNECT`` is refused as it is not yet implemented. This can be reversed temporarily by setting the runtime feature ``envoy.reloadable_features.strict_method_validation`` to false.
+    added strict validation that ``CONNECT`` is refused as it is not yet implemented. This can be reversed temporarily by
+    setting the runtime feature ``envoy.reloadable_features.strict_method_validation`` to false.
 - area: http
   change: |
-    added support for http1 trailers. To enable use :ref:`enable_trailers <envoy_api_field_core.Http1ProtocolOptions.enable_trailers>`.
+    added support for http1 trailers. To enable use :ref:`enable_trailers
+    <envoy_api_field_core.Http1ProtocolOptions.enable_trailers>`.
 - area: http
   change: |
-    added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by ``envoy.reloadable_features.connection_header_sanitization`` which defaults to true.
+    added the ability to sanitize headers nominated by the Connection header. This new behavior is guarded by
+    ``envoy.reloadable_features.connection_header_sanitization`` which defaults to true.
 - area: http
   change: |
-    blocks unsupported transfer-encodings. Can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.reject_unsupported_transfer_encodings`` to false.
+    blocks unsupported transfer-encodings. Can be reverted temporarily by setting runtime feature
+    ``envoy.reloadable_features.reject_unsupported_transfer_encodings`` to false.
 - area: http
   change: |
-    support :ref:`auto_host_rewrite_header <envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the dynamic forward proxy.
+    support :ref:`auto_host_rewrite_header
+    <envoy_api_field_config.filter.http.dynamic_forward_proxy.v2alpha.PerRouteConfig.auto_host_rewrite_header>` in the
+    dynamic forward proxy.
 - area: jwt_authn
   change: |
-    added :ref:`allow_missing <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtRequirement.allow_missing>` option that accepts request without token but rejects bad request with bad tokens.
+    added :ref:`allow_missing <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtRequirement.allow_missing>` option
+    that accepts request without token but rejects bad request with bad tokens.
 - area: jwt_authn
   change: |
-    added :ref:`bypass_cors_preflight <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.bypass_cors_preflight>` to allow bypassing the CORS preflight request.
+    added :ref:`bypass_cors_preflight
+    <envoy_api_field_config.filter.http.jwt_authn.v2alpha.JwtAuthentication.bypass_cors_preflight>` to allow bypassing the
+    CORS preflight request.
 - area: lb_subset_config
   change: |
-    new fallback policy for selectors: :ref:`KEYS_SUBSET <envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`.
+    new fallback policy for selectors: :ref:`KEYS_SUBSET
+    <envoy_api_enum_value_Cluster.LbSubsetConfig.LbSubsetSelector.LbSubsetSelectorFallbackPolicy.KEYS_SUBSET>`.
 - area: listeners
   change: |
     added :ref:`reuse_port <envoy_api_field_Listener.reuse_port>` option.
@@ -93,7 +110,8 @@ changes:
     added :ref:`local rate limit <config_network_filters_local_rate_limit>` network filter.
 - area: rbac
   change: |
-    added support for matching all subject alt names instead of first in :ref:`principal_name <envoy_api_field_config.rbac.v2.Principal.Authenticated.principal_name>`.
+    added support for matching all subject alt names instead of first in :ref:`principal_name
+    <envoy_api_field_config.rbac.v2.Principal.Authenticated.principal_name>`.
 - area: redis
   change: |
     performance improvement for larger split commands by avoiding string copies.
@@ -102,7 +120,10 @@ changes:
     correctly follow MOVE/ASK redirection for mirrored clusters.
 - area: redis
   change: |
-    add :ref:`host_degraded_refresh_threshold <envoy_api_field_config.cluster.redis.RedisClusterConfig.host_degraded_refresh_threshold>` and :ref:`failure_refresh_threshold <envoy_api_field_config.cluster.redis.RedisClusterConfig.failure_refresh_threshold>` to refresh topology when nodes are degraded or when requests fails.
+    add :ref:`host_degraded_refresh_threshold
+    <envoy_api_field_config.cluster.redis.RedisClusterConfig.host_degraded_refresh_threshold>` and
+    :ref:`failure_refresh_threshold <envoy_api_field_config.cluster.redis.RedisClusterConfig.failure_refresh_threshold>` to
+    refresh topology when nodes are degraded or when requests fails.
 - area: router
   change: |
     added histograms to show timeout budget usage to the :ref:`cluster stats <config_cluster_manager_cluster_stats>`.
@@ -111,32 +132,36 @@ changes:
     added support for testing and marking coverage for routes of runtime fraction 0.
 - area: router
   change: |
-    added :ref:`request_mirror_policies <envoy_api_field_route.RouteAction.request_mirror_policies>` to support sending multiple mirrored requests in one route.
+    added :ref:`request_mirror_policies <envoy_api_field_route.RouteAction.request_mirror_policies>` to support sending
+    multiple mirrored requests in one route.
 - area: router
   change: |
     added support for ``REQ(header-name)`` :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 - area: router
   change: |
-    added support for percentage-based :ref:`retry budgets <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`.
+    added support for percentage-based :ref:`retry budgets
+    <envoy_api_field_cluster.CircuitBreakers.Thresholds.retry_budget>`.
 - area: router
   change: |
-    allow using a :ref:`query parameter <envoy_api_field_route.RouteAction.HashPolicy.query_parameter>` for HTTP consistent hashing.
+    allow using a :ref:`query parameter <envoy_api_field_route.RouteAction.HashPolicy.query_parameter>` for HTTP consistent
+    hashing.
 - area: router
   change: |
     exposed ``DOWNSTREAM_REMOTE_ADDRESS`` as custom HTTP request/response headers.
 - area: router
   change: |
-    added support for :ref:`max_internal_redirects <envoy_api_field_route.RouteAction.max_internal_redirects>` for configurable maximum internal redirect hops.
+    added support for :ref:`max_internal_redirects <envoy_api_field_route.RouteAction.max_internal_redirects>` for
+    configurable maximum internal redirect hops.
 - area: router
   change: |
     skip the Location header when the response code is not a 201 or a 3xx.
 - area: router
   change: |
-    added :ref:`auto_sni <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_sni>` to support setting SNI to transport socket for new upstream connections based on the downstream HTTP host/authority header.
+    added :ref:`auto_sni <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_sni>` to support setting SNI to transport
+    socket for new upstream connections based on the downstream HTTP host/authority header.
 - area: router
   change: |
-    added support for ``HOSTNAME`` :ref:`header formatter
-    <config_http_conn_man_headers_custom_request_headers>`.
+    added support for ``HOSTNAME`` :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 - area: server
   change: |
     added the :option:`--disable-extensions` CLI option, to disable extensions at startup.
@@ -145,10 +170,12 @@ changes:
     fixed a bug in config validation for configs with runtime layers.
 - area: server
   change: |
-    added :ref:`workers_started <config_listener_manager_stats>` that indicates whether listeners have been fully initialized on workers.
+    added :ref:`workers_started <config_listener_manager_stats>` that indicates whether listeners have been fully
+    initialized on workers.
 - area: tcp_proxy
   change: |
-    added :ref:`ClusterWeight.metadata_match <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.WeightedCluster.ClusterWeight.metadata_match>`.
+    added :ref:`ClusterWeight.metadata_match
+    <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.WeightedCluster.ClusterWeight.metadata_match>`.
 - area: tcp_proxy
   change: |
     added :ref:`hash_policy <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.hash_policy>`.
@@ -163,16 +190,20 @@ changes:
     remove TLS 1.0 and 1.1 from client defaults.
 - area: tls
   change: |
-    added support for :ref:`generic string matcher <envoy_api_field_auth.CertificateValidationContext.match_subject_alt_names>` for subject alternative names.
+    added support for :ref:`generic string matcher
+    <envoy_api_field_auth.CertificateValidationContext.match_subject_alt_names>` for subject alternative names.
 - area: tracing
   change: |
-    added the ability to set custom tags on both the :ref:`HTTP connection manager <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` and the :ref:`HTTP route <envoy_api_field_route.Route.tracing>`.
+    added the ability to set custom tags on both the :ref:`HTTP connection manager
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>` and the :ref:`HTTP
+    route <envoy_api_field_route.Route.tracing>`.
 - area: tracing
   change: |
     added upstream_address tag.
 - area: tracing
   change: |
-    added initial support for AWS X-Ray (local sampling rules only) :ref:`X-Ray Tracing <envoy_api_msg_config.trace.v2alpha.XRayConfig>`.
+    added initial support for AWS X-Ray (local sampling rules only) :ref:`X-Ray Tracing
+    <envoy_api_msg_config.trace.v2alpha.XRayConfig>`.
 - area: tracing
   change: |
     added tags for gRPC request path, authority, content-type and timeout.
@@ -184,25 +215,22 @@ deprecated:
 - area: tracing
   change: |
     The ``request_headers_for_tags`` field in :ref:`HTTP connection manager
-    <envoy_api_msg_config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing>`
-    has been deprecated in favor of the :ref:`custom_tags
+    <envoy_api_msg_config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing>` has been deprecated in
+    favor of the :ref:`custom_tags
     <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing.custom_tags>` field.
 - area: certificates
   change: |
     The ``verify_subject_alt_name`` field in :ref:`Certificate Validation Context
-    <envoy_api_field_auth.CertificateValidationContext.verify_subject_alt_name>`
-    has been deprecated in favor of the :ref:`match_subject_alt_names
-    <envoy_api_field_auth.CertificateValidationContext.match_subject_alt_names>` field.
+    <envoy_api_field_auth.CertificateValidationContext.verify_subject_alt_name>` has been deprecated in favor of the
+    :ref:`match_subject_alt_names <envoy_api_field_auth.CertificateValidationContext.match_subject_alt_names>` field.
 - area: router
   change: |
-    The ``request_mirror_policy`` field in :ref:`RouteMatch <envoy_api_msg_route.RouteAction>` has been deprecated in
-    favor of the ``request_mirror_policies`` field.
+    The ``request_mirror_policy`` field in :ref:`RouteMatch <envoy_api_msg_route.RouteAction>` has been deprecated in favor
+    of the ``request_mirror_policies`` field.
 - area: health_checker
   change: |
-    The ``service_name`` field in
-    :ref:`HTTP health checker <envoy_api_msg_core.HealthCheck.HttpHealthCheck>` has been deprecated in
-    favor of the ``service_name_matcher`` field.
+    The ``service_name`` field in :ref:`HTTP health checker <envoy_api_msg_core.HealthCheck.HttpHealthCheck>` has been
+    deprecated in favor of the ``service_name_matcher`` field.
 - area: xds
   change: |
-    The v2 xDS API is deprecated. It will be supported by Envoy until EOY 2020. See
-    :ref:`api_supported_versions`.
+    The v2 xDS API is deprecated. It will be supported by Envoy until EOY 2020. See :ref:`api_supported_versions`.

--- a/changelogs/1.13.1.yaml
+++ b/changelogs/1.13.1.yaml
@@ -6,13 +6,17 @@ changes:
     force copy when appending small slices to OwnedImpl buffer to avoid fragmentation.
 - area: http
   change: |
-    added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature ``envoy.reloadable_features.http1_flood_protection``.
+    added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature
+    ``envoy.reloadable_features.http1_flood_protection``.
 - area: listeners
   change: |
-    fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed by a client using only TLS 1.3.
+    fixed issue where :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` could have been bypassed
+    by a client using only TLS 1.3.
 - area: rbac
   change: |
-    added :ref:`url_path <envoy_api_field_config.rbac.v2.Permission.url_path>` for matching URL path without the query and fragment string.
+    added :ref:`url_path <envoy_api_field_config.rbac.v2.Permission.url_path>` for matching URL path without the query and
+    fragment string.
 - area: sds
   change: |
-    fixed the SDS vulnerability that TLS validation context (e.g., subject alt name or hash) cannot be effectively validated in some cases.
+    fixed the SDS vulnerability that TLS validation context (e.g., subject alt name or hash) cannot be effectively validated
+    in some cases.

--- a/changelogs/1.13.2.yaml
+++ b/changelogs/1.13.2.yaml
@@ -3,7 +3,10 @@ date: June 8, 2020
 changes:
 - area: http
   change: |
-    added :ref:`headers_with_underscores_action setting <envoy_api_field_core.HttpProtocolOptions.headers_with_underscores_action>` to control how client requests with header names containing underscore characters are handled. The options are to allow such headers, reject request or drop headers. The default is to allow headers, preserving existing behavior.
+    added :ref:`headers_with_underscores_action setting
+    <envoy_api_field_core.HttpProtocolOptions.headers_with_underscores_action>` to control how client requests with header
+    names containing underscore characters are handled. The options are to allow such headers, reject request or drop
+    headers. The default is to allow headers, preserving existing behavior.
 - area: http
   change: |
     fixed CVE-2020-11080 by rejecting HTTP/2 SETTINGS frames with too many parameters.

--- a/changelogs/1.13.3.yaml
+++ b/changelogs/1.13.3.yaml
@@ -6,14 +6,19 @@ changes:
     fixed CVE-2020-12603 by avoiding fragmentation, and tracking of HTTP/2 data and control frames in the output buffer.
 - area: http
   change: |
-    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
-    to also defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a downstream client.
+    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>` to also
+    defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a
+    downstream client.
 - area: http
   change: |
-    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that exceed configured limits.
+    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that
+    exceed configured limits.
 - area: listener
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on
+    active/accepted connections.
 - area: overload management
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted
+    connections.

--- a/changelogs/1.13.4.yaml
+++ b/changelogs/1.13.4.yaml
@@ -3,4 +3,5 @@ date: July 7, 2020
 changes:
 - area: tls
   change: |
-    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.
+    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be
+    temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.

--- a/changelogs/1.13.7.yaml
+++ b/changelogs/1.13.7.yaml
@@ -3,7 +3,8 @@ date: December 7, 2020
 changes:
 - area: tls
   change: |
-    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the
+    SSL connection's internal buffers.
 - area: udp
   change: |
     fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.

--- a/changelogs/1.14.0.yaml
+++ b/changelogs/1.14.0.yaml
@@ -24,7 +24,8 @@ changes:
     consecutive sampling intervals.
 - area: admin
   change: |
-    added support for displaying ip address subject alternate names in :ref:`certs <operations_admin_interface_certs>` end point.
+    added support for displaying ip address subject alternate names in :ref:`certs <operations_admin_interface_certs>`
+    end point.
 - area: admin
   change: |
     added :http:post:`/reopen_logs` endpoint to control log rotation.
@@ -45,26 +46,34 @@ changes:
     added stat :ref:`update_time <config_cluster_manager_cds>`.
 - area: config
   change: |
-    use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
+    use type URL to select an extension whenever the config type URL (or its previous versions) uniquely identify a typed
+    extension, see :ref:`extension configuration <config_overview_extension_configuration>`.
 - area: datasource
   change: |
     added retry policy for remote async data source.
 - area: dns
   change: |
-    added support for :ref:`dns_failure_refresh_rate <envoy_api_field_config.common.dynamic_forward_proxy.v2alpha.DnsCacheConfig.dns_failure_refresh_rate>` for the :ref:`dns cache <envoy_api_msg_config.common.dynamic_forward_proxy.v2alpha.DnsCacheConfig>` to set the DNS refresh rate during failures.
+    added support for :ref:`dns_failure_refresh_rate
+    <envoy_api_field_config.common.dynamic_forward_proxy.v2alpha.DnsCacheConfig.dns_failure_refresh_rate>` for the :ref:`dns
+    cache <envoy_api_msg_config.common.dynamic_forward_proxy.v2alpha.DnsCacheConfig>` to set the DNS refresh rate during
+    failures.
 - area: dns
   change: |
     the STRICT_DNS cluster now only resolves to 0 hosts if DNS resolution successfully returns 0 hosts.
 - area: eds
   change: |
-    added :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>` field for endpoints and :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.hostname>` field for endpoint's health check config. This enables auto host rewrite and customizing the host header during health checks for eds endpoints.
+    added :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>` field for endpoints and :ref:`hostname
+    <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.hostname>` field for endpoint's health check config.
+    This enables auto host rewrite and customizing the host header during health checks for eds endpoints.
 - area: ext_authz
   change: |
     disabled the use of lowercase string matcher for headers matching in HTTP-based ``ext_authz``.
-    Can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher`` to false.
+    Can be reverted temporarily by setting runtime feature
+    ``envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher`` to false.
 - area: fault
   change: |
-    added support for controlling abort faults with :ref:`HTTP header fault configuration <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
+    added support for controlling abort faults with :ref:`HTTP header fault configuration
+    <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 - area: grpc-json
   change: |
     added support for building HTTP request into
@@ -74,29 +83,36 @@ changes:
     added option to limit which messages stats are created for.
 - area: http
   change: |
-    added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature ``envoy.reloadable_features.http1_flood_protection``.
+    added HTTP/1.1 flood protection. Can be temporarily disabled using the runtime feature
+    ``envoy.reloadable_features.http1_flood_protection``.
 - area: http
   change: |
-    added :ref:`headers_with_underscores_action setting <envoy_api_field_core.HttpProtocolOptions.headers_with_underscores_action>` to control how client requests with header names containing underscore characters are handled. The options are to allow such headers, reject request or drop headers. The default is to allow headers, preserving existing behavior.
+    added :ref:`headers_with_underscores_action setting <envoy_api_field_core.HttpProtocolOptions.headers_with_underscores_action>`
+    to control how client requests with header names containing underscore characters are handled. The options are to allow such
+    headers, reject request or drop headers. The default is to allow headers, preserving existing behavior.
 - area: http
   change: |
-    added :ref:`max_stream_duration <envoy_api_field_core.HttpProtocolOptions.max_stream_duration>` to specify the duration of existing streams. See :ref:`connection and stream timeouts <faq_configuration_timeouts>`.
+    added :ref:`max_stream_duration <envoy_api_field_core.HttpProtocolOptions.max_stream_duration>` to specify the duration of
+    existing streams. See :ref:`connection and stream timeouts <faq_configuration_timeouts>`.
 - area: http
   change: |
-    connection header sanitizing has been modified to always sanitize if there is no upgrade, including when an h2c upgrade attempt has been removed.
+    connection header sanitizing has been modified to always sanitize if there is no upgrade, including when an h2c upgrade
+    attempt has been removed.
 - area: http
   change: |
-    fixed a bug that could send extra METADATA frames and underflow memory when encoding METADATA frames on a connection that was dispatching data.
+    fixed a bug that could send extra METADATA frames and underflow memory when encoding METADATA frames on a connection that was
+    dispatching data.
 - area: http
   change: |
     fixing a bug in HTTP/1.0 responses where Connection: keep-alive was not appended for connections which were kept alive.
 - area: http
   change: |
-    http filter extensions use the "envoy.filters.http" name space. A mapping
-    of extension names is available in the :ref:`deprecated <deprecated>` documentation.
+    http filter extensions use the "envoy.filters.http" name space. A mapping of extension names is available in the
+    :ref:`deprecated <deprecated>` documentation.
 - area: http
   change: |
-    the runtime feature ``http.connection_manager.log_flood_exception`` is removed and replaced with a connection access log response code.
+    the runtime feature ``http.connection_manager.log_flood_exception`` is removed and replaced with a connection access log
+    response code.
 - area: http
   change: |
     upgrade parser library, which removes support for "identity" transfer-encoding value.
@@ -106,13 +122,16 @@ changes:
     mapping of extension names is available in the :ref:`deprecated <deprecated>` documentation.
 - area: listeners
   change: |
-    added :ref:`listener filter matcher api <envoy_api_field_listener.ListenerFilter.filter_disabled>` to disable individual listener filter on matching downstream connections.
+    added :ref:`listener filter matcher api <envoy_api_field_listener.ListenerFilter.filter_disabled>` to disable individual
+    listener filter on matching downstream connections.
 - area: loadbalancing
   change: |
-    added support for using hostname for consistent hash loadbalancing via :ref:`consistent_hash_lb_config <envoy_api_field_Cluster.CommonLbConfig.consistent_hashing_lb_config>`.
+    added support for using hostname for consistent hash loadbalancing via :ref:`consistent_hash_lb_config
+    <envoy_api_field_Cluster.CommonLbConfig.consistent_hashing_lb_config>`.
 - area: loadbalancing
   change: |
-    added support for :ref:`retry host predicates <envoy_api_field_route.RetryPolicy.retry_host_predicate>` in conjunction with consistent hashing load balancers (ring hash and maglev).
+    added support for :ref:`retry host predicates <envoy_api_field_route.RetryPolicy.retry_host_predicate>` in conjunction
+    with consistent hashing load balancers (ring hash and maglev).
 - area: lua
   change: |
     added a parameter to ``httpCall`` that makes it possible to have the call be asynchronous.
@@ -121,36 +140,44 @@ changes:
     added moonjit support.
 - area: mongo
   change: |
-    the stat emitted for queries without a max time set in the :ref:`MongoDB filter <config_network_filters_mongo_proxy>` was modified to emit correctly for Mongo v3.2+.
+    the stat emitted for queries without a max time set in the :ref:`MongoDB filter <config_network_filters_mongo_proxy>` was
+    modified to emit correctly for Mongo v3.2+.
 - area: network filters
   change: |
     added a :ref:`direct response filter <config_network_filters_direct_response>`.
 - area: network filters
   change: |
-    network filter extensions use the "envoy.filters.network" name space. A mapping
-    of extension names is available in the :ref:`deprecated <deprecated>` documentation.
+    network filter extensions use the "envoy.filters.network" name space. A mapping of extension names is available in the
+    :ref:`deprecated <deprecated>` documentation.
 - area: rbac
   change: |
-    added :ref:`remote_ip <envoy_api_field_config.rbac.v2.Principal.remote_ip>` and :ref:`direct_remote_ip <envoy_api_field_config.rbac.v2.Principal.direct_remote_ip>` for matching downstream remote IP address.
+    added :ref:`remote_ip <envoy_api_field_config.rbac.v2.Principal.remote_ip>` and :ref:`direct_remote_ip
+    <envoy_api_field_config.rbac.v2.Principal.direct_remote_ip>` for matching downstream remote IP address.
 - area: rbac
   change: |
-    deprecated :ref:`source_ip <envoy_api_field_config.rbac.v2.Principal.source_ip>` with :ref:`direct_remote_ip <envoy_api_field_config.rbac.v2.Principal.direct_remote_ip>` and :ref:`remote_ip <envoy_api_field_config.rbac.v2.Principal.remote_ip>`.
+    deprecated :ref:`source_ip <envoy_api_field_config.rbac.v2.Principal.source_ip>` with
+    :ref:`direct_remote_ip <envoy_api_field_config.rbac.v2.Principal.direct_remote_ip>` and
+    :ref:`remote_ip <envoy_api_field_config.rbac.v2.Principal.remote_ip>`.
 - area: request_id_extension
   change: |
-    added an ability to extend request ID handling at :ref:`HTTP connection manager <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.request_id_extension>`.
+    added an ability to extend request ID handling at :ref:`HTTP connection manager
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.request_id_extension>`.
 - area: retry
   change: |
-    added a retry predicate that :ref:`rejects hosts based on metadata. <envoy_api_field_route.RetryPolicy.retry_host_predicate>`.
+    added a retry predicate that :ref:`rejects hosts based on metadata.
+    <envoy_api_field_route.RetryPolicy.retry_host_predicate>`.
 - area: router
   change: |
-    added ability to set attempt count in downstream response, see :ref:`virtual host's include response
-    attempt count config <envoy_api_field_route.VirtualHost.include_attempt_count_in_response>`.
+    added ability to set attempt count in downstream response, see :ref:`virtual host's include response attempt count config
+    <envoy_api_field_route.VirtualHost.include_attempt_count_in_response>`.
 - area: router
   change: |
     added additional stats for :ref:`virtual clusters <config_http_filters_router_vcluster_stats>`.
 - area: router
   change: |
-    added :ref:`auto_san_validation <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_san_validation>` to support overrriding SAN validation to transport socket for new upstream connections based on the downstream HTTP host/authority header.
+    added :ref:`auto_san_validation <envoy_api_field_core.UpstreamHttpProtocolOptions.auto_san_validation>` to support
+    overrriding SAN validation to transport socket for new upstream connections based on the downstream HTTP host/authority
+    header.
 - area: router
   change: |
     added the ability to match a route based on whether a downstream TLS connection certificate has been
@@ -164,14 +191,16 @@ changes:
     added support for ``%DOWNSTREAM_LOCAL_PORT%`` :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 - area: router
   change: |
-    don't ignore :ref:`per_try_timeout <envoy_api_field_route.RetryPolicy.per_try_timeout>` when the :ref:`global route timeout <envoy_api_field_route.RouteAction.timeout>` is disabled.
+    don't ignore :ref:`per_try_timeout <envoy_api_field_route.RetryPolicy.per_try_timeout>` when the
+    :ref:`global route timeout <envoy_api_field_route.RouteAction.timeout>` is disabled.
 - area: router
   change: |
-    strip whitespace for :ref:`retry_on <envoy_api_field_route.RetryPolicy.retry_on>`, :ref:`grpc-retry-on header <config_http_filters_router_x-envoy-retry-grpc-on>` and :ref:`retry-on header <config_http_filters_router_x-envoy-retry-on>`.
+    strip whitespace for :ref:`retry_on <envoy_api_field_route.RetryPolicy.retry_on>`, :ref:`grpc-retry-on header
+    <config_http_filters_router_x-envoy-retry-grpc-on>` and :ref:`retry-on header <config_http_filters_router_x-envoy-retry-on>`.
 - area: runtime
   change: |
-    enabling the runtime feature ``envoy.deprecated_features.allow_deprecated_extension_names``
-    disables the use of deprecated extension names.
+    enabling the runtime feature ``envoy.deprecated_features.allow_deprecated_extension_names`` disables the use of deprecated
+    extension names.
 - area: runtime
   change: |
     integer values may now be parsed as booleans.
@@ -186,37 +215,39 @@ changes:
     the SIGUSR1 access log reopen warning now is logged at info level.
 - area: stat sinks
   change: |
-    stat sink extensions use the ``envoy.stat_sinks`` name space. A mapping of extension
-    names is available in the :ref:`deprecated <deprecated>` documentation.
+    stat sink extensions use the ``envoy.stat_sinks`` name space. A mapping of extension names is available in the
+    :ref:`deprecated <deprecated>` documentation.
 - area: thrift_proxy
   change: |
     added router filter stats to docs.
 - area: tls
   change: |
-    added configuration to disable stateless TLS session resumption :ref:`disable_stateless_session_resumption <envoy_api_field_auth.DownstreamTlsContext.disable_stateless_session_resumption>`.
+    added configuration to disable stateless TLS session resumption :ref:`disable_stateless_session_resumption
+    <envoy_api_field_auth.DownstreamTlsContext.disable_stateless_session_resumption>`.
 - area: tracing
   change: |
     added gRPC service configuration to the OpenCensus Stackdriver and OpenCensus Agent tracers.
 - area: tracing
   change: |
-    tracer extensions use the "envoy.tracers" name space. A mapping of extension names is
-    available in the :ref:`deprecated <deprecated>` documentation.
+    tracer extensions use the "envoy.tracers" name space. A mapping of extension names is available in the
+    :ref:`deprecated <deprecated>` documentation.
 - area: upstream
   change: |
-    added ``upstream_rq_retry_limit_exceeded`` to :ref:`cluster <config_cluster_manager_cluster_stats>`, and :ref:`virtual cluster <config_http_filters_router_vcluster_stats>` stats.
+    added ``upstream_rq_retry_limit_exceeded`` to :ref:`cluster <config_cluster_manager_cluster_stats>`, and
+    :ref:`virtual cluster <config_http_filters_router_vcluster_stats>` stats.
 - area: upstream
   change: |
-    changed load distribution algorithm when all priorities enter :ref:`panic mode <arch_overview_load_balancing_panic_threshold>`.
+    changed load distribution algorithm when all priorities enter
+    :ref:`panic mode <arch_overview_load_balancing_panic_threshold>`.
 - area: upstream
   change: |
-    combined HTTP/1 and HTTP/2 connection pool code. This means that circuit breaker
-    limits for both requests and connections apply to both pool types. Also, HTTP/2 now has
-    the option to limit concurrent requests on a connection, and allow multiple draining
-    connections. The old behavior is deprecated, but can be used during the deprecation
-    period by disabling runtime feature ``envoy.reloadable_features.new_http1_connection_pool_behavior`` or
-    ``envoy.reloadable_features.new_http2_connection_pool_behavior`` and then re-configure your clusters or
-    restart Envoy. The behavior will not switch until the connection pools are recreated. The new
-    circuit breaker behavior is described :ref:`here <arch_overview_circuit_break>`.
+    combined HTTP/1 and HTTP/2 connection pool code. This means that circuit breaker limits for both requests and connections
+    apply to both pool types. Also, HTTP/2 now has the option to limit concurrent requests on a connection, and allow multiple
+    draining connections. The old behavior is deprecated, but can be used during the deprecation period by disabling runtime
+    feature ``envoy.reloadable_features.new_http1_connection_pool_behavior`` or
+    ``envoy.reloadable_features.new_http2_connection_pool_behavior`` and then re-configure your clusters or restart Envoy.
+    The behavior will not switch until the connection pools are recreated. The new circuit breaker behavior is described
+    :ref:`here <arch_overview_circuit_break>`.
 - area: zlib
   change: |
     by default zlib is initialized to use its default strategy (Z_DEFAULT_STRATEGY)
@@ -231,11 +262,10 @@ deprecated:
     been deprecated in favor of the new behavior described :ref:`here <arch_overview_circuit_break>`.
 - area: logging
   change: |
-    Access Logger, Listener Filter, HTTP Filter, Network Filter, Stats Sink, and Tracer names have
-    been deprecated in favor of the extension name from the envoy build system. Disable the runtime
-    feature "envoy.deprecated_features.allow_deprecated_extension_names" to disallow the deprecated
-    names. Use of these extension names generates a log message and increments the
-    "deprecated_feature_use" metric in stats.
+    Access Logger, Listener Filter, HTTP Filter, Network Filter, Stats Sink, and Tracer names have been deprecated in favor of
+    the extension name from the envoy build system. Disable the runtime feature
+    ``envoy.deprecated_features.allow_deprecated_extension_names`` to disallow the deprecated names. Use of these extension
+    names generates a log message and increments the ``deprecated_feature_use`` metric in stats.
 
     .. csv-table::
       :header: Canonical Names, Deprecated Names

--- a/changelogs/1.14.2.yaml
+++ b/changelogs/1.14.2.yaml
@@ -6,14 +6,13 @@ changes:
     fixed CVE-2020-11080 by rejecting HTTP/2 SETTINGS frames with too many parameters.
 - area: http
   change: |
-    the :ref:`stream_idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
-    now also defends against an HTTP/2 peer that does not open stream window once an entire response
-    has been buffered to be sent to a downstream client.
+    the :ref:`stream_idle_timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>` now also
+    defends against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to
+    a downstream client.
 - area: listener
   change: |
-    Add runtime support for :ref:`per-listener limits <config_listeners>` on
-    active/accepted connections.
+    Add runtime support for :ref:`per-listener limits <config_listeners>` on active/accepted connections.
 - area: overload management
   change: |
-    Add runtime support for :ref:`global limits <config_overload_manager>`
-    on active/accepted connections.
+    Add runtime support for :ref:`global limits <config_overload_manager>` on active/accepted connections.

--- a/changelogs/1.14.3.yaml
+++ b/changelogs/1.14.3.yaml
@@ -6,14 +6,19 @@ changes:
     fixed CVE-2020-12603 by avoiding fragmentation, and tracking of HTTP/2 data and control frames in the output buffer.
 - area: http
   change: |
-    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
-    to also defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a downstream client.
+    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>` to also
+    defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a
+    downstream client.
 - area: http
   change: |
-    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that exceed configured limits.
+    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that
+    exceed configured limits.
 - area: listener
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on
+    active/accepted connections.
 - area: overload management
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted
+    connections.

--- a/changelogs/1.14.4.yaml
+++ b/changelogs/1.14.4.yaml
@@ -3,4 +3,5 @@ date: July 7, 2020
 changes:
 - area: tls
   change: |
-    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.
+    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be
+    temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.

--- a/changelogs/1.14.6.yaml
+++ b/changelogs/1.14.6.yaml
@@ -6,7 +6,8 @@ changes:
     fix crash when disabling or re-enabling listeners due to overload while processing LDS updates.
 - area: tls
   change: |
-    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the
+    SSL connection's internal buffers.
 - area: udp
   change: |
     fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.

--- a/changelogs/1.14.7.yaml
+++ b/changelogs/1.14.7.yaml
@@ -3,7 +3,8 @@ date: April 15, 2020
 changes:
 - area: http
   change: |
-    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
+    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2
+    codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
 - area: http
   change: |
     fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.

--- a/changelogs/1.15.0.yaml
+++ b/changelogs/1.15.0.yaml
@@ -6,69 +6,90 @@ behavior_changes:
     official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
 - area: client_ssl_auth
   change: |
-    the ``auth_ip_white_list`` stat has been renamed to
-    :ref:`auth_ip_allowlist <config_network_filters_client_ssl_auth_stats>`.
+    the ``auth_ip_white_list`` stat has been renamed to :ref:`auth_ip_allowlist
+    <config_network_filters_client_ssl_auth_stats>`.
 - area: header to metadata
   change: |
     on_header_missing rules with empty values are now rejected (they were skipped before).
 - area: router
   change: |
-    path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature ``envoy.reloadable_features.preserve_query_string_in_path_redirects`` to false.
+    path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature
+    ``envoy.reloadable_features.preserve_query_string_in_path_redirects`` to false.
 - area: tls
   change: |
-    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.
+    fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be
+    temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_wildcard_matching`` to false.
 
 minor_behavior_changes:
 - area: access loggers
   change: |
-    applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.disallow_unbounded_access_logs`` to false.
+    applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped
+    logs. This can be reverted temporarily by setting runtime feature
+    ``envoy.reloadable_features.disallow_unbounded_access_logs`` to false.
 - area: build
   change: |
-    runs as non-root inside Docker containers. Existing behaviour can be restored by setting the environment variable ``ENVOY_UID`` to ``0``. ``ENVOY_UID`` and ``ENVOY_GID`` can be used to set the envoy user's ``uid`` and ``gid`` respectively.
+    runs as non-root inside Docker containers. Existing behaviour can be restored by setting the environment variable
+    ``ENVOY_UID`` to ``0``. ``ENVOY_UID`` and ``ENVOY_GID`` can be used to set the envoy user's ``uid`` and ``gid``
+    respectively.
 - area: health check
   change: |
-    in the health check filter the :ref:`percentage of healthy servers in upstream clusters <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` is now interpreted as an integer.
+    in the health check filter the :ref:`percentage of healthy servers in upstream clusters
+    <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` is now interpreted as
+    an integer.
 - area: hot restart
   change: |
-    added the option :option:`--use-dynamic-base-id` to select an unused base ID at startup and the option :option:`--base-id-path` to write the base id to a file (for reuse with later hot restarts).
+    added the option :option:`--use-dynamic-base-id` to select an unused base ID at startup and the option
+    :option:`--base-id-path` to write the base id to a file (for reuse with later hot restarts).
 - area: http
   change: |
-    changed early error path for HTTP/1.1 so that responses consistently flow through the http connection manager, and the http filter chains. This behavior may be temporarily reverted by setting runtime feature ``envoy.reloadable_features.early_errors_via_hcm`` to false.
+    changed early error path for HTTP/1.1 so that responses consistently flow through the http connection manager, and the
+    http filter chains. This behavior may be temporarily reverted by setting runtime feature
+    ``envoy.reloadable_features.early_errors_via_hcm`` to false.
 - area: http
   change: |
-    fixed several bugs with applying correct connection close behavior across the http connection manager, health checker, and connection pool. This behavior may be temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_connection_close`` to false.
+    fixed several bugs with applying correct connection close behavior across the http connection manager, health checker,
+    and connection pool. This behavior may be temporarily reverted by setting runtime feature
+    ``envoy.reloadable_features.fix_connection_close`` to false.
 - area: http
   change: |
-    fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.
-    Can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.fix_upgrade_response`` to false.
+    fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests. Can be reverted temporarily
+    by setting runtime feature ``envoy.reloadable_features.fix_upgrade_response`` to false.
 - area: http
   change: |
-    stopped overwriting ``date`` response headers. Responses without a ``date`` header will still have the header properly set. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.preserve_upstream_date`` to false.
+    stopped overwriting ``date`` response headers. Responses without a ``date`` header will still have the header properly
+    set. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.preserve_upstream_date`` to false.
 - area: http
   change: |
-    stopped adding a synthetic path to CONNECT requests, meaning unconfigured CONNECT requests will now return 404 instead of 403. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.stop_faking_paths`` to false.
+    stopped adding a synthetic path to CONNECT requests, meaning unconfigured CONNECT requests will now return 404 instead
+    of 403. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.stop_faking_paths`` to false.
 - area: http
   change: |
-    stopped allowing upstream 1xx or 204 responses with Transfer-Encoding or non-zero Content-Length headers. Content-Length of 0 is allowed, but stripped. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strict_1xx_and_204_response_headers`` to false.
+    stopped allowing upstream 1xx or 204 responses with Transfer-Encoding or non-zero Content-Length headers. Content-Length
+    of 0 is allowed, but stripped. This behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.strict_1xx_and_204_response_headers`` to false.
 - area: http
   change: |
-    upstream connections will now automatically set ALPN when this value is not explicitly set elsewhere (e.g. on the upstream TLS config). This behavior may be temporarily reverted by setting runtime feature ``envoy.reloadable_features.http_default_alpn`` to false.
+    upstream connections will now automatically set ALPN when this value is not explicitly set elsewhere (e.g. on the
+    upstream TLS config). This behavior may be temporarily reverted by setting runtime feature
+    ``envoy.reloadable_features.http_default_alpn`` to false.
 - area: listener
   change: |
-    fixed a bug where when a static listener fails to be added to a worker, the listener was not removed from the active listener list.
+    fixed a bug where when a static listener fails to be added to a worker, the listener was not removed from the active
+    listener list.
 - area: router
   change: |
-    extended to allow retries of streaming or incomplete requests. This removes stat ``rq_retry_skipped_request_not_complete``.
+    extended to allow retries of streaming or incomplete requests. This removes stat
+    ``rq_retry_skipped_request_not_complete``.
 - area: router
   change: |
-    extended to allow retries by default when upstream responds with :ref:`x-envoy-overloaded <config_http_filters_router_x-envoy-overloaded_set>`.
+    extended to allow retries by default when upstream responds with :ref:`x-envoy-overloaded
+    <config_http_filters_router_x-envoy-overloaded_set>`.
 
 bug_fixes:
 - area: adaptive concurrency
   change: |
-    fixed a minRTT calculation bug where requests started before the concurrency
-    limit was pinned to the minimum would skew the new minRTT value if the replies arrived after the
-    start of the new minRTT window.
+    fixed a minRTT calculation bug where requests started before the concurrency limit was pinned to the minimum would skew
+    the new minRTT value if the replies arrived after the start of the new minRTT window.
 - area: buffer
   change: |
     fixed CVE-2020-12603 by avoiding fragmentation, and tracking of HTTP/2 data and control frames in the output buffer.
@@ -77,34 +98,42 @@ bug_fixes:
     fixed a bug when in trailers only gRPC response (e.g. error) HTTP status code is not being re-written.
 - area: http
   change: |
-    fixed a bug in the grpc_http1_reverse_bridge filter where header-only requests were forwarded with a non-zero content length.
+    fixed a bug in the grpc_http1_reverse_bridge filter where header-only requests were forwarded with a non-zero content
+    length.
 - area: http
   change: |
-    fixed a bug where in some cases slash was moved from path to query string when :ref:`merging of adjacent slashes <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` is enabled.
+    fixed a bug where in some cases slash was moved from path to query string when :ref:`merging of adjacent slashes
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` is enabled.
 - area: http
   change: |
-    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
-    to also defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a downstream client.
+    fixed CVE-2020-12604 by changing :ref:`stream_idle_timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>` to also
+    defend against an HTTP/2 peer that does not open stream window once an entire response has been buffered to be sent to a
+    downstream client.
 - area: http
   change: |
-    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that exceed configured limits.
+    fixed CVE-2020-12605 by including request URL in request header size computation, and rejecting partial headers that
+    exceed configured limits.
 - area: http
   change: |
-    fixed several bugs with applying correct connection close behavior across the http connection manager, health checker, and connection pool. This behavior may be temporarily reverted by setting runtime feature ``envoy.reloadable_features.fix_connection_close`` to false.
+    fixed several bugs with applying correct connection close behavior across the http connection manager, health checker,
+    and connection pool. This behavior may be temporarily reverted by setting runtime feature
+    ``envoy.reloadable_features.fix_connection_close`` to false.
 - area: listener
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`per-listener limits <config_listeners_runtime>` on
+    active/accepted connections.
 - area: overload management
   change: |
-    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted connections.
+    fixed CVE-2020-8663 by adding runtime support for :ref:`global limits <config_overload_manager>` on active/accepted
+    connections.
 - area: prometheus stats
   change: |
     fixed the sort order of output lines to comply with the standard.
 - area: udp
   change: |
-    the :ref:`reuse_port <envoy_api_field_Listener.reuse_port>` listener option must now be
-    specified for UDP listeners if concurrency is > 1. This previously crashed so is considered a
-    bug fix.
+    the :ref:`reuse_port <envoy_api_field_Listener.reuse_port>` listener option must now be specified for UDP listeners if
+    concurrency is > 1. This previously crashed so is considered a bug fix.
 - area: upstream
   change: |
     fixed a bug where Envoy would panic when receiving a GRPC SERVICE_UNKNOWN status on the health check.
@@ -112,28 +141,35 @@ bug_fixes:
 removed_config_or_runtime:
 - area: http
   change: |
-    removed legacy connection pool code and their runtime features: ``envoy.reloadable_features.new_http1_connection_pool_behavior`` and
+    removed legacy connection pool code and their runtime features:
+    ``envoy.reloadable_features.new_http1_connection_pool_behavior`` and
     ``envoy.reloadable_features.new_http2_connection_pool_behavior``.
 
 new_features:
 - area: access loggers
   change: |
-    added file access logger config :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    added file access logger config :ref:`log_format
+    <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
 - area: access loggers
   change: |
     added GRPC_STATUS operator on logging format.
 - area: access loggers
   change: |
-    added gRPC access logger config added :ref:`API version <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
+    added gRPC access logger config added :ref:`API version
+    <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.transport_api_version>` to explicitly
+    set the version of gRPC service endpoint and message to be used.
 - area: access loggers
   change: |
-    extended specifier for FilterStateFormatter to output :ref:`unstructured log string <config_access_log_format_filter_state>`.
+    extended specifier for FilterStateFormatter to output :ref:`unstructured log string
+    <config_access_log_format_filter_state>`.
 - area: admin
   change: |
-    added support for dumping EDS config at :ref:`/config_dump?include_eds <operations_admin_interface_config_dump_include_eds>`.
+    added support for dumping EDS config at :ref:`/config_dump?include_eds
+    <operations_admin_interface_config_dump_include_eds>`.
 - area: aggregate cluster
   change: |
-    made route :ref:`retry_priority <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_priority>` predicates work with :ref:`this cluster type <envoy_v3_api_msg_extensions.clusters.aggregate.v3.ClusterConfig>`.
+    made route :ref:`retry_priority <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_priority>` predicates work with
+    :ref:`this cluster type <envoy_v3_api_msg_extensions.clusters.aggregate.v3.ClusterConfig>`.
 - area: build
   change: |
     official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
@@ -142,7 +178,8 @@ new_features:
     official released binary is now built with Clang 10.0.0.
 - area: cluster
   change: |
-    added an extension point for configurable :ref:`upstreams <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_config>`.
+    added an extension point for configurable :ref:`upstreams
+    <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_config>`.
 - area: compressor
   change: |
     exposed generic :ref:`compressor <config_http_filters_compressor>` filter to users.
@@ -160,41 +197,53 @@ new_features:
     added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
 - area: dynamic forward proxy
   change: |
-    added configurable :ref:`circuit breakers <dns_cache_circuit_breakers>` for resolver on DNS cache.
-    This behavior can be temporarily disabled by the runtime feature ``envoy.reloadable_features.enable_dns_cache_circuit_breakers``.
-    If this runtime feature is disabled, the upstream circuit breakers for the cluster will be used even if the :ref:`DNS Cache circuit breakers <dns_cache_circuit_breakers>` are configured.
+    added configurable :ref:`circuit breakers <dns_cache_circuit_breakers>` for resolver on DNS cache. This behavior can be
+    temporarily disabled by the runtime feature ``envoy.reloadable_features.enable_dns_cache_circuit_breakers``. If this
+    runtime feature is disabled, the upstream circuit breakers for the cluster will be used even if the :ref:`DNS Cache
+    circuit breakers <dns_cache_circuit_breakers>` are configured.
 - area: dynamic forward proxy
   change: |
-    added :ref:`allow_insecure_cluster_options <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_insecure_cluster_options>` to allow disabling of auto_san_validation and auto_sni.
+    added :ref:`allow_insecure_cluster_options
+    <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_insecure_cluster_options>` to allow
+    disabling of auto_san_validation and auto_sni.
 - area: ext_authz filter
   change: |
-    added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3 deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows force denying protected paths while filter gets disabled, by setting this key to true.
+    added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3
+    deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows force
+    denying protected paths while filter gets disabled, by setting this key to true.
 - area: ext_authz filter
   change: |
-    added API version field for both :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.transport_api_version>`
-    and :ref:`Network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.transport_api_version>` filters to explicitly set the version of gRPC service endpoint and message to be used.
+    added API version field for both :ref:`HTTP
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.transport_api_version>` and :ref:`Network
+    <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.transport_api_version>` filters to explicitly set
+    the version of gRPC service endpoint and message to be used.
 - area: ext_authz filter
   change: |
-    added :ref:`v3 allowed_upstream_headers_to_append <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_upstream_headers_to_append>` to allow appending multiple header entries (returned by the authorization server) with the same key to the original request headers.
+    added :ref:`v3 allowed_upstream_headers_to_append
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_upstream_headers_to_append>` to
+    allow appending multiple header entries (returned by the authorization server) with the same key to the original request
+    headers.
 - area: fault
   change: |
-    added support for controlling the percentage of requests that abort, delay and response rate limits faults
-    are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
+    added support for controlling the percentage of requests that abort, delay and response rate limits faults are applied
+    to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 - area: fault
   change: |
-    added support for specifying grpc_status code in abort faults using
-    :ref:`HTTP header <config_http_filters_fault_injection_http_header>` or abort fault configuration in HTTP fault filter.
+    added support for specifying grpc_status code in abort faults using :ref:`HTTP header
+    <config_http_filters_fault_injection_http_header>` or abort fault configuration in HTTP fault filter.
 - area: filter
   change: |
-    added ``upstream_rq_time`` stats to the GPRC stats filter.
-    Disabled by default and can be enabled via :ref:`enable_upstream_stats <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.enable_upstream_stats>`.
+    added ``upstream_rq_time`` stats to the GPRC stats filter. Disabled by default and can be enabled via
+    :ref:`enable_upstream_stats
+    <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.enable_upstream_stats>`.
 - area: grpc
   change: |
-    added support for Google gRPC :ref:`custom channel arguments <envoy_v3_api_field_config.core.v3.GrpcService.GoogleGrpc.channel_args>`.
+    added support for Google gRPC :ref:`custom channel arguments
+    <envoy_v3_api_field_config.core.v3.GrpcService.GoogleGrpc.channel_args>`.
 - area: grpc-json
   change: |
-    added support for streaming response using
-    `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
+    added support for streaming response using `google.api.HttpBody
+    <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
 - area: grpc-json
   change: |
     send a ``x-envoy-original-method`` header to grpc services.
@@ -209,30 +258,38 @@ new_features:
     added support for regex substitutions on header values.
 - area: health checks
   change: |
-    allowed configuring health check transport sockets by specifying :ref:`transport socket match criteria <envoy_v3_api_field_config.core.v3.HealthCheck.transport_socket_match_criteria>`.
+    allowed configuring health check transport sockets by specifying :ref:`transport socket match criteria
+    <envoy_v3_api_field_config.core.v3.HealthCheck.transport_socket_match_criteria>`.
 - area: http
   change: |
-    added :ref:`local_reply config <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.local_reply_config>` to http_connection_manager to customize :ref:`local reply <config_http_conn_man_local_reply>`.
+    added :ref:`local_reply config
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.local_reply_config>` to
+    http_connection_manager to customize :ref:`local reply <config_http_conn_man_local_reply>`.
 - area: http
   change: |
-    added :ref:`stripping port from host header <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_matching_host_port>` support.
+    added :ref:`stripping port from host header
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_matching_host_port>`
+    support.
 - area: http
   change: |
-    added support for proxying CONNECT requests, terminating CONNECT requests, and converting raw TCP streams into HTTP/2 CONNECT requests. See :ref:`upgrade documentation <arch_overview_upgrades>` for details.
+    added support for proxying CONNECT requests, terminating CONNECT requests, and converting raw TCP streams into HTTP/2
+    CONNECT requests. See :ref:`upgrade documentation <arch_overview_upgrades>` for details.
 - area: listener
   change: |
-    added in place filter chain update flow for tcp listener update which doesn't close connections if the corresponding network filter chain is equivalent during the listener update.
-    Can be disabled by setting runtime feature ``envoy.reloadable_features.listener_in_place_filterchain_update`` to false.
-    Also added additional draining filter chain stat for :ref:`listener manager <config_listener_manager_stats>` to track the number of draining filter chains and the number of in place update attempts.
+    added in place filter chain update flow for tcp listener update which doesn't close connections if the corresponding
+    network filter chain is equivalent during the listener update. Can be disabled by setting runtime feature
+    ``envoy.reloadable_features.listener_in_place_filterchain_update`` to false. Also added additional draining filter chain
+    stat for :ref:`listener manager <config_listener_manager_stats>` to track the number of draining filter chains and the
+    number of in place update attempts.
 - area: logger
   change: |
     added ``--log-format-prefix-with-location`` command line option to prefix '%v' with file path and line number.
 - area: lrs
   change: |
-    added new ``envoy_api_field_service.load_stats.v2.LoadStatsResponse.send_all_clusters`` field
-    in LRS response, which allows management servers to avoid explicitly listing all clusters it is
-    interested in; behavior is allowed based on new ``envoy.lrs.supports_send_all_clusters`` capability
-    in :ref:`client_features <envoy_v3_api_field_config.core.v3.Node.client_features>` field.
+    added new ``envoy_api_field_service.load_stats.v2.LoadStatsResponse.send_all_clusters`` field in LRS response, which
+    allows management servers to avoid explicitly listing all clusters it is interested in; behavior is allowed based on new
+    ``envoy.lrs.supports_send_all_clusters`` capability in :ref:`client_features
+    <envoy_v3_api_field_config.core.v3.Node.client_features>` field.
 - area: lrs
   change: |
     updated to allow to explicitly set the API version of gRPC service endpoint and message to be used.
@@ -244,7 +301,8 @@ new_features:
     added tracing to the ``httpCall()`` API.
 - area: metrics service
   change: |
-    added :ref:`API version <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
+    added :ref:`API version <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.transport_api_version>` to explicitly
+    set the version of gRPC service endpoint and message to be used.
 - area: network filters
   change: |
     added a :ref:`postgres proxy filter <config_network_filters_postgres_proxy>`.
@@ -253,28 +311,36 @@ new_features:
     added a :ref:`rocketmq proxy filter <config_network_filters_rocketmq_proxy>`.
 - area: performance
   change: |
-    enabled stats symbol table implementation by default. To disable it, add
-    ``--use-fake-symbol-table 1`` to the command-line arguments when starting Envoy.
+    enabled stats symbol table implementation by default. To disable it, add ``--use-fake-symbol-table 1`` to the command-
+    line arguments when starting Envoy.
 - area: ratelimit
   change: |
-    added support for use of dynamic metadata :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` as a ratelimit action.
+    added support for use of dynamic metadata :ref:`dynamic_metadata
+    <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` as a ratelimit action.
 - area: ratelimit
   change: |
-    added :ref:`API version <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
+    added :ref:`API version <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.transport_api_version>` to
+    explicitly set the version of gRPC service endpoint and message to be used.
 - area: ratelimit
   change: |
-    support specifying dynamic overrides in rate limit descriptors using :ref:`limit override <envoy_v3_api_field_config.route.v3.RateLimit.limit>` config.
+    support specifying dynamic overrides in rate limit descriptors using :ref:`limit override
+    <envoy_v3_api_field_config.route.v3.RateLimit.limit>` config.
 - area: redis
   change: |
-    added acl support :ref:`downstream_auth_username <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_username>` for downstream client ACL authentication, and :ref:`auth_username <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProtocolOptions.auth_username>` to configure authentication usernames for upstream Redis 6+ server clusters with ACL enabled.
+    added acl support :ref:`downstream_auth_username
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_username>` for downstream
+    client ACL authentication, and :ref:`auth_username
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProtocolOptions.auth_username>` to configure
+    authentication usernames for upstream Redis 6+ server clusters with ACL enabled.
 - area: regex
   change: |
-    added support for enforcing max program size via runtime and stats to monitor program size for :ref:`Google RE2 <envoy_v3_api_field_type.matcher.v3.RegexMatcher.GoogleRE2.max_program_size>`.
+    added support for enforcing max program size via runtime and stats to monitor program size for :ref:`Google RE2
+    <envoy_v3_api_field_type.matcher.v3.RegexMatcher.GoogleRE2.max_program_size>`.
 - area: request_id
   change: |
-    added to :ref:`always_set_request_id_in_response setting <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.always_set_request_id_in_response>`
-    to set :ref:`x-request-id <config_http_conn_man_headers_x-request-id>` header in response even if
-    tracing is not forced.
+    added to :ref:`always_set_request_id_in_response setting
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.always_set_request_id_in_response>`
+    to set :ref:`x-request-id <config_http_conn_man_headers_x-request-id>` header in response even if tracing is not forced.
 - area: router
   change: |
     added more fine grained internal redirect configs to the :ref:`internal_redirect_policy
@@ -288,7 +354,8 @@ new_features:
     <config_http_conn_man_headers_custom_request_headers>`.
 - area: router
   change: |
-    allow Rate Limiting Service to be called in case of missing request header for a descriptor if the :ref:`skip_if_absent <envoy_v3_api_field_config.route.v3.RateLimit.Action.RequestHeaders.skip_if_absent>` field is set to true.
+    allow Rate Limiting Service to be called in case of missing request header for a descriptor if the :ref:`skip_if_absent
+    <envoy_v3_api_field_config.route.v3.RateLimit.Action.RequestHeaders.skip_if_absent>` field is set to true.
 - area: runtime
   change: |
     added new gauge :ref:`deprecated_feature_seen_since_process_start <runtime_stats>` that gets reset across hot restarts.
@@ -300,11 +367,14 @@ new_features:
     added :ref:`server.envoy_bug_failures <server_statistics>` statistic to count ENVOY_BUG failures.
 - area: stats
   change: |
-    added the option to :ref:`report counters as deltas <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.report_counters_as_deltas>` to the metrics service stats sink.
+    added the option to :ref:`report counters as deltas
+    <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.report_counters_as_deltas>` to the metrics service stats
+    sink.
 - area: tracing
   change: |
-    made tracing configuration fully dynamic and every HTTP connection manager
-    can now have a separate :ref:`tracing provider <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.provider>`.
+    made tracing configuration fully dynamic and every HTTP connection manager can now have a separate :ref:`tracing
+    provider
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.provider>`.
 - area: udp
   change: |
     upgraded :ref:`udp_proxy <config_udp_listener_filters_udp_proxy>` filter to v3 and promoted it out of alpha.
@@ -312,34 +382,41 @@ new_features:
 deprecated:
 - area: tracing
   change: |
-    Tracing provider configuration as part of :ref:`bootstrap config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.tracing>`
-    has been deprecated in favor of configuration as part of :ref:`HTTP connection manager
+    Tracing provider configuration as part of :ref:`bootstrap config
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.tracing>` has been deprecated in favor of configuration as part of
+    :ref:`HTTP connection manager
     <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.provider>`.
 - area: compression
   change: |
-    The :ref:`HTTP Gzip filter <config_http_filters_gzip>` has been deprecated in favor of
-    :ref:`Compressor <config_http_filters_compressor>`.
+    The :ref:`HTTP Gzip filter <config_http_filters_gzip>` has been deprecated in favor of :ref:`Compressor
+    <config_http_filters_compressor>`.
 - area: matching
   change: |
-    The - change: |
-      :ref:`GoogleRE2.max_program_size <envoy_v3_api_field_type.matcher.v3.RegexMatcher.GoogleRE2.max_program_size>`
-      field is now deprecated. Management servers are expected to validate regexp program sizes
-      instead of expecting the client to do it. Alternatively, the max program size can be enforced by Envoy via runtime.
+    The - change: |   :ref:`GoogleRE2.max_program_size
+    <envoy_v3_api_field_type.matcher.v3.RegexMatcher.GoogleRE2.max_program_size>`   field is now deprecated. Management
+    servers are expected to validate regexp program sizes   instead of expecting the client to do it. Alternatively, the max
+    program size can be enforced by Envoy via runtime.
 - area: routing
   change: |
-    The :ref:`internal_redirect_action <envoy_v3_api_field_config.route.v3.RouteAction.internal_redirect_action>`
-    field and :ref:`max_internal_redirects <envoy_v3_api_field_config.route.v3.RouteAction.max_internal_redirects>` field
-    are now deprecated. This changes the implemented default cross scheme redirect behavior.
-    All cross scheme redirects are disallowed by default. To restore
-    the previous behavior, set allow_cross_scheme_redirect=true and use
-    :ref:`safe_cross_scheme <envoy_v3_api_msg_extensions.internal_redirect.safe_cross_scheme.v3.SafeCrossSchemeConfig>`,
-    in :ref:`predicates <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`.
+    The :ref:`internal_redirect_action <envoy_v3_api_field_config.route.v3.RouteAction.internal_redirect_action>` field and
+    :ref:`max_internal_redirects <envoy_v3_api_field_config.route.v3.RouteAction.max_internal_redirects>` field are now
+    deprecated. This changes the implemented default cross scheme redirect behavior. All cross scheme redirects are
+    disallowed by default. To restore the previous behavior, set allow_cross_scheme_redirect=true and use
+    :ref:`safe_cross_scheme <envoy_v3_api_msg_extensions.internal_redirect.safe_cross_scheme.v3.SafeCrossSchemeConfig>`, in
+    :ref:`predicates <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`.
 - area: logging
   change: |
-    File access logger fields :ref:`format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.format>`, :ref:`json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.json_format>` and :ref:`typed_json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.typed_json_format>` are deprecated in favor of :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    File access logger fields :ref:`format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.format>`,
+    :ref:`json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.json_format>` and
+    :ref:`typed_json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.typed_json_format>` are
+    deprecated in favor of :ref:`log_format
+    <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
 - area: xds
   change: |
-    A warning is now logged when v2 xDS api is used. This behavior can be temporarily disabled by setting ``envoy.reloadable_features.enable_deprecated_v2_api_warning`` to ``false``.
+    A warning is now logged when v2 xDS api is used. This behavior can be temporarily disabled by setting
+    ``envoy.reloadable_features.enable_deprecated_v2_api_warning`` to ``false``.
 - area: dns
   change: |
-    Using cluster circuit breakers for DNS Cache is now deprecated in favor of :ref:`DNS cache circuit breakers <dns_cache_circuit_breakers>`. This behavior can be temporarily disabled by setting ``envoy.reloadable_features.enable_dns_cache_circuit_breakers`` to ``false``.
+    Using cluster circuit breakers for DNS Cache is now deprecated in favor of :ref:`DNS cache circuit breakers
+    <dns_cache_circuit_breakers>`. This behavior can be temporarily disabled by setting
+    ``envoy.reloadable_features.enable_dns_cache_circuit_breakers`` to ``false``.

--- a/changelogs/1.15.3.yaml
+++ b/changelogs/1.15.3.yaml
@@ -6,10 +6,13 @@ changes:
     fix crash when disabling or re-enabling listeners due to overload while processing LDS updates.
 - area: proxy_proto
   change: |
-    fixed a bug where network filters would not have the correct downstreamRemoteAddress() when accessed from the StreamInfo. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.
+    fixed a bug where network filters would not have the correct downstreamRemoteAddress() when accessed from the
+    StreamInfo. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC
+    HTTP filter), or incorrect access log addresses from tcp_proxy.
 - area: tls
   change: |
-    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the
+    SSL connection's internal buffers.
 - area: udp
   change: |
     fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.

--- a/changelogs/1.15.4.yaml
+++ b/changelogs/1.15.4.yaml
@@ -3,7 +3,8 @@ date: April 15, 2021
 changes:
 - area: http
   change: |
-    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
+    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2
+    codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
 - area: http
   change: |
     fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
@@ -15,7 +16,9 @@ changes:
     fixed bugs in datadog and squash filter's handling of responses with no bodies.
 - area: http
   change: |
-    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
+    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection
+    failures. The change back to the original behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
 - area: tls
   change: |
     fix detection of the upstream connection close event.

--- a/changelogs/1.15.5.yaml
+++ b/changelogs/1.15.5.yaml
@@ -3,4 +3,11 @@ date: May 11, 2021
 new_features:
 - area: http
   change: |
-    added the ability to :ref:`unescape slash sequences <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>` in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By default this feature is disabled. The default behavior can be overridden through :ref:`http_connection_manager.path_with_escaped_slashes_action <config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling <config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.
+    added the ability to :ref:`unescape slash sequences
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>`
+    in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By
+    default this feature is disabled. The default behavior can be overridden through
+    :ref:`http_connection_manager.path_with_escaped_slashes_action
+    <config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively
+    enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling
+    <config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.

--- a/changelogs/1.16.0.yaml
+++ b/changelogs/1.16.0.yaml
@@ -3,21 +3,26 @@ date: October 8, 2020
 behavior_changes:
 - area: build
   change: |
-    added visibility rules for upstream. If these cause visibility related breakage, see notes in `BUILD <https://github.com/envoyproxy/envoy/blob/release/v1.16/BUILD>`_.
+    added visibility rules for upstream. If these cause visibility related breakage, see notes in `BUILD
+    <https://github.com/envoyproxy/envoy/blob/release/v1.16/BUILD>`_.
 - area: build
   change: |
-    tcmalloc changes require Clang 9. This requirement change can be avoided by building with ``--define tcmalloc=gperftools`` to use the older tcmalloc code.
+    tcmalloc changes require Clang 9. This requirement change can be avoided by building with ``--define
+    tcmalloc=gperftools`` to use the older tcmalloc code.
 - area: config
   change: |
-    additional warnings have been added for the use of v2 APIs. These appear as log messages
-    and are also captured in the :ref:`deprecated_feature_use <runtime_stats>` counter after server
-    initialization.
+    additional warnings have been added for the use of v2 APIs. These appear as log messages and are also captured in the
+    :ref:`deprecated_feature_use <runtime_stats>` counter after server initialization.
 - area: dns
   change: |
-    ``envoy.restart_features.use_apple_api_for_dns_lookups`` is on by default. This flag only affects Apple platforms (macOS, iOS). It is incompatible to have the runtime flag set to true at the same time as specifying the ````use_tcp_for_dns_lookups```` option or custom dns resolvers. Doing so will cause failure.
+    ``envoy.restart_features.use_apple_api_for_dns_lookups`` is on by default. This flag only affects Apple platforms
+    (macOS, iOS). It is incompatible to have the runtime flag set to true at the same time as specifying the
+    ````use_tcp_for_dns_lookups```` option or custom dns resolvers. Doing so will cause failure.
 - area: watchdog
   change: |
-    added two guarddogs, breaking the aggregated stats for the single guarddog system. The aggregated stats for the guarddogs will have the following prefixes: ``main_thread`` and ``workers``. Concretely, anything monitoring ``server.watchdog_miss`` and ``server.watchdog_mega_miss`` will need to be updated.
+    added two guarddogs, breaking the aggregated stats for the single guarddog system. The aggregated stats for the
+    guarddogs will have the following prefixes: ``main_thread`` and ``workers``. Concretely, anything monitoring
+    ``server.watchdog_miss`` and ``server.watchdog_mega_miss`` will need to be updated.
 
 minor_behavior_changes:
 - area: adaptive concurrency
@@ -31,97 +36,148 @@ minor_behavior_changes:
     an :ref:`Ubuntu based debug image <install_binaries>` is built and published in DockerHub.
 - area: build
   change: |
-    the debug information will be generated separately to reduce target size and reduce compilation time when build in compilation mode ``dbg`` and ``opt``. Users will need to build dwp file to debug with gdb.
+    the debug information will be generated separately to reduce target size and reduce compilation time when build in
+    compilation mode ``dbg`` and ``opt``. Users will need to build dwp file to debug with gdb.
 - area: compressor
   change: |
-    always insert ``Vary`` headers for compressible resources even if it's decided not to compress a response due to incompatible ``Accept-Encoding`` value. The ``Vary`` header needs to be inserted to let a caching proxy in front of Envoy know that the requested resource still can be served with compression applied.
+    always insert ``Vary`` headers for compressible resources even if it's decided not to compress a response due to
+    incompatible ``Accept-Encoding`` value. The ``Vary`` header needs to be inserted to let a caching proxy in front of
+    Envoy know that the requested resource still can be served with compression applied.
 - area: decompressor
   change: |
     headers-only requests were incorrectly not advertising accept-encoding when configured to do so. This is now fixed.
 - area: ext_authz filter
   change: |
-    request timeout will now count from the time the check request is created, instead of when it becomes active. This makes sure that the timeout is enforced even if the ``ext_authz`` cluster's circuit breaker is engaged.
-    This behavior can be reverted by setting runtime feature ``envoy.reloadable_features.ext_authz_measure_timeout_on_check_created`` to false. When enabled, a new ``ext_authz.timeout`` stat is counted when timeout occurs. See :ref:`stats <config_http_filters_ext_authz_stats>`.
+    request timeout will now count from the time the check request is created, instead of when it becomes active. This makes
+    sure that the timeout is enforced even if the ``ext_authz`` cluster's circuit breaker is engaged. This behavior can be
+    reverted by setting runtime feature ``envoy.reloadable_features.ext_authz_measure_timeout_on_check_created`` to false.
+    When enabled, a new ``ext_authz.timeout`` stat is counted when timeout occurs. See :ref:`stats
+    <config_http_filters_ext_authz_stats>`.
 - area: grpc reverse bridge
   change: |
     upstream headers will no longer be propagated when the response is missing or contains an unexpected content-type.
 - area: http
   change: |
-    added :ref:`contains <envoy_api_msg_type.matcher.StringMatcher>`, a new string matcher type which matches if the value of the string has the substring mentioned in contains matcher.
+    added :ref:`contains <envoy_api_msg_type.matcher.StringMatcher>`, a new string matcher type which matches if the value
+    of the string has the substring mentioned in contains matcher.
 - area: http
   change: |
-    added :ref:`contains <envoy_api_msg_route.HeaderMatcher>`, a new header matcher type which matches if the value of the header has the substring mentioned in contains matcher.
+    added :ref:`contains <envoy_api_msg_route.HeaderMatcher>`, a new header matcher type which matches if the value of the
+    header has the substring mentioned in contains matcher.
 - area: http
   change: |
-    added :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to local replies.
+    added :ref:`headers_to_add
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local
+    reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to
+    local replies.
 - area: http
   change: |
-    added HCM level configuration of :ref:`error handling on invalid messaging <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>` which substantially changes Envoy's behavior when encountering invalid HTTP/1.1 defaulting to closing the connection instead of allowing reuse. This can temporarily be reverted by setting ``envoy.reloadable_features.hcm_stream_error_on_invalid_message`` to false, or permanently reverted by setting the HTTP/1 configuration :ref:`override_stream_error_on_invalid_http_message <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.override_stream_error_on_invalid_http_message>` to true to restore prior HTTP/1.1 behavior (i.e. connection isn't terminated) and to retain prior HTTP/2 behavior (i.e. connection is terminated).
+    added HCM level configuration of :ref:`error handling on invalid messaging
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`
+    which substantially changes Envoy's behavior when encountering invalid HTTP/1.1 defaulting to closing the connection
+    instead of allowing reuse. This can temporarily be reverted by setting
+    ``envoy.reloadable_features.hcm_stream_error_on_invalid_message`` to false, or permanently reverted by setting the
+    HTTP/1 configuration :ref:`override_stream_error_on_invalid_http_message
+    <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.override_stream_error_on_invalid_http_message>` to true to
+    restore prior HTTP/1.1 behavior (i.e. connection isn't terminated) and to retain prior HTTP/2 behavior (i.e. connection
+    is terminated).
 - area: http
   change: |
-    added HCM level configuration of :ref:`error handling on invalid messaging <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>` which substantially changes Envoy's behavior when encountering invalid HTTP/1.1 defaulting to closing the connection instead of allowing reuse. This can temporarily be reverted by setting ``envoy.reloadable_features.hcm_stream_error_on_invalid_message`` to false, or permanently reverted by setting the :ref:`HCM option <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>` to true to restore prior HTTP/1.1 beavior and setting the *new* HTTP/2 configuration :ref:`override_stream_error_on_invalid_http_message <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.override_stream_error_on_invalid_http_message>` to false to retain prior HTTP/2 behavior.
+    added HCM level configuration of :ref:`error handling on invalid messaging
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`
+    which substantially changes Envoy's behavior when encountering invalid HTTP/1.1 defaulting to closing the connection
+    instead of allowing reuse. This can temporarily be reverted by setting
+    ``envoy.reloadable_features.hcm_stream_error_on_invalid_message`` to false, or permanently reverted by setting the
+    :ref:`HCM option
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stream_error_on_invalid_http_message>`
+    to true to restore prior HTTP/1.1 beavior and setting the *new* HTTP/2 configuration
+    :ref:`override_stream_error_on_invalid_http_message
+    <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.override_stream_error_on_invalid_http_message>` to false to
+    retain prior HTTP/2 behavior.
 - area: http
   change: |
-    applying route level header modifications to local replies sent on that route. This behavior may be temporarily reverted by setting ``envoy.reloadable_features.always_apply_route_header_rules`` to false.
+    applying route level header modifications to local replies sent on that route. This behavior may be temporarily reverted
+    by setting ``envoy.reloadable_features.always_apply_route_header_rules`` to false.
 - area: http
   change: |
-    changed Envoy to send GOAWAY to HTTP2 downstreams when the :ref:`disable_keepalive <config_overload_manager_overload_actions>` overload action is active. This behavior may be temporarily reverted by setting ``envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2`` to false.
+    changed Envoy to send GOAWAY to HTTP2 downstreams when the :ref:`disable_keepalive
+    <config_overload_manager_overload_actions>` overload action is active. This behavior may be temporarily reverted by
+    setting ``envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2`` to false.
 - area: http
   change: |
-    changed Envoy to send error headers and body when possible. This behavior may be temporarily reverted by setting ``envoy.reloadable_features.allow_response_for_timeout`` to false.
+    changed Envoy to send error headers and body when possible. This behavior may be temporarily reverted by setting
+    ``envoy.reloadable_features.allow_response_for_timeout`` to false.
 - area: http
   change: |
-    changed empty trailers encoding behavior by sending empty data with ``end_stream`` true (instead of sending empty trailers) for HTTP/2. This behavior can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.http2_skip_encoding_empty_trailers`` to false.
+    changed empty trailers encoding behavior by sending empty data with ``end_stream`` true (instead of sending empty
+    trailers) for HTTP/2. This behavior can be reverted temporarily by setting runtime feature
+    ``envoy.reloadable_features.http2_skip_encoding_empty_trailers`` to false.
 - area: http
   change: |
-    changed how local replies are processed for requests which transform from grpc to not-grpc, or not-grpc to grpc. Previously the initial generated reply depended on which filter sent the reply, but now the reply is consistently generated the way the downstream expects. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.unify_grpc_handling`` to false.
+    changed how local replies are processed for requests which transform from grpc to not-grpc, or not-grpc to grpc.
+    Previously the initial generated reply depended on which filter sent the reply, but now the reply is consistently
+    generated the way the downstream expects. This behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.unify_grpc_handling`` to false.
 - area: http
   change: |
-    clarified and enforced 1xx handling. Multiple 100-continue headers are coalesced when proxying. 1xx headers other than {100, 101} are dropped.
+    clarified and enforced 1xx handling. Multiple 100-continue headers are coalesced when proxying. 1xx headers other than
+    {100, 101} are dropped.
 - area: http
   change: |
-    fixed a bug in access logs where early stream termination could be incorrectly tagged as a downstream disconnect, and disconnects after partial response were not flagged.
+    fixed a bug in access logs where early stream termination could be incorrectly tagged as a downstream disconnect, and
+    disconnects after partial response were not flagged.
 - area: http
   change: |
-    fixed the 100-continue response path to properly handle upstream failure by sending 5xx responses. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.allow_500_after_100`` to false.
+    fixed the 100-continue response path to properly handle upstream failure by sending 5xx responses. This behavior can be
+    temporarily reverted by setting ``envoy.reloadable_features.allow_500_after_100`` to false.
 - area: http
   change: |
-    the per-stream FilterState maintained by the HTTP connection manager will now provide read/write access to the downstream connection FilterState. As such, code that relies on interacting with this might
-    see a change in behavior.
+    the per-stream FilterState maintained by the HTTP connection manager will now provide read/write access to the
+    downstream connection FilterState. As such, code that relies on interacting with this might see a change in behavior.
 - area: logging
   change: |
-    added fine-grain logging for file level log control with logger management at administration interface. It can be enabled by option :option:`--enable-fine-grain-logging`.
+    added fine-grain logging for file level log control with logger management at administration interface. It can be
+    enabled by option :option:`--enable-fine-grain-logging`.
 - area: logging
   change: |
-    changed default log format to ``"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"`` and default value of ``--log-format-prefix-with-location`` to ``0``.
+    changed default log format to ``"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"`` and default value of ``--log-format-prefix-
+    with-location`` to ``0``.
 - area: logging
   change: |
-    nghttp2 log messages no longer appear at trace level unless ``ENVOY_NGHTTP2_TRACE`` is set
-    in the environment.
+    nghttp2 log messages no longer appear at trace level unless ``ENVOY_NGHTTP2_TRACE`` is set in the environment.
 - area: lua
   change: |
     changed the response body returned by ``httpCall()`` API to raw data. Previously, the returned data was string.
 - area: memory
   change: |
-    switched to the `new tcmalloc <https://github.com/google/tcmalloc>`_ for linux_x86_64 builds. The `old tcmalloc <https://github.com/gperftools/gperftools>`_ can still be enabled with the ``--define tcmalloc=gperftools`` option.
+    switched to the `new tcmalloc <https://github.com/google/tcmalloc>`_ for linux_x86_64 builds. The `old tcmalloc
+    <https://github.com/gperftools/gperftools>`_ can still be enabled with the ``--define tcmalloc=gperftools`` option.
 - area: postgres
   change: |
     changed log format to tokenize fields of Postgres messages.
 - area: router
   change: |
-    added transport failure reason to response body when upstream reset happens. After this change, the response body will be of the form ``upstream connect error or disconnect/reset before headers. reset reason:{}, transport failure reason:{}``.This behavior may be reverted by setting runtime feature ``envoy.reloadable_features.http_transport_failure_reason_in_body`` to false.
+    added transport failure reason to response body when upstream reset happens. After this change, the response body will
+    be of the form ``upstream connect error or disconnect/reset before headers. reset reason:{}, transport failure
+    reason:{}``.This behavior may be reverted by setting runtime feature
+    ``envoy.reloadable_features.http_transport_failure_reason_in_body`` to false.
 - area: router
   change: |
-    now consumes all retry related headers to prevent them from being propagated to the upstream. This behavior may be reverted by setting runtime feature ``envoy.reloadable_features.consume_all_retry_headers`` to false.
+    now consumes all retry related headers to prevent them from being propagated to the upstream. This behavior may be
+    reverted by setting runtime feature ``envoy.reloadable_features.consume_all_retry_headers`` to false.
 - area: stats
   change: |
-    the fake symbol table implemention has been removed from the binary, and the option ``--use-fake-symbol-table`` is now a no-op with a warning.
+    the fake symbol table implemention has been removed from the binary, and the option ``--use-fake-symbol-table`` is now a
+    no-op with a warning.
 - area: thrift_proxy
   change: |
     special characters {'\0', '\r', '\n'} will be stripped from thrift headers.
 - area: watchdog
   change: |
-    replaced single watchdog with separate watchdog configuration for worker threads and for the main thread configured via :ref:`Watchdogs <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdogs>`. It works with :ref:`watchdog <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdog>` by having the worker thread and main thread watchdogs have same config.
+    replaced single watchdog with separate watchdog configuration for worker threads and for the main thread configured via
+    :ref:`Watchdogs <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdogs>`. It works with :ref:`watchdog
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdog>` by having the worker thread and main thread watchdogs have
+    same config.
 
 bug_fixes:
 - area: csrf
@@ -129,7 +185,8 @@ bug_fixes:
     fixed issues with regards to origin and host header parsing.
 - area: dynamic_forward_proxy
   change: |
-    only perform DNS lookups for routes to Dynamic Forward Proxy clusters since other cluster types handle DNS lookup themselves.
+    only perform DNS lookups for routes to Dynamic Forward Proxy clusters since other cluster types handle DNS lookup
+    themselves.
 - area: fault
   change: |
     fixed an issue with ``active_faults`` gauge not being decremented for when abort faults were injected.
@@ -138,10 +195,12 @@ bug_fixes:
     made the HeaderNameValues::prefix() method const.
 - area: grpc-web
   change: |
-    fixed an issue with failing HTTP/2 requests on some browsers. Notably, WebKit-based browsers (https://bugs.webkit.org/show_bug.cgi?id=210108), Internet Explorer 11, and Edge (pre-Chromium).
+    fixed an issue with failing HTTP/2 requests on some browsers. Notably, WebKit-based browsers
+    (https://bugs.webkit.org/show_bug.cgi?id=210108), Internet Explorer 11, and Edge (pre-Chromium).
 - area: http
   change: |
-    fixed CVE-2020-25018 by rolling back the ``GURL`` dependency to previous state (reverted: ``2d69e30``, ``d828958``, and ``c9c4709`` commits) due to potential of crashing when Unicode URIs are present in requests.
+    fixed CVE-2020-25018 by rolling back the ``GURL`` dependency to previous state (reverted: ``2d69e30``, ``d828958``, and
+    ``c9c4709`` commits) due to potential of crashing when Unicode URIs are present in requests.
 - area: http
   change: |
     fixed bugs in datadog and squash filter's handling of responses with no bodies.
@@ -156,7 +215,8 @@ bug_fixes:
     fixed crash at listener inplace update when connection load balancer is set.
 - area: rocketmq_proxy
   change: |
-    fixed an issue involving incorrect header lengths. In debug mode it causes crash and in release mode it causes underflow.
+    fixed an issue involving incorrect header lengths. In debug mode it causes crash and in release mode it causes
+    underflow.
 - area: thrift_proxy
   change: |
     fixed crashing bug on request overflow.
@@ -170,7 +230,8 @@ removed_config_or_runtime:
     removed legacy header sanitization and the runtime guard ``envoy.reloadable_features.strict_header_validation``.
 - area: http
   change: |
-    removed legacy transfer-encoding enforcement and runtime guard ``envoy.reloadable_features.reject_unsupported_transfer_encodings``.
+    removed legacy transfer-encoding enforcement and runtime guard
+    ``envoy.reloadable_features.reject_unsupported_transfer_encodings``.
 - area: http
   change: |
     removed configurable strict host validation and runtime guard ``envoy.reloadable_features.strict_authority_validation``.
@@ -181,119 +242,173 @@ removed_config_or_runtime:
 new_features:
 - area: access log
   change: |
-    added a :ref:`dynamic metadata filter <envoy_v3_api_msg_config.accesslog.v3.MetadataFilter>` for access logs, which filters whether to log based on matching dynamic metadata.
+    added a :ref:`dynamic metadata filter <envoy_v3_api_msg_config.accesslog.v3.MetadataFilter>` for access logs, which
+    filters whether to log based on matching dynamic metadata.
 - area: access log
   change: |
     added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_access_log_format_response_flags>` as a response flag.
 - area: access log
   change: |
-    added support for :ref:`%CONNECTION_TERMINATION_DETAILS% <config_access_log_format_connection_termination_details>` as a log command operator about why the connection is terminated by Envoy.
+    added support for :ref:`%CONNECTION_TERMINATION_DETAILS% <config_access_log_format_connection_termination_details>` as a
+    log command operator about why the connection is terminated by Envoy.
 - area: access log
   change: |
     added support for nested objects in :ref:`JSON logging mode <config_access_log_format_dictionaries>`.
 - area: access log
   change: |
-    added :ref:`omit_empty_values <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.omit_empty_values>` option to omit unset value from formatted log.
+    added :ref:`omit_empty_values <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.omit_empty_values>` option to
+    omit unset value from formatted log.
 - area: access log
   change: |
-    added support for :ref:`%CONNECTION_ID% <config_access_log_format_connection_id>` for the downstream connection identifier.
+    added support for :ref:`%CONNECTION_ID% <config_access_log_format_connection_id>` for the downstream connection
+    identifier.
 - area: admin
   change: |
-    added :ref:`circuit breakers settings <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers>` information to GET /clusters?format=json :ref:`cluster status <envoy_v3_api_msg_admin.v3.ClusterStatus>`.
+    added :ref:`circuit breakers settings <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers>` information to GET
+    /clusters?format=json :ref:`cluster status <envoy_v3_api_msg_admin.v3.ClusterStatus>`.
 - area: admin
   change: |
-    added :ref:`node <envoy_v3_api_msg_config.core.v3.Node>` information to GET /server_info :ref:`response object <envoy_v3_api_msg_admin.v3.ServerInfo>`.
+    added :ref:`node <envoy_v3_api_msg_config.core.v3.Node>` information to GET /server_info :ref:`response object
+    <envoy_v3_api_msg_admin.v3.ServerInfo>`.
 - area: admin
   change: |
-    added the ability to dump init manager unready targets information :ref:`/init_dump <operations_admin_interface_init_dump>` and :ref:`/init_dump?mask={} <operations_admin_interface_init_dump_by_mask>`.
+    added the ability to dump init manager unready targets information :ref:`/init_dump
+    <operations_admin_interface_init_dump>` and :ref:`/init_dump?mask={} <operations_admin_interface_init_dump_by_mask>`.
 - area: admission control
   change: |
-    added the :ref:`admission control <envoy_v3_api_msg_extensions.filters.http.admission_control.v3alpha.AdmissionControl>` filter for client-side request throttling.
+    added the :ref:`admission control <envoy_v3_api_msg_extensions.filters.http.admission_control.v3alpha.AdmissionControl>`
+    filter for client-side request throttling.
 - area: build
   change: |
     enable building envoy :ref:`arm64 images <install_binaries>` by buildx tool in x86 CI platform.
 - area: cluster
   change: |
-    added new :ref:`connection_pool_per_downstream_connection <envoy_v3_api_field_config.cluster.v3.Cluster.connection_pool_per_downstream_connection>` flag, which enable creation of a new connection pool for each downstream connection.
+    added new :ref:`connection_pool_per_downstream_connection
+    <envoy_v3_api_field_config.cluster.v3.Cluster.connection_pool_per_downstream_connection>` flag, which enable creation of
+    a new connection pool for each downstream connection.
 - area: decompressor filter
   change: |
     reports compressed and uncompressed bytes in trailers.
 - area: dns
   change: |
-    added support for doing DNS resolution using Apple's DnsService APIs in Apple platforms (macOS, iOS). This feature is ON by default, and is only configurable via the ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime key. Note that this value is latched during server startup and changing the runtime key is a no-op during the lifetime of the process.
+    added support for doing DNS resolution using Apple's DnsService APIs in Apple platforms (macOS, iOS). This feature is ON
+    by default, and is only configurable via the ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime key. Note
+    that this value is latched during server startup and changing the runtime key is a no-op during the lifetime of the
+    process.
 - area: dns_filter
   change: |
     added support for answering :ref:`service record <envoy_v3_api_msg_data.dns.v3.DnsTable.DnsService>` queries.
 - area: dynamic_forward_proxy
   change: |
-    added :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` option to use TCP for DNS lookups in order to match the DNS options for :ref:`Clusters <envoy_v3_api_msg_config.cluster.v3.Cluster>`.
+    added :ref:`use_tcp_for_dns_lookups
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` option to use
+    TCP for DNS lookups in order to match the DNS options for :ref:`Clusters <envoy_v3_api_msg_config.cluster.v3.Cluster>`.
 - area: ext_authz filter
   change: |
-    added support for emitting dynamic metadata for both :ref:`HTTP <config_http_filters_ext_authz_dynamic_metadata>` and :ref:`network <config_network_filters_ext_authz_dynamic_metadata>` filters.
-    The emitted dynamic metadata is set by :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field in a returned :ref:`CheckResponse <envoy_v3_api_msg_service.auth.v3.CheckResponse>`.
+    added support for emitting dynamic metadata for both :ref:`HTTP <config_http_filters_ext_authz_dynamic_metadata>` and
+    :ref:`network <config_network_filters_ext_authz_dynamic_metadata>` filters. The emitted dynamic metadata is set by
+    :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field in a returned
+    :ref:`CheckResponse <envoy_v3_api_msg_service.auth.v3.CheckResponse>`.
 - area: ext_authz filter
   change: |
-    added :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.stat_prefix>` as an optional additional prefix for the statistics emitted from ``ext_authz`` HTTP filter.
+    added :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.stat_prefix>` as an optional
+    additional prefix for the statistics emitted from ``ext_authz`` HTTP filter.
 - area: ext_authz filter
   change: |
-    added support for enabling the filter based on :ref:`dynamic metadata <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.filter_enabled_metadata>`.
+    added support for enabling the filter based on :ref:`dynamic metadata
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.filter_enabled_metadata>`.
 - area: ext_authz filter
   change: |
-    added support for letting the authorization server instruct Envoy to remove headers from the original request by setting the new field :ref:`headers_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.headers_to_remove>` before forwarding it to the upstream.
+    added support for letting the authorization server instruct Envoy to remove headers from the original request by setting
+    the new field :ref:`headers_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.headers_to_remove>` before
+    forwarding it to the upstream.
 - area: ext_authz filter
   change: |
-    added support for sending :ref:`raw bytes as request body <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.raw_body>` of a gRPC check request by setting :ref:`pack_as_bytes <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.BufferSettings.pack_as_bytes>` to true.
+    added support for sending :ref:`raw bytes as request body
+    <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.raw_body>` of a gRPC check request by setting
+    :ref:`pack_as_bytes <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.BufferSettings.pack_as_bytes>` to true.
 - area: ext_authz_filter
   change: |
-    added :ref:`disable_request_body_buffering <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>` to disable request data buffering per-route.
+    added :ref:`disable_request_body_buffering
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>` to disable
+    request data buffering per-route.
 - area: grpc-json
   change: |
     support specifying ``response_body`` field in for ``google.api.HttpBody`` message.
 - area: hds
   change: |
-    added :ref:`cluster_endpoints_health <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.cluster_endpoints_health>` to HDS responses, keeping endpoints in the same groupings as they were configured in the HDS specifier by cluster and locality instead of as a flat list.
+    added :ref:`cluster_endpoints_health
+    <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.cluster_endpoints_health>` to HDS responses, keeping
+    endpoints in the same groupings as they were configured in the HDS specifier by cluster and locality instead of as a
+    flat list.
 - area: hds
   change: |
-    added :ref:`transport_socket_matches <envoy_v3_api_field_service.health.v3.ClusterHealthCheck.transport_socket_matches>` to HDS cluster health check specifier, so the existing match filter :ref:`transport_socket_match_criteria <envoy_v3_api_field_config.core.v3.HealthCheck.transport_socket_match_criteria>` in the repeated field :ref:`health_checks <envoy_v3_api_field_service.health.v3.ClusterHealthCheck.health_checks>` has context to match against. This unblocks support for health checks over HTTPS and HTTP/2.
+    added :ref:`transport_socket_matches <envoy_v3_api_field_service.health.v3.ClusterHealthCheck.transport_socket_matches>`
+    to HDS cluster health check specifier, so the existing match filter :ref:`transport_socket_match_criteria
+    <envoy_v3_api_field_config.core.v3.HealthCheck.transport_socket_match_criteria>` in the repeated field
+    :ref:`health_checks <envoy_v3_api_field_service.health.v3.ClusterHealthCheck.health_checks>` has context to match
+    against. This unblocks support for health checks over HTTPS and HTTP/2.
 - area: hot restart
   change: |
-    added :option:`--socket-path` and :option:`--socket-mode` to configure UDS path in the filesystem and set permission to it.
+    added :option:`--socket-path` and :option:`--socket-mode` to configure UDS path in the filesystem and set permission to
+    it.
 - area: http
   change: |
-    added HTTP/2 support for :ref:`connection keepalive <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.connection_keepalive>` via PING.
+    added HTTP/2 support for :ref:`connection keepalive
+    <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.connection_keepalive>` via PING.
 - area: http
   change: |
-    added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_http_conn_man_headers_custom_request_headers>` as custom header.
+    added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_http_conn_man_headers_custom_request_headers>` as custom
+    header.
 - area: http
   change: |
-    added :ref:`allow_chunked_length <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.allow_chunked_length>` configuration option for HTTP/1 codec to allow processing requests/responses with both Content-Length and Transfer-Encoding: chunked headers. If such message is served and option is enabled - per RFC Content-Length is ignored and removed.
+    added :ref:`allow_chunked_length <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.allow_chunked_length>`
+    configuration option for HTTP/1 codec to allow processing requests/responses with both Content-Length and Transfer-
+    Encoding: chunked headers. If such message is served and option is enabled - per RFC Content-Length is ignored and
+    removed.
 - area: http
   change: |
-    added :ref:`CDN Loop filter <envoy_v3_api_msg_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig>` and :ref:`documentation <config_http_filters_cdn_loop>`.
+    added :ref:`CDN Loop filter <envoy_v3_api_msg_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig>` and
+    :ref:`documentation <config_http_filters_cdn_loop>`.
 - area: http
   change: |
-    added :ref:`MaxStreamDuration proto <envoy_v3_api_msg_config.route.v3.RouteAction.MaxStreamDuration>` for configuring per-route downstream duration timeouts.
+    added :ref:`MaxStreamDuration proto <envoy_v3_api_msg_config.route.v3.RouteAction.MaxStreamDuration>` for configuring
+    per-route downstream duration timeouts.
 - area: http
   change: |
-    introduced new HTTP/1 and HTTP/2 codec implementations that will remove the use of exceptions for control flow due to high risk factors and instead use error statuses. The old behavior is used by default for HTTP/1.1 and HTTP/2 server connections. The new codecs can be enabled for testing by setting the runtime feature ``envoy.reloadable_features.new_codec_behavior`` to true. The new codecs will be in development for one month, and then enabled by default while the old codecs are deprecated.
+    introduced new HTTP/1 and HTTP/2 codec implementations that will remove the use of exceptions for control flow due to
+    high risk factors and instead use error statuses. The old behavior is used by default for HTTP/1.1 and HTTP/2 server
+    connections. The new codecs can be enabled for testing by setting the runtime feature
+    ``envoy.reloadable_features.new_codec_behavior`` to true. The new codecs will be in development for one month, and then
+    enabled by default while the old codecs are deprecated.
 - area: http
   change: |
-    modified the HTTP header-map data-structure to use an underlying dictionary and a list (no change to the header-map API). To conform with previous versions, the use of a dictionary is currently disabled. It can be enabled by setting the ``envoy.http.headermap.lazy_map_min_size`` runtime feature to a non-negative number which defines the minimal number of headers in a request/response/trailers required for using a dictionary in addition to the list. Our current benchmarks suggest that the value 3 is a good threshold for most workloads.
+    modified the HTTP header-map data-structure to use an underlying dictionary and a list (no change to the header-map
+    API). To conform with previous versions, the use of a dictionary is currently disabled. It can be enabled by setting the
+    ``envoy.http.headermap.lazy_map_min_size`` runtime feature to a non-negative number which defines the minimal number of
+    headers in a request/response/trailers required for using a dictionary in addition to the list. Our current benchmarks
+    suggest that the value 3 is a good threshold for most workloads.
 - area: load balancer
   change: |
-    added :ref:`RingHashLbConfig <envoy_v3_api_msg_config.cluster.v3.Cluster.MaglevLbConfig>` to configure the table size of Maglev consistent hash.
+    added :ref:`RingHashLbConfig <envoy_v3_api_msg_config.cluster.v3.Cluster.MaglevLbConfig>` to configure the table size of
+    Maglev consistent hash.
 - area: load balancer
   change: |
-    added a :ref:`configuration <envoy_v3_api_msg_config.cluster.v3.Cluster.LeastRequestLbConfig>` option to specify the active request bias used by the least request load balancer.
+    added a :ref:`configuration <envoy_v3_api_msg_config.cluster.v3.Cluster.LeastRequestLbConfig>` option to specify the
+    active request bias used by the least request load balancer.
 - area: load balancer
   change: |
-    added an :ref:`option <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector.single_host_per_subset>` to optimize subset load balancing when there is only one host per subset.
+    added an :ref:`option
+    <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector.single_host_per_subset>` to optimize
+    subset load balancing when there is only one host per subset.
 - area: load balancer
   change: |
-    added support for bounded load per host for consistent hash load balancers via :ref:`hash_balance_factor <envoy_api_field_Cluster.CommonLbConfig.consistent_hashing_lb_config>`.
+    added support for bounded load per host for consistent hash load balancers via :ref:`hash_balance_factor
+    <envoy_api_field_Cluster.CommonLbConfig.consistent_hashing_lb_config>`.
 - area: local_reply config
   change: |
-    added :ref:`content_type <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.content_type>` field to set content-type.
+    added :ref:`content_type <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.content_type>` field to set
+    content-type.
 - area: lua
   change: |
     added Lua APIs to access :ref:`SSL connection info <config_http_filters_lua_ssl_socket_info>` object.
@@ -305,7 +420,8 @@ new_features:
     added Lua API for :ref:`setting the current buffer content <config_http_filters_lua_buffer_wrapper_api_set_bytes>`.
 - area: lua
   change: |
-    added new :ref:`source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.LuaPerRoute.source_code>` field to support the dispatching of inline Lua code in per route configuration of Lua filter.
+    added new :ref:`source_code <envoy_v3_api_field_extensions.filters.http.lua.v3.LuaPerRoute.source_code>` field to
+    support the dispatching of inline Lua code in per route configuration of Lua filter.
 - area: overload management
   change: |
     add :ref:`scaling <envoy_v3_api_field_config.overload.v3.Trigger.scaled>` trigger for OverloadManager actions.
@@ -314,33 +430,41 @@ new_features:
     :ref:`metadata <config_network_filters_postgres_proxy_dynamic_metadata>` is produced based on SQL query.
 - area: proxy protocol
   change: |
-    added support for generating the header upstream using :ref:`Proxy Protocol Transport Socket <extension_envoy.transport_sockets.upstream_proxy_protocol>`.
+    added support for generating the header upstream using :ref:`Proxy Protocol Transport Socket
+    <extension_envoy.transport_sockets.upstream_proxy_protocol>`.
 - area: ratelimit
   change: |
-    added :ref:`enable_x_ratelimit_headers <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option to enable ``X-RateLimit-*`` headers as defined in `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
+    added :ref:`enable_x_ratelimit_headers <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option to
+    enable ``X-RateLimit-*`` headers as defined in `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-
+    headers-03.html>`_.
 - area: ratelimit
   change: |
-    added :ref:`per route config <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimitPerRoute>` for rate limit filter.
+    added :ref:`per route config <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimitPerRoute>` for rate limit
+    filter.
 - area: ratelimit
   change: |
-    added support for optional :ref:`descriptor_key <envoy_v3_api_field_config.route.v3.RateLimit.Action.generic_key>` to Generic Key action.
+    added support for optional :ref:`descriptor_key <envoy_v3_api_field_config.route.v3.RateLimit.Action.generic_key>` to
+    Generic Key action.
 - area: rbac filter
   change: |
     added the name of the matched policy to the response code detail when a request is rejected by the RBAC filter.
 - area: rbac filter
   change: |
-    added a log action to the :ref:`RBAC filter <envoy_v3_api_msg_config.rbac.v3.RBAC>` which sets dynamic metadata to inform access loggers whether to log.
+    added a log action to the :ref:`RBAC filter <envoy_v3_api_msg_config.rbac.v3.RBAC>` which sets dynamic metadata to
+    inform access loggers whether to log.
 - area: redis
   change: |
-    added fault injection support :ref:`fault injection for redis proxy <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.faults>`, described further in :ref:`configuration documentation <config_network_filters_redis_proxy>`.
+    added fault injection support :ref:`fault injection for redis proxy
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.faults>`, described further in
+    :ref:`configuration documentation <config_network_filters_redis_proxy>`.
 - area: router
   change: |
-    added a new :ref:`rate limited retry back off <envoy_v3_api_msg_config.route.v3.RetryPolicy.RateLimitedRetryBackOff>` strategy that uses headers like ``Retry-After`` or ``X-RateLimit-Reset`` to decide the back off interval.
+    added a new :ref:`rate limited retry back off <envoy_v3_api_msg_config.route.v3.RetryPolicy.RateLimitedRetryBackOff>`
+    strategy that uses headers like ``Retry-After`` or ``X-RateLimit-Reset`` to decide the back off interval.
 - area: router
   change: |
-    added new
-    :ref:`envoy-ratelimited <config_http_filters_router_retry_policy-envoy-ratelimited>`
-    retry policy, which allows retrying envoy's own rate limited responses.
+    added new :ref:`envoy-ratelimited <config_http_filters_router_retry_policy-envoy-ratelimited>` retry policy, which
+    allows retrying envoy's own rate limited responses.
 - area: router
   change: |
     added new :ref:`host_rewrite_path_regex <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_path_regex>`
@@ -350,62 +474,83 @@ new_features:
     added support for DYNAMIC_METADATA :ref:`header formatter <config_http_conn_man_headers_custom_request_headers>`.
 - area: router_check_tool
   change: |
-    added support for ``request_header_matches``, ``response_header_matches`` to :ref:`router check tool <config_tools_router_check_tool>`.
+    added support for ``request_header_matches``, ``response_header_matches`` to :ref:`router check tool
+    <config_tools_router_check_tool>`.
 - area: signal
   change: |
-    added support for calling fatal error handlers without envoy's signal handler, via FatalErrorHandler::callFatalErrorHandlers().
+    added support for calling fatal error handlers without envoy's signal handler, via
+    FatalErrorHandler::callFatalErrorHandlers().
 - area: stats
   change: |
-    added optional histograms to :ref:`cluster stats <config_cluster_manager_cluster_stats_request_response_sizes>`
-    that track headers and body sizes of requests and responses.
+    added optional histograms to :ref:`cluster stats <config_cluster_manager_cluster_stats_request_response_sizes>` that
+    track headers and body sizes of requests and responses.
 - area: stats
   change: |
     allow configuring histogram buckets for stats sinks and admin endpoints that support it.
 - area: tap
   change: |
-    added :ref:`generic body matcher <envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and responses for text or hex patterns.
+    added :ref:`generic body matcher <envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and
+    responses for text or hex patterns.
 - area: tcp_proxy
   change: |
-    added :ref:`max_downstream_connection_duration <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.max_downstream_connection_duration>` for downstream connection. When max duration is reached the connection will be closed.
+    added :ref:`max_downstream_connection_duration
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.max_downstream_connection_duration>` for downstream
+    connection. When max duration is reached the connection will be closed.
 - area: tcp_proxy
   change: |
     allow earlier network filters to set metadataMatchCriteria on the connection StreamInfo to influence load balancing.
 - area: tls
   change: |
-    added OCSP stapling support through the :ref:`ocsp_staple <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.TlsCertificate>` and :ref:`ocsp_staple_policy <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.DownstreamTlsContext>` configuration options. See :ref:`OCSP Stapling <arch_overview_ssl_ocsp_stapling>` for usage and runtime flags.
+    added OCSP stapling support through the :ref:`ocsp_staple
+    <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.TlsCertificate>` and :ref:`ocsp_staple_policy
+    <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.DownstreamTlsContext>` configuration options. See :ref:`OCSP
+    Stapling <arch_overview_ssl_ocsp_stapling>` for usage and runtime flags.
 - area: tls
   change: |
-    introduce new :ref:`extension point <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.custom_handshaker>` for overriding :ref:`TLS handshaker <arch_overview_ssl>` behavior.
+    introduce new :ref:`extension point
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.custom_handshaker>` for overriding :ref:`TLS
+    handshaker <arch_overview_ssl>` behavior.
 - area: tls
   change: |
-    switched from using socket BIOs to using custom BIOs that know how to interact with IoHandles. The feature can be disabled by setting runtime feature ``envoy.reloadable_features.tls_use_io_handle_bio`` to false.
+    switched from using socket BIOs to using custom BIOs that know how to interact with IoHandles. The feature can be
+    disabled by setting runtime feature ``envoy.reloadable_features.tls_use_io_handle_bio`` to false.
 - area: tracing
   change: |
-    added ability to set some :ref:`optional segment fields <envoy_v3_api_field_config.trace.v3.XRayConfig.segment_fields>` in the AWS  X-Ray tracer.
+    added ability to set some :ref:`optional segment fields <envoy_v3_api_field_config.trace.v3.XRayConfig.segment_fields>`
+    in the AWS  X-Ray tracer.
 - area: udp_proxy
   change: |
-    added :ref:`hash_policies <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>` to support hash based routing.
+    added :ref:`hash_policies <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>` to support hash based
+    routing.
 - area: udp_proxy
   change: |
-    added :ref:`use_original_src_ip <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>` option to replicate the downstream remote address of the packets on the upstream side of Envoy. It is similar to :ref:`original source filter <envoy_v3_api_msg_extensions.filters.listener.original_src.v3.OriginalSrc>`.
+    added :ref:`use_original_src_ip <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>` option to
+    replicate the downstream remote address of the packets on the upstream side of Envoy. It is similar to :ref:`original
+    source filter <envoy_v3_api_msg_extensions.filters.listener.original_src.v3.OriginalSrc>`.
 - area: watchdog
   change: |
-    support randomizing the watchdog's kill timeout to prevent synchronized kills via a maximium jitter parameter :ref:`max_kill_timeout_jitter <envoy_v3_api_field_config.bootstrap.v3.Watchdog.max_kill_timeout_jitter>`.
+    support randomizing the watchdog's kill timeout to prevent synchronized kills via a maximium jitter parameter
+    :ref:`max_kill_timeout_jitter <envoy_v3_api_field_config.bootstrap.v3.Watchdog.max_kill_timeout_jitter>`.
 - area: watchdog
   change: |
-    supports an extension point where actions can be registered to fire on watchdog events such as miss, megamiss, kill and multikill. See :ref:`watchdog actions <envoy_v3_api_field_config.bootstrap.v3.Watchdog.actions>`.
+    supports an extension point where actions can be registered to fire on watchdog events such as miss, megamiss, kill and
+    multikill. See :ref:`watchdog actions <envoy_v3_api_field_config.bootstrap.v3.Watchdog.actions>`.
 - area: watchdog
   change: |
-    watchdog action extension that does cpu profiling. See :ref:`Profile Action <envoy_v3_api_file_envoy/extensions/watchdog/profile_action/v3alpha/profile_action.proto>`.
+    watchdog action extension that does cpu profiling. See :ref:`Profile Action
+    <envoy_v3_api_file_envoy/extensions/watchdog/profile_action/v3alpha/profile_action.proto>`.
 - area: watchdog
   change: |
-    watchdog action extension that sends SIGABRT to the stuck thread to terminate the process. See :ref:`Abort Action <envoy_v3_api_msg_extensions.watchdog.abort_action.v3alpha.abortactionconfig>`.
+    watchdog action extension that sends SIGABRT to the stuck thread to terminate the process. See :ref:`Abort Action
+    <envoy_v3_api_msg_extensions.watchdog.abort_action.v3alpha.abortactionconfig>`.
 - area: xds
   change: |
-    added :ref:`extension config discovery <envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP filters.
+    added :ref:`extension config discovery <envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP
+    filters.
 - area: xds
   change: |
-    added support for mixed v2/v3 discovery response, which enable type url downgrade and upgrade. This feature is disabled by default and is controlled by runtime guard ``envoy.reloadable_features.enable_type_url_downgrade_and_upgrade``.
+    added support for mixed v2/v3 discovery response, which enable type url downgrade and upgrade. This feature is disabled
+    by default and is controlled by runtime guard ``envoy.reloadable_features.enable_type_url_downgrade_and_upgrade``.
 - area: zlib
   change: |
     added option to use `zlib-ng <https://github.com/zlib-ng/zlib-ng>`_ as zlib library.
@@ -416,32 +561,45 @@ deprecated:
     alpine based debug image is deprecated in favor of :ref:`Ubuntu based debug image <install_binaries>`.
 - area: cluster
   change: |
-    the :ref:`track_timeout_budgets <envoy_v3_api_field_config.cluster.v3.Cluster.track_timeout_budgets>`
-    field has been deprecated in favor of ``timeout_budgets`` part of an :ref:`Optional Configuration <envoy_v3_api_field_config.cluster.v3.Cluster.track_cluster_stats>`.
+    the :ref:`track_timeout_budgets <envoy_v3_api_field_config.cluster.v3.Cluster.track_timeout_budgets>` field has been
+    deprecated in favor of ``timeout_budgets`` part of an :ref:`Optional Configuration
+    <envoy_v3_api_field_config.cluster.v3.Cluster.track_cluster_stats>`.
 - area: ext_authz
   change: |
-    the :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.OkHttpResponse.dynamic_metadata>` field in :ref:`OkHttpResponse <envoy_v3_api_msg_service.auth.v3.OkHttpResponse>` has been deprecated in favor of :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field in :ref:`CheckResponse <envoy_v3_api_msg_service.auth.v3.CheckResponse>`.
+    the :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.OkHttpResponse.dynamic_metadata>` field in
+    :ref:`OkHttpResponse <envoy_v3_api_msg_service.auth.v3.OkHttpResponse>` has been deprecated in favor of :ref:`dynamic
+    metadata <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field in :ref:`CheckResponse
+    <envoy_v3_api_msg_service.auth.v3.CheckResponse>`.
 - area: hds
   change: |
-    the :ref:`endpoints_health <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.endpoints_health>`
-    field has been deprecated in favor of :ref:`cluster_endpoints_health <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.cluster_endpoints_health>` to maintain
-    grouping by cluster and locality.
+    the :ref:`endpoints_health <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.endpoints_health>` field has
+    been deprecated in favor of :ref:`cluster_endpoints_health
+    <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.cluster_endpoints_health>` to maintain grouping by cluster
+    and locality.
 - area: router
   change: |
-    the :ref:`include_vh_rate_limits <envoy_v3_api_field_config.route.v3.RouteAction.include_vh_rate_limits>` field has been deprecated in favor of :ref:`vh_rate_limits <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.vh_rate_limits>`.
+    the :ref:`include_vh_rate_limits <envoy_v3_api_field_config.route.v3.RouteAction.include_vh_rate_limits>` field has been
+    deprecated in favor of :ref:`vh_rate_limits
+    <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.vh_rate_limits>`.
 - area: router
   change: |
-    the :ref:`max_grpc_timeout <envoy_v3_api_field_config.route.v3.RouteAction.max_grpc_timeout>` field has been deprecated in favor of :ref:`grpc_timeout_header_max <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`.
+    the :ref:`max_grpc_timeout <envoy_v3_api_field_config.route.v3.RouteAction.max_grpc_timeout>` field has been deprecated
+    in favor of :ref:`grpc_timeout_header_max
+    <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`.
 - area: router
   change: |
-    the :ref:`grpc_timeout_offset <envoy_v3_api_field_config.route.v3.RouteAction.grpc_timeout_offset>` field has been deprecated in favor of :ref:`grpc_timeout_header_offset <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
+    the :ref:`grpc_timeout_offset <envoy_v3_api_field_config.route.v3.RouteAction.grpc_timeout_offset>` field has been
+    deprecated in favor of :ref:`grpc_timeout_header_offset
+    <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
 - area: tap
   change: |
     the :ref:`match_config <envoy_v3_api_field_config.tap.v3.TapConfig.match_config>` field has been deprecated in favor of
     :ref:`match <envoy_v3_api_field_config.tap.v3.TapConfig.match>` field.
 - area: router_check_tool
   change: |
-    ``request_header_fields``, ``response_header_fields`` config deprecated in favor of ``request_header_matches``, ``response_header_matches``.
+    ``request_header_fields``, ``response_header_fields`` config deprecated in favor of ``request_header_matches``,
+    ``response_header_matches``.
 - area: watchdog
   change: |
-    :ref:`watchdog <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdog>` deprecated in favor of :ref:`watchdogs <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdogs>`.
+    :ref:`watchdog <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdog>` deprecated in favor of :ref:`watchdogs
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.watchdogs>`.

--- a/changelogs/1.16.1.yaml
+++ b/changelogs/1.16.1.yaml
@@ -12,10 +12,13 @@ bug_fixes:
     fixed a bug where the wrong downstream address got sent to upstream connections.
 - area: proxy_proto
   change: |
-    fixed a bug where network filters would not have the correct ``downstreamRemoteAddress()`` when accessed from the ``StreamInfo``. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.
+    fixed a bug where network filters would not have the correct ``downstreamRemoteAddress()`` when accessed from the
+    ``StreamInfo``. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC
+    HTTP filter), or incorrect access log addresses from tcp_proxy.
 - area: tls
   change: |
-    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+    fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the
+    SSL connection's internal buffers.
 - area: udp
   change: |
     fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.

--- a/changelogs/1.16.3.yaml
+++ b/changelogs/1.16.3.yaml
@@ -6,13 +6,16 @@ bug_fixes:
     fixed a crash due to a TLS initialization issue.
 - area: http
   change: |
-    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
+    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2
+    codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
 - area: http
   change: |
     fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
 - area: http
   change: |
-    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
+    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection
+    failures. The change back to the original behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
 - area: lua
   change: |
     fixed crash when Lua script contains ``streamInfo():downstreamSslConnection()``.

--- a/changelogs/1.16.4.yaml
+++ b/changelogs/1.16.4.yaml
@@ -3,4 +3,11 @@ date: May 11, 2021
 new_features:
 - area: http
   change: |
-    added the ability to :ref:`unescape slash sequences<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>` in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By default this feature is disabled. The default behavior can be overridden through :ref:`http_connection_manager.path_with_escaped_slashes_action<config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling<config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.
+    added the ability to :ref:`unescape slash sequences
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>`
+    in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By
+    default this feature is disabled. The default behavior can be overridden through
+    :ref:`http_connection_manager.path_with_escaped_slashes_action<config_http_conn_man_runtime_path_with_escaped_slashes_action>`
+    runtime variable. This action can be selectively enabled for a portion of requests by setting the
+    :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling<config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>`
+    runtime variable.

--- a/changelogs/1.16.5.yaml
+++ b/changelogs/1.16.5.yaml
@@ -3,15 +3,17 @@ date: August 24, 2021
 minor_behavior_changes:
 - area: http
   change: |
-    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request
-    URI according to RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed
-    to stripping the \#fragment instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment``
-    to false. This behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
-    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set
-    to false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
-    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the standard deprecation period.
+    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request URI according to
+    RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed to stripping the \#fragment
+    instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment`` to false. This
+    behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
+    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set to
+    false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
+    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the
+    standard deprecation period.
 
 bug_fixes:
 - area: ext_authz
   change: |
-    fix the ext_authz filter to correctly merge multiple same headers using the ',' as separator in the check request to the external authorization service.
+    fix the ext_authz filter to correctly merge multiple same headers using the ',' as separator in the check request to the
+    external authorization service.

--- a/changelogs/1.17.0.yaml
+++ b/changelogs/1.17.0.yaml
@@ -3,7 +3,8 @@ date: January 11, 2021
 behavior_changes:
 - area: config
   change: |
-    v2 is now fatal-by-default. This may be overridden by setting ``--bootstrap-version 2`` on the CLI for a v2 bootstrap file and also enabling the runtime ``envoy.reloadable_features.enable_deprecated_v2_api`` feature.
+    v2 is now fatal-by-default. This may be overridden by setting ``--bootstrap-version 2`` on the CLI for a v2 bootstrap
+    file and also enabling the runtime ``envoy.reloadable_features.enable_deprecated_v2_api`` feature.
 
 minor_behavior_changes:
 - area: build
@@ -11,60 +12,77 @@ minor_behavior_changes:
     the Alpine based debug images are no longer built in CI, use Ubuntu based images instead.
 - area: decompressor
   change: |
-    set the default value of window_bits of the decompressor to 15 to be able to decompress responses compressed by a compressor with any window size.
+    set the default value of window_bits of the decompressor to 15 to be able to decompress responses compressed by a
+    compressor with any window size.
 - area: expr filter
   change: |
     added ``connection.termination_details`` property support.
 - area: formatter
   change: |
-    the :ref:`text_format <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format>` field no longer requires at least one byte, and may now be the empty string. It has also become :ref:`deprecated <1_17_deprecated>`.
+    the :ref:`text_format <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format>` field no longer requires
+    at least one byte, and may now be the empty string. It has also become :ref:`deprecated <1_17_deprecated>`.
 - area: grpc_web filter
   change: |
-    if a ``grpc-accept-encoding`` header is present it's passed as-is to the upstream and if it isn't ``grpc-accept-encoding:identity`` is sent instead. The header was always overwriten with ``grpc-accept-encoding:identity,deflate,gzip`` before.
+    if a ``grpc-accept-encoding`` header is present it's passed as-is to the upstream and if it isn't ``grpc-accept-
+    encoding:identity`` is sent instead. The header was always overwriten with ``grpc-accept-
+    encoding:identity,deflate,gzip`` before.
 - area: http
   change: |
     upstream protocol will now only be logged if an upstream stream was established.
 - area: jwt_authn filter
   change: |
-    added support of JWT time constraint verification with a clock skew (default to 60 seconds) and added a filter config field :ref:`clock_skew_seconds <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.clock_skew_seconds>` to configure it.
+    added support of JWT time constraint verification with a clock skew (default to 60 seconds) and added a filter config
+    field :ref:`clock_skew_seconds <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.clock_skew_seconds>`
+    to configure it.
 - area: listener
   change: |
-    injection of the :ref:`TLS inspector <config_listener_filters_tls_inspector>` has been disabled by default. This feature is controlled by the runtime guard ``envoy.reloadable_features.disable_tls_inspector_injection``.
+    injection of the :ref:`TLS inspector <config_listener_filters_tls_inspector>` has been disabled by default. This feature
+    is controlled by the runtime guard ``envoy.reloadable_features.disable_tls_inspector_injection``.
 - area: lua
   change: |
-    added ``always_wrap_body`` argument to ``body()`` API to always return a :ref:`buffer object <config_http_filters_lua_buffer_wrapper>` even if the body is empty.
+    added ``always_wrap_body`` argument to ``body()`` API to always return a :ref:`buffer object
+    <config_http_filters_lua_buffer_wrapper>` even if the body is empty.
 - area: memory
   change: |
     enabled new tcmalloc with restartable sequences for aarch64 builds.
 - area: mongo proxy metrics
   change: |
-    swapped network connection remote and local closed counters previously set reversed (``cx_destroy_local_with_active_rq`` and ``cx_destroy_remote_with_active_rq``).
+    swapped network connection remote and local closed counters previously set reversed (``cx_destroy_local_with_active_rq``
+    and ``cx_destroy_remote_with_active_rq``).
 - area: outlier detection
   change: |
-    added :ref:`max_ejection_time <envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_time>` to limit ejection time growth when a node stays unhealthy for extended period of time. By default :ref:`max_ejection_time <envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_time>` limits ejection time to 5 minutes. Additionally, when the node stays healthy, ejection time decreases. See :ref:`ejection algorithm <arch_overview_outlier_detection_algorithm>` for more info. Previously, ejection time could grow without limit and never decreased.
+    added :ref:`max_ejection_time <envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_time>` to limit
+    ejection time growth when a node stays unhealthy for extended period of time. By default :ref:`max_ejection_time
+    <envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_time>` limits ejection time to 5 minutes.
+    Additionally, when the node stays healthy, ejection time decreases. See :ref:`ejection algorithm
+    <arch_overview_outlier_detection_algorithm>` for more info. Previously, ejection time could grow without limit and never
+    decreased.
 - area: performance
   change: |
     improved performance when handling large HTTP/1 bodies.
 - area: tcp_proxy
   change: |
-    now waits for HTTP tunnel to be established before start streaming the downstream data, the runtime guard ``envoy.reloadable_features.http_upstream_wait_connect_response`` can be set to "false" to disable this behavior.
+    now waits for HTTP tunnel to be established before start streaming the downstream data, the runtime guard
+    ``envoy.reloadable_features.http_upstream_wait_connect_response`` can be set to "false" to disable this behavior.
 - area: tls
   change: |
     removed RSA key transport and SHA-1 cipher suites from the client-side defaults.
 - area: watchdog
   change: |
-    the watchdog action :ref:`abort_action <envoy_v3_api_msg_watchdog.v3alpha.AbortActionConfig>` is now the default action to terminate the process if watchdog kill / multikill is enabled.
+    the watchdog action :ref:`abort_action <envoy_v3_api_msg_watchdog.v3alpha.AbortActionConfig>` is now the default action
+    to terminate the process if watchdog kill / multikill is enabled.
 - area: xds
   change: |
-    to support TTLs, heartbeating has been added to xDS. As a result, responses that contain empty resources without updating the version will no longer be propagated to the
-    subscribers. To undo this for VHDS (which is the only subscriber that wants empty resources), the ``envoy.reloadable_features.vhds_heartbeats`` can be set to "false".
+    to support TTLs, heartbeating has been added to xDS. As a result, responses that contain empty resources without
+    updating the version will no longer be propagated to the subscribers. To undo this for VHDS (which is the only
+    subscriber that wants empty resources), the ``envoy.reloadable_features.vhds_heartbeats`` can be set to "false".
 
 bug_fixes:
-
-
 - area: config
   change: |
-    validate that upgrade configs have a non-empty :ref:`upgrade_type <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.UpgradeConfig.upgrade_type>`, fixing a bug where an errant "-" could result in unexpected behavior.
+    validate that upgrade configs have a non-empty :ref:`upgrade_type
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.UpgradeConfig.upgrade_type>`,
+    fixing a bug where an errant "-" could result in unexpected behavior.
 - area: dns
   change: |
     fixed a bug where custom resolvers provided in configuration were not preserved after network issues.
@@ -73,7 +91,8 @@ bug_fixes:
     correctly associate DNS response IDs when multiple queries are received.
 - area: grpc mux
   change: |
-    fixed sending node again after stream is reset when :ref:`set_node_on_first_message_only <envoy_api_field_core.ApiConfigSource.set_node_on_first_message_only>` is set.
+    fixed sending node again after stream is reset when :ref:`set_node_on_first_message_only
+    <envoy_api_field_core.ApiConfigSource.set_node_on_first_message_only>` is set.
 - area: http
   change: |
     fixed URL parsing for HTTP/1.1 fully qualified URLs and connect requests containing IPv6 addresses.
@@ -88,7 +107,9 @@ bug_fixes:
     fixed a bug where the wrong downstream address got sent to upstream connections.
 - area: proxy_proto
   change: |
-    fixed a bug where network filters would not have the correct ``downstreamRemoteAddress()`` when accessed from the ``StreamInfo``. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.
+    fixed a bug where network filters would not have the correct ``downstreamRemoteAddress()`` when accessed from the
+    ``StreamInfo``. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC
+    HTTP filter), or incorrect access log addresses from tcp_proxy.
 - area: sds
   change: |
     fixed a bug that clusters sharing same sds target are marked active immediately.
@@ -97,7 +118,8 @@ bug_fixes:
     fixed detection of the upstream connection close event.
 - area: tls
   change: |
-    fixed read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+    fixed read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the
+    SSL connection's internal buffers.
 - area: udp
   change: |
     fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.
@@ -108,10 +130,13 @@ bug_fixes:
 removed_config_or_runtime:
 - area: dispatcher
   change: |
-    removed legacy socket read/write resumption code path and runtime guard ``envoy.reloadable_features.activate_fds_next_event_loop``.
+    removed legacy socket read/write resumption code path and runtime guard
+    ``envoy.reloadable_features.activate_fds_next_event_loop``.
 - area: ext_authz
   change: |
-    removed auto ignore case in HTTP-based ``ext_authz`` header matching and the runtime guard ``envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher``. To ignore case, set the :ref:`ignore_case <envoy_api_field_type.matcher.StringMatcher.ignore_case>` field to true.
+    removed auto ignore case in HTTP-based ``ext_authz`` header matching and the runtime guard
+    ``envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher``. To ignore case, set the
+    :ref:`ignore_case <envoy_api_field_type.matcher.StringMatcher.ignore_case>` field to true.
 - area: ext_authz
   change: |
     the deprecated field ``use_alpha`` is no longer supported and cannot be set anymore.
@@ -125,58 +150,93 @@ removed_config_or_runtime:
 new_features:
 - area: compression
   change: |
-    the :ref:`compressor <envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>` filter added support for compressing request payloads. Its configuration is unified with the :ref:`decompressor <envoy_v3_api_msg_extensions.filters.http.decompressor.v3.Decompressor>` filter with two new fields for different directions - :ref:`requests <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.request_direction_config>` and :ref:`responses <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.response_direction_config>`. The latter deprecates the old response-specific fields and, if used, roots the response-specific stats in ``<stat_prefix>.compressor.<compressor_library.name>.<compressor_library_stat_prefix>.response.*`` instead of ``<stat_prefix>.compressor.<compressor_library.name>.<compressor_library_stat_prefix>.*``.
+    the :ref:`compressor <envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>` filter added support for
+    compressing request payloads. Its configuration is unified with the :ref:`decompressor
+    <envoy_v3_api_msg_extensions.filters.http.decompressor.v3.Decompressor>` filter with two new fields for different
+    directions - :ref:`requests
+    <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.request_direction_config>` and :ref:`responses
+    <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.response_direction_config>`. The latter deprecates
+    the old response-specific fields and, if used, roots the response-specific stats in
+    ``<stat_prefix>.compressor.<compressor_library.name>.<compressor_library_stat_prefix>.response.*`` instead of
+    ``<stat_prefix>.compressor.<compressor_library.name>.<compressor_library_stat_prefix>.*``.
 - area: config
   change: |
-    added ability to flush stats when the admin's :ref:`/stats endpoint <operations_admin_interface_stats>` is hit instead of on a timer via :ref:`stats_flush_on_admin <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.stats_flush_on_admin>`.
+    added ability to flush stats when the admin's :ref:`/stats endpoint <operations_admin_interface_stats>` is hit instead
+    of on a timer via :ref:`stats_flush_on_admin <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.stats_flush_on_admin>`.
 - area: config
   change: |
-    added new runtime feature ``envoy.features.enable_all_deprecated_features`` that allows the use of all deprecated features.
+    added new runtime feature ``envoy.features.enable_all_deprecated_features`` that allows the use of all deprecated
+    features.
 - area: crash support
   change: |
     added the ability to dump L4 connection data on crash.
 - area: formatter
   change: |
-    added new :ref:`text_format_source <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format_source>` field to support format strings both inline and from a file.
+    added new :ref:`text_format_source <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format_source>`
+    field to support format strings both inline and from a file.
 - area: formatter
   change: |
-    added support for custom date formatting to :ref:`%DOWNSTREAM_PEER_CERT_V_START% <config_access_log_format_downstream_peer_cert_v_start>` and :ref:`%DOWNSTREAM_PEER_CERT_V_END% <config_access_log_format_downstream_peer_cert_v_end>`, similar to :ref:`%START_TIME% <config_access_log_format_start_time>`.
+    added support for custom date formatting to :ref:`%DOWNSTREAM_PEER_CERT_V_START%
+    <config_access_log_format_downstream_peer_cert_v_start>` and :ref:`%DOWNSTREAM_PEER_CERT_V_END%
+    <config_access_log_format_downstream_peer_cert_v_end>`, similar to :ref:`%START_TIME%
+    <config_access_log_format_start_time>`.
 - area: grpc
   change: |
-    implemented header value syntax support when defining :ref:`initial metadata <envoy_v3_api_field_config.core.v3.GrpcService.initial_metadata>` for gRPC-based ``ext_authz`` :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>` and :ref:`network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.grpc_service>` filters, and :ref:`ratelimit <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.grpc_service>` filters.
+    implemented header value syntax support when defining :ref:`initial metadata
+    <envoy_v3_api_field_config.core.v3.GrpcService.initial_metadata>` for gRPC-based ``ext_authz`` :ref:`HTTP
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>` and :ref:`network
+    <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.grpc_service>` filters, and :ref:`ratelimit
+    <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.grpc_service>` filters.
 - area: grpc-json
   change: |
-    added support for configuring :ref:`unescaping behavior <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.url_unescape_spec>` for path components.
+    added support for configuring :ref:`unescaping behavior
+    <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.url_unescape_spec>` for path
+    components.
 - area: hds
   change: |
-    added support for delta updates in the :ref:`HealthCheckSpecifier <envoy_v3_api_msg_service.health.v3.HealthCheckSpecifier>`, making only the Endpoints and Health Checkers that changed be reconstructed on receiving a new message, rather than the entire HDS.
+    added support for delta updates in the :ref:`HealthCheckSpecifier
+    <envoy_v3_api_msg_service.health.v3.HealthCheckSpecifier>`, making only the Endpoints and Health Checkers that changed
+    be reconstructed on receiving a new message, rather than the entire HDS.
 - area: health_check
   change: |
-    added option to use :ref:`no_traffic_healthy_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_healthy_interval>` which allows a different no traffic interval when the host is healthy.
+    added option to use :ref:`no_traffic_healthy_interval
+    <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_healthy_interval>` which allows a different no traffic
+    interval when the host is healthy.
 - area: http
   change: |
-    added HCM :ref:`request_headers_timeout config field <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.request_headers_timeout>` to control how long a downstream has to finish sending headers before the stream is cancelled.
+    added HCM :ref:`request_headers_timeout config field
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.request_headers_timeout>`
+    to control how long a downstream has to finish sending headers before the stream is cancelled.
 - area: http
   change: |
-    added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the ``envoy.reloadable_features.upstream_http2_flood_checks`` runtime key to true.
+    added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by
+    setting the ``envoy.reloadable_features.upstream_http2_flood_checks`` runtime key to true.
 - area: http
   change: |
-    added :ref:`stripping any port from host header <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_any_host_port>` support.
+    added :ref:`stripping any port from host header
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_any_host_port>`
+    support.
 - area: http
   change: |
-    clusters added support for selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
+    clusters added support for selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config
+    <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options
+    <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 - area: jwt_authn
   change: |
     added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
 - area: jwt_authn
   change: |
-    changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT `RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ requirements.
+    changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be
+    optional to comply with JWT `RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ requirements.
 - area: kill_request
   change: |
     added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 - area: listener
   change: |
-    added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
+    added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If
+    this field is supplied, and none of the :ref:`filter_chains
+    <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the
+    connection.
 - area: listener
   change: |
     added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.
@@ -188,25 +248,35 @@ new_features:
     added a new custom flag ``%_`` to the log pattern to print the actual message to log, but with escaped newlines.
 - area: lua
   change: |
-    added ``downstreamDirectRemoteAddress()`` and ``downstreamLocalAddress()`` APIs to :ref:`streamInfo() <config_http_filters_lua_stream_info_wrapper>`.
+    added ``downstreamDirectRemoteAddress()`` and ``downstreamLocalAddress()`` APIs to :ref:`streamInfo()
+    <config_http_filters_lua_stream_info_wrapper>`.
 - area: mongo_proxy
   change: |
-    the list of commands to produce metrics for is now :ref:`configurable <envoy_v3_api_field_extensions.filters.network.mongo_proxy.v3.MongoProxy.commands>`.
+    the list of commands to produce metrics for is now :ref:`configurable
+    <envoy_v3_api_field_extensions.filters.network.mongo_proxy.v3.MongoProxy.commands>`.
 - area: network
   change: |
-    added a :ref:`transport_socket_connect_timeout config field <envoy_v3_api_field_config.listener.v3.FilterChain.transport_socket_connect_timeout>` for incoming connections completing transport-level negotiation, including TLS and ALTS hanshakes.
+    added a :ref:`transport_socket_connect_timeout config field
+    <envoy_v3_api_field_config.listener.v3.FilterChain.transport_socket_connect_timeout>` for incoming connections
+    completing transport-level negotiation, including TLS and ALTS hanshakes.
 - area: overload
   change: |
-    added :ref:`envoy.overload_actions.reduce_timeouts <config_overload_manager_overload_actions>` overload action to enable scaling timeouts down with load. Scaling support :ref:`is limited <envoy_v3_api_enum_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType>` to the HTTP connection and stream idle timeouts.
+    added :ref:`envoy.overload_actions.reduce_timeouts <config_overload_manager_overload_actions>` overload action to enable
+    scaling timeouts down with load. Scaling support :ref:`is limited
+    <envoy_v3_api_enum_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType>` to the HTTP connection and stream idle
+    timeouts.
 - area: ratelimit
   change: |
-    added support for use of various :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` as a ratelimit action.
+    added support for use of various :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` as a
+    ratelimit action.
 - area: ratelimit
   change: |
-    added :ref:`disable_x_envoy_ratelimited_header <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option to disable ``X-Envoy-RateLimited`` header.
+    added :ref:`disable_x_envoy_ratelimited_header <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option
+    to disable ``X-Envoy-RateLimited`` header.
 - area: ratelimit
   change: |
-    added :ref:`body <envoy_v3_api_field_service.ratelimit.v3.RateLimitResponse.raw_body>` field to support custom response bodies for non-OK responses from the external ratelimit service.
+    added :ref:`body <envoy_v3_api_field_service.ratelimit.v3.RateLimitResponse.raw_body>` field to support custom response
+    bodies for non-OK responses from the external ratelimit service.
 - area: ratelimit
   change: |
     added :ref:`descriptor extensions <envoy_v3_api_field_config.route.v3.RateLimit.Action.extension>`.
@@ -215,27 +285,35 @@ new_features:
     added :ref:`computed descriptors <envoy_v3_api_msg_extensions.rate_limit_descriptors.expr.v3.Descriptor>`.
 - area: ratelimit
   change: |
-    added :ref:`dynamic_metadata <envoy_v3_api_field_service.ratelimit.v3.RateLimitResponse.dynamic_metadata>` field to support setting dynamic metadata from the ratelimit service.
+    added :ref:`dynamic_metadata <envoy_v3_api_field_service.ratelimit.v3.RateLimitResponse.dynamic_metadata>` field to
+    support setting dynamic metadata from the ratelimit service.
 - area: router
   change: |
-    added support for regex rewrites during HTTP redirects using :ref:`regex_rewrite <envoy_v3_api_field_config.route.v3.RedirectAction.regex_rewrite>`.
+    added support for regex rewrites during HTTP redirects using :ref:`regex_rewrite
+    <envoy_v3_api_field_config.route.v3.RedirectAction.regex_rewrite>`.
 - area: sds
   change: |
     improved support for atomic :ref:`key rotations <xds_certificate_rotation>` and added configurable rotation triggers for
     :ref:`TlsCertificate <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.watched_directory>` and
-    :ref:`CertificateValidationContext <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.watched_directory>`.
+    :ref:`CertificateValidationContext
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.watched_directory>`.
 - area: signal
   change: |
-    added an extension point for custom actions to run on the thread that has encountered a fatal error. Actions are configurable via :ref:`fatal_actions <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.fatal_actions>`.
+    added an extension point for custom actions to run on the thread that has encountered a fatal error. Actions are
+    configurable via :ref:`fatal_actions <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.fatal_actions>`.
 - area: start_tls
   change: |
-    added new :ref:`transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.StartTlsConfig>` which starts in clear-text but may programatically be converted to use tls.
+    added new :ref:`transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.StartTlsConfig>` which
+    starts in clear-text but may programatically be converted to use tls.
 - area: tcp
   change: |
-    added a new :ref:`envoy.overload_actions.reject_incoming_connections <config_overload_manager_overload_actions>` action to reject incoming TCP connections.
+    added a new :ref:`envoy.overload_actions.reject_incoming_connections <config_overload_manager_overload_actions>` action
+    to reject incoming TCP connections.
 - area: thrift_proxy
   change: |
-    added a new :ref:`payload_passthrough <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.payload_passthrough>` option to skip decoding body in the Thrift message.
+    added a new :ref:`payload_passthrough
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.payload_passthrough>` option to skip decoding
+    body in the Thrift message.
 - area: tls
   change: |
     added support for RSA certificates with 4096-bit keys in FIPS mode.
@@ -244,36 +322,67 @@ new_features:
     added :ref:`SkyWalking tracer <envoy_v3_api_msg_config.trace.v3.SkyWalkingConfig>`.
 - area: tracing
   change: |
-    added support for setting the hostname used when sending spans to a Zipkin collector using the :ref:`collector_hostname <envoy_v3_api_field_config.trace.v3.ZipkinConfig.collector_hostname>` field.
+    added support for setting the hostname used when sending spans to a Zipkin collector using the :ref:`collector_hostname
+    <envoy_v3_api_field_config.trace.v3.ZipkinConfig.collector_hostname>` field.
 - area: xds
   change: |
-    added support for resource TTLs. A TTL is specified on the :ref:`Resource <envoy_api_msg_Resource>`. For SotW, a :ref:`Resource <envoy_api_msg_Resource>` can be embedded in the list of resources to specify the TTL.
+    added support for resource TTLs. A TTL is specified on the :ref:`Resource <envoy_api_msg_Resource>`. For SotW, a
+    :ref:`Resource <envoy_api_msg_Resource>` can be embedded in the list of resources to specify the TTL.
 
 deprecated:
 - area: cluster
   change: |
-    HTTP configuration for upstream clusters has been reworked. HTTP-specific configuration is now done in the new :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message, configured via the cluster's :ref:`extension_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`. This replaces explicit HTTP configuration in cluster config, including :ref:`upstream_http_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_http_protocol_options>` :ref:`common_http_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.common_http_protocol_options>` :ref:`http_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.http_protocol_options>` :ref:`http2_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.http2_protocol_options>` and :ref:`protocol_selection <envoy_v3_api_field_config.cluster.v3.Cluster.protocol_selection>`. Examples of before-and-after configuration can be found in the :ref:`http_protocol_options docs <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` and all of Envoy's example configurations have been updated to the new style of config.
+    HTTP configuration for upstream clusters has been reworked. HTTP-specific configuration is now done in the new
+    :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message, configured via
+    the cluster's :ref:`extension_protocol_options
+    <envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`. This replaces explicit HTTP
+    configuration in cluster config, including :ref:`upstream_http_protocol_options
+    <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_http_protocol_options>` :ref:`common_http_protocol_options
+    <envoy_v3_api_field_config.cluster.v3.Cluster.common_http_protocol_options>` :ref:`http_protocol_options
+    <envoy_v3_api_field_config.cluster.v3.Cluster.http_protocol_options>` :ref:`http2_protocol_options
+    <envoy_v3_api_field_config.cluster.v3.Cluster.http2_protocol_options>` and :ref:`protocol_selection
+    <envoy_v3_api_field_config.cluster.v3.Cluster.protocol_selection>`. Examples of before-and-after configuration can be
+    found in the :ref:`http_protocol_options docs <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` and
+    all of Envoy's example configurations have been updated to the new style of config.
 - area: compression
   change: |
-    the fields :ref:`content_length <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.content_length>`, :ref:`content_type <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.content_type>`, :ref:`disable_on_etag_header <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.disable_on_etag_header>`, :ref:`remove_accept_encoding_header <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.remove_accept_encoding_header>` and :ref:`runtime_enabled <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.runtime_enabled>` of the :ref:`Compressor <envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>` message have been deprecated in favor of :ref:`response_direction_config <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.response_direction_config>`.
+    the fields :ref:`content_length <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.content_length>`,
+    :ref:`content_type <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.content_type>`,
+    :ref:`disable_on_etag_header
+    <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.disable_on_etag_header>`,
+    :ref:`remove_accept_encoding_header
+    <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.remove_accept_encoding_header>` and
+    :ref:`runtime_enabled <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.runtime_enabled>` of the
+    :ref:`Compressor <envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>` message have been deprecated in
+    favor of :ref:`response_direction_config
+    <envoy_v3_api_field_extensions.filters.http.compressor.v3.Compressor.response_direction_config>`.
 - area: formatter
   change: |
-    :ref:`text_format <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format>` is now deprecated in favor of :ref:`text_format_source <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format_source>`. To migrate existing text format strings, use the :ref:`inline_string <envoy_v3_api_field_config.core.v3.DataSource.inline_string>` field.
+    :ref:`text_format <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format>` is now deprecated in favor
+    of :ref:`text_format_source <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.text_format_source>`. To migrate
+    existing text format strings, use the :ref:`inline_string <envoy_v3_api_field_config.core.v3.DataSource.inline_string>`
+    field.
 - area: gzip
   change: |
-    :ref:`HTTP Gzip filter <config_http_filters_gzip>` is rejected now unless explicitly allowed with :ref:`runtime override <config_runtime_deprecation>` ``envoy.deprecated_features.allow_deprecated_gzip_http_filter`` set to ``true``. Use the :ref:`compressor filter <config_http_filters_compressor>`.
+    :ref:`HTTP Gzip filter <config_http_filters_gzip>` is rejected now unless explicitly allowed with :ref:`runtime override
+    <config_runtime_deprecation>` ``envoy.deprecated_features.allow_deprecated_gzip_http_filter`` set to ``true``. Use the
+    :ref:`compressor filter <config_http_filters_compressor>`.
 - area: listener
   change: |
-    :ref:`use_proxy_proto <envoy_v3_api_field_config.listener.v3.FilterChain.use_proxy_proto>` has been deprecated in favor of adding a :ref:`PROXY protocol listener filter <config_listener_filters_proxy_protocol>` explicitly.
+    :ref:`use_proxy_proto <envoy_v3_api_field_config.listener.v3.FilterChain.use_proxy_proto>` has been deprecated in favor
+    of adding a :ref:`PROXY protocol listener filter <config_listener_filters_proxy_protocol>` explicitly.
 - area: logging
   change: |
     the ``--log-format-prefix-with-location`` option is removed.
 - area: ratelimit
   change: |
-    the :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` action is deprecated in favor of the more generic :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` action.
+    the :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` action is deprecated
+    in favor of the more generic :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` action.
 - area: stats
   change: |
     the ``--use-fake-symbol-table`` option is removed.
 - area: tracing
   change: |
-    OpenCensus :ref:`Zipkin configuration <envoy_api_field_config.trace.v2.OpenCensusConfig.zipkin_exporter_enabled>` is now deprecated, the preferred Zipkin export is via Envoy's :ref:`native Zipkin tracer <envoy_v3_api_msg_config.trace.v3.ZipkinConfig>`.
+    OpenCensus :ref:`Zipkin configuration <envoy_api_field_config.trace.v2.OpenCensusConfig.zipkin_exporter_enabled>` is now
+    deprecated, the preferred Zipkin export is via Envoy's :ref:`native Zipkin tracer
+    <envoy_v3_api_msg_config.trace.v3.ZipkinConfig>`.

--- a/changelogs/1.17.1.yaml
+++ b/changelogs/1.17.1.yaml
@@ -3,7 +3,8 @@ date: February 25, 2021
 bug_fixes:
 - area: jwt_authn
   change: |
-    reject requests with a proper error if JWT has the wrong issuer when allow_missing is used. Before this change, the requests are accepted.
+    reject requests with a proper error if JWT has the wrong issuer when allow_missing is used. Before this change, the
+    requests are accepted.
 - area: overload
   change: |
     fix a bug that can cause use-after-free when one scaled timer disables another one with the same duration.

--- a/changelogs/1.17.2.yaml
+++ b/changelogs/1.17.2.yaml
@@ -3,13 +3,16 @@ date: April 15, 2021
 bug_fixes:
 - area: http
   change: |
-    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
+    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2
+    codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
 - area: http
   change: |
     fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
 - area: http
   change: |
-    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
+    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection
+    failures. The change back to the original behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
 - area: tls
   change: |
     fix a crash when peer sends a TLS Alert with an unknown code.
@@ -17,4 +20,5 @@ bug_fixes:
 new_features:
 - area: dispatcher
   change: |
-    supports a stack of ``Envoy::ScopeTrackedObject`` instead of a single tracked object. This will allow Envoy to dump more debug information on crash.
+    supports a stack of ``Envoy::ScopeTrackedObject`` instead of a single tracked object. This will allow Envoy to dump more
+    debug information on crash.

--- a/changelogs/1.17.3.yaml
+++ b/changelogs/1.17.3.yaml
@@ -3,4 +3,11 @@ date: May 11, 2021
 new_features:
 - area: http
   change: |
-    added the ability to :ref:`unescape slash sequences <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>` in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By default this feature is disabled. The default behavior can be overridden through :ref:`http_connection_manager.path_with_escaped_slashes_action <config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling <config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.
+    added the ability to :ref:`unescape slash sequences
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>`
+    in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By
+    default this feature is disabled. The default behavior can be overridden through
+    :ref:`http_connection_manager.path_with_escaped_slashes_action
+    <config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively
+    enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling
+    <config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.

--- a/changelogs/1.17.4.yaml
+++ b/changelogs/1.17.4.yaml
@@ -3,21 +3,24 @@ date: August 24, 2021
 minor_behavior_changes:
 - area: http
   change: |
-    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request
-    URI according to RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed
-    to stripping the \#fragment instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment``
-    to false. This behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
-    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set
-    to false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
-    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the standard deprecation period.
+    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request URI according to
+    RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed to stripping the \#fragment
+    instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment`` to false. This
+    behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
+    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set to
+    false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
+    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the
+    standard deprecation period.
 
 bug_fixes:
 - area: ext_authz
   change: |
-    fix the ext_authz filter to correctly merge multiple same headers using the ``,`` as separator in the check request to the external authorization service.
+    fix the ext_authz filter to correctly merge multiple same headers using the ``,`` as separator in the check request to
+    the external authorization service.
 - area: http
   change: |
-    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections can result in incorrect behavior and performance problems.
+    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections
+    can result in incorrect behavior and performance problems.
 - area: jwt_authn
   change: |
     unauthorized responses now correctly include a ``www-authenticate`` header.
@@ -25,4 +28,6 @@ bug_fixes:
 new_features:
 - area: listener
   change: |
-    added an option when balancing across active listeners and wildcard matching is used to return the listener that matches the IP family type associated with the listener's socket address. It is off by default, but is turned on by default in v1.19. To set change the runtime guard ``envoy.reloadable_features.listener_wildcard_match_ip_family`` to true.
+    added an option when balancing across active listeners and wildcard matching is used to return the listener that matches
+    the IP family type associated with the listener's socket address. It is off by default, but is turned on by default in
+    v1.19. To set change the runtime guard ``envoy.reloadable_features.listener_wildcard_match_ip_family`` to true.

--- a/changelogs/1.18.0.yaml
+++ b/changelogs/1.18.0.yaml
@@ -6,208 +6,260 @@ behavior_changes:
     the v2 xDS API is no longer supported by the Envoy binary.
 - area: grpc_stats
   change: |
-    the default value for :ref:`stats_for_all_methods <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_methods>` is switched from true to false, in order to avoid possible memory exhaustion due to an untrusted downstream sending a large number of unique method names. The previous default value was deprecated in version 1.14.0. This only changes the behavior when the value is not set. The previous behavior can be used by setting the value to true. This behavior change by be overridden by setting runtime feature ``envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default``.
+    the default value for :ref:`stats_for_all_methods
+    <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_methods>` is switched from true to
+    false, in order to avoid possible memory exhaustion due to an untrusted downstream sending a large number of unique
+    method names. The previous default value was deprecated in version 1.14.0. This only changes the behavior when the value
+    is not set. The previous behavior can be used by setting the value to true. This behavior change by be overridden by
+    setting runtime feature ``envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default``.
 - area: http
   change: |
-    fixing a standards compliance issue with :scheme. The :scheme header sent upstream is now based on the original URL scheme, rather than set based on the security of the upstream connection. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.preserve_downstream_scheme`` to false.
+    fixing a standards compliance issue with :scheme. The :scheme header sent upstream is now based on the original URL
+    scheme, rather than set based on the security of the upstream connection. This behavior can be temporarily reverted by
+    setting ``envoy.reloadable_features.preserve_downstream_scheme`` to false.
 - area: http
   change: |
-    http3 is now enabled/disabled via build option ``--define http3=disabled`` rather than the extension framework. The behavior is the same, but builds may be affected for platforms or build configurations where http3 is not supported.
+    http3 is now enabled/disabled via build option ``--define http3=disabled`` rather than the extension framework. The
+    behavior is the same, but builds may be affected for platforms or build configurations where http3 is not supported.
 - area: http
   change: |
-    resolving inconsistencies between :scheme and X-Forwarded-Proto. :scheme will now be set for all HTTP/1.1 requests. This changes the behavior of the gRPC access logger, Wasm filters, CSRF filter and oath2 filter for HTTP/1 traffic, where :scheme was previously not set. This change also validates that for front-line Envoys (Envoys configured with  :ref:`xff_num_trusted_hops <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>` set to 0 and :ref:`use_remote_address <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.use_remote_address>` set to true) that HTTP/1.1 https schemed requests can not be sent over non-TLS connections. All behavioral changes listed here can be temporarily reverted by setting ``envoy.reloadable_features.add_and_validate_scheme_header`` to false.
+    resolving inconsistencies between :scheme and X-Forwarded-Proto. :scheme will now be set for all HTTP/1.1 requests. This
+    changes the behavior of the gRPC access logger, Wasm filters, CSRF filter and oath2 filter for HTTP/1 traffic, where
+    :scheme was previously not set. This change also validates that for front-line Envoys (Envoys configured with
+    :ref:`xff_num_trusted_hops
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>`
+    set to 0 and :ref:`use_remote_address
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.use_remote_address>` set
+    to true) that HTTP/1.1 https schemed requests can not be sent over non-TLS connections. All behavioral changes listed
+    here can be temporarily reverted by setting ``envoy.reloadable_features.add_and_validate_scheme_header`` to false.
 - area: http
   change: |
-    when a protocol error is detected in response from upstream, Envoy sends 502 BadGateway downstream and access log entry contains UPE flag. This behavior change can be overwritten to use error code 503 by setting ``envoy.reloadable_features.return_502_for_upstream_protocol_errors`` to false.
+    when a protocol error is detected in response from upstream, Envoy sends 502 BadGateway downstream and access log entry
+    contains UPE flag. This behavior change can be overwritten to use error code 503 by setting
+    ``envoy.reloadable_features.return_502_for_upstream_protocol_errors`` to false.
 
 minor_behavior_changes:
 - area: access_logs
   change: |
-    change command operator %UPSTREAM_CLUSTER% to resolve to :ref:`alt_stat_name <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` if provided. This behavior can be reverted by disabling the runtime feature ``envoy.reloadable_features.use_observable_cluster_name``.
+    change command operator %UPSTREAM_CLUSTER% to resolve to :ref:`alt_stat_name
+    <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` if provided. This behavior can be reverted by disabling
+    the runtime feature ``envoy.reloadable_features.use_observable_cluster_name``.
 - area: access_logs
   change: |
     fix substition formatter to recognize commands ending with an integer such as DOWNSTREAM_PEER_FINGERPRINT_256.
 - area: access_logs
   change: |
-    set the error flag ``NC`` for ``no cluster found`` instead of ``NR`` if the route is found but the corresponding cluster is not available.
+    set the error flag ``NC`` for ``no cluster found`` instead of ``NR`` if the route is found but the corresponding cluster
+    is not available.
 - area: admin
   change: |
-    added :ref:`observability_name <envoy_v3_api_field_admin.v3.ClusterStatus.observability_name>` information to GET /clusters?format=json :ref:`cluster status <envoy_v3_api_msg_admin.v3.ClusterStatus>`.
+    added :ref:`observability_name <envoy_v3_api_field_admin.v3.ClusterStatus.observability_name>` information to GET
+    /clusters?format=json :ref:`cluster status <envoy_v3_api_msg_admin.v3.ClusterStatus>`.
 - area: dns
   change: |
-    both the :ref:`strict DNS <arch_overview_service_discovery_types_strict_dns>` and
-    :ref:`logical DNS <arch_overview_service_discovery_types_logical_dns>` cluster types now honor the
-    :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>` field if not empty.
-    Previously resolved hosts would have their hostname set to the configured DNS address for use with
-    logging, :ref:`auto_host_rewrite <envoy_api_field_route.RouteAction.auto_host_rewrite>`, etc.
-    Setting the hostname manually allows overriding the internal hostname used for such features while
-    still allowing the original DNS resolution name to be used.
+    both the :ref:`strict DNS <arch_overview_service_discovery_types_strict_dns>` and :ref:`logical DNS
+    <arch_overview_service_discovery_types_logical_dns>` cluster types now honor the :ref:`hostname
+    <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>` field if not empty. Previously resolved hosts would have
+    their hostname set to the configured DNS address for use with logging, :ref:`auto_host_rewrite
+    <envoy_api_field_route.RouteAction.auto_host_rewrite>`, etc. Setting the hostname manually allows overriding the
+    internal hostname used for such features while still allowing the original DNS resolution name to be used.
 - area: grpc_json_transcoder
   change: |
-    the filter now adheres to encoder and decoder buffer limits. Requests and responses
-    that require buffering over the limits will be directly rejected. The behavior can be reverted by
-    disabling runtime feature ``envoy.reloadable_features.grpc_json_transcoder_adhere_to_buffer_limits``.
-    To reduce or increase the buffer limits the filter adheres to, reference the :ref:`flow control documentation <faq_flow_control>`.
+    the filter now adheres to encoder and decoder buffer limits. Requests and responses that require buffering over the
+    limits will be directly rejected. The behavior can be reverted by disabling runtime feature
+    ``envoy.reloadable_features.grpc_json_transcoder_adhere_to_buffer_limits``. To reduce or increase the buffer limits the
+    filter adheres to, reference the :ref:`flow control documentation <faq_flow_control>`.
 - area: hds
   change: |
-    support custom health check port via :ref:`health_check_config <envoy_v3_api_msg_config.endpoint.v3.endpoint.healthcheckconfig>`.
+    support custom health check port via :ref:`health_check_config
+    <envoy_v3_api_msg_config.endpoint.v3.endpoint.healthcheckconfig>`.
 - area: healthcheck
   change: |
-    the :ref:`health check filter <config_http_filters_health_check>` now sends the
-    :ref:`x-envoy-immediate-health-check-fail <config_http_filters_router_x-envoy-immediate-health-check-fail>` header
-    for all responses when Envoy is in the health check failed state. Additionally, receiving the
-    :ref:`x-envoy-immediate-health-check-fail <config_http_filters_router_x-envoy-immediate-health-check-fail>`
-    header (either in response to normal traffic or in response to an HTTP :ref:`active health check <arch_overview_health_checking>`) will
-    cause Envoy to immediately :ref:`exclude <arch_overview_load_balancing_excluded>` the host from
-    load balancing calculations. This has the useful property that such hosts, which are being
-    explicitly told to disable traffic, will not be counted for panic routing calculations. See the
-    excluded documentation for more information. This behavior can be temporarily reverted by setting
-    the ``envoy.reloadable_features.health_check.immediate_failure_exclude_from_cluster`` feature flag
-    to false. Note that the runtime flag covers *both* the health check filter responding with
-    ``x-envoy-immediate-health-check-fail`` in all cases (versus just non-HC requests) as well as
-    whether receiving ``x-envoy-immediate-health-check-fail`` will cause exclusion or not. Thus,
-    depending on the Envoy deployment, the feature flag may need to be flipped on both downstream
+    the :ref:`health check filter <config_http_filters_health_check>` now sends the :ref:`x-envoy-immediate-health-check-
+    fail <config_http_filters_router_x-envoy-immediate-health-check-fail>` header for all responses when Envoy is in the
+    health check failed state. Additionally, receiving the :ref:`x-envoy-immediate-health-check-fail
+    <config_http_filters_router_x-envoy-immediate-health-check-fail>` header (either in response to normal traffic or in
+    response to an HTTP :ref:`active health check <arch_overview_health_checking>`) will cause Envoy to immediately
+    :ref:`exclude <arch_overview_load_balancing_excluded>` the host from load balancing calculations. This has the useful
+    property that such hosts, which are being explicitly told to disable traffic, will not be counted for panic routing
+    calculations. See the excluded documentation for more information. This behavior can be temporarily reverted by setting
+    the ``envoy.reloadable_features.health_check.immediate_failure_exclude_from_cluster`` feature flag to false. Note that
+    the runtime flag covers *both* the health check filter responding with ``x-envoy-immediate-health-check-fail`` in all
+    cases (versus just non-HC requests) as well as whether receiving ``x-envoy-immediate-health-check-fail`` will cause
+    exclusion or not. Thus, depending on the Envoy deployment, the feature flag may need to be flipped on both downstream
     and upstream instances, depending on the reason.
 - area: http
   change: |
-    added support for internal redirects with bodies. This behavior can be disabled temporarily by setting ``envoy.reloadable_features.internal_redirects_with_body`` to false.
+    added support for internal redirects with bodies. This behavior can be disabled temporarily by setting
+    ``envoy.reloadable_features.internal_redirects_with_body`` to false.
 - area: http
   change: |
     increase the maximum allowed number of initial connection WINDOW_UPDATE frames sent by the peer from 1 to 5.
 - area: http
   change: |
-    no longer adding content-length: 0 for requests which should not have bodies. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.dont_add_content_length_for_bodiless_requests`` false.
+    no longer adding content-length: 0 for requests which should not have bodies. This behavior can be temporarily reverted
+    by setting ``envoy.reloadable_features.dont_add_content_length_for_bodiless_requests`` false.
 - area: http
   change: |
-    switched the path canonicalizer to `googleurl <https://quiche.googlesource.com/googleurl>`_
-    instead of ``//source/common/chromium_url``. The new path canonicalizer is enabled by default. To
-    revert to the legacy path canonicalizer, enable the runtime flag
-    ``envoy.reloadable_features.remove_forked_chromium_url``.
+    switched the path canonicalizer to `googleurl <https://quiche.googlesource.com/googleurl>`_ instead of
+    ``//source/common/chromium_url``. The new path canonicalizer is enabled by default. To revert to the legacy path
+    canonicalizer, enable the runtime flag ``envoy.reloadable_features.remove_forked_chromium_url``.
 - area: http
   change: |
-    upstream flood and abuse checks now increment the count of opened HTTP/2 streams when Envoy sends
-    initial HEADERS frame for the new stream. Before the counter was incrementred when Envoy received
-    response HEADERS frame with the END_HEADERS flag set from upstream server.
+    upstream flood and abuse checks now increment the count of opened HTTP/2 streams when Envoy sends initial HEADERS frame
+    for the new stream. Before the counter was incrementred when Envoy received response HEADERS frame with the END_HEADERS
+    flag set from upstream server.
 - area: lua
   change: |
-    added function ``timestamp`` to provide millisecond resolution timestamps by passing in ``EnvoyTimestampResolution.MILLISECOND``.
+    added function ``timestamp`` to provide millisecond resolution timestamps by passing in
+    ``EnvoyTimestampResolution.MILLISECOND``.
 - area: oauth filter
   change: |
-    added the optional parameter :ref:`auth_scopes <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.auth_scopes>` with default value of 'user' if not provided. This allows this value to be overridden in the Authorization request to the OAuth provider.
+    added the optional parameter :ref:`auth_scopes
+    <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.auth_scopes>` with default value of 'user' if
+    not provided. This allows this value to be overridden in the Authorization request to the OAuth provider.
 - area: perf
   change: |
     allow reading more bytes per operation from raw sockets to improve performance.
 - area: router
   change: |
-    extended custom date formatting to DOWNSTREAM_PEER_CERT_V_START and DOWNSTREAM_PEER_CERT_V_END when using :ref:`custom request/response header formats <config_http_conn_man_headers_custom_request_headers>`.
+    extended custom date formatting to DOWNSTREAM_PEER_CERT_V_START and DOWNSTREAM_PEER_CERT_V_END when using :ref:`custom
+    request/response header formats <config_http_conn_man_headers_custom_request_headers>`.
 - area: router
   change: |
-    made the path rewrite available without finalizing headers, so the filter could calculate the current value of the final url.
+    made the path rewrite available without finalizing headers, so the filter could calculate the current value of the final
+    url.
 - area: tracing
   change: |
-    added ``upstream_cluster.name`` tag that resolves to resolve to :ref:`alt_stat_name <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` if provided (and otherwise the cluster name).
+    added ``upstream_cluster.name`` tag that resolves to resolve to :ref:`alt_stat_name
+    <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` if provided (and otherwise the cluster name).
 - area: udp
   change: |
-    configuration has been added for :ref:`GRO <envoy_v3_api_field_config.core.v3.UdpSocketConfig.prefer_gro>`
-    which used to be force enabled if the OS supports it. The default is now disabled for server
-    sockets and enabled for client sockets (see the new features section for links).
+    configuration has been added for :ref:`GRO <envoy_v3_api_field_config.core.v3.UdpSocketConfig.prefer_gro>` which used to
+    be force enabled if the OS supports it. The default is now disabled for server sockets and enabled for client sockets
+    (see the new features section for links).
 - area: upstream
   change: |
-    host weight changes now cause a full load balancer rebuild as opposed to happening
-    atomically inline. This change has been made to support load balancer pre-computation of data
-    structures based on host weight, but may have performance implications if host weight changes
-    are very frequent. This change can be disabled by setting the ``envoy.reloadable_features.upstream_host_weight_change_causes_rebuild``
-    feature flag to false. If setting this flag to false is required in a deployment please open an
-    issue against the project.
+    host weight changes now cause a full load balancer rebuild as opposed to happening atomically inline. This change has
+    been made to support load balancer pre-computation of data structures based on host weight, but may have performance
+    implications if host weight changes are very frequent. This change can be disabled by setting the
+    ``envoy.reloadable_features.upstream_host_weight_change_causes_rebuild`` feature flag to false. If setting this flag to
+    false is required in a deployment please open an issue against the project.
 
 bug_fixes:
 - area: active http health checks
   change: |
-    properly handles HTTP/2 GOAWAY frames from the upstream. Previously a GOAWAY frame due to a graceful listener drain could cause improper failed health checks due to streams being refused by the upstream on a connection that is going away. To revert to old GOAWAY handling behavior, set the runtime feature ``envoy.reloadable_features.health_check.graceful_goaway_handling`` to false.
+    properly handles HTTP/2 GOAWAY frames from the upstream. Previously a GOAWAY frame due to a graceful listener drain
+    could cause improper failed health checks due to streams being refused by the upstream on a connection that is going
+    away. To revert to old GOAWAY handling behavior, set the runtime feature
+    ``envoy.reloadable_features.health_check.graceful_goaway_handling`` to false.
 - area: adaptive concurrency
   change: |
     fixed a bug where concurrent requests on different worker threads could update minRTT back-to-back.
 - area: buffer
   change: |
-    tighten network connection read and write buffer high watermarks in preparation to more careful enforcement of read limits. Buffer high-watermark is now set to the exact configured value; previously it was set to value + 1.
+    tighten network connection read and write buffer high watermarks in preparation to more careful enforcement of read
+    limits. Buffer high-watermark is now set to the exact configured value; previously it was set to value + 1.
 - area: cdn_loop
   change: |
-    check that the entirety of the :ref:`cdn_id <envoy_v3_api_field_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig.cdn_id>` field is a valid CDN identifier.
+    check that the entirety of the :ref:`cdn_id
+    <envoy_v3_api_field_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig.cdn_id>` field is a valid CDN identifier.
 - area: cds
   change: |
     fix blocking the update for a warming cluster when the update is the same as the active version.
 - area: ext_authz
   change: |
-    emit :ref:`CheckResponse.dynamic_metadata <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` when the external authorization response has "Denied" check status.
+    emit :ref:`CheckResponse.dynamic_metadata <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` when the
+    external authorization response has "Denied" check status.
 - area: fault injection
   change: |
-    stop counting as active fault after delay elapsed. Previously fault injection filter continues to count the injected delay as an active fault even after it has elapsed. This produces incorrect output statistics and impacts the max number of consecutive faults allowed (e.g., for long-lived streams). This change decreases the active fault count when the delay fault is the only active and has gone finished.
+    stop counting as active fault after delay elapsed. Previously fault injection filter continues to count the injected
+    delay as an active fault even after it has elapsed. This produces incorrect output statistics and impacts the max number
+    of consecutive faults allowed (e.g., for long-lived streams). This change decreases the active fault count when the
+    delay fault is the only active and has gone finished.
 - area: filter_chain
   change: |
     fix filter chain matching with the server name as the case-insensitive way.
 - area: grpc-web
   change: |
-    fix local reply and non-proto-encoded gRPC response handling for small response bodies. This fix can be temporarily reverted by setting ``envoy.reloadable_features.grpc_web_fix_non_proto_encoded_response_handling`` to false.
+    fix local reply and non-proto-encoded gRPC response handling for small response bodies. This fix can be temporarily
+    reverted by setting ``envoy.reloadable_features.grpc_web_fix_non_proto_encoded_response_handling`` to false.
 - area: grpc_http_bridge
   change: |
     the downstream HTTP status is now correctly set for trailers-only responses from the upstream.
 - area: header map
   change: |
-    pick the right delimiter to append multiple header values to the same key. Previouly header with multiple values were coalesced with ",", after this fix cookie headers should be coalesced with " ;". This doesn't affect Http1 or Http2 requests because these 2 codecs coalesce cookie headers before adding it to header map. To revert to the old behavior, set the runtime feature ``envoy.reloadable_features.header_map_correctly_coalesce_cookies`` to false.
+    pick the right delimiter to append multiple header values to the same key. Previouly header with multiple values were
+    coalesced with ",", after this fix cookie headers should be coalesced with " ;". This doesn't affect Http1 or Http2
+    requests because these 2 codecs coalesce cookie headers before adding it to header map. To revert to the old behavior,
+    set the runtime feature ``envoy.reloadable_features.header_map_correctly_coalesce_cookies`` to false.
 - area: http
   change: |
     avoid grpc-status overwrite on when sending local replies if that field has already been set.
 - area: http
   change: |
-    disallowing "host:" in request_headers_to_add for behavioral consistency with rejecting :authority header. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.treat_host_like_authority`` to false.
+    disallowing "host:" in request_headers_to_add for behavioral consistency with rejecting :authority header. This behavior
+    can be temporarily reverted by setting ``envoy.reloadable_features.treat_host_like_authority`` to false.
 - area: http
   change: |
-    fixed an issue where Envoy did not handle peer stream limits correctly, and queued streams in nghttp2 rather than establish new connections. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.improved_stream_limit_handling`` to false.
+    fixed an issue where Envoy did not handle peer stream limits correctly, and queued streams in nghttp2 rather than
+    establish new connections. This behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.improved_stream_limit_handling`` to false.
 - area: http
   change: |
-    fixed a bug where setting :ref:`MaxStreamDuration proto <envoy_v3_api_msg_config.route.v3.RouteAction.MaxStreamDuration>` did not disable legacy timeout defaults.
+    fixed a bug where setting :ref:`MaxStreamDuration proto
+    <envoy_v3_api_msg_config.route.v3.RouteAction.MaxStreamDuration>` did not disable legacy timeout defaults.
 - area: http
   change: |
-    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
+    fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2
+    codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
 - area: http
   change: |
     fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
 - area: http
   change: |
-    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
+    reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection
+    failures. The change back to the original behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure`` to false.
 - area: jwt_authn
   change: |
-    reject requests with a proper error if JWT has the wrong issuer when allow_missing is used. Before this change, the requests are accepted.
+    reject requests with a proper error if JWT has the wrong issuer when allow_missing is used. Before this change, the
+    requests are accepted.
 - area: listener
   change: |
     prevent crashing when an unknown listener config proto is received and debug logging is enabled.
 - area: mysql_filter
   change: |
-    improve the codec ability of mysql filter at connection phase, it can now decode MySQL5.7+ connection phase protocol packet.
+    improve the codec ability of mysql filter at connection phase, it can now decode MySQL5.7+ connection phase protocol
+    packet.
 - area: overload
   change: |
     fix a bug that can cause use-after-free when one scaled timer disables another one with the same duration.
 - area: sni
   change: |
-    as the server name in sni should be case-insensitive, envoy will convert the server name as lower case first before any other process inside envoy.
+    as the server name in sni should be case-insensitive, envoy will convert the server name as lower case first before any
+    other process inside envoy.
 - area: tls
   change: |
     fix a crash when peer sends a TLS Alert with an unknown code.
 - area: tls
   change: |
-    fix the subject alternative name of the presented certificate matches the specified matchers as the case-insensitive way when it uses DNS name.
+    fix the subject alternative name of the presented certificate matches the specified matchers as the case-insensitive way
+    when it uses DNS name.
 - area: tls
   change: |
     fix issue where OCSP was inadvertently removed from SSL response in multi-context scenarios.
 - area: upstream
   change: |
-    fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
+    fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher
+    numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
 - area: upstream
   change: |
     retry budgets will now set default values for xDS configurations.
 - area: zipkin
   change: |
-    fix 'verbose' mode to emit annotations for stream events. This was the documented behavior, but wasn't behaving as documented.
+    fix 'verbose' mode to emit annotations for stream events. This was the documented behavior, but wasn't behaving as
+    documented.
 
 removed_config_or_runtime:
 - area: access_logs
@@ -230,10 +282,12 @@ removed_config_or_runtime:
     removed legacy HTTP/1.1 error reporting path and runtime guard ``envoy.reloadable_features.early_errors_via_hcm``.
 - area: http
   change: |
-    removed legacy sanitization path for upgrade response headers and runtime guard ``envoy.reloadable_features.fix_upgrade_response``.
+    removed legacy sanitization path for upgrade response headers and runtime guard
+    ``envoy.reloadable_features.fix_upgrade_response``.
 - area: http
   change: |
-    removed legacy date header overwriting logic and runtime guard ``envoy.reloadable_features.preserve_upstream_date deprecation``.
+    removed legacy date header overwriting logic and runtime guard ``envoy.reloadable_features.preserve_upstream_date
+    deprecation``.
 - area: http
   change: |
     removed legacy ALPN handling and runtime guard ``envoy.reloadable_features.http_default_alpn``.
@@ -250,16 +304,22 @@ removed_config_or_runtime:
 new_features:
 - area: access log
   change: |
-    added a new :ref:`OpenTelemetry access logger <envoy_v3_api_msg_extensions.access_loggers.open_telemetry.v3alpha.OpenTelemetryAccessLogConfig>` extension, allowing a flexible log structure with native Envoy access log formatting.
+    added a new :ref:`OpenTelemetry access logger
+    <envoy_v3_api_msg_extensions.access_loggers.open_telemetry.v3alpha.OpenTelemetryAccessLogConfig>` extension, allowing a
+    flexible log structure with native Envoy access log formatting.
 - area: access log
   change: |
-    added the new response flag ``NC`` for upstream cluster not found. The error flag is set when the http or tcp route is found for the request but the cluster is not available.
+    added the new response flag ``NC`` for upstream cluster not found. The error flag is set when the http or tcp route is
+    found for the request but the cluster is not available.
 - area: access log
   change: |
-    added the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point for custom formatters (command operators).
+    added the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point for
+    custom formatters (command operators).
 - area: access log
   change: |
-    added support for cross platform writing to :ref:`standard output <envoy_v3_api_msg_extensions.access_loggers.stream.v3.StdoutAccessLog>` and :ref:`standard error <envoy_v3_api_msg_extensions.access_loggers.stream.v3.StderrAccessLog>`.
+    added support for cross platform writing to :ref:`standard output
+    <envoy_v3_api_msg_extensions.access_loggers.stream.v3.StdoutAccessLog>` and :ref:`standard error
+    <envoy_v3_api_msg_extensions.access_loggers.stream.v3.StderrAccessLog>`.
 - area: access log
   change: |
     support command operator: %FILTER_CHAIN_NAME% for the downstream tcp and http request.
@@ -271,58 +331,82 @@ new_features:
     added support for :ref:`access loggers <envoy_v3_api_msg_config.accesslog.v3.AccessLog>` to the admin interface.
 - area: composite filter
   change: |
-    added new :ref:`composite filter <config_http_filters_composite>` that can be used to instantiate different filter configuratios based on matching incoming data.
+    added new :ref:`composite filter <config_http_filters_composite>` that can be used to instantiate different filter
+    configuratios based on matching incoming data.
 - area: compression
   change: |
-    add brotli :ref:`compressor <envoy_v3_api_msg_extensions.compression.brotli.compressor.v3.Brotli>` and :ref:`decompressor <envoy_v3_api_msg_extensions.compression.brotli.decompressor.v3.Brotli>`.
+    add brotli :ref:`compressor <envoy_v3_api_msg_extensions.compression.brotli.compressor.v3.Brotli>` and
+    :ref:`decompressor <envoy_v3_api_msg_extensions.compression.brotli.decompressor.v3.Brotli>`.
 - area: compression
   change: |
-    extended the compression allow compressing when the content length header is not present. This behavior may be temporarily reverted by setting ``envoy.reloadable_features.enable_compression_without_content_length_header`` to false.
+    extended the compression allow compressing when the content length header is not present. This behavior may be
+    temporarily reverted by setting ``envoy.reloadable_features.enable_compression_without_content_length_header`` to false.
 - area: config
   change: |
-    add ``envoy.features.fail_on_any_deprecated_feature`` runtime key, which matches the behaviour of compile-time flag ``ENVOY_DISABLE_DEPRECATED_FEATURES``, i.e. use of deprecated fields will cause a crash.
+    add ``envoy.features.fail_on_any_deprecated_feature`` runtime key, which matches the behaviour of compile-time flag
+    ``ENVOY_DISABLE_DEPRECATED_FEATURES``, i.e. use of deprecated fields will cause a crash.
 - area: config
   change: |
-    the ``Node`` :ref:`dynamic context parameters <envoy_v3_api_field_config.core.v3.Node.dynamic_parameters>` are populated in discovery requests when set on the server instance.
+    the ``Node`` :ref:`dynamic context parameters <envoy_v3_api_field_config.core.v3.Node.dynamic_parameters>` are populated
+    in discovery requests when set on the server instance.
 - area: dispatcher
   change: |
-    supports a stack of ``Envoy::ScopeTrackedObject`` instead of a single tracked object. This will allow Envoy to dump more debug information on crash.
+    supports a stack of ``Envoy::ScopeTrackedObject`` instead of a single tracked object. This will allow Envoy to dump more
+    debug information on crash.
 - area: ext_authz
   change: |
-    added :ref:`response_headers_to_add <envoy_v3_api_field_service.auth.v3.OkHttpResponse.response_headers_to_add>` to support sending response headers to downstream clients on OK authorization checks via gRPC.
+    added :ref:`response_headers_to_add <envoy_v3_api_field_service.auth.v3.OkHttpResponse.response_headers_to_add>` to
+    support sending response headers to downstream clients on OK authorization checks via gRPC.
 - area: ext_authz
   change: |
-    added :ref:`allowed_client_headers_on_success <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers_on_success>` to support sending response headers to downstream clients on OK external authorization checks via HTTP.
+    added :ref:`allowed_client_headers_on_success
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers_on_success>` to
+    support sending response headers to downstream clients on OK external authorization checks via HTTP.
 - area: grpc_json_transcoder
   change: |
-    added :ref:`request_validation_options <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.request_validation_options>` to reject invalid requests early.
+    added :ref:`request_validation_options
+    <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.request_validation_options>` to
+    reject invalid requests early.
 - area: grpc_json_transcoder
   change: |
-    filter can now be configured on per-route/per-vhost level as well. Leaving empty list of services in the filter configuration disables transcoding on the specific route.
+    filter can now be configured on per-route/per-vhost level as well. Leaving empty list of services in the filter
+    configuration disables transcoding on the specific route.
 - area: http
   change: |
-    added support for ``Envoy::ScopeTrackedObject`` for HTTP/1 and HTTP/2 dispatching. Crashes while inside the dispatching loop should dump debug information. Furthermore, HTTP/1 and HTTP/2 clients now dumps the originating request whose response from the upstream caused Envoy to crash.
+    added support for ``Envoy::ScopeTrackedObject`` for HTTP/1 and HTTP/2 dispatching. Crashes while inside the dispatching
+    loop should dump debug information. Furthermore, HTTP/1 and HTTP/2 clients now dumps the originating request whose
+    response from the upstream caused Envoy to crash.
 - area: http
   change: |
-    added support for :ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
+    added support for :ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is
+    off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
 - area: http
   change: |
-    added support for stream filters to mutate the cached route set by HCM route resolution. Useful for filters in a filter chain that want to override specific methods/properties of a route. See :ref:`http route mutation <arch_overview_http_filters_route_mutation>` docs for more information.
+    added support for stream filters to mutate the cached route set by HCM route resolution. Useful for filters in a filter
+    chain that want to override specific methods/properties of a route. See :ref:`http route mutation
+    <arch_overview_http_filters_route_mutation>` docs for more information.
 - area: http
   change: |
-    added new runtime config ``envoy.reloadable_features.check_unsupported_typed_per_filter_config``, the default value is true. When the value is true, envoy will reject virtual host-specific typed per filter config when the filter doesn't support it.
+    added new runtime config ``envoy.reloadable_features.check_unsupported_typed_per_filter_config``, the default value is
+    true. When the value is true, envoy will reject virtual host-specific typed per filter config when the filter doesn't
+    support it.
 - area: http
   change: |
-    added the ability to preserve HTTP/1 header case across the proxy. See the :ref:`header casing <config_http_conn_man_header_casing>` documentation for more information.
+    added the ability to preserve HTTP/1 header case across the proxy. See the :ref:`header casing
+    <config_http_conn_man_header_casing>` documentation for more information.
 - area: http
   change: |
-    change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the ``envoy.reloadable_features.upstream_http2_flood_checks`` runtime key to false.
+    change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the
+    ``envoy.reloadable_features.upstream_http2_flood_checks`` runtime key to false.
 - area: http
   change: |
-    hash multiple header values instead of only hash the first header value. It can be disabled by setting the ``envoy.reloadable_features.hash_multiple_header_values`` runtime key to false. See the :ref:`HashPolicy's Header configuration <envoy_v3_api_msg_config.route.v3.RouteAction.HashPolicy.Header>` for more information.
+    hash multiple header values instead of only hash the first header value. It can be disabled by setting the
+    ``envoy.reloadable_features.hash_multiple_header_values`` runtime key to false. See the :ref:`HashPolicy's Header
+    configuration <envoy_v3_api_msg_config.route.v3.RouteAction.HashPolicy.Header>` for more information.
 - area: json
   change: |
-    introduced new JSON parser (https://github.com/nlohmann/json) to replace RapidJSON. The new parser is disabled by default. To test the new RapidJSON parser, enable the runtime feature ``envoy.reloadable_features.remove_legacy_json``.
+    introduced new JSON parser (https://github.com/nlohmann/json) to replace RapidJSON. The new parser is disabled by
+    default. To test the new RapidJSON parser, enable the runtime feature ``envoy.reloadable_features.remove_legacy_json``.
 - area: kill_request
   change: |
     :ref:`Kill Request <config_http_filters_kill_request>` now supports bidirection killing.
@@ -331,31 +415,45 @@ new_features:
     added an optional :ref:`stat_prefix <envoy_v3_api_field_config.listener.v3.Listener.stat_prefix>`.
 - area: loadbalancer
   change: |
-    added the ability to specify the hash_key for a host when using a consistent hashing loadbalancer (ringhash, maglev) using the :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: ``"envoy.lb": {"hash_key": "..."}``.
+    added the ability to specify the hash_key for a host when using a consistent hashing loadbalancer (ringhash, maglev)
+    using the :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: ``"envoy.lb": {"hash_key":
+    "..."}``.
 - area: log
   change: |
     added a new custom flag ``%j`` to the log pattern to print the actual message to log as JSON escaped string.
 - area: oauth filter
   change: |
-    added the optional parameter :ref:`resources <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.resources>`. Set this value to add multiple "resource" parameters in the Authorization request sent to the OAuth provider. This acts as an identifier representing the protected resources the client is requesting a token for.
+    added the optional parameter :ref:`resources
+    <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.resources>`. Set this value to add multiple
+    "resource" parameters in the Authorization request sent to the OAuth provider. This acts as an identifier representing
+    the protected resources the client is requesting a token for.
 - area: original_dst
   change: |
-    added support for :ref:`Original Destination <config_listener_filters_original_dst>` on Windows. This enables the use of Envoy as a sidecar proxy on Windows.
+    added support for :ref:`Original Destination <config_listener_filters_original_dst>` on Windows. This enables the use of
+    Envoy as a sidecar proxy on Windows.
 - area: overload
   change: |
-    add support for scaling :ref:`transport connection timeouts <envoy_v3_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.TRANSPORT_SOCKET_CONNECT>`. This can be used to reduce the TLS handshake timeout in response to overload.
+    add support for scaling :ref:`transport connection timeouts
+    <envoy_v3_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.TRANSPORT_SOCKET_CONNECT>`. This
+    can be used to reduce the TLS handshake timeout in response to overload.
 - area: postgres
   change: |
-    added ability to :ref:`terminate SSL <envoy_v3_api_field_extensions.filters.network.postgres_proxy.v3alpha.PostgresProxy.terminate_ssl>`.
+    added ability to :ref:`terminate SSL
+    <envoy_v3_api_field_extensions.filters.network.postgres_proxy.v3alpha.PostgresProxy.terminate_ssl>`.
 - area: rbac
   change: |
-    added :ref:`shadow_rules_stat_prefix <envoy_v3_api_field_extensions.filters.http.rbac.v3.RBAC.shadow_rules_stat_prefix>` to allow adding custom prefix to the stats emitted by shadow rules.
+    added :ref:`shadow_rules_stat_prefix <envoy_v3_api_field_extensions.filters.http.rbac.v3.RBAC.shadow_rules_stat_prefix>`
+    to allow adding custom prefix to the stats emitted by shadow rules.
 - area: route config
   change: |
-    added :ref:`allow_post field <envoy_v3_api_field_config.route.v3.RouteAction.UpgradeConfig.ConnectConfig.allow_post>` for allowing POST payload as raw TCP.
+    added :ref:`allow_post field <envoy_v3_api_field_config.route.v3.RouteAction.UpgradeConfig.ConnectConfig.allow_post>`
+    for allowing POST payload as raw TCP.
 - area: route config
   change: |
-    added :ref:`max_direct_response_body_size_bytes <envoy_v3_api_field_config.route.v3.RouteConfiguration.max_direct_response_body_size_bytes>` to set maximum :ref:`direct response body <envoy_v3_api_field_config.route.v3.DirectResponseAction.body>` size in bytes. If not specified the default remains 4096 bytes.
+    added :ref:`max_direct_response_body_size_bytes
+    <envoy_v3_api_field_config.route.v3.RouteConfiguration.max_direct_response_body_size_bytes>` to set maximum :ref:`direct
+    response body <envoy_v3_api_field_config.route.v3.DirectResponseAction.body>` size in bytes. If not specified the
+    default remains 4096 bytes.
 - area: server
   change: |
     added ``fips_mode`` to :ref:`server compilation settings <server_compilation_settings_statistics>` related statistic.
@@ -364,50 +462,63 @@ new_features:
     added :option:`--enable-core-dump` flag to enable core dumps via prctl (Linux-based systems only).
 - area: tcp_proxy
   change: |
-    add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation <tunneling-tcp-over-http>` for details.
+    add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation
+    <tunneling-tcp-over-http>` for details.
 - area: tcp_proxy
   change: |
-    added a :ref:`use_post field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>` for using HTTP POST to proxy TCP streams.
+    added a :ref:`use_post field
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>` for using HTTP POST to
+    proxy TCP streams.
 - area: tcp_proxy
   change: |
-    added a :ref:`headers_to_add field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.headers_to_add>` for setting additional headers to the HTTP requests for TCP proxing.
+    added a :ref:`headers_to_add field
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.headers_to_add>` for setting
+    additional headers to the HTTP requests for TCP proxing.
 - area: thrift_proxy
   change: |
-    added a :ref:`max_requests_per_connection field <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.max_requests_per_connection>` for setting maximum requests for per downstream connection.
+    added a :ref:`max_requests_per_connection field
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.max_requests_per_connection>` for setting
+    maximum requests for per downstream connection.
 - area: thrift_proxy
   change: |
-    added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for messagetype counters in request/response.
+    added per upstream metrics within the :ref:`thrift router
+    <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for messagetype counters in
+    request/response.
 - area: thrift_proxy
   change: |
-    added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request time histograms.
+    added per upstream metrics within the :ref:`thrift router
+    <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request time histograms.
 - area: tls peer certificate validation
   change: |
-    added :ref:`SPIFFE validator <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig>` for supporting isolated multiple trust bundles in a single listener or cluster.
+    added :ref:`SPIFFE validator <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig>` for
+    supporting isolated multiple trust bundles in a single listener or cluster.
 - area: tracing
   change: |
-    added the :ref:`pack_trace_reason <envoy_v3_api_field_extensions.request_id.uuid.v3.UuidRequestIdConfig.pack_trace_reason>`
-    field as well as explicit configuration for the built-in :ref:`UuidRequestIdConfig <envoy_v3_api_msg_extensions.request_id.uuid.v3.UuidRequestIdConfig>`
-    request ID implementation. See the trace context propagation :ref:`architecture overview
-    <arch_overview_tracing_context_propagation>` for more information.
+    added the :ref:`pack_trace_reason
+    <envoy_v3_api_field_extensions.request_id.uuid.v3.UuidRequestIdConfig.pack_trace_reason>` field as well as explicit
+    configuration for the built-in :ref:`UuidRequestIdConfig
+    <envoy_v3_api_msg_extensions.request_id.uuid.v3.UuidRequestIdConfig>` request ID implementation. See the trace context
+    propagation :ref:`architecture overview <arch_overview_tracing_context_propagation>` for more information.
 - area: udp
   change: |
-    added :ref:`downstream <config_listener_stats_udp>` and
-    :ref:`upstream <config_udp_listener_filters_udp_proxy_stats>` statistics for dropped datagrams.
+    added :ref:`downstream <config_listener_stats_udp>` and :ref:`upstream <config_udp_listener_filters_udp_proxy_stats>`
+    statistics for dropped datagrams.
 - area: udp
   change: |
     added :ref:`downstream_socket_config <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.downstream_socket_config>`
     listener configuration to allow configuration of downstream max UDP datagram size. Also added
-    :ref:`upstream_socket_config <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.upstream_socket_config>`
-    UDP proxy configuration to allow configuration of upstream max UDP datagram size. The defaults for
-    both remain 1500 bytes.
+    :ref:`upstream_socket_config
+    <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.upstream_socket_config>` UDP proxy configuration
+    to allow configuration of upstream max UDP datagram size. The defaults for both remain 1500 bytes.
 - area: udp
   change: |
-    added configuration for :ref:`GRO
-    <envoy_v3_api_field_config.core.v3.UdpSocketConfig.prefer_gro>`. The default is disabled for
-    :ref:`downstream sockets <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.downstream_socket_config>`
-    and enabled for :ref:`upstream sockets <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.upstream_socket_config>`.
+    added configuration for :ref:`GRO <envoy_v3_api_field_config.core.v3.UdpSocketConfig.prefer_gro>`. The default is
+    disabled for :ref:`downstream sockets
+    <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.downstream_socket_config>` and enabled for :ref:`upstream
+    sockets <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.upstream_socket_config>`.
 
 deprecated:
 - area: admin
   change: |
-    :ref:`access_log_path <envoy_v3_api_field_config.bootstrap.v3.Admin.access_log_path>` is deprecated in favor for :ref:`access loggers <envoy_v3_api_msg_config.accesslog.v3.AccessLog>`.
+    :ref:`access_log_path <envoy_v3_api_field_config.bootstrap.v3.Admin.access_log_path>` is deprecated in favor for
+    :ref:`access loggers <envoy_v3_api_msg_config.accesslog.v3.AccessLog>`.

--- a/changelogs/1.18.3.yaml
+++ b/changelogs/1.18.3.yaml
@@ -3,7 +3,8 @@ date: May 11, 2021
 bug_fixes:
 - area: zipkin
   change: |
-    fix timestamp serializaiton in annotations. A prior bug fix exposed an issue with timestamps being serialized as strings.
+    fix timestamp serializaiton in annotations. A prior bug fix exposed an issue with timestamps being serialized as
+    strings.
 
 removed_config_or_runtime:
 - area: tls
@@ -13,4 +14,11 @@ removed_config_or_runtime:
 new_features:
 - area: http
   change: |
-    added the ability to :ref:`unescape slash sequences <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>` in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By default this feature is disabled. The default behavior can be overridden through :ref:`http_connection_manager.path_with_escaped_slashes_action <config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling <config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.
+    added the ability to :ref:`unescape slash sequences
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>`
+    in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By
+    default this feature is disabled. The default behavior can be overridden through
+    :ref:`http_connection_manager.path_with_escaped_slashes_action
+    <config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively
+    enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling
+    <config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.

--- a/changelogs/1.18.4.yaml
+++ b/changelogs/1.18.4.yaml
@@ -3,29 +3,34 @@ date: August 24, 2021
 minor_behavior_changes:
 - area: http
   change: |
-    disable the integration between :ref:`ExtensionWithMatcher <envoy_v3_api_msg_extensions.common.matching.v3.ExtensionWithMatcher>`
-    and HTTP filters by default to reflects its experimental status. This feature can be enabled by seting
-    ``envoy.reloadable_features.experimental_matching_api`` to true.
+    disable the integration between :ref:`ExtensionWithMatcher
+    <envoy_v3_api_msg_extensions.common.matching.v3.ExtensionWithMatcher>` and HTTP filters by default to reflects its
+    experimental status. This feature can be enabled by seting ``envoy.reloadable_features.experimental_matching_api`` to
+    true.
 - area: http
   change: |
-    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request
-    URI according to RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed
-    to stripping the \#fragment instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment``
-    to false. This behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
-    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set
-    to false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
-    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the standard deprecation period.
+    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request URI according to
+    RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed to stripping the \#fragment
+    instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment`` to false. This
+    behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
+    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set to
+    false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
+    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the
+    standard deprecation period.
 - area: http
   change: |
-    stop processing pending H/2 frames if connection transitioned to a closed state. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.skip_dispatching_frames_for_closed_connection`` to false.
+    stop processing pending H/2 frames if connection transitioned to a closed state. This behavior can be temporarily
+    reverted by setting the ``envoy.reloadable_features.skip_dispatching_frames_for_closed_connection`` to false.
 
 bug_fixes:
 - area: ext_authz
   change: |
-    fix the ext_authz filter to correctly merge multiple same headers using the ``,`` as separator in the check request to the external authorization service.
+    fix the ext_authz filter to correctly merge multiple same headers using the ``,`` as separator in the check request to
+    the external authorization service.
 - area: http
   change: |
-    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections can result in incorrect behavior and performance problems.
+    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections
+    can result in incorrect behavior and performance problems.
 - area: jwt_authn
   change: |
     unauthorized responses now correctly include a ``www-authenticate`` header.
@@ -33,4 +38,6 @@ bug_fixes:
 new_features:
 - area: listener
   change: |
-    added an option when balancing across active listeners and wildcard matching is used to return the listener that matches the IP family type associated with the listener's socket address. It is off by default, but is turned on by default in v1.19. To set change the runtime guard ``envoy.reloadable_features.listener_wildcard_match_ip_family`` to true.
+    added an option when balancing across active listeners and wildcard matching is used to return the listener that matches
+    the IP family type associated with the listener's socket address. It is off by default, but is turned on by default in
+    v1.19. To set change the runtime guard ``envoy.reloadable_features.listener_wildcard_match_ip_family`` to true.

--- a/changelogs/1.18.6.yaml
+++ b/changelogs/1.18.6.yaml
@@ -9,4 +9,6 @@ bug_fixes:
     fixed the crash when a CONNECT request is sent to JWT filter configured with regex match on the Host header.
 - area: tcp_proxy
   change: |
-    fix a crash that occurs when configured for :ref:`upstream tunneling <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection disconnects while the the upstream connection or http/2 stream is still being established.
+    fix a crash that occurs when configured for :ref:`upstream tunneling
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection
+    disconnects while the the upstream connection or http/2 stream is still being established.

--- a/changelogs/1.19.0.yaml
+++ b/changelogs/1.19.0.yaml
@@ -3,11 +3,12 @@ date: July 13, 2021
 behavior_changes:
 - area: grpc_bridge_filter
   change: |
-    the filter no longer collects grpc stats in favor of the existing grpc stats filter.
-    The behavior can be reverted by changing runtime key ``envoy.reloadable_features.grpc_bridge_stats_disabled``.
+    the filter no longer collects grpc stats in favor of the existing grpc stats filter. The behavior can be reverted by
+    changing runtime key ``envoy.reloadable_features.grpc_bridge_stats_disabled``.
 - area: tracing
   change: |
-    update Apache SkyWalking tracer version to be compatible with 8.4.0 data collect protocol. This change will introduce incompatibility with SkyWalking 8.3.0.
+    update Apache SkyWalking tracer version to be compatible with 8.4.0 data collect protocol. This change will introduce
+    incompatibility with SkyWalking 8.3.0.
 
 minor_behavior_changes:
 - area: access_log
@@ -15,90 +16,109 @@ minor_behavior_changes:
     added new access_log command operator ``%REQUEST_TX_DURATION%``.
 - area: access_log
   change: |
-    removed extra quotes on metadata string values. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.unquote_log_string_values`` to false.
+    removed extra quotes on metadata string values. This behavior can be temporarily reverted by setting
+    ``envoy.reloadable_features.unquote_log_string_values`` to false.
 - area: admission control
   change: |
-    added :ref:`max_rejection_probability <envoy_v3_api_field_extensions.filters.http.admission_control.v3alpha.AdmissionControl.max_rejection_probability>` which defaults to 80%, which means that the upper limit of the default rejection probability of the filter is changed from 100% to 80%.
+    added :ref:`max_rejection_probability
+    <envoy_v3_api_field_extensions.filters.http.admission_control.v3alpha.AdmissionControl.max_rejection_probability>` which
+    defaults to 80%, which means that the upper limit of the default rejection probability of the filter is changed from
+    100% to 80%.
 - area: aws_request_signing
   change: |
-    requests are now buffered by default to compute signatures which include the
-    payload hash, making the filter compatible with most AWS services. Previously, requests were
-    never buffered, which only produced correct signatures for requests without a body, or for
-    requests to S3, ES or Glacier, which used the literal string ``UNSIGNED-PAYLOAD``. Buffering can
-    be now be disabled in favor of using unsigned payloads with compatible services via the new
-    ``use_unsigned_payload`` filter option (default false).
+    requests are now buffered by default to compute signatures which include the payload hash, making the filter compatible
+    with most AWS services. Previously, requests were never buffered, which only produced correct signatures for requests
+    without a body, or for requests to S3, ES or Glacier, which used the literal string ``UNSIGNED-PAYLOAD``. Buffering can
+    be now be disabled in favor of using unsigned payloads with compatible services via the new ``use_unsigned_payload``
+    filter option (default false).
 - area: cache filter
   change: |
     serve HEAD requests from cache.
 - area: cluster
   change: |
-    added default value of 5 seconds for :ref:`connect_timeout <envoy_v3_api_field_config.cluster.v3.Cluster.connect_timeout>`.
+    added default value of 5 seconds for :ref:`connect_timeout
+    <envoy_v3_api_field_config.cluster.v3.Cluster.connect_timeout>`.
 - area: dns
   change: |
     changed apple resolver implementation to not reuse the UDS to the local DNS daemon.
 - area: dns cache
   change: |
-    the new :ref:`dns_query_timeout <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_query_timeout>` option has a default of 5s. See below for more information.
+    the new :ref:`dns_query_timeout
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_query_timeout>` option has a default
+    of 5s. See below for more information.
 - area: http
   change: |
-    disable the integration between :ref:`ExtensionWithMatcher <envoy_v3_api_msg_extensions.common.matching.v3.ExtensionWithMatcher>`
-    and HTTP filters by default to reflect its experimental status. This feature can be enabled by setting
-    ``envoy.reloadable_features.experimental_matching_api`` to true.
+    disable the integration between :ref:`ExtensionWithMatcher
+    <envoy_v3_api_msg_extensions.common.matching.v3.ExtensionWithMatcher>` and HTTP filters by default to reflect its
+    experimental status. This feature can be enabled by setting ``envoy.reloadable_features.experimental_matching_api`` to
+    true.
 - area: http
   change: |
     replaced setting ``envoy.reloadable_features.strict_1xx_and_204_response_headers`` with settings
-    ``envoy.reloadable_features.require_strict_1xx_and_204_response_headers``
-    (require upstream 1xx or 204 responses to not have Transfer-Encoding or non-zero Content-Length headers) and
-    ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers``
-    (do not send 1xx or 204 responses with these headers). Both are true by default.
+    ``envoy.reloadable_features.require_strict_1xx_and_204_response_headers`` (require upstream 1xx or 204 responses to not
+    have Transfer-Encoding or non-zero Content-Length headers) and
+    ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers`` (do not send 1xx or 204 responses with these
+    headers). Both are true by default.
 - area: http
   change: |
     stop sending the transfer-encoding header for 304. This behavior can be temporarily reverted by setting
     ``envoy.reloadable_features.no_chunked_encoding_header_for_304`` to false.
 - area: http
   change: |
-    the behavior of the ``present_match`` in route header matcher changed. The value of ``present_match`` was ignored in the past. The new behavior is ``present_match`` is performed when the value is true. An absent match performed when the value is false. Please reference :ref:`present_match
-    <envoy_v3_api_field_config.route.v3.HeaderMatcher.present_match>`.
+    the behavior of the ``present_match`` in route header matcher changed. The value of ``present_match`` was ignored in the
+    past. The new behavior is ``present_match`` is performed when the value is true. An absent match performed when the
+    value is false. Please reference :ref:`present_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.present_match>`.
 - area: listener
   change: |
     respect the :ref:`connection balance config <envoy_v3_api_field_config.listener.v3.Listener.connection_balance_config>`
     defined within the listener where the sockets are redirected to. Clear that field to restore the previous behavior.
 - area: listener
   change: |
-    when balancing across active listeners and wildcard matching is used, the behavior has been changed to return the listener that matches the IP family type associated with the listener's socket address. Any unexpected behavioral changes can be reverted by setting runtime guard ``envoy.reloadable_features.listener_wildcard_match_ip_family`` to false.
+    when balancing across active listeners and wildcard matching is used, the behavior has been changed to return the
+    listener that matches the IP family type associated with the listener's socket address. Any unexpected behavioral
+    changes can be reverted by setting runtime guard ``envoy.reloadable_features.listener_wildcard_match_ip_family`` to
+    false.
 - area: tcp
   change: |
-    switched to the new connection pool by default. Any unexpected behavioral changes can be reverted by setting runtime guard ``envoy.reloadable_features.new_tcp_connection_pool`` to false.
+    switched to the new connection pool by default. Any unexpected behavioral changes can be reverted by setting runtime
+    guard ``envoy.reloadable_features.new_tcp_connection_pool`` to false.
 - area: udp
   change: |
-    limit each UDP listener to read maximum 6000 packets per event loop. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.udp_per_event_loop_read_limit`` to false.
+    limit each UDP listener to read maximum 6000 packets per event loop. This behavior can be temporarily reverted by
+    setting ``envoy.reloadable_features.udp_per_event_loop_read_limit`` to false.
 
 bug_fixes:
 - area: aws_lambda
   change: |
-    if ``payload_passthrough`` is set to ``false``, the downstream response content-type header will now be set from the content-type entry in the JSON response's headers map, if present.
+    if ``payload_passthrough`` is set to ``false``, the downstream response content-type header will now be set from the
+    content-type entry in the JSON response's headers map, if present.
 - area: cluster
   change: |
-    fixed the :ref:`cluster stats <config_cluster_manager_cluster_stats_request_response_sizes>` histograms by moving the accounting into the router
-    filter. This means that we now properly compute the number of bytes sent as well as handling retries which were previously ignored.
+    fixed the :ref:`cluster stats <config_cluster_manager_cluster_stats_request_response_sizes>` histograms by moving the
+    accounting into the router filter. This means that we now properly compute the number of bytes sent as well as handling
+    retries which were previously ignored.
 - area: hot_restart
   change: |
-    fix double counting of ``server.seconds_until_first_ocsp_response_expiring`` and ``server.days_until_first_cert_expiring`` during hot-restart. This stat was only incorrect until the parent process terminated.
+    fix double counting of ``server.seconds_until_first_ocsp_response_expiring`` and
+    ``server.days_until_first_cert_expiring`` during hot-restart. This stat was only incorrect until the parent process
+    terminated.
 - area: http
   change: |
-    fix erroneous handling of invalid nghttp2 frames with the ``NGHTTP2_ERR_REFUSED_STREAM`` error. Prior to the fix,
-    Envoy would close the entire connection when nghttp2 triggered the invalid frame callback for the said error. The fix
-    will cause Envoy to terminate just the refused stream and retain the connection. This behavior can be temporarily
-    reverted by setting the ``envoy.reloadable_features.http2_consume_stream_refused_errors`` runtime guard to false.
+    fix erroneous handling of invalid nghttp2 frames with the ``NGHTTP2_ERR_REFUSED_STREAM`` error. Prior to the fix, Envoy
+    would close the entire connection when nghttp2 triggered the invalid frame callback for the said error. The fix will
+    cause Envoy to terminate just the refused stream and retain the connection. This behavior can be temporarily reverted by
+    setting the ``envoy.reloadable_features.http2_consume_stream_refused_errors`` runtime guard to false.
 - area: http
   change: |
-    port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
+    port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream.
+    This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
 - area: jwt_authn
   change: |
     unauthorized responses now correctly include a ``www-authenticate`` header.
 - area: listener
   change: |
-    fix a crash which could happen when a filter chain only listener update is followed by listener removal or a full listener update.
+    fix a crash which could happen when a filter chain only listener update is followed by listener removal or a full
+    listener update.
 - area: validation
   change: |
     fix an issue that causes TAP sockets to panic during config validation mode.
@@ -107,7 +127,8 @@ bug_fixes:
     fix the default sampling rate for AWS X-Ray tracer extension to be 5% as opposed to 50%.
 - area: zipkin
   change: |
-    fix timestamp serialization in annotations. A prior bug fix exposed an issue with timestamps being serialized as strings.
+    fix timestamp serialization in annotations. A prior bug fix exposed an issue with timestamps being serialized as
+    strings.
 
 removed_config_or_runtime:
 - area: event
@@ -124,13 +145,18 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.always_apply_route_header_rules`` runtime guard and legacy code path.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.hcm_stream_error_on_invalid_message`` for disabling closing HTTP/1.1 connections on error. Connection-closing can still be disabled by setting the HTTP/1 configuration :ref:`override_stream_error_on_invalid_http_message <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.override_stream_error_on_invalid_http_message>`.
+    removed ``envoy.reloadable_features.hcm_stream_error_on_invalid_message`` for disabling closing HTTP/1.1 connections on
+    error. Connection-closing can still be disabled by setting the HTTP/1 configuration
+    :ref:`override_stream_error_on_invalid_http_message
+    <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.override_stream_error_on_invalid_http_message>`.
 - area: http
   change: |
     removed ``envoy.reloadable_features.http_set_copy_replace_all_headers`` runtime guard and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2``; Envoy will now always send GOAWAY to HTTP2 downstreams when the :ref:`disable_keepalive <config_overload_manager_overload_actions>` overload action is active.
+    removed ``envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2``; Envoy will now always send GOAWAY
+    to HTTP2 downstreams when the :ref:`disable_keepalive <config_overload_manager_overload_actions>` overload action is
+    active.
 - area: http
   change: |
     removed ``envoy.reloadable_features.http_match_on_all_headers`` runtime guard and legacy code paths.
@@ -144,25 +170,40 @@ removed_config_or_runtime:
 new_features:
 - area: access_log
   change: |
-    added the new response flag for :ref:`overload manager termination <envoy_v3_api_field_data.accesslog.v3.ResponseFlags.overload_manager>`. The response flag will be set when the http stream is terminated by overload manager.
+    added the new response flag for :ref:`overload manager termination
+    <envoy_v3_api_field_data.accesslog.v3.ResponseFlags.overload_manager>`. The response flag will be set when the http
+    stream is terminated by overload manager.
 - area: admission control
   change: |
-    added :ref:`rps_threshold <envoy_v3_api_field_extensions.filters.http.admission_control.v3alpha.AdmissionControl.rps_threshold>` option that when average RPS of the sampling window is below this threshold, the filter will not throttle requests. Added :ref:`max_rejection_probability <envoy_v3_api_field_extensions.filters.http.admission_control.v3alpha.AdmissionControl.max_rejection_probability>` option to set an upper limit on the probability of rejection.
+    added :ref:`rps_threshold
+    <envoy_v3_api_field_extensions.filters.http.admission_control.v3alpha.AdmissionControl.rps_threshold>` option that when
+    average RPS of the sampling window is below this threshold, the filter will not throttle requests. Added
+    :ref:`max_rejection_probability
+    <envoy_v3_api_field_extensions.filters.http.admission_control.v3alpha.AdmissionControl.max_rejection_probability>`
+    option to set an upper limit on the probability of rejection.
 - area: bandwidth_limit
   change: |
     added new :ref:`HTTP bandwidth limit filter <config_http_filters_bandwidth_limit>`.
 - area: bootstrap
   change: |
-    added :ref:`dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>` to aggregate all of the DNS resolver configuration in a single message. By setting ``no_default_search_domain`` to true the DNS resolver will not use the default search domains. By setting the ``resolvers`` the external DNS servers to be used for external DNS queries can be specified.
+    added :ref:`dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>` to aggregate
+    all of the DNS resolver configuration in a single message. By setting ``no_default_search_domain`` to true the DNS
+    resolver will not use the default search domains. By setting the ``resolvers`` the external DNS servers to be used for
+    external DNS queries can be specified.
 - area: cluster
   change: |
-    added :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>` to aggregate all of the DNS resolver configuration in a single message. By setting ``no_default_search_domain`` to true the DNS resolver will not use the default search domains.
+    added :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>` to aggregate all
+    of the DNS resolver configuration in a single message. By setting ``no_default_search_domain`` to true the DNS resolver
+    will not use the default search domains.
 - area: cluster
   change: |
-    added :ref:`host_rewrite_literal <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.host_rewrite_literal>` to WeightedCluster.
+    added :ref:`host_rewrite_literal
+    <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.host_rewrite_literal>` to WeightedCluster.
 - area: cluster
   change: |
-    added :ref:`wait_for_warm_on_init <envoy_v3_api_field_config.cluster.v3.Cluster.wait_for_warm_on_init>`, which allows cluster readiness to not block on cluster warm-up. It is true by default, which preserves existing behavior. Currently, only applicable for DNS-based clusters.
+    added :ref:`wait_for_warm_on_init <envoy_v3_api_field_config.cluster.v3.Cluster.wait_for_warm_on_init>`, which allows
+    cluster readiness to not block on cluster warm-up. It is true by default, which preserves existing behavior. Currently,
+    only applicable for DNS-based clusters.
 - area: composite filter
   change: |
     can now be used with filters that also add an access logger, such as the WASM filter.
@@ -174,109 +215,181 @@ new_features:
     added new :ref:`Network connection limit filter <config_network_filters_connection_limit>`.
 - area: crash support
   change: |
-    restore crash context when continuing to processing requests or responses as a result of an asynchronous callback that invokes a filter directly. This is unlike the call stacks that go through the various network layers, to eventually reach the filter. For a concrete example see: ``Envoy::Extensions::HttpFilters::Cache::CacheFilter::getHeaders`` which posts a callback on the dispatcher that will invoke the filter directly.
+    restore crash context when continuing to processing requests or responses as a result of an asynchronous callback that
+    invokes a filter directly. This is unlike the call stacks that go through the various network layers, to eventually
+    reach the filter. For a concrete example see: ``Envoy::Extensions::HttpFilters::Cache::CacheFilter::getHeaders`` which
+    posts a callback on the dispatcher that will invoke the filter directly.
 - area: dns cache
   change: |
-    added :ref:`preresolve_hostnames <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.preresolve_hostnames>` option to the DNS cache config. This option allows hostnames to be preresolved into the cache upon cache creation. This might provide performance improvement, in the form of cache hits, for hostnames that are going to be resolved during steady state and are known at config load time.
+    added :ref:`preresolve_hostnames
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.preresolve_hostnames>` option to the DNS
+    cache config. This option allows hostnames to be preresolved into the cache upon cache creation. This might provide
+    performance improvement, in the form of cache hits, for hostnames that are going to be resolved during steady state and
+    are known at config load time.
 - area: dns cache
   change: |
-    added :ref:`dns_query_timeout <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_query_timeout>` option to the DNS cache config. This option allows explicitly controlling the timeout of underlying queries independently of the underlying DNS platform implementation. Coupled with success and failure retry policies the use of this timeout will lead to more deterministic DNS resolution times.
+    added :ref:`dns_query_timeout
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_query_timeout>` option to the DNS
+    cache config. This option allows explicitly controlling the timeout of underlying queries independently of the
+    underlying DNS platform implementation. Coupled with success and failure retry policies the use of this timeout will
+    lead to more deterministic DNS resolution times.
 - area: dns resolver
   change: |
-    added ``DnsResolverOptions`` protobuf message to reconcile all of the DNS lookup option flags. By setting the configuration option :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_config.core.v3.DnsResolverOptions.use_tcp_for_dns_lookups>` as true we can make the underlying dns resolver library to make only TCP queries to the DNS servers and by setting the configuration option :ref:`no_default_search_domain <envoy_v3_api_field_config.core.v3.DnsResolverOptions.no_default_search_domain>` as true the DNS resolver library will not use the default search domains.
+    added ``DnsResolverOptions`` protobuf message to reconcile all of the DNS lookup option flags. By setting the
+    configuration option :ref:`use_tcp_for_dns_lookups
+    <envoy_v3_api_field_config.core.v3.DnsResolverOptions.use_tcp_for_dns_lookups>` as true we can make the underlying dns
+    resolver library to make only TCP queries to the DNS servers and by setting the configuration option
+    :ref:`no_default_search_domain <envoy_v3_api_field_config.core.v3.DnsResolverOptions.no_default_search_domain>` as true
+    the DNS resolver library will not use the default search domains.
 - area: dns resolver
   change: |
-    added ``DnsResolutionConfig`` to combine :ref:`dns_resolver_options <envoy_v3_api_field_config.core.v3.DnsResolutionConfig.dns_resolver_options>` and :ref:`resolvers <envoy_v3_api_field_config.core.v3.DnsResolutionConfig.resolvers>` in a single protobuf message. The field ``resolvers`` can be specified with a list of DNS resolver addresses. If specified, DNS client library will perform resolution via the underlying DNS resolvers. Otherwise, the default system resolvers (e.g., /etc/resolv.conf) will be used.
+    added ``DnsResolutionConfig`` to combine :ref:`dns_resolver_options
+    <envoy_v3_api_field_config.core.v3.DnsResolutionConfig.dns_resolver_options>` and :ref:`resolvers
+    <envoy_v3_api_field_config.core.v3.DnsResolutionConfig.resolvers>` in a single protobuf message. The field ``resolvers``
+    can be specified with a list of DNS resolver addresses. If specified, DNS client library will perform resolution via the
+    underlying DNS resolvers. Otherwise, the default system resolvers (e.g., /etc/resolv.conf) will be used.
 - area: dns_filter
   change: |
-    added :ref:`dns_resolution_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig.dns_resolution_config>` to aggregate all of the DNS resolver configuration in a single message. By setting the configuration option ``use_tcp_for_dns_lookups`` to true we can make dns filter's external resolvers to answer queries using TCP only, by setting the configuration option ``no_default_search_domain`` as true the DNS resolver will not use the default search domains. And by setting the configuration ``resolvers`` we can specify the external DNS servers to be used for external DNS query which replaces the pre-existing alpha api field ``upstream_resolvers``.
+    added :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig.dns_resolution_config>`
+    to aggregate all of the DNS resolver configuration in a single message. By setting the configuration option
+    ``use_tcp_for_dns_lookups`` to true we can make dns filter's external resolvers to answer queries using TCP only, by
+    setting the configuration option ``no_default_search_domain`` as true the DNS resolver will not use the default search
+    domains. And by setting the configuration ``resolvers`` we can specify the external DNS servers to be used for external
+    DNS query which replaces the pre-existing alpha api field ``upstream_resolvers``.
 - area: dynamic_forward_proxy
   change: |
-    added :ref:`dns_resolution_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_resolution_config>` option to the DNS cache config in order to aggregate all of the DNS resolver configuration in a single message. By setting one such configuration option ``no_default_search_domain`` as true the DNS resolver will not use the default search domains. And by setting the configuration ``resolvers`` we can specify the external DNS servers to be used for external DNS query instead of the system default resolvers.
+    added :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_resolution_config>` option to the DNS
+    cache config in order to aggregate all of the DNS resolver configuration in a single message. By setting one such
+    configuration option ``no_default_search_domain`` as true the DNS resolver will not use the default search domains. And
+    by setting the configuration ``resolvers`` we can specify the external DNS servers to be used for external DNS query
+    instead of the system default resolvers.
 - area: ext_authz_filter
   change: |
-    added :ref:`bootstrap_metadata_labels_key <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.bootstrap_metadata_labels_key>` option to configure labels of destination service.
+    added :ref:`bootstrap_metadata_labels_key
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.bootstrap_metadata_labels_key>` option to configure
+    labels of destination service.
 - area: http
   change: |
-    added new field ``is_optional`` to ``extensions.filters.network.http_connection_manager.v3.HttpFilter``. When
-    set to ``true``, unsupported http filters will be ignored by envoy. This is also same with unsupported http filter
-    in the typed per filter config. For more information, please reference
-    :ref:`HttpFilter <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.is_optional>`.
+    added new field ``is_optional`` to ``extensions.filters.network.http_connection_manager.v3.HttpFilter``. When set to
+    ``true``, unsupported http filters will be ignored by envoy. This is also same with unsupported http filter in the typed
+    per filter config. For more information, please reference :ref:`HttpFilter
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.is_optional>`.
 - area: http
   change: |
-    added :ref:`scheme options <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.scheme_header_transformation>` for adding or overwriting scheme.
+    added :ref:`scheme options
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.scheme_header_transformation>`
+    for adding or overwriting scheme.
 - area: http
   change: |
-    added :ref:`stripping trailing host dot from host header <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_trailing_host_dot>` support.
+    added :ref:`stripping trailing host dot from host header
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_trailing_host_dot>`
+    support.
 - area: http
   change: |
-    added support for :ref:`original IP detection extensions <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.original_ip_detection_extensions>`.
-    Two initial extensions were added, the :ref:`custom header <envoy_v3_api_msg_extensions.http.original_ip_detection.custom_header.v3.CustomHeaderConfig>` extension and the
+    added support for :ref:`original IP detection extensions
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.original_ip_detection_extensions>`.
+    Two initial extensions were added, the :ref:`custom header
+    <envoy_v3_api_msg_extensions.http.original_ip_detection.custom_header.v3.CustomHeaderConfig>` extension and the
     :ref:`xff <envoy_v3_api_msg_extensions.http.original_ip_detection.xff.v3.XffConfig>` extension.
 - area: http
   change: |
-    added a new option to upstream HTTP/2 :ref:`keepalive <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.connection_keepalive>` to send a PING ahead of a new stream if the connection has been idle for a sufficient duration.
+    added a new option to upstream HTTP/2 :ref:`keepalive
+    <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.connection_keepalive>` to send a PING ahead of a new stream if
+    the connection has been idle for a sufficient duration.
 - area: http
   change: |
-    added the ability to :ref:`unescape slash sequences <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>` in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By default this feature is disabled. The default behavior can be overridden through :ref:`http_connection_manager.path_with_escaped_slashes_action<config_http_conn_man_runtime_path_with_escaped_slashes_action>` runtime variable. This action can be selectively enabled for a portion of requests by setting the :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling<config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>` runtime variable.
+    added the ability to :ref:`unescape slash sequences
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.path_with_escaped_slashes_action>`
+    in the path. Requests with unescaped slashes can be proxied, rejected or redirected to the new unescaped path. By
+    default this feature is disabled. The default behavior can be overridden through
+    :ref:`http_connection_manager.path_with_escaped_slashes_action<config_http_conn_man_runtime_path_with_escaped_slashes_action>`
+    runtime variable. This action can be selectively enabled for a portion of requests by setting the
+    :ref:`http_connection_manager.path_with_escaped_slashes_action_sampling<config_http_conn_man_runtime_path_with_escaped_slashes_action_enabled>`
+    runtime variable.
 - area: http
   change: |
-    added upstream and downstream alpha HTTP/3 support! See :ref:`quic_options <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` for downstream and the new http3_protocol_options in :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` for upstream HTTP/3.
+    added upstream and downstream alpha HTTP/3 support! See :ref:`quic_options
+    <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.quic_options>` for downstream and the new
+    http3_protocol_options in :ref:`http_protocol_options
+    <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` for upstream HTTP/3.
 - area: http
   change: |
     raise max configurable max_request_headers_kb limit to 8192 KiB (8MiB) from 96 KiB in http connection manager.
 - area: input matcher
   change: |
-    added a new input matcher that :ref:`matches an IP address against a list of CIDR ranges <envoy_v3_api_file_envoy/extensions/matching/input_matchers/ip/v3/ip.proto>`.
+    added a new input matcher that :ref:`matches an IP address against a list of CIDR ranges
+    <envoy_v3_api_file_envoy/extensions/matching/input_matchers/ip/v3/ip.proto>`.
 - area: jwt_authn
   change: |
-    added support to fetch remote jwks asynchronously specified by :ref:`async_fetch <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.RemoteJwks.async_fetch>`.
+    added support to fetch remote jwks asynchronously specified by :ref:`async_fetch
+    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.RemoteJwks.async_fetch>`.
 - area: jwt_authn
   change: |
-    added support to add padding in the forwarded JWT payload specified by :ref:`pad_forward_payload_header <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.pad_forward_payload_header>`.
+    added support to add padding in the forwarded JWT payload specified by :ref:`pad_forward_payload_header
+    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.pad_forward_payload_header>`.
 - area: listener
   change: |
     added ability to change an existing listener's address.
 - area: listener
   change: |
-    added filter chain match support for :ref:`direct source address <envoy_v3_api_field_config.listener.v3.FilterChainMatch.direct_source_prefix_ranges>`.
+    added filter chain match support for :ref:`direct source address
+    <envoy_v3_api_field_config.listener.v3.FilterChainMatch.direct_source_prefix_ranges>`.
 - area: local_rate_limit_filter
   change: |
-    added support for locally rate limiting http requests on a per connection basis. This can be enabled by setting the :ref:`local_rate_limit_per_downstream_connection <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.local_rate_limit_per_downstream_connection>` field to true.
+    added support for locally rate limiting http requests on a per connection basis. This can be enabled by setting the
+    :ref:`local_rate_limit_per_downstream_connection
+    <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.local_rate_limit_per_downstream_connection>`
+    field to true.
 - area: metric service
   change: |
-    added support for sending metric tags as labels. This can be enabled by setting the :ref:`emit_tags_as_labels <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.emit_tags_as_labels>` field to true.
+    added support for sending metric tags as labels. This can be enabled by setting the :ref:`emit_tags_as_labels
+    <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.emit_tags_as_labels>` field to true.
 - area: proxy protocol
   change: |
-    added support for generating the header while using the :ref:`HTTP connection manager <config_http_conn_man>`. This is done using the :ref:`Proxy Protocol Transport Socket <extension_envoy.transport_sockets.upstream_proxy_protocol>` on upstream clusters.
-    This feature is currently affected by a memory leak `issue <https://github.com/envoyproxy/envoy/issues/16682>`_.
+    added support for generating the header while using the :ref:`HTTP connection manager <config_http_conn_man>`. This is
+    done using the :ref:`Proxy Protocol Transport Socket <extension_envoy.transport_sockets.upstream_proxy_protocol>` on
+    upstream clusters. This feature is currently affected by a memory leak `issue
+    <https://github.com/envoyproxy/envoy/issues/16682>`_.
 - area: req_without_query
   change: |
-    added access log formatter extension implementing command operator :ref:`REQ_WITHOUT_QUERY <envoy_v3_api_msg_extensions.formatter.req_without_query.v3.ReqWithoutQuery>` to log the request path, while excluding the query string.
+    added access log formatter extension implementing command operator :ref:`REQ_WITHOUT_QUERY
+    <envoy_v3_api_msg_extensions.formatter.req_without_query.v3.ReqWithoutQuery>` to log the request path, while excluding
+    the query string.
 - area: router
   change: |
-    added option ``suppress_grpc_request_failure_code_stats`` to :ref:`the router <envoy_v3_api_msg_extensions.filters.http.router.v3.Router>` to allow users to exclude incrementing HTTP status code stats on gRPC requests.
+    added option ``suppress_grpc_request_failure_code_stats`` to :ref:`the router
+    <envoy_v3_api_msg_extensions.filters.http.router.v3.Router>` to allow users to exclude incrementing HTTP status code
+    stats on gRPC requests.
 - area: stats
   change: |
-    added native :ref:`Graphite-formatted tag <envoy_v3_api_msg_extensions.stat_sinks.graphite_statsd.v3.GraphiteStatsdSink>` support.
+    added native :ref:`Graphite-formatted tag
+    <envoy_v3_api_msg_extensions.stat_sinks.graphite_statsd.v3.GraphiteStatsdSink>` support.
 - area: tcp
   change: |
-    added support for :ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic.
+    added support for :ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is
+    off by default, but recommended for clusters serving latency-sensitive traffic.
 - area: thrift_proxy
   change: |
-    added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request and response size histograms.
+    added per upstream metrics within the :ref:`thrift router
+    <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request and response size histograms.
 - area: thrift_proxy
   change: |
     added support for :ref:`outlier detection <arch_overview_outlier_detection>`.
 - area: tls
   change: |
-    allow dual ECDSA/RSA certs via SDS. Previously, SDS only supported a single certificate per context, and dual cert was only supported via non-SDS.
+    allow dual ECDSA/RSA certs via SDS. Previously, SDS only supported a single certificate per context, and dual cert was
+    only supported via non-SDS.
 - area: tracing
   change: |
-    add option :ref:`use_request_id_for_trace_sampling <envoy_v3_api_field_extensions.request_id.uuid.v3.UuidRequestIdConfig.use_request_id_for_trace_sampling>` which allows configuring whether to perform sampling based on :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` or not.
+    add option :ref:`use_request_id_for_trace_sampling
+    <envoy_v3_api_field_extensions.request_id.uuid.v3.UuidRequestIdConfig.use_request_id_for_trace_sampling>` which allows
+    configuring whether to perform sampling based on :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` or not.
 - area: udp_proxy
   change: |
-    added :ref:`key <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.HashPolicy>` as another hash policy to support hash based routing on any given key.
+    added :ref:`key <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.HashPolicy>` as another hash policy
+    to support hash based routing on any given key.
 - area: windows container image
   change: |
     added user, EnvoyUser which is part of the Network Configuration Operators group to the container image.
@@ -284,16 +397,30 @@ new_features:
 deprecated:
 - area: bootstrap
   change: |
-    the field :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.use_tcp_for_dns_lookups>` is deprecated in favor of :ref:`dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>` which aggregates all of the DNS resolver configuration in a single message.
+    the field :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.use_tcp_for_dns_lookups>` is
+    deprecated in favor of :ref:`dns_resolution_config
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>` which aggregates all of the DNS resolver
+    configuration in a single message.
 - area: cluster
   change: |
-    the fields :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_config.cluster.v3.Cluster.use_tcp_for_dns_lookups>` and :ref:`dns_resolvers <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolvers>` are deprecated in favor of :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>` which aggregates all of the DNS resolver configuration in a single message.
+    the fields :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_config.cluster.v3.Cluster.use_tcp_for_dns_lookups>` and
+    :ref:`dns_resolvers <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolvers>` are deprecated in favor of
+    :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>` which aggregates all
+    of the DNS resolver configuration in a single message.
 - area: dns_filter
   change: |
-    the field :ref:`known_suffixes <envoy_v3_api_field_data.dns.v3.DnsTable.known_suffixes>` is deprecated. The internal data management of the filter has changed and the filter no longer uses the known_suffixes field.
+    the field :ref:`known_suffixes <envoy_v3_api_field_data.dns.v3.DnsTable.known_suffixes>` is deprecated. The internal
+    data management of the filter has changed and the filter no longer uses the known_suffixes field.
 - area: dynamic_forward_proxy
   change: |
-    the field :ref:`use_tcp_for_dns_lookups <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` is deprecated in favor of :ref:`dns_resolution_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_resolution_config>` which aggregates all of the DNS resolver configuration in a single message.
+    the field :ref:`use_tcp_for_dns_lookups
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` is deprecated in
+    favor of :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_resolution_config>` which aggregates
+    all of the DNS resolver configuration in a single message.
 - area: http
   change: |
-    :ref:`xff_num_trusted_hops <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>` is deprecated in favor of :ref:`original IP detection extensions <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.original_ip_detection_extensions>`.
+    :ref:`xff_num_trusted_hops
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>`
+    is deprecated in favor of :ref:`original IP detection extensions
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.original_ip_detection_extensions>`.

--- a/changelogs/1.19.1.yaml
+++ b/changelogs/1.19.1.yaml
@@ -1,31 +1,27 @@
 date: August 24, 2021
 
-behavior_changes:
-
 minor_behavior_changes:
 - area: http
   change: |
-    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request
-    URI according to RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed
-    to stripping the \#fragment instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment``
-    to false. This behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
-    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set
-    to false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
-    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the standard deprecation period.
+    reject requests with \#fragment in the URI path. The fragment is not allowed to be part of request URI according to
+    RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed to stripping the \#fragment
+    instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment`` to false. This
+    behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
+    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set to
+    false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
+    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the
+    standard deprecation period.
 - area: http
   change: |
-    stop processing pending H/2 frames if connection transitioned to the closed state. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.skip_dispatching_frames_for_closed_connection`` to false.
+    stop processing pending H/2 frames if connection transitioned to the closed state. This behavior can be temporarily
+    reverted by setting the ``envoy.reloadable_features.skip_dispatching_frames_for_closed_connection`` to false.
 
 bug_fixes:
 - area: ext_authz
   change: |
-    fix the ext_authz filter to correctly merge multiple same headers using the ``,`` as separator in the check request to the external authorization service.
+    fix the ext_authz filter to correctly merge multiple same headers using the ``,`` as separator in the check request to
+    the external authorization service.
 - area: http
   change: |
-    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections can result in incorrect behavior and performance problems.
-
-removed_config_or_runtime:
-
-new_features:
-
-deprecated:
+    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections
+    can result in incorrect behavior and performance problems.

--- a/changelogs/1.19.3.yaml
+++ b/changelogs/1.19.3.yaml
@@ -3,15 +3,13 @@ date: February 22, 2022
 behavior_changes:
 - area: dns_filter
   change: |
-    :ref:`dns_filter <envoy_v3_api_msg_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig>`
-    protobuf fields have been renumbered to restore compatibility with Envoy
-    1.18, breaking compatibility with Envoy 1.19.0 and 1.19.1. The new field
-    numbering allows control planes supporting Envoy 1.18 to gracefully upgrade to
-    :ref:`dns_resolution_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig.dns_resolution_config>`,
-    provided they skip over Envoy 1.19.0 and 1.19.1.
-    Control planes upgrading from Envoy 1.19.0 and 1.19.1 will need to
-    vendor the corresponding protobuf definitions to ensure that the
-    renumbered fields have the types expected by those releases.
+    :ref:`dns_filter <envoy_v3_api_msg_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig>` protobuf fields have been
+    renumbered to restore compatibility with Envoy 1.18, breaking compatibility with Envoy 1.19.0 and 1.19.1. The new field
+    numbering allows control planes supporting Envoy 1.18 to gracefully upgrade to :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3alpha.DnsFilterConfig.ClientContextConfig.dns_resolution_config>`,
+    provided they skip over Envoy 1.19.0 and 1.19.1. Control planes upgrading from Envoy 1.19.0 and 1.19.1 will need to
+    vendor the corresponding protobuf definitions to ensure that the renumbered fields have the types expected by those
+    releases.
 
 bug_fixes:
 - area: data plane
@@ -25,4 +23,6 @@ bug_fixes:
     fixed an issue on Windows where connections are not handled by all worker threads.
 - area: tcp_proxy
   change: |
-    fix a crash that occurs when configured for :ref:`upstream tunneling <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection disconnects while the the upstream connection or http/2 stream is still being established.
+    fix a crash that occurs when configured for :ref:`upstream tunneling
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection
+    disconnects while the the upstream connection or http/2 stream is still being established.

--- a/changelogs/1.19.4.yaml
+++ b/changelogs/1.19.4.yaml
@@ -3,7 +3,8 @@ date: April 25, 2022
 minor_behavior_changes:
 - area: perf
   change: |
-    ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
+    ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret
+    update.
 
 bug_fixes:
 - area: docker

--- a/changelogs/1.19.5.yaml
+++ b/changelogs/1.19.5.yaml
@@ -3,16 +3,27 @@ date: June 9, 2022
 bug_fixes:
 - area: decompression
   change: |
-    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max inflation payload size is now limited.  This change can be reverted via the ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
+    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory
+    inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max
+    inflation payload size is now limited.  This change can be reverted via the
+    ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
 - area: health_check
   change: |
-    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
+    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is
+    health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
 - area: oauth
   change: |
-    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing access in the presence of any access token attached to the request.
+    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a
+    mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow
+    should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing
+    access in the presence of any access token attached to the request.
 - area: oauth
   change: |
-    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in newer versions and corrupts memory on earlier versions.
+    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter
+    would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in
+    newer versions and corrupts memory on earlier versions.
 - area: router
   change: |
-    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an Envoy-generated local reply.
+    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously
+    crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an
+    Envoy-generated local reply.

--- a/changelogs/1.2.0.yaml
+++ b/changelogs/1.2.0.yaml
@@ -12,12 +12,12 @@ changes:
     Envoy configuration is now checked against a JSON schema.
 - area: routing
   change: |
-    :ref:`Ring hash <v1.5:arch_overview_load_balancing_types>` consistent load balancer, as well as HTTP
-    consistent hash routing based on a policy.
+    :ref:`Ring hash <v1.5:arch_overview_load_balancing_types>` consistent load balancer, as well as HTTP consistent hash
+    routing based on a policy.
 - area: rate_limiting
   change: |
-    Vastly :ref:`enhanced global rate limit configuration <v1.5:arch_overview_rate_limit>` via the HTTP
-    rate limiting filter.
+    Vastly :ref:`enhanced global rate limit configuration <v1.5:arch_overview_rate_limit>` via the HTTP rate limiting
+    filter.
 - area: routing
   change: |
     HTTP routing to a cluster retrieved from a header.
@@ -45,8 +45,8 @@ changes:
     <v1.5:config_http_filters_router_x-envoy-upstream-rq-timeout-alt-response>` support.
 - area: listener
   change: |
-    ``use_original_dst`` and ``bind_to_port`` :ref:`listener options <v1.5:config_listeners>` (useful for
-    iptables based transparent proxy support).
+    ``use_original_dst`` and ``bind_to_port`` :ref:`listener options <v1.5:config_listeners>` (useful for iptables based
+    transparent proxy support).
 - area: routing
   change: |
     TCP proxy filter :ref:`route table support <v1.5:config_network_filters_tcp_proxy>`.
@@ -55,12 +55,12 @@ changes:
     Configurable stats flush interval.
 - area: ssl
   change: |
-    Various :ref:`third party library upgrades <v1.5:install_requirements>`, including using BoringSSL as
-    the default SSL provider.
+    Various :ref:`third party library upgrades <v1.5:install_requirements>`, including using BoringSSL as the default SSL
+    provider.
 - area: http2
   change: |
-    No longer maintain closed HTTP/2 streams for priority calculations. Leads to substantial memory
-    savings for large meshes.
+    No longer maintain closed HTTP/2 streams for priority calculations. Leads to substantial memory savings for large
+    meshes.
 - area: envoy
   change: |
     Numerous small changes and fixes not listed here.

--- a/changelogs/1.20.0.yaml
+++ b/changelogs/1.20.0.yaml
@@ -58,7 +58,8 @@ behavior_changes:
     protobuf fields have been renumbered to restore compatibility with Envoy
     1.18, breaking compatibility with Envoy 1.19.0 and 1.19.1. The new field
     numbering allows control planes supporting Envoy 1.18 to gracefully upgrade to
-    :ref:`dns_resolution_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.dns_resolution_config>`,
+    :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.dns_resolution_config>`,
     provided they skip over Envoy 1.19.0 and 1.19.1.
     Control planes upgrading from Envoy 1.19.0 and 1.19.1 will need to
     vendor the corresponding protobuf definitions to ensure that the
@@ -97,10 +98,13 @@ minor_behavior_changes:
     also been added in :ref:`server statistics <server_statistics>` to track this.
 - area: ext_authz
   change: |
-    fixed skipping authentication when returning either a direct response or a redirect. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.http_ext_authz_do_not_skip_direct_response_and_redirect`` runtime guard to false.
+    fixed skipping authentication when returning either a direct response or a redirect. This behavior can be temporarily
+    reverted by setting the ``envoy.reloadable_features.http_ext_authz_do_not_skip_direct_response_and_redirect`` runtime
+    guard to false.
 - area: grpc
   change: |
-    gRPC async client can be cached and shared across filter instances in the same thread, this feature is turned off by default, can be turned on by setting runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to true.
+    gRPC async client can be cached and shared across filter instances in the same thread, this feature is turned off by
+    default, can be turned on by setting runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to true.
 - area: http
   change: |
     correct the use of the ``x-forwarded-proto`` header and the ``:scheme`` header. Where they differ
@@ -111,10 +115,11 @@ minor_behavior_changes:
     reject requests with \#fragment in the URI path. The fragment is not allowed to be part of the request
     URI according to RFC3986 (3.5), RFC7230 (5.1) and RFC 7540 (8.1.2.3). Rejection of requests can be changed
     to stripping the \#fragment instead by setting the runtime guard ``envoy.reloadable_features.http_reject_path_with_fragment``
-    to false. This behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime guard
-    ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set
+    to false. This behavior can further be changed to the deprecated behavior of keeping the fragment by setting the runtime
+    guard ``envoy.reloadable_features.http_strip_fragment_from_path_unsafe_if_disabled``. This runtime guard must only be set
     to false when existing non-compliant traffic relies on \#fragment in URI. When this option is enabled, Envoy request
-    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the standard deprecation period.
+    authorization extensions may be bypassed. This override and its associated behavior will be decommissioned after the
+    standard deprecation period.
 - area: http
   change: |
     set the default :ref:`lazy headermap threshold <arch_overview_http_header_map_settings>` to 3,
@@ -123,7 +128,8 @@ minor_behavior_changes:
     feature to a non-negative number will override the default value.
 - area: http
   change: |
-    stop processing pending H/2 frames if connection transitioned to a closed state. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.skip_dispatching_frames_for_closed_connection`` to false.
+    stop processing pending H/2 frames if connection transitioned to a closed state. This behavior can be temporarily reverted
+    by setting the ``envoy.reloadable_features.skip_dispatching_frames_for_closed_connection`` to false.
 - area: listener
   change: |
     added the :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`
@@ -141,10 +147,13 @@ minor_behavior_changes:
     destroy per network filter chain stats when a network filter chain is removed during the listener in-place update.
 - area: quic
   change: |
-    enables IETF connection migration. This feature requires a stable UDP packet routine in the L4 load balancer with the same first-4-bytes in connection id. It can be turned off by setting runtime guard ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_connection_migration_use_new_cid_v2`` to false.
+    enables IETF connection migration. This feature requires a stable UDP packet routine in the L4 load balancer with the
+    same first-4-bytes in connection id. It can be turned off by setting runtime guard
+    ``envoy.reloadable_features.FLAGS_quic_reloadable_flag_quic_connection_migration_use_new_cid_v2`` to false.
 - area: thrift_proxy
   change: |
-    allow Framed and Header transport combinations to perform :ref:`payload passthrough <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.payload_passthrough>`.
+    allow Framed and Header transport combinations to perform :ref:`payload passthrough
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.payload_passthrough>`.
 
 bug_fixes:
 - area: access log
@@ -152,46 +161,65 @@ bug_fixes:
     fix ``%UPSTREAM_CLUSTER%`` when used in http upstream access logs. Previously, it was always logging as an unset value.
 - area: aws request signer
   change: |
-    fix the AWS Request Signer extension to correctly normalize the path and query string to be signed according to AWS' guidelines, so that the hash on the server side matches. See `AWS SigV4 documentation <https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html>`_.
+    fix the AWS Request Signer extension to correctly normalize the path and query string to be signed according to AWS'
+    guidelines, so that the hash on the server side matches. See `AWS SigV4 documentation
+    <https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html>`_.
 - area: cluster
   change: |
-    delete pools when they're idle to fix unbounded memory use when using PROXY protocol upstream with tcp_proxy. This behavior can be temporarily reverted by setting the ``envoy.reloadable_features.conn_pool_delete_when_idle`` runtime guard to false.
+    delete pools when they're idle to fix unbounded memory use when using PROXY protocol upstream with tcp_proxy. This
+    behavior can be temporarily reverted by setting the ``envoy.reloadable_features.conn_pool_delete_when_idle`` runtime guard
+    to false.
 - area: cluster
   change: |
-    finish cluster warming even if hosts are removed before health check initialization. This only affected clusters with :ref:`ignore_health_on_host_removal <envoy_v3_api_field_config.cluster.v3.Cluster.ignore_health_on_host_removal>`.
+    finish cluster warming even if hosts are removed before health check initialization. This only affected clusters with
+    :ref:`ignore_health_on_host_removal <envoy_v3_api_field_config.cluster.v3.Cluster.ignore_health_on_host_removal>`.
 - area: compressor
   change: |
-    fix a bug where if trailers were added and a subsequent filter paused the filter chain, the request could be stalled. This behavior can be reverted by setting ``envoy.reloadable_features.fix_added_trailers`` to false.
+    fix a bug where if trailers were added and a subsequent filter paused the filter chain, the request could be stalled.
+    This behavior can be reverted by setting ``envoy.reloadable_features.fix_added_trailers`` to false.
 - area: dynamic forward proxy
   change: |
-    fixing a validation bug where san and sni checks were not applied setting :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` via :ref:`typed_extension_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
+    fixing a validation bug where san and sni checks were not applied setting :ref:`http_protocol_options
+    <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` via
+    :ref:`typed_extension_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.
 - area: ext_authz
   change: |
-    fix the ext_authz filter to correctly merge multiple same headers using the ',' as separator in the check request to the external authorization service.
+    fix the ext_authz filter to correctly merge multiple same headers using the ',' as separator in the check request to
+    the external authorization service.
 - area: ext_authz
   change: |
-    fix the use of ``append`` field of :ref:`response_headers_to_add <envoy_v3_api_field_service.auth.v3.OkHttpResponse.response_headers_to_add>` to set or append encoded response headers from a gRPC auth server.
+    fix the use of ``append`` field of :ref:`response_headers_to_add
+    <envoy_v3_api_field_service.auth.v3.OkHttpResponse.response_headers_to_add>` to set or append encoded response headers
+    from a gRPC auth server.
 - area: ext_authz
   change: |
-    fix the HTTP ext_authz filter to respond with ``403 Forbidden`` when a gRPC auth server sends a denied check response with an empty HTTP status code.
+    fix the HTTP ext_authz filter to respond with ``403 Forbidden`` when a gRPC auth server sends a denied check response
+    with an empty HTTP status code.
 - area: ext_authz
   change: |
-    the network ext_authz filter now correctly sets dynamic metadata returned by the authorization service for non-OK responses. This behavior now matches the http ext_authz filter.
+    the network ext_authz filter now correctly sets dynamic metadata returned by the authorization service for non-OK responses.
+    This behavior now matches the http ext_authz filter.
 - area: hcm
   change: |
-    remove deprecation for :ref:`xff_num_trusted_hops <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>` and forbid mixing ip detection extensions with old related knobs.
+    remove deprecation for :ref:`xff_num_trusted_hops
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.xff_num_trusted_hops>`
+    and forbid mixing ip detection extensions with old related knobs.
 - area: http
   change: |
-    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections can result in incorrect behavior and performance problems.
+    limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections
+    can result in incorrect behavior and performance problems.
 - area: listener
   change: |
     fixed an issue on Windows where connections are not handled by all worker threads.
 - area: lua
   change: |
-    fix ``BodyBuffer`` setting a Lua string and printing Lua string containing hex characters. Previously, ``BodyBuffer`` setting a Lua string or printing strings with hex characters will be truncated.
+    fix ``BodyBuffer`` setting a Lua string and printing Lua string containing hex characters. Previously, ``BodyBuffer``
+    setting a Lua string or printing strings with hex characters will be truncated.
 - area: xray
   change: |
-    fix the AWS X-Ray tracer bug where span's error, fault and throttle information was not reported properly as per the `AWS X-Ray documentation <https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html>`_. Before this fix, server error was reported under the 'annotations' section of the segment data.
+    fix the AWS X-Ray tracer bug where span's error, fault and throttle information was not reported properly as per the
+    `AWS X-Ray documentation <https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html>`_. Before
+    this fix, server error was reported under the 'annotations' section of the segment data.
 
 removed_config_or_runtime:
 - area: http
@@ -216,106 +244,151 @@ removed_config_or_runtime:
 new_features:
 - area: access_log
   change: |
-    added :ref:`METADATA <envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>` token to handle all types of metadata (DYNAMIC, CLUSTER, ROUTE).
+    added :ref:`METADATA <envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>` token to handle all types of metadata
+    (DYNAMIC, CLUSTER, ROUTE).
 - area: bootstrap
   change: |
-    added :ref:`inline_headers <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.inline_headers>` in the bootstrap to make custom inline headers bootstrap configurable.
+    added :ref:`inline_headers <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.inline_headers>` in the bootstrap to make
+    custom inline headers bootstrap configurable.
 - area: contrib
   change: |
     added new :ref:`contrib images <install_contrib>` which contain contrib extensions.
 - area: dns
   change: |
-    added :ref:`V4_PREFERRED <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.V4_PREFERRED>` option to return V6 addresses only if V4 addresses are not available.
+    added :ref:`V4_PREFERRED <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.V4_PREFERRED>` option to return
+    V6 addresses only if V4 addresses are not available.
 - area: ext_authz
   change: |
-    added :ref:`dynamic_metadata_from_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.dynamic_metadata_from_headers>` to support emitting dynamic metadata from headers returned by an external authorization service via HTTP.
+    added :ref:`dynamic_metadata_from_headers
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.dynamic_metadata_from_headers>` to support
+    emitting dynamic metadata from headers returned by an external authorization service via HTTP.
 - area: grpc reverse bridge
   change: |
-    added a new :ref:`option <envoy_v3_api_field_extensions.filters.http.grpc_http1_reverse_bridge.v3.FilterConfig.response_size_header>` to support streaming response bodies when withholding gRPC frames from the upstream.
+    added a new :ref:`option
+    <envoy_v3_api_field_extensions.filters.http.grpc_http1_reverse_bridge.v3.FilterConfig.response_size_header>` to support
+    streaming response bodies when withholding gRPC frames from the upstream.
 - area: grpc_json_transcoder
   change: |
-    added support to unescape '+' in query parameters to space with a new config field :ref:`query_param_unescape_plus <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.query_param_unescape_plus>`.
+    added support to unescape '+' in query parameters to space with a new config field :ref:`query_param_unescape_plus
+    <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.query_param_unescape_plus>`.
 - area: http
   change: |
-    added cluster_header in :ref:`weighted_clusters <envoy_v3_api_field_config.route.v3.RouteAction.weighted_clusters>` to allow routing to the weighted cluster specified in the request_header.
+    added cluster_header in :ref:`weighted_clusters <envoy_v3_api_field_config.route.v3.RouteAction.weighted_clusters>`
+    to allow routing to the weighted cluster specified in the request_header.
 - area: http
   change: |
-    added :ref:`alternate_protocols_cache_options <envoy_v3_api_msg_config.core.v3.AlternateProtocolsCacheOptions>` for enabling HTTP/3 connections to servers which advertise HTTP/3 support via `HTTP Alternative Services <https://tools.ietf.org/html/rfc7838>`_ and caching the advertisements to disk.
+    added :ref:`alternate_protocols_cache_options <envoy_v3_api_msg_config.core.v3.AlternateProtocolsCacheOptions>` for enabling
+    HTTP/3 connections to servers which advertise HTTP/3 support via
+    `HTTP Alternative Services <https://tools.ietf.org/html/rfc7838>`_ and caching the advertisements to disk.
 - area: http
   change: |
     added :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>` in the header matcher.
 - area: http
   change: |
-    added :ref:`x-envoy-upstream-stream-duration-ms <config_http_filters_router_x-envoy-upstream-stream-duration-ms>` that allows configuring the max stream duration via a request header.
+    added :ref:`x-envoy-upstream-stream-duration-ms <config_http_filters_router_x-envoy-upstream-stream-duration-ms>` that
+    allows configuring the max stream duration via a request header.
 - area: http
   change: |
-    added support for :ref:`max_requests_per_connection <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_requests_per_connection>` for both upstream and downstream connections.
+    added support for :ref:`max_requests_per_connection
+    <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_requests_per_connection>` for both upstream and downstream
+    connections.
 - area: http
   change: |
-    sanitizing the referer header as documented :ref:`here <config_http_conn_man_headers_referer>`. This feature can be temporarily turned off by setting runtime guard ``envoy.reloadable_features.sanitize_http_header_referer`` to false.
+    sanitizing the referer header as documented :ref:`here <config_http_conn_man_headers_referer>`. This feature can be
+    temporarily turned off by setting runtime guard ``envoy.reloadable_features.sanitize_http_header_referer`` to false.
 - area: http
   change: |
-    validating outgoing HTTP/2 CONNECT requests to ensure that if ``:path`` is set that ``:protocol`` is present. This behavior can be temporarily turned off by setting runtime guard ``envoy.reloadable_features.validate_connect`` to false.
+    validating outgoing HTTP/2 CONNECT requests to ensure that if ``:path`` is set that ``:protocol`` is present. This
+    behavior can be temporarily turned off by setting runtime guard ``envoy.reloadable_features.validate_connect`` to false.
 - area: jwt_authn
   change: |
-    added support for :ref:`Jwt Cache <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.jwt_cache_config>` and its size can be specified by :ref:`jwt_cache_size <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtCacheConfig.jwt_cache_size>`.
+    added support for :ref:`Jwt Cache <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.jwt_cache_config>`
+    and its size can be specified by
+    :ref:`jwt_cache_size <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtCacheConfig.jwt_cache_size>`.
 - area: jwt_authn
   change: |
-    added support for extracting JWTs from request cookies using :ref:`from_cookies <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.from_cookies>`.
+    added support for extracting JWTs from request cookies using
+    :ref:`from_cookies <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.from_cookies>`.
 - area: jwt_authn
   change: |
-    added support for setting the extracted headers from a successfully verified JWT using :ref:`header_in_metadata <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.header_in_metadata>` to dynamic metadata.
+    added support for setting the extracted headers from a successfully verified JWT using
+    :ref:`header_in_metadata <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.header_in_metadata>` to
+    dynamic metadata.
 - area: listener
   change: |
     new listener metric ``downstream_cx_transport_socket_connect_timeout`` to track transport socket timeouts.
 - area: lua
   change: |
-    added ``header:getAtIndex()`` and ``header:getNumValues()`` methods to :ref:`header object <config_http_filters_lua_header_wrapper>` for retrieving the value of a header at certain index and get the total number of values for a given header.
+    added ``header:getAtIndex()`` and ``header:getNumValues()`` methods to :ref:`header object
+    <config_http_filters_lua_header_wrapper>` for retrieving the value of a header at certain index and get the total number
+    of values for a given header.
 - area: matcher
   change: |
-    added :ref:`invert <envoy_v3_api_field_type.matcher.v3.MetadataMatcher.invert>` for inverting the match result in the metadata matcher.
+    added :ref:`invert <envoy_v3_api_field_type.matcher.v3.MetadataMatcher.invert>` for inverting the match result in the
+    metadata matcher.
 - area: overload
   change: |
-    add a new overload action that resets streams using a lot of memory. To enable the tracking of allocated bytes in buffers that a stream is using we need to configure the minimum threshold for tracking via :ref:`buffer_factory_config <envoy_v3_api_field_config.overload.v3.OverloadManager.buffer_factory_config>`. We have an overload action ``Envoy::Server::OverloadActionNameValues::ResetStreams`` that takes advantage of the tracking to reset the most expensive stream first.
+    add a new overload action that resets streams using a lot of memory. To enable the tracking of allocated bytes in buffers
+    that a stream is using we need to configure the minimum threshold for tracking via
+    :ref:`buffer_factory_config <envoy_v3_api_field_config.overload.v3.OverloadManager.buffer_factory_config>`. We have an
+    overload action ``Envoy::Server::OverloadActionNameValues::ResetStreams`` that takes advantage of the tracking to reset
+    the most expensive stream first.
 - area: rbac
   change: |
-    added :ref:`destination_port_range <envoy_v3_api_field_config.rbac.v3.Permission.destination_port_range>` for matching range of destination ports.
+    added :ref:`destination_port_range <envoy_v3_api_field_config.rbac.v3.Permission.destination_port_range>` for matching
+    range of destination ports.
 - area: rbac
   change: |
-    added :ref:`matcher <envoy_v3_api_field_config.rbac.v3.Permission.matcher>` along with extension category ``extension_category_envoy.rbac.matchers`` for custom RBAC permission matchers. Added reference implementation for matchers :ref:`envoy.rbac.matchers.upstream_ip_port <extension_envoy.rbac.matchers.upstream_ip_port>`.
+    added :ref:`matcher <envoy_v3_api_field_config.rbac.v3.Permission.matcher>` along with extension category
+    ``extension_category_envoy.rbac.matchers`` for custom RBAC permission matchers. Added reference implementation for matchers
+    :ref:`envoy.rbac.matchers.upstream_ip_port <extension_envoy.rbac.matchers.upstream_ip_port>`.
 - area: route config
   change: |
-    added :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RouteMatch.dynamic_metadata>` for routing based on dynamic metadata.
+    added :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RouteMatch.dynamic_metadata>` for routing based on dynamic
+    metadata.
 - area: router
   change: |
-    added retry options predicate extensions configured via :ref:`retry_options_predicates. <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_options_predicates>` These extensions allow modification of requests between retries at the router level. There are not currently any built-in extensions that implement this extension point.
+    added retry options predicate extensions configured via :ref:`retry_options_predicates.
+    <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_options_predicates>` These extensions allow modification of requests
+    between retries at the router level. There are not currently any built-in extensions that implement this extension point.
 - area: router
   change: |
     added :ref:`per_try_idle_timeout <envoy_v3_api_field_config.route.v3.RetryPolicy.per_try_idle_timeout>` timeout configuration.
 - area: router
   change: |
-    added an optional :ref:`override_auto_sni_header <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.override_auto_sni_header>` to support setting SNI value from an arbitrary header other than host/authority.
+    added an optional :ref:`override_auto_sni_header
+    <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.override_auto_sni_header>` to support setting SNI value
+    from an arbitrary header other than host/authority.
 - area: sxg_filter
   change: |
-    added filter to transform response to SXG package to :ref:`contrib images <install_contrib>`. This can be enabled by setting :ref:`SXG <envoy_v3_api_msg_extensions.filters.http.sxg.v3alpha.SXG>` configuration.
+    added filter to transform response to SXG package to :ref:`contrib images <install_contrib>`. This can be enabled by setting
+    :ref:`SXG <envoy_v3_api_msg_extensions.filters.http.sxg.v3alpha.SXG>` configuration.
 - area: thrift_proxy
   change: |
-    added support for :ref:`mirroring requests <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.RouteAction.request_mirror_policies>`.
+    added support for :ref:`mirroring requests
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.RouteAction.request_mirror_policies>`.
 - area: udp
   change: |
-    allows updating filter chain in-place through LDS, which is supported by Quic listener. Such listener config will be rejected in other connection-less UDP listener implementations. It can be reverted by ``envoy.reloadable_features.udp_listener_updates_filter_chain_in_place``.
+    allows updating filter chain in-place through LDS, which is supported by Quic listener. Such listener config will be
+    rejected in other connection-less UDP listener implementations. It can be reverted by
+    ``envoy.reloadable_features.udp_listener_updates_filter_chain_in_place``.
 - area: udp
   change: |
-    disallow L4 filter chain in config which configures connection-less UDP listener. It can be reverted by ``envoy.reloadable_features.udp_listener_updates_filter_chain_in_place``.
+    disallow L4 filter chain in config which configures connection-less UDP listener. It can be reverted by
+    ``envoy.reloadable_features.udp_listener_updates_filter_chain_in_place``.
 - area: upstream
   change: |
-    added support for :ref:`slow start mode <arch_overview_load_balancing_slow_start>`, which allows to progresively increase traffic for new endpoints.
+    added support for :ref:`slow start mode <arch_overview_load_balancing_slow_start>`, which allows to progresively increase
+    traffic for new endpoints.
 - area: upstream
   change: |
-    extended :ref:`Round Robin load balancer configuration <envoy_v3_api_field_config.cluster.v3.Cluster.round_robin_lb_config>` with :ref:`slow start <envoy_v3_api_field_config.cluster.v3.Cluster.RoundRobinLbConfig.slow_start_config>` support.
+    extended :ref:`Round Robin load balancer configuration <envoy_v3_api_field_config.cluster.v3.Cluster.round_robin_lb_config>`
+    with :ref:`slow start <envoy_v3_api_field_config.cluster.v3.Cluster.RoundRobinLbConfig.slow_start_config>` support.
 - area: upstream
   change: |
-    extended :ref:`Least Request load balancer configuration <envoy_v3_api_field_config.cluster.v3.Cluster.least_request_lb_config>` with :ref:`slow start <envoy_v3_api_field_config.cluster.v3.Cluster.LeastRequestLbConfig.slow_start_config>` support.
+    extended :ref:`Least Request load balancer configuration
+    <envoy_v3_api_field_config.cluster.v3.Cluster.least_request_lb_config>` with :ref:`slow start
+    <envoy_v3_api_field_config.cluster.v3.Cluster.LeastRequestLbConfig.slow_start_config>` support.
 - area: windows
   change: |
     added a new container image based on Windows Nanoserver 2022.
@@ -326,16 +399,22 @@ new_features:
 deprecated:
 - area: api
   change: |
-    the :ref:`matcher <envoy_v3_api_field_extensions.common.matching.v3.ExtensionWithMatcher.matcher>` field has been deprecated in favor of
-    :ref:`matcher <envoy_v3_api_field_extensions.common.matching.v3.ExtensionWithMatcher.xds_matcher>` in order to break a build dependency.
+    the :ref:`matcher <envoy_v3_api_field_extensions.common.matching.v3.ExtensionWithMatcher.matcher>` field has been
+    deprecated in favor of :ref:`matcher <envoy_v3_api_field_extensions.common.matching.v3.ExtensionWithMatcher.xds_matcher>`
+    in order to break a build dependency.
 - area: cluster
   change: |
-    :ref:`max_requests_per_connection <envoy_v3_api_field_config.cluster.v3.Cluster.max_requests_per_connection>` is deprecated in favor of :ref:`max_requests_per_connection <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_requests_per_connection>`.
+    :ref:`max_requests_per_connection <envoy_v3_api_field_config.cluster.v3.Cluster.max_requests_per_connection>` is deprecated
+    in favor of
+    :ref:`max_requests_per_connection <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_requests_per_connection>`.
 - area: http
   change: |
-    the HeaderMatcher fields :ref:`exact_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.exact_match>`, :ref:`safe_regex_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.safe_regex_match>`,
-    :ref:`prefix_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.prefix_match>`, :ref:`suffix_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.suffix_match>` and
-    :ref:`contains_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.contains_match>` are deprecated by :ref:`string_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
+    the HeaderMatcher fields :ref:`exact_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.exact_match>`,
+    :ref:`safe_regex_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.safe_regex_match>`,
+    :ref:`prefix_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.prefix_match>`,
+    :ref:`suffix_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.suffix_match>` and
+    :ref:`contains_match <envoy_v3_api_field_config.route.v3.HeaderMatcher.contains_match>` are deprecated by :ref:`string_match
+    <envoy_v3_api_field_config.route.v3.HeaderMatcher.string_match>`.
 - area: listener
   change: |
     :ref:`reuse_port <envoy_v3_api_field_config.listener.v3.Listener.reuse_port>` has been

--- a/changelogs/1.20.1.yaml
+++ b/changelogs/1.20.1.yaml
@@ -1,12 +1,10 @@
 date: November 30, 2021
 
-behavior_changes:
-
 minor_behavior_changes:
 - area: config
   change: |
-    the log message for "gRPC config stream closed" now uses the most recent error message, and reports seconds instead of milliseconds for how long the most recent status has been received.
-
+    the log message for "gRPC config stream closed" now uses the most recent error message, and reports seconds instead of
+    milliseconds for how long the most recent status has been received.
 
 bug_fixes:
 - area: http
@@ -24,9 +22,3 @@ bug_fixes:
 - area: tcp
   change: |
     fixed a bug where upstream circuit breakers applied HTTP per-request bounds to TCP connections.
-
-removed_config_or_runtime:
-
-new_features:
-
-deprecated:

--- a/changelogs/1.20.2.yaml
+++ b/changelogs/1.20.2.yaml
@@ -1,9 +1,5 @@
 date: February 22, 2022
 
-behavior_changes:
-
-minor_behavior_changes:
-
 bug_fixes:
 - area: data plane
   change: |
@@ -13,21 +9,25 @@ bug_fixes:
     fixed the crash when a CONNECT request is sent to JWT filter configured with regex match on the Host header.
 - area: tcp_proxy
   change: |
-    fix a crash that occurs when configured for :ref:`upstream tunneling <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection disconnects while the the upstream connection or http/2 stream is still being established.
+    fix a crash that occurs when configured for :ref:`upstream tunneling
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection
+    disconnects while the the upstream connection or http/2 stream is still being established.
 - area: upstream
   change: |
     fix stack overflow when a cluster with large number of idle connections is removed.
 
-removed_config_or_runtime:
-
 new_features:
-# TODO(phlax): These links/refs have been set to v1.21 due to v1.20.2 not building/publishing - update once v1.20.3 lands
 - area: tls
   change: |
-    added support for :ref:`match_typed_subject_alt_names <v1.21:envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` for subject alternative names to enforce specifying the subject alternative name type for the matcher to prevent matching against an unintended type in the certificate.
+    added support for :ref:`match_typed_subject_alt_names
+    <v1.21:envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`
+    for subject alternative names to enforce specifying the subject alternative name type for the matcher to prevent
+    matching against an unintended type in the certificate.
 
 deprecated:
-# TODO(phlax): These links/refs have been set to v1.21 due to v1.20.2 not building/publishing - update once v1.20.3 lands
 - area: tls
   change: |
-    :ref:`match_subject_alt_names <v1.21:envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` has been deprecated in favor of the :ref:`match_typed_subject_alt_names <v1.21:envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`.
+    :ref:`match_subject_alt_names
+    <v1.21:envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` has
+    been deprecated in favor of the :ref:`match_typed_subject_alt_names
+    <v1.21:envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`.

--- a/changelogs/1.20.3.yaml
+++ b/changelogs/1.20.3.yaml
@@ -3,7 +3,8 @@ date: April 26, 2022
 minor_behavior_changes:
 - area: perf
   change: |
-    ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
+    ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret
+    update.
 
 bug_fixes:
 - area: docker

--- a/changelogs/1.20.4.yaml
+++ b/changelogs/1.20.4.yaml
@@ -8,16 +8,27 @@ minor_behavior_changes:
 bug_fixes:
 - area: decompression
   change: |
-    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max inflation payload size is now limited.  This change can be reverted via the ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
+    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory
+    inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max
+    inflation payload size is now limited.  This change can be reverted via the
+    ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
 - area: health_check
   change: |
-    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
+    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is
+    health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
 - area: oauth
   change: |
-    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing access in the presence of any access token attached to the request.
+    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a
+    mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow
+    should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing
+    access in the presence of any access token attached to the request.
 - area: oauth
   change: |
-    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in newer versions and corrupts memory on earlier versions.
+    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter
+    would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in
+    newer versions and corrupts memory on earlier versions.
 - area: router
   change: |
-    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an Envoy-generated local reply.
+    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously
+    crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an
+    Envoy-generated local reply.

--- a/changelogs/1.21.0.yaml
+++ b/changelogs/1.21.0.yaml
@@ -3,48 +3,78 @@ date: January 12, 2022
 behavior_changes:
 - area: auto_config
   change: |
-    :ref:`auto_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` now verifies that any transport sockets configured via :ref:`transport_socket_matches <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket_matches>` support ALPN. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.correctly_validate_alpn`` to false.
+    :ref:`auto_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` now verifies that
+    any transport sockets configured via :ref:`transport_socket_matches
+    <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket_matches>` support ALPN. This behavioral change can be
+    temporarily reverted by setting runtime guard ``envoy.reloadable_features.correctly_validate_alpn`` to false.
 - area: xds
   change: |
-    ``*`` became a reserved name for a wildcard resource that can be subscribed to and unsubscribed from at any time. This is a requirement for implementing the on-demand xDSes (like on-demand CDS) that can subscribe to specific resources next to their wildcard subscription. If such xDS is subscribed to both wildcard resource and to other specific resource, then in stream reconnection scenario, the xDS will not send an empty initial request, but a request containing ``*`` for wildcard subscription and the rest of the resources the xDS is subscribed to. If the xDS is only subscribed to wildcard resource, it will try to send a legacy wildcard request. This behavior implements the recent changes in :ref:`xDS protocol <xds_protocol>` and can be temporarily reverted by setting the ``envoy.restart_features.explicit_wildcard_resource`` runtime guard to false.
+    ``*`` became a reserved name for a wildcard resource that can be subscribed to and unsubscribed from at any time. This
+    is a requirement for implementing the on-demand xDSes (like on-demand CDS) that can subscribe to specific resources next
+    to their wildcard subscription. If such xDS is subscribed to both wildcard resource and to other specific resource, then
+    in stream reconnection scenario, the xDS will not send an empty initial request, but a request containing ``*`` for
+    wildcard subscription and the rest of the resources the xDS is subscribed to. If the xDS is only subscribed to wildcard
+    resource, it will try to send a legacy wildcard request. This behavior implements the recent changes in :ref:`xDS
+    protocol <xds_protocol>` and can be temporarily reverted by setting the
+    ``envoy.restart_features.explicit_wildcard_resource`` runtime guard to false.
 
 minor_behavior_changes:
 - area: bandwidth_limit
   change: |
-    added :ref:`response trailers <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_response_trailers>` when request or response delay are enforced.
+    added :ref:`response trailers
+    <envoy_v3_api_field_extensions.filters.http.bandwidth_limit.v3.BandwidthLimit.enable_response_trailers>` when request or
+    response delay are enforced.
 - area: bandwidth_limit
   change: |
     added :ref:`bandwidth limit stats <config_http_filters_bandwidth_limit>` ``request_enforced`` and ``response_enforced``.
 - area: dns
   change: |
-    now respecting the returned DNS TTL for resolved hosts, rather than always relying on the hard-coded :ref:`dns_refresh_rate. <envoy_v3_api_field_config.cluster.v3.Cluster.dns_refresh_rate>`. This behavior can be temporarily reverted by setting the runtime guard ``envoy.reloadable_features.use_dns_ttl`` to false.
+    now respecting the returned DNS TTL for resolved hosts, rather than always relying on the hard-coded
+    :ref:`dns_refresh_rate. <envoy_v3_api_field_config.cluster.v3.Cluster.dns_refresh_rate>`. This behavior can be
+    temporarily reverted by setting the runtime guard ``envoy.reloadable_features.use_dns_ttl`` to false.
 - area: ext_authz
   change: |
-    the ext_authz span was always getting sampled, even if the parent span was not; now the ext_authz span follows the parent's sampling status.
+    the ext_authz span was always getting sampled, even if the parent span was not; now the ext_authz span follows the
+    parent's sampling status.
 - area: http
   change: |
-    directly responding with only a 1xx http status code isn't valid, and is now refused as invalid :ref:`direct_response <envoy_v3_api_field_config.route.v3.Route.direct_response>` config.
+    directly responding with only a 1xx http status code isn't valid, and is now refused as invalid :ref:`direct_response
+    <envoy_v3_api_field_config.route.v3.Route.direct_response>` config.
 - area: http
   change: |
-    envoy will now proxy 102 and 103 headers from upstream, though as with 100s only the first 1xx response headers will be sent. This behavioral change by can temporarily reverted by setting runtime guard ``envoy.reloadable_features.proxy_102_103`` to false.
+    envoy will now proxy 102 and 103 headers from upstream, though as with 100s only the first 1xx response headers will be
+    sent. This behavioral change by can temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.proxy_102_103`` to false.
 - area: http
   change: |
-    usage of the experimental matching API is no longer guarded behind a feature flag, as the corresponding protobuf fields have been marked as WIP.
+    usage of the experimental matching API is no longer guarded behind a feature flag, as the corresponding protobuf fields
+    have been marked as WIP.
 - area: http
   change: |
-    when a downstream connection hits a configured ``max_requests_per_connection``, it will send an HTTP/2 "shutdown notification" (GOAWAY frame with max stream ID) and go to a default grace period of 5000 milliseconds (5 seconds) if :ref:`drain_timeout <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>` is not specified. During this grace period, envoy will continue to accept new streams. After the grace period, a final GOAWAY is sent and envoy will start refusing new streams. However before the bugfix, during the grace period, every time a new stream is received, envoy would restart the drain which caused the grace period to be extended and so making it longer than the configured drain timeout.
+    when a downstream connection hits a configured ``max_requests_per_connection``, it will send an HTTP/2 "shutdown
+    notification" (GOAWAY frame with max stream ID) and go to a default grace period of 5000 milliseconds (5 seconds) if
+    :ref:`drain_timeout
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>` is not
+    specified. During this grace period, envoy will continue to accept new streams. After the grace period, a final GOAWAY
+    is sent and envoy will start refusing new streams. However before the bugfix, during the grace period, every time a new
+    stream is received, envoy would restart the drain which caused the grace period to be extended and so making it longer
+    than the configured drain timeout.
 - area: json
   change: |
-    switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.remove_legacy_json`` to false.
+    switching from rapidjson to nlohmann/json. This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.remove_legacy_json`` to false.
 - area: listener
   change: |
     destroy per network filter chain stats when a network filter chain is removed during the listener in place update.
 - area: router
   change: |
-    take elapsed time into account when setting the ``x-envoy-expected-rq-timeout-ms header`` for retries, and never send a value that's longer than the request timeout. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
+    take elapsed time into account when setting the ``x-envoy-expected-rq-timeout-ms header`` for retries, and never send a
+    value that's longer than the request timeout. This behavioral change can be temporarily reverted by setting runtime
+    guard ``envoy.reloadable_features.update_expected_rq_timeout_on_retry`` to false.
 - area: stream_info
   change: |
-    response code details with empty space characters (' ', '\\t', '\\f', '\\v', '\\n', '\\r') is not accepted by the ``setResponseCodeDetails()`` API.
+    response code details with empty space characters (' ', '\\t', '\\f', '\\v', '\\n', '\\r') is not accepted by the
+    ``setResponseCodeDetails()`` API.
 - area: upstream
   change: |
     fixed a bug where auto_config didn't work for wrapped TLS sockets (e.g. if proxy proto were configured for TLS).
@@ -55,13 +85,16 @@ bug_fixes:
     fix the ext_authz http filter to correctly set response flags to ``UAEX`` when a connection is denied.
 - area: ext_authz
   change: |
-    fix the ext_authz network filter to correctly set response flag and code details to ``UAEX`` when a connection is denied.
+    fix the ext_authz network filter to correctly set response flag and code details to ``UAEX`` when a connection is
+    denied.
 - area: hcm
   change: |
-    stop processing the response if encoding it has caused downstream reset. The fix is guarded by ``envoy.reloadable_features.handle_stream_reset_during_hcm_encoding``.
+    stop processing the response if encoding it has caused downstream reset. The fix is guarded by
+    ``envoy.reloadable_features.handle_stream_reset_during_hcm_encoding``.
 - area: listener
   change: |
-    fixed issue where more than one listener could listen on the same port if using reuse port, thus randomly accepting connections on different listeners. This configuration is now rejected.
+    fixed issue where more than one listener could listen on the same port if using reuse port, thus randomly accepting
+    connections on different listeners. This configuration is now rejected.
 - area: tcp
   change: |
     fixing a log error where errors both from the kernel and the transport were not handled gracefully.
@@ -70,12 +103,14 @@ bug_fixes:
     do not close downstream connections when an upstream connection overflow happens.
 - area: thrift_proxy
   change: |
-    fix the thrift_proxy connection manager to correctly report success/error response metrics when performing :ref:`payload passthrough <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.payload_passthrough>`.
+    fix the thrift_proxy connection manager to correctly report success/error response metrics when performing :ref:`payload
+    passthrough <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.payload_passthrough>`.
 
 removed_config_or_runtime:
 - area: compression
   change: |
-    removed ``envoy.reloadable_features.enable_compression_without_content_length_header`` runtime guard and legacy code paths.
+    removed ``envoy.reloadable_features.enable_compression_without_content_length_header`` runtime guard and legacy code
+    paths.
 - area: grpc-web
   change: |
     removed ``envoy.reloadable_features.grpc_web_fix_non_proto_encoded_response_handling`` and legacy code paths.
@@ -84,13 +119,15 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.header_map_correctly_coalesce_cookies`` and legacy code paths.
 - area: health check
   change: |
-    removed ``envoy.reloadable_features.health_check.immediate_failure_exclude_from_cluster`` runtime guard and legacy code paths.
+    removed ``envoy.reloadable_features.health_check.immediate_failure_exclude_from_cluster`` runtime guard and legacy code
+    paths.
 - area: http
   change: |
     removed ``envoy.reloadable_features.add_and_validate_scheme_header`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.check_unsupported_typed_per_filter_config``, Envoy will always check unsupported typed per filter config if the filter isn't optional.
+    removed ``envoy.reloadable_features.check_unsupported_typed_per_filter_config``, Envoy will always check unsupported
+    typed per filter config if the filter isn't optional.
 - area: http
   change: |
     removed ``envoy.reloadable_features.dont_add_content_length_for_bodiless_requests`` and legacy code paths.
@@ -99,7 +136,8 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.grpc_json_transcoder_adhere_to_buffer_limits`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.http2_skip_encoding_empty_trailers`` and legacy code paths. Envoy will always encode empty trailers by sending empty data with ``end_stream`` true (instead of sending empty trailers) for HTTP/2.
+    removed ``envoy.reloadable_features.http2_skip_encoding_empty_trailers`` and legacy code paths. Envoy will always encode
+    empty trailers by sending empty data with ``end_stream`` true (instead of sending empty trailers) for HTTP/2.
 - area: http
   change: |
     removed ``envoy.reloadable_features.improved_stream_limit_handling`` and legacy code paths.
@@ -108,7 +146,8 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.remove_forked_chromium_url`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.return_502_for_upstream_protocol_errors``. Envoy will always return 502 code upon encountering upstream protocol error.
+    removed ``envoy.reloadable_features.return_502_for_upstream_protocol_errors``. Envoy will always return 502 code upon
+    encountering upstream protocol error.
 - area: http
   change: |
     removed ``envoy.reloadable_features.treat_host_like_authority`` and legacy code paths.
@@ -125,70 +164,99 @@ removed_config_or_runtime:
 new_features:
 - area: access log
   change: |
-    added :ref:`custom_tags <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.custom_tags>` to annotate log entries with custom tags.
+    added :ref:`custom_tags <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.custom_tags>` to
+    annotate log entries with custom tags.
 - area: access log
   change: |
-    added :ref:`grpc_stream_retry_policy <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.grpc_stream_retry_policy>` to the gRPC logger to reconnect when a connection fails to be established.
+    added :ref:`grpc_stream_retry_policy
+    <envoy_v3_api_field_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig.grpc_stream_retry_policy>` to the gRPC
+    logger to reconnect when a connection fails to be established.
 - area: access_log
   change: |
-    added :ref:`METADATA <envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>` token to handle all types of metadata (DYNAMIC, CLUSTER, ROUTE).
+    added :ref:`METADATA <envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>` token to handle all types of metadata
+    (DYNAMIC, CLUSTER, ROUTE).
 - area: access_log
   change: |
     added a CEL extension filter to enable filtering of access logs based on Envoy attribute expressions.
 - area: access_log
   change: |
-    added new access_log command operator ``%UPSTREAM_REQUEST_ATTEMPT_COUNT%`` to retrieve the number of times given request got attempted upstream.
+    added new access_log command operator ``%UPSTREAM_REQUEST_ATTEMPT_COUNT%`` to retrieve the number of times given request
+    got attempted upstream.
 - area: access_log
   change: |
     added new access_log command operator ``%VIRTUAL_CLUSTER_NAME%`` to retrieve the matched Virtual Cluster name.
 - area: api
   change: |
-    added support for ``xds.type.v3.TypedStruct`` in addition to the now-deprecated ``udpa.type.v1.TypedStruct`` proto message, which is a wrapper proto used to encode typed JSON data in a ``google.protobuf.Any`` field.
+    added support for ``xds.type.v3.TypedStruct`` in addition to the now-deprecated ``udpa.type.v1.TypedStruct`` proto
+    message, which is a wrapper proto used to encode typed JSON data in a ``google.protobuf.Any`` field.
 - area: aws_request_signing_filter
   change: |
-    added :ref:`match_excluded_headers <envoy_v3_api_field_extensions.filters.http.aws_request_signing.v3.AwsRequestSigning.match_excluded_headers>` to the signing filter to optionally exclude request headers from signing.
+    added :ref:`match_excluded_headers
+    <envoy_v3_api_field_extensions.filters.http.aws_request_signing.v3.AwsRequestSigning.match_excluded_headers>` to the
+    signing filter to optionally exclude request headers from signing.
 - area: bootstrap
   change: |
-    added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>` in the bootstrap to support DNS resolver as an extension.
+    added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>` in
+    the bootstrap to support DNS resolver as an extension.
 - area: cluster
   change: |
-    added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>` in the cluster to support DNS resolver as an extension.
+    added :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>` in the
+    cluster to support DNS resolver as an extension.
 - area: config
   change: |
-    added :ref:`environment_variable <envoy_v3_api_field_config.core.v3.datasource.environment_variable>` to the :ref:`DataSource <envoy_v3_api_msg_config.core.v3.datasource>`.
+    added :ref:`environment_variable <envoy_v3_api_field_config.core.v3.datasource.environment_variable>` to the
+    :ref:`DataSource <envoy_v3_api_msg_config.core.v3.datasource>`.
 - area: decompressor
   change: |
-    added :ref:`ignore_no_transform_header <envoy_v3_api_field_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>` to run decompression regardless of the value of the ``no-transform`` cache control header.
+    added :ref:`ignore_no_transform_header
+    <envoy_v3_api_field_extensions.filters.http.decompressor.v3.Decompressor.CommonDirectionConfig.ignore_no_transform_header>`
+    to run decompression regardless of the value of the ``no-transform`` cache control header.
 - area: dns
   change: |
-    added :ref:`ALL <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` option to return both IPv4 and IPv6 addresses.
+    added :ref:`ALL <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` option to return both IPv4 and
+    IPv6 addresses.
 - area: dns_cache
   change: |
-    added :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.typed_dns_resolver_config>` in the dns_cache to support DNS resolver as an extension.
+    added :ref:`typed_dns_resolver_config
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.typed_dns_resolver_config>` in the
+    dns_cache to support DNS resolver as an extension.
 - area: dns_filter
   change: |
-    added :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.typed_dns_resolver_config>` in the dns_filter to support DNS resolver as an extension.
+    added :ref:`typed_dns_resolver_config
+    <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.typed_dns_resolver_config>`
+    in the dns_filter to support DNS resolver as an extension.
 - area: dns_resolver
   change: |
-    added :ref:`CaresDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>` to support c-ares DNS resolver as an extension.
+    added :ref:`CaresDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>`
+    to support c-ares DNS resolver as an extension.
 - area: dns_resolver
   change: |
-    added :ref:`use_resolvers_as_fallback <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.use_resolvers_as_fallback>` to the c-ares DNS resolver.
+    added :ref:`use_resolvers_as_fallback
+    <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.use_resolvers_as_fallback>` to the
+    c-ares DNS resolver.
 - area: dns_resolver
   change: |
-    added :ref:`filter_unroutable_families <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.filter_unroutable_families>` to the c-ares DNS resolver.
+    added :ref:`filter_unroutable_families
+    <envoy_v3_api_field_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig.filter_unroutable_families>` to the
+    c-ares DNS resolver.
 - area: dns_resolver
   change: |
-    added :ref:`AppleDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>` to support apple DNS resolver as an extension.
+    added :ref:`AppleDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>`
+    to support apple DNS resolver as an extension.
 - area: ext_authz
   change: |
-    added :ref:`query_parameters_to_set <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_set>` and :ref:`query_parameters_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_remove>` for adding and removing query string parameters when using a gRPC authorization server.
+    added :ref:`query_parameters_to_set <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_set>` and
+    :ref:`query_parameters_to_remove <envoy_v3_api_field_service.auth.v3.OkHttpResponse.query_parameters_to_remove>` for
+    adding and removing query string parameters when using a gRPC authorization server.
 - area: grpc_http_bridge
   change: |
-    added :ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` option for automatically framing protobuf payloads as gRPC requests.
+    added :ref:`upgrade_protobuf_to_grpc
+    <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` option for
+    automatically framing protobuf payloads as gRPC requests.
 - area: grpc_json_transcoder
   change: |
-    added support for matching unregistered custom verb :ref:`match_unregistered_custom_verb <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.match_unregistered_custom_verb>`.
+    added support for matching unregistered custom verb :ref:`match_unregistered_custom_verb
+    <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.match_unregistered_custom_verb>`.
 - area: http
   change: |
     added support for ``%REQUESTED_SERVER_NAME%`` to extract SNI as a custom header.
@@ -197,28 +265,35 @@ new_features:
     added support for ``%VIRTUAL_CLUSTER_NAME%`` to extract the matched Virtual Cluster name as a custom header.
 - area: http
   change: |
-    added support for :ref:`retriable health check status codes <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`.
+    added support for :ref:`retriable health check status codes
+    <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`.
 - area: http
   change: |
-    added timing information about upstream connection and encryption establishment to stream info. These can currently be accessed via custom access loggers.
+    added timing information about upstream connection and encryption establishment to stream info. These can currently be
+    accessed via custom access loggers.
 - area: http
   change: |
-    added support for :ref:`forwarding HTTP1 reason phrase <envoy_v3_api_field_extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig.forward_reason_phrase>`.
+    added support for :ref:`forwarding HTTP1 reason phrase
+    <envoy_v3_api_field_extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig.forward_reason_phrase>`.
 - area: listener
   change: |
-    added API for extensions to access :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` configured in the listener's :ref:`metadata <envoy_v3_api_field_config.listener.v3.Listener.metadata>` field.
+    added API for extensions to access :ref:`typed_filter_metadata
+    <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` configured in the listener's :ref:`metadata
+    <envoy_v3_api_field_config.listener.v3.Listener.metadata>` field.
 - area: listener
   change: |
     added support for :ref:`MPTCP <envoy_v3_api_field_config.listener.v3.Listener.enable_mptcp>` (multipath TCP).
 - area: listener
   change: |
-    added support for opting out listeners from the globally set downstream connection limit via :ref:`ignore_global_conn_limit <envoy_v3_api_field_config.listener.v3.Listener.ignore_global_conn_limit>`.
+    added support for opting out listeners from the globally set downstream connection limit via
+    :ref:`ignore_global_conn_limit <envoy_v3_api_field_config.listener.v3.Listener.ignore_global_conn_limit>`.
 - area: matcher
   change: |
     added support for ``xds.type.matcher.v3.IPMatcher`` IP trie matching.
 - area: oauth filter
   change: |
-    added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.
+    added :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow
+    overriding (default) cookie names (``BearerToken``, ``OauthHMAC``, and ``OauthExpires``) set by the filter.
 - area: oauth filter
   change: |
     setting ``IdToken`` and ``RefreshToken`` cookies if they are provided by Identity provider along with ``AccessToken``.
@@ -236,7 +311,10 @@ new_features:
     added text_readouts query parameter to prometheus stats to return gauges made from text readouts.
 - area: tcp
   change: |
-    added a :ref:`FilterState <envoy_v3_api_msg_type.v3.HashPolicy.FilterState>` :ref:`hash policy <envoy_v3_api_msg_type.v3.HashPolicy>`, used by :ref:`TCP proxy <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.hash_policy>` to allow hashing load balancer algorithms to hash on objects in filter state.
+    added a :ref:`FilterState <envoy_v3_api_msg_type.v3.HashPolicy.FilterState>` :ref:`hash policy
+    <envoy_v3_api_msg_type.v3.HashPolicy>`, used by :ref:`TCP proxy
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.hash_policy>` to allow hashing load balancer
+    algorithms to hash on objects in filter state.
 - area: tcp_proxy
   change: |
     added support to populate upstream http connect header values from stream info.
@@ -245,10 +323,12 @@ new_features:
     add header to metadata filter for turning headers into dynamic metadata.
 - area: thrift_proxy
   change: |
-    add upstream response zone metrics in the form ``cluster.cluster_name.zone.local_zone.upstream_zone.thrift.upstream_resp_success``.
+    add upstream response zone metrics in the form
+    ``cluster.cluster_name.zone.local_zone.upstream_zone.thrift.upstream_resp_success``.
 - area: thrift_proxy
   change: |
-    add upstream metrics to show decoding errors and whether exception is from local or remote, e.g. ``cluster.cluster_name.thrift.upstream_resp_exception_remote``.
+    add upstream metrics to show decoding errors and whether exception is from local or remote, e.g.
+    ``cluster.cluster_name.thrift.upstream_resp_exception_remote``.
 - area: thrift_proxy
   change: |
     add host level success/error metrics where success is a reply of type success and error is any other response to a call.
@@ -260,48 +340,73 @@ new_features:
     support subset lb when using request or route metadata.
 - area: tls
   change: |
-    added support for :ref:`match_typed_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` for subject alternative names to enforce specifying the subject alternative name type for the matcher to prevent matching against an unintended type in the certificate.
+    added support for :ref:`match_typed_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` for
+    subject alternative names to enforce specifying the subject alternative name type for the matcher to prevent matching
+    against an unintended type in the certificate.
 - area: tls
   change: |
-    added support for only verifying the leaf CRL in the certificate chain with :ref:`only_verify_leaf_cert_crl <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.only_verify_leaf_cert_crl>`.
+    added support for only verifying the leaf CRL in the certificate chain with :ref:`only_verify_leaf_cert_crl
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.only_verify_leaf_cert_crl>`.
 - area: tls
   change: |
-    support loading certificate chain and private key via :ref:`pkcs12 <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.pkcs12>`.
+    support loading certificate chain and private key via :ref:`pkcs12
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.pkcs12>`.
 - area: tls_inspector filter
   change: |
-    added :ref:`enable_ja3_fingerprinting <envoy_v3_api_field_extensions.filters.listener.tls_inspector.v3.TlsInspector.enable_ja3_fingerprinting>` to create JA3 fingerprint hash from Client Hello message.
+    added :ref:`enable_ja3_fingerprinting
+    <envoy_v3_api_field_extensions.filters.listener.tls_inspector.v3.TlsInspector.enable_ja3_fingerprinting>` to create JA3
+    fingerprint hash from Client Hello message.
 - area: transport_socket
   change: |
-    added :ref:`envoy.transport_sockets.tcp_stats <envoy_v3_api_msg_extensions.transport_sockets.tcp_stats.v3.Config>` which generates additional statistics gathered from the OS TCP stack.
+    added :ref:`envoy.transport_sockets.tcp_stats <envoy_v3_api_msg_extensions.transport_sockets.tcp_stats.v3.Config>` which
+    generates additional statistics gathered from the OS TCP stack.
 - area: udp
   change: |
     add support for multiple listener filters.
 - area: udp_proxy
   change: |
-    added :ref:`use_per_packet_load_balancing <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>` option to enable per packet load balancing (selection of upstream host on each data chunk).
+    added :ref:`use_per_packet_load_balancing
+    <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_per_packet_load_balancing>` option to enable
+    per packet load balancing (selection of upstream host on each data chunk).
 - area: upstream
   change: |
-    added the ability to :ref:`configure max connection duration <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>` for upstream clusters.
+    added the ability to :ref:`configure max connection duration
+    <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>` for upstream clusters.
 - area: vcl_socket_interface
   change: |
-    added VCL socket interface extension for fd.io VPP integration to :ref:`contrib images <install_contrib>`. This can be enabled via :ref:`VCL <envoy_v3_api_msg_extensions.vcl.v3alpha.VclSocketInterface>` configuration.
+    added VCL socket interface extension for fd.io VPP integration to :ref:`contrib images <install_contrib>`. This can be
+    enabled via :ref:`VCL <envoy_v3_api_msg_extensions.vcl.v3alpha.VclSocketInterface>` configuration.
 - area: xds
   change: |
-    re-introduced unified delta and sotw xDS multiplexers that share most of the implementation. Added a new runtime config ``envoy.reloadable_features.unified_mux`` (disabled by default) that when enabled, switches xDS to use unified multiplexers.
+    re-introduced unified delta and sotw xDS multiplexers that share most of the implementation. Added a new runtime config
+    ``envoy.reloadable_features.unified_mux`` (disabled by default) that when enabled, switches xDS to use unified
+    multiplexers.
 
 deprecated:
 - area: bootstrap
   change: |
-    :ref:`dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>` is deprecated in favor of :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>`.
+    :ref:`dns_resolution_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.dns_resolution_config>` is deprecated in
+    favor of :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.typed_dns_resolver_config>`.
 - area: cluster
   change: |
-    :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>` is deprecated in favor of :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`.
+    :ref:`dns_resolution_config <envoy_v3_api_field_config.cluster.v3.Cluster.dns_resolution_config>` is deprecated in favor
+    of :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`.
 - area: dns_cache
   change: |
-    :ref:`dns_resolution_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_resolution_config>` is deprecated in favor of :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.typed_dns_resolver_config>`.
+    :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_resolution_config>` is deprecated in
+    favor of :ref:`typed_dns_resolver_config
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.typed_dns_resolver_config>`.
 - area: tls
   change: |
-    :ref:`match_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` has been deprecated in favor of the :ref:`match_typed_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`.
+    :ref:`match_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` has been
+    deprecated in favor of the :ref:`match_typed_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`.
 - area: dns_filter
   change: |
-    :ref:`dns_resolution_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.dns_resolution_config>` is deprecated in favor of :ref:`typed_dns_resolver_config <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.typed_dns_resolver_config>`.
+    :ref:`dns_resolution_config
+    <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.dns_resolution_config>` is
+    deprecated in favor of :ref:`typed_dns_resolver_config
+    <envoy_v3_api_field_extensions.filters.udp.dns_filter.v3.DnsFilterConfig.ClientContextConfig.typed_dns_resolver_config>`.

--- a/changelogs/1.21.1.yaml
+++ b/changelogs/1.21.1.yaml
@@ -1,9 +1,5 @@
 date: February 22, 2022
 
-behavior_changes:
-
-minor_behavior_changes:
-
 bug_fixes:
 - area: data plane
   change: |
@@ -13,13 +9,9 @@ bug_fixes:
     fixed the crash when a CONNECT request is sent to JWT filter configured with regex match on the Host header.
 - area: tcp_proxy
   change: |
-    fix a crash that occurs when configured for :ref:`upstream tunneling <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection disconnects while the the upstream connection or http/2 stream is still being established.
+    fix a crash that occurs when configured for :ref:`upstream tunneling
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection
+    disconnects while the the upstream connection or http/2 stream is still being established.
 - area: upstream
   change: |
     fix stack overflow when a cluster with large number of idle connections is removed.
-
-removed_config_or_runtime:
-
-new_features:
-
-deprecated:

--- a/changelogs/1.21.2.yaml
+++ b/changelogs/1.21.2.yaml
@@ -6,4 +6,5 @@ minor_behavior_changes:
     remove RSA PKCS1 v1.5 padding support.
 - area: perf
   change: |
-    ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret update.
+    ssl contexts are now tracked without scan based garbage collection and greatly improved the performance on secret
+    update.

--- a/changelogs/1.21.3.yaml
+++ b/changelogs/1.21.3.yaml
@@ -3,16 +3,27 @@ date: June 9, 2022
 bug_fixes:
 - area: decompression
   change: |
-    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max inflation payload size is now limited.  This change can be reverted via the ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
+    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory
+    inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max
+    inflation payload size is now limited.  This change can be reverted via the
+    ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
 - area: health_check
   change: |
-    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
+    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is
+    health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
 - area: oauth
   change: |
-    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing access in the presence of any access token attached to the request.
+    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a
+    mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow
+    should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing
+    access in the presence of any access token attached to the request.
 - area: oauth
   change: |
-    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in newer versions and corrupts memory on earlier versions.
+    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter
+    would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in
+    newer versions and corrupts memory on earlier versions.
 - area: router
   change: |
-    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an Envoy-generated local reply.
+    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously
+    crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an
+    Envoy-generated local reply.

--- a/changelogs/1.21.4.yaml
+++ b/changelogs/1.21.4.yaml
@@ -3,7 +3,11 @@ date: June 14, 2022
 minor_behavior_changes:
 - area: tls
   change: |
-    if both :ref:`match_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` and :ref:`match_typed_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` are specified, the former (deprecated) field is ignored. Previously, setting both fields would result in an error.
+    if both :ref:`match_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` and
+    :ref:`match_typed_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` are
+    specified, the former (deprecated) field is ignored. Previously, setting both fields would result in an error.
 
 bug_fixes:
 - area: docker

--- a/changelogs/1.22.0.yaml
+++ b/changelogs/1.22.0.yaml
@@ -3,10 +3,13 @@ date: April 15, 2022
 behavior_changes:
 - area: sip-proxy
   change: |
-    change API by replacing ``own_domain`` with :ref:`local_services <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.LocalService>`.
+    change API by replacing ``own_domain`` with :ref:`local_services
+    <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.LocalService>`.
 - area: tls
   change: |
-    set TLS v1.2 as the default minimal version for servers. Users can still explicitly opt-in to 1.0 and 1.1 using :ref:`tls_minimum_protocol_version <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.tls_minimum_protocol_version>`.
+    set TLS v1.2 as the default minimal version for servers. Users can still explicitly opt-in to 1.0 and 1.1 using
+    :ref:`tls_minimum_protocol_version
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.tls_minimum_protocol_version>`.
 
 minor_behavior_changes:
 - area: access_log
@@ -14,10 +17,13 @@ minor_behavior_changes:
     log all header values in the grpc access log.
 - area: build
   change: |
-    ``VERSION`` and ``API_VERSION`` have been renamed to ``VERSION.txt`` and ``API_VERSION.txt`` respectively to avoid conflicts with the C++ ``<version>`` header.
+    ``VERSION`` and ``API_VERSION`` have been renamed to ``VERSION.txt`` and ``API_VERSION.txt`` respectively to avoid
+    conflicts with the C++ ``<version>`` header.
 - area: config
   change: |
-    type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` to false.
+    type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter
+    configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted
+    by setting runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` to false.
 - area: config
   change: |
     warning messages for protobuf unknown fields now contain ancestors for easier troubleshooting.
@@ -26,55 +32,83 @@ minor_behavior_changes:
     remove RSA PKCS1 v1.5 padding support.
 - area: decompressor
   change: |
-    decompressor does not duplicate ``accept-encoding`` header values anymore. This behavioral change can be reverted by setting runtime guard ``envoy.reloadable_features.append_to_accept_content_encoding_only_once`` to false.
+    decompressor does not duplicate ``accept-encoding`` header values anymore. This behavioral change can be reverted by
+    setting runtime guard ``envoy.reloadable_features.append_to_accept_content_encoding_only_once`` to false.
 - area: dynamic_forward_proxy
   change: |
-    if a DNS resolution fails, failing immediately with a specific resolution error, rather than finishing up all local filters and failing to select an upstream host.
+    if a DNS resolution fails, failing immediately with a specific resolution error, rather than finishing up all local
+    filters and failing to select an upstream host.
 - area: ecds
   change: |
-    changed to use ``http_filter`` stat prefix as the metrics root for ECDS subscriptions. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.top_level_ecds_stats`` to false.
+    changed to use ``http_filter`` stat prefix as the metrics root for ECDS subscriptions. This behavior can be temporarily
+    reverted by setting ``envoy.reloadable_features.top_level_ecds_stats`` to false.
 - area: ext_authz
   change: |
     added requested server name in ext_authz network filter for auth review.
 - area: ext_authz
   change: |
-    forward :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` selected by :ref:`typed_metadata_context_namespaces <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.typed_metadata_context_namespaces>` to external auth service.
+    forward :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` selected by
+    :ref:`typed_metadata_context_namespaces
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.typed_metadata_context_namespaces>` to external auth
+    service.
 - area: file
   change: |
-    changed disk based files to truncate files which are not being appended to. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.append_or_truncate`` to false.
+    changed disk based files to truncate files which are not being appended to. This behavioral change can be temporarily
+    reverted by setting runtime guard ``envoy.reloadable_features.append_or_truncate`` to false.
 - area: grpc
   change: |
-    flip runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to be default enabled. async grpc client created through ``getOrCreateRawAsyncClient`` will be cached by default.
+    flip runtime guard ``envoy.reloadable_features.enable_grpc_async_client_cache`` to be default enabled. async grpc client
+    created through ``getOrCreateRawAsyncClient`` will be cached by default.
 - area: health_checker
   change: |
     exposing ``initial_metadata`` to GrpcHealthCheck in a way similar to ``request_headers_to_add`` of HttpHealthCheck.
 - area: http
   change: |
-    added the ability to have multiple URI type Subject Alternative Names of the client certificate in the :ref:`config_http_conn_man_headers_x-forwarded-client-cert` header.
+    added the ability to have multiple URI type Subject Alternative Names of the client certificate in the
+    :ref:`config_http_conn_man_headers_x-forwarded-client-cert` header.
 - area: http
   change: |
-    avoiding delay-close for HTTP/1.0 responses framed by ``connection: close`` as well as HTTP/1.1 if the request is fully read. This means for responses to such requests, the FIN will be sent immediately after the response. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.skip_delay_close`` to false.  If clients are seen to be receiving sporadic partial responses and flipping this flag fixes it, please notify the project immediately.
+    avoiding delay-close for HTTP/1.0 responses framed by ``connection: close`` as well as HTTP/1.1 if the request is fully
+    read. This means for responses to such requests, the FIN will be sent immediately after the response. This behavior can
+    be temporarily reverted by setting ``envoy.reloadable_features.skip_delay_close`` to false.  If clients are seen to be
+    receiving sporadic partial responses and flipping this flag fixes it, please notify the project immediately.
 - area: http
   change: |
-    changed the http status code to 504 from 408 if the request times out after the request is completed. This behavior can be temporarily reverted by setting the runtime guard ``envoy.reloadable_features.override_request_timeout_by_gateway_timeout`` to false.
+    changed the http status code to 504 from 408 if the request times out after the request is completed. This behavior can
+    be temporarily reverted by setting the runtime guard
+    ``envoy.reloadable_features.override_request_timeout_by_gateway_timeout`` to false.
 - area: http
   change: |
-    lazy disable downstream connection reading in the HTTP/1 codec to reduce unnecessary system calls. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.http1_lazy_read_disable`` to false.
+    lazy disable downstream connection reading in the HTTP/1 codec to reduce unnecessary system calls. This behavioral
+    change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.http1_lazy_read_disable`` to
+    false.
 - area: http
   change: |
-    now the max concurrent streams of http2 connection can not only be adjusted down according to the SETTINGS frame but also can be adjusted up. Of course, it can not exceed the configured upper bounds. This fix is guarded by ``envoy.reloadable_features.http2_allow_capacity_increase_by_settings``.
+    now the max concurrent streams of http2 connection can not only be adjusted down according to the SETTINGS frame but
+    also can be adjusted up. Of course, it can not exceed the configured upper bounds. This fix is guarded by
+    ``envoy.reloadable_features.http2_allow_capacity_increase_by_settings``.
 - area: http
   change: |
-    respecting ``content-type`` in :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` even when the response body is modified. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.allow_adding_content_type_in_local_replies`` to false.
+    respecting ``content-type`` in :ref:`headers_to_add
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` even when the
+    response body is modified. This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.allow_adding_content_type_in_local_replies`` to false.
 - area: http
   change: |
-    when writing custom filters, ``injectEncodedDataToFilterChain`` and ``injectDecodedDataToFilterChain`` now trigger sending of headers if they were not yet sent due to ``StopIteration``. Previously, calling one of the inject functions in that state would trigger an assertion. See issue #19891 for more details.
+    when writing custom filters, ``injectEncodedDataToFilterChain`` and ``injectDecodedDataToFilterChain`` now trigger
+    sending of headers if they were not yet sent due to ``StopIteration``. Previously, calling one of the inject functions
+    in that state would trigger an assertion. See issue #19891 for more details.
 - area: listener
   change: |
-    the :ref:`ipv4_compat <envoy_v3_api_field_config.core.v3.socketaddress.ipv4_compat>` flag can only be set on Ipv6 address and Ipv4-mapped Ipv6 address. A runtime guard is added ``envoy.reloadable_features.strict_check_on_ipv4_compat`` and the default is true.
+    the :ref:`ipv4_compat <envoy_v3_api_field_config.core.v3.socketaddress.ipv4_compat>` flag can only be set on Ipv6
+    address and Ipv4-mapped Ipv6 address. A runtime guard is added ``envoy.reloadable_features.strict_check_on_ipv4_compat``
+    and the default is true.
 - area: network
   change: |
-    add a new ConnectionEvent ``ConnectedZeroRtt`` which may be raised by QUIC connections to allow early data to be sent before the handshake finishes. This event is ignored at callsites which is only reachable for TCP connections in the Envoy core code. Any extensions which depend on ConnectionEvent enum value should audit their usage of it to make sure this new event is handled appropriately.
+    add a new ConnectionEvent ``ConnectedZeroRtt`` which may be raised by QUIC connections to allow early data to be sent
+    before the handshake finishes. This event is ignored at callsites which is only reachable for TCP connections in the
+    Envoy core code. Any extensions which depend on ConnectionEvent enum value should audit their usage of it to make sure
+    this new event is handled appropriately.
 - area: oauth2
   change: |
     disable chunked transfer encoding in the token request to be compatible with Azure AD (login.microsoftonline.com).
@@ -83,73 +117,100 @@ minor_behavior_changes:
     tls contexts are now tracked without scan based garbage collection greatly improving the performance on secret update.
 - area: ratelimit
   change: |
-    the :ref:`header_value_match <envoy_v3_api_msg_config.route.v3.ratelimit.action.HeaderValueMatch>` config now supports custom descriptor keys.
+    the :ref:`header_value_match <envoy_v3_api_msg_config.route.v3.ratelimit.action.HeaderValueMatch>` config now supports
+    custom descriptor keys.
 - area: router
   change: |
-    record upstream request timeouts for all cases and not just for those requests which are awaiting headers. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` to false.
+    record upstream request timeouts for all cases and not just for those requests which are awaiting headers. This
+    behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.do_not_await_headers_on_upstream_timeout_to_emit_stats`` to false.
 - area: runtime
   change: |
-    deprecated runtime flags set via configuration files or xDS will now ENVOY_BUG, rather than silently resulting in unexpected behavior on the data plane by no longer applying removed code paths.
+    deprecated runtime flags set via configuration files or xDS will now ENVOY_BUG, rather than silently resulting in
+    unexpected behavior on the data plane by no longer applying removed code paths.
 - area: runtime
   change: |
-    removed global runtime as Envoy default. This behavioral change can be reverted by setting runtime guard ``envoy.restart_features.no_runtime_singleton`` to false.
+    removed global runtime as Envoy default. This behavioral change can be reverted by setting runtime guard
+    ``envoy.restart_features.no_runtime_singleton`` to false.
 - area: sip-proxy
   change: |
-    add customized affinity support by adding :ref:`tra_service_config <envoy_v3_api_msg_extensions.filters.network.sip_proxy.tra.v3alpha.TraServiceConfig>` and :ref:`customized_affinity <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.CustomizedAffinity>`.
+    add customized affinity support by adding :ref:`tra_service_config
+    <envoy_v3_api_msg_extensions.filters.network.sip_proxy.tra.v3alpha.TraServiceConfig>` and :ref:`customized_affinity
+    <envoy_v3_api_msg_extensions.filters.network.sip_proxy.v3alpha.CustomizedAffinity>`.
 - area: sip-proxy
   change: |
-    add support for the ``503`` response code. When there is something wrong occurred, send ``503 Service Unavailable`` back to downstream.
+    add support for the ``503`` response code. When there is something wrong occurred, send ``503 Service Unavailable`` back
+    to downstream.
 - area: stateful session http filter
   change: |
     only enable cookie based session state when request path matches the configured cookie path.
 - area: tracing
   change: |
-    set tracing error tag for grpc non-ok response code only when it is a upstream error. Client error will not be tagged as a grpc error. This fix is guarded by ``envoy.reloadable_features.update_grpc_response_error_tag``.
+    set tracing error tag for grpc non-ok response code only when it is a upstream error. Client error will not be tagged as
+    a grpc error. This fix is guarded by ``envoy.reloadable_features.update_grpc_response_error_tag``.
 
 bug_fixes:
 - area: access_log
   change: |
-    fix memory leak when reopening an access log fails. Access logs will now try to be reopened on each subsequent flush attempt after a failure.
+    fix memory leak when reopening an access log fails. Access logs will now try to be reopened on each subsequent flush
+    attempt after a failure.
 - area: data plane
   change: |
     fix crash when internal redirect selects a route configured with direct response or redirect actions.
 - area: data plane
   change: |
-    fix error handling where writing to a socket failed while under the stack of processing. This should only effect HTTP/3. This behavioral change can be reverted by setting ``envoy.reloadable_features.allow_upstream_inline_write`` to false.
+    fix error handling where writing to a socket failed while under the stack of processing. This should only effect HTTP/3.
+    This behavioral change can be reverted by setting ``envoy.reloadable_features.allow_upstream_inline_write`` to false.
 - area: eds
   change: |
-    fix the eds cluster update by allowing update on the locality of the cluster endpoints. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.support_locality_update_on_eds_cluster_endpoints`` to false.
+    fix the eds cluster update by allowing update on the locality of the cluster endpoints. This behavioral change can be
+    temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.support_locality_update_on_eds_cluster_endpoints`` to false.
 - area: hot restart
   change: |
-    fixed a bug where an incorrect fd was passed to child when a tcp listener and a udp listener listen to the same address because socket type was not used to find the matching listener for a url.
+    fixed a bug where an incorrect fd was passed to child when a tcp listener and a udp listener listen to the same address
+    because socket type was not used to find the matching listener for a url.
 - area: http
   change: |
-    fixed a bug where ``%RESPONSE_CODE_DETAILS%`` was not set correctly in :ref:`request_headers_to_add <envoy_v3_api_field_config.route.v3.RouteConfiguration.request_headers_to_add>`.
+    fixed a bug where ``%RESPONSE_CODE_DETAILS%`` was not set correctly in :ref:`request_headers_to_add
+    <envoy_v3_api_field_config.route.v3.RouteConfiguration.request_headers_to_add>`.
 - area: http
   change: |
-    fixed a bug where ``100-continue`` comparison in the ``Expect`` request header field was case sensitive. This RFC compliant behavior can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.http_100_continue_case_insensitive`` to false.
+    fixed a bug where ``100-continue`` comparison in the ``Expect`` request header field was case sensitive. This RFC
+    compliant behavior can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.http_100_continue_case_insensitive`` to false.
 - area: jwt_authn
   change: |
-    fixed a bug where a JWT with empty "iss" is passed even the field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` is specified. If the "issuer" field is specified, "iss" in the JWT should match it.
+    fixed a bug where a JWT with empty "iss" is passed even the field :ref:`issuer
+    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` is specified. If the "issuer" field is
+    specified, "iss" in the JWT should match it.
 - area: jwt_authn
   change: |
     fixed the crash when a CONNECT request is sent to JWT filter configured with regex match on the Host header.
 - area: router
   change: |
-    fixed mirror policy :ref:`runtime_fraction <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.runtime_fraction>` to
-    correctly allow reading from a fractional percent value stored in runtime in all cases. Previously
-    it would only do this if the default numerator was above 0, otherwise it would use the integer
-    variant with a default of 0. The default of 0 is retained, but runtime lookup will happen in
-    all cases and recognize a stored fractional percent.
+    fixed mirror policy :ref:`runtime_fraction
+    <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.runtime_fraction>` to correctly allow reading from a
+    fractional percent value stored in runtime in all cases. Previously it would only do this if the default numerator was
+    above 0, otherwise it would use the integer variant with a default of 0. The default of 0 is retained, but runtime
+    lookup will happen in all cases and recognize a stored fractional percent.
 - area: tcp_proxy
   change: |
-    fix a crash that occurs when configured for :ref:`upstream tunneling <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection disconnects while the the upstream connection or http/2 stream is still being established.
+    fix a crash that occurs when configured for :ref:`upstream tunneling
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.tunneling_config>` and the downstream connection
+    disconnects while the the upstream connection or http/2 stream is still being established.
 - area: tls
   change: |
-    fix a bug while matching a certificate SAN with an exact value in ``match_typed_subject_alt_names`` of a listener where wildcard ``*`` character is not the only character of the dns label. Example, ``baz*.example.net`` and ``*baz.example.net`` and ``b*z.example.net`` will match ``baz1.example.net`` and ``foobaz.example.net`` and ``buzz.example.net``, respectively.
+    fix a bug while matching a certificate SAN with an exact value in ``match_typed_subject_alt_names`` of a listener where
+    wildcard ``*`` character is not the only character of the dns label. Example, ``baz*.example.net`` and
+    ``*baz.example.net`` and ``b*z.example.net`` will match ``baz1.example.net`` and ``foobaz.example.net`` and
+    ``buzz.example.net``, respectively.
 - area: upstream
   change: |
-    added cluster slow start config :ref:`min_weight_percent <envoy_v3_api_field_config.cluster.v3.Cluster.SlowStartConfig.min_weight_percent>` field to avoid too big EDF deadline which cause slow start endpoints receiving no traffic, default 10%. This fix is related to `issue \#19526 <https://github.com/envoyproxy/envoy/issues/19526>`_.
+    added cluster slow start config :ref:`min_weight_percent
+    <envoy_v3_api_field_config.cluster.v3.Cluster.SlowStartConfig.min_weight_percent>` field to avoid too big EDF deadline
+    which cause slow start endpoints receiving no traffic, default 10%. This fix is related to `issue \#19526
+    <https://github.com/envoyproxy/envoy/issues/19526>`_.
 - area: upstream
   change: |
     fix stack overflow when a cluster with large number of idle connections is removed.
@@ -161,16 +222,20 @@ bug_fixes:
     fix the wildcard resource versions that are sent upon reconnection when using delta-xds mode.
 - area: xray
   change: |
-    fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header ``x-amzn-trace-id``.
+    fix the AWS X-Ray tracer extension to not sample the trace if ``sampled=`` keyword is not present in the header
+    ``x-amzn-trace-id``.
 - area: xray
   change: |
-    fix the AWS X-Ray tracer extension to annotate a child span with ``type=subsegment`` to correctly relate subsegments to a parent segment. Previously a subsegment would be treated as an independent segment.
+    fix the AWS X-Ray tracer extension to annotate a child span with ``type=subsegment`` to correctly relate subsegments to
+    a parent segment. Previously a subsegment would be treated as an independent segment.
 - area: xray
   change: |
-    fix the AWS X-Ray tracer extension to reuse the trace ID already present in the header ``x-amzn-trace-id`` instead of creating a new one.
+    fix the AWS X-Ray tracer extension to reuse the trace ID already present in the header ``x-amzn-trace-id`` instead of
+    creating a new one.
 - area: xray
   change: |
-    fix the AWS X-Ray tracer extension to set the HTTP ``X-Forwarded-For`` header value as ``client_ip`` in the segment data.
+    fix the AWS X-Ray tracer extension to set the HTTP ``X-Forwarded-For`` header value as ``client_ip`` in the segment
+    data.
 
 removed_config_or_runtime:
 - area: access_log
@@ -190,7 +255,8 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.preserve_downstream_scheme`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.require_strict_1xx_and_204_response_headers`` and ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers`` and legacy code paths.
+    removed ``envoy.reloadable_features.require_strict_1xx_and_204_response_headers`` and
+    ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers`` and legacy code paths.
 - area: http
   change: |
     removed ``envoy.reloadable_features.strip_port_from_connect`` and legacy code paths.
@@ -237,31 +303,41 @@ new_features:
     added new access_log command operator ``%ENVIRONMENT(X):Z%``.
 - area: access_log
   change: |
-    added TCP proxy upstream and downstream byte logging. This can be accessed through the ``%DOWNSTREAM_WIRE_BYTES_SENT%``, ``%DOWNSTREAM_WIRE_BYTES_RECEIVED%``, ``%UPSTREAM_WIRE_BYTES_SENT%``, and ``%UPSTREAM_WIRE_BYTES_RECEIVED%`` access_log command operatrors.
+    added TCP proxy upstream and downstream byte logging. This can be accessed through the ``%DOWNSTREAM_WIRE_BYTES_SENT%``,
+    ``%DOWNSTREAM_WIRE_BYTES_RECEIVED%``, ``%UPSTREAM_WIRE_BYTES_SENT%``, and ``%UPSTREAM_WIRE_BYTES_RECEIVED%`` access_log
+    command operatrors.
 - area: access_log
   change: |
-    make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
+    make consistent access_log format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations
+    of local & remote addresses for upstream & downstream connections.
 - area: admin
   change: |
-    :http:post:`/logging` now accepts ``/logging?paths=name1:level1,name2:level2,...`` to change multiple log levels at once.
+    :http:post:`/logging` now accepts ``/logging?paths=name1:level1,name2:level2,...`` to change multiple log levels at
+    once.
 - area: cluster
   change: |
-    added support for per host limits in :ref:`circuit breakers settings <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers>`. Currently only :ref:`max_connections <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.max_connections>` is supported.
+    added support for per host limits in :ref:`circuit breakers settings
+    <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers>`. Currently only :ref:`max_connections
+    <envoy_v3_api_field_config.cluster.v3.CircuitBreakers.Thresholds.max_connections>` is supported.
 - area: cluster
   change: |
-    added support to restore original destination address from any desired header via setting :ref:`http_header_name <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.http_header_name>`.
+    added support to restore original destination address from any desired header via setting :ref:`http_header_name
+    <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.http_header_name>`.
 - area: cluster
   change: |
-    support :ref:`override host status restriction <envoy_v3_api_field_config.cluster.v3.Cluster.CommonLbConfig.override_host_status>`.
+    support :ref:`override host status restriction
+    <envoy_v3_api_field_config.cluster.v3.Cluster.CommonLbConfig.override_host_status>`.
 - area: compression
   change: |
-    add zstd :ref:`compressor <envoy_v3_api_msg_extensions.compression.zstd.compressor.v3.Zstd>` and :ref:`decompressor <envoy_v3_api_msg_extensions.compression.zstd.decompressor.v3.Zstd>`.
+    add zstd :ref:`compressor <envoy_v3_api_msg_extensions.compression.zstd.compressor.v3.Zstd>` and :ref:`decompressor
+    <envoy_v3_api_msg_extensions.compression.zstd.decompressor.v3.Zstd>`.
 - area: config
   change: |
-    added new file based xDS configuration via :ref:`path_config_source <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`.
-    :ref:`watched_directory <envoy_v3_api_field_config.core.v3.PathConfigSource.watched_directory>` can
-    be used to setup an independent watch for when to reload the file path, for example when using
-    Kubernetes ConfigMaps to deliver configuration. See the linked documentation for more information.
+    added new file based xDS configuration via :ref:`path_config_source
+    <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`. :ref:`watched_directory
+    <envoy_v3_api_field_config.core.v3.PathConfigSource.watched_directory>` can be used to setup an independent watch for
+    when to reload the file path, for example when using Kubernetes ConfigMaps to deliver configuration. See the linked
+    documentation for more information.
 - area: config
   change: |
     added new :ref:`custom config validators <config_config_validation>` to dynamically verify config updates.
@@ -270,116 +346,151 @@ new_features:
     add dynamic support for headers ``access-control-allow-methods`` and ``access-control-allow-headers`` in cors.
 - area: dns
   change: |
-    added :ref:`dns_min_refresh_rate <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_min_refresh_rate>`
-    to the DNS cache implementation to configure the minimum DNS refresh rate, regardless of returned
-    TTL. This was previously hard coded to 5s and defaults to 5s if unset.
+    added :ref:`dns_min_refresh_rate
+    <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_min_refresh_rate>` to the DNS cache
+    implementation to configure the minimum DNS refresh rate, regardless of returned TTL. This was previously hard coded to
+    5s and defaults to 5s if unset.
 - area: gcp authentication http filter
   change: |
     added :ref:`gcp authentication http filter <config_http_filters_gcp_authn>`.
 - area: http
   change: |
-    added ``random_value_specifier`` in :ref:`weighted_clusters <envoy_v3_api_field_config.route.v3.RouteAction.weighted_clusters>` to allow random value to be specified from configuration proto.
+    added ``random_value_specifier`` in :ref:`weighted_clusters
+    <envoy_v3_api_field_config.route.v3.RouteAction.weighted_clusters>` to allow random value to be specified from
+    configuration proto.
 - area: http
   change: |
-    added ``request_mirror_policies`` to higher levels (i.e., :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.RouteConfiguration.request_mirror_policies>` in :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` and :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.VirtualHost.request_mirror_policies>` in :ref:`VirtualHost <envoy_v3_api_msg_config.route.v3.VirtualHost>`) which applies to :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.RouteAction.request_mirror_policies>` in all routes underneath without configured mirror policies.
+    added ``request_mirror_policies`` to higher levels (i.e., :ref:`request_mirror_policies
+    <envoy_v3_api_field_config.route.v3.RouteConfiguration.request_mirror_policies>` in :ref:`RouteConfiguration
+    <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` and :ref:`request_mirror_policies
+    <envoy_v3_api_field_config.route.v3.VirtualHost.request_mirror_policies>` in :ref:`VirtualHost
+    <envoy_v3_api_msg_config.route.v3.VirtualHost>`) which applies to :ref:`request_mirror_policies
+    <envoy_v3_api_field_config.route.v3.RouteAction.request_mirror_policies>` in all routes underneath without configured
+    mirror policies.
 - area: http
   change: |
-    added support for :ref:`cidr_ranges <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.InternalAddressConfig.cidr_ranges>` for configuring list of CIDR ranges that are considered internal.
+    added support for :ref:`cidr_ranges
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.InternalAddressConfig.cidr_ranges>`
+    for configuring list of CIDR ranges that are considered internal.
 - area: http
   change: |
-    added support for :ref:`proxy_status_config <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.proxy_status_config>` for configuring `Proxy-Status <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-08>`_ HTTP response header fields.
+    added support for :ref:`proxy_status_config
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.proxy_status_config>`
+    for configuring `Proxy-Status <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-proxy-status-08>`_ HTTP response
+    header fields.
 - area: http
   change: |
-    make consistent custom header format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all combinations of local & remote addresses for upstream & downstream connections.
+    make consistent custom header format fields ``%(DOWN|DIRECT_DOWN|UP)STREAM_(LOCAL|REMOTE)_*%`` to provide all
+    combinations of local & remote addresses for upstream & downstream connections.
 - area: http2
   change: |
-    adds the new runtime feature ``envoy.reloadable_features.http2_use_oghttp2``, disabled by default, that guards use of a new HTTP/2 implementation.
+    adds the new runtime feature ``envoy.reloadable_features.http2_use_oghttp2``, disabled by default, that guards use of a
+    new HTTP/2 implementation.
 - area: http2
   change: |
-    re-enabled the HTTP/2 wrapper API. This should be a transparent change that does not affect functionality. Any behavior changes can be reverted by setting the ``envoy.reloadable_features.http2_new_codec_wrapper`` runtime feature to false.
+    re-enabled the HTTP/2 wrapper API. This should be a transparent change that does not affect functionality. Any behavior
+    changes can be reverted by setting the ``envoy.reloadable_features.http2_new_codec_wrapper`` runtime feature to false.
 - area: http3
   change: |
-    add :ref:`enable_early_data <envoy_v3_api_field_extensions.transport_sockets.quic.v3.QuicDownstreamTransport.enable_early_data>` to turn on/off downstream early data support.
+    add :ref:`enable_early_data
+    <envoy_v3_api_field_extensions.transport_sockets.quic.v3.QuicDownstreamTransport.enable_early_data>` to turn on/off
+    downstream early data support.
 - area: http3
   change: |
-    downstream HTTP/3 support is now GA! Upstream HTTP/3 also GA for specific deployments. See :ref:`here <arch_overview_http3>` for details.
+    downstream HTTP/3 support is now GA! Upstream HTTP/3 also GA for specific deployments. See :ref:`here
+    <arch_overview_http3>` for details.
 - area: http3
   change: |
-    supports upstream HTTP/3 retries. Automatically retry `0-RTT safe requests <https://www.rfc-editor.org/rfc/rfc7231#section-4.2.1>`_ if they are rejected because they are sent `too early <https://datatracker.ietf.org/doc/html/rfc8470#section-5.2>`_. And automatically retry 0-RTT safe requests if connect attempt fails later on and the cluster is configured with TCP fallback. And add retry on ``http3-post-connect-failure`` policy which allows retry of failed HTTP/3 requests with TCP fallback even after handshake if the cluster is configured with TCP fallback. This feature is guarded by ``envoy.reloadable_features.conn_pool_new_stream_with_early_data_and_http3``.
+    supports upstream HTTP/3 retries. Automatically retry `0-RTT safe requests <https://www.rfc-
+    editor.org/rfc/rfc7231#section-4.2.1>`_ if they are rejected because they are sent `too early
+    <https://datatracker.ietf.org/doc/html/rfc8470#section-5.2>`_. And automatically retry 0-RTT safe requests if connect
+    attempt fails later on and the cluster is configured with TCP fallback. And add retry on ``http3-post-connect-failure``
+    policy which allows retry of failed HTTP/3 requests with TCP fallback even after handshake if the cluster is configured
+    with TCP fallback. This feature is guarded by
+    ``envoy.reloadable_features.conn_pool_new_stream_with_early_data_and_http3``.
 - area: listener
   change: |
     implement :ref:`matching API <arch_overview_matching_listener>` for selecting filter chains.
 - area: local_ratelimit
   change: |
-    added support for sharing the rate limiter between multiple network filter chains or listeners via :ref:`share_key <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.share_key>`.
+    added support for sharing the rate limiter between multiple network filter chains or listeners via :ref:`share_key
+    <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.share_key>`.
 - area: local_ratelimit
   change: |
-    added support for ``X-RateLimit-*`` headers as defined in `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
+    added support for ``X-RateLimit-*`` headers as defined in `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-
+    headers-03.html>`_.
 - area: matching
   change: |
     the matching API can now express a match tree that will always match by omitting a matcher at the top level.
 - area: outlier_detection
   change: |
-    :ref:`max_ejection_time_jitter <envoy_v3_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>` configuration added to allow adding a random value to the ejection time to prevent 'thundering herd' scenarios. Defaults to 0 so as to not break or change the behavior of existing deployments.
+    :ref:`max_ejection_time_jitter <envoy_v3_api_field_config.cluster.v3.OutlierDetection.base_ejection_time>` configuration
+    added to allow adding a random value to the ejection time to prevent 'thundering herd' scenarios. Defaults to 0 so as to
+    not break or change the behavior of existing deployments.
 - area: ratelimit
   change: |
-    added :ref:`rate_limited_status <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.rate_limited_status>` to support return a custom HTTP response status code to the downstream client when the request has been rate limited.
+    added :ref:`rate_limited_status <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.rate_limited_status>`
+    to support return a custom HTTP response status code to the downstream client when the request has been rate limited.
 - area: ratelimit
   change: |
-    network rate limiter supports runtime value substitution using stream info and substitution formatting via :ref:`Network Rate Limiter <config_network_filters_ratelimit_substitution_formatter>`.
+    network rate limiter supports runtime value substitution using stream info and substitution formatting via :ref:`Network
+    Rate Limiter <config_network_filters_ratelimit_substitution_formatter>`.
 - area: redis
   change: |
     support for hostnames returned in ``cluster_slots`` response is now available.
 - area: router
   change: |
-    added :ref:`path_separated_prefix <envoy_v3_api_field_config.route.v3.RouteMatch.path_separated_prefix>` to make route creation more efficient.
+    added :ref:`path_separated_prefix <envoy_v3_api_field_config.route.v3.RouteMatch.path_separated_prefix>` to make route
+    creation more efficient.
 - area: schema_validator_tool
   change: |
-    added ``bootstrap`` checking to the
-    :ref:`schema validator check tool <install_tools_schema_validator_check_tool>`.
+    added ``bootstrap`` checking to the :ref:`schema validator check tool <install_tools_schema_validator_check_tool>`.
 - area: schema_validator_tool
   change: |
-    added ``--fail-on-deprecated`` and ``--fail-on-wip`` to the
-    :ref:`schema validator check tool <install_tools_schema_validator_check_tool>` to allow failing
-    the check if either deprecated or work-in-progress fields are used.
+    added ``--fail-on-deprecated`` and ``--fail-on-wip`` to the :ref:`schema validator check tool
+    <install_tools_schema_validator_check_tool>` to allow failing the check if either deprecated or work-in-progress fields
+    are used.
 - area: schema_validator_tool
   change: |
-    fixed linking of all extensions into the
-    :ref:`schema validator check tool <install_tools_schema_validator_check_tool>` so that all typed
-    configurations can be properly verified.
+    fixed linking of all extensions into the :ref:`schema validator check tool <install_tools_schema_validator_check_tool>`
+    so that all typed configurations can be properly verified.
 - area: schema_validator_tool
   change: |
-    the
-    :ref:`schema validator check tool <install_tools_schema_validator_check_tool>` will now recurse
-    into all sub messages, including Any messages, and perform full validation (deprecation,
-    work-in-progress, PGV, etc.). Previously only top-level messages were fully validated.
+    the :ref:`schema validator check tool <install_tools_schema_validator_check_tool>` will now recurse into all sub
+    messages, including Any messages, and perform full validation (deprecation, work-in-progress, PGV, etc.). Previously
+    only top-level messages were fully validated.
 - area: stats
   change: |
     histogram_buckets query parameter added to stats endpoint to change histogram output to show buckets.
 - area: tap
   change: |
-    added support for buffering an arbitrary number of tapped traces before returning to the client via a new :ref:`buffered admin sink <envoy_v3_api_field_config.tap.v3.OutputSink.buffered_admin>`.
+    added support for buffering an arbitrary number of tapped traces before returning to the client via a new :ref:`buffered
+    admin sink <envoy_v3_api_field_config.tap.v3.OutputSink.buffered_admin>`.
 - area: tcp_proxy
   change: |
-    added support for on demand cluster. If the :ref:`on_demand <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.on_demand>` is set and the destination cluster is not present, a delta CDS request will be sent and the tcp proxy flow will be resumed after that cds response.
+    added support for on demand cluster. If the :ref:`on_demand
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.on_demand>` is set and the destination cluster is
+    not present, a delta CDS request will be sent and the tcp proxy flow will be resumed after that cds response.
 - area: thrift
   change: |
-    add support for connection draining. This can be enabled by setting the runtime guard ``envoy.reloadable_features.thrift_connection_draining`` to true.
+    add support for connection draining. This can be enabled by setting the runtime guard
+    ``envoy.reloadable_features.thrift_connection_draining`` to true.
 - area: thrift
   change: |
     added support for dynamic routing through aggregated discovery service.
 - area: tls
   change: |
-    add support for tls key log :ref:`key_log <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.key_log>`.
+    add support for tls key log :ref:`key_log
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.key_log>`.
 - area: tools
   change: |
-    the project now ships a :ref:`tools docker image <install_tools>` which contains tools
-    useful in support systems such as CI, CD, etc. The
-    :ref:`schema validator check tool <install_tools_schema_validator_check_tool>` has been added
-    to the tools image.
+    the project now ships a :ref:`tools docker image <install_tools>` which contains tools useful in support systems such as
+    CI, CD, etc. The :ref:`schema validator check tool <install_tools_schema_validator_check_tool>` has been added to the
+    tools image.
 - area: udp_proxy
   change: |
-    added :ref:`matcher <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.matcher>` to support matching and routing to different clusters.
+    added :ref:`matcher <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.matcher>` to support matching
+    and routing to different clusters.
 - area: udp_proxy
   change: |
     added support for :ref:`access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.access_log>`.
@@ -387,11 +498,13 @@ new_features:
 deprecated:
 - area: config
   change: |
-    deprecated :ref:`path <envoy_v3_api_field_config.core.v3.ConfigSource.path>` in favor of
-    :ref:`path_config_source <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`.
+    deprecated :ref:`path <envoy_v3_api_field_config.core.v3.ConfigSource.path>` in favor of :ref:`path_config_source
+    <envoy_v3_api_field_config.core.v3.ConfigSource.path_config_source>`.
 - area: http
   change: |
-    deprecated ``envoy.http.headermap.lazy_map_min_size``.  If you are using this config knob you can revert this temporarily by setting ``envoy.reloadable_features.deprecate_global_ints`` to true but you MUST file an upstream issue to ensure this feature remains available.
+    deprecated ``envoy.http.headermap.lazy_map_min_size``.  If you are using this config knob you can revert this
+    temporarily by setting ``envoy.reloadable_features.deprecate_global_ints`` to true but you MUST file an upstream issue
+    to ensure this feature remains available.
 - area: http
   change: |
     removing support for long-deprecated old style filter names, e.g. envoy.router, envoy.lua.
@@ -403,4 +516,5 @@ deprecated:
     deprecated TTwitter protocol since we believe it's not used and it's causing significant maintenance burden.
 - area: udp_proxy
   change: |
-    deprecated :ref:`cluster <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.cluster>` in favor of :ref:`matcher <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.matcher>`.
+    deprecated :ref:`cluster <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.cluster>` in favor of
+    :ref:`matcher <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.matcher>`.

--- a/changelogs/1.22.1.yaml
+++ b/changelogs/1.22.1.yaml
@@ -3,16 +3,27 @@ date: June 9, 2022
 bug_fixes:
 - area: decompression
   change: |
-    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max inflation payload size is now limited.  This change can be reverted via the ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
+    fixed CVE-2022-29225 due to which decompressors can be zip bombed. Previously decompressors were susceptible to memory
+    inflation in takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max
+    inflation payload size is now limited.  This change can be reverted via the
+    ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
 - area: health_check
   change: |
-    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
+    fixed CVE-2022-29224 which caused a segfault in GrpcHealthCheckerImpl. An attacker-controlled upstream server that is
+    health checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
 - area: oauth
   change: |
-    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing access in the presence of any access token attached to the request.
+    fixed CVE-2022-29226 due to which oauth filter allows trivial bypass. The OAuth filter implementation does not include a
+    mechanism for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow
+    should be triggered. However, the current implementation assumes that access tokens are always validated thus allowing
+    access in the presence of any access token attached to the request.
 - area: oauth
   change: |
-    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in newer versions and corrupts memory on earlier versions.
+    fixed CVE-2022-29228 due to which oauth filter calls continueDecoding() from within decodeHeaders(). The OAuth filter
+    would try to invoke the remaining filters in the chain after emitting a local response, which triggers an ASSERT() in
+    newer versions and corrupts memory on earlier versions.
 - area: router
   change: |
-    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an Envoy-generated local reply.
+    fixed CVE-2022-29227 which caused an internal redirect crash for requests with body/trailers. Envoy would previously
+    crash in some cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an
+    Envoy-generated local reply.

--- a/changelogs/1.22.5.yaml
+++ b/changelogs/1.22.5.yaml
@@ -3,10 +3,12 @@ date: August 12, 2022
 bug_fixes:
 - area: listener
   change: |
-    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a memory leak.
+    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a
+    memory leak.
 - area: repo
   change: |
     fix version to resolve release issue.
 - area: transport_socket
   change: |
-    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.
+    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy
+    was built.

--- a/changelogs/1.23.0.yaml
+++ b/changelogs/1.23.0.yaml
@@ -3,51 +3,53 @@ date: July 15, 2022
 behavior_changes:
 - area: tls-inspector
   change: |
-    the listener filter tls inspector's stats ``connection_closed`` and ``read_error`` are removed. New stats are introduced for listener,
-    ``downstream_peek_remote_close`` and ``read_error``, in :ref:`listener stats <config_listener_stats>`.
+    the listener filter tls inspector's stats ``connection_closed`` and ``read_error`` are removed. New stats are introduced
+    for listener, ``downstream_peek_remote_close`` and ``read_error``, in :ref:`listener stats <config_listener_stats>`.
 - area: config
   change: |
-    multiple SDS resources of multiple clusters or listeners are sent in a single SDS requests, instead of multiple SDS requests.
-    This behavioral change can be reverted by setting ``envoy.reloadable_features.combine_sds_requests`` to ``false``.
+    multiple SDS resources of multiple clusters or listeners are sent in a single SDS requests, instead of multiple SDS
+    requests. This behavioral change can be reverted by setting ``envoy.reloadable_features.combine_sds_requests`` to
+    ``false``.
 - area: stats listener
   change: |
-    fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_config.listener.v3.Listener.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    ``envoy_listener_myprefix_downstream_cx_overflow{}`` to ``envoy_listener_downstream_cx_overflow{envoy_listener_address="myprefix"}``.
-    This does not affect the Prometheus name if ``stat_prefix`` is not set.
+    fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_config.listener.v3.Listener.stat_prefix>` is
+    properly extracted. This changes the Prometheus name from ``envoy_listener_myprefix_downstream_cx_overflow{}`` to
+    ``envoy_listener_downstream_cx_overflow{envoy_listener_address="myprefix"}``. This does not affect the Prometheus name
+    if ``stat_prefix`` is not set.
 - area: stats listener
   change: |
-    fixed metric tag extraction so that ``worker_id`` is properly extracted from the listener stats. This changes the Prometheus name from
-    ``envoy_listener_worker_1_downstream_cx_active{envoy_listener_address="0.0.0.0_10000"}``
-    to ``envoy_listener_downstream_cx_active{envoy_listener_address="0.0.0.0_10000", envoy_worker_id="1"}``.
+    fixed metric tag extraction so that ``worker_id`` is properly extracted from the listener stats. This changes the
+    Prometheus name from ``envoy_listener_worker_1_downstream_cx_active{envoy_listener_address="0.0.0.0_10000"}`` to
+    ``envoy_listener_downstream_cx_active{envoy_listener_address="0.0.0.0_10000", envoy_worker_id="1"}``.
 - area: stats server
   change: |
-    fixed metric tag extraction so that ``worker_id`` is properly extracted fromt the server stats. This changes the Prometheus name from
-    ``envoy_server_worker_1_watchdog_miss{}`` to ``envoy_server_watchdog_miss{envoy_worker_id="1"}``.
+    fixed metric tag extraction so that ``worker_id`` is properly extracted fromt the server stats. This changes the
+    Prometheus name from ``envoy_server_worker_1_watchdog_miss{}`` to ``envoy_server_watchdog_miss{envoy_worker_id="1"}``.
 - area: stats thrift_proxy
   change: |
-    fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    ``envoy_thrift_myprefix_request{}`` to ``envoy_thrift_request{envoy_thrift_prefix="myprefix"}``.
+    fixed metric tag extraction so that :ref:`stat_prefix
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.stat_prefix>` is properly extracted. This
+    changes the Prometheus name from ``envoy_thrift_myprefix_request{}`` to
+    ``envoy_thrift_request{envoy_thrift_prefix="myprefix"}``.
 - area: stats redis_proxy
   change: |
-    fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    ``envoy_redis_myprefix_command_pttl_latency_sum{}`` to ``envoy_redis_command_pttl_latency_sum{envoy_redis_prefix="myprefix"}``.
+    fixed metric tag extraction so that :ref:`stat_prefix
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.stat_prefix>` is properly extracted. This
+    changes the Prometheus name from ``envoy_redis_myprefix_command_pttl_latency_sum{}`` to
+    ``envoy_redis_command_pttl_latency_sum{envoy_redis_prefix="myprefix"}``.
 - area: router
   change: |
     updated all HTTP filters to get per-filter config by the :ref:`HTTP filter config name
-    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
-    If there is no entry referred by the filter config name, the canonical filter name
-    (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer filter) will be used for the backwards
-    compatibility.
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`. If there is no entry
+    referred by the filter config name, the canonical filter name (e.g., ``envoy.filters.http.buffer`` for the HTTP buffer
+    filter) will be used for the backwards compatibility.
 - area: router
   change: |
     weighted cluster's :ref:`total_weight <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>` is now
-    optional. If not set, Envoy will no longer validate that all weights add up to 100. The sum of
-    :ref:`weights <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.weight>`
-    across all entries in the clusters array must add up to the
-    :ref:`total_weight <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>`, when it's greater than 0.
+    optional. If not set, Envoy will no longer validate that all weights add up to 100. The sum of :ref:`weights
+    <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.weight>` across all entries in the clusters array must
+    add up to the :ref:`total_weight <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>`, when it's greater
+    than 0.
 
 minor_behavior_changes:
 - area: thrift
@@ -55,40 +57,40 @@ minor_behavior_changes:
     keep downstream connection if the response is completed without underflow.
 - area: tls
   change: |
-    if both :ref:`match_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`
-    and :ref:`match_typed_subject_alt_names <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`
-    are specified, the former (deprecated) field is ignored. Previously, setting both fields would result in an error.
+    if both :ref:`match_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>` and
+    :ref:`match_typed_subject_alt_names
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>` are
+    specified, the former (deprecated) field is ignored. Previously, setting both fields would result in an error.
 - area: tls
   change: |
     removed SHA-1 and RSA key transport cipher suites from the server-side defaults.
 - area: http
   change: |
-    the behavior of the :ref:`timeout <envoy_v3_api_field_config.core.v3.KeepaliveSettings.timeout>`
-    field has been modified to extend the timeout when *any* frame is received on the owning HTTP/2
-    connection. This negates the effect of head-of-line (HOL) blocking for slow connections. If
-    any frame is received the assumption is that the connection is working. This behavior change
-    can be reverted by setting ``envoy.reloadable_features.http2_delay_keepalive_timeout`` to ``false``.
+    the behavior of the :ref:`timeout <envoy_v3_api_field_config.core.v3.KeepaliveSettings.timeout>` field has been modified
+    to extend the timeout when *any* frame is received on the owning HTTP/2 connection. This negates the effect of head-of-
+    line (HOL) blocking for slow connections. If any frame is received the assumption is that the connection is working.
+    This behavior change can be reverted by setting ``envoy.reloadable_features.http2_delay_keepalive_timeout`` to
+    ``false``.
 - area: http
   change: |
-    changing the behavior for ``CONNECT`` and upgrade requests over HTTP/1.1 to not delay close. This behavioral change
-    can be reverted by setting ``envoy.reloadable_features.no_delay_close_for_upgrades`` to ``false``.
+    changing the behavior for ``CONNECT`` and upgrade requests over HTTP/1.1 to not delay close. This behavioral change can
+    be reverted by setting ``envoy.reloadable_features.no_delay_close_for_upgrades`` to ``false``.
 - area: http
   change: |
     the :ref:`dynamo filter <config_http_filters_dynamo>` has been moved to :ref:`contrib images <install_contrib>`.
 - area: http-cache
   change: |
-    HTTP cache filter ``getCache`` interface changed from returning a reference to
-    returning a shared_ptr - any third-party implementations of this interface will need to be
-    updated accordingly. See changes to ``simple_http_cache.cc`` and ``simple_http_cache.h`` in
-    `PR21114 <https://github.com/envoyproxy/envoy/pull/21114>`_ for example.
+    HTTP cache filter ``getCache`` interface changed from returning a reference to returning a shared_ptr - any third-party
+    implementations of this interface will need to be updated accordingly. See changes to ``simple_http_cache.cc`` and
+    ``simple_http_cache.h`` in `PR21114 <https://github.com/envoyproxy/envoy/pull/21114>`_ for example.
 - area: lua
   change: |
-    export symbols of LuaJit by default on Linux. This is useful in cases where you have a lua script
-    that loads shared object libraries, such as those installed via luarocks.
+    export symbols of LuaJit by default on Linux. This is useful in cases where you have a lua script that loads shared
+    object libraries, such as those installed via luarocks.
 - area: admin
   change: |
-    changed default regex engine for ``/stats?filter=`` from ``std::regex`` to RE2, improving
-    filtering speed 20x.
+    changed default regex engine for ``/stats?filter=`` from ``std::regex`` to RE2, improving filtering speed 20x.
 - area: skywalking
   change: |
     use request path as operation name of ``ENTRY``/``EXIT`` spans.
@@ -97,24 +99,22 @@ minor_behavior_changes:
     use upstream host address as ``addressUsedAtClient`` in propagation header.
 - area: dns
   change: |
-    allow propagating DNS responses with no records back to callers like ``strict_dns`` cluster,
-    guarded by ``envoy.reloadable_features.cares_accept_nodata``.
+    allow propagating DNS responses with no records back to callers like ``strict_dns`` cluster, guarded by
+    ``envoy.reloadable_features.cares_accept_nodata``.
 - area: local_ratelimit
   change: |
-    ``local_ratelimit`` will consume tokens of all matched descriptors sorted by tokens per second.
-    This behavioral change can be reverted by setting runtime guard
-    ``envoy.reloadable_features.http_local_ratelimit_match_all_descriptors`` to ``false``.
+    ``local_ratelimit`` will consume tokens of all matched descriptors sorted by tokens per second. This behavioral change
+    can be reverted by setting runtime guard ``envoy.reloadable_features.http_local_ratelimit_match_all_descriptors`` to
+    ``false``.
 - area: router
   change: |
-    get route config factories by the configuration proto full names by default. This behavior change
-    can be reverted by setting the ``envoy.reloadable_features.get_route_config_factory_by_type``
-    runtime flag to ``false``.
+    get route config factories by the configuration proto full names by default. This behavior change can be reverted by
+    setting the ``envoy.reloadable_features.get_route_config_factory_by_type`` runtime flag to ``false``.
 - area: lua
   change: |
-    lua ``respond`` api will call ``sendLocalReply`` instead of ``encodeHeaders`` and ``encodeData``.
-    This means that encoder filters will be correctly invoked, including adding configured response
-    headers, etc. This behavioral change can be reverted by setting runtime guard
-    ``envoy.reloadable_features.lua_respond_with_send_local_reply`` to ``false``.
+    lua ``respond`` api will call ``sendLocalReply`` instead of ``encodeHeaders`` and ``encodeData``. This means that
+    encoder filters will be correctly invoked, including adding configured response headers, etc. This behavioral change can
+    be reverted by setting runtime guard ``envoy.reloadable_features.lua_respond_with_send_local_reply`` to ``false``.
 - area: logging
   change: |
     changed flag ``--log-format-escaped`` to only log one trailing newline per log line.
@@ -130,18 +130,21 @@ minor_behavior_changes:
     remove unnecessary ``spawnChild`` annotations in OpenCensus tracer.
 - area: conn pool
   change: |
-    changed HTTP/2 connection pooling and the :ref:`ALPN pool <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>`
-    to remember the number of streams allowed by the endpoint and cap multiplexed streams for subsequent connections based on that.
-    With that working, defaulted the ALPN pool to assume HTTP/2 will work, as it will only incur a latency hit once until the TLS handshake is complete,
-    and then will cache that the effective stream limit is ``1``. This behavioral change can be revered by setting
+    changed HTTP/2 connection pooling and the :ref:`ALPN pool
+    <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` to remember the number of streams
+    allowed by the endpoint and cap multiplexed streams for subsequent connections based on that. With that working,
+    defaulted the ALPN pool to assume HTTP/2 will work, as it will only incur a latency hit once until the TLS handshake is
+    complete, and then will cache that the effective stream limit is ``1``. This behavioral change can be revered by setting
     ``envoy.reloadable_features.allow_concurrency_for_alpn_pool`` to ``false``.
 - area: network
   change: |
-    the :ref:`client ssl auth filter <config_network_filters_client_ssl_auth>` has been moved to :ref:`contrib images <install_contrib>`.
+    the :ref:`client ssl auth filter <config_network_filters_client_ssl_auth>` has been moved to :ref:`contrib images
+    <install_contrib>`.
 - area: tcp_proxy
   change: |
-    added support for command operators in :ref:`TunnelingConfig hostname <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.hostname>`
-    to dynamically set upstream hostname.
+    added support for command operators in :ref:`TunnelingConfig hostname
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.hostname>` to dynamically set
+    upstream hostname.
 
 bug_fixes:
 - area: grpc_json_transcoder
@@ -149,41 +152,38 @@ bug_fixes:
     respond with a error messsage if a proto message is too deep (>64). Before the fix the response was an empty JSON.
 - area: http
   change: |
-    fixed HTTP/2 CONNECT to be RFC compliant, rather than following the abandoned extended connect draft.
-    This behavioral change can be reverted by setting runtime guard ``envoy.reloadable_features.use_rfc_connect`` to ``false``.
+    fixed HTTP/2 CONNECT to be RFC compliant, rather than following the abandoned extended connect draft. This behavioral
+    change can be reverted by setting runtime guard ``envoy.reloadable_features.use_rfc_connect`` to ``false``.
 - area: decompression
   change: |
-    fixed CVE-2022-29225: Decompressors can be zip bombed. Previously decompressors were
-    susceptible to memory inflation in takes in which specially crafted payloads could cause a
-    large amount of memory usage by Envoy. The max inflation payload size is now limited.
-    This change can be reverted via the ``envoy.reloadable_features.enable_compression_bomb_protection``
-    runtime flag.
+    fixed CVE-2022-29225: Decompressors can be zip bombed. Previously decompressors were susceptible to memory inflation in
+    takes in which specially crafted payloads could cause a large amount of memory usage by Envoy. The max inflation payload
+    size is now limited. This change can be reverted via the
+    ``envoy.reloadable_features.enable_compression_bomb_protection`` runtime flag.
 - area: router
   change: |
-    fixed CVE-2022-29227: Internal redirect crash for requests with body/trailers. Envoy would
-    previously crash in some cases when processing internal redirects for requests with bodies or
-    trailers if the redirect prompts an Envoy-generated local reply.
+    fixed CVE-2022-29227: Internal redirect crash for requests with body/trailers. Envoy would previously crash in some
+    cases when processing internal redirects for requests with bodies or trailers if the redirect prompts an Envoy-generated
+    local reply.
 - area: oauth
   change: |
-    fixed CVE-2022-29226: oauth filter allows trivial bypass. The OAuth filter implementation does
-    not include a mechanism for validating access tokens, so by design when the HMAC signed cookie
-    is missing a full authentication flow should be triggered. However, the current implementation
-    assumes that access tokens are always validated thus allowing access in the presence of any
-    access token attached to the request.
+    fixed CVE-2022-29226: oauth filter allows trivial bypass. The OAuth filter implementation does not include a mechanism
+    for validating access tokens, so by design when the HMAC signed cookie is missing a full authentication flow should be
+    triggered. However, the current implementation assumes that access tokens are always validated thus allowing access in
+    the presence of any access token attached to the request.
 - area: oauth
   change: |
-    fixed CVE-2022-29228: oauth filter calls ``continueDecoding()`` from within ``decodeHeaders()``. The
-    OAuth filter would try to invoke the remaining filters in the chain after emitting a local
-    response, which triggers an ``ASSERT()`` in newer versions and corrupts memory on earlier versions.
+    fixed CVE-2022-29228: oauth filter calls ``continueDecoding()`` from within ``decodeHeaders()``. The OAuth filter would
+    try to invoke the remaining filters in the chain after emitting a local response, which triggers an ``ASSERT()`` in
+    newer versions and corrupts memory on earlier versions.
 - area: health_check
   change: |
-    fixed CVE-2022-29224: Segfault in ``GrpcHealthCheckerImpl``. An attacker-controlled upstream server
-    that is health checked using gRPC health checking can crash Envoy via a null pointer dereference
-    in certain circumstances.
+    fixed CVE-2022-29224: Segfault in ``GrpcHealthCheckerImpl``. An attacker-controlled upstream server that is health
+    checked using gRPC health checking can crash Envoy via a null pointer dereference in certain circumstances.
 - area: runtime
   change: |
-    fixed a bug where ``envoy.restart_features.no_runtime_singleton`` was inverted.
-    Runtime singleton status is now guarded by non-inverted ``envoy.restart_features.remove_runtime_singleton``.
+    fixed a bug where ``envoy.restart_features.no_runtime_singleton`` was inverted. Runtime singleton status is now guarded
+    by non-inverted ``envoy.restart_features.remove_runtime_singleton``.
 - area: tcp_proxy
   change: |
     fixed an issue using the cluster wide ``CONNECT`` termination so it will successfully proxy payloads.
@@ -221,7 +221,8 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.conn_pool_delete_when_idle`` and legacy code paths.
 - area: runtime
   change: |
-    removed ``envoy.restart_features.no_runtime_singleton`` and replaced with ``envoy.restart_features.remove_runtime_singleton``.
+    removed ``envoy.restart_features.no_runtime_singleton`` and replaced with
+    ``envoy.restart_features.remove_runtime_singleton``.
 - area: udp listener
   change: |
     removed ``envoy.reloadable_features.udp_listener_updates_filter_chain_in_place`` and legacy code paths.
@@ -232,136 +233,158 @@ removed_config_or_runtime:
 new_features:
 - area: lua
   change: |
-    added new function :ref:`timestampString <config_http_filters_lua_stream_handle_api_timestamp_string>`
-    returning the time since epoch as a string. Supported resolutions are millisecond and microsecond.
+    added new function :ref:`timestampString <config_http_filters_lua_stream_handle_api_timestamp_string>` returning the
+    time since epoch as a string. Supported resolutions are millisecond and microsecond.
 - area: access_log
   change: |
-    added formatters for :ref:`UPSTREAM_METADATA<config_access_log_format_upstream_host_metadata>`
-    and :ref:`METADATA(UPSTREAM_HOST)<envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>`.
+    added formatters for :ref:`UPSTREAM_METADATA<config_access_log_format_upstream_host_metadata>` and
+    :ref:`METADATA(UPSTREAM_HOST)<envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>`.
 - area: access_log
   change: |
-    added new ``access_log`` command operators to retrieve upstream connection information change:
-    ``%UPSTREAM_PROTOCOL%``, ``%UPSTREAM_PEER_SUBJECT%``, ``%UPSTREAM_PEER_ISSUER%``, ``%UPSTREAM_TLS_SESSION_ID%``,
-    ``%UPSTREAM_TLS_CIPHER%``, ``%UPSTREAM_TLS_VERSION%``, ``%UPSTREAM_PEER_CERT_V_START%``, ``%UPSTREAM_PEER_CERT_V_END%``,
-    ``%UPSTREAM_PEER_CERT%`` and ``%UPSTREAM_FILTER_STATE%``.
+    added new ``access_log`` command operators to retrieve upstream connection information change: ``%UPSTREAM_PROTOCOL%``,
+    ``%UPSTREAM_PEER_SUBJECT%``, ``%UPSTREAM_PEER_ISSUER%``, ``%UPSTREAM_TLS_SESSION_ID%``, ``%UPSTREAM_TLS_CIPHER%``,
+    ``%UPSTREAM_TLS_VERSION%``, ``%UPSTREAM_PEER_CERT_V_START%``, ``%UPSTREAM_PEER_CERT_V_END%``, ``%UPSTREAM_PEER_CERT%``
+    and ``%UPSTREAM_FILTER_STATE%``.
 - area: open_telemetry
   change: |
-    added :ref:`resource_attributes <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.resource_attributes>`
+    added :ref:`resource_attributes
+    <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.resource_attributes>`
     configuration to OpenTelemetry.
 - area: dns_resolver
   change: |
-    added :ref:`include_unroutable_families<envoy_v3_api_field_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig.include_unroutable_families>`
-    to the Apple DNS resolver.
+    added :ref:`include_unroutable_families
+    <envoy_v3_api_field_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig.include_unroutable_families>` to the
+    Apple DNS resolver.
 - area: dns_resolver
   change: |
-    added support for multiple addresses. This is most valuable when used in conjunction with
-    :ref:`ALL <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` enabling full happy eyeballs support
-    for Envoy (see detailed documentation :ref:`here <arch_overview_conn_pool>` but will also result in trying multiple addresses
-    for resolvers doing only IPv4 or IPv6. This behavioral change can be temporarily disabled by setting runtime guard
+    added support for multiple addresses. This is most valuable when used in conjunction with :ref:`ALL
+    <envoy_v3_api_enum_value_config.cluster.v3.Cluster.DnsLookupFamily.ALL>` enabling full happy eyeballs support for Envoy
+    (see detailed documentation :ref:`here <arch_overview_conn_pool>` but will also result in trying multiple addresses for
+    resolvers doing only IPv4 or IPv6. This behavioral change can be temporarily disabled by setting runtime guard
     ``envoy.restart_features.remove_runtime_singleton`` to ``false``.
 - area: dns_resolver
   change: |
-    added :ref:`GetAddrInfoDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig>`,
-    a new DNS resolver that uses the system's ``getaddrinfo()`` function to resolve DNS. This was primarily added for use on Android
-    but can also be used in other situations in which the system resolver is desired.
+    added :ref:`GetAddrInfoDnsResolverConfig
+    <envoy_v3_api_msg_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig>`, a new DNS resolver that
+    uses the system's ``getaddrinfo()`` function to resolve DNS. This was primarily added for use on Android but can also be
+    used in other situations in which the system resolver is desired.
 - area: dubbo_proxy
   change: |
-    added :ref:`dynamic routes discovery <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.drds>` support to dubbo proxy.
+    added :ref:`dynamic routes discovery <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.drds>`
+    support to dubbo proxy.
 - area: ext_proc
   change: |
-    added support for per-route :ref:`grpc_service <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExtProcOverrides.grpc_service>`.
+    added support for per-route :ref:`grpc_service
+    <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExtProcOverrides.grpc_service>`.
 - area: http
   change: |
     added new :ref:`file_system_buffer <config_http_filters_file_system_buffer>` HTTP filter.
 - area: http
   change: |
-    added a :ref:`send_fully_qualified_url <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.send_fully_qualified_url>` configuration option
-    to send absolute URLs for HTTP/1.1.
+    added a :ref:`send_fully_qualified_url
+    <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.send_fully_qualified_url>` configuration option to send absolute
+    URLs for HTTP/1.1.
 - area: http
   change: |
-    preserve case header formatter support innner formatter on Envoy headers in
-    :ref:`formatter_type_on_envoy_headers <envoy_v3_api_field_extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig.formatter_type_on_envoy_headers>`.
+    preserve case header formatter support innner formatter on Envoy headers in :ref:`formatter_type_on_envoy_headers
+    <envoy_v3_api_field_extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig.formatter_type_on_envoy_headers>`.
 - area: http3
   change: |
-    added :ref:`early_data_policy <envoy_v3_api_field_config.route.v3.RouteAction.early_data_policy>` extension to allow upstream HTTP/3 sending
-    requests over early data. If no extension is configured, HTTP/3 pool will send safe requests as early data to the host
-    if the pool already cached 0-RTT credentials of that host. If those requests fail and the underlying connection pool supports
-    TCP fallback, the request may be retried automatically. If the :ref:`default extension <envoy_v3_api_msg_extensions.early_data.v3.DefaultEarlyDataPolicy>`
-    is configured, no requests are allowed to be sent as early data. Note that if any customized extension configures non-safe requests to be allowed over early data,
-    the Envoy will not automatically retry them. If desired, explicitly config their :ref:`retry_policy <envoy_v3_api_field_config.route.v3.RouteAction.retry_policy>`.
-    Sending early data requires both ``envoy.reloadable_features.conn_pool_new_stream_with_early_data_and_http3`` and ``envoy.reloadable_features.http3_sends_early_data``
-    runtime flags to be set to ``true``.
+    added :ref:`early_data_policy <envoy_v3_api_field_config.route.v3.RouteAction.early_data_policy>` extension to allow
+    upstream HTTP/3 sending requests over early data. If no extension is configured, HTTP/3 pool will send safe requests as
+    early data to the host if the pool already cached 0-RTT credentials of that host. If those requests fail and the
+    underlying connection pool supports TCP fallback, the request may be retried automatically. If the :ref:`default
+    extension <envoy_v3_api_msg_extensions.early_data.v3.DefaultEarlyDataPolicy>` is configured, no requests are allowed to
+    be sent as early data. Note that if any customized extension configures non-safe requests to be allowed over early data,
+    the Envoy will not automatically retry them. If desired, explicitly config their :ref:`retry_policy
+    <envoy_v3_api_field_config.route.v3.RouteAction.retry_policy>`. Sending early data requires both
+    ``envoy.reloadable_features.conn_pool_new_stream_with_early_data_and_http3`` and
+    ``envoy.reloadable_features.http3_sends_early_data`` runtime flags to be set to ``true``.
 - area: listener
   change: |
-    added :ref:`dynamic listener filter configuration <envoy_v3_api_field_config.listener.v3.ListenerFilter.config_discovery>`
-    for listener filters. This dynamic listener filter configuration is only supported by TCP listeners.
+    added :ref:`dynamic listener filter configuration
+    <envoy_v3_api_field_config.listener.v3.ListenerFilter.config_discovery>` for listener filters. This dynamic listener
+    filter configuration is only supported by TCP listeners.
 - area: redis
   change: |
-    added support for multiple passwords to the redis proxy. See
-    :ref:`downstream_auth_passwords <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
+    added support for multiple passwords to the redis proxy. See :ref:`downstream_auth_passwords
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
 - area: thrift
   change: |
-    added :ref:`close_downstream_on_upstream_error <envoy_v3_api_field_extensions.filters.network.thrift_proxy.router.v3.Router.close_downstream_on_upstream_error>`
-    flag to router to control downstream local close.
+    added :ref:`close_downstream_on_upstream_error
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.router.v3.Router.close_downstream_on_upstream_error>` flag
+    to router to control downstream local close.
 - area: thrift
   change: |
     added support for access logging for :ref:`Thrift Proxy <config_network_filters_thrift_proxy>`.
 - area: thrift
   change: |
-    added support for preserving header keys. See :ref:`header_keys_preserve_case <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.header_keys_preserve_case>`.
+    added support for preserving header keys. See :ref:`header_keys_preserve_case
+    <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.header_keys_preserve_case>`.
 - area: thrift
   change: |
-    added support for propogating connection draining if local replies try to end downstream. Can be enabled by setting the runtime flag ``envoy.reloadable_features.thrift_connection_draining`` to true.
+    added support for propogating connection draining if local replies try to end downstream. Can be enabled by setting the
+    runtime flag ``envoy.reloadable_features.thrift_connection_draining`` to true.
 - area: thrift
   change: |
     added ``onLocalReply`` support to inform filters of local replies.
 - area: thrift
   change: |
-    introduced thrift configurable encoder and bidirectional filters, which allows peeking and modifying the thrift response message.
+    introduced thrift configurable encoder and bidirectional filters, which allows peeking and modifying the thrift response
+    message.
 - area: on_demand
   change: |
-    :ref:`OnDemand <envoy_v3_api_msg_extensions.filters.http.on_demand.v3.OnDemand>` got extended to hold configuration for on-demand cluster discovery.
-    A similar message for :ref:`per-route configuration <envoy_v3_api_msg_extensions.filters.http.on_demand.v3.PerRouteConfig>` is also added.
+    :ref:`OnDemand <envoy_v3_api_msg_extensions.filters.http.on_demand.v3.OnDemand>` got extended to hold configuration for
+    on-demand cluster discovery. A similar message for :ref:`per-route configuration
+    <envoy_v3_api_msg_extensions.filters.http.on_demand.v3.PerRouteConfig>` is also added.
 - area: proxy_protcol
   change: |
-    added :ref:`allow_requests_without_proxy_protocol<envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.allow_requests_without_proxy_protocol>`
+    added :ref:`allow_requests_without_proxy_protocol
+    <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.allow_requests_without_proxy_protocol>`
     to allow requests without proxy protocol on the listener from trusted downstreams as an opt-in flag.
 - area: udp
   change: |
-    added :ref:`udp_packet_packet_writer_config <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.udp_packet_packet_writer_config>`
-    config to specify the UDP packet writer factory.
+    added :ref:`udp_packet_packet_writer_config
+    <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.udp_packet_packet_writer_config>` config to specify the UDP
+    packet writer factory.
 - area: build
   change: |
     enabled building arm64 envoy-distroless and envoy-tools :ref:`docker images <install_binaries>`.
 - area: ratelimit
   change: |
-    added support for :ref:`masked_remote_address <envoy_v3_api_field_config.route.v3.RateLimit.Action.masked_remote_address>`.
+    added support for :ref:`masked_remote_address
+    <envoy_v3_api_field_config.route.v3.RateLimit.Action.masked_remote_address>`.
 - area: ratelimit
   change: |
     added support for :ref:`HTTP matching input functions <arch_overview_matching_api>` as descriptor producers.
 - area: http
   change: |
     added :ref:`cluster_header <envoy_v3_api_field_config.route.v3.RouteAction.RequestMirrorPolicy.cluster_header>` in
-    :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.RouteAction.request_mirror_policies>` to allow routing shadow request
-    to the cluster specified in the request_header.
+    :ref:`request_mirror_policies <envoy_v3_api_field_config.route.v3.RouteAction.request_mirror_policies>` to allow routing
+    shadow request to the cluster specified in the request_header.
 - area: upstream
   change: |
-    added :ref:`internal upstream transport <envoy_v3_api_msg_extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport>`
-    for passing metadata and filter state across the user space sockets and the internal listeners.
+    added :ref:`internal upstream transport
+    <envoy_v3_api_msg_extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport>` for passing metadata and
+    filter state across the user space sockets and the internal listeners.
 - area: router
   change: |
-    added :ref:`keep_empty_value <envoy_v3_api_field_config.core.v3.HeaderValueOption.keep_empty_value>` to allow keeping empty values in custom headers.
+    added :ref:`keep_empty_value <envoy_v3_api_field_config.core.v3.HeaderValueOption.keep_empty_value>` to allow keeping
+    empty values in custom headers.
 - area: dubbo_proxy
   change: |
-    added :ref:`metadata_match <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.RouteAction.metadata_match>` support to the dubbo proxy.
+    added :ref:`metadata_match <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.RouteAction.metadata_match>`
+    support to the dubbo proxy.
 - area: network
   change: |
-    extended conection balancer with :ref:`extend balance <envoy_v3_api_field_config.listener.v3.Listener.ConnectionBalanceConfig.extend_balance>`,
-    and added :ref:`Dlb connection balancer <envoy_v3_api_msg_extensions.network.connection_balance.dlb.v3alpha.Dlb>` to use
-    `DLB <https://www.intel.com/content/www/us/en/download/686372/intel-dynamic-load-balancer.html>`_ hardware to balance.
+    extended conection balancer with :ref:`extend balance
+    <envoy_v3_api_field_config.listener.v3.Listener.ConnectionBalanceConfig.extend_balance>`, and added :ref:`Dlb connection
+    balancer <envoy_v3_api_msg_extensions.network.connection_balance.dlb.v3alpha.Dlb>` to use `DLB
+    <https://www.intel.com/content/www/us/en/download/686372/intel-dynamic-load-balancer.html>`_ hardware to balance.
 - area: router
   change: |
-    added :ref:`stat_prefix <envoy_v3_api_field_config.route.v3.Route.stat_prefix>` support to generate route level statistics.
+    added :ref:`stat_prefix <envoy_v3_api_field_config.route.v3.Route.stat_prefix>` support to generate route level
+    statistics.
 - area: router
   change: |
     added :ref:`INTERNAL_SERVER_ERROR option
@@ -375,25 +398,30 @@ new_features:
     added :ref:`matcher <arch_overview_rbac_matcher>` for selecting connections and requests to different actions.
 - area: http
   change: |
-    added :ref:`treat_missing_header_as_empty <envoy_v3_api_field_config.route.v3.HeaderMatcher.treat_missing_header_as_empty>`
-    to allow header match rule to treat the header value as empty and apply the match rule when the header is missing.
+    added :ref:`treat_missing_header_as_empty
+    <envoy_v3_api_field_config.route.v3.HeaderMatcher.treat_missing_header_as_empty>` to allow header match rule to treat
+    the header value as empty and apply the match rule when the header is missing.
 - area: thrift
   change: |
-    added ``validate_clusters`` in :ref:`RouteConfiguration <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.v3.RouteConfiguration>`
-    to override the default behavior of cluster validation.
+    added ``validate_clusters`` in :ref:`RouteConfiguration
+    <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.v3.RouteConfiguration>` to override the default behavior of
+    cluster validation.
 - area: admin
   change: |
     added compile-time option ``--define=admin_html=disabled`` to disable HTML home page.
 - area: router
   change: |
-    added :ref:`ignore_port_in_host_matching <envoy_v3_api_field_config.route.v3.RouteConfiguration.ignore_port_in_host_matching>`. When set to ``true``,
-    port number (if any) in host header is ignored during host matching.
+    added :ref:`ignore_port_in_host_matching
+    <envoy_v3_api_field_config.route.v3.RouteConfiguration.ignore_port_in_host_matching>`. When set to ``true``, port number
+    (if any) in host header is ignored during host matching.
 - area: router
   change: |
-    added :ref:`ignore_path_parameters_in_path_matching <envoy_v3_api_field_config.route.v3.RouteConfiguration.ignore_path_parameters_in_path_matching>`.
-    When set to ``true``, path-parameters(`rfc1808 <https://datatracker.ietf.org/doc/html/rfc1808>`_) is ignored during path matching.
-    added :ref:`ignore_path_parameters_in_path_matching <envoy_v3_api_field_config.route.v3.RouteConfiguration.ignore_path_parameters_in_path_matching>`.
-    When set to ``true``, path-parameters(rfc1808) is ignored during path matching.
+    added :ref:`ignore_path_parameters_in_path_matching
+    <envoy_v3_api_field_config.route.v3.RouteConfiguration.ignore_path_parameters_in_path_matching>`. When set to ``true``,
+    path-parameters(`rfc1808 <https://datatracker.ietf.org/doc/html/rfc1808>`_) is ignored during path matching. added
+    :ref:`ignore_path_parameters_in_path_matching
+    <envoy_v3_api_field_config.route.v3.RouteConfiguration.ignore_path_parameters_in_path_matching>`. When set to ``true``,
+    path-parameters(rfc1808) is ignored during path matching.
 - area: examples
   change: |
     fixed issues with documentation/compositions usage of ``docker-compose pull``.
@@ -404,21 +432,25 @@ new_features:
 deprecated:
 - area: dubbo_proxy
   change: |
-    deprecated :ref:`old dubbo route config <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.route_config>`. Please use
-    :ref:`multiple route config <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.multiple_route_config>` or
-    :ref:`DRDS <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.drds>` first.
+    deprecated :ref:`old dubbo route config
+    <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.route_config>`. Please use :ref:`multiple route
+    config <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.multiple_route_config>` or :ref:`DRDS
+    <envoy_v3_api_field_extensions.filters.network.dubbo_proxy.v3.DubboProxy.drds>` first.
 - area: http
   change: |
     deprecated the short name ``preserve_case`` for the header formatter extension in favor of the fully-qualified name
     ``envoy.http.stateful_header_formatters.preserve_case``.
 - area: matching
   change: |
-    :ref:`google_re2 <envoy_v3_api_field_type.matcher.v3.RegexMatcher.google_re2>` has been deprecated. A default regex engine can be set using
-    :ref:`default_regex_engine <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.default_regex_engine>`.
+    :ref:`google_re2 <envoy_v3_api_field_type.matcher.v3.RegexMatcher.google_re2>` has been deprecated. A default regex
+    engine can be set using :ref:`default_regex_engine
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.default_regex_engine>`.
 - area: redis
   change: |
-    deprecated :ref:`downstream_auth_password <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_password>`. Please use
-    :ref:`downstream_auth_passwords <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
+    deprecated :ref:`downstream_auth_password
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_password>`. Please use
+    :ref:`downstream_auth_passwords
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_passwords>`.
 - area: lua
   change: |
     deprecated :ref:`inline_code <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>`. Please use

--- a/changelogs/1.23.1.yaml
+++ b/changelogs/1.23.1.yaml
@@ -3,4 +3,5 @@ date: August 23, 2022
 bug_fixes:
 - area: listener
   change: |
-    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly and that will lead to a memory leak.
+    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly and that will lead to a
+    memory leak.

--- a/changelogs/1.23.2.yaml
+++ b/changelogs/1.23.2.yaml
@@ -3,5 +3,5 @@ date: October 17, 2022
 bug_fixes:
 - area: lua
   change: |
-    fixed a bug causing response headers set by a Lua script to not be sent in the response (https://github.com/envoyproxy/envoy/issues/22401).
-    This bug was introduced in Envoy v1.23.0.
+    fixed a bug causing response headers set by a Lua script to not be sent in the response
+    (https://github.com/envoyproxy/envoy/issues/22401). This bug was introduced in Envoy v1.23.0.

--- a/changelogs/1.23.3.yaml
+++ b/changelogs/1.23.3.yaml
@@ -9,5 +9,4 @@ bug_fixes:
     update Curl, Kafka, Wasm to mitigate CVEs.
 - area: docker
   change: |
-    update Docker images (``distroless`` -> ``4b22ca3c6``) to resolve CVE issues
-    in container packages.
+    update Docker images (``distroless`` -> ``4b22ca3c6``) to resolve CVE issues in container packages.

--- a/changelogs/1.24.0.yaml
+++ b/changelogs/1.24.0.yaml
@@ -6,74 +6,94 @@ behavior_changes:
     official released binary is now built on Ubuntu 20.04, requires glibc >= 2.30.
 - area: stats http local_rate_limit
   change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    envoy_http_local_rate_limit_myprefix_rate_limited{} to envoy_http_local_rate_limit_rate_limited{envoy_local_http_ratelimit_prefix="myprefix"}.
+    Fixed metric tag extraction so that :ref:`stat_prefix
+    <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.stat_prefix>` is properly extracted. This
+    changes the Prometheus name from envoy_http_local_rate_limit_myprefix_rate_limited{} to
+    envoy_http_local_rate_limit_rate_limited{envoy_local_http_ratelimit_prefix="myprefix"}.
 - area: stats network local_rate_limit
   change: |
-    Fixed metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.stat_prefix>`
-    is properly extracted. This changes the Prometheus name from
-    envoy_local_rate_limit_myprefix_rate_limited{} to envoy_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix="myprefix"}.
+    Fixed metric tag extraction so that :ref:`stat_prefix
+    <envoy_v3_api_field_extensions.filters.network.local_ratelimit.v3.LocalRateLimit.stat_prefix>` is properly extracted.
+    This changes the Prometheus name from envoy_local_rate_limit_myprefix_rate_limited{} to
+    envoy_local_rate_limit_rate_limited{envoy_local_ratelimit_prefix="myprefix"}.
 - area: http
   change: |
-    Envoy no longer adds ``content-length: 0`` header when proxying UPGRADE requests without ``content-length`` and ``transfer-encoding`` headers.
-    This behavior change can be reverted by setting the ``envoy.reloadable_features.http_skip_adding_content_length_to_upgrade`` runtime flag to false.
+    Envoy no longer adds ``content-length: 0`` header when proxying UPGRADE requests without ``content-length`` and
+    ``transfer-encoding`` headers. This behavior change can be reverted by setting the
+    ``envoy.reloadable_features.http_skip_adding_content_length_to_upgrade`` runtime flag to false.
 - area: tls
   change: |
-    Change TLS and QUIC transport sockets to support asynchronous cert validation extension. This behavior change can be reverted by setting runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` to false.
+    Change TLS and QUIC transport sockets to support asynchronous cert validation extension. This behavior change can be
+    reverted by setting runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` to false.
 - area: gcp_authn
   change: |
-    Add GCP Authentication filter which can be used to fetch authentication tokens from Google Compute Engine(GCE) metadata server.
+    Add GCP Authentication filter which can be used to fetch authentication tokens from Google Compute Engine(GCE) metadata
+    server.
 - area: http
   change: |
     For HTTP/2 and HTTP/3 codecs, all clients now continue sending data upstream after receiving an end of the server
-    stream. This supports the server half-close semantics for TCP tunneling with CONNECT as well as bi-directional
-    streaming calls. This behavior change can be reverted by setting the
-    ``envoy.reloadable_features.http_response_half_close`` runtime flag to false.
+    stream. This supports the server half-close semantics for TCP tunneling with CONNECT as well as bi-directional streaming
+    calls. This behavior change can be reverted by setting the ``envoy.reloadable_features.http_response_half_close``
+    runtime flag to false.
 - area: original_dst
   change: |
-    ORIGINAL_DST cluster will not attempt to remove and drain the stale hosts during cleanup if they are still used by
-    the connection pools. For HTTP pools, please set :ref:`idle_timeout <faq_configuration_connection_timeouts>` to
-    limit the duration of the upstream connections (the default value is 1h, and the recommended value is 5min). This
-    behavior change can be reverted by setting runtime guard
-    ``envoy.reloadable_features.original_dst_rely_on_idle_timeout``.
+    ORIGINAL_DST cluster will not attempt to remove and drain the stale hosts during cleanup if they are still used by the
+    connection pools. For HTTP pools, please set :ref:`idle_timeout <faq_configuration_connection_timeouts>` to limit the
+    duration of the upstream connections (the default value is 1h, and the recommended value is 5min). This behavior change
+    can be reverted by setting runtime guard ``envoy.reloadable_features.original_dst_rely_on_idle_timeout``.
 - area: config
   change: |
-    Fixed resource tracking when using the Incremental (Delta-xDS) protocol. The protocol state will be updated after
-    the resources are successfully ingested and an ACK is sent. This behavior change can be reverted by setting the
+    Fixed resource tracking when using the Incremental (Delta-xDS) protocol. The protocol state will be updated after the
+    resources are successfully ingested and an ACK is sent. This behavior change can be reverted by setting the
     ``envoy.reloadable_features.delta_xds_subscription_state_tracking_fix`` runtime flag to false.
 
 minor_behavior_changes:
 - area: logging
   change: |
-    changed the ``UPSTREAM_REMOTE_ADDRESS``, ``UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT``, and ``UPSTREAM_REMOTE_PORT`` fields to log based on the actual upstream connection rather than the upstream host. This fixes a bug where the address components were not consistently correct for Happy Eyeballs connections and proxied connections, but also means in cases where the host was selected but a connection was not established, the fields will be absent. This change can be temporarily reverted by setting the runtime guard ``envoy.reloadable_features.correct_remote_address`` to false.
+    changed the ``UPSTREAM_REMOTE_ADDRESS``, ``UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT``, and ``UPSTREAM_REMOTE_PORT`` fields
+    to log based on the actual upstream connection rather than the upstream host. This fixes a bug where the address
+    components were not consistently correct for Happy Eyeballs connections and proxied connections, but also means in cases
+    where the host was selected but a connection was not established, the fields will be absent. This change can be
+    temporarily reverted by setting the runtime guard ``envoy.reloadable_features.correct_remote_address`` to false.
 - area: resource_monitors
   change: |
-    changed behavior of the fixed heap monitor to count pages allocated to TCMalloc as free memory if it's not used by Envoy. This change can be reverted temporarily by setting the runtime guard ``envoy.reloadable_features.do_not_count_mapped_pages_as_free`` to true.
+    changed behavior of the fixed heap monitor to count pages allocated to TCMalloc as free memory if it's not used by
+    Envoy. This change can be reverted temporarily by setting the runtime guard
+    ``envoy.reloadable_features.do_not_count_mapped_pages_as_free`` to true.
 - area: prometheus_stats
   change: |
     removed blank line for being compatible with OpenMetrics.
 - area: quic
   change: |
-    changed the timing of QUIC connection writing data in response to incoming packets in non-Windowns platforms. This change can be reverted by setting runtime guard ``envoy.reloadable_features.quic_defer_send_in_response_to_packet`` to false.
+    changed the timing of QUIC connection writing data in response to incoming packets in non-Windowns platforms. This
+    change can be reverted by setting runtime guard ``envoy.reloadable_features.quic_defer_send_in_response_to_packet`` to
+    false.
 - area: original_dst
   change: |
     transparent listener can use original_dst filter without nf_conntrack enabled.
 - area: cache_filter
   change: |
-    added a completion callback to insertHeaders and insertTrailers in cache interface. Any external cache implementation extensions will need to also add this callback, and call it on completion.
+    added a completion callback to insertHeaders and insertTrailers in cache interface. Any external cache implementation
+    extensions will need to also add this callback, and call it on completion.
 - area: udp_proxy
   change: |
-    changed behavior of UDP proxy to connect UDP sockets unless ``use_original_src_ip`` is set. This change can be reverted by setting runtime guard ``envoy.reloadable_features.udp_proxy_connect`` to false.
+    changed behavior of UDP proxy to connect UDP sockets unless ``use_original_src_ip`` is set. This change can be reverted
+    by setting runtime guard ``envoy.reloadable_features.udp_proxy_connect`` to false.
 - area: local_ratelimit
   change: |
-    added :ref:`virtual host level configuration <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.vh_rate_limits>` support for the local ratelimit filter.
+    added :ref:`virtual host level configuration
+    <envoy_v3_api_field_extensions.filters.http.local_ratelimit.v3.LocalRateLimit.vh_rate_limits>` support for the local
+    ratelimit filter.
 - area: health_check
   change: |
-    support custom health check address via :ref:`health_check_config <envoy_v3_api_msg_config.endpoint.v3.endpoint.healthcheckconfig>`.
+    support custom health check address via :ref:`health_check_config
+    <envoy_v3_api_msg_config.endpoint.v3.endpoint.healthcheckconfig>`.
 - area: http
   change: |
-    changed shadow requests to more closely behave like the requests they are shadowing. This includes matching the upstream logging for the original request, dynamic stats, suppressing Envoy headers, respecting expected request timeout, suppressing grpc request failure code stats and strict header checks. This behaviorial change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.closer_shadow_behavior`` to false.
+    changed shadow requests to more closely behave like the requests they are shadowing. This includes matching the upstream
+    logging for the original request, dynamic stats, suppressing Envoy headers, respecting expected request timeout,
+    suppressing grpc request failure code stats and strict header checks. This behaviorial change can be temporarily
+    reverted by setting runtime guard ``envoy.reloadable_features.closer_shadow_behavior`` to false.
 - area: http
   change: |
     changed the filter callback interfaces to make sure that downstream-only functionality is explicit.
@@ -82,22 +102,19 @@ minor_behavior_changes:
     the upstream remote address is now available to downstream filters via the ``upstreamRemoteAddress`` function.
 - area: stats
   change: |
-    Default tag extraction rules were changed for ``worker_id`` extraction. Previously, ``worker_`` was removed from the original name during the extraction. This
-    led to the same base stat name for both the per-worker and overall stat. For instance, in prometheus stats, the following stats were produced: ::
-
-      envoy_listener_downstream_cx_total{} 2.
-      envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1.
-      envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1.
-
-    This resulted in ``sum(envoy_listener_downstream_cx_total)`` producing 4, even though there are only 2 connections.
-    The new behavior results in stats such as this: ::
-
-      envoy_listener_downstream_cx_total{} 2.
-      envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1.
-      envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1.
+    Default tag extraction rules were changed for ``worker_id`` extraction. Previously, ``worker_`` was removed from the
+    original name during the extraction. This led to the same base stat name for both the per-worker and overall stat. For
+    instance, in prometheus stats, the following stats were produced: ::    envoy_listener_downstream_cx_total{} 2.
+    envoy_listener_downstream_cx_total{envoy_worker_id="0"} 1.   envoy_listener_downstream_cx_total{envoy_worker_id="1"} 1.
+    This resulted in ``sum(envoy_listener_downstream_cx_total)`` producing 4, even though there are only 2 connections. The
+    new behavior results in stats such as this: ::    envoy_listener_downstream_cx_total{} 2.
+    envoy_listener_worker_downstream_cx_total{envoy_worker_id="0"} 1.
+    envoy_listener_worker_downstream_cx_total{envoy_worker_id="1"} 1.
 - area: dynamic_forward_proxy
   change: |
-    No longer waiting on DNS responses in the dynamic forward proxy filter if upstream proxying is turned on. This behaviorial change can be reverted by setting runtime guard ``envoy.reloadable_features.skip_dns_lookup_for_proxied_requests`` to false.
+    No longer waiting on DNS responses in the dynamic forward proxy filter if upstream proxying is turned on. This
+    behaviorial change can be reverted by setting runtime guard
+    ``envoy.reloadable_features.skip_dns_lookup_for_proxied_requests`` to false.
 
 bug_fixes:
 - area: http
@@ -111,10 +128,12 @@ bug_fixes:
     fixed a bug where a request with a wrong binding type is not rejected if the request body is empty.
 - area: listener
   change: |
-    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a memory leak.
+    fixed a bug that doesn't handle of an update for a listener with IPv4-mapped address correctly, and that will lead to a
+    memory leak.
 - area: transport_socket
   change: |
-    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy was built.
+    fixed a bug that prevented the tcp stats to be retrieved when running on kernels different than the kernel where Envoy
+    was built.
 - area: logger
   change: |
     added the %j and %_ format support for fine-grain loggers to make it consistant with default loggers.
@@ -126,10 +145,12 @@ bug_fixes:
     fixed edge-case interaction between weighted clusters, cluster headers and (request|response)_headers_to_(add|remove).
 - area: upstream
   change: |
-    fixed a bug where custom transport socket hashes might not be respected by wrapper passthrough sockets. This change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.fix_hash_key`` to false.
+    fixed a bug where custom transport socket hashes might not be respected by wrapper passthrough sockets. This change can
+    be temporarily reverted by setting runtime guard ``envoy.reloadable_features.fix_hash_key`` to false.
 - area: tls
   change: |
-    fixed a bug where, when runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` is set to false, the wrong TLS alerts would sometimes be sent in response to certificate validation failures.
+    fixed a bug where, when runtime guard ``envoy.reloadable_features.tls_async_cert_validation`` is set to false, the wrong
+    TLS alerts would sometimes be sent in response to certificate validation failures.
 
 removed_config_or_runtime:
 - area: auto_config
@@ -166,12 +187,13 @@ removed_config_or_runtime:
 new_features:
 - area: header_formatters
   change: |
-    all access log formatters can be used as custom request/response headers. Custom header's syntax is parsed using access logger's parser and
-    header values are obtained using access log's substitution formatters. This feature can be reversed by setting runtime guard
-    ``envoy.reloadable_features.unified_header_formatter`` to false.
+    all access log formatters can be used as custom request/response headers. Custom header's syntax is parsed using access
+    logger's parser and header values are obtained using access log's substitution formatters. This feature can be reversed
+    by setting runtime guard ``envoy.reloadable_features.unified_header_formatter`` to false.
 - area: http
   change: |
-    made the :ref:`admission control <envoy_v3_api_msg_extensions.filters.http.admission_control.v3.AdmissionControl>` work as an upstream filter.
+    made the :ref:`admission control <envoy_v3_api_msg_extensions.filters.http.admission_control.v3.AdmissionControl>` work
+    as an upstream filter.
 - area: http
   change: |
     added default-false ``envoy.reloadable_features.http1_use_balsa_parser`` for experimental BalsaParser.
@@ -183,7 +205,7 @@ new_features:
     added DNS stats for c-ares DNS resolver. Detailed documentation is available :ref:`here <arch_overview_dns_resolution>`.
 - area: gzip
   change: |
-    added support for :ref:`max_inflate_ratio<envoy_v3_api_msg_extensions.compression.gzip.decompressor.v3.Gzip>`.
+    added support for :ref:`max_inflate_ratio <envoy_v3_api_msg_extensions.compression.gzip.decompressor.v3.Gzip>`.
 - area: access_log
   change: |
     added downstream handshake timing to connection streamInfo. Can be accessed by custom access loggers.
@@ -192,34 +214,43 @@ new_features:
     official released binary is now built on Ubuntu 20.04, requires glibc >= 2.30.
 - area: listener
   change: |
-    added multiple listening addresses in single listener. :ref:`listener additional addresses<envoy_v3_api_field_config.listener.v3.Listener.additional_addresses>`.
+    added multiple listening addresses in single listener. :ref:`listener additional addresses
+    <envoy_v3_api_field_config.listener.v3.Listener.additional_addresses>`.
 - area: load balancer
   change: |
-    added a new field to subset load balancer config: :ref:`metadata_fallback_policy<envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.metadata_fallback_policy>`.
+    added a new field to subset load balancer config: :ref:`metadata_fallback_policy
+    <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.metadata_fallback_policy>`.
 - area: thrift
   change: |
     added stats for downstream connection close to detect SR drop.
 - area: compression
   change: |
-    added support for :ref:`choose_first<envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>`.
+    added support for :ref:`choose_first <envoy_v3_api_msg_extensions.filters.http.compressor.v3.Compressor>`.
 - area: cors
   change: |
-    added support for cors PNA. This behavioral change can be temporarily reverted by setting runtime guard ``envoy_reloadable_features_cors_private_network_access`` to false. More details refer to https://developer.chrome.com/blog/private-network-access-preflight.
+    added support for cors PNA. This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy_reloadable_features_cors_private_network_access`` to false. More details refer to
+    https://developer.chrome.com/blog/private-network-access-preflight.
 - area: upstream
   change: |
-    added a filter state object to control the destination address in :ref:`ORIGINAL_DST clusters <arch_overview_load_balancing_types_original_destination_request_header_filter_state>`.
+    added a filter state object to control the destination address in :ref:`ORIGINAL_DST clusters
+    <arch_overview_load_balancing_types_original_destination_request_header_filter_state>`.
 - area: upstream
   change: |
-    added a new field :ref:`extra_source_addresses <envoy_v3_api_field_config.core.v3.BindConfig.extra_source_addresses>` to the BindConfig, it enables to specify multiple source addresses, and the source address selection is based on target host's address' version.
+    added a new field :ref:`extra_source_addresses <envoy_v3_api_field_config.core.v3.BindConfig.extra_source_addresses>` to
+    the BindConfig, it enables to specify multiple source addresses, and the source address selection is based on target
+    host's address' version.
 - area: admin
   change: |
     added new :ref:`/heap_dump <operations_admin_interface_heap_dump>` endpoint to dump heap profile of Envoy.
 - area: health check
   change: |
-    added :ref:`method <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.method>` support to configure http health check http method.
+    added :ref:`method <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.method>` support to configure http
+    health check http method.
 - area: health check
   change: |
-    added :ref:`thrift health check <envoy_v3_api_msg_extensions.health_checkers.thrift.v3.Thrift>` as a :ref:`custom health check <envoy_v3_api_msg_config.core.v3.HealthCheck.CustomHealthCheck>`.
+    added :ref:`thrift health check <envoy_v3_api_msg_extensions.health_checkers.thrift.v3.Thrift>` as a :ref:`custom health
+    check <envoy_v3_api_msg_config.core.v3.HealthCheck.CustomHealthCheck>`.
 - area: access_log
   change: |
     updated command operator ``%GRPC_STATUS%`` to suppoprt the snake case.
@@ -231,82 +262,96 @@ new_features:
     expose the implementation of :ref:`internal listener <config_internal_listener>` in xDS API.
 - area: ratelimit
   change: |
-    add support for :ref:`adding response headers <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.response_headers_to_add>` to rate-limited responses.
+    add support for :ref:`adding response headers
+    <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimit.response_headers_to_add>` to rate-limited responses.
 - area: access_log
   change: |
     added support for number values in substitution format string in json_format.
 - area: http
   change: |
-    added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check for HTTP health check.
-    Added :ref:`response_buffer_size <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.response_buffer_size>` to configure the maximum HTTP health check response buffer size.
+    added the expected :ref:`receive <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.receive>` payload check
+    for HTTP health check. Added :ref:`response_buffer_size
+    <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.response_buffer_size>` to configure the maximum HTTP
+    health check response buffer size.
 - area: lua
   change: |
-    added new headers method "setHttp1ReasonPhrase" for lua filter, please see :ref:`lua header wrapper <config_http_filters_lua_header_wrapper>`.
+    added new headers method "setHttp1ReasonPhrase" for lua filter, please see :ref:`lua header wrapper
+    <config_http_filters_lua_header_wrapper>`.
 - area: lua
   change: |
     added stats for lua filter, please see :ref:`lua filter stats <config_http_filters_lua_stats>`.
 - area: subset load balancer
   change: |
-    added multiple keys or multiple selectors support for :ref:`single host per subset mode <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector.single_host_per_subset>`.
+    added multiple keys or multiple selectors support for :ref:`single host per subset mode
+    <envoy_v3_api_field_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector.single_host_per_subset>`.
 - area: listener
   change: |
     allow network filters other than HTTP Connection Manager to be created for QUIC listeners.
 - area: lua
   change: |
-    added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling the produced trace span
-    by setting ``{["trace_sampled"] = false}`` as the ``options``. And this allows to return multiple header values for same header name by setting
-    ``{["return_duplicate_headers"] = true}`` as the ``options``.
+    added an alternative function signature to ``httpCall()`` with ``options`` as an argument. This allows to skip sampling
+    the produced trace span by setting ``{["trace_sampled"] = false}`` as the ``options``. And this allows to return
+    multiple header values for same header name by setting ``{["return_duplicate_headers"] = true}`` as the ``options``.
 - area: zipkin
   change: |
-    added :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>` to make Envoy appear
-    as an independent hop for zipkin tracing.
+    added :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>` to make
+    Envoy appear as an independent hop for zipkin tracing.
 - area: cluster
   change: |
-    added support to override original destination port via setting :ref:`upstream_port_override <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.upstream_port_override>`.
+    added support to override original destination port via setting :ref:`upstream_port_override
+    <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.upstream_port_override>`.
 - area: generic_proxy
   change: |
-    added an new network filter :ref:`generic_proxy filter <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
+    added an new network filter :ref:`generic_proxy filter
+    <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
 - area: redis
   change: |
     added support for quit command to the redis proxy.
 - area: tcp_proxy
   change: |
     added support for propagating the response headers in :ref:`TunnelingConfig
-    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_headers>` to
-    the downstream info filter state.
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_headers>` to the
+    downstream info filter state.
 - area: access_log
   change: |
-    log ``duration``, ``upstream_request_attempt_count``, ``connection_termination_details`` and tls ``ja3`` field in the grpc access log
-    and also log the tls ``sni`` and ``ja3`` field in the grpc access log when envoy is configured as a tls forward proxy.
+    log ``duration``, ``upstream_request_attempt_count``, ``connection_termination_details`` and tls ``ja3`` field in the
+    grpc access log and also log the tls ``sni`` and ``ja3`` field in the grpc access log when envoy is configured as a tls
+    forward proxy.
 - area: grpc_json_transcoder
   change: |
-    added support for parsing enum value case insensitively enabled by the config :ref:`case_insensitive_enum_parsing <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.case_insensitive_enum_parsing>`.
+    added support for parsing enum value case insensitively enabled by the config :ref:`case_insensitive_enum_parsing
+    <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.case_insensitive_enum_parsing>`.
 - area: grpc_json_transcoder
   change: |
-    added support for newline-delimited streams in :ref:`stream_newline_delimited <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.PrintOptions.stream_newline_delimited>`.
+    added support for newline-delimited streams in :ref:`stream_newline_delimited
+    <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.PrintOptions.stream_newline_delimited>`.
 - area: grpc_stats
   change: |
-    added support for replacing dots of gRPC service name with underscores in the gRPC stats by the config :ref:`replace_dots_in_grpc_service_name <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.replace_dots_in_grpc_service_name>`.
+    added support for replacing dots of gRPC service name with underscores in the gRPC stats by the config
+    :ref:`replace_dots_in_grpc_service_name
+    <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.replace_dots_in_grpc_service_name>`.
 - area: http
   change: |
-    Added :ref:`HeaderBasedSessionState <envoy_v3_api_msg_extensions.http.stateful_session.header.v3.HeaderBasedSessionState>` to manage
-    :ref:`StatefulSession State <envoy_v3_api_msg_extensions.filters.http.stateful_session.v3.StatefulSession>` via request/response header.
+    Added :ref:`HeaderBasedSessionState
+    <envoy_v3_api_msg_extensions.http.stateful_session.header.v3.HeaderBasedSessionState>` to manage :ref:`StatefulSession
+    State <envoy_v3_api_msg_extensions.filters.http.stateful_session.v3.StatefulSession>` via request/response header.
 
 deprecated:
 - area: http
   change: |
-    deprecated :ref:`append <envoy_v3_api_field_config.core.v3.HeaderValueOption.append>` and please use
-    :ref:`append_action <envoy_v3_api_field_config.core.v3.HeaderValueOption.append_action>` first.
+    deprecated :ref:`append <envoy_v3_api_field_config.core.v3.HeaderValueOption.append>` and please use :ref:`append_action
+    <envoy_v3_api_field_config.core.v3.HeaderValueOption.append_action>` first.
 - area: router
   change: |
-    deprecated :ref:`total weight <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>` for weighted
-    clusters. The sum of the :ref:`clusters' weights <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.weight>`
-    will be used as the total weight.
+    deprecated :ref:`total weight <envoy_v3_api_field_config.route.v3.WeightedCluster.total_weight>` for weighted clusters.
+    The sum of the :ref:`clusters' weights <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.weight>` will
+    be used as the total weight.
 - area: cors
   change: |
-    deprecated :ref:`cors field of virtual host <envoy_v3_api_field_config.route.v3.VirtualHost.cors>` and
-    :ref:`cors field of route action <envoy_v3_api_field_config.route.v3.RouteAction.cors>`. Please use
-    :ref:`VirtualHost.typed_per_filter_config<envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>`,
-    :ref:`Route.typed_per_filter_config<envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>` or
-    :ref:`WeightedCluster.ClusterWeight.typed_per_filter_config<envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.typed_per_filter_config>`
-    to configure the CORS HTTP filter by the type :ref:`CorsPolicy in filter <envoy_v3_api_msg_extensions.filters.http.cors.v3.CorsPolicy>`.
+    deprecated :ref:`cors field of virtual host <envoy_v3_api_field_config.route.v3.VirtualHost.cors>` and :ref:`cors field
+    of route action <envoy_v3_api_field_config.route.v3.RouteAction.cors>`. Please use
+    :ref:`VirtualHost.typed_per_filter_config <envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>`,
+    :ref:`Route.typed_per_filter_config <envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>` or
+    :ref:`WeightedCluster.ClusterWeight.typed_per_filter_config
+    <envoy_v3_api_field_config.route.v3.WeightedCluster.ClusterWeight.typed_per_filter_config>` to configure the CORS HTTP
+    filter by the type :ref:`CorsPolicy in filter <envoy_v3_api_msg_extensions.filters.http.cors.v3.CorsPolicy>`.

--- a/changelogs/1.24.1.yaml
+++ b/changelogs/1.24.1.yaml
@@ -9,5 +9,4 @@ bug_fixes:
     update Curl, Kafka, Wasm to mitigate CVEs.
 - area: docker
   change: |
-    update Docker images (``distroless`` -> ``4b22ca3c6``) to resolve CVE issues
-    in container packages.
+    update Docker images (``distroless`` -> ``4b22ca3c6``) to resolve CVE issues in container packages.

--- a/changelogs/1.25.0.yaml
+++ b/changelogs/1.25.0.yaml
@@ -3,102 +3,134 @@ date: January 18, 2023
 behavior_changes:
 - area: listener
   change: |
-    Previously a listener update with different :ref:`transparent <envoy_v3_api_field_config.listener.v3.Listener.transparent>`, :ref:`freebind <envoy_v3_api_field_config.listener.v3.Listener.freebind>`,
-    :ref:`tcp_fast_open_queue_length <envoy_v3_api_field_config.listener.v3.Listener.tcp_fast_open_queue_length>` or :ref:`socket_options <envoy_v3_api_field_config.listener.v3.Listener.socket_options>` was ignored.
-    Now, when those fields are updated, a new socket will be created for
-    the listener and the updated values of those fields will be applied to it. This only happens when :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>` is true.
-    Otherwise if those fields change the update is rejected.
-    The runtime flag ``envoy.reloadable_features.enable_update_listener_socket_options`` can be used to revert this behavior.
+    Previously a listener update with different :ref:`transparent
+    <envoy_v3_api_field_config.listener.v3.Listener.transparent>`, :ref:`freebind
+    <envoy_v3_api_field_config.listener.v3.Listener.freebind>`, :ref:`tcp_fast_open_queue_length
+    <envoy_v3_api_field_config.listener.v3.Listener.tcp_fast_open_queue_length>` or :ref:`socket_options
+    <envoy_v3_api_field_config.listener.v3.Listener.socket_options>` was ignored. Now, when those fields are updated, a new
+    socket will be created for the listener and the updated values of those fields will be applied to it. This only happens
+    when :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>` is true. Otherwise if
+    those fields change the update is rejected. The runtime flag
+    ``envoy.reloadable_features.enable_update_listener_socket_options`` can be used to revert this behavior.
 - area: build
   change: |
-    removed the c-ares and apple resolvers as required extensions. Envoy now only creates DNS resolvers when necessary (e.g. for logical DNS cluster); as such, it does not require these resolvers to always be included. If your Envoys do DNS resolution and override ``extensions_build_config.bzl`` you will need to include c-ares / apple resolver explicitly.
+    removed the c-ares and apple resolvers as required extensions. Envoy now only creates DNS resolvers when necessary (e.g.
+    for logical DNS cluster); as such, it does not require these resolvers to always be included. If your Envoys do DNS
+    resolution and override ``extensions_build_config.bzl`` you will need to include c-ares / apple resolver explicitly.
 - area: build
   change: |
-    moved the ``strict_dns``, ``original_dst``, ``logical_dns``, ``static``, and ``eds`` clusters to extensions. If you use these clusters and override ``extensions_build_config.bzl`` you will now need to include it explicitly.
+    moved the ``strict_dns``, ``original_dst``, ``logical_dns``, ``static``, and ``eds`` clusters to extensions. If you use
+    these clusters and override ``extensions_build_config.bzl`` you will now need to include it explicitly.
 - area: stats http ext_authz
   change: |
-    Fixed ``ext_authz`` metric tag extraction so that :ref:`stat_prefix <envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.ExtAuthz>`
-    is properly extracted. This changes the Prometheus name from
-    ``envoy_http_ext_authz_prefixval_denied{}`` to ``envoy_http_ext_authz_denied{envoy_ext_authz_prefix="prefixval"}``.
-    ``envoy_cluster_X_ext_authz_Y_denied`` follows the same pattern.
+    Fixed ``ext_authz`` metric tag extraction so that :ref:`stat_prefix
+    <envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.ExtAuthz>` is properly extracted. This changes the Prometheus
+    name from ``envoy_http_ext_authz_prefixval_denied{}`` to
+    ``envoy_http_ext_authz_denied{envoy_ext_authz_prefix="prefixval"}``. ``envoy_cluster_X_ext_authz_Y_denied`` follows the
+    same pattern.
 - area: loadbalancing
   change: |
-    When active health checking is enabled per cluster, slow start calculations will now start after first passing health check. The cluster membership duration condition is dropped from the slow start calculation.
-    Endpoints can now re-enter slow start if active health checking is configured per cluster, on each ``unhealthy`` -> ``healthy`` state transition.
+    When active health checking is enabled per cluster, slow start calculations will now start after first passing health
+    check. The cluster membership duration condition is dropped from the slow start calculation. Endpoints can now re-enter
+    slow start if active health checking is configured per cluster, on each ``unhealthy`` -> ``healthy`` state transition.
 
 minor_behavior_changes:
 - area: tls
   change: |
     added support for intermediate CA as trusted CA. The peer certificate issued by an intermediate CA will be trusted by
-    building valid partial chain. Before, it could not be verified without trusting its ancestor root CA and building
-    a full chain.
-    :ref:`trust_ca<envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+    building valid partial chain. Before, it could not be verified without trusting its ancestor root CA and building a full
+    chain. :ref:`trust_ca <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
     This change can be reverted via the runtime flag ``envoy.reloadable_features.enable_intermediate_ca``.
 - area: cache_filter
   change: |
-    add a completion callback to ``updateHeaders`` interface. Any external cache implementations should be updated to match this new interface. See changes to simple_http_cache in `PR \#23666 <https://github.com/envoyproxy/envoy/pull/23666>`_ for example.
+    add a completion callback to ``updateHeaders`` interface. Any external cache implementations should be updated to match
+    this new interface. See changes to simple_http_cache in `PR \#23666 <https://github.com/envoyproxy/envoy/pull/23666>`_
+    for example.
 - area: cache_filter
   change: |
-    api path of work-in-progress extension changed from ``api/extensions/cache/simple_http_cache`` to ``api/extensions/http/cache/simple_http_cache``, and source code moved to match extension category.
+    api path of work-in-progress extension changed from ``api/extensions/cache/simple_http_cache`` to
+    ``api/extensions/http/cache/simple_http_cache``, and source code moved to match extension category.
 - area: http filter
   change: |
-    Avoid re-entrant filter invocations if we do a local reply via the filter chain when executing decoder filters. This behavioral change can be temporarily reverted by setting runtime flag ``envoy_reloadable_features_http_filter_avoid_reentrant_local_reply`` to false.
+    Avoid re-entrant filter invocations if we do a local reply via the filter chain when executing decoder filters. This
+    behavioral change can be temporarily reverted by setting runtime flag
+    ``envoy_reloadable_features_http_filter_avoid_reentrant_local_reply`` to false.
 - area: http filters
   change: |
-    change ``StreamEncoderFilter::encode1xxHeaders`` to use its own enum class ``Http::Filter1xxHeadersStatus``. Previously we shared the same enum class for general headers, but the implementation did not support most of them. We also fixed ``StreamEncoderFilter::encode1xxHeaders`` to send local replies without trailing 1xx headers afterward.
+    change ``StreamEncoderFilter::encode1xxHeaders`` to use its own enum class ``Http::Filter1xxHeadersStatus``. Previously
+    we shared the same enum class for general headers, but the implementation did not support most of them. We also fixed
+    ``StreamEncoderFilter::encode1xxHeaders`` to send local replies without trailing 1xx headers afterward.
 - area: oauth2
   change: |
-    Requests which match the passthrough header now have their own metric ``oauth_passthrough`` and aren't included in ``oauth_success`` anymore.
+    Requests which match the passthrough header now have their own metric ``oauth_passthrough`` and aren't included in
+    ``oauth_success`` anymore.
 - area: oauth2
   change: |
-    query parameters in the :ref:`authorization_endpoint <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.authorization_endpoint>` are now preserved.
+    query parameters in the :ref:`authorization_endpoint
+    <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.authorization_endpoint>` are now preserved.
 - area: upstream
   change: |
-    detailed health status is used for override host selection. This behavior can be reverted by setting runtime flag ``envoy.reloadable_features.validate_detailed_override_host_statuses`` to false.
+    detailed health status is used for override host selection. This behavior can be reverted by setting runtime flag
+    ``envoy.reloadable_features.validate_detailed_override_host_statuses`` to false.
 - area: rate_limit
   change: |
     add ``MONTH`` and ``YEAR`` to the unit of time for rate limit.
 - area: router
   change: |
-    Virtual cluster statistics are no longer created for routes without any ``virtual_clusters``. Previously statistics for a ``catch all`` virtual cluster were created, but never updated.
+    Virtual cluster statistics are no longer created for routes without any ``virtual_clusters``. Previously statistics for
+    a ``catch all`` virtual cluster were created, but never updated.
 - area: jwt_authn
   change: |
-    adjust the refetch time for ``remote_jwks`` ``async_fetch`` feature. For a good fetch, refetch 5 seconds before jwks cache duration. For a failed fetch, refetch time can be specified by :ref:`failed_refetch_duration <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwksAsyncFetch.failed_refetch_duration>` with default 1 second.
+    adjust the refetch time for ``remote_jwks`` ``async_fetch`` feature. For a good fetch, refetch 5 seconds before jwks
+    cache duration. For a failed fetch, refetch time can be specified by :ref:`failed_refetch_duration
+    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwksAsyncFetch.failed_refetch_duration>` with default 1 second.
 - area: config
   change: |
-    add support for thrift connection draining. This can be disabled by setting the runtime guard ``envoy.reloadable_features.thrift_connection_draining`` to false.
+    add support for thrift connection draining. This can be disabled by setting the runtime guard
+    ``envoy.reloadable_features.thrift_connection_draining`` to false.
 - area: http
   change: |
-    reverted the behavioral change to have ``CONNECT`` and upgrade requests over HTTP/1.1 not delay close.  One can reinstate
-    delay close for upgrades by setting ``envoy.reloadable_features.no_delay_close_for_upgrades`` to ``true``.
+    reverted the behavioral change to have ``CONNECT`` and upgrade requests over HTTP/1.1 not delay close.  One can
+    reinstate delay close for upgrades by setting ``envoy.reloadable_features.no_delay_close_for_upgrades`` to ``true``.
 - area: tcp
   change: |
-    added :ref:`idle_timeout <envoy_v3_api_field_extensions.upstreams.tcp.v3.TcpProtocolOptions.idle_timeout>` to support per client idle timeout for tcp connection pool. The timeout is guarded by ``envoy.reloadable_features.tcp_pool_idle_timeout`` and timeout defaults to 10 minutes if runtime flag is enabled.
+    added :ref:`idle_timeout <envoy_v3_api_field_extensions.upstreams.tcp.v3.TcpProtocolOptions.idle_timeout>` to support
+    per client idle timeout for tcp connection pool. The timeout is guarded by
+    ``envoy.reloadable_features.tcp_pool_idle_timeout`` and timeout defaults to 10 minutes if runtime flag is enabled.
 
 bug_fixes:
 - area: aws_lambda
   change: |
-    fix a bug when :ref:`PerRouteConfig <envoy_v3_api_msg_extensions.filters.http.aws_lambda.v3.PerRouteConfig>` is defined and was routing to a target cluster's AWS Lambda endpoint
-    in a region that is different from the region obtained in :ref:`arn <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.arn>` of ``aws_lambda`` ``http_filter`` configuration
-    then the authorization header included in the request towards AWS Lambda was not signed with the region specified in ``PerRouteConfig``.
+    fix a bug when :ref:`PerRouteConfig <envoy_v3_api_msg_extensions.filters.http.aws_lambda.v3.PerRouteConfig>` is defined
+    and was routing to a target cluster's AWS Lambda endpoint in a region that is different from the region obtained in
+    :ref:`arn <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.arn>` of ``aws_lambda`` ``http_filter``
+    configuration then the authorization header included in the request towards AWS Lambda was not signed with the region
+    specified in ``PerRouteConfig``.
 - area: grpc_json_transcoder
   change: |
-    fix a bug when using http2, request body has ``google.api.HttpBody`` and the size is < 16KB, it will cause EOF from the backend grpc server.
+    fix a bug when using http2, request body has ``google.api.HttpBody`` and the size is < 16KB, it will cause EOF from the
+    backend grpc server.
 - area: router
   change: |
     fixed a bug that incorrectly rewrote the path when using ``regex_rewrite`` for redirects matched on prefix.
 - area: oauth2
   change: |
-    fixed a bug when passthrough header was matched, envoy would always remove the authorization header. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.oauth_header_passthrough_fix`` to false.
+    fixed a bug when passthrough header was matched, envoy would always remove the authorization header. This behavioral
+    change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.oauth_header_passthrough_fix``
+    to false.
 - area: generic_proxy
   change: |
-    fixed a bug that encoder filters and decoder filters of generic proxy will be executed in the same order. The encoder filters' execuate order should be the reverse of decoder filters' in the generic proxy.
+    fixed a bug that encoder filters and decoder filters of generic proxy will be executed in the same order. The encoder
+    filters' execuate order should be the reverse of decoder filters' in the generic proxy.
 - area: quic
   change: |
-    reject configs that specify require_client_certificate with QUIC since clients certificates are currently unsupported in QUIC. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.reject_require_client_certificate_with_quic`` to false.
+    reject configs that specify require_client_certificate with QUIC since clients certificates are currently unsupported in
+    QUIC. This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.reject_require_client_certificate_with_quic`` to false.
 - area: http
   change: |
-    fixed a bug where ``Utility::PercentEncoding::encode()`` encodes some characters incorrectly because it was treating the value as negative.
+    fixed a bug where ``Utility::PercentEncoding::encode()`` encodes some characters incorrectly because it was treating the
+    value as negative.
 - area: upstream
   change: |
     fixed a bug that only coarse health status is used for override host selection.
@@ -107,28 +139,35 @@ bug_fixes:
     fixed a crash that could happen when optional ``engine_type`` is not provided in regex.
 - area: upstream
   change: |
-    fixed a bug when specify both a single address in bootstrap and cluster upstream binding config but with a different IP version. It should be allowed but it is rejected.
+    fixed a bug when specify both a single address in bootstrap and cluster upstream binding config but with a different IP
+    version. It should be allowed but it is rejected.
 - area: upstream
   change: |
     fixed a bug for tcp upstream where we did not count the header and data to/from the upstream.
 - area: jwt_authn
   change: |
-    fix a bug that ``jwt_cache`` breaks the :ref:`provider_and_audiences <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.provider_and_audiences>` JWT requirement.
+    fix a bug that ``jwt_cache`` breaks the :ref:`provider_and_audiences
+    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.provider_and_audiences>` JWT requirement.
 - area: skywalking
   change: |
     fixed a crash that could happen when skywalking tracer is enabled and illegal ``sw8`` header is received.
 - area: health_checker
   change: |
-    prevent writing pending data for health checkers by introducing ``ConnectionCloseType::Abort`` to avoid cascading handshake overhead from health checker's requests on timeout. This fix is related to `issue \#23718 <https://github.com/envoyproxy/envoy/issues/23718>`_.
+    prevent writing pending data for health checkers by introducing ``ConnectionCloseType::Abort`` to avoid cascading
+    handshake overhead from health checker's requests on timeout. This fix is related to `issue \#23718
+    <https://github.com/envoyproxy/envoy/issues/23718>`_.
 - area: router
   change: |
-    fixed a bug that truncated query parameters from paths rewritten with a ``path_rewrite_policy``, query parameters are now appended. ``envoy_reloadable_features_append_query_parameters_path_rewriter`` can be used to revert to truncation.
+    fixed a bug that truncated query parameters from paths rewritten with a ``path_rewrite_policy``, query parameters are
+    now appended. ``envoy_reloadable_features_append_query_parameters_path_rewriter`` can be used to revert to truncation.
 - area: grpc_http_bridge
   change: |
     fixed a bug where response data could be lost for requests that were upgraded from Protobuf.
 - area: tcp_proxy
   change: |
-    When tunneling TCP over HTTP, mark the upstream connection as done reading when upstream trailers are read. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.finish_reading_on_decode_trailers`` to false.
+    When tunneling TCP over HTTP, mark the upstream connection as done reading when upstream trailers are read. This
+    behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.finish_reading_on_decode_trailers`` to false.
 
 removed_config_or_runtime:
 - area: eds
@@ -151,13 +190,13 @@ removed_config_or_runtime:
     removed ``envoy.reloadable_features.append_or_truncate`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.use_new_codec_wrapper`` and legacy code paths.
-    removed ``envoy.reloadable_features.append_to_accept_content_encoding_only_once`` and legacy code paths.
-    removed ``envoy.reloadable_features.http1_lazy_read_disable`` and legacy code paths.
+    removed ``envoy.reloadable_features.use_new_codec_wrapper`` and legacy code paths. removed
+    ``envoy.reloadable_features.append_to_accept_content_encoding_only_once`` and legacy code paths. removed
+    ``envoy.reloadable_features.http1_lazy_read_disable`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.http_100_continue_case_insensitive`` and legacy code paths.
-    removed ``envoy.reloadable_features.override_request_timeout_by_gateway_timeout`` and legacy code paths.
+    removed ``envoy.reloadable_features.http_100_continue_case_insensitive`` and legacy code paths. removed
+    ``envoy.reloadable_features.override_request_timeout_by_gateway_timeout`` and legacy code paths.
 - area: ecds
   change: |
     removed ``envoy.reloadable_features.top_level_ecds_stats`` and legacy code paths.
@@ -171,109 +210,143 @@ removed_config_or_runtime:
 new_features:
 - area: aws
   change: |
-    added support to prefer fetching AWS instance role credentials securely
-    (`IMDSv2 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>`_)
-    from EC2 instance metadata by getting the token first or falling back to insecure way (IMDSv1) if token fetch fails.
+    added support to prefer fetching AWS instance role credentials securely (`IMDSv2
+    <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html>`_) from EC2 instance
+    metadata by getting the token first or falling back to insecure way (IMDSv1) if token fetch fails.
 - area: grpc_json_transcoder
   change: |
-    added ``max_request_body_size`` and ``max_response_body_size`` fields, which can either increase or decrease
-    the size of messages that can be processed. It can increase (but does not decrease) the stream buffer size,
-    and can reject messages even if they're smaller than the stream buffer size if configured smaller.
+    added ``max_request_body_size`` and ``max_response_body_size`` fields, which can either increase or decrease the size of
+    messages that can be processed. It can increase (but does not decrease) the stream buffer size, and can reject messages
+    even if they're smaller than the stream buffer size if configured smaller.
 - area: tls
   change: |
-    added support for SNI-based cert selection in tls downstream transport socket. Detailed documentation is available :ref:`cert selection<arch_overview_ssl_cert_select>`.
-    New config option :ref:`full_scan_certs_on_sni_mismatch <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.full_scan_certs_on_sni_mismatch>`
-    is introduced to disable or enable full scan when no cert matches to SNI, defaults to false.
-    New runtime flag ``envoy.reloadable_features.no_full_scan_certs_on_sni_mismatch`` can be used for override the default value.
+    added support for SNI-based cert selection in tls downstream transport socket. Detailed documentation is available
+    :ref:`cert selection<arch_overview_ssl_cert_select>`. New config option :ref:`full_scan_certs_on_sni_mismatch
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.full_scan_certs_on_sni_mismatch>` is
+    introduced to disable or enable full scan when no cert matches to SNI, defaults to false. New runtime flag
+    ``envoy.reloadable_features.no_full_scan_certs_on_sni_mismatch`` can be used for override the default value.
 - area: build
   change: |
     added an option ``--define=library_autolink=disabled`` to disable autolinking libraries.
 - area: compression
   change: |
-    added :ref:`CompressorPerRoute proto <envoy_v3_api_msg_extensions.filters.http.compressor.v3.CompressorPerRoute>` for per-route configuration.
+    added :ref:`CompressorPerRoute proto <envoy_v3_api_msg_extensions.filters.http.compressor.v3.CompressorPerRoute>` for
+    per-route configuration.
 - area: generic_proxy
   change: |
-    added :ref:`dubbo codec support <envoy_v3_api_msg_extensions.filters.network.generic_proxy.codecs.dubbo.v3.DubboCodecConfig>` to the
-    :ref:`generic_proxy filter <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
+    added :ref:`dubbo codec support
+    <envoy_v3_api_msg_extensions.filters.network.generic_proxy.codecs.dubbo.v3.DubboCodecConfig>` to the :ref:`generic_proxy
+    filter <envoy_v3_api_msg_extensions.filters.network.generic_proxy.v3.GenericProxy>`.
 - area: golang
   change: |
     added new :ref:`HTTP golang extension filter <config_http_filters_golang>`.
 - area: custom response http filter
   change: |
-    added :ref:`custom response http filter <config_http_filters_custom_response>` which adds the ability to customize responses sent to downstreams using local or remote sources.
+    added :ref:`custom response http filter <config_http_filters_custom_response>` which adds the ability to customize
+    responses sent to downstreams using local or remote sources.
 - area: upstream
   change: |
-    added a new field :ref:`socket_options <envoy_v3_api_field_config.core.v3.ExtraSourceAddress.socket_options>` to the ``ExtraSourceAddress``, allowing specifying discrete socket options for each source address.
+    added a new field :ref:`socket_options <envoy_v3_api_field_config.core.v3.ExtraSourceAddress.socket_options>` to the
+    ``ExtraSourceAddress``, allowing specifying discrete socket options for each source address.
 - area: access_log
   change: |
-    added a new field :ref:`intermediate_log_entry <envoy_v3_api_field_data.accesslog.v3.AccessLogCommon.intermediate_log_entry>` to detect if the gRPC log entry is an intermediate log entry or not and added
-    support to flush TCP log entries periodly according to the configured :ref:`inteval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.access_log_flush_interval>`.
+    added a new field :ref:`intermediate_log_entry
+    <envoy_v3_api_field_data.accesslog.v3.AccessLogCommon.intermediate_log_entry>` to detect if the gRPC log entry is an
+    intermediate log entry or not and added support to flush TCP log entries periodly according to the configured
+    :ref:`inteval <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.access_log_flush_interval>`.
 - area: access_log
   change: |
     added support for :ref:`%STREAM_ID% <config_access_log_format_stream_id>` for stream unique identifier.
 - area: thrift
   change: |
-    added payload to metadata filter which matches a given payload field's value would be extracted and attached to the request as dynamic metadata.
+    added payload to metadata filter which matches a given payload field's value would be extracted and attached to the
+    request as dynamic metadata.
 - area: http
   change: |
-    enhanced dynamic forward proxy cluster to :ref:`allow_coalesced_connections <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_coalesced_connections>` for HTTP/2 and HTTP/3 connections.
+    enhanced dynamic forward proxy cluster to :ref:`allow_coalesced_connections
+    <envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_coalesced_connections>` for HTTP/2
+    and HTTP/3 connections.
 - area: upstream
   change: |
-    added :ref:`least request extension <envoy_v3_api_msg_extensions.load_balancing_policies.least_request.v3.LeastRequest>` to suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
+    added :ref:`least request extension <envoy_v3_api_msg_extensions.load_balancing_policies.least_request.v3.LeastRequest>`
+    to suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
 - area: upstream
   change: |
-    added :ref:`random extension <envoy_v3_api_msg_extensions.load_balancing_policies.random.v3.Random>` to suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
+    added :ref:`random extension <envoy_v3_api_msg_extensions.load_balancing_policies.random.v3.Random>` to suppport the
+    :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
 - area: upstream
   change: |
-    added :ref:`round robin extension <envoy_v3_api_msg_extensions.load_balancing_policies.round_robin.v3.RoundRobin>` to suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
+    added :ref:`round robin extension <envoy_v3_api_msg_extensions.load_balancing_policies.round_robin.v3.RoundRobin>` to
+    suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
 - area: generic_proxy
   change: |
-    added :ref:`generic rds support <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.generic_rds>`.
+    added :ref:`generic rds support
+    <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.generic_rds>`.
 - area: listener
   change: |
-    added a new field :ref:`socket_options <envoy_v3_api_field_config.listener.v3.AdditionalAddress.socket_options>` to the ``AdditionalAddress``, allowing specifying discrete socket options for each listener address.
+    added a new field :ref:`socket_options <envoy_v3_api_field_config.listener.v3.AdditionalAddress.socket_options>` to the
+    ``AdditionalAddress``, allowing specifying discrete socket options for each listener address.
 - area: listener
   change: |
-    added ``continueFilterChain()`` and ``dispatcher()`` methods to the ``ListenerFilterCallback``. This allows listener filters to continue listener filter iteration after stopping iteration e.g. if the listener filter depends on an async process.
+    added ``continueFilterChain()`` and ``dispatcher()`` methods to the ``ListenerFilterCallback``. This allows listener
+    filters to continue listener filter iteration after stopping iteration e.g. if the listener filter depends on an async
+    process.
 - area: thrift_proxy
   change: |
-    added ``envoy.reloadable_features.thrift_allow_negative_field_ids`` to support negative field ids for legacy thrift service.
+    added ``envoy.reloadable_features.thrift_allow_negative_field_ids`` to support negative field ids for legacy thrift
+    service.
 - area: bandwidth_limit
   change: |
-    added two new response trailers ``bandwidth-request-filter-delay-ms`` and ``bandwidth-response-filter-delay-ms`` to measure the delays added by this filter.
+    added two new response trailers ``bandwidth-request-filter-delay-ms`` and ``bandwidth-response-filter-delay-ms`` to
+    measure the delays added by this filter.
 - area: udp_proxy
   change: |
-    added support for :ref:`proxy_access_log <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.
+    added support for :ref:`proxy_access_log
+    <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.proxy_access_log>`.
 - area: tcp_proxy
   change: |
-    added new config :ref:`post_path field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.post_path>` to specifiy a custom path for HTTP tunneling with POST method.
+    added new config :ref:`post_path field
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.post_path>` to specifiy a custom
+    path for HTTP tunneling with POST method.
 - area: health_check
   change: |
-    added an optional bool flag :ref:`disable_active_health_check <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.disable_active_health_check>` to disable the active health check for the endpoint.
+    added an optional bool flag :ref:`disable_active_health_check
+    <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.disable_active_health_check>` to disable the active
+    health check for the endpoint.
 - area: mobile
   change: |
     merged the Envoy mobile library into the main Envoy repo.
 - area: matching
   change: |
-    support filter chain selection based on the dynamic metadata and the filter state using :ref:`formatter actions <extension_envoy.matching.actions.format_string>`.
+    support filter chain selection based on the dynamic metadata and the filter state using :ref:`formatter actions
+    <extension_envoy.matching.actions.format_string>`.
 - area: postgres
   change: |
     added support for upstream SSL.
 - area: redis
   change: |
-    extended :ref:`cluster support <arch_overview_redis_cluster_support>` by adding a :ref:`dns_cache_config <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.ConnPoolSettings.dns_cache_config>` option that can be used to resolve hostnames returned by ``MOVED``/``ASK`` responses.
+    extended :ref:`cluster support <arch_overview_redis_cluster_support>` by adding a :ref:`dns_cache_config
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.ConnPoolSettings.dns_cache_config>` option that
+    can be used to resolve hostnames returned by ``MOVED``/``ASK`` responses.
 - area: gcp_authn
   change: |
-    added support for configuring header that holds token fetched from GCE metadata server in new field :ref:`token_header <envoy_v3_api_field_extensions.filters.http.gcp_authn.v3.GcpAuthnFilterConfig.token_header>`.
+    added support for configuring header that holds token fetched from GCE metadata server in new field :ref:`token_header
+    <envoy_v3_api_field_extensions.filters.http.gcp_authn.v3.GcpAuthnFilterConfig.token_header>`.
 - area: tracing
   change: |
-    added support for setting the hostname used when sending spans to a Datadog collector using the :ref:`collector_hostname <envoy_v3_api_field_config.trace.v3.DatadogConfig.collector_hostname>` field.
+    added support for setting the hostname used when sending spans to a Datadog collector using the :ref:`collector_hostname
+    <envoy_v3_api_field_config.trace.v3.DatadogConfig.collector_hostname>` field.
 - area: stats
   change: |
-    added ``includeHistogram()`` method to ``Stats::SinkPredicates`` to filter histograms to be flushed to stat sinks. Use ``envoy.reloadable_features.enable_include_histograms`` to enable this feature, which is disabled by default.
+    added ``includeHistogram()`` method to ``Stats::SinkPredicates`` to filter histograms to be flushed to stat sinks. Use
+    ``envoy.reloadable_features.enable_include_histograms`` to enable this feature, which is disabled by default.
 - area: http
   change: |
-    added support of :ref:`header mutation <envoy_v3_api_msg_extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation>` to the HTTP connection manager via :ref:`early header mutation <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.early_header_mutation_extensions>` field.
+    added support of :ref:`header mutation
+    <envoy_v3_api_msg_extensions.http.early_header_mutation.header_mutation.v3.HeaderMutation>` to the HTTP connection
+    manager via :ref:`early header mutation
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.early_header_mutation_extensions>`
+    field.
 - area: jwt_authn
   change: |
     added support for copying jwt claims to http headers.
@@ -282,35 +355,45 @@ new_features:
     added drain support to generic proxy to doing graceful closes on connections when possible.
 - area: http
   change: |
-    added :ref:`append_x_forwarded_port <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.append_x_forwarded_port>` to append the ``x-forwarded-port`` header to HTTP upstream requests.
+    added :ref:`append_x_forwarded_port
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.append_x_forwarded_port>`
+    to append the ``x-forwarded-port`` header to HTTP upstream requests.
 - area: tcp
   change: |
-    added :ref:`idle_timeout <envoy_v3_api_field_extensions.upstreams.tcp.v3.TcpProtocolOptions.idle_timeout>` to support per client idle timeout for tcp connection pool. See also `minor behaviour changes <#minor-behavior-changes>`__.
+    added :ref:`idle_timeout <envoy_v3_api_field_extensions.upstreams.tcp.v3.TcpProtocolOptions.idle_timeout>` to support
+    per client idle timeout for tcp connection pool. See also `minor behaviour changes <#minor-behavior-changes>`__.
 - area: ext_authz
   change: |
-    added support to allowlist headers included in the check request to gRPC authorization server (previously only available for HTTP authorization server).
-    Pre-existing field :ref:`allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationRequest.allowed_headers>` is deprecated in favour
-    of the new field :ref:`allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.
+    added support to allowlist headers included in the check request to gRPC authorization server (previously only available
+    for HTTP authorization server). Pre-existing field :ref:`allowed_headers
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationRequest.allowed_headers>` is deprecated in favour
+    of the new field :ref:`allowed_headers
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.
 - area: attributes
   change: |
     added :ref:`attributes <arch_overview_attributes>` for looking up xDS configuration information.
 - area: router
   change: |
-    added :ref:`RouteList <envoy_v3_api_msg_config.route.v3.RouteList>` to support route list in :ref:`VirtualHost.matcher <envoy_v3_api_field_config.route.v3.VirtualHost.matcher>`.
+    added :ref:`RouteList <envoy_v3_api_msg_config.route.v3.RouteList>` to support route list in :ref:`VirtualHost.matcher
+    <envoy_v3_api_field_config.route.v3.VirtualHost.matcher>`.
 - area: router
   change: |
-    added a :ref:`x-envoy-is-timeout-retry <config_http_filters_router_x-envoy-is-timeout-retry>` request header on retries initiated by request timeouts; enabled by setting :ref:`include_is_timeout_retry_header <envoy_v3_api_field_config.route.v3.VirtualHost.include_is_timeout_retry_header>` to ``true``.
+    added a :ref:`x-envoy-is-timeout-retry <config_http_filters_router_x-envoy-is-timeout-retry>` request header on retries
+    initiated by request timeouts; enabled by setting :ref:`include_is_timeout_retry_header
+    <envoy_v3_api_field_config.route.v3.VirtualHost.include_is_timeout_retry_header>` to ``true``.
 - area: upstream
   change: |
     allow configuring :ref:`cluster bind config <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_bind_config>` and
-    :ref:`cluster manager bind config <envoy_v3_api_field_config.bootstrap.v3.ClusterManager.upstream_bind_config>` without specifying a
-    :ref:`source_address <envoy_v3_api_field_config.core.v3.BindConfig.source_address>`. This allows setting
-    :ref:`socket options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>` when using the default unspecified bind address
-    is desired.
+    :ref:`cluster manager bind config <envoy_v3_api_field_config.bootstrap.v3.ClusterManager.upstream_bind_config>` without
+    specifying a :ref:`source_address <envoy_v3_api_field_config.core.v3.BindConfig.source_address>`. This allows setting
+    :ref:`socket options <envoy_v3_api_field_config.core.v3.BindConfig.socket_options>` when using the default unspecified
+    bind address is desired.
 - area: xds
   change: |
-    added an api configuration :ref:`xds_config_tracker_extension <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.xds_config_tracker_extension>` in the bootstrap
-    to allow tracking xDS responses in external components, and provided the extension interface.
+    added an api configuration :ref:`xds_config_tracker_extension
+    <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.xds_config_tracker_extension>` in the bootstrap to allow tracking xDS
+    responses in external components, and provided the extension interface.
 - area: build
   change: |
-    added compile-time option ``--define=static_extension_registration=disabled`` to disable the automatic static registration of extension factories.
+    added compile-time option ``--define=static_extension_registration=disabled`` to disable the automatic static
+    registration of extension factories.

--- a/changelogs/1.3.0.yaml
+++ b/changelogs/1.3.0.yaml
@@ -3,88 +3,76 @@ date: May 17, 2017
 changes:
 - area: envoy
   change: |
-    As of this release, we now have an official :repo:`breaking change policy
-    <v1.5:/CONTRIBUTING.md#breaking-change-policy>`. Note that there are numerous breaking configuration
-    changes in this release. They are not listed here. Future releases will adhere to the policy and
-    have clear documentation on deprecations and changes.
+    As of this release, we now have an official :repo:`breaking change policy <v1.5:/CONTRIBUTING.md#breaking-change-
+    policy>`. Note that there are numerous breaking configuration changes in this release. They are not listed here. Future
+    releases will adhere to the policy and have clear documentation on deprecations and changes.
 - area: build
   change: |
-    Bazel is now the canonical build system (replacing CMake). There have been a huge number of
-    changes to the development/build/test flow. See :repo:`/bazel/README.md` and
-    :repo:`/ci/README.md` for more information.
+    Bazel is now the canonical build system (replacing CMake). There have been a huge number of changes to the
+    development/build/test flow. See :repo:`/bazel/README.md` and :repo:`/ci/README.md` for more information.
 - area: outlier_detection
   change: |
-    :ref:`Outlier detection <v1.5:arch_overview_outlier_detection>` has been expanded to include success
-    rate variance, and all parameters are now configurable in both runtime and in the JSON
-    configuration.
+    :ref:`Outlier detection <v1.5:arch_overview_outlier_detection>` has been expanded to include success rate variance, and
+    all parameters are now configurable in both runtime and in the JSON configuration.
 - area: listener
   change: |
-    TCP level listener and cluster connections now have configurable receive buffer
-    limits at which point connection level back pressure is applied.
-    Full end to end flow control will be available in a future release.
+    TCP level listener and cluster connections now have configurable receive buffer limits at which point connection level
+    back pressure is applied. Full end to end flow control will be available in a future release.
 - area: redis
   change: |
-    :ref:`Redis health checking <v1.5:config_cluster_manager_cluster_hc>` has been added as an active
-    health check type. Full Redis support will be documented/supported in 1.4.0.
+    :ref:`Redis health checking <v1.5:config_cluster_manager_cluster_hc>` has been added as an active health check type.
+    Full Redis support will be documented/supported in 1.4.0.
 - area: health_checking
   change: |
-    :ref:`TCP health checking <v1.5:config_cluster_manager_cluster_hc_tcp_health_checking>` now supports a
-    "connect only" mode that only checks if the remote server can be connected to without
-    writing/reading any data.
+    :ref:`TCP health checking <v1.5:config_cluster_manager_cluster_hc_tcp_health_checking>` now supports a "connect only"
+    mode that only checks if the remote server can be connected to without writing/reading any data.
 - area: ssl
   change: |
-    `BoringSSL <https://boringssl.googlesource.com/boringssl>`_ is now the only supported TLS provider.
-    The default cipher suites and ECDH curves have been updated with more modern defaults for both
-    listener and cluster connections.
+    `BoringSSL <https://boringssl.googlesource.com/boringssl>`_ is now the only supported TLS provider. The default cipher
+    suites and ECDH curves have been updated with more modern defaults for both listener and cluster connections.
 - area: matching
   change: |
-    The ``header value match`` rate limit action has been expanded to include an ``expect
-    match`` parameter.
+    The ``header value match`` rate limit action has been expanded to include an ``expect match`` parameter.
 - area: rate_limiting
   change: |
-    Route level HTTP rate limit configurations now do not inherit the virtual host level
-    configurations by default. Use ``include_vh_rate_limits`` to inherit the virtual host
-    level options if desired.
+    Route level HTTP rate limit configurations now do not inherit the virtual host level configurations by default. Use
+    ``include_vh_rate_limits`` to inherit the virtual host level options if desired.
 - area: routing
   change: |
-    HTTP routes can now add request headers on a per route and per virtual host basis via the
-    :ref:`request_headers_to_add <v1.5:config_http_conn_man_headers_custom_request_headers>` option.
+    HTTP routes can now add request headers on a per route and per virtual host basis via the :ref:`request_headers_to_add
+    <v1.5:config_http_conn_man_headers_custom_request_headers>` option.
 - area: examples
   change: |
-    The :ref:`example configurations <v1.5:install_ref_configs>` have been refreshed to demonstrate the
-    latest features.
+    The :ref:`example configurations <v1.5:install_ref_configs>` have been refreshed to demonstrate the latest features.
 - area: retry
   change: |
-    ``per_try_timeout_ms`` can now be configured in
-    a route's retry policy in addition to via the :ref:`x-envoy-upstream-rq-per-try-timeout-ms
-    <v1.5:config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms>` HTTP header.
+    ``per_try_timeout_ms`` can now be configured in a route's retry policy in addition to via the :ref:`x-envoy-upstream-rq-
+    per-try-timeout-ms <v1.5:config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms>` HTTP header.
 - area: matching
   change: |
     HTTP virtual host matching now includes support for prefix wildcard domains (e.g., ``*.lyft.com``).
 - area: tracing
   change: |
-    The default for tracing random sampling has been changed to 100% and is still configurable in
-    :ref:`runtime <v1.5:config_http_conn_man_runtime>`.
+    The default for tracing random sampling has been changed to 100% and is still configurable in :ref:`runtime
+    <v1.5:config_http_conn_man_runtime>`.
 - area: tracing
   change: |
-    HTTP tracing configuration has been extended to allow tags
-    to be populated from arbitrary HTTP headers.
+    HTTP tracing configuration has been extended to allow tags to be populated from arbitrary HTTP headers.
 - area: rate_limiting
   change: |
-    The :ref:`HTTP rate limit filter <v1.5:config_http_filters_rate_limit>` can now be applied to internal,
-    external, or all requests via the ``request_type`` option.
+    The :ref:`HTTP rate limit filter <v1.5:config_http_filters_rate_limit>` can now be applied to internal, external, or all
+    requests via the ``request_type`` option.
 - area: listener
   change: |
-    :ref:`Listener binding <v1.5:config_listeners>` now requires specifying an ``address`` field. This can be
-    used to bind a listener to both a specific address as well as a port.
+    :ref:`Listener binding <v1.5:config_listeners>` now requires specifying an ``address`` field. This can be used to bind a
+    listener to both a specific address as well as a port.
 - area: mongodb
   change: |
-    The :ref:`MongoDB filter <v1.5:config_network_filters_mongo_proxy>` now emits a stat for queries that
-    do not have ``$maxTimeMS`` set.
+    The :ref:`MongoDB filter <v1.5:config_network_filters_mongo_proxy>` now emits a stat for queries that do not have
+    ``$maxTimeMS`` set.
 - area: mongodb
   change: |
-    The :ref:`MongoDB filter <v1.5:config_network_filters_mongo_proxy>` now emits logs that are fully valid
-    JSON.
+    The :ref:`MongoDB filter <v1.5:config_network_filters_mongo_proxy>` now emits logs that are fully valid JSON.
 - area: profiling
   change: |
     The CPU profiler output path is now configurable.
@@ -93,26 +81,26 @@ changes:
     A watchdog system has been added that can kill the server if a deadlock is detected.
 - area: routing
   change: |
-    A :ref:`route table checking tool <v1.5:install_tools_route_table_check_tool>` has been added that can
-    be used to test route tables before use.
+    A :ref:`route table checking tool <v1.5:install_tools_route_table_check_tool>` has been added that can be used to test
+    route tables before use.
 - area: examples
   change: |
     We have added an :ref:`example repo <v1.5:extending>` that shows how to compile/link a custom filter.
 - area: outlier_detection
   change: |
-    Added additional cluster wide information related to outlier detection to the :ref:`/clusters
-    admin endpoint <v1.5:operations_admin_interface>`.
+    Added additional cluster wide information related to outlier detection to the :ref:`/clusters admin endpoint
+    <v1.5:operations_admin_interface>`.
 - area: certificates
   change: |
-    Multiple SANs can now be verified via the ``verify_subject_alt_name`` setting.
-    Additionally, URI type SANs can be verified.
+    Multiple SANs can now be verified via the ``verify_subject_alt_name`` setting. Additionally, URI type SANs can be
+    verified.
 - area: filters
   change: |
     HTTP filters can now be passed opaque configuration specified on a per route basis.
 - area: debugging
   change: |
-    By default Envoy now has a built in crash handler that will print a back trace. This behavior can
-    be disabled if desired via the ``--define=signal_trace=disabled`` Bazel option.
+    By default Envoy now has a built in crash handler that will print a back trace. This behavior can be disabled if desired
+    via the ``--define=signal_trace=disabled`` Bazel option.
 - area: zipkin
   change: |
     Zipkin has been added as a supported :ref:`tracing provider <v1.5:arch_overview_tracing>`.

--- a/changelogs/1.4.0.yaml
+++ b/changelogs/1.4.0.yaml
@@ -3,8 +3,8 @@ date: August 24, 2017
 changes:
 - area: mac
   change: |
-    macOS is :repo:`now supported <v1.5:/bazel#quick-start-bazel-build-for-developers>`. (A few features
-    are missing such as hot restart and original destination routing).
+    macOS is :repo:`now supported <v1.5:/bazel#quick-start-bazel-build-for-developers>`. (A few features are missing such as
+    hot restart and original destination routing).
 - area: config
   change: |
     YAML is now directly supported for config files.
@@ -13,8 +13,8 @@ changes:
     Added /routes admin endpoint.
 - area: flow_control
   change: |
-    End-to-end flow control is now supported for TCP proxy, HTTP/1, and HTTP/2. HTTP flow control
-    that includes filter buffering is incomplete and will be implemented in 1.5.0.
+    End-to-end flow control is now supported for TCP proxy, HTTP/1, and HTTP/2. HTTP flow control that includes filter
+    buffering is incomplete and will be implemented in 1.5.0.
 - area: logging
   change: |
     Log verbosity :repo:`compile time flag <v1.5:/bazel#log-verbosity>` added.
@@ -23,26 +23,24 @@ changes:
     Hot restart :repo:`compile time flag <v1.5:/bazel#hot-restart>` added.
 - area: load_balancing
   change: |
-    Original destination :ref:`cluster <v1.5:arch_overview_service_discovery_types_original_destination>`
-    and :ref:`load balancer <v1.5:arch_overview_load_balancing_types_original_destination>` added.
+    Original destination :ref:`cluster <v1.5:arch_overview_service_discovery_types_original_destination>` and :ref:`load
+    balancer <v1.5:arch_overview_load_balancing_types_original_destination>` added.
 - area: websockets
   change: |
     :ref:`WebSocket <v1.5:arch_overview_websocket>` is now supported.
 - area: clusters
   change: |
-    Virtual cluster priorities have been hard removed without deprecation as we are reasonably sure
-    no one is using this feature.
+    Virtual cluster priorities have been hard removed without deprecation as we are reasonably sure no one is using this
+    feature.
 - area: clusters
   change: |
     Route ``validate_clusters`` option added.
 - area: headers
   change: |
-    :ref:`x-envoy-downstream-service-node <v1.5:config_http_conn_man_headers_downstream-service-node>`
-    header added.
+    :ref:`x-envoy-downstream-service-node <v1.5:config_http_conn_man_headers_downstream-service-node>` header added.
 - area: headers
   change: |
-    :ref:`x-forwarded-client-cert <v1.5:config_http_conn_man_headers_x-forwarded-client-cert>` header
-    added.
+    :ref:`x-forwarded-client-cert <v1.5:config_http_conn_man_headers_x-forwarded-client-cert>` header added.
 - area: http1
   change: |
     Initial HTTP/1 forward proxy support for absolute URLs has been added.
@@ -57,9 +55,8 @@ changes:
     gRPC web :ref:`filter <v1.5:config_http_filters_grpc_web>` added.
 - area: rate_limting
   change: |
-    Configurable timeout for the rate limit service call in the :ref:`network
-    <v1.5:config_network_filters_rate_limit>` and :ref:`HTTP <v1.5:config_http_filters_rate_limit>` rate limit
-    filters.
+    Configurable timeout for the rate limit service call in the :ref:`network <v1.5:config_network_filters_rate_limit>` and
+    :ref:`HTTP <v1.5:config_http_filters_rate_limit>` rate limit filters.
 - area: headers
   change: |
     :ref:`x-envoy-retry-grpc-on <v1.5:config_http_filters_router_x-envoy-retry-grpc-on>` header added.
@@ -95,9 +92,9 @@ changes:
     :ref:`Fault filter <v1.5:config_http_filters_fault_injection>` enhancements and fixes.
 - area: deprecation
   change: |
-    Several features are `deprecated as of the 1.4.0 release <https://github.com/envoyproxy/envoy/blob/v1.4.0/DEPRECATED.md>`_. They
-    will be removed at the beginning of the 1.5.0 release cycle. We explicitly call out that the
-    ``HttpFilterConfigFactory`` filter API has been deprecated in favor of
+    Several features are `deprecated as of the 1.4.0 release
+    <https://github.com/envoyproxy/envoy/blob/v1.4.0/DEPRECATED.md>`_. They will be removed at the beginning of the 1.5.0
+    release cycle. We explicitly call out that the ``HttpFilterConfigFactory`` filter API has been deprecated in favor of
     ``NamedHttpFilterConfigFactory``.
 - area: envoy
   change: |
@@ -106,8 +103,7 @@ changes:
 deprecated:
 - area: options
   change: |
-    Config option ``statsd_local_udp_port`` has been deprecated and has been replaced with
-    ``statsd_udp_ip_address``.
+    Config option ``statsd_local_udp_port`` has been deprecated and has been replaced with ``statsd_udp_ip_address``.
 - area: http_filters
   change: |
     ``HttpFilterConfigFactory`` filter API has been deprecated in favor of ``NamedHttpFilterConfigFactory``.
@@ -116,23 +112,21 @@ deprecated:
     Config option ``http_codec_options`` has been deprecated and has been replaced with ``http2_settings``.
 - area: logging
   change: |
-    The following log macros have been deprecated: ``log_trace``, ``log_debug``, ``conn_log``,
-    ``conn_log_info``, ``conn_log_debug``, ``conn_log_trace``, ``stream_log``, ``stream_log_info``,
-    ``stream_log_debug``, ``stream_log_trace``. For replacements, please see
-    `logger.h <https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.h>`_.
+    The following log macros have been deprecated: ``log_trace``, ``log_debug``, ``conn_log``, ``conn_log_info``,
+    ``conn_log_debug``, ``conn_log_trace``, ``stream_log``, ``stream_log_info``, ``stream_log_debug``, ``stream_log_trace``.
+    For replacements, please see `logger.h <https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.h>`_.
 - area: streaming
   change: |
-    The connectionId() and ssl() callbacks of StreamFilterCallbacks have been deprecated and
-    replaced with a more general connection() callback, which, when not returning a nullptr, can be
-    used to get the connection id and SSL connection from the returned Connection object pointer.
+    The connectionId() and ssl() callbacks of StreamFilterCallbacks have been deprecated and replaced with a more general
+    connection() callback, which, when not returning a nullptr, can be used to get the connection id and SSL connection from
+    the returned Connection object pointer.
 - area: grpc
   change: |
-    The protobuf stub gRPC support via ``Grpc::RpcChannelImpl`` is now replaced with ``Grpc::AsyncClientImpl``.
-    This no longer uses ``protoc`` generated stubs but instead utilizes C++ template generation of the
-    RPC stubs. ``Grpc::AsyncClientImpl`` supports streaming, in addition to the previous unary, RPCs.
+    The protobuf stub gRPC support via ``Grpc::RpcChannelImpl`` is now replaced with ``Grpc::AsyncClientImpl``. This no
+    longer uses ``protoc`` generated stubs but instead utilizes C++ template generation of the RPC stubs.
+    ``Grpc::AsyncClientImpl`` supports streaming, in addition to the previous unary, RPCs.
 - area: filters
   change: |
-    The direction of network and HTTP filters in the configuration will be ignored from 1.4.0 and
-    later removed from the configuration in the v2 APIs. Filter direction is now implied at the C++ type
-    level. The ``type()`` methods on the ``NamedNetworkFilterConfigFactory`` and
-    ``NamedHttpFilterConfigFactory`` interfaces have been removed to reflect this.
+    The direction of network and HTTP filters in the configuration will be ignored from 1.4.0 and later removed from the
+    configuration in the v2 APIs. Filter direction is now implied at the C++ type level. The ``type()`` methods on the
+    ``NamedNetworkFilterConfigFactory`` and ``NamedHttpFilterConfigFactory`` interfaces have been removed to reflect this.

--- a/changelogs/1.5.0.yaml
+++ b/changelogs/1.5.0.yaml
@@ -3,15 +3,14 @@ date: December 4, 2017
 changes:
 - area: access log
   change: |
-    added fields for :ref:`UPSTREAM_LOCAL_ADDRESS and DOWNSTREAM_ADDRESS
-    <config_access_log_format>`.
+    added fields for :ref:`UPSTREAM_LOCAL_ADDRESS and DOWNSTREAM_ADDRESS <config_access_log_format>`.
 - area: admin
   change: |
     added :ref:`JSON output <operations_admin_interface_stats>` for stats admin endpoint.
 - area: admin
   change: |
-    added basic :ref:`Prometheus output <operations_admin_interface_stats>` for stats admin
-    endpoint. Histograms are not currently output.
+    added basic :ref:`Prometheus output <operations_admin_interface_stats>` for stats admin endpoint. Histograms are not
+    currently output.
 - area: admin
   change: |
     added ``version_info`` to the :ref:`/clusters admin endpoint <operations_admin_interface_clusters>`.
@@ -26,8 +25,8 @@ changes:
     added :ref:`CORS filter <config_http_filters_cors>`.
 - area: health check
   change: |
-    added :ref:`x-envoy-immediate-health-check-fail
-    <config_http_filters_router_x-envoy-immediate-health-check-fail>` header support.
+    added :ref:`x-envoy-immediate-health-check-fail <config_http_filters_router_x-envoy-immediate-health-check-fail>` header
+    support.
 - area: health check
   change: |
     added :ref:`reuse_connection <envoy_api_field_HealthCheck.reuse_connection>` option.
@@ -42,13 +41,12 @@ changes:
     added :ref:`subset load balancer <arch_overview_load_balancer_subsets>`.
 - area: load balancer
   change: |
-    added ring size and hash :ref:`configuration options
-    <envoy_api_msg_Cluster.RingHashLbConfig>`. This used to be configurable via runtime. The runtime
-    configuration was deleted without deprecation as we are fairly certain no one is using it.
+    added ring size and hash :ref:`configuration options <envoy_api_msg_Cluster.RingHashLbConfig>`. This used to be
+    configurable via runtime. The runtime configuration was deleted without deprecation as we are fairly certain no one is
+    using it.
 - area: log
   change: |
-    added the ability to optionally log to a file instead of stderr via the
-    :option:`--log-path` option.
+    added the ability to optionally log to a file instead of stderr via the :option:`--log-path` option.
 - area: listeners
   change: |
     added :ref:`drain_type <envoy_api_field_Listener.drain_type>` option.
@@ -63,13 +61,12 @@ changes:
     added :ref:`"drain close" <arch_overview_draining>` support.
 - area: outlier detection
   change: |
-    added :ref:`HTTP gateway failure type <arch_overview_outlier_detection>`.
-    See `deprecated log <https://github.com/envoyproxy/envoy/blob/v1.5.0/DEPRECATED.md>`_
-    for outlier detection stats deprecations in this release.
+    added :ref:`HTTP gateway failure type <arch_overview_outlier_detection>`. See `deprecated log
+    <https://github.com/envoyproxy/envoy/blob/v1.5.0/DEPRECATED.md>`_ for outlier detection stats deprecations in this
+    release.
 - area: redis
   change: |
-    the :ref:`redis proxy filter <config_network_filters_redis_proxy>` is now considered
-    production ready.
+    the :ref:`redis proxy filter <config_network_filters_redis_proxy>` is now considered production ready.
 - area: redis
   change: |
     added :ref:`"drain close" <arch_overview_draining>` functionality.
@@ -81,34 +78,32 @@ changes:
     added :ref:`regex <envoy_api_field_RouteMatch.regex>` route matching.
 - area: router
   change: |
-    added :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`
-    for upstream requests.
+    added :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>` for upstream requests.
 - area: router
   change: |
-    added :ref:`downstream IP hashing
-    <envoy_api_field_RouteAction.HashPolicy.connection_properties>` for HTTP ketama routing.
+    added :ref:`downstream IP hashing <envoy_api_field_RouteAction.HashPolicy.connection_properties>` for HTTP ketama
+    routing.
 - area: router
   change: |
     added :ref:`cookie hashing <envoy_api_msg_RouteAction.HashPolicy.Cookie>`.
 - area: router
   change: |
-    added :ref:`start_child_span <envoy_api_field_filter.http.Router.start_child_span>` option
-    to create child span for egress calls.
+    added :ref:`start_child_span <envoy_api_field_filter.http.Router.start_child_span>` option to create child span for
+    egress calls.
 - area: router
   change: |
     added optional :ref:`upstream logs <envoy_api_field_filter.http.Router.upstream_log>`.
 - area: router
   change: |
-    added complete :ref:`custom append/override/remove support
-    <config_http_conn_man_headers_custom_request_headers>` of request/response headers.
+    added complete :ref:`custom append/override/remove support <config_http_conn_man_headers_custom_request_headers>` of
+    request/response headers.
 - area: router
   change: |
-    added support to :ref:`specify response code during redirect
-    <envoy_api_field_RedirectAction.response_code>`.
+    added support to :ref:`specify response code during redirect <envoy_api_field_RedirectAction.response_code>`.
 - area: router
   change: |
-    added :ref:`configuration <envoy_api_field_RouteAction.cluster_not_found_response_code>`
-    to return either a 404 or 503 if the upstream cluster does not exist.
+    added :ref:`configuration <envoy_api_field_RouteAction.cluster_not_found_response_code>` to return either a 404 or 503
+    if the upstream cluster does not exist.
 - area: runtime
   change: |
     added :ref:`comment capability <config_runtime_comments>`.
@@ -117,15 +112,14 @@ changes:
     change default log level (:option:`-l`) to ``info``.
 - area: stats
   change: |
-    maximum stat/name sizes and maximum number of stats are now variable via the
-    ``--max-obj-name-len`` and ``--max-stats`` options.
+    maximum stat/name sizes and maximum number of stats are now variable via the ``--max-obj-name-len`` and ``--max-stats``
+    options.
 - area: tcp proxy
   change: |
     added :ref:`access logging <envoy_api_field_filter.network.TcpProxy.access_log>`.
 - area: tcp proxy
   change: |
-    added :ref:`configurable connect retries
-    <envoy_api_field_filter.network.TcpProxy.max_connect_attempts>`.
+    added :ref:`configurable connect retries <envoy_api_field_filter.network.TcpProxy.max_connect_attempts>`.
 - area: tcp proxy
   change: |
     enable use of :ref:`outlier detector <arch_overview_outlier_detection>`.
@@ -134,12 +128,10 @@ changes:
     added :ref:`SNI support <faq_how_to_setup_sni>`.
 - area: tls
   change: |
-    added support for specifying :ref:`TLS session ticket keys
-    <envoy_api_field_DownstreamTlsContext.session_ticket_keys>`.
+    added support for specifying :ref:`TLS session ticket keys <envoy_api_field_DownstreamTlsContext.session_ticket_keys>`.
 - area: tls
   change: |
-    allow configuration of the :ref:`min
-    <envoy_api_field_TlsParameters.tls_minimum_protocol_version>` and :ref:`max
+    allow configuration of the :ref:`min <envoy_api_field_TlsParameters.tls_minimum_protocol_version>` and :ref:`max
     <envoy_api_field_TlsParameters.tls_minimum_protocol_version>` TLS protocol versions.
 - area: tracing
   change: |
@@ -151,9 +143,9 @@ changes:
 deprecated:
 - area: outlier_detection
   change: |
-    The outlier detection ``ejections_total`` stats counter has been deprecated and not replaced. Monitor
-    the individual ``ejections_detected_*`` counters for the detectors of interest, or
-    ``ejections_enforced_total`` for the total number of ejections that actually occurred.
+    The outlier detection ``ejections_total`` stats counter has been deprecated and not replaced. Monitor the individual
+    ``ejections_detected_*`` counters for the detectors of interest, or ``ejections_enforced_total`` for the total number of
+    ejections that actually occurred.
 - area: outlier_detection
   change: |
     The outlier detection ``ejections_consecutive_5xx`` stats counter has been deprecated in favour of

--- a/changelogs/1.6.0.yaml
+++ b/changelogs/1.6.0.yaml
@@ -3,71 +3,64 @@ date: March 20, 2018
 changes:
 - area: access log
   change: |
-    added ``DOWNSTREAM_REMOTE_ADDRESS``, ``DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT``, and
-    ``DOWNSTREAM_LOCAL_ADDRESS`` :ref:`access log formatters <config_access_log_format>`.
-    ``DOWNSTREAM_ADDRESS`` access log formatter has been deprecated.
+    added ``DOWNSTREAM_REMOTE_ADDRESS``, ``DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT``, and ``DOWNSTREAM_LOCAL_ADDRESS``
+    :ref:`access log formatters <config_access_log_format>`. ``DOWNSTREAM_ADDRESS`` access log formatter has been
+    deprecated.
 - area: access log
   change: |
-    added less than or equal (LE) :ref:`comparison filter
-    <envoy_api_msg_config.filter.accesslog.v2.ComparisonFilter>`.
+    added less than or equal (LE) :ref:`comparison filter <envoy_api_msg_config.filter.accesslog.v2.ComparisonFilter>`.
 - area: access log
   change: |
-    added configuration to :ref:`runtime filter
-    <envoy_api_msg_config.filter.accesslog.v2.RuntimeFilter>` to set default sampling rate, divisor,
-    and whether to use independent randomness or not.
+    added configuration to :ref:`runtime filter <envoy_api_msg_config.filter.accesslog.v2.RuntimeFilter>` to set default
+    sampling rate, divisor, and whether to use independent randomness or not.
 - area: admin
   change: |
-    added :ref:`/runtime <operations_admin_interface_runtime>` admin endpoint to read the
-    current runtime values.
+    added :ref:`/runtime <operations_admin_interface_runtime>` admin endpoint to read the current runtime values.
 - area: build
   change: |
-    added support for :repo:`building Envoy with exported symbols
-    <bazel#enabling-optional-features>`. This change allows scripts loaded with the Lua filter to
-    load shared object libraries such as those installed via `LuaRocks <https://luarocks.org/>`_.
+    added support for :repo:`building Envoy with exported symbols <bazel#enabling-optional-features>`. This change allows
+    scripts loaded with the Lua filter to load shared object libraries such as those installed via `LuaRocks
+    <https://luarocks.org/>`_.
 - area: config
   change: |
-    added support for sending error details as
-    `grpc.rpc.Status <https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto>`_
-    in :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>`.
+    added support for sending error details as `grpc.rpc.Status
+    <https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto>`_ in :ref:`DiscoveryRequest
+    <envoy_api_msg_DiscoveryRequest>`.
 - area: config
   change: |
-    added support for :ref:`inline delivery <envoy_api_msg_core.DataSource>` of TLS
-    certificates and private keys.
+    added support for :ref:`inline delivery <envoy_api_msg_core.DataSource>` of TLS certificates and private keys.
 - area: config
   change: |
-    added restrictions for the backing :ref:`config sources <envoy_api_msg_core.ConfigSource>`
-    of xDS resources. For filesystem based xDS the file must exist at configuration time. For cluster
-    based xDS the backing cluster must be statically defined and be of non-EDS type.
+    added restrictions for the backing :ref:`config sources <envoy_api_msg_core.ConfigSource>` of xDS resources. For
+    filesystem based xDS the file must exist at configuration time. For cluster based xDS the backing cluster must be
+    statically defined and be of non-EDS type.
 - area: grpc
   change: |
-    the Google gRPC C++ library client is now supported as specified in the :ref:`gRPC services
-    overview <arch_overview_grpc_services>` and :ref:`GrpcService <envoy_api_msg_core.GrpcService>`.
+    the Google gRPC C++ library client is now supported as specified in the :ref:`gRPC services overview
+    <arch_overview_grpc_services>` and :ref:`GrpcService <envoy_api_msg_core.GrpcService>`.
 - area: grpc-json
   change: |
     added support for :ref:`inline descriptors
     <envoy_api_field_config.filter.http.transcoder.v2.GrpcJsonTranscoder.proto_descriptor_bin>`.
 - area: health check
   change: |
-    added :ref:`gRPC health check <envoy_api_field_core.HealthCheck.grpc_health_check>`
-    based on `grpc.health.v1.Health <https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto>`_
-    service.
+    added :ref:`gRPC health check <envoy_api_field_core.HealthCheck.grpc_health_check>` based on `grpc.health.v1.Health
+    <https://github.com/grpc/grpc/blob/master/src/proto/grpc/health/v1/health.proto>`_ service.
 - area: health check
   change: |
-    added ability to set :ref:`host header value
-    <envoy_api_field_core.HealthCheck.HttpHealthCheck.host>` for http health check.
+    added ability to set :ref:`host header value <envoy_api_field_core.HealthCheck.HttpHealthCheck.host>` for http health
+    check.
 - area: health check
   change: |
-    extended the health check filter to support computation of the health check response
-    based on the :ref:`percentage of healthy servers in upstream clusters
+    extended the health check filter to support computation of the health check response based on the :ref:`percentage of
+    healthy servers in upstream clusters
     <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>`.
 - area: health check
   change: |
-    added setting for :ref:`no-traffic
-    interval <envoy_api_field_core.HealthCheck.no_traffic_interval>`.
+    added setting for :ref:`no-traffic interval <envoy_api_field_core.HealthCheck.no_traffic_interval>`.
 - area: http
   change: |
-    added idle timeout for :ref:`upstream http connections
-    <envoy_api_field_core.HttpProtocolOptions.idle_timeout>`.
+    added idle timeout for :ref:`upstream http connections <envoy_api_field_core.HttpProtocolOptions.idle_timeout>`.
 - area: http
   change: |
     added support for :ref:`proxying 100-Continue responses
@@ -78,43 +71,38 @@ changes:
     :ref:`config_http_conn_man_headers_x-forwarded-client-cert` header.
 - area: http
   change: |
-    added support for trusting additional hops in the
-    :ref:`config_http_conn_man_headers_x-forwarded-for` request header.
+    added support for trusting additional hops in the :ref:`config_http_conn_man_headers_x-forwarded-for` request header.
 - area: http
   change: |
-    added support for :ref:`incoming HTTP/1.0
-    <envoy_api_field_core.Http1ProtocolOptions.accept_http_10>`.
+    added support for :ref:`incoming HTTP/1.0 <envoy_api_field_core.Http1ProtocolOptions.accept_http_10>`.
 - area: hot restart
   change: |
-    added SIGTERM propagation to children to :ref:`hot-restarter.py
-    <operations_hot_restarter>`, which enables using it as a parent of containers.
+    added SIGTERM propagation to children to :ref:`hot-restarter.py <operations_hot_restarter>`, which enables using it as a
+    parent of containers.
 - area: ip tagging
   change: |
     added :ref:`HTTP IP Tagging filter <config_http_filters_ip_tagging>`.
 - area: listeners
   change: |
-    added support for :ref:`listening for both IPv4 and IPv6
-    <envoy_api_field_core.SocketAddress.ipv4_compat>` when binding to ::.
+    added support for :ref:`listening for both IPv4 and IPv6 <envoy_api_field_core.SocketAddress.ipv4_compat>` when binding
+    to ::.
 - area: listeners
   change: |
-    added support for listening on :ref:`UNIX domain sockets
-    <envoy_api_field_core.Address.pipe>`.
+    added support for listening on :ref:`UNIX domain sockets <envoy_api_field_core.Address.pipe>`.
 - area: listeners
   change: |
-    added support for :ref:`abstract unix domain sockets <envoy_api_msg_core.Pipe>` on
-    Linux. The abstract namespace can be used by prepending '@' to a socket path.
+    added support for :ref:`abstract unix domain sockets <envoy_api_msg_core.Pipe>` on Linux. The abstract namespace can be
+    used by prepending '@' to a socket path.
 - area: load balancer
   change: |
     added cluster configuration for :ref:`healthy panic threshold
     <envoy_api_field_Cluster.CommonLbConfig.healthy_panic_threshold>` percentage.
 - area: load balancer
   change: |
-    added :ref:`Maglev <arch_overview_load_balancing_types_maglev>` consistent hash
-    load balancer.
+    added :ref:`Maglev <arch_overview_load_balancing_types_maglev>` consistent hash load balancer.
 - area: load balancer
   change: |
-    added support for
-    :ref:`LocalityLbEndpoints <envoy_api_msg_endpoint.LocalityLbEndpoints>` priorities.
+    added support for :ref:`LocalityLbEndpoints <envoy_api_msg_endpoint.LocalityLbEndpoints>` priorities.
 - area: lua
   change: |
     added headers :ref:`replace() <config_http_filters_lua_header_wrapper>` API.
@@ -126,14 +114,13 @@ changes:
     added local ``PING`` support to the :ref:`Redis filter <arch_overview_redis>`.
 - area: redis
   change: |
-    added ``GEORADIUS_RO`` and ``GEORADIUSBYMEMBER_RO`` to the :ref:`Redis command splitter
-    <arch_overview_redis>` allowlist.
+    added ``GEORADIUS_RO`` and ``GEORADIUSBYMEMBER_RO`` to the :ref:`Redis command splitter <arch_overview_redis>`
+    allowlist.
 - area: router
   change: |
     added ``DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT``, ``DOWNSTREAM_LOCAL_ADDRESS``,
-    ``DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT``, ``PROTOCOL``, and ``UPSTREAM_METADATA`` :ref:`header
-    formatters <config_http_conn_man_headers_custom_request_headers>`. The ``CLIENT_IP`` header formatter
-    has been deprecated.
+    ``DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT``, ``PROTOCOL``, and ``UPSTREAM_METADATA`` :ref:`header formatters
+    <config_http_conn_man_headers_custom_request_headers>`. The ``CLIENT_IP`` header formatter has been deprecated.
 - area: router
   change: |
     added gateway-error :ref:`retry-on <config_http_filters_router_x-envoy-retry-on>` policy.
@@ -147,37 +134,33 @@ changes:
     <envoy_api_field_route.WeightedCluster.total_weight>` to be specified in configuration.
 - area: router
   change: |
-    added support for :ref:`custom request/response headers
-    <config_http_conn_man_headers_custom_request_headers>` with mixed static and dynamic values.
+    added support for :ref:`custom request/response headers <config_http_conn_man_headers_custom_request_headers>` with
+    mixed static and dynamic values.
 - area: router
   change: |
-    added support for :ref:`direct responses <envoy_api_field_route.Route.direct_response>`.
-    I.e., sending a preconfigured HTTP response without proxying anywhere.
+    added support for :ref:`direct responses <envoy_api_field_route.Route.direct_response>`. I.e., sending a preconfigured
+    HTTP response without proxying anywhere.
 - area: router
   change: |
-    added support for :ref:`HTTPS redirects
-    <envoy_api_field_route.RedirectAction.https_redirect>` on specific routes.
+    added support for :ref:`HTTPS redirects <envoy_api_field_route.RedirectAction.https_redirect>` on specific routes.
 - area: router
   change: |
-    added support for :ref:`prefix_rewrite
-    <envoy_api_field_route.RedirectAction.prefix_rewrite>` for redirects.
+    added support for :ref:`prefix_rewrite <envoy_api_field_route.RedirectAction.prefix_rewrite>` for redirects.
 - area: router
   change: |
-    added support for :ref:`stripping the query string
-    <envoy_api_field_route.RedirectAction.strip_query>` for redirects.
+    added support for :ref:`stripping the query string <envoy_api_field_route.RedirectAction.strip_query>` for redirects.
 - area: router
   change: |
-    added support for downstream request/upstream response
-    :ref:`header manipulation <config_http_conn_man_headers_custom_request_headers>` in :ref:`weighted
-    cluster <envoy_api_msg_route.WeightedCluster>`.
+    added support for downstream request/upstream response :ref:`header manipulation
+    <config_http_conn_man_headers_custom_request_headers>` in :ref:`weighted cluster <envoy_api_msg_route.WeightedCluster>`.
 - area: router
   change: |
-    added support for :ref:`range based header matching
-    <envoy_api_field_route.HeaderMatcher.range_match>` for request routing.
+    added support for :ref:`range based header matching <envoy_api_field_route.HeaderMatcher.range_match>` for request
+    routing.
 - area: squash
   change: |
-    added support for the :ref:`Squash microservices debugger <config_http_filters_squash>`.
-    Allows debugging an incoming request to a microservice in the mesh.
+    added support for the :ref:`Squash microservices debugger <config_http_filters_squash>`. Allows debugging an incoming
+    request to a microservice in the mesh.
 - area: stats
   change: |
     added metrics service API implementation.
@@ -186,47 +169,44 @@ changes:
     added native :ref:`DogStatsd <envoy_api_msg_config.metrics.v2.DogStatsdSink>` support.
 - area: stats
   change: |
-    added support for :ref:`fixed stats tag values
-    <envoy_api_field_config.metrics.v2.TagSpecifier.fixed_value>` which will be added to all metrics.
+    added support for :ref:`fixed stats tag values <envoy_api_field_config.metrics.v2.TagSpecifier.fixed_value>` which will
+    be added to all metrics.
 - area: tcp proxy
   change: |
     added support for specifying a :ref:`metadata matcher
-    <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.metadata_match>` for upstream
-    clusters in the tcp filter.
+    <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.metadata_match>` for upstream clusters in the tcp filter.
 - area: tcp proxy
   change: |
     improved TCP proxy to correctly proxy TCP half-close.
 - area: tcp proxy
   change: |
-    added :ref:`idle timeout
-    <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.idle_timeout>`.
+    added :ref:`idle timeout <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.idle_timeout>`.
 - area: tcp proxy
   change: |
-    access logs now bring an IP address without a port when using DOWNSTREAM_ADDRESS.
-    Use :ref:`DOWNSTREAM_REMOTE_ADDRESS <config_access_log_format>` instead.
+    access logs now bring an IP address without a port when using DOWNSTREAM_ADDRESS. Use :ref:`DOWNSTREAM_REMOTE_ADDRESS
+    <config_access_log_format>` instead.
 - area: tracing
   change: |
-    added support for dynamically loading an :ref:`OpenTracing tracer
-    <envoy_api_msg_config.trace.v2.DynamicOtConfig>`.
+    added support for dynamically loading an :ref:`OpenTracing tracer <envoy_api_msg_config.trace.v2.DynamicOtConfig>`.
 - area: tracing
   change: |
-    when using the Zipkin tracer, it is now possible for clients to specify the sampling
-    decision (using the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header) and
-    have the decision propagated through to subsequently invoked services.
+    when using the Zipkin tracer, it is now possible for clients to specify the sampling decision (using the
+    :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header) and have the decision propagated through to
+    subsequently invoked services.
 - area: tracing
   change: |
-    when using the Zipkin tracer, it is no longer necessary to propagate the
-    :ref:`x-ot-span-context <config_http_conn_man_headers_x-ot-span-context>` header.
-    See more on trace context propagation :ref:`here <arch_overview_tracing>`.
+    when using the Zipkin tracer, it is no longer necessary to propagate the :ref:`x-ot-span-context
+    <config_http_conn_man_headers_x-ot-span-context>` header. See more on trace context propagation :ref:`here
+    <arch_overview_tracing>`.
 - area: transport sockets
   change: |
-    added transport socket interface to allow custom implementations of transport
-    sockets. A transport socket provides read and write logic with buffer encryption and decryption
-    (if applicable). The existing TLS implementation has been refactored with the interface.
+    added transport socket interface to allow custom implementations of transport sockets. A transport socket provides read
+    and write logic with buffer encryption and decryption (if applicable). The existing TLS implementation has been
+    refactored with the interface.
 - area: upstream
   change: |
-    added support for specifying an :ref:`alternate stats name
-    <envoy_api_field_Cluster.alt_stat_name>` while emitting stats for clusters.
+    added support for specifying an :ref:`alternate stats name <envoy_api_field_Cluster.alt_stat_name>` while emitting stats
+    for clusters.
 - area: envoy
   change: |
     Many small bug fixes and performance improvements not listed.
@@ -234,16 +214,14 @@ changes:
 deprecated:
 - area: logging
   change: |
-    ``DOWNSTREAM_ADDRESS`` log formatter is deprecated. Use ``DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT``
-    instead.
+    ``DOWNSTREAM_ADDRESS`` log formatter is deprecated. Use ``DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT`` instead.
 - area: headers
   change: |
     ``CLIENT_IP`` header formatter is deprecated. Use ``DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT`` instead.
 - area: lds
   change: |
-    'use_original_dst' field in the v2 LDS API is deprecated. Use listener filters and filter chain
-    matching instead.
+    'use_original_dst' field in the v2 LDS API is deprecated. Use listener filters and filter chain matching instead.
 - area: matching
   change: |
-    ``value`` and ``regex`` fields in the ``HeaderMatcher`` message is deprecated. Use the ``exact_match``
-    or ``regex_match`` oneof instead.
+    ``value`` and ``regex`` fields in the ``HeaderMatcher`` message is deprecated. Use the ``exact_match`` or
+    ``regex_match`` oneof instead.

--- a/changelogs/1.7.0.yaml
+++ b/changelogs/1.7.0.yaml
@@ -1,7 +1,6 @@
 date: June 21, 2018
 
 changes:
-
 - area: access log
   change: |
     added ability to log response trailers.
@@ -13,8 +12,8 @@ changes:
     added ``DYNAMIC_METADATA`` :ref:`access log formatter <config_access_log_format>`.
 - area: access log
   change: |
-    added :ref:`HeaderFilter <envoy_api_msg_config.filter.accesslog.v2.HeaderFilter>`
-    to filter logs based on request headers.
+    added :ref:`HeaderFilter <envoy_api_msg_config.filter.accesslog.v2.HeaderFilter>` to filter logs based on request
+    headers.
 - area: access log
   change: |
     added ``%([1-9])?f`` as one of ``START_TIME`` specifiers to render subseconds.
@@ -27,12 +26,12 @@ changes:
     improved WebSocket logging.
 - area: admin
   change: |
-    added :http:get:`/config_dump` for dumping the current configuration and associated xDS
-    version information (if applicable).
+    added :http:get:`/config_dump` for dumping the current configuration and associated xDS version information (if
+    applicable).
 - area: admin
   change: |
-    added :http:get:`/clusters?format=json` for outputing a JSON-serialized proto detailing
-    the current status of all clusters.
+    added :http:get:`/clusters?format=json` for outputing a JSON-serialized proto detailing the current status of all
+    clusters.
 - area: admin
   change: |
     added :http:get:`/stats/prometheus` as an alternative endpoint for getting stats in prometheus format.
@@ -41,31 +40,30 @@ changes:
     added :ref:`/runtime_modify endpoint <operations_admin_interface_runtime_modify>` to add or change runtime values.
 - area: admin
   change: |
-    mutations must be sent as POSTs, rather than GETs. Mutations include:
-    :http:post:`/cpuprofiler`, :http:post:`/healthcheck/fail`, :http:post:`/healthcheck/ok`,
-    :http:post:`/logging`, :http:post:`/quitquitquit`, :http:post:`/reset_counters`,
-    :http:post:`/runtime_modify?key1=value1&key2=value2&keyN=valueN`.
+    mutations must be sent as POSTs, rather than GETs. Mutations include: :http:post:`/cpuprofiler`,
+    :http:post:`/healthcheck/fail`, :http:post:`/healthcheck/ok`, :http:post:`/logging`, :http:post:`/quitquitquit`,
+    :http:post:`/reset_counters`, :http:post:`/runtime_modify?key1=value1&key2=value2&keyN=valueN`.
 - area: admin
   change: |
-    removed ``/routes`` endpoint; route configs can now be found at the :ref:`/config_dump endpoint <operations_admin_interface_config_dump>`.
+    removed ``/routes`` endpoint; route configs can now be found at the :ref:`/config_dump endpoint
+    <operations_admin_interface_config_dump>`.
 - area: buffer filter
   change: |
-    the buffer filter can be optionally
-    :ref:`disabled <envoy_api_field_config.filter.http.buffer.v2.BufferPerRoute.disabled>` or
-    :ref:`overridden <envoy_api_field_config.filter.http.buffer.v2.BufferPerRoute.buffer>` with
-    route-local configuration.
+    the buffer filter can be optionally :ref:`disabled
+    <envoy_api_field_config.filter.http.buffer.v2.BufferPerRoute.disabled>` or :ref:`overridden
+    <envoy_api_field_config.filter.http.buffer.v2.BufferPerRoute.buffer>` with route-local configuration.
 - area: cli
   change: |
-    added ``--config-yaml`` flag to the Envoy binary. When set its value is interpreted as a yaml
-    representation of the bootstrap config and overrides ``--config-path``.
+    added ``--config-yaml`` flag to the Envoy binary. When set its value is interpreted as a yaml representation of the
+    bootstrap config and overrides ``--config-path``.
 - area: cluster
   change: |
-    added :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>`
-    to close ``tcp_proxy`` upstream connections when health checks fail.
+    added :ref:`option <envoy_api_field_Cluster.close_connections_on_host_health_failure>` to close ``tcp_proxy`` upstream
+    connections when health checks fail.
 - area: cluster
   change: |
-    added :ref:`option <envoy_api_field_Cluster.drain_connections_on_host_removal>` to drain
-    connections from hosts after they are removed from service discovery, regardless of health status.
+    added :ref:`option <envoy_api_field_Cluster.drain_connections_on_host_removal>` to drain connections from hosts after
+    they are removed from service discovery, regardless of health status.
 - area: cluster
   change: |
     fixed bug preventing the deletion of all endpoints in a priority.
@@ -94,14 +92,13 @@ changes:
     <envoy_api_field_core.HealthCheck.HttpHealthCheck.request_headers_to_add>` for HTTP health check.
 - area: health check
   change: |
-    added support for EDS delivered :ref:`endpoint health status
-    <envoy_api_field_endpoint.LbEndpoint.health_status>`.
+    added support for EDS delivered :ref:`endpoint health status <envoy_api_field_endpoint.LbEndpoint.health_status>`.
 - area: health check
   change: |
     added interval overrides for health state transitions from :ref:`healthy to unhealthy
     <envoy_api_field_core.HealthCheck.unhealthy_edge_interval>`, :ref:`unhealthy to healthy
-    <envoy_api_field_core.HealthCheck.healthy_edge_interval>` and for subsequent checks on
-    :ref:`unhealthy hosts <envoy_api_field_core.HealthCheck.unhealthy_interval>`.
+    <envoy_api_field_core.HealthCheck.healthy_edge_interval>` and for subsequent checks on :ref:`unhealthy hosts
+    <envoy_api_field_core.HealthCheck.unhealthy_interval>`.
 - area: health check
   change: |
     added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
@@ -110,149 +107,135 @@ changes:
     health check connections can now be configured to use http/2.
 - area: health check http filter
   change: |
-    added
-    :ref:`generic header matching <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.headers>`
-    to trigger health check response. Deprecated the endpoint option.
+    added :ref:`generic header matching <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.headers>` to trigger
+    health check response. Deprecated the endpoint option.
 - area: http
   change: |
-    filters can now optionally support
-    :ref:`virtual host <envoy_api_field_route.VirtualHost.per_filter_config>`,
-    :ref:`route <envoy_api_field_route.Route.per_filter_config>`, and
-    :ref:`weighted cluster <envoy_api_field_route.WeightedCluster.ClusterWeight.per_filter_config>`
-    local configuration.
+    filters can now optionally support :ref:`virtual host <envoy_api_field_route.VirtualHost.per_filter_config>`,
+    :ref:`route <envoy_api_field_route.Route.per_filter_config>`, and :ref:`weighted cluster
+    <envoy_api_field_route.WeightedCluster.ClusterWeight.per_filter_config>` local configuration.
 - area: http
   change: |
     added the ability to pass DNS type Subject Alternative Names of the client certificate in the
     :ref:`v1.7:config_http_conn_man_headers_x-forwarded-client-cert` header.
 - area: http
   change: |
-    local responses to gRPC requests are now sent as trailers-only gRPC responses instead of plain HTTP responses.
-    Notably the HTTP response code is always "200" in this case, and the gRPC error code is carried in "grpc-status"
-    header, optionally accompanied with a text message in "grpc-message" header.
+    local responses to gRPC requests are now sent as trailers-only gRPC responses instead of plain HTTP responses. Notably
+    the HTTP response code is always "200" in this case, and the gRPC error code is carried in "grpc-status" header,
+    optionally accompanied with a text message in "grpc-message" header.
 - area: http
   change: |
     added support for :ref:`via header
-    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.via>`
-    append.
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.via>` append.
 - area: http
   change: |
     added a :ref:`configuration option
-    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.skip_xff_append>`
-    to elide ``x-forwarded-for-`` header modifications.
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.skip_xff_append>` to elide
+    ``x-forwarded-for-`` header modifications.
 - area: http
   change: |
-    fixed a bug in inline headers where ``addCopy`` and ``addViaMove`` didn't add header values when
-    encountering inline headers with multiple instances.
+    fixed a bug in inline headers where ``addCopy`` and ``addViaMove`` didn't add header values when encountering inline
+    headers with multiple instances.
 - area: listeners
   change: |
     added :ref:`tcp_fast_open_queue_length <envoy_api_field_Listener.tcp_fast_open_queue_length>` option.
 - area: listeners
   change: |
-    added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using
-    :ref:`application_protocols <envoy_api_field_listener.FilterChainMatch.application_protocols>`
-    (e.g. ALPN for TLS protocol).
+    added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using :ref:`application_protocols
+    <envoy_api_field_listener.FilterChainMatch.application_protocols>` (e.g. ALPN for TLS protocol).
 - area: listeners
   change: |
-    ``sni_domains`` has been deprecated/renamed to :ref:`server_names <envoy_api_field_listener.FilterChainMatch.server_names>`.
+    ``sni_domains`` has been deprecated/renamed to :ref:`server_names
+    <envoy_api_field_listener.FilterChainMatch.server_names>`.
 - area: listeners
   change: |
     removed restriction on all filter chains having identical filters.
 - area: load balancer
   change: |
-    added :ref:`weighted round robin
-    <arch_overview_load_balancing_types_round_robin>` support. The round robin
-    scheduler now respects endpoint weights and also has improved fidelity across
-    picks.
+    added :ref:`weighted round robin <arch_overview_load_balancing_types_round_robin>` support. The round robin scheduler
+    now respects endpoint weights and also has improved fidelity across picks.
 - area: load balancer
   change: |
-    :ref:`locality weighted load balancing
-    <arch_overview_load_balancer_subsets>` is now supported.
+    :ref:`locality weighted load balancing <arch_overview_load_balancer_subsets>` is now supported.
 - area: load balancer
   change: |
     ability to configure zone aware load balancer settings :ref:`through the API
     <envoy_api_field_Cluster.CommonLbConfig.zone_aware_lb_config>`.
 - area: load balancer
   change: |
-    the :ref:`weighted least request
-    <arch_overview_load_balancing_types_least_request>` load balancing algorithm has been improved
-    to have better balance when operating in weighted mode.
+    the :ref:`weighted least request <arch_overview_load_balancing_types_least_request>` load balancing algorithm has been
+    improved to have better balance when operating in weighted mode.
 - area: logger
   change: |
     added the ability to optionally set the log format via the :option:`--log-format` option.
 - area: logger
   change: |
-    all :ref:`logging levels <operations_admin_interface_logging>` can be configured
-    at run-time: trace debug info warning error critical.
+    all :ref:`logging levels <operations_admin_interface_logging>` can be configured at run-time: trace debug info warning
+    error critical.
 - area: rbac http filter
   change: |
     a :ref:`role-based access control http filter <config_http_filters_rbac>` has been added.
 - area: router
   change: |
-    the behavior of per-try timeouts have changed in the case where a portion of the response has
-    already been proxied downstream when the timeout occurs. Previously, the response would be reset
-    leading to either an HTTP/2 reset or an HTTP/1 closed connection and a partial response. Now, the
-    timeout will be ignored and the response will continue to proxy up to the global request timeout.
+    the behavior of per-try timeouts have changed in the case where a portion of the response has already been proxied
+    downstream when the timeout occurs. Previously, the response would be reset leading to either an HTTP/2 reset or an
+    HTTP/1 closed connection and a partial response. Now, the timeout will be ignored and the response will continue to
+    proxy up to the global request timeout.
 - area: router
   change: |
-    changed the behavior of :ref:`source IP routing <envoy_api_field_route.RouteAction.HashPolicy.ConnectionProperties.source_ip>`
-    to ignore the source port.
+    changed the behavior of :ref:`source IP routing
+    <envoy_api_field_route.RouteAction.HashPolicy.ConnectionProperties.source_ip>` to ignore the source port.
 - area: router
   change: |
-    added an :ref:`prefix_match <envoy_api_field_route.HeaderMatcher.prefix_match>` match type
-    to explicitly match based on the prefix of a header value.
+    added an :ref:`prefix_match <envoy_api_field_route.HeaderMatcher.prefix_match>` match type to explicitly match based on
+    the prefix of a header value.
 - area: router
   change: |
-    added an :ref:`suffix_match <envoy_api_field_route.HeaderMatcher.suffix_match>` match type
-    to explicitly match based on the suffix of a header value.
+    added an :ref:`suffix_match <envoy_api_field_route.HeaderMatcher.suffix_match>` match type to explicitly match based on
+    the suffix of a header value.
 - area: router
   change: |
-    added an :ref:`present_match <envoy_api_field_route.HeaderMatcher.present_match>` match type
-    to explicitly match based on a header's presence.
+    added an :ref:`present_match <envoy_api_field_route.HeaderMatcher.present_match>` match type to explicitly match based
+    on a header's presence.
 - area: router
   change: |
-    added an :ref:`invert_match <envoy_api_field_route.HeaderMatcher.invert_match>` config option
-    which supports inverting all other match types to match based on headers which are not a desired value.
+    added an :ref:`invert_match <envoy_api_field_route.HeaderMatcher.invert_match>` config option which supports inverting
+    all other match types to match based on headers which are not a desired value.
 - area: router
   change: |
-    allow :ref:`cookie routing <envoy_api_msg_route.RouteAction.HashPolicy.Cookie>` to
-    generate session cookies.
+    allow :ref:`cookie routing <envoy_api_msg_route.RouteAction.HashPolicy.Cookie>` to generate session cookies.
 - area: router
   change: |
-    added ``START_TIME`` as one of supported variables in :ref:`header
-    formatters <config_http_conn_man_headers_custom_request_headers>`.
+    added ``START_TIME`` as one of supported variables in :ref:`header formatters
+    <config_http_conn_man_headers_custom_request_headers>`.
 - area: router
   change: |
-    added a :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
-    config option to specify the maximum allowable value for timeouts decoded from gRPC header field
-    ``grpc-timeout``.
+    added a :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>` config option to specify the
+    maximum allowable value for timeouts decoded from gRPC header field ``grpc-timeout``.
 - area: router
   change: |
-    added a :ref:`configuration option
-    <envoy_api_field_config.filter.http.router.v2.Router.suppress_envoy_headers>` to disable *x-envoy-*
-    header generation.
+    added a :ref:`configuration option <envoy_api_field_config.filter.http.router.v2.Router.suppress_envoy_headers>` to
+    disable *x-envoy-* header generation.
 - area: router
   change: |
-    added 'unavailable' to the retriable gRPC status codes that can be specified
-    through :ref:`x-envoy-retry-grpc-on <config_http_filters_router_x-envoy-retry-grpc-on>`.
+    added 'unavailable' to the retriable gRPC status codes that can be specified through :ref:`x-envoy-retry-grpc-on
+    <config_http_filters_router_x-envoy-retry-grpc-on>`.
 - area: sockets
   change: |
-    added :ref:`tap transport socket extension <operations_traffic_capture>` to support
-    recording plain text traffic and PCAP generation.
+    added :ref:`tap transport socket extension <operations_traffic_capture>` to support recording plain text traffic and
+    PCAP generation.
 - area: sockets
   change: |
-    added ``IP_FREEBIND`` socket option support for :ref:`listeners
-    <envoy_api_field_Listener.freebind>` and upstream connections via
-    :ref:`cluster manager wide
-    <envoy_api_field_config.bootstrap.v2.ClusterManager.upstream_bind_config>` and
-    :ref:`cluster specific <envoy_api_field_Cluster.upstream_bind_config>` options.
+    added ``IP_FREEBIND`` socket option support for :ref:`listeners <envoy_api_field_Listener.freebind>` and upstream
+    connections via :ref:`cluster manager wide <envoy_api_field_config.bootstrap.v2.ClusterManager.upstream_bind_config>`
+    and :ref:`cluster specific <envoy_api_field_Cluster.upstream_bind_config>` options.
 - area: sockets
   change: |
-    added ``IP_TRANSPARENT`` socket option support for :ref:`listeners
-    <envoy_api_field_Listener.transparent>`.
+    added ``IP_TRANSPARENT`` socket option support for :ref:`listeners <envoy_api_field_Listener.transparent>`.
 - area: sockets
   change: |
-    added ``SO_KEEPALIVE`` socket option for upstream connections
-    :ref:`per cluster <envoy_api_field_Cluster.upstream_connection_options>`.
+    added ``SO_KEEPALIVE`` socket option for upstream connections :ref:`per cluster
+    <envoy_api_field_Cluster.upstream_connection_options>`.
 - area: stats
   change: |
     added support for histograms.
@@ -264,41 +247,41 @@ changes:
     updated stats sink interface to flush through a single call.
 - area: tls
   change: |
-    added support for
-    :ref:`verify_certificate_spki <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>`.
+    added support for :ref:`verify_certificate_spki
+    <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>`.
 - area: tls
   change: |
-    added support for multiple
-    :ref:`verify_certificate_hash <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>`
-    values.
+    added support for multiple :ref:`verify_certificate_hash
+    <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>` values.
 - area: tls
   change: |
-    added support for using
-    :ref:`verify_certificate_spki <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>`
-    and :ref:`verify_certificate_hash <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>`
-    without :ref:`trusted_ca <envoy_api_field_auth.CertificateValidationContext.trusted_ca>`.
+    added support for using :ref:`verify_certificate_spki
+    <envoy_api_field_auth.CertificateValidationContext.verify_certificate_spki>` and :ref:`verify_certificate_hash
+    <envoy_api_field_auth.CertificateValidationContext.verify_certificate_hash>` without :ref:`trusted_ca
+    <envoy_api_field_auth.CertificateValidationContext.trusted_ca>`.
 - area: tls
   change: |
-    added support for allowing expired certificates with
-    :ref:`allow_expired_certificate <envoy_api_field_auth.CertificateValidationContext.allow_expired_certificate>`.
+    added support for allowing expired certificates with :ref:`allow_expired_certificate
+    <envoy_api_field_auth.CertificateValidationContext.allow_expired_certificate>`.
 - area: tls
   change: |
-    added support for :ref:`renegotiation <envoy_api_field_auth.UpstreamTlsContext.allow_renegotiation>`
-    when acting as a client.
+    added support for :ref:`renegotiation <envoy_api_field_auth.UpstreamTlsContext.allow_renegotiation>` when acting as a
+    client.
 - area: tls
   change: |
     removed support for legacy SHA-2 CBC cipher suites.
 - area: tracing
   change: |
-    the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if
-    to use it. For example, if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header
-    is supplied with the client request, its value will override any sampling decision made by the Envoy proxy.
+    the sampling decision is now delegated to the tracers, allowing the tracer to decide when and if to use it. For example,
+    if the :ref:`x-b3-sampled <config_http_conn_man_headers_x-b3-sampled>` header is supplied with the client request, its
+    value will override any sampling decision made by the Envoy proxy.
 - area: websocket
   change: |
     support configuring idle_timeout and max_connect_attempts.
 - area: upstream
   change: |
-    added support for host override for a request in :ref:`Original destination host request header <arch_overview_load_balancing_types_original_destination_request_header>`.
+    added support for host override for a request in :ref:`Original destination host request header
+    <arch_overview_load_balancing_types_original_destination_request_header>`.
 - area: header to metadata
   change: |
     added :ref:`HTTP Header to Metadata filter <config_http_filters_header_to_metadata>`.
@@ -306,29 +289,27 @@ changes:
 deprecated:
 - area: admin
   change: |
-    Admin mutations should be sent as POSTs rather than GETs. HTTP GETs will result in an error
-    status code and will not have their intended effect. Prior to 1.7, GETs can be used for
-    admin mutations, but a warning is logged.
+    Admin mutations should be sent as POSTs rather than GETs. HTTP GETs will result in an error status code and will not
+    have their intended effect. Prior to 1.7, GETs can be used for admin mutations, but a warning is logged.
 - area: rate_limiting
   change: |
-    Rate limit service configuration via the ``cluster_name`` field is deprecated. Use ``grpc_service``
-    instead.
+    Rate limit service configuration via the ``cluster_name`` field is deprecated. Use ``grpc_service`` instead.
 - area: grpc
   change: |
-    gRPC service configuration via the ``cluster_names`` field in ``ApiConfigSource`` is deprecated. Use
-    ``grpc_services`` instead. Prior to 1.7, a warning is logged.
+    gRPC service configuration via the ``cluster_names`` field in ``ApiConfigSource`` is deprecated. Use ``grpc_services``
+    instead. Prior to 1.7, a warning is logged.
 - area: health_checking
   change: |
-    Redis health checker configuration via the ``redis_health_check`` field in ``HealthCheck`` is
-    deprecated. Use ``custom_health_check`` with name ``envoy.health_checkers.redis`` instead. Prior
-    to 1.7, ``redis_health_check`` can be used, but warning is logged.
+    Redis health checker configuration via the ``redis_health_check`` field in ``HealthCheck`` is deprecated. Use
+    ``custom_health_check`` with name ``envoy.health_checkers.redis`` instead. Prior to 1.7, ``redis_health_check`` can be
+    used, but warning is logged.
 - area: tls
   change: |
     ``SAN`` is replaced by ``URI`` in the ``x-forwarded-client-cert`` header.
 - area: health_checking
   change: |
-    The ``endpoint`` field in the http health check filter is deprecated in favor of the ``headers``
-    field where one can specify HeaderMatch objects to match on.
+    The ``endpoint`` field in the http health check filter is deprecated in favor of the ``headers`` field where one can
+    specify HeaderMatch objects to match on.
 - area: sni
   change: |
     The ``sni_domains`` field in the filter chain match was deprecated/renamed to ``server_names``.

--- a/changelogs/1.7.1.yaml
+++ b/changelogs/1.7.1.yaml
@@ -3,4 +3,6 @@ date: August 3, 2018
 changes:
 - area: upstream
   change: |
-    require opt-in to use the :ref:`x-envoy-orignal-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>` header for overriding destination address when using the :ref:`Original Destination <arch_overview_load_balancing_types_original_destination>` load balancing policy.
+    require opt-in to use the :ref:`x-envoy-orignal-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>`
+    header for overriding destination address when using the :ref:`Original Destination
+    <arch_overview_load_balancing_types_original_destination>` load balancing policy.

--- a/changelogs/1.8.0.yaml
+++ b/changelogs/1.8.0.yaml
@@ -3,8 +3,8 @@ date: October 4, 2018
 changes:
 - area: access log
   change: |
-    added :ref:`response flag filter <envoy_api_msg_config.filter.accesslog.v2.ResponseFlagFilter>`
-    to filter based on the presence of Envoy response flags.
+    added :ref:`response flag filter <envoy_api_msg_config.filter.accesslog.v2.ResponseFlagFilter>` to filter based on the
+    presence of Envoy response flags.
 - area: access log
   change: |
     added ``RESPONSE_DURATION`` and ``RESPONSE_TX_DURATION``.
@@ -13,15 +13,16 @@ changes:
     added ``REQUESTED_SERVER_NAME`` for SNI to tcp_proxy and http.
 - area: admin
   change: |
-    added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics
-    through `Hystrix dashboard <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
+    added :http:get:`/hystrix_event_stream` as an endpoint for monitoring envoy's statistics through `Hystrix dashboard
+    <https://github.com/Netflix-Skunkworks/hystrix-dashboard/wiki>`_.
 - area: cli
   change: |
-    added support for :ref:`component log level <operations_cli>` command line option for configuring log levels of individual components.
+    added support for :ref:`component log level <operations_cli>` command line option for configuring log levels of
+    individual components.
 - area: cluster
   change: |
-    added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge
-    health check/weight/metadata updates within the given duration.
+    added :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>` to merge health check/weight/metadata
+    updates within the given duration.
 - area: config
   change: |
     regex validation added to limit to a maximum of 1024 characters.
@@ -33,25 +34,27 @@ changes:
     v1 disabled by default. v1 support remains available until October via deprecated flag ``--allow-deprecated-v1-api``.
 - area: config
   change: |
-    fixed stat inconsistency between xDS and ADS implementation. :ref:`update_failure <config_cluster_manager_cds>`
-    stat is incremented in case of network failure and :ref:`update_rejected <config_cluster_manager_cds>` stat is incremented
-    in case of schema/validation error.
+    fixed stat inconsistency between xDS and ADS implementation. :ref:`update_failure <config_cluster_manager_cds>` stat is
+    incremented in case of network failure and :ref:`update_rejected <config_cluster_manager_cds>` stat is incremented in
+    case of schema/validation error.
 - area: config
   change: |
     added a stat :ref:`connected_state <management_server_stats>` that indicates current connected state of Envoy with
     management server.
 - area: ext_authz
   change: |
-    added support for configuring additional :ref:`authorization headers <envoy_api_field_config.filter.http.ext_authz.v2alpha.httpservice.authorization_headers_to_add>`
-    to be sent from Envoy to the authorization service.
+    added support for configuring additional :ref:`authorization headers
+    <envoy_api_field_config.filter.http.ext_authz.v2alpha.httpservice.authorization_headers_to_add>` to be sent from Envoy
+    to the authorization service.
 - area: fault
   change: |
-    added support for fractional percentages in :ref:`FaultDelay <envoy_api_field_config.filter.fault.v2.FaultDelay.percentage>`
-    and in :ref:`FaultAbort <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>`.
+    added support for fractional percentages in :ref:`FaultDelay
+    <envoy_api_field_config.filter.fault.v2.FaultDelay.percentage>` and in :ref:`FaultAbort
+    <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>`.
 - area: grpc-json
   change: |
-    added support for building HTTP response from
-    `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
+    added support for building HTTP response from `google.api.HttpBody
+    <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
 - area: health check
   change: |
     added support for :ref:`custom health check <envoy_api_field_core.HealthCheck.custom_health_check>`.
@@ -63,27 +66,28 @@ changes:
     added support for :ref:`health check event logging <arch_overview_health_check_logging>`.
 - area: health_check
   change: |
-    added :ref:`timestamp <envoy_api_field_data.core.v2alpha.HealthCheckEvent.timestamp>`
-    to the :ref:`health check event <envoy_api_msg_data.core.v2alpha.HealthCheckEvent>` definition.
+    added :ref:`timestamp <envoy_api_field_data.core.v2alpha.HealthCheckEvent.timestamp>` to the :ref:`health check event
+    <envoy_api_msg_data.core.v2alpha.HealthCheckEvent>` definition.
 - area: health_check
   change: |
-    added support for specifying :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>`
-    to HTTP health checker requests.
+    added support for specifying :ref:`custom request headers <config_http_conn_man_headers_custom_request_headers>` to HTTP
+    health checker requests.
 - area: http
   change: |
-    added support for a :ref:`per-stream idle timeout
-    <envoy_api_field_route.RouteAction.idle_timeout>`. This applies at both :ref:`connection manager
-    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>`
-    and :ref:`per-route granularity <envoy_api_field_route.RouteAction.idle_timeout>`. The timeout
-    defaults to 5 minutes; if you have other timeouts (e.g. connection idle timeout, upstream
-    response per-retry) that are longer than this in duration, you may want to consider setting a
-    non-default per-stream idle timeout.
+    added support for a :ref:`per-stream idle timeout <envoy_api_field_route.RouteAction.idle_timeout>`. This applies at
+    both :ref:`connection manager
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.stream_idle_timeout>` and
+    :ref:`per-route granularity <envoy_api_field_route.RouteAction.idle_timeout>`. The timeout defaults to 5 minutes; if you
+    have other timeouts (e.g. connection idle timeout, upstream response per-retry) that are longer than this in duration,
+    you may want to consider setting a non-default per-stream idle timeout.
 - area: http
   change: |
-    added upstream_rq_completed counter for :ref:`total requests completed <config_cluster_manager_cluster_stats_dynamic_http>` to dynamic HTTP counters.
+    added upstream_rq_completed counter for :ref:`total requests completed
+    <config_cluster_manager_cluster_stats_dynamic_http>` to dynamic HTTP counters.
 - area: http
   change: |
-    added downstream_rq_completed counter for :ref:`total requests completed <config_http_conn_man_stats>`, including on a :ref:`per-listener basis <config_http_conn_man_stats_per_listener>`.
+    added downstream_rq_completed counter for :ref:`total requests completed <config_http_conn_man_stats>`, including on a
+    :ref:`per-listener basis <config_http_conn_man_stats_per_listener>`.
 - area: http
   change: |
     added generic :ref:`Upgrade support
@@ -93,40 +97,39 @@ changes:
     better handling of HEAD requests. Now sending transfer-encoding: chunked rather than content-length: 0.
 - area: http
   change: |
-    fixed missing support for appending to predefined inline headers, e.g.
-    ``authorization``, in features that interact with request and response headers,
-    e.g. :ref:`request_headers_to_add
-    <envoy_api_field_route.Route.request_headers_to_add>`. For example, a
-    request header ``authorization: token1`` will appear as ``authorization:
-    token1,token2``, after having :ref:`request_headers_to_add
-    <envoy_api_field_route.Route.request_headers_to_add>` with ``authorization:
-    token2`` applied.
+    fixed missing support for appending to predefined inline headers, e.g. ``authorization``, in features that interact with
+    request and response headers, e.g. :ref:`request_headers_to_add <envoy_api_field_route.Route.request_headers_to_add>`.
+    For example, a request header ``authorization: token1`` will appear as ``authorization: token1,token2``, after having
+    :ref:`request_headers_to_add <envoy_api_field_route.Route.request_headers_to_add>` with ``authorization: token2``
+    applied.
 - area: http
   change: |
     response filters not applied to early error paths such as http_parser generated 400s.
 - area: http
   change: |
-    restrictions added to reject ``:``-prefixed pseudo-headers in :ref:`custom
-    request headers <config_http_conn_man_headers_custom_request_headers>`.
+    restrictions added to reject ``:``-prefixed pseudo-headers in :ref:`custom request headers
+    <config_http_conn_man_headers_custom_request_headers>`.
 - area: http
   change: |
-    :ref:`hpack_table_size <envoy_api_field_core.Http2ProtocolOptions.hpack_table_size>` now controls
-    dynamic table size of both: encoder and decoder.
+    :ref:`hpack_table_size <envoy_api_field_core.Http2ProtocolOptions.hpack_table_size>` now controls dynamic table size of
+    both: encoder and decoder.
 - area: http
   change: |
     added support for removing request headers using :ref:`request_headers_to_remove
     <envoy_api_field_route.Route.request_headers_to_remove>`.
 - area: http
   change: |
-    added support for a :ref:`delayed close timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` to mitigate race conditions when closing connections to downstream HTTP clients. The timeout defaults to 1 second.
+    added support for a :ref:`delayed close timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` to
+    mitigate race conditions when closing connections to downstream HTTP clients. The timeout defaults to 1 second.
 - area: jwt-authn filter
   change: |
     add support for per route JWT requirements.
 - area: listeners
   change: |
-    added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using
-    :ref:`destination_port <envoy_api_field_listener.FilterChainMatch.destination_port>` and
-    :ref:`prefix_ranges <envoy_api_field_listener.FilterChainMatch.prefix_ranges>`.
+    added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using :ref:`destination_port
+    <envoy_api_field_listener.FilterChainMatch.destination_port>` and :ref:`prefix_ranges
+    <envoy_api_field_listener.FilterChainMatch.prefix_ranges>`.
 - area: lua
   change: |
     added :ref:`connection() <config_http_filters_lua_connection_wrapper>` wrapper and ``ssl()`` API.
@@ -145,15 +148,15 @@ changes:
     added support for HAProxy Proxy Protocol v2 (AF_INET/AF_INET6 only).
 - area: ratelimit
   change: |
-    added support for :repo:`api/envoy/service/ratelimit/v2/rls.proto`.
-    Lyft's reference implementation of the `ratelimit <https://github.com/envoyproxy/ratelimit>`_ service also supports the data-plane-api proto as of v1.1.0.
-    Envoy can use either proto to send client requests to a ratelimit server with the use of the
-    ``use_data_plane_proto`` boolean flag in the ratelimit configuration.
-    Support for the legacy proto ``source/common/ratelimit/ratelimit.proto`` is deprecated and will be removed at the start of the 1.9.0 release cycle.
+    added support for :repo:`api/envoy/service/ratelimit/v2/rls.proto`. Lyft's reference implementation of the `ratelimit
+    <https://github.com/envoyproxy/ratelimit>`_ service also supports the data-plane-api proto as of v1.1.0. Envoy can use
+    either proto to send client requests to a ratelimit server with the use of the ``use_data_plane_proto`` boolean flag in
+    the ratelimit configuration. Support for the legacy proto ``source/common/ratelimit/ratelimit.proto`` is deprecated and
+    will be removed at the start of the 1.9.0 release cycle.
 - area: ratelimit
   change: |
-    added :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` option to control traffic flow in
-    case of rate limit service error.
+    added :ref:`failure_mode_deny <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` option to control traffic flow
+    in case of rate limit service error.
 - area: rbac config
   change: |
     added a :ref:`principal_name <envoy_api_field_config.rbac.v2alpha.principal.authenticated.principal_name>` field and
@@ -163,7 +166,8 @@ changes:
     a :ref:`role-based access control network filter <config_network_filters_rbac>` has been added.
 - area: rest-api
   change: |
-    added ability to set the :ref:`request timeout <envoy_api_field_core.ApiConfigSource.request_timeout>` for REST API requests.
+    added ability to set the :ref:`request timeout <envoy_api_field_core.ApiConfigSource.request_timeout>` for REST API
+    requests.
 - area: route checker
   change: |
     added v2 config support and removed support for v1 configs.
@@ -172,10 +176,12 @@ changes:
     added ability to set request/response headers at the :ref:`v1.8:envoy_api_msg_route.Route` level.
 - area: stats
   change: |
-    added :ref:`option to configure the DogStatsD metric name prefix <envoy_api_field_config.metrics.v2.DogStatsdSink.prefix>` to DogStatsdSink.
+    added :ref:`option to configure the DogStatsD metric name prefix
+    <envoy_api_field_config.metrics.v2.DogStatsdSink.prefix>` to DogStatsdSink.
 - area: tcp_proxy
   change: |
-    added support for :ref:`weighted clusters <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.weighted_clusters>`.
+    added support for :ref:`weighted clusters
+    <envoy_api_field_config.filter.network.tcp_proxy.v2.TcpProxy.weighted_clusters>`.
 - area: thrift_proxy
   change: |
     introduced thrift routing, moved configuration to correct location.
@@ -191,56 +197,58 @@ changes:
     <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.tracing>`.
 - area: upstream
   change: |
-    added configuration option to the subset load balancer to take locality weights into account when
-    selecting a host from a subset.
+    added configuration option to the subset load balancer to take locality weights into account when selecting a host from
+    a subset.
 - area: upstream
   change: |
-    require opt-in to use the :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>` header
-    for overriding destination address when using the :ref:`Original Destination <arch_overview_load_balancing_types_original_destination>`
-    load balancing policy.
+    require opt-in to use the :ref:`x-envoy-original-dst-host <config_http_conn_man_headers_x-envoy-original-dst-host>`
+    header for overriding destination address when using the :ref:`Original Destination
+    <arch_overview_load_balancing_types_original_destination>` load balancing policy.
 
 deprecated:
 - area: api
   change: |
-    Use of the v1 API (including ``*.deprecated_v1`` fields in the v2 API) is deprecated.
-    See envoy-announce `email <https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U>`_.
+    Use of the v1 API (including ``*.deprecated_v1`` fields in the v2 API) is deprecated. See envoy-announce `email
+    <https://groups.google.com/forum/#!topic/envoy-announce/oPnYMZw8H4U>`_.
 - area: rate_limiting
   change: |
-    Use of the legacy
-    `ratelimit.proto <https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto>`_
-    is deprecated, in favor of the proto defined in
-    `date-plane-api <https://github.com/envoyproxy/envoy/blob/main/api/envoy/service/ratelimit/v2/rls.proto>`_
-    Prior to 1.8.0, Envoy can use either proto to send client requests to a ratelimit server with the use of the
-    ``use_data_plane_proto`` boolean flag in the `ratelimit configuration <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/ratelimit/v2/rls.proto>`_.
+    Use of the legacy `ratelimit.proto
+    <https://github.com/envoyproxy/envoy/blob/b0a518d064c8255e0e20557a8f909b6ff457558f/source/common/ratelimit/ratelimit.proto>`_
+    is deprecated, in favor of the proto defined in `date-plane-api
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/service/ratelimit/v2/rls.proto>`_ Prior to 1.8.0, Envoy can use
+    either proto to send client requests to a ratelimit server with the use of the ``use_data_plane_proto`` boolean flag in
+    the `ratelimit configuration <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/ratelimit/v2/rls.proto>`_.
     However, when using the deprecated client a warning is logged.
 - area: options
   change: |
     Use of the ``--v2-config-only`` flag.
 - area: websockets
   change: |
-    Use of both ``use_websocket`` and ``websocket_config`` in
-    `route.proto <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/route/route.proto>`_
-    is deprecated. Please use the new ``upgrade_configs`` in the
-    `HttpConnectionManager <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_
+    Use of both ``use_websocket`` and ``websocket_config`` in `route.proto
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/route/route.proto>`_ is deprecated. Please use the new
+    ``upgrade_configs`` in the `HttpConnectionManager
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_
     instead.
 - area: fault_delay
   change: |
-    Use of the integer ``percent`` field in `FaultDelay <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/fault/v2/fault.proto>`_
-    and in `FaultAbort <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/http/fault/v2/fault.proto>`_ is deprecated in favor
-    of the new ``FractionalPercent`` based ``percentage`` field.
+    Use of the integer ``percent`` field in `FaultDelay
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/fault/v2/fault.proto>`_ and in `FaultAbort
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/http/fault/v2/fault.proto>`_ is deprecated in
+    favor of the new ``FractionalPercent`` based ``percentage`` field.
 - area: clusters
   change: |
     Setting hosts via ``hosts`` field in ``Cluster`` is deprecated. Use ``load_assignment`` instead.
 - area: routing
   change: |
-    Use of ``response_headers_to_*`` and ``request_headers_to_add`` are deprecated at the ``RouteAction``
-    level. Please use the configuration options at the ``Route`` level.
+    Use of ``response_headers_to_*`` and ``request_headers_to_add`` are deprecated at the ``RouteAction`` level. Please use
+    the configuration options at the ``Route`` level.
 - area: routing
   change: |
-    Use of ``runtime`` in ``RouteMatch``, found in
-    `route.proto <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/route/route.proto>`_.
-    Set the ``runtime_fraction`` field instead.
+    Use of ``runtime`` in ``RouteMatch``, found in `route.proto
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/route/route.proto>`_. Set the ``runtime_fraction`` field
+    instead.
 - area: rbac
   change: |
-    Use of the string ``user`` field in ``Authenticated`` in `rbac.proto <https://github.com/envoyproxy/envoy/blob/release/v1.8/api/envoy/config/rbac/v2alpha/rbac.proto>`_
-    is deprecated in favor of the new ``StringMatcher`` based ``principal_name`` field.
+    Use of the string ``user`` field in ``Authenticated`` in `rbac.proto
+    <https://github.com/envoyproxy/envoy/blob/release/v1.8/api/envoy/config/rbac/v2alpha/rbac.proto>`_ is deprecated in
+    favor of the new ``StringMatcher`` based ``principal_name`` field.

--- a/changelogs/1.9.0.yaml
+++ b/changelogs/1.9.0.yaml
@@ -30,8 +30,8 @@ changes:
     added support for displaying command line options in :http:get:`/server_info` end point.
 - area: circuit-breaker
   change: |
-    added cx_open, rq_pending_open, rq_open and rq_retry_open gauges to expose live
-    state via :ref:`circuit breakers statistics <config_cluster_manager_cluster_stats_circuit_breakers>`.
+    added cx_open, rq_pending_open, rq_open and rq_retry_open gauges to expose live state via :ref:`circuit breakers
+    statistics <config_cluster_manager_cluster_stats_circuit_breakers>`.
 - area: cluster
   change: |
     set a default of 1s for :ref:`option <envoy_api_field_Cluster.CommonLbConfig.update_merge_window>`.
@@ -59,45 +59,49 @@ changes:
     added :ref:`logging health check failure events <envoy_api_field_core.HealthCheck.always_log_health_check_failures>`.
 - area: health check
   change: |
-    added ability to set :ref:`authority header value
-    <envoy_api_field_core.HealthCheck.GrpcHealthCheck.authority>` for gRPC health check.
+    added ability to set :ref:`authority header value <envoy_api_field_core.HealthCheck.GrpcHealthCheck.authority>` for gRPC
+    health check.
 - area: http
   change: |
     added HTTP/2 WebSocket proxying via :ref:`extended CONNECT <envoy_api_field_core.Http2ProtocolOptions.allow_connect>`.
 - area: http
   change: |
-    added limits to the number and length of header modifications in all fields request_headers_to_add and response_headers_to_add. These limits are very high and should only be used as a last-resort safeguard.
+    added limits to the number and length of header modifications in all fields request_headers_to_add and
+    response_headers_to_add. These limits are very high and should only be used as a last-resort safeguard.
 - area: http
   change: |
-    added support for a :ref:`request timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.request_timeout>`. The timeout is disabled by default.
+    added support for a :ref:`request timeout
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.request_timeout>`. The timeout
+    is disabled by default.
 - area: http
   change: |
-    no longer adding whitespace when appending ``X-Forwarded-For headers``. **Warning**: this is not
-    compatible with 1.7.0 builds prior to `9d3a4eb4ac44be9f0651fcc7f87ad98c538b01ee <https://github.com/envoyproxy/envoy/pull/3610>`_.
-    See `#3611 <https://github.com/envoyproxy/envoy/issues/3611>`_ for details.
+    no longer adding whitespace when appending ``X-Forwarded-For headers``. **Warning**: this is not compatible with 1.7.0
+    builds prior to `9d3a4eb4ac44be9f0651fcc7f87ad98c538b01ee <https://github.com/envoyproxy/envoy/pull/3610>`_. See `#3611
+    <https://github.com/envoyproxy/envoy/issues/3611>`_ for details.
 - area: http
   change: |
-    augmented the ``sendLocalReply`` filter API to accept an optional ``GrpcStatus``
-    value to override the default HTTP to gRPC status mapping.
+    augmented the ``sendLocalReply`` filter API to accept an optional ``GrpcStatus`` value to override the default HTTP to
+    gRPC status mapping.
 - area: http
   change: |
-    no longer close the TCP connection when a HTTP/1 request is retried due
-    to a response with empty body.
+    no longer close the TCP connection when a HTTP/1 request is retried due to a response with empty body.
 - area: http
   change: |
-    added support for more gRPC content-type headers in :ref:`gRPC bridge filter <config_http_filters_grpc_bridge>`, like application/grpc+proto.
+    added support for more gRPC content-type headers in :ref:`gRPC bridge filter <config_http_filters_grpc_bridge>`, like
+    application/grpc+proto.
 - area: listeners
   change: |
     all listener filters are now governed by the :ref:`listener_filters_timeout
-    <envoy_api_field_Listener.listener_filters_timeout>` setting. The hard coded 15s timeout in
-    the :ref:`TLS inspector listener filter <config_listener_filters_tls_inspector>` is superseded by
-    this setting.
+    <envoy_api_field_Listener.listener_filters_timeout>` setting. The hard coded 15s timeout in the :ref:`TLS inspector
+    listener filter <config_listener_filters_tls_inspector>` is superseded by this setting.
 - area: listeners
   change: |
-    added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using :ref:`source_type <envoy_api_field_listener.FilterChainMatch.source_type>`.
+    added the ability to match :ref:`FilterChain <envoy_api_msg_listener.FilterChain>` using :ref:`source_type
+    <envoy_api_field_listener.FilterChainMatch.source_type>`.
 - area: load balancer
   change: |
-    added a :ref:`configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made in P2C.
+    added a :ref:`configuration <envoy_api_msg_Cluster.LeastRequestLbConfig>` option to specify the number of choices made
+    in P2C.
 - area: logging
   change: |
     added missing ``[`` in log prefix.
@@ -109,16 +113,17 @@ changes:
     removed the reference to ``FilterState`` in ``Connection`` in favor of ``StreamInfo``.
 - area: rate-limit
   change: |
-    added :ref:`configuration <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>`
-    to specify whether the ``GrpcStatus`` status returned should be ``RESOURCE_EXHAUSTED`` or
-    ``UNAVAILABLE`` when a gRPC call is rate limited.
+    added :ref:`configuration
+    <envoy_api_field_config.filter.http.rate_limit.v2.RateLimit.rate_limited_as_resource_exhausted>` to specify whether the
+    ``GrpcStatus`` status returned should be ``RESOURCE_EXHAUSTED`` or ``UNAVAILABLE`` when a gRPC call is rate limited.
 - area: rate-limit
   change: |
-    removed support for the legacy ratelimit service and made the data-plane-api
-    :ref:`rls.proto <envoy_api_file_envoy/service/ratelimit/v2/rls.proto>` based implementation default.
+    removed support for the legacy ratelimit service and made the data-plane-api :ref:`rls.proto
+    <envoy_api_file_envoy/service/ratelimit/v2/rls.proto>` based implementation default.
 - area: rate-limit
   change: |
-    removed the deprecated cluster_name attribute in :ref:`rate limit service configuration <envoy_api_file_envoy/config/ratelimit/v2/rls.proto>`.
+    removed the deprecated cluster_name attribute in :ref:`rate limit service configuration
+    <envoy_api_file_envoy/config/ratelimit/v2/rls.proto>`.
 - area: rate-limit
   change: |
     added :ref:`rate_limit_service <envoy_api_msg_config.filter.http.rate_limit.v2.RateLimit>` configuration to filters.
@@ -127,45 +132,46 @@ changes:
     added dynamic metadata to the network level filter.
 - area: rbac
   change: |
-    added support for permission matching by :ref:`requested server name <envoy_api_field_config.rbac.v2alpha.permission.requested_server_name>`.
+    added support for permission matching by :ref:`requested server name
+    <envoy_api_field_config.rbac.v2alpha.permission.requested_server_name>`.
 - area: redis
   change: |
-    static cluster configuration is no longer required. Redis proxy will work with clusters
-    delivered via CDS.
+    static cluster configuration is no longer required. Redis proxy will work with clusters delivered via CDS.
 - area: router
   change: |
-    added ability to configure arbitrary :ref:`retriable status codes. <envoy_api_field_route.routeaction.retrypolicy.retriable_status_codes>`
+    added ability to configure arbitrary :ref:`retriable status codes
+    <envoy_api_field_route.routeaction.retrypolicy.retriable_status_codes>`.
 - area: router
   change: |
-    added ability to set attempt count in upstream requests, see :ref:`virtual host's include request
-    attempt count flag <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
+    added ability to set attempt count in upstream requests, see :ref:`virtual host's include request attempt count flag
+    <envoy_api_field_route.VirtualHost.include_request_attempt_count>`.
 - area: router
   change: |
     added internal :ref:`grpc-retry-on <config_http_filters_router_x-envoy-retry-grpc-on>` policy.
 - area: router
   change: |
-    added :ref:`scheme_redirect <envoy_api_field_route.RedirectAction.scheme_redirect>` and
-    :ref:`port_redirect <envoy_api_field_route.RedirectAction.port_redirect>` to define the respective
-    scheme and port rewriting RedirectAction.
+    added :ref:`scheme_redirect <envoy_api_field_route.RedirectAction.scheme_redirect>` and :ref:`port_redirect
+    <envoy_api_field_route.RedirectAction.port_redirect>` to define the respective scheme and port rewriting RedirectAction.
 - area: router
   change: |
-    when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>`
-    is set, Envoy will now add or update the grpc-timeout header to reflect Envoy's expected timeout.
+    when :ref:`max_grpc_timeout <envoy_api_field_route.RouteAction.max_grpc_timeout>` is set, Envoy will now add or update
+    the grpc-timeout header to reflect Envoy's expected timeout.
 - area: router
   change: |
-    per try timeouts now starts when an upstream stream is ready instead of when the request has
-    been fully decoded by Envoy.
+    per try timeouts now starts when an upstream stream is ready instead of when the request has been fully decoded by
+    Envoy.
 - area: router
   change: |
-    added support for not retrying :ref:`rate limited requests <config_http_filters_router_x-envoy-ratelimited>`. Rate limit filter now sets the :ref:`x-envoy-ratelimited <config_http_filters_router_x-envoy-ratelimited>`
-    header so the rate limited requests that may have been retried earlier will not be retried with this change.
+    added support for not retrying :ref:`rate limited requests <config_http_filters_router_x-envoy-ratelimited>`. Rate limit
+    filter now sets the :ref:`x-envoy-ratelimited <config_http_filters_router_x-envoy-ratelimited>` header so the rate
+    limited requests that may have been retried earlier will not be retried with this change.
 - area: router
   change: |
     added support for enabling upgrades on a :ref:`per-route <envoy_api_field_route.RouteAction.upgrade_configs>` basis.
 - area: router
   change: |
-    support configuring a default fraction of mirror traffic via
-    :ref:`runtime_fraction <envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_key>`.
+    support configuring a default fraction of mirror traffic via :ref:`runtime_fraction
+    <envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_key>`.
 - area: sandbox
   change: |
     added :ref:`cors sandbox <install_sandboxes_cors>`.
@@ -174,11 +180,12 @@ changes:
     added ``SIGINT`` (Ctrl-C) handler to gracefully shutdown Envoy like ``SIGTERM``.
 - area: stats
   change: |
-    added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for granular control of stat instantiation.
+    added :ref:`stats_matcher <envoy_api_field_config.metrics.v2.StatsConfig.stats_matcher>` to the bootstrap config for
+    granular control of stat instantiation.
 - area: stream
   change: |
-    renamed the ``RequestInfo`` namespace to ``StreamInfo`` to better match
-    its behaviour within TCP and HTTP implementations.
+    renamed the ``RequestInfo`` namespace to ``StreamInfo`` to better match its behaviour within TCP and HTTP
+    implementations.
 - area: stream
   change: |
     renamed ``perRequestState`` to ``filterState`` in ``StreamInfo``.
@@ -190,8 +197,8 @@ changes:
     introduced thrift rate limiter filter.
 - area: tls
   change: |
-    added ssl.curves.<curve>, ssl.sigalgs.<sigalg> and ssl.versions.<version> to
-    :ref:`listener metrics <config_listener_stats>` to track TLS algorithms and versions in use.
+    added ssl.curves.<curve>, ssl.sigalgs.<sigalg> and ssl.versions.<version> to :ref:`listener metrics
+    <config_listener_stats>` to track TLS algorithms and versions in use.
 - area: tls
   change: |
     added support for :ref:`client-side session resumption <envoy_api_field_auth.UpstreamTlsContext.max_session_keys>`.
@@ -206,7 +213,8 @@ changes:
     added support for :ref:`password encrypted private keys <envoy_api_field_auth.TlsCertificate.password>`.
 - area: tls
   change: |
-    added the ability to build :ref:`BoringSSL FIPS <arch_overview_ssl_fips>` using ``--define boringssl=fips`` Bazel option.
+    added the ability to build :ref:`BoringSSL FIPS <arch_overview_ssl_fips>` using ``--define boringssl=fips`` Bazel
+    option.
 - area: tls
   change: |
     removed support for ECDSA certificates with curves other than P-256.
@@ -221,26 +229,37 @@ changes:
     added support for :ref:`Datadog <arch_overview_tracing>` tracer.
 - area: upstream
   change: |
-    added :ref:`scale_locality_weight <envoy_api_field_Cluster.LbSubsetConfig.scale_locality_weight>` to enable
-    scaling locality weights by number of hosts removed by subset lb predicates.
+    added :ref:`scale_locality_weight <envoy_api_field_Cluster.LbSubsetConfig.scale_locality_weight>` to enable scaling
+    locality weights by number of hosts removed by subset lb predicates.
 - area: upstream
   change: |
-    changed how load calculation for :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and :ref:`panic thresholds <arch_overview_load_balancing_panic_threshold>` interact. As long as normalized total health is 100% panic thresholds are disregarded.
+    changed how load calculation for :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and :ref:`panic
+    thresholds <arch_overview_load_balancing_panic_threshold>` interact. As long as normalized total health is 100% panic
+    thresholds are disregarded.
 - area: upstream
   change: |
-    changed the default hash for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` from std::hash to `xxHash <https://github.com/Cyan4973/xxHash>`_.
+    changed the default hash for :ref:`ring hash <envoy_api_msg_Cluster.RingHashLbConfig>` from std::hash to `xxHash
+    <https://github.com/Cyan4973/xxHash>`_.
 - area: upstream
   change: |
-    when using active health checking and STRICT_DNS with several addresses that resolve
-    to the same hosts, Envoy will now health check each host independently.
+    when using active health checking and STRICT_DNS with several addresses that resolve to the same hosts, Envoy will now
+    health check each host independently.
 
 deprecated:
 - area: filters
   change: |
-    Order of execution of the network write filter chain has been reversed. Prior to this release cycle it was incorrect, see `#4599 <https://github.com/envoyproxy/envoy/issues/4599>`_. In the 1.9.0 release cycle we introduced ``bugfix_reverse_write_filter_order`` in `lds.proto <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/lds.proto>`_ to temporarily support both old and new behaviors. Note this boolean field is deprecated.
+    Order of execution of the network write filter chain has been reversed. Prior to this release cycle it was incorrect,
+    see `#4599 <https://github.com/envoyproxy/envoy/issues/4599>`_. In the 1.9.0 release cycle we introduced
+    ``bugfix_reverse_write_filter_order`` in `lds.proto
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/lds.proto>`_ to temporarily support both old and new
+    behaviors. Note this boolean field is deprecated.
 - area: filters
   change: |
-    Order of execution of the HTTP encoder filter chain has been reversed. Prior to this release cycle it was incorrect, see `#4599 <https://github.com/envoyproxy/envoy/issues/4599>`_. In the 1.9.0 release cycle we introduced ``bugfix_reverse_encode_order`` in `http_connection_manager.proto <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_ to temporarily support both old and new behaviors. Note this boolean field is deprecated.
+    Order of execution of the HTTP encoder filter chain has been reversed. Prior to this release cycle it was incorrect, see
+    `#4599 <https://github.com/envoyproxy/envoy/issues/4599>`_. In the 1.9.0 release cycle we introduced
+    ``bugfix_reverse_encode_order`` in `http_connection_manager.proto
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_
+    to temporarily support both old and new behaviors. Note this boolean field is deprecated.
 - area: api
   change: |
     Use of the v1 ``REST_LEGACY`` ``ApiConfigSource`` is deprecated.
@@ -249,12 +268,14 @@ deprecated:
     Use of std::hash in the ring hash load balancer is deprecated.
 - area: rate_limiting
   change: |
-    Use of ``rate_limit_service`` configuration in the `bootstrap configuration <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/bootstrap/v2/bootstrap.proto>`_ is deprecated.
+    Use of ``rate_limit_service`` configuration in the `bootstrap configuration
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/bootstrap/v2/bootstrap.proto>`_ is deprecated.
 - area: routing
   change: |
-    Use of ``runtime_key`` in ``RequestMirrorPolicy``, found in
-    `route.proto <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/route/route.proto>`_
-    is deprecated. Set the ``runtime_fraction`` field instead.
+    Use of ``runtime_key`` in ``RequestMirrorPolicy``, found in `route.proto
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/api/v2/route/route.proto>`_ is deprecated. Set the
+    ``runtime_fraction`` field instead.
 - area: hcm
   change: |
-    Use of buffer filter ``max_request_time`` is deprecated in favor of the request timeout found in `HttpConnectionManager <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_.
+    Use of buffer filter ``max_request_time`` is deprecated in favor of the request timeout found in `HttpConnectionManager
+    <https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto>`_.

--- a/changelogs/1.9.1.yaml
+++ b/changelogs/1.9.1.yaml
@@ -6,7 +6,7 @@ changes:
     fixed CVE-2019-9900 by rejecting HTTP/1.x headers with embedded NUL characters.
 - area: http
   change: |
-    fixed CVE-2019-9901 by normalizing HTTP paths prior to routing or L7 data plane processing.
-    This defaults off and is configurable via either HTTP connection manager :ref:`normalize_path
-    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.normalize_path>`
-    or the :ref:`runtime <config_http_conn_man_runtime_normalize_path>`.
+    fixed CVE-2019-9901 by normalizing HTTP paths prior to routing or L7 data plane processing. This defaults off and is
+    configurable via either HTTP connection manager :ref:`normalize_path
+    <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.normalize_path>` or the
+    :ref:`runtime <config_http_conn_man_runtime_normalize_path>`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -1,78 +1,102 @@
 date: Pending
 
 behavior_changes:
-# *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 - area: oauth2
   change: |
-    OAuth filter now URL-encodes URL in query parameters. These query parameters are decoded, leaving intact character sequences that must remain encoded in URLs. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.oauth_use_url_encoding`` to false.
+    OAuth filter now URL-encodes URL in query parameters. These query parameters are decoded, leaving intact character
+    sequences that must remain encoded in URLs. This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.oauth_use_url_encoding`` to false.
 - area: admin
   change: |
-    Adds a new admin stats format option 'html-active' to display a periodically updated list of the top most frequently changed stats.
+    Adds a new admin stats format option 'html-active' to display a periodically updated list of the top most frequently
+    changed stats.
 - area: build
   change: |
-    moved the tcp, http, and grpc health checkers to extensions. If you use these and override extensions_build_config.bzl you will now need to include them explicitly.
+    moved the tcp, http, and grpc health checkers to extensions. If you use these and override extensions_build_config.bzl
+    you will now need to include them explicitly.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
 - area: build
   change: |
-    Moved the REST config subscripton code into extensions. If you use REST for config updates and override extensions_build_config.bzl you will now need to include it explicitly.
+    Moved the REST config subscripton code into extensions. If you use REST for config updates and override
+    extensions_build_config.bzl you will now need to include it explicitly.
 - area: quic
   change: |
-    Access logging is now deferred to the QUIC ack listener, and roundtrip response time is added as a downstream timing metric. New runtime flag ``envoy.reloadable_features.quic_defer_logging_to_ack_listener`` can be used for revert this behavior.
+    Access logging is now deferred to the QUIC ack listener, and roundtrip response time is added as a downstream timing
+    metric. New runtime flag ``envoy.reloadable_features.quic_defer_logging_to_ack_listener`` can be used for revert this
+    behavior.
 - area: healthcheck
   change: |
-    If active HC is enabled and a host is ejected by outlier detection, a successful active health check unejects the host and consider it healthy. This also clears all the outlier detection counters. This behavior change can be reverted by setting ``envoy.reloadable_features_successful_active_health_check_uneject_host`` to ``false``.
+    If active HC is enabled and a host is ejected by outlier detection, a successful active health check unejects the host
+    and consider it healthy. This also clears all the outlier detection counters. This behavior change can be reverted by
+    setting ``envoy.reloadable_features_successful_active_health_check_uneject_host`` to ``false``.
 - area: local_ratelimit
   change: |
     Tokens from local descriptor's token buckets are burned before tokens from the default token bucket.
 - area: http stream
   change: |
-    Extended the lifetime of the protocol agnostic stream object to correct discrepancies between what is access logged and what occurred with the protocol specific stream. This behavior change can be reverted by setting ``envoy_reloadable_features_expand_agnostic_stream_lifetime`` to ``false``.
+    Extended the lifetime of the protocol agnostic stream object to correct discrepancies between what is access logged and
+    what occurred with the protocol specific stream. This behavior change can be reverted by setting
+    ``envoy_reloadable_features_expand_agnostic_stream_lifetime`` to ``false``.
 - area: http2
   change: |
-    Request authorities are now validated with a library function from QUICHE rather than nghttp2. This behavior change can be reverted by setting ``envoy.reloadable_features.http2_validate_authority_with_quiche`` to ``false``.
+    Request authorities are now validated with a library function from QUICHE rather than nghttp2. This behavior change can
+    be reverted by setting ``envoy.reloadable_features.http2_validate_authority_with_quiche`` to ``false``.
 - area: lua
   change: |
     dropped moonjit support.
 - area: ext_proc
   change: |
-    Make the :ref:`grpc service <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.grpc_service>` required.
+    Make the :ref:`grpc service <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.grpc_service>`
+    required.
 - area: http2
   change: |
-    Metadata is parsed with the QUICHE HPACK library, rather than nghttp2. This behavior change can be reverted by setting ``envoy.reloadable_features.http2_decode_metadata_with_quiche`` to ``false``.
+    Metadata is parsed with the QUICHE HPACK library, rather than nghttp2. This behavior change can be reverted by setting
+    ``envoy.reloadable_features.http2_decode_metadata_with_quiche`` to ``false``.
 - area: upstream
   change: |
-    Changed HTTP/1 and HTTP/3 upstream streams not to disable reading (in case where downstream buffer reaches high watermark) till the full response headers have been received. This fixes a bug where Envoy upstream timeouts were not correctly adjusting to the fact that the response headers have already been sent from upstream. This behavior change can be reverted by setting ``envoy.reloadable_features.upstream_wait_for_response_headers_before_disabling_read`` to ``false``.
+    Changed HTTP/1 and HTTP/3 upstream streams not to disable reading (in case where downstream buffer reaches high
+    watermark) till the full response headers have been received. This fixes a bug where Envoy upstream timeouts were not
+    correctly adjusting to the fact that the response headers have already been sent from upstream. This behavior change can
+    be reverted by setting ``envoy.reloadable_features.upstream_wait_for_response_headers_before_disabling_read`` to
+    ``false``.
 - area: custom response
   change: |
-    Changed how the uri for redirect policy is specified. It can now be specified either as a single fully qualified string, or by specifying individual components of the uri.
+    Changed how the uri for redirect policy is specified. It can now be specified either as a single fully qualified string,
+    or by specifying individual components of the uri.
 - area: matchers
   change: |
-    Moved all of the network input matchers to extensions. If you use network matchers and override extensions_build_config.bzl you will now need to include them explicitly.
+    Moved all of the network input matchers to extensions. If you use network matchers and override
+    extensions_build_config.bzl you will now need to include them explicitly.
 - area: matchers
   change: |
-    Added dynamic metadata to the MatchingData object to enable writing matcher_tree input objects that can parse provided dynamic metadata.
+    Added dynamic metadata to the MatchingData object to enable writing matcher_tree input objects that can parse provided
+    dynamic metadata.
 - area: skywalking
   change: |
-    If sw8 header is invalid, skywalking extension will create a new trace context and a null span respectively when sampling is enabled and disabled.
+    If sw8 header is invalid, skywalking extension will create a new trace context and a null span respectively when
+    sampling is enabled and disabled.
 - area: http3
   change: |
-    Convert HTTP/3 extended connect to/from HTTP/1 upgrade. This behavior change can be reverted by setting ``envoy.reloadable_features.use_http3_header_normalisation`` to ``false``.
+    Convert HTTP/3 extended connect to/from HTTP/1 upgrade. This behavior change can be reverted by setting
+    ``envoy.reloadable_features.use_http3_header_normalisation`` to ``false``.
 
 bug_fixes:
-# *Changes expected to improve the state of the world and are unlikely to have negative effects*
 - area: http
   change: |
-    sanitization of the referer header has been relaxed to allow relative URLs, and also tightened to remove referers containing userinfo or fragment components, as documented here :ref:`here <config_http_conn_man_headers_referer>`.
-    This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.http_allow_partial_urls_in_referer`` to false.
+    sanitization of the referer header has been relaxed to allow relative URLs, and also tightened to remove referers
+    containing userinfo or fragment components, as documented here :ref:`here <config_http_conn_man_headers_referer>`. This
+    behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.http_allow_partial_urls_in_referer`` to false.
 - area: stats
   change: |
     now updating upstream total connection stats as happy eyeballs connections are created.
 - area: eds
   change: |
-    added ``envoy.reloadable_features.multiplex_eds`` to disable eds multiplexing. Eds multiplexing is enabled by default, so that all subscriptions for the same resource type and management server reuse a single channel/mux.
-    When eds multiplexing is disabled each subscription uses a dedicated channel/mux.
+    added ``envoy.reloadable_features.multiplex_eds`` to disable eds multiplexing. Eds multiplexing is enabled by default,
+    so that all subscriptions for the same resource type and management server reuse a single channel/mux. When eds
+    multiplexing is disabled each subscription uses a dedicated channel/mux.
 - area: router
   change: |
     fixed the bug that custom tags of the route metadata type are not set for upstream spans.
@@ -87,43 +111,49 @@ bug_fixes:
     Add boringssl patch to resolve CVE-2023-0286. Note that the FIPS build is not patched/fixed.
 - area: access log
   change: |
-    in JSON logs, port numbers were logged as strings and are now logged as numbers (``%DOWNSTREAM_LOCAL_PORT%``, ``%DOWNSTREAM_REMOTE_PORT%``, ``%DOWNSTREAM_DIRECT_REMOTE_PORT%``, ``%UPSTREAM_LOCAL_PORT%``, ``%UPSTREAM_REMOTE_PORT%``).
-    This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.format_ports_as_numbers`` to false.
+    in JSON logs, port numbers were logged as strings and are now logged as numbers (``%DOWNSTREAM_LOCAL_PORT%``,
+    ``%DOWNSTREAM_REMOTE_PORT%``, ``%DOWNSTREAM_DIRECT_REMOTE_PORT%``, ``%UPSTREAM_LOCAL_PORT%``,
+    ``%UPSTREAM_REMOTE_PORT%``). This behavioral change can be temporarily reverted by setting runtime guard
+    ``envoy.reloadable_features.format_ports_as_numbers`` to false.
 - area: ext_proc
   change: |
-    Let onData always raise StopIterationAndWatermark when waiting for headers response, to avoid http errors (413 on request path, and 500 on response path) when data size goes above high watermark.
+    Let onData always raise StopIterationAndWatermark when waiting for headers response, to avoid http errors (413 on
+    request path, and 500 on response path) when data size goes above high watermark.
 - area: http filter
   change: |
-    Fix possible illegal memory access in the header_mutaion filter when the request is aborted before the request headers are received completely.
+    Fix possible illegal memory access in the header_mutaion filter when the request is aborted before the request headers
+    are received completely.
 - area: upstream
   change: |
-    Initialize upstream network read filters via their ``onNewConnection()`` callback once the upstream connection has been established even if there is no data available for reading on the new upstream connection. This behavior change can be reverted by setting ``envoy.reloadable_features.initialize_upstream_filters`` to ``false``.
+    Initialize upstream network read filters via their ``onNewConnection()`` callback once the upstream connection has been
+    established even if there is no data available for reading on the new upstream connection. This behavior change can be
+    reverted by setting ``envoy.reloadable_features.initialize_upstream_filters`` to ``false``.
 - area: ecds
   change: |
-    Delay listener activation until after the new ECDS filter configuration is created. Previously, listeners were activated with the xDS acceptance before the new extension config is fully processed.
+    Delay listener activation until after the new ECDS filter configuration is created. Previously, listeners were activated
+    with the xDS acceptance before the new extension config is fully processed.
 - area: dubbo
   change: |
     Fix a bug that the dubbo proxy will treat the response with status 80 as a illegal response.
 
 removed_config_or_runtime:
-# *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 - area: config
   change: |
-    removed ``envoy.reloadable_features.admin_stats_filter_use_re2`` and legacy code paths.
-    removed ``envoy.reloadable_features.combine_sds_requests`` and legacy code paths.
+    removed ``envoy.reloadable_features.admin_stats_filter_use_re2`` and legacy code paths. removed
+    ``envoy.reloadable_features.combine_sds_requests`` and legacy code paths.
 - area: dns
   change: |
     removed ``envoy.reloadable_features.dns_multiple_addresses`` runtime flag and legacy code paths.
 - area: router
   change: |
-    removed ``envoy.reloadable_features.get_route_config_factory_by_type`` runtime flag. The flag is no longer needed as the behavior is now the default.
+    removed ``envoy.reloadable_features.get_route_config_factory_by_type`` runtime flag. The flag is no longer needed as the
+    behavior is now the default.
 - area: http
   change: |
     removed ``envoy.reloadable_features.http2_delay_keepalive_timeout`` and legacy code paths.
 - area: http
   change: |
     removed ``envoy.reloadable_features.local_ratelimit_match_all_descriptors`` and legacy code paths.
-
 - area: http
   change: |
     removed ``envoy.reloadable_features.use_rfc_connect`` and legacy code path.
@@ -158,117 +188,154 @@ new_features:
     added upstream/downstream header and wire bytes fields to the grpc access log service proto.
 - area: oauth filter
   change: |
-    extended :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to allow overriding (default) cookie names (``IdToken``, ``RefreshToken``) set by the filter.
+    extended :ref:`cookie_names <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Credentials.cookie_names>` to
+    allow overriding (default) cookie names (``IdToken``, ``RefreshToken``) set by the filter.
 - area: tracing
   change: |
-    allow :ref:`grpc_service <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.grpc_service>` to be optional. This enables a means to disable collection of traces.
+    allow :ref:`grpc_service <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.grpc_service>` to be optional. This
+    enables a means to disable collection of traces.
 - area: upstream
   change: |
-    added :ref:`ring hash extension <envoy_v3_api_msg_extensions.load_balancing_policies.ring_hash.v3.RingHash>` to suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
+    added :ref:`ring hash extension <envoy_v3_api_msg_extensions.load_balancing_policies.ring_hash.v3.RingHash>` to suppport
+    the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
 - area: upstream
   change: |
-    added :ref:`maglev extension <envoy_v3_api_msg_extensions.load_balancing_policies.maglev.v3.Maglev>` to suppport the :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
+    added :ref:`maglev extension <envoy_v3_api_msg_extensions.load_balancing_policies.maglev.v3.Maglev>` to suppport the
+    :ref:`load balancer policy <envoy_v3_api_field_config.cluster.v3.Cluster.load_balancing_policy>`.
 - area: maglev
   change: |
-    added ``envoy.reloadable_features.allow_compact_maglev`` to allow the use of a more compact maglev load balancer representation. This can be reverted by setting ``envoy.reloadable_features.allow_compact_maglev`` to false.
+    added ``envoy.reloadable_features.allow_compact_maglev`` to allow the use of a more compact maglev load balancer
+    representation. This can be reverted by setting ``envoy.reloadable_features.allow_compact_maglev`` to false.
 - area: router
   change: |
     support route info in upstream access log.
 - area: lua
   change: |
-    added an new option to the options of lua ``httpCall``. This allows to skip adding ``x-forwarded-for`` by setting ``{["send_xff"] = false}`` as the ``options``.
+    added an new option to the options of lua ``httpCall``. This allows to skip adding ``x-forwarded-for`` by setting
+    ``{["send_xff"] = false}`` as the ``options``.
 - area: ratelimit
   change: |
     added local rate limit listener filter to enable rate limit before TLS handshake and filter matching.
 - area: proxy_protocol
   change: |
-    added the support :ref:`pass_through_tlvs for listener <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.pass_through_tlvs>`
-    and :ref:`pass_through_tlvs for upsteam <envoy_v3_api_field_config.core.v3.ProxyProtocolConfig.pass_through_tlvs>`.
-    They can control which Proxy Protocol V2 TLVs can be passed through by listener and upstream separately.
+    added the support :ref:`pass_through_tlvs for listener
+    <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.pass_through_tlvs>` and
+    :ref:`pass_through_tlvs for upsteam <envoy_v3_api_field_config.core.v3.ProxyProtocolConfig.pass_through_tlvs>`. They can
+    control which Proxy Protocol V2 TLVs can be passed through by listener and upstream separately.
 - area: tcp_proxy
   change: |
-    added support for propagating the response trailers in :ref:`TunnelingConfig <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_trailers>` to the downstream info filter state.
+    added support for propagating the response trailers in :ref:`TunnelingConfig
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_trailers>` to
+    the downstream info filter state.
 - area: sni_dynamic_forward_proxy
   change: |
-    added an option to dynamically set the host used by the SNI dynamic forward proxy filter, by setting a filter state object under the key ``envoy.upstream.dynamic_host``.
+    added an option to dynamically set the host used by the SNI dynamic forward proxy filter, by setting a filter state
+    object under the key ``envoy.upstream.dynamic_host``.
 - area: access_log
   change: |
-    added support for :ref:`%DOWNSTREAM_TRANSPORT_FAILURE_REASON% <config_access_log_format_downstream_transport_failure_reason>` as a log command operator about why listener may have failed due to a transport socket error,
-    including TLS handshake failures.
-    added the field :ref:`downstream_transport_failure_reason <envoy_v3_api_field_data.accesslog.v3.AccessLogCommon.downstream_transport_failure_reason>` for common usage as well.
+    added support for :ref:`%DOWNSTREAM_TRANSPORT_FAILURE_REASON%
+    <config_access_log_format_downstream_transport_failure_reason>` as a log command operator about why listener may have
+    failed due to a transport socket error, including TLS handshake failures. added the field
+    :ref:`downstream_transport_failure_reason
+    <envoy_v3_api_field_data.accesslog.v3.AccessLogCommon.downstream_transport_failure_reason>` for common usage as well.
 - area: generic_proxy
   change: |
-    added :ref:`tracing support <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.tracing>` for the generic proxy.
+    added :ref:`tracing support <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.tracing>` for
+    the generic proxy.
 - area: jwt_authn
   change: |
-    added :ref:`failed_status_in_metadata <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.failed_status_in_metadata>` to support setting the JWT
-    authentication failure status code and message in dynamic metadata.
+    added :ref:`failed_status_in_metadata
+    <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.failed_status_in_metadata>` to support setting the
+    JWT authentication failure status code and message in dynamic metadata.
 - area: ext_proc
   change: |
-    added the support :ref:`override_message_timeout <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.override_message_timeout>` for the ext_proc server to send back a message to Envoy to extend the ext_proc timer.
-    added the field :ref:`max_message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>` for specifying the max override_message_timeout could be sent back by the ext_proc server.
+    added the support :ref:`override_message_timeout
+    <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.override_message_timeout>` for the ext_proc server to send
+    back a message to Envoy to extend the ext_proc timer. added the field :ref:`max_message_timeout
+    <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>` for specifying the max
+    override_message_timeout could be sent back by the ext_proc server.
 - area: http filter
   change: |
-    added :ref:`header mutation http filter <config_http_filters_header_mutation>` which adds the ability to modify request and response headers in any position of HTTP filter chain.
+    added :ref:`header mutation http filter <config_http_filters_header_mutation>` which adds the ability to modify request
+    and response headers in any position of HTTP filter chain.
 - area: matching
   change: |
-    added :ref:`Filter State Input <envoy_v3_api_msg_extensions.matching.common_inputs.network.v3.FilterStateInput>` for matching based on filter state objects.
+    added :ref:`Filter State Input <envoy_v3_api_msg_extensions.matching.common_inputs.network.v3.FilterStateInput>` for
+    matching based on filter state objects.
 - area: overload manager
   change: |
-    added stat ``overload.refresh_interval_delay`` to track the delay between overload manager resource loop refresh in milliseconds.
+    added stat ``overload.refresh_interval_delay`` to track the delay between overload manager resource loop refresh in
+    milliseconds.
 - area: http
   change: |
     make adding ProxyProtocolFilterState in the HCM optional.
 - area: sni_dynamic_forward_proxy
   change: |
-    added an option to dynamically set the port used by the SNI dynamic forward proxy filter, by setting a filter state object under the key ``envoy.upstream.dynamic_port``.
+    added an option to dynamically set the port used by the SNI dynamic forward proxy filter, by setting a filter state
+    object under the key ``envoy.upstream.dynamic_port``.
 - area: route
   change: |
     support dynamic clusters for :ref:`VirtualHost.matcher <envoy_v3_api_field_config.route.v3.VirtualHost.matcher>`.
 - area: route
   change: |
-    support route callback after route matches for :ref:`VirtualHost.matcher <envoy_v3_api_field_config.route.v3.VirtualHost.matcher>`.
+    support route callback after route matches for :ref:`VirtualHost.matcher
+    <envoy_v3_api_field_config.route.v3.VirtualHost.matcher>`.
 - area: tcp_proxy
   change: |
-    added an option to dynamically disable TCP tunneling even if set in the filter config, by setting a filter state object for the key ``envoy.tcp_proxy.disable_tunneling``.
+    added an option to dynamically disable TCP tunneling even if set in the filter config, by setting a filter state object
+    for the key ``envoy.tcp_proxy.disable_tunneling``.
 - area: tcp_proxy
   change: |
-    add :ref:`flush access log on connected <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>` to allow recording an access log entry
-    on the connection open event. This option does not require periodic access logging enabled, and the other way around.
+    add :ref:`flush access log on connected
+    <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.flush_access_log_on_connected>` to allow recording
+    an access log entry on the connection open event. This option does not require periodic access logging enabled, and the
+    other way around.
 - area: http
   change: |
-    add :ref:`periodic access logging <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`
-    to http access logs for long-lived requests (Websockets, CONNECT, etc). :ref:`%DURATION% <config_access_log_format_duration>` will
-    be empty for mid-request logs. Enabling this may affect access loggers and filters that register as access loggers that expect to be called only once.
+    add :ref:`periodic access logging
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.access_log_flush_interval>`
+    to http access logs for long-lived requests (Websockets, CONNECT, etc). :ref:`%DURATION%
+    <config_access_log_format_duration>` will be empty for mid-request logs. Enabling this may affect access loggers and
+    filters that register as access loggers that expect to be called only once.
 - area: http
   change: |
-    add :ref:`flush access log on new request <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.flush_access_log_on_new_request>` to allow recording
-    an access log entry when a new HTTP request is received by the HTTP connection manager. Details related to upstream cluster, such as upstream host, will not be available for this log.
-    This option does not require periodic access logging enabled, and the other way around.
+    add :ref:`flush access log on new request
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.flush_access_log_on_new_request>`
+    to allow recording an access log entry when a new HTTP request is received by the HTTP connection manager. Details
+    related to upstream cluster, such as upstream host, will not be available for this log. This option does not require
+    periodic access logging enabled, and the other way around.
 - area: redis_health_check
   change: |
-    added :ref:`exists_failure <config_health_checkers_redis>` stat to indicate health check failures caused by EXISTS check failure.
+    added :ref:`exists_failure <config_health_checkers_redis>` stat to indicate health check failures caused by EXISTS check
+    failure.
 - area: redis
   change: |
-    added :ref:`wait_for_warm_on_init <envoy_v3_api_field_config.cluster.v3.Cluster.wait_for_warm_on_init>` support for :ref:`Redis Cluster<arch_overview_redis>`.
+    added :ref:`wait_for_warm_on_init <envoy_v3_api_field_config.cluster.v3.Cluster.wait_for_warm_on_init>` support for
+    :ref:`Redis Cluster<arch_overview_redis>`.
 - area: access_log
   change: |
-    added access log support for ``%STREAM_STATE%`` command operator. Using the command operator will extract a value representing the state of the stream.
-    Access logs at the beginning of the stream will have 'Started' value. Periodic access logs during an active stream, will have 'InProgress' value. Default access log,
-    at the end of a stream will have 'Ended' value. In case the stream has not started yet, the value will be null.
+    added access log support for ``%STREAM_STATE%`` command operator. Using the command operator will extract a value
+    representing the state of the stream. Access logs at the beginning of the stream will have 'Started' value. Periodic
+    access logs during an active stream, will have 'InProgress' value. Default access log, at the end of a stream will have
+    'Ended' value. In case the stream has not started yet, the value will be null.
 - area: stream info
   change: |
-    added the latency for how long an upstream request spends waiting for the connection pool callback to ``UpstreamTiming``.
+    added the latency for how long an upstream request spends waiting for the connection pool callback to
+    ``UpstreamTiming``.
 - area: ext_authz
   change: |
-    added :ref:`include_tls_session <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.include_tls_session>` to support sending TLS SNI data
-    as part of CheckRequest for authorization check.
+    added :ref:`include_tls_session <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.include_tls_session>`
+    to support sending TLS SNI data as part of CheckRequest for authorization check.
 - area: tls
   change: |
-    added new field :ref:`signature_algorithms <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.signature_algorithms>` to set signature algorithms.
+    added new field :ref:`signature_algorithms
+    <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.signature_algorithms>` to set signature
+    algorithms.
 
 deprecated:
 - area: ext_authz
   change: |
-    deprecated (1.25.0) :ref:`ext_authz.v3.AuthorizationRequest.allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationRequest.allowed_headers>` in favour
-    of :ref:`ext_authz.v3.ExtAuthz.allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.
+    deprecated (1.25.0) :ref:`ext_authz.v3.AuthorizationRequest.allowed_headers
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationRequest.allowed_headers>` in favour of
+    :ref:`ext_authz.v3.ExtAuthz.allowed_headers
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`.

--- a/docs/root/configuration/http/http_filters/_include/composite.yaml
+++ b/docs/root/configuration/http/http_filters/_include/composite.yaml
@@ -21,7 +21,8 @@ static_resources:
               domains: ["*"]
               routes:
               # NOTE: by default, matching happens based on the gRPC route, and not on the incoming request path.
-              # Reference: https://envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter#route-configs-for-transcoded-requests
+              # Reference:
+              # https://envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_json_transcoder_filter#route-configs-for-transcoded-requests
               - match: {prefix: "/helloworld.Greeter"}
                 route: {cluster: grpc, timeout: 60s}
           http_filters:

--- a/docs/root/intro/arch_overview/advanced/matching/_include/complicated.yaml
+++ b/docs/root/intro/arch_overview/advanced/matching/_include/complicated.yaml
@@ -41,7 +41,8 @@ static_resources:
                     # Note this additional indirection; this is a workaround for Protobuf oneof limitations.
                     map:
                       some_value_to_match_on:  # This is the header value we're trying to match against.
-                        # The OnMatch resulting on matching with this branch of the exact matcher is another matcher, allowing for recursive matching.
+                        # The OnMatch resulting on matching with this branch of the exact matcher is another matcher,
+                        # allowing for recursive matching.
                         matcher:
                           # The inner matcher is a matcher list, which attempts to match a list of predicates.
                           matcher_list:

--- a/mobile/.kotlinlint.yml
+++ b/mobile/.kotlinlint.yml
@@ -1,4 +1,5 @@
-# We build upon the default config provided by https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml
+# We build upon the default config provided by
+# https://github.com/arturbosch/detekt/blob/master/detekt-cli/src/main/resources/default-detekt-config.yml
 build:
   maxIssues: 0
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1201,17 +1201,26 @@ envoy.wasm.runtime.v8:
 envoy.wasm.runtime.wamr:
   categories:
   - envoy.wasm.runtime
-  security_posture: unknown  # "This may never change from unknown until the threat model at https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#core-and-extensions is updated to capture additional Wasm runtimes".
+  # "This may never change from unknown until the threat model at
+  # https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#core-and-extensions
+  # is updated to capture additional Wasm runtimes".
+  security_posture: unknown
   status: alpha
 envoy.wasm.runtime.wasmtime:
   categories:
   - envoy.wasm.runtime
-  security_posture: unknown  # "This may never change from unknown until the threat model at https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#core-and-extensions is updated to capture additional Wasm runtimes".
+  # "This may never change from unknown until the threat model at
+  # https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#core-and-extensions
+  # is updated to capture additional Wasm runtimes".
+  security_posture: unknown
   status: alpha
 envoy.wasm.runtime.wavm:
   categories:
   - envoy.wasm.runtime
-  security_posture: unknown  # "This may never change from unknown until the threat model at https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#core-and-extensions is updated to capture additional Wasm runtimes".
+  # "This may never change from unknown until the threat model at
+  # https://envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/threat_model#core-and-extensions
+  # is updated to capture additional Wasm runtimes".
+  security_posture: unknown
   status: alpha
 envoy.watchdog.profile_action:
   categories:


### PR DESCRIPTION
- fix changelogs
- assorted cleanups
- set max yaml width to 140 (allowing for non-breaking words)
- make excess width an error

Fix #26462 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
