### PR TITLE
Using newly supported X-Serverless-Authorization header.

### DIFF
--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
@@ -18,7 +18,7 @@ namespace GcpAuthn {
 
 inline constexpr absl::string_view FilterName = "envoy.filters.http.gcp_authn";
 inline const Envoy::Http::LowerCaseString& authorizationHeaderKey() {
-  CONSTRUCT_ON_FIRST_USE(Envoy::Http::LowerCaseString, "Authorization");
+  CONSTRUCT_ON_FIRST_USE(Envoy::Http::LowerCaseString, "X-Serverless-Authorization");
 }
 /**
  * All stats for the gcp authentication filter. @see stats_macros.h


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Uses newly supported X-Serverless-Authorization header. This frees up the Authorization header to be used
Additional Description: |-
    Google Docs: https://cloud.google.com/run/docs/authenticating/service-to-service
    Both headers receive the same values.
    This might have side-effects in some cases.
        * Someone currently has their Authorization header overriden by this filter and with this change it would get passed on to the target application. This is not a change in documented behaviour.
        *  Not all GCP services might support this new feature. I am not sure this filter can be used with something else then cloudrun even.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
