### PR TITLE
test: waiting on a counter

### DIFF
--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -228,7 +228,7 @@ TEST_P(FilterIntegrationTest, RetryAfterHttp3ZeroRttHandshakeFailed) {
   // Wait for the upstream to connect timeout and the failed early data request to be retried.
   test_server_->waitForCounterEq("cluster.cluster_0.upstream_rq_retry", 1);
   EXPECT_EQ(1u, test_server_->counter("cluster.cluster_0.upstream_rq_0rtt")->value());
-  EXPECT_EQ(3u, test_server_->counter("cluster.cluster_0.upstream_cx_destroy")->value());
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_destroy", 3);
 
   // The retry should attempt both HTTP/3 and HTTP/2. And the TCP connection will win the race.
   waitForNextUpstreamRequest(0);


### PR DESCRIPTION
https://dev.azure.com/cncf/envoy/_build/results?buildId=133169&view=logs&j=bbe4b42d-86e6-5e9c-8a0b-fea01d818a24&t=00ade0d6-ffae-5af0-b5e0-e33b1813c8bc


test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc:231: Failure
Expected equality of these values:
  3u
    Which is: 3
  test_server_->counter("cluster.cluster_0.upstream_cx_destroy")->value()
    Which is: 2
Stack trace:
  0x9bc70a: (unknown)
  0x7f0f4048d32d: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
  0x7f0f404740ae: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x7f0f4045b9ad: testing::Test::Run()
  0x7f0f4045c49e: testing::TestInfo::Run()
... Google Test internal frames ...
