### PR TITLE
test: fix the race of UpdateListenerWithDifferentSocketOptionsWhenReusePortDisabled

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -1555,6 +1555,7 @@ TEST_P(ListenerFilterIntegrationTest,
   config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     listener_config_.Swap(bootstrap.mutable_static_resources()->mutable_listeners(0));
     listener_config_.set_name("listener_foo");
+    listener_config_.set_stat_prefix("listener_stat");
     listener_config_.mutable_enable_reuse_port()->set_value(false);
     ENVOY_LOG_MISC(debug, "listener config: {}", listener_config_.DebugString());
     bootstrap.mutable_static_resources()->mutable_listeners()->Clear();
@@ -1587,6 +1588,7 @@ TEST_P(ListenerFilterIntegrationTest,
   ASSERT_TRUE(fake_upstream_connection->waitForData(data.size(), &data));
   tcp_client->close();
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
+  test_server_->waitForGaugeEq("listener.listener_stat.downstream_cx_active", 0);
 
   auto* socket_option = listener_config_.add_socket_options();
   socket_option->set_level(IPPROTO_IP);


### PR DESCRIPTION
Commit Message: test: fix the race of UpdateListenerWithDifferentSocketOptionsWhenReusePortDisabled
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes #26082

