### PR TITLE
ci: disable unused icu features

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -154,6 +154,7 @@ configure_make(
         "--disable-draft",
         "--disable-dyload",
         "--disable-extras",
+        "--disable-icuio",
         "--disable-plugins",
         "--disable-samples",
         "--disable-shared",
@@ -162,7 +163,7 @@ configure_make(
     ],
     data = ["@com_github_unicode_org_icu//:all"],
     env = {
-        "CXXFLAGS": "-fPIC",
+        "CXXFLAGS": "-fPIC -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0 -DUCONFIG_ONLY_HTML_CONVERSION=1 -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_BREAK_ITERATION=1 -DUCONFIG_NO_COLLATION=1 -DUCONFIG_NO_FORMATTING=1 -DUCONFIG_NO_TRANSLITERATION=1 -DUCONFIG_NO_REGULAR_EXPRESSIONS=1",
         "CFLAGS": "-fPIC",
         "ICU_DATA_FILTER_FILE": "$(execpath //bazel/foreign_cc:icu_data_filter.json)",
     },
@@ -177,20 +178,6 @@ configure_make(
 
 cc_library(
     name = "unicode_icu",
-    defines = [
-        "UCONFIG_ONLY_HTML_CONVERSION=1",
-        "U_CHARSET_IS_UTF8=1",
-        "U_USING_ICU_NAMESPACE=0",
-        "UNISTR_FROM_STRING_EXPLICIT=",
-        "UNISTR_FROM_CHAR_EXPLICIT=",
-    ] + select({
-        "//bazel:windows_x86_64": [
-            "U_STATIC_IMPLEMENTATION",
-            "UNICODE",
-            "_UNICODE",
-        ],
-        "//conditions:default": [],
-    }),
     tags = ["skip_on_windows"],
     # Can not be used for the core dataplane due to security concerns
     visibility = ["//contrib/language/filters/http/source:__pkg__"],


### PR DESCRIPTION
Disables unused icu features by using configuration options and environment variables and reduces the icu build time by half.

- Disables the icu-io (ustdio/iostream) library (`--disable-icuio`)
- Hardcodes the default icu charset to UTF-8
- Turns off conversion apart from UTF, CESU-8, SCSU, BOCU-1, US-ASCII, and ISO-8859-1
- Turns off break iteration
- Turns off collation and collation-based string search
- Turns off all formatting (date, time, number, etc), and calendar/timezone services
- Turns off script-to-script transliteration
- Turns off the regular expression functionality

Documentation

- icu feature flags: [https://github.com/unicode-org/icu/icu4c/source/configure#L1449](https://github.com/unicode-org/icu/blob/29443b8be710640ded073116b768da35f00cf0dd/icu4c/source/configure#L1449)
- [https://github.com/unicode-org/icu/docs/userguide/icu4c/build.md#recommended-build-options](https://github.com/unicode-org/icu/blob/29443b8be710640ded073116b768da35f00cf0dd/docs/userguide/icu4c/build.md#recommended-build-options)
- [https://github.com/unicode-org/icu/docs/userguide/icu4c/packaging.md#disable-icu-features](https://github.com/unicode-org/icu/blob/29443b8be710640ded073116b768da35f00cf0dd/docs/userguide/icu4c/packaging.md#disable-icu-features)

Related

- https://github.com/envoyproxy/envoy/issues/26395#issuecomment-1493398199

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]