### PR TITLE
ci: Switch postsubmit default tests -> cached  in separated CI pipelines

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -20,6 +20,10 @@ parameters:
 - name: envoyBuildFilterExample
   type: string
   default: ""
+- name: cacheTestResults
+  displayName: "Cache test results"
+  type: boolean
+  default: true
 
 steps:
 # Set up tmpfs directories for self-hosted agents which have a surplus of mem.
@@ -76,6 +80,8 @@ steps:
     REPO_URI: $(Build.Repository.Uri)
     BUILD_URI: $(Build.BuildUri)
     ENVOY_BUILD_FILTER_EXAMPLE: ${{ parameters.envoyBuildFilterExample }}
+    ${{ if ne(parameters['cacheTestResults'], true) }}:
+      BAZEL_NO_CACHE_TEST_RESULTS: 1
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       AZP_TARGET_BRANCH: "origin/$(System.PullRequest.TargetBranch)"
     ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -26,6 +26,19 @@ variables:
   # A release branch can be either `main` or a `release/v1.x` stable branch
   value: $[or(eq(variables['isMain'], 'true'), eq(variables['isReleaseBranch'], 'true'))]
 
+## CI runs
+# Any scheduled run
+- name: pipelineScheduled
+  value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+# Non-scheduled postsubmit run
+- name: pipelinePostsubmit
+  value: ${{ and(eq(variables['Build.DefinitionName'], 'envoy-postsubmit'), ne(variables.pipelineScheduled, true)) }}
+- name: pipelineCacheWarm
+  value: ${{ and(eq(variables['Build.DefinitionName'], 'envoy-presubmit'), ne(variables['Build.Reason'], 'PullRequest')) }}
+# Any other run (ie PRs)
+- name: pipelineDefault
+  value: ${{ and(ne(variables.pipelineScheduled, true), ne(variables.pipelinePostubmit, true), ne(variables.pipelineCacheWarm, true)) }}
+
 ## Variable settings
 # Caches (tip: append a version suffix while testing caches)
 - name: cacheKeyBuildImage
@@ -37,12 +50,33 @@ variables:
 
 
 stages:
+
 # Presubmit/default
-- ${{ if ne(variables['Build.DefinitionName'], 'envoy-postsubmit') }}:
+- ${{ if eq(variables.pipelineDefault, true) }}:
   - template: stages.yml
 
-# Postsubmit
-- ${{ if eq(variables['Build.DefinitionName'], 'envoy-postsubmit') }}:
+# Scheduled run anywhere
+- ${{ if eq(variables.pipelineScheduled, true) }}:
+  - template: stages.yml
+    parameters:
+      cacheTestResults: false
+
+# Cache warming in presubmit
+- ${{ if eq(variables.pipelineCacheWarm, true) }}:
+  - template: stages.yml
+    parameters:
+      buildStageDeps:
+      - env
+      checkStageDeps:
+      - env
+      checksConcurrency: 10
+      macBuildStageDeps:
+      - env
+      windowsBuildStageDeps:
+      - env
+
+# Postsubmit main/release branches
+- ${{ if eq(variables.pipelinePostsubmit, true) }}:
   - template: stages.yml
     parameters:
       buildStageDeps:

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -1,5 +1,6 @@
 
 parameters:
+## Build stages
 # NB: all stages _must_ depend on `env`
 - name: buildStageDeps
   displayName: "Build stage dependencies"
@@ -29,6 +30,12 @@ parameters:
   displayName: "Check concurrency"
   type: number
   default: 3
+
+## Build settings
+- name: cacheTestResults
+  displayName: "Cache test results"
+  type: boolean
+  default: true
 
 stages:
 - stage: env
@@ -450,6 +457,7 @@ stages:
         managedAgent: false
         ciTarget: bazel.release
         bazelBuildExtraOptions: "--sandbox_base=/tmp/sandbox_base"
+        cacheTestResults: ${{ parameters.cacheTestResults }}
 
   - job: released
     displayName: Complete
@@ -485,6 +493,7 @@ stages:
         rbe: false
         artifactSuffix: ".arm64"
         bazelBuildExtraOptions: "--sandbox_base=/tmp/sandbox_base"
+        cacheTestResults: ${{ parameters.cacheTestResults }}
 
   - job: released
     displayName: Complete
@@ -542,6 +551,7 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
         envoyBuildFilterExample: $(ENVOY_FILTER_EXAMPLE)
+        cacheTestResults: ${{ parameters.cacheTestResults }}
 
   - job: coverage
     displayName: "Linux x64"
@@ -565,6 +575,7 @@ stages:
         rbe: false
         # /tmp/sandbox_base is a tmpfs in CI environment to optimize large I/O for coverage traces
         bazelBuildExtraOptions: "--define=no_debug_info=1 --linkopt=-Wl,-s --test_env=ENVOY_IP_TEST_VERSIONS=v4only --sandbox_base=/tmp/sandbox_base"
+        cacheTestResults: ${{ parameters.cacheTestResults }}
 
     - script: ci/run_envoy_docker.sh 'ci/upload_gcs_artifact.sh /source/generated/$(CI_TARGET) $(CI_TARGET)'
       displayName: "Upload $(CI_TARGET) Report to GCS"

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -91,7 +91,7 @@ trap cleanup EXIT
 
 "$(dirname "$0")"/../bazel/setup_clang.sh "${LLVM_ROOT}"
 
-if [[ "${BUILD_REASON}" != "PullRequest" ]]; then
+if [[ -n "$BAZEL_NO_CACHE_TEST_RESULTS" ]]; then
     VERSION_DEV="$(cut -d- -f2 "${ENVOY_SRCDIR}/VERSION.txt")"
     # Use uncached test results for non-release commits to a branch.
     if [[ $VERSION_DEV == "dev" ]]; then

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -106,6 +106,7 @@ docker run --rm \
        -e BAZEL_REMOTE_CACHE \
        -e ENVOY_STDLIB \
        -e BUILD_REASON \
+       -e BAZEL_NO_CACHE_TEST_RESULTS \
        -e BAZEL_REMOTE_INSTANCE \
        -e BAZEL_REMOTE_INSTANCE_BRANCH \
        -e GOOGLE_BES_PROJECT_ID \


### PR DESCRIPTION
This separates the pipelines ->  schedule/post/presubmit and allows setting test cache policies independently

 In this Pr only scheduled jobs run tests uncached, which should massively speed up the normal postsubmit run, increase the pass rate and reduce resources

To compensate for the loss of information about flaky tests (that can sometimes pass and will be cached) scheduled uncached runs are configured

I will set up the azp scheduling for this as soon as this lands - Im thinking `main` 2x daily and `release/vX` 2x weekly

Fix #26643 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
