### PR TITLE
Remove unused public UHV API for individual header validation

### DIFF
--- a/envoy/http/header_validator.h
+++ b/envoy/http/header_validator.h
@@ -54,25 +54,8 @@ public:
 
   enum class RejectAction { Accept, Reject };
   enum class RejectOrRedirectAction { Accept, Reject, Redirect };
-  enum class RejectOrDropHeaderAction { Accept, Reject, DropHeader };
   using RejectResult = Result<RejectAction>;
   using RejectOrRedirectResult = Result<RejectOrRedirectAction>;
-  using RejectOrDropHeaderResult = Result<RejectOrDropHeaderAction>;
-
-  /**
-   * Method for validating a request header entry.
-   * Returning the Reject value causes the request to be rejected with the 400 status.
-   */
-  using HeaderEntryValidationResult = RejectOrDropHeaderResult;
-  virtual HeaderEntryValidationResult validateRequestHeaderEntry(const HeaderString& key,
-                                                                 const HeaderString& value) PURE;
-
-  /**
-   * Method for validating a response header entry.
-   * Returning the Reject value causes the downstream request to be rejected with the 502 status.
-   */
-  virtual HeaderEntryValidationResult validateResponseHeaderEntry(const HeaderString& key,
-                                                                  const HeaderString& value) PURE;
 
   /**
    * Validate the entire request header map.

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -164,7 +164,7 @@ HeaderValidator::validateStatusHeader(const HeaderString& value) {
   return HeaderValueValidationResult::success();
 }
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+HeaderValidator::HeaderEntryValidationResult
 HeaderValidator::validateGenericHeaderName(const HeaderString& name) {
   // Verify that the header name is valid. This also honors the underscore in
   // header configuration setting.
@@ -445,8 +445,7 @@ bool HeaderValidator::hasChunkedTransferEncoding(const HeaderString& value) {
   return false;
 }
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
-HeaderValidator::validateGenericRequestHeaderEntry(
+HeaderValidator::HeaderEntryValidationResult HeaderValidator::validateGenericRequestHeaderEntry(
     const ::Envoy::Http::HeaderString& key, const ::Envoy::Http::HeaderString& value,
     const HeaderValidatorMap& protocol_specific_header_validators) {
   const auto& key_string_view = key.getStringView();

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -27,6 +27,9 @@ public:
           config,
       ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
+  enum class RejectOrDropHeaderAction { Accept, Reject, DropHeader };
+
+  using HeaderEntryValidationResult = Result<RejectOrDropHeaderAction>;
   using HeaderValueValidationResult = RejectResult;
   /*
    * Validate the :method pseudo header, honoring the restrict_http_methods configuration option.
@@ -141,7 +144,7 @@ protected:
   using HeaderValidatorFunction = std::function<HeaderValidator::HeaderValueValidationResult(
       const ::Envoy::Http::HeaderString&)>;
   using HeaderValidatorMap = absl::node_hash_map<absl::string_view, HeaderValidatorFunction>;
-  ::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+  HeaderEntryValidationResult
   validateGenericRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,
                                     const ::Envoy::Http::HeaderString& value,
                                     const HeaderValidatorMap& protocol_specific_header_validators);

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -53,7 +53,7 @@ Http1HeaderValidator::Http1HeaderValidator(const HeaderValidatorConfig& config, 
           {"content-length", absl::bind_front(&HeaderValidator::validateContentLengthHeader, this)},
       } {}
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+HeaderValidator::HeaderEntryValidationResult
 Http1HeaderValidator::validateRequestHeaderEntry(const HeaderString& key,
                                                  const HeaderString& value) {
   // Pseudo headers in HTTP/1.1 are synthesized by the codec from the request line prior to
@@ -62,7 +62,7 @@ Http1HeaderValidator::validateRequestHeaderEntry(const HeaderString& key,
   return validateGenericRequestHeaderEntry(key, value, request_header_validator_map_);
 }
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+HeaderValidator::HeaderEntryValidationResult
 Http1HeaderValidator::validateResponseHeaderEntry(const HeaderString& key,
                                                   const HeaderString& value) {
   const auto& key_string_view = key.getStringView();

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.h
@@ -15,14 +15,6 @@ public:
           config,
       ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
-  HeaderEntryValidationResult
-  validateRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,
-                             const ::Envoy::Http::HeaderString& value) override;
-
-  HeaderEntryValidationResult
-  validateResponseHeaderEntry(const ::Envoy::Http::HeaderString& key,
-                              const ::Envoy::Http::HeaderString& value) override;
-
   RequestHeaderMapValidationResult
   validateRequestHeaderMap(::Envoy::Http::RequestHeaderMap& header_map) override;
 
@@ -42,6 +34,12 @@ public:
   validateTransferEncodingHeader(const ::Envoy::Http::HeaderString& value) const;
 
 private:
+  HeaderEntryValidationResult validateRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,
+                                                         const ::Envoy::Http::HeaderString& value);
+
+  HeaderEntryValidationResult validateResponseHeaderEntry(const ::Envoy::Http::HeaderString& key,
+                                                          const ::Envoy::Http::HeaderString& value);
+
   const HeaderValidatorMap request_header_validator_map_;
 };
 

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -57,13 +57,13 @@ Http2HeaderValidator::Http2HeaderValidator(const HeaderValidatorConfig& config, 
            absl::bind_front(&Http2HeaderValidator::validateContentLengthHeader, this)},
       } {}
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+HeaderValidator::HeaderEntryValidationResult
 Http2HeaderValidator::validateRequestHeaderEntry(const HeaderString& key,
                                                  const HeaderString& value) {
   return validateGenericRequestHeaderEntry(key, value, request_header_validator_map_);
 }
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+HeaderValidator::HeaderEntryValidationResult
 Http2HeaderValidator::validateResponseHeaderEntry(const HeaderString& key,
                                                   const HeaderString& value) {
   const auto& key_string_view = key.getStringView();
@@ -345,7 +345,7 @@ Http2HeaderValidator::validateProtocolHeader(const ::Envoy::Http::HeaderString& 
   return validateGenericHeaderValue(value);
 }
 
-::Envoy::Http::HeaderValidator::HeaderEntryValidationResult
+HeaderValidator::HeaderEntryValidationResult
 Http2HeaderValidator::validateGenericHeaderName(const HeaderString& name) {
   // Verify that the header name is valid. This also honors the underscore in
   // header configuration setting.

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.h
@@ -15,14 +15,6 @@ public:
           config,
       ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
-  HeaderEntryValidationResult
-  validateRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,
-                             const ::Envoy::Http::HeaderString& value) override;
-
-  HeaderEntryValidationResult
-  validateResponseHeaderEntry(const ::Envoy::Http::HeaderString& key,
-                              const ::Envoy::Http::HeaderString& value) override;
-
   RequestHeaderMapValidationResult
   validateRequestHeaderMap(::Envoy::Http::RequestHeaderMap& header_map) override;
 
@@ -54,6 +46,12 @@ public:
   validateGenericHeaderName(const ::Envoy::Http::HeaderString& name) override;
 
 private:
+  HeaderEntryValidationResult validateRequestHeaderEntry(const ::Envoy::Http::HeaderString& key,
+                                                         const ::Envoy::Http::HeaderString& value);
+
+  HeaderEntryValidationResult validateResponseHeaderEntry(const ::Envoy::Http::HeaderString& key,
+                                                          const ::Envoy::Http::HeaderString& value);
+
   const HeaderValidatorMap request_header_validator_map_;
 };
 

--- a/test/extensions/http/header_validators/envoy_default/BUILD
+++ b/test/extensions/http/header_validators/envoy_default/BUILD
@@ -66,7 +66,6 @@ envoy_extension_cc_test_library(
     ],
     extension_names = ["envoy.http.header_validators.envoy_default"],
     deps = [
-        "//source/extensions/http/header_validators/envoy_default:config",
         "//test/mocks/http:header_validator_mocks",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],

--- a/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
@@ -28,16 +28,6 @@ public:
       Protocol protocol, HeaderValidatorStats& stats)
       : HeaderValidator(config, protocol, stats) {}
 
-  HeaderEntryValidationResult validateRequestHeaderEntry(const HeaderString&,
-                                                         const HeaderString&) override {
-    return HeaderEntryValidationResult::success();
-  }
-
-  HeaderEntryValidationResult validateResponseHeaderEntry(const HeaderString&,
-                                                          const HeaderString&) override {
-    return HeaderEntryValidationResult::success();
-  }
-
   RequestHeaderMapValidationResult validateRequestHeaderMap(RequestHeaderMap&) override {
     return RequestHeaderMapValidationResult::success();
   }

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -13,7 +13,12 @@ namespace EnvoyDefault {
 namespace {
 
 using ::Envoy::Http::HeaderString;
+using ::Envoy::Http::LowerCaseString;
 using ::Envoy::Http::Protocol;
+using ::Envoy::Http::TestRequestHeaderMapImpl;
+using ::Envoy::Http::TestRequestTrailerMapImpl;
+using ::Envoy::Http::TestResponseHeaderMapImpl;
+using ::Envoy::Http::TestResponseTrailerMapImpl;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 class Http1HeaderValidatorTest : public HeaderValidatorTest {
@@ -25,141 +30,145 @@ protected:
 
     return std::make_unique<Http1HeaderValidator>(typed_config, Protocol::Http11, stats_);
   }
+
+  TestRequestHeaderMapImpl makeGoodRequestHeaders() {
+    return TestRequestHeaderMapImpl{
+        {":method", "GET"}, {":authority", "envoy.com"}, {":path", "/"}};
+  }
+
+  TestResponseHeaderMapImpl makeGoodResponseHeaders() {
+    return TestResponseHeaderMapImpl{{":status", "200"}};
+  }
 };
 
-TEST_F(Http1HeaderValidatorTest, ValidateTransferEncoding) {
-  HeaderString valid{"chunked"};
-  HeaderString valid_mixed_case{"ChuNKeD"};
-  HeaderString invalid{"gzip"};
+TEST_F(Http1HeaderValidatorTest, GoodHeadersAccepted) {
+  auto uhv = createH1(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  EXPECT_ACCEPT(uhv->validateResponseHeaderMap(response_headers));
+}
+
+TEST_F(Http1HeaderValidatorTest, ValidateTransferEncodingInRequest) {
   auto uhv = createH1(empty_config);
 
-  EXPECT_ACCEPT(uhv->validateTransferEncodingHeader(valid));
-  EXPECT_ACCEPT(uhv->validateTransferEncodingHeader(valid_mixed_case));
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setCopy(LowerCaseString("transfer-encoding"), "ChuNKeD");
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateTransferEncodingHeader(invalid),
+  request_headers.setCopy(LowerCaseString("transfer-encoding"), "gzip");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              "uhv.http1.invalid_transfer_encoding");
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryEmpty) {
-  HeaderString empty{""};
-  HeaderString value{"foo"};
+TEST_F(Http1HeaderValidatorTest, ValidateTransferEncodingInResponse) {
   auto uhv = createH1(empty_config);
 
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(empty, value),
-                             UhvResponseCodeDetail::get().EmptyHeaderName);
+  TestResponseHeaderMapImpl request_headers = makeGoodResponseHeaders();
+  request_headers.setCopy(LowerCaseString("transfer-encoding"), "ChuNKeD");
+  EXPECT_ACCEPT(uhv->validateResponseHeaderMap(request_headers));
+
+  request_headers.setCopy(LowerCaseString("transfer-encoding"), "gzip");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(request_headers),
+                             "uhv.http1.invalid_transfer_encoding");
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryMethod) {
-  HeaderString name{":method"};
-  HeaderString valid{"GET"};
-  HeaderString valid_custom{"CUSTOM-METHOD"};
+TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryCustomMethod) {
   auto uhv = createH1(empty_config);
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, valid));
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, valid_custom));
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setMethod("CUSTOM-METHOD");
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryAuthority) {
-  HeaderString name{":authority"};
-  HeaderString valid{"envoy.com"};
-  HeaderString invalid{"user:pass@envoy.com"};
+TEST_F(Http1HeaderValidatorTest, AuthorityWithUserInfoRejected) {
+  // TODO(yanavlasov): check if this restriction is applied to H/1 protocol
   auto uhv = createH1(empty_config);
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(name, invalid),
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setHost("user:pass@envoy.com");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidHostDeprecatedUserInfo);
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntrySchemeValid) {
-  HeaderString scheme{":scheme"};
-  HeaderString valid{"https"};
-  HeaderString invalid{"http_ssh"};
+TEST_F(Http1HeaderValidatorTest, InvalidSchemeRejected) {
   auto uhv = createH1(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(scheme, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(scheme, invalid),
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setScheme("http_ssh");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidScheme);
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryPath) {
-  HeaderString name{":path"};
-  HeaderString valid{"/"};
-  HeaderString invalid{"/ bad path"};
+TEST_F(Http1HeaderValidatorTest, InvalidPathIsRejected) {
   auto uhv = createH1(empty_config);
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(name, invalid),
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setPath("/ bad path");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidUrl);
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryTransferEncoding) {
-  HeaderString name{"transfer-encoding"};
-  HeaderString valid{"chunked"};
-  HeaderString invalid{"{deflate}"};
+TEST_F(Http1HeaderValidatorTest, ValidateRequestContentLength) {
   auto uhv = createH1(empty_config);
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(name, invalid),
-                             "uhv.http1.invalid_transfer_encoding");
-}
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setContentLength("100");
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestEntryHeaderContentLength) {
-  HeaderString content_length{"content-length"};
-  HeaderString valid{"100"};
-  HeaderString invalid{"10a2"};
-  auto uhv = createH1(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(content_length, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(content_length, invalid),
+  request_headers.setContentLength("10a2");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidContentLength);
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderEntryGeneric) {
-  HeaderString valid_name{"x-foo"};
-  HeaderString invalid_name{"foo oo"};
-  HeaderString valid_value{"bar"};
+TEST_F(Http1HeaderValidatorTest, InvalidRequestHeaderNameRejected) {
+  auto uhv = createH1(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  // This header name is valid
+  request_headers.addCopy("x-foo", "bar");
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 
+  // Reject invalid name
+  request_headers.addCopy("foo oo", "bar");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
+                             UhvResponseCodeDetail::get().InvalidNameCharacters);
+}
+
+TEST_F(Http1HeaderValidatorTest, InvalidRequestHeaderValueRejected) {
+  auto uhv = createH1(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
   HeaderString invalid_value{};
   setHeaderStringUnvalidated(invalid_value, "hello\nworld");
-
-  auto uhv = createH1(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(valid_name, valid_value));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(invalid_name, valid_value),
-                             UhvResponseCodeDetail::get().InvalidNameCharacters);
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(valid_name, invalid_value),
+  request_headers.addViaMove(HeaderString(absl::string_view("x-foo")), std::move(invalid_value));
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidValueCharacters);
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateResponseHeaderEntryEmpty) {
-  HeaderString name{""};
-  HeaderString valid{"chunked"};
+TEST_F(Http1HeaderValidatorTest, InvalidResponseHeaderNameRejected) {
   auto uhv = createH1(empty_config);
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(name, valid),
-                             UhvResponseCodeDetail::get().EmptyHeaderName);
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  // This header name is valid
+  response_headers.addCopy("x-foo", "bar");
+  EXPECT_ACCEPT(uhv->validateResponseHeaderMap(response_headers));
+
+  // Reject invalid name
+  response_headers.addCopy("foo oo", "bar");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
+                             UhvResponseCodeDetail::get().InvalidNameCharacters);
 }
 
-TEST_F(Http1HeaderValidatorTest, ValidateResponseHeaderEntryStatus) {
-  HeaderString name{":status"};
-  HeaderString valid{"200"};
-  HeaderString invalid{"1024"};
+TEST_F(Http1HeaderValidatorTest, InvalidResponseHeaderValueRejected) {
+
   auto uhv = createH1(empty_config);
-  EXPECT_ACCEPT(uhv->validateResponseHeaderEntry(name, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(name, invalid),
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  HeaderString invalid_value{};
+  setHeaderStringUnvalidated(invalid_value, "hello\nworld");
+  response_headers.addViaMove(HeaderString(absl::string_view("x-foo")), std::move(invalid_value));
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
+                             UhvResponseCodeDetail::get().InvalidValueCharacters);
+}
+
+TEST_F(Http1HeaderValidatorTest, InvalidResponseStatusRejected) {
+  auto uhv = createH1(empty_config);
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  response_headers.setStatus("1024");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
                              UhvResponseCodeDetail::get().InvalidStatus);
-}
-
-TEST_F(Http1HeaderValidatorTest, ValidateResponseHeaderEntryGeneric) {
-  HeaderString valid_name{"x-foo"};
-  HeaderString invalid_name{"foo oo"};
-  HeaderString valid_value{"bar"};
-
-  HeaderString invalid_value{};
-  setHeaderStringUnvalidated(invalid_value, "hello\nworld");
-
-  auto uhv = createH1(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateResponseHeaderEntry(valid_name, valid_value));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(invalid_name, valid_value),
-                             UhvResponseCodeDetail::get().InvalidNameCharacters);
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(valid_name, invalid_value),
-                             UhvResponseCodeDetail::get().InvalidValueCharacters);
 }
 
 TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderMapAllowed) {

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -18,7 +18,6 @@ using ::Envoy::Http::Protocol;
 using ::Envoy::Http::TestRequestHeaderMapImpl;
 using ::Envoy::Http::TestRequestTrailerMapImpl;
 using ::Envoy::Http::TestResponseHeaderMapImpl;
-using ::Envoy::Http::TestResponseTrailerMapImpl;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 class Http1HeaderValidatorTest : public HeaderValidatorTest {

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -16,6 +16,10 @@ namespace {
 using ::Envoy::Extensions::Http::HeaderValidators::EnvoyDefault::Http2HeaderValidator;
 using ::Envoy::Http::HeaderString;
 using ::Envoy::Http::Protocol;
+using ::Envoy::Http::TestRequestHeaderMapImpl;
+using ::Envoy::Http::TestRequestTrailerMapImpl;
+using ::Envoy::Http::TestResponseHeaderMapImpl;
+using ::Envoy::Http::TestResponseTrailerMapImpl;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 class Http2HeaderValidatorTest : public HeaderValidatorTest {
@@ -27,7 +31,24 @@ protected:
 
     return std::make_unique<Http2HeaderValidator>(typed_config, Protocol::Http2, stats_);
   }
+
+  TestRequestHeaderMapImpl makeGoodRequestHeaders() {
+    return TestRequestHeaderMapImpl{
+        {":scheme", "https"}, {":method", "GET"}, {":authority", "envoy.com"}, {":path", "/"}};
+  }
+
+  TestResponseHeaderMapImpl makeGoodResponseHeaders() {
+    return TestResponseHeaderMapImpl{{":status", "200"}};
+  }
 };
+
+TEST_F(Http2HeaderValidatorTest, GoodHeadersAccepted) {
+  auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  EXPECT_ACCEPT(uhv->validateResponseHeaderMap(response_headers));
+}
 
 TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMapAllowed) {
   ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
@@ -294,161 +315,165 @@ TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderMapDropUnderscoreHeaders)
   EXPECT_EQ(headers, ::Envoy::Http::TestResponseHeaderMapImpl({{":status", "200"}}));
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateTE) {
-  HeaderString trailers{"trailers"};
-  HeaderString deflate{"deflate"};
-  auto uhv = createH2(empty_config);
-  EXPECT_ACCEPT(uhv->validateTEHeader(trailers));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateTEHeader(deflate), "uhv.http2.invalid_te");
-}
-
 TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderNameRejectConnectionHeaders) {
-  HeaderString transfer_encodings[] = {HeaderString("transfer-encoding"),
-                                       HeaderString("connection"), HeaderString("keep-alive"),
-                                       HeaderString("upgrade"), HeaderString("proxy-connection")};
+  std::string connection_headers[] = {"transfer-encoding", "connection", "keep-alive", "upgrade",
+                                      "proxy-connection"};
   auto uhv = createH2(empty_config);
 
-  for (auto& encoding : transfer_encodings) {
-    EXPECT_REJECT_WITH_DETAILS(uhv->validateGenericHeaderName(encoding),
+  for (auto& header : connection_headers) {
+    TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+    request_headers.addCopy(header, "some-value");
+    EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                                "uhv.http2.connection_header_rejected");
   }
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderAuthority) {
-  HeaderString authority{":authority"};
-  HeaderString valid{"envoy.com"};
-  HeaderString invalid{"user:pass@envoy.com"};
-  auto uhv = createH2(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(authority, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(authority, invalid),
-                             UhvResponseCodeDetail::get().InvalidHostDeprecatedUserInfo);
-}
-
 TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderPath) {
-  HeaderString path{":path"};
-  HeaderString valid{"/"};
-  HeaderString invalid{"/ bad path"};
   auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setPath("/ bad path");
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(path, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(path, invalid),
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidUrl);
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderTE) {
-  HeaderString name{"te"};
-  HeaderString valid{"trailers"};
-  HeaderString invalid{"chunked"};
+TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderTETrailersAllowed) {
   auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.addCopy("te", "trailers");
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(name, invalid),
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
+}
+
+TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderInvalidTERejected) {
+  auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.addCopy("te", "deflate");
+
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              "uhv.http2.invalid_te");
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMethod) {
-  HeaderString method{":method"};
-  HeaderString valid{"GET"};
-  HeaderString invalid{"CUSTOM-METHOD"};
+TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderCustomMethod) {
   auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setMethod("CUSTOM-METHOD");
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(method, valid));
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(method, invalid));
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 }
 
 TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderContentLength) {
-  HeaderString content_length{"content-length"};
-  HeaderString valid{"100"};
-  HeaderString invalid{"10a2"};
   auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setContentLength("100");
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(content_length, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(content_length, invalid),
+  request_headers.setContentLength("10a2");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidContentLength);
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderScheme) {
-  HeaderString scheme{":scheme"};
-  HeaderString valid{"https"};
-  HeaderString invalid{"http_ssh"};
+TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderContentLength) {
   auto uhv = createH2(empty_config);
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  response_headers.setContentLength("100");
+  EXPECT_ACCEPT(uhv->validateResponseHeaderMap(response_headers));
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(scheme, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(scheme, invalid),
+  response_headers.setContentLength("10a2");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
+}
+
+TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderInvalidScheme) {
+  auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  request_headers.setScheme("http_ssh");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidScheme);
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderProtocol) {
-  HeaderString scheme{":protocol"};
-  HeaderString valid{"websocket"};
-  HeaderString invalid{"something \x7F bad"};
+TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderInvalidProtocol) {
   auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl headers{{":scheme", "https"},
+                                   {":method", "CONNECT"},
+                                   {":protocol", "something \x7F bad"},
+                                   {":path", "/foo/bar"},
+                                   {":authority", "envoy.com"}};
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(scheme, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(scheme, invalid),
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(headers),
                              UhvResponseCodeDetail::get().InvalidValueCharacters);
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderGeneric) {
-  HeaderString valid_name{"x-foo"};
-  HeaderString invalid_name{""};
-  HeaderString valid_value{"bar"};
-
-  HeaderString invalid_value;
-  setHeaderStringUnvalidated(invalid_value, "hello\nworld");
-
+TEST_F(Http2HeaderValidatorTest, InvalidRequestHeaderNameRejected) {
   auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  // This header name is valid
+  request_headers.addCopy("x-foo", "bar");
+  EXPECT_ACCEPT(uhv->validateRequestHeaderMap(request_headers));
 
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(valid_name, valid_value));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(invalid_name, valid_value),
-                             UhvResponseCodeDetail::get().EmptyHeaderName);
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderEntry(valid_name, invalid_value),
-                             UhvResponseCodeDetail::get().InvalidValueCharacters);
-}
-
-TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderAllowUnderscores) {
-  HeaderString name{"x_foo"};
-  HeaderString value{"bar"};
-  auto uhv = createH2(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateRequestHeaderEntry(name, value));
-}
-
-TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderStatus) {
-  HeaderString status{":status"};
-  HeaderString valid{"200"};
-  HeaderString invalid{"1024"};
-  auto uhv = createH2(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateResponseHeaderEntry(status, valid));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(status, invalid),
-                             UhvResponseCodeDetail::get().InvalidStatus);
-}
-
-TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderGeneric) {
-  HeaderString valid_name{"x-foo"};
-  HeaderString valid_name_underscore{"x_foo"};
-  HeaderString invalid_name{""};
-  HeaderString valid_value{"bar"};
-  HeaderString invalid_name_uppercase{"X-Foo"};
-
-  HeaderString invalid_value;
-  setHeaderStringUnvalidated(invalid_value, "hello\nworld");
-
-  auto uhv = createH2(empty_config);
-
-  EXPECT_ACCEPT(uhv->validateResponseHeaderEntry(valid_name, valid_value));
-  EXPECT_ACCEPT(uhv->validateResponseHeaderEntry(valid_name_underscore, valid_value));
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(invalid_name, valid_value),
-                             UhvResponseCodeDetail::get().EmptyHeaderName);
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(valid_name, invalid_value),
-                             UhvResponseCodeDetail::get().InvalidValueCharacters);
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderEntry(invalid_name_uppercase, valid_value),
+  // Reject invalid name
+  request_headers.addCopy("foo oo", "bar");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
                              UhvResponseCodeDetail::get().InvalidNameCharacters);
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderName) {
+TEST_F(Http2HeaderValidatorTest, InvalidRequestHeaderValueRejected) {
+  auto uhv = createH2(empty_config);
+  TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+  HeaderString invalid_value{};
+  setHeaderStringUnvalidated(invalid_value, "hello\nworld");
+  request_headers.addViaMove(HeaderString(absl::string_view("x-foo")), std::move(invalid_value));
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaderMap(request_headers),
+                             UhvResponseCodeDetail::get().InvalidValueCharacters);
+}
+
+TEST_F(Http2HeaderValidatorTest, InvalidResponseHeaderNameRejected) {
+  auto uhv = createH2(empty_config);
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  // This header name is valid
+  response_headers.addCopy("x-foo", "bar");
+  EXPECT_ACCEPT(uhv->validateResponseHeaderMap(response_headers));
+
+  // Reject invalid name
+  response_headers.addCopy("foo oo", "bar");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
+                             UhvResponseCodeDetail::get().InvalidNameCharacters);
+}
+
+TEST_F(Http2HeaderValidatorTest, InvalidResponseHeaderValueRejected) {
+
+  auto uhv = createH2(empty_config);
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  HeaderString invalid_value{};
+  setHeaderStringUnvalidated(invalid_value, "hello\nworld");
+  response_headers.addViaMove(HeaderString(absl::string_view("x-foo")), std::move(invalid_value));
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
+                             UhvResponseCodeDetail::get().InvalidValueCharacters);
+}
+
+TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderInvalidStatusRejected) {
+  auto uhv = createH2(empty_config);
+  TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
+  response_headers.setStatus("1024");
+
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(response_headers),
+                             UhvResponseCodeDetail::get().InvalidStatus);
+}
+
+TEST_F(Http2HeaderValidatorTest, ValidateUppercaseResponseHeaderRejected) {
+  auto uhv = createH2(empty_config);
+
+  HeaderString invalid_name_uppercase;
+  setHeaderStringUnvalidated(invalid_name_uppercase, "X-Foo");
+  TestResponseHeaderMapImpl headers = makeGoodResponseHeaders();
+  headers.addViaMove(std::move(invalid_name_uppercase),
+                     HeaderString(absl::string_view("some value")));
+
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaderMap(headers),
+                             UhvResponseCodeDetail::get().InvalidNameCharacters);
+}
+
+TEST_F(Http2HeaderValidatorTest, ValidateRequestGenericHeaderName) {
   auto uhv = createH2(empty_config);
   std::string name{"aaaaa"};
   for (int i = 0; i < 0xff; ++i) {
@@ -457,8 +482,11 @@ TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderName) {
     name[2] = c;
 
     setHeaderStringUnvalidated(header_string, name);
+    TestRequestHeaderMapImpl request_headers = makeGoodRequestHeaders();
+    request_headers.addViaMove(std::move(header_string),
+                               HeaderString(absl::string_view("some value")));
 
-    auto result = uhv->validateGenericHeaderName(header_string);
+    auto result = uhv->validateRequestHeaderMap(request_headers);
     if (testChar(kGenericHeaderNameCharTable, c) && (c < 'A' || c > 'Z')) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
@@ -469,21 +497,27 @@ TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderName) {
   }
 }
 
-TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderKeyStrictInvalidEmpty) {
-  HeaderString invalid_empty{""};
+TEST_F(Http2HeaderValidatorTest, ValidateResponseGenericHeaderName) {
   auto uhv = createH2(empty_config);
+  std::string name{"aaaaa"};
+  for (int i = 0; i < 0xff; ++i) {
+    char c = static_cast<char>(i);
+    HeaderString header_string{"x"};
+    name[2] = c;
 
-  EXPECT_REJECT_WITH_DETAILS(uhv->validateGenericHeaderName(invalid_empty),
-                             UhvResponseCodeDetail::get().EmptyHeaderName);
-}
+    setHeaderStringUnvalidated(header_string, name);
+    TestResponseHeaderMapImpl headers = makeGoodResponseHeaders();
+    headers.addViaMove(std::move(header_string), HeaderString(absl::string_view("some value")));
 
-TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderKeyDropUnderscores) {
-  HeaderString drop_underscore{"x_foo"};
-  auto uhv = createH2(drop_headers_with_underscores_config);
-
-  auto result = uhv->validateGenericHeaderName(drop_underscore);
-  EXPECT_EQ(result.action(), decltype(result)::Action::DropHeader);
-  EXPECT_EQ(result.details(), UhvResponseCodeDetail::get().InvalidUnderscore);
+    auto result = uhv->validateResponseHeaderMap(headers);
+    if (testChar(kGenericHeaderNameCharTable, c) && (c < 'A' || c > 'Z')) {
+      EXPECT_ACCEPT(result);
+    } else if (c != '_') {
+      EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);
+    } else {
+      EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidUnderscore);
+    }
+  }
 }
 
 TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMapNormalizePath) {

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -19,7 +19,6 @@ using ::Envoy::Http::Protocol;
 using ::Envoy::Http::TestRequestHeaderMapImpl;
 using ::Envoy::Http::TestRequestTrailerMapImpl;
 using ::Envoy::Http::TestResponseHeaderMapImpl;
-using ::Envoy::Http::TestResponseTrailerMapImpl;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 class Http2HeaderValidatorTest : public HeaderValidatorTest {

--- a/test/mocks/http/header_validator.h
+++ b/test/mocks/http/header_validator.h
@@ -10,10 +10,6 @@ namespace Http {
 class MockHeaderValidator : public HeaderValidator {
 public:
   ~MockHeaderValidator() override = default;
-  MOCK_METHOD(HeaderEntryValidationResult, validateRequestHeaderEntry,
-              (const HeaderString& key, const HeaderString& value));
-  MOCK_METHOD(HeaderEntryValidationResult, validateResponseHeaderEntry,
-              (const HeaderString& key, const HeaderString& value));
   MOCK_METHOD(RequestHeaderMapValidationResult, validateRequestHeaderMap,
               (RequestHeaderMap & header_map));
   MOCK_METHOD(ResponseHeaderMapValidationResult, validateResponseHeaderMap,


### PR DESCRIPTION
Additional Description:
The public API for individual header validation was not used. This PR removes it from public interface and updates unit tests for these methods with equivalent tests using entire header map validation.

Risk Level: Low, build flag protected
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
