### PR TITLE
[file_system_http_cache] add hit/miss stats

### DIFF
--- a/source/extensions/http/cache/file_system_http_cache/lookup_context.cc
+++ b/source/extensions/http/cache/file_system_http_cache/lookup_context.cc
@@ -34,6 +34,7 @@ void FileLookupContext::getHeadersWithLock(LookupHeadersCallback cb) {
         absl::MutexLock lock(&mu_);
         cancel_action_in_flight_ = nullptr;
         if (!open_result.ok()) {
+          cache_.stats().cache_miss_.inc();
           cb(LookupResult{});
           return;
         }
@@ -47,12 +48,14 @@ void FileLookupContext::getHeadersWithLock(LookupHeadersCallback cb) {
               if (!read_result.ok() ||
                   read_result.value()->length() != CacheFileFixedBlock::size()) {
                 invalidateCacheEntry();
+                cache_.stats().cache_miss_.inc();
                 cb(LookupResult{});
                 return;
               }
               header_block_.populateFromStringView(read_result.value()->toString());
               if (!header_block_.isValid()) {
                 invalidateCacheEntry();
+                cache_.stats().cache_miss_.inc();
                 cb(LookupResult{});
                 return;
               }
@@ -64,6 +67,7 @@ void FileLookupContext::getHeadersWithLock(LookupHeadersCallback cb) {
                     if (!read_result.ok() ||
                         read_result.value()->length() != header_block_.headerSize()) {
                       invalidateCacheEntry();
+                      cache_.stats().cache_miss_.inc();
                       cb(LookupResult{});
                       return;
                     }
@@ -75,6 +79,7 @@ void FileLookupContext::getHeadersWithLock(LookupHeadersCallback cb) {
                           absl::StrSplit(header_proto.headers().at(0).value(), ','),
                           lookup().requestHeaders());
                       if (!maybe_vary_key.has_value()) {
+                        cache_.stats().cache_miss_.inc();
                         cb(LookupResult{});
                         return;
                       }
@@ -91,6 +96,7 @@ void FileLookupContext::getHeadersWithLock(LookupHeadersCallback cb) {
                       ASSERT(queued.ok(), queued.ToString());
                       return;
                     }
+                    cache_.stats().cache_hit_.inc();
                     cb(lookup().makeLookupResult(
                         headersFromHeaderProto(header_proto), metadataFromHeaderProto(header_proto),
                         header_block_.bodySize(), header_block_.trailerSize() > 0));

--- a/source/extensions/http/cache/file_system_http_cache/stats.h
+++ b/source/extensions/http/cache/file_system_http_cache/stats.h
@@ -18,6 +18,9 @@ namespace FileSystemHttpCache {
  * - Changes in file size due to header updates are assumed to be negligible, and are ignored.
  *
  * Drift will eventually be reconciled at the next pre-cache-purge measurement.
+ *
+ * There are also cache_hit_ and cache_miss_, defined separately to accommodate extra tags;
+ * these two both go into the stat with key `event`, and with tag `event_type=(hit|miss)`
  **/
 
 #define ALL_CACHE_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)                         \
@@ -27,9 +30,14 @@ namespace FileSystemHttpCache {
   GAUGE(size_limit_bytes, NeverImport)                                                             \
   GAUGE(size_limit_count, NeverImport)                                                             \
   STATNAME(cache)                                                                                  \
-  STATNAME(cache_path)
+  STATNAME(cache_path)                                                                             \
+  STATNAME(event)                                                                                  \
+  STATNAME(event_type)                                                                             \
+  STATNAME(hit)                                                                                    \
+  STATNAME(miss)
 // TODO(ravenblack): Add other stats from DESIGN.md
 
+#define BEEP boop
 #define COUNTER_HELPER_(NAME)                                                                      \
   , NAME##_(                                                                                       \
         Envoy::Stats::Utility::counterFromStatNames(scope, {prefix_, stat_names.NAME##_}, tags_))
@@ -44,15 +52,31 @@ struct CacheStats {
   CacheStats(const CacheStatNames& stat_names, Envoy::Stats::Scope& scope,
              Stats::StatName cache_path)
       : stat_names_(stat_names), prefix_(stat_names_.cache_), cache_path_(cache_path),
-        tags_({{stat_names_.cache_path_, cache_path_}})
+        tags_({{stat_names_.cache_path_, cache_path_}}),
+        tags_hit_(
+            {{stat_names_.cache_path_, cache_path_}, {stat_names_.event_type_, stat_names_.hit_}}),
+        tags_miss_(
+            {{stat_names_.cache_path_, cache_path_}, {stat_names_.event_type_, stat_names_.miss_}})
             ALL_CACHE_STATS(COUNTER_HELPER_, GAUGE_HELPER_, HISTOGRAM_HELPER_, TEXT_READOUT_HELPER_,
-                            STATNAME_HELPER_) {}
+                            STATNAME_HELPER_),
+        cache_hit_(Envoy::Stats::Utility::counterFromStatNames(scope, {prefix_, stat_names.event_},
+                                                               tags_hit_)),
+        cache_miss_(Envoy::Stats::Utility::counterFromStatNames(scope, {prefix_, stat_names.event_},
+                                                                tags_miss_)) {}
+
+private:
   const CacheStatNames& stat_names_;
   const Stats::StatName prefix_;
   const Stats::StatName cache_path_;
   Stats::StatNameTagVector tags_;
+  Stats::StatNameTagVector tags_hit_;
+  Stats::StatNameTagVector tags_miss_;
+
+public:
   ALL_CACHE_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT,
-                  GENERATE_TEXT_READOUT_STRUCT, GENERATE_STATNAME_STRUCT)
+                  GENERATE_TEXT_READOUT_STRUCT, GENERATE_STATNAME_STRUCT);
+  Stats::Counter& cache_hit_;
+  Stats::Counter& cache_miss_;
 };
 
 CacheStats generateStats(CacheStatNames& stat_names, Stats::Scope& scope,

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -214,6 +214,14 @@ TEST_F(FileSystemHttpCacheTest, StatsAreConstructedCorrectly) {
   EXPECT_EQ(cache_->stats().eviction_runs_.tagExtractedName(), "cache.eviction_runs");
   EXPECT_THAT(cache_->stats().eviction_runs_.tags(),
               ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods)));
+  EXPECT_EQ(cache_->stats().cache_hit_.tagExtractedName(), "cache.event");
+  EXPECT_EQ(cache_->stats().cache_miss_.tagExtractedName(), "cache.event");
+  EXPECT_THAT(cache_->stats().cache_hit_.tags(),
+              ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods),
+                                     IsStatTag("event_type", "hit")));
+  EXPECT_THAT(cache_->stats().cache_miss_.tags(),
+              ::testing::ElementsAre(IsStatTag("cache_path", cache_path_no_periods),
+                                     IsStatTag("event_type", "miss")));
 }
 
 TEST_F(FileSystemHttpCacheTest, TrackFileRemovedClampsAtZero) {
@@ -531,6 +539,8 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, FailedOpenForReadReturnsMiss) {
   // File handle didn't get used but is expected to be closed.
   EXPECT_OK(mock_async_file_handle_->close([](absl::Status) {}));
   EXPECT_EQ(result.cache_entry_status_, CacheEntryStatus::Unusable);
+  EXPECT_EQ(cache_->stats().cache_miss_.value(), 1);
+  EXPECT_EQ(cache_->stats().cache_hit_.value(), 0);
 }
 
 TEST_F(FileSystemHttpCacheTestWithMockFiles, FailedReadOfHeaderBlockInvalidatesTheCacheEntry) {


### PR DESCRIPTION
Commit Message: [file_system_http_cache] add hit/miss stats
Additional Description: Add counters for file_system_http_cache, counting cache hits and misses. 
Risk Level: Very low, change is to a WIP extension.
Testing: Covered.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
