### PR TITLE
bugfix: should only set the paused_for_connect_ flag to true when the upstream connection is not established.

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -382,7 +382,7 @@ void UpstreamRequest::acceptHeadersFromRouter(bool end_stream) {
 
   // Make sure that when we are forwarding CONNECT payload we do not do so until
   // the upstream has accepted the CONNECT request.
-  if (headers->getMethodValue() == Http::Headers::get().MethodValues.Connect) {
+  if (!upstream_.get() && headers->getMethodValue() == Http::Headers::get().MethodValues.Connect) {
     paused_for_connect_ = true;
   }
 


### PR DESCRIPTION
Otherwise, it will hit the assert in commonContinue, in such a stack:
```
Envoy::Http::ActiveStreamDecoderFilter::continueDecoding() 
Envoy::Router::UpstreamCodecFilter::CodecBridge::decodeHeaders()
Envoy::Extensions::Upstreams::Http::Tcp::TcpUpstream::encodeHeaders()
Envoy::Router::UpstreamCodecFilter::decodeHeaders() Envoy::Http::ActiveStreamDecoderFilter::decodeHeaders()
Envoy::Http::FilterManager::decodeHeaders()
Envoy::Http::FilterManager::decodeHeaders()
Envoy::Router::UpstreamRequest::acceptHeadersFromRouter()
```

In the connection not reusing case:
`paused_for_connect_` will be set to false in onPoolReady after it's true.

But, in the connection reusing case:
onPoolReady is invoked before `paused_for_connect_` is set to true.

it could be reproduced easily when preconnect is enabled, with `CONNECT` requests.
```
    preconnect_policy:
      per_upstream_preconnect_ratio: 2
```

I'm not pretty sure it's a proper fix, suggestions are welcome, thanks!

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
