### PR TITLE
Fix bad assertion on malformed QUIC trailer

### DIFF
--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -302,11 +302,11 @@ void EnvoyQuicServerStream::OnBodyAvailable() {
 void EnvoyQuicServerStream::OnTrailingHeadersComplete(bool fin, size_t frame_len,
                                                       const quic::QuicHeaderList& header_list) {
   mutableBytesMeter()->addHeaderBytesReceived(frame_len);
+  ENVOY_STREAM_LOG(debug, "Received trailers: {}.", *this, received_trailers().DebugString());
+  quic::QuicSpdyServerStreamBase::OnTrailingHeadersComplete(fin, frame_len, header_list);
   if (read_side_closed()) {
     return;
   }
-  ENVOY_STREAM_LOG(debug, "Received trailers: {}.", *this, received_trailers().DebugString());
-  quic::QuicSpdyServerStreamBase::OnTrailingHeadersComplete(fin, frame_len, header_list);
   ASSERT(trailers_decompressed());
   if (session()->connection()->connected() && !rst_sent()) {
     maybeDecodeTrailers();

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1390,6 +1390,28 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithInternalRedirect) {
   EXPECT_EQ(/* RESP(test-header) */ metrics.at(21), "-");
 }
 
+TEST_P(QuicHttpIntegrationTest, InvalidTrailer) {
+  initialize();
+  // Empty string in trailer key is invalid.
+  Http::TestRequestTrailerMapImpl request_trailers{{"", "foo"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"a", "b"}, {"c", "d"}};
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "sni.lyft.com"}});
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+  codec_client_->sendData(*request_encoder_, 1024, false);
+  codec_client_->sendTrailers(*request_encoder_, request_trailers);
+
+  // Request fails due to invalid trailer.
+  ASSERT_TRUE(response->waitForReset());
+  EXPECT_FALSE(response->complete());
+}
+
 class QuicInplaceLdsIntegrationTest : public QuicHttpIntegrationTest {
 public:
   void inplaceInitialize(bool add_default_filter_chain = false) {

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1394,7 +1394,6 @@ TEST_P(QuicHttpIntegrationTest, InvalidTrailer) {
   initialize();
   // Empty string in trailer key is invalid.
   Http::TestRequestTrailerMapImpl request_trailers{{"", "foo"}};
-  Http::TestResponseTrailerMapImpl response_trailers{{"a", "b"}, {"c", "d"}};
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =


### PR DESCRIPTION
Commit Message: Fix bad assertion on malformed QUIC trailer
Additional Description: This change allows for a graceful stream reset instead of failing an assertion on a malformed QUIC trailer (e.g. uppercase or empty name). Found via fuzz testing by robert.femmer@x41-dsec.de.
Risk Level: Low
Testing: Includes unit test