### PR TITLE
fix panic in golang filter: req_ may be nullptr

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -179,6 +179,11 @@ Http::FilterTrailersStatus Filter::encodeTrailers(Http::ResponseTrailerMap& trai
 void Filter::onDestroy() {
   ENVOY_LOG(debug, "golang filter on destroy");
 
+  // do nothing, stream reset may happen before entering this filter.
+  if (req_ == nullptr) {
+    return;
+  }
+
   {
     Thread::LockGuard lock(mutex_);
     if (has_destroyed_) {
@@ -188,7 +193,6 @@ void Filter::onDestroy() {
     has_destroyed_ = true;
   }
 
-  ASSERT(req_ != nullptr);
   auto& state = getProcessorState();
   auto reason = state.isProcessingInGo() ? DestroyReason::Terminate : DestroyReason::Normal;
 

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -39,9 +39,6 @@ namespace {
 class TestFilter : public Filter {
 public:
   using Filter::Filter;
-  void onDestroy() override {
-    // do nothing
-  }
 };
 
 class GolangHttpFilterTest : public testing::Test {


### PR DESCRIPTION
i.e. stream reset may happen before entering a golang filter, so that onDestroy will be invoked before any decodeHeaders or encodeHeaders.

fix #26537

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
