### PR TITLE
distribution: Remove `linkopts` from bundle rule

### DIFF
--- a/distribution/binary/compiler.bzl
+++ b/distribution/binary/compiler.bzl
@@ -19,7 +19,7 @@
 # You can define the `targets` to be compiled, along with the destination `path`
 # of the compiled binary.
 #
-# You can also define lists of `stripopts` and `linkopts`.
+# You can also define lists of `stripopts`.
 #
 # For example, you can bundle some stripped binaries together in `opt` mode:
 #
@@ -59,7 +59,6 @@ def _compilation_config_impl(settings, attr):
     _ignore = settings
     return {
         "//command_line_option:compilation_mode": attr.mode,
-        "//command_line_option:linkopt": attr.linkopts,
         "//command_line_option:stripopt": attr.stripopts,
     }
 
@@ -68,7 +67,6 @@ compilation_config = transition(
     inputs = [],
     outputs = [
         "//command_line_option:compilation_mode",
-        "//command_line_option:linkopt",
         "//command_line_option:stripopt",
     ],
 )
@@ -97,7 +95,6 @@ bundled = rule(
     implementation = _bundled_impl,
     attrs = {
         "mode": attr.string(),
-        "linkopts": attr.string_list(),
         "stripopts": attr.string_list(),
         "targets": attr.label_keyed_string_dict(
             allow_files = True,


### PR DESCRIPTION
this wasnt needed for current use, and its effect is not entirely clear

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
