### PR TITLE
Add createPath to Filesystem abstraction

### DIFF
--- a/envoy/filesystem/filesystem.h
+++ b/envoy/filesystem/filesystem.h
@@ -175,6 +175,12 @@ public:
   virtual Api::IoCallResult<FileInfo> stat(absl::string_view path) PURE;
 
   /**
+   * Attempts to create the given path, recursively if necessary.
+   * @return bool true if the directory exists afterwards, or an error status.
+   */
+  virtual Api::IoCallBoolResult createPath(absl::string_view path) PURE;
+
+  /**
    * @return bool whether a directory exists on disk and can be opened for read.
    */
   virtual bool directoryExists(const std::string& path) PURE;

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -182,6 +183,12 @@ Api::IoCallResult<FileInfo> InstanceImplPosix::stat(absl::string_view path) {
     return resultFailure<FileInfo>({}, errno);
   }
   return resultSuccess(infoFromStat(path, s));
+}
+
+Api::IoCallBoolResult InstanceImplPosix::createPath(absl::string_view path) {
+  std::error_code ec;
+  bool result = std::filesystem::create_directories(std::string{path}, ec);
+  return result ? resultSuccess(true) : resultFailure(false, ec.value());
 }
 
 FileImplPosix::FlagsAndMode FileImplPosix::translateFlag(FlagSet in) {

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -62,6 +62,7 @@ public:
   PathSplitResult splitPathFromFilename(absl::string_view path) override;
   bool illegalPath(const std::string& path) override;
   Api::IoCallResult<FileInfo> stat(absl::string_view path) override;
+  Api::IoCallBoolResult createPath(absl::string_view path) override;
 
 private:
   Api::SysCallStringResult canonicalPath(const std::string& path);

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 
 #include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -184,6 +185,12 @@ Api::IoCallResult<FileInfo> InstanceImplWin32::stat(absl::string_view path) {
     return resultFailure<FileInfo>({}, ::GetLastError());
   }
   return resultSuccess(fileInfoFromAttributeData(full_path, data));
+}
+
+Api::IoCallBoolResult InstanceImplWin32::createPath(absl::string_view path) {
+  std::error_code ec;
+  bool result = std::filesystem::create_directories(std::string{path}, ec);
+  return result ? resultSuccess(true) : resultFailure(false, ec.value());
 }
 
 FileImplWin32::FlagsAndMode FileImplWin32::translateFlag(FlagSet in) {

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -96,6 +96,7 @@ public:
   PathSplitResult splitPathFromFilename(absl::string_view path) override;
   bool illegalPath(const std::string& path) override;
   Api::IoCallResult<FileInfo> stat(absl::string_view path) override;
+  Api::IoCallBoolResult createPath(absl::string_view path) override;
 };
 
 using FileImpl = FileImplWin32;

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -361,6 +361,20 @@ TEST_F(FileSystemImplTest, StatOnDirectoryReturnsDirectoryType) {
   EXPECT_EQ(info_result.return_value_.file_type_, FileType::Directory);
 }
 
+TEST_F(FileSystemImplTest, CreatePathCreatesDirectory) {
+  const std::string new_dir_path = TestEnvironment::temporaryPath("envoy_test_dir");
+  const Api::IoCallBoolResult result = file_system_.createPath(new_dir_path);
+  Cleanup cleanup{[new_dir_path]() { TestEnvironment::removePath(new_dir_path); }};
+  EXPECT_TRUE(result.return_value_);
+  EXPECT_THAT(result.err_, ::testing::IsNull()) << result.err_->getErrorDetails();
+  // A bit awkwardly using file_system_.stat to test that the directory exists, because
+  // otherwise we might have to do windows/linux conditional code for this.
+  const Api::IoCallResult<FileInfo> info_result = file_system_.stat(new_dir_path);
+  EXPECT_THAT(info_result.err_, ::testing::IsNull()) << info_result.err_->getErrorDetails();
+  EXPECT_EQ(info_result.return_value_.name_, "envoy_test_dir");
+  EXPECT_EQ(info_result.return_value_.file_type_, FileType::Directory);
+}
+
 TEST_F(FileSystemImplTest, StatOnFileOpenOrClosedMeasuresTheExpectedValues) {
   const std::string file_path =
       TestEnvironment::writeStringToFileForTest("test_envoy", "0123456789");

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -67,6 +67,7 @@ public:
   MOCK_METHOD(PathSplitResult, splitPathFromFilename, (absl::string_view));
   MOCK_METHOD(bool, illegalPath, (const std::string&));
   MOCK_METHOD(Api::IoCallResult<FileInfo>, stat, (absl::string_view));
+  MOCK_METHOD(Api::IoCallBoolResult, createPath, (absl::string_view));
 };
 
 class MockWatcher : public Watcher {

--- a/test/test_common/file_system_for_test.cc
+++ b/test/test_common/file_system_for_test.cc
@@ -121,6 +121,11 @@ Api::IoCallResult<FileInfo> MemfileInstanceImpl::stat(absl::string_view path) {
   return file_system_->stat(path);
 }
 
+Api::IoCallBoolResult MemfileInstanceImpl::createPath(absl::string_view) {
+  // Creating an imaginary path is always successful.
+  return resultSuccess(true);
+}
+
 MemfileInstanceImpl::MemfileInstanceImpl()
     : file_system_{new InstanceImpl()}, use_memfiles_(false) {}
 

--- a/test/test_common/file_system_for_test.h
+++ b/test/test_common/file_system_for_test.h
@@ -42,6 +42,8 @@ public:
 
   Api::IoCallResult<FileInfo> stat(absl::string_view path) override;
 
+  Api::IoCallBoolResult createPath(absl::string_view path) override;
+
 private:
   friend class ScopedUseMemfiles;
 


### PR DESCRIPTION
Commit Message: Add createPath to Filesystem abstraction
Additional Description: This will be useful for file_system_http_cache, enabling it to create a cache directory rather than requiring the target path to already exist.
Risk Level: None, the additional function is not used in this change, and will only impact where it is added later.
Testing: Added test for the success behavior; not sure it's feasible to reliably test the failure behavior.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Implemented identically per-platform.
