### PR TITLE
test: fix the flaky of RemoveListenerAfterInPlaceUpdate

### DIFF
--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -918,16 +918,18 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterInPlaceUpdate) {
 
   // All the listen socket are closed. include the sockets in the active listener and
   // the sockets in the filter chain draining listener. The new connection should be reset.
-  auto codec1 =
-      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  // The socket are closed asynchronously, so waiting the connection closed here.
-  ASSERT_TRUE(codec1->waitForDisconnect());
-
-  // Test the connection again to ensure the socket is closed.
-  auto codec2 =
-      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  EXPECT_FALSE(codec2->connected());
-  EXPECT_THAT(codec2->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+  while (true) {
+    auto codec =
+        makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
+    // The socket are closed asynchronously, if the socket is connected directly, it means
+    // the listener socket isn't closed yet, we will try next connection.
+    if (codec->connected()) {
+      ASSERT_TRUE(codec->waitForDisconnect());
+      continue;
+    }
+    EXPECT_THAT(codec->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+    break;
+  }
 
   // Ensure the old listener is still in filter chain draining.
   test_server_->waitForGaugeEq("listener_manager.total_filter_chains_draining", 1);
@@ -1010,16 +1012,18 @@ TEST_P(ListenerIntegrationTest, RemoveListenerAfterMultipleInPlaceUpdate) {
 
   // All the listen socket are closed. include the sockets in the active listener and
   // the sockets in the filter chain draining listener. The new connection should be reset.
-  auto codec1 =
-      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  // The socket are closed asynchronously, so waiting the connection closed here.
-  ASSERT_TRUE(codec1->waitForDisconnect());
-
-  // Test the connection again to ensure the socket is closed.
-  auto codec2 =
-      makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
-  EXPECT_FALSE(codec2->connected());
-  EXPECT_THAT(codec2->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+  while (true) {
+    auto codec =
+        makeRawHttpConnection(makeClientConnection(lookupPort(listener_name_)), absl::nullopt);
+    // The socket are closed asynchronously, if the socket is connected directly, it means
+    // the listener socket isn't closed yet, we will try next connection.
+    if (codec->connected()) {
+      ASSERT_TRUE(codec->waitForDisconnect());
+      continue;
+    }
+    EXPECT_THAT(codec->connection()->transportFailureReason(), StartsWith("delayed connect error"));
+    break;
+  }
 
   // Ensure the old listener is still in filter chain draining.
   test_server_->waitForGaugeEq("listener_manager.total_filter_chains_draining", 2);


### PR DESCRIPTION
Commit Message: test: fix the flaky of RemoveListenerAfterInPlaceUpdate
Additional Description:
The listener sockets are closed async, so using a while loop to detect a connect success or not.
Risk Level: low
Testing: flaky test
Fixes #22348

