### PR TITLE
http1 codec fuzzing: fuzz balsa, too

### DIFF
--- a/test/common/http/http1/http1_connection_fuzz_test.cc
+++ b/test/common/http/http1/http1_connection_fuzz_test.cc
@@ -33,42 +33,44 @@ static Http1Settings fromHttp1Settings() {
 class Http1Harness {
 public:
   Http1Harness(const Http1Settings& server_settings, const Http1Settings& client_settings)
-      : server_settings(server_settings), client_settings(client_settings) {
-    ON_CALL(mock_server_callbacks, newStream(_, _))
+      : server_settings_(server_settings), client_settings_(client_settings) {
+    ON_CALL(mock_server_callbacks_, newStream(_, _))
         .WillByDefault(Invoke(
-            [&](ResponseEncoder&, bool) -> RequestDecoder& { return orphan_request_decoder; }));
+            [&](ResponseEncoder&, bool) -> RequestDecoder& { return orphan_request_decoder_; }));
   }
 
-  void fuzz_response(Buffer::Instance& payload, bool use_balsa) {
-    client_settings.use_balsa_parser_ = use_balsa;
+  void fuzzResponse(Buffer::Instance& payload, bool use_balsa) {
+    client_settings_.use_balsa_parser_ = use_balsa;
     client_ = std::make_unique<Http1::ClientConnectionImpl>(
-        mock_client_connection, Http1::CodecStats::atomicGet(http1_stats, *stats_store.rootScope()),
-        mock_client_callbacks, client_settings, Http::DEFAULT_MAX_HEADERS_COUNT);
+        mock_client_connection_,
+        Http1::CodecStats::atomicGet(http1_stats_, *stats_store_.rootScope()),
+        mock_client_callbacks_, client_settings_, Http::DEFAULT_MAX_HEADERS_COUNT);
     Status status = client_->dispatch(payload);
   }
 
-  void fuzz_request(Buffer::Instance& payload, bool use_balsa) {
-    server_settings.use_balsa_parser_ = use_balsa;
+  void fuzzRequest(Buffer::Instance& payload, bool use_balsa) {
+    server_settings_.use_balsa_parser_ = use_balsa;
     server_ = std::make_unique<Http1::ServerConnectionImpl>(
-        mock_server_connection, Http1::CodecStats::atomicGet(http1_stats, *stats_store.rootScope()),
-        mock_server_callbacks, server_settings, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
+        mock_server_connection_,
+        Http1::CodecStats::atomicGet(http1_stats_, *stats_store_.rootScope()),
+        mock_server_callbacks_, server_settings_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
         Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
 
     Status status = server_->dispatch(payload);
   }
 
 private:
-  Http1Settings server_settings, client_settings;
-  Stats::IsolatedStoreImpl stats_store;
-  Http1::CodecStats::AtomicPtr http1_stats;
+  Http1Settings server_settings_, client_settings_;
+  Stats::IsolatedStoreImpl stats_store_;
+  Http1::CodecStats::AtomicPtr http1_stats_;
 
-  NiceMock<MockConnectionCallbacks> mock_client_callbacks;
-  NiceMock<Network::MockConnection> mock_client_connection;
+  NiceMock<MockConnectionCallbacks> mock_client_callbacks_;
+  NiceMock<Network::MockConnection> mock_client_connection_;
   ClientConnectionPtr client_;
 
-  NiceMock<MockRequestDecoder> orphan_request_decoder;
-  NiceMock<Network::MockConnection> mock_server_connection;
-  NiceMock<MockServerConnectionCallbacks> mock_server_callbacks;
+  NiceMock<MockRequestDecoder> orphan_request_decoder_;
+  NiceMock<Network::MockConnection> mock_server_connection_;
+  NiceMock<MockServerConnectionCallbacks> mock_server_callbacks_;
 
   ServerConnectionPtr server_;
 };
@@ -91,10 +93,10 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   httpmsg.add(buf, len);
   // HTTP requests and responses are handled differently in the codec, hence we
   // setup two instances of the parser, which do not interact.
-  harness->fuzz_request(httpmsg, false);
-  harness->fuzz_response(httpmsg, false);
-  harness->fuzz_request(httpmsg, true);
-  harness->fuzz_response(httpmsg, true);
+  harness->fuzzRequest(httpmsg, false);
+  harness->fuzzResponse(httpmsg, false);
+  harness->fuzzRequest(httpmsg, true);
+  harness->fuzzResponse(httpmsg, true);
 }
 
 } // namespace


### PR DESCRIPTION
Currently, the http1 connection fuzz test only fuzzes the (default-enabled) "legacy" http1 codec.
This patch enables fuzzing the balsa codec.