### PR TITLE
mobile: Add a select on Google gRPC to the RTDS and CDS tests

### DIFF
--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -27,7 +27,6 @@ envoy_cc_test(
     name = "rtds_integration_test",
     # The test relies on the Google gRPC library.
     srcs = envoy_select_google_grpc(["rtds_integration_test.cc"], "@envoy"),
-    # srcs = ["rtds_integration_test.cc"],
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
@@ -48,7 +47,6 @@ envoy_cc_test(
     name = "cds_integration_test",
     # The test relies on the Google gRPC library.
     srcs = envoy_select_google_grpc(["cds_integration_test.cc"], "@envoy"),
-    # srcs = ["cds_integration_test.cc"],
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -26,7 +26,10 @@ envoy_cc_test(
 envoy_cc_test(
     name = "rtds_integration_test",
     # The test relies on the Google gRPC library.
-    srcs = envoy_select_google_grpc(["rtds_integration_test.cc"], "@envoy"),
+    srcs = envoy_select_google_grpc(
+        ["rtds_integration_test.cc"],
+        "@envoy",
+    ),
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
@@ -46,7 +49,10 @@ envoy_cc_test(
 envoy_cc_test(
     name = "cds_integration_test",
     # The test relies on the Google gRPC library.
-    srcs = envoy_select_google_grpc(["cds_integration_test.cc"], "@envoy"),
+    srcs = envoy_select_google_grpc(
+        ["cds_integration_test.cc"],
+        "@envoy",
+    ),
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
@@ -147,8 +153,8 @@ envoy_cc_test_library(
     ],
     repository = "@envoy",
     deps = [
-        "@envoy//test/integration:autonomous_upstream_lib",
         "@envoy//source/exe:process_wide_lib",
+        "@envoy//test/integration:autonomous_upstream_lib",
         "@envoy//test/integration:utility_lib",
         "@envoy//test/mocks/server:transport_socket_factory_context_mocks",
         "@envoy//test/test_common:environment_lib",

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
+    "envoy_select_google_grpc",
 )
 
 licenses(["notice"])  # Apache 2
@@ -24,7 +25,9 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "rtds_integration_test",
-    srcs = ["rtds_integration_test.cc"],
+    # The test relies on the Google gRPC library.
+    srcs = envoy_select_google_grpc(["rtds_integration_test.cc"], "@envoy"),
+    # srcs = ["rtds_integration_test.cc"],
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
@@ -43,7 +46,9 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "cds_integration_test",
-    srcs = ["cds_integration_test.cc"],
+    # The test relies on the Google gRPC library.
+    srcs = envoy_select_google_grpc(["cds_integration_test.cc"], "@envoy"),
+    # srcs = ["cds_integration_test.cc"],
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",


### PR DESCRIPTION
Both the RTDS and CDS integration tests rely on Google gRPC now, and should only be run if the tests are run with
`--define=ENVOY_GOOGLE_GRPC`.
