### PR TITLE
Revert "Add createPath to Filesystem abstraction (#26609)"

### DIFF
--- a/envoy/filesystem/filesystem.h
+++ b/envoy/filesystem/filesystem.h
@@ -175,12 +175,6 @@ public:
   virtual Api::IoCallResult<FileInfo> stat(absl::string_view path) PURE;
 
   /**
-   * Attempts to create the given path, recursively if necessary.
-   * @return bool true if the directory exists afterwards, or an error status.
-   */
-  virtual Api::IoCallBoolResult createPath(absl::string_view path) PURE;
-
-  /**
    * @return bool whether a directory exists on disk and can be opened for read.
    */
   virtual bool directoryExists(const std::string& path) PURE;

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -4,7 +4,6 @@
 #include <unistd.h>
 
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -183,12 +182,6 @@ Api::IoCallResult<FileInfo> InstanceImplPosix::stat(absl::string_view path) {
     return resultFailure<FileInfo>({}, errno);
   }
   return resultSuccess(infoFromStat(path, s));
-}
-
-Api::IoCallBoolResult InstanceImplPosix::createPath(absl::string_view path) {
-  std::error_code ec;
-  bool result = std::filesystem::create_directories(std::string{path}, ec);
-  return result ? resultSuccess(true) : resultFailure(false, ec.value());
 }
 
 FileImplPosix::FlagsAndMode FileImplPosix::translateFlag(FlagSet in) {

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -62,7 +62,6 @@ public:
   PathSplitResult splitPathFromFilename(absl::string_view path) override;
   bool illegalPath(const std::string& path) override;
   Api::IoCallResult<FileInfo> stat(absl::string_view path) override;
-  Api::IoCallBoolResult createPath(absl::string_view path) override;
 
 private:
   Api::SysCallStringResult canonicalPath(const std::string& path);

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -1,7 +1,6 @@
 #include <fcntl.h>
 
 #include <chrono>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -185,12 +184,6 @@ Api::IoCallResult<FileInfo> InstanceImplWin32::stat(absl::string_view path) {
     return resultFailure<FileInfo>({}, ::GetLastError());
   }
   return resultSuccess(fileInfoFromAttributeData(full_path, data));
-}
-
-Api::IoCallBoolResult InstanceImplWin32::createPath(absl::string_view path) {
-  std::error_code ec;
-  bool result = std::filesystem::create_directories(std::string{path}, ec);
-  return result ? resultSuccess(true) : resultFailure(false, ec.value());
 }
 
 FileImplWin32::FlagsAndMode FileImplWin32::translateFlag(FlagSet in) {

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -96,7 +96,6 @@ public:
   PathSplitResult splitPathFromFilename(absl::string_view path) override;
   bool illegalPath(const std::string& path) override;
   Api::IoCallResult<FileInfo> stat(absl::string_view path) override;
-  Api::IoCallBoolResult createPath(absl::string_view path) override;
 };
 
 using FileImpl = FileImplWin32;

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -361,20 +361,6 @@ TEST_F(FileSystemImplTest, StatOnDirectoryReturnsDirectoryType) {
   EXPECT_EQ(info_result.return_value_.file_type_, FileType::Directory);
 }
 
-TEST_F(FileSystemImplTest, CreatePathCreatesDirectory) {
-  const std::string new_dir_path = TestEnvironment::temporaryPath("envoy_test_dir");
-  const Api::IoCallBoolResult result = file_system_.createPath(new_dir_path);
-  Cleanup cleanup{[new_dir_path]() { TestEnvironment::removePath(new_dir_path); }};
-  EXPECT_TRUE(result.return_value_);
-  EXPECT_THAT(result.err_, ::testing::IsNull()) << result.err_->getErrorDetails();
-  // A bit awkwardly using file_system_.stat to test that the directory exists, because
-  // otherwise we might have to do windows/linux conditional code for this.
-  const Api::IoCallResult<FileInfo> info_result = file_system_.stat(new_dir_path);
-  EXPECT_THAT(info_result.err_, ::testing::IsNull()) << info_result.err_->getErrorDetails();
-  EXPECT_EQ(info_result.return_value_.name_, "envoy_test_dir");
-  EXPECT_EQ(info_result.return_value_.file_type_, FileType::Directory);
-}
-
 TEST_F(FileSystemImplTest, StatOnFileOpenOrClosedMeasuresTheExpectedValues) {
   const std::string file_path =
       TestEnvironment::writeStringToFileForTest("test_envoy", "0123456789");

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -67,7 +67,6 @@ public:
   MOCK_METHOD(PathSplitResult, splitPathFromFilename, (absl::string_view));
   MOCK_METHOD(bool, illegalPath, (const std::string&));
   MOCK_METHOD(Api::IoCallResult<FileInfo>, stat, (absl::string_view));
-  MOCK_METHOD(Api::IoCallBoolResult, createPath, (absl::string_view));
 };
 
 class MockWatcher : public Watcher {

--- a/test/test_common/file_system_for_test.cc
+++ b/test/test_common/file_system_for_test.cc
@@ -121,11 +121,6 @@ Api::IoCallResult<FileInfo> MemfileInstanceImpl::stat(absl::string_view path) {
   return file_system_->stat(path);
 }
 
-Api::IoCallBoolResult MemfileInstanceImpl::createPath(absl::string_view) {
-  // Creating an imaginary path is always successful.
-  return resultSuccess(true);
-}
-
 MemfileInstanceImpl::MemfileInstanceImpl()
     : file_system_{new InstanceImpl()}, use_memfiles_(false) {}
 

--- a/test/test_common/file_system_for_test.h
+++ b/test/test_common/file_system_for_test.h
@@ -42,8 +42,6 @@ public:
 
   Api::IoCallResult<FileInfo> stat(absl::string_view path) override;
 
-  Api::IoCallBoolResult createPath(absl::string_view path) override;
-
 private:
   friend class ScopedUseMemfiles;
 


### PR DESCRIPTION
This reverts commit 7b18ae855ab2605234420d85b5d6e3ada808ff55.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
