### PR TITLE
ci: Fix publishing in postsubmit

### DIFF
--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -706,7 +706,6 @@ stages:
     #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#job-to-job-dependencies-within-one-stage
     condition: |
       and(
-        eq(variables['Build.Reason'], 'PullRequest'),
         in(dependencies.docker.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
         in(dependencies.package_x64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
         in(dependencies.package_arm64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))


### PR DESCRIPTION
In #26535 the skip checks were skipped in postsubmit

In the case of publishing this check is required to proceed to publish docs etc

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
