### PR TITLE
bazel/ci: Cleanups/fix/update

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -24,6 +24,18 @@ sh_library(
     srcs = ["volatile_env.sh"],
 )
 
+# Stamp derived from tree hash + dirty status if `BAZEL_VOLATILE_DIRTY`
+# is set, otherwise the git commit
+genrule(
+    name = "volatile-scm-hash",
+    outs = ["volatile-scm-hash.txt"],
+    cmd = """
+    grep BUILD_SCM_HASH bazel-out/volatile-status.txt > $@
+    """,
+    stamp = 1,
+    tags = ["no-remote-exec"],
+)
+
 genrule(
     name = "gnu_build_id",
     outs = ["gnu_build_id.ldscript"],

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -35,17 +35,22 @@ echo "STABLE_BUILD_SCM_REVISION ${git_rev}"
 
 # If BAZEL_VOLATILE_DIRTY is set then stamped builds will rebuild uncached when
 # either a tracked file changes or an untracked file is added or removed.
+# Otherwise this just tracks changes to tracked files.
+tracked_hash="$(git ls-files -s | sha256sum | head -c 40)"
 if [[ -n "$BAZEL_VOLATILE_DIRTY" ]]; then
     porcelain_status="$(git status --porcelain | sha256sum)"
-    tracked_status="$(git ls-files -s | sha256sum)"
-    tree_status="$(echo "${porcelain_status}:${tracked_status}" | sha256sum | head -c 40)"
+    diff_status="$(git --no-pager diff | sha256sum)"
+    tree_hash="$(echo "${tracked_hash}:${porcelain_status}:${diff_status}" | sha256sum | head -c 40)"
+    echo "BUILD_SCM_HASH ${tree_hash}"
 else
-    # Check whether there are any uncommitted changes
-    tree_status="Clean"
-    git diff-index --quiet HEAD -- || {
-        tree_status="Modified"
-    }
+    echo "BUILD_SCM_HASH ${tracked_hash}"
 fi
+
+# Check whether there are any uncommitted changes
+tree_status="Clean"
+git diff-index --quiet HEAD -- || {
+    tree_status="Modified"
+}
 
 echo "BUILD_SCM_STATUS ${tree_status}"
 echo "STABLE_BUILD_SCM_STATUS ${tree_status}"

--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -42,8 +42,12 @@ trap_errors () {
 trap trap_errors ERR
 trap exit 1 INT
 
+
 CURRENT=check
-bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/code:check -- --fix -v warn -x mobile/dist/envoy-pom.xml
+# This test runs code check with:
+#   bazel run //tools/code:check -- --fix -v warn -x mobile/dist/envoy-pom.xml
+# see: /tools/code/BUILD
+time bazel test "${BAZEL_BUILD_OPTIONS[@]}" //tools/code:check_test
 
 CURRENT=configs
 bazel run "${BAZEL_BUILD_OPTIONS[@]}" //configs:example_configs_validation

--- a/tools/code/BUILD
+++ b/tools/code/BUILD
@@ -33,3 +33,35 @@ envoy_entry_point(
     ],
     pkg = "envoy.code.check",
 )
+
+genrule(
+    name = "checked",
+    outs = ["checked.txt"],
+    cmd = """
+    $(location :check) \
+        --fix \
+        -v warn \
+        -x mobile/dist/envoy-pom.xml \
+        --extensions_build_config=$(location :extensions_build_config) \
+        --path=%s \
+        -b shellcheck:$(location @com_github_aignas_rules_shellcheck//:shellcheck) \
+        -b gofmt:$(location @go_sdk//:bin/gofmt) \
+      > $@ 2>&1 || :
+    """ % PATH,
+    tags = ["no-remote-exec"],
+    tools = [
+        ":check",
+        ":extensions_build_config",
+        "//bazel:volatile-scm-hash",
+        "@com_github_aignas_rules_shellcheck//:shellcheck",
+        "@go_sdk//:bin/gofmt",
+    ],
+)
+
+sh_test(
+    name = "check_test",
+    srcs = [":check_test.sh"],
+    args = ["$(location :checked)"],
+    data = [":checked"],
+    tags = ["no-remote-exec"],
+)

--- a/tools/code/check_test.sh
+++ b/tools/code/check_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+
+if [[ -s "$1" ]]; then
+    cat "$1"
+    exit 1
+fi

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -196,7 +196,7 @@ genrule(
         '" "api/'.join(API_FILES),
     ),
     stamp = True,
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
 )
 
 # Stamped, local build to get porcelain status of local api tree
@@ -211,5 +211,5 @@ genrule(
         '" "api/'.join(API_FILES),
     ),
     stamp = True,
-    tags = ["no-remote"],
+    tags = ["no-remote-exec"],
 )


### PR DESCRIPTION
- fix a subtle bug introduced in #26496 
- use `no-remote-exec` over `no-remote` to get caching
- switch `envoy.code.check` to use bazel test

Switching to bazel test gives a reasonable speedup in the default case, and in some rare circumstances (cached run against same files) it will allow the test to use cached results

it will also potentially allow the test to be run alongside others, but it already uses any procs available so this probably wont help unless either this test or the other is run remotely - in the case of this test that is probs not desirable as currently it checks non-bazel files from the local fs

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
