### PR TITLE
tracing: get cluster name from cluster info rather than upstream info

### DIFF
--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -197,6 +197,9 @@ TEST_F(RouterFilterTest, UpstreamRequestResetBeforePoolCallbackWithTracing) {
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "local_reset"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
+
   EXPECT_CALL(*child_span_, finishSpan());
 
   EXPECT_CALL(
@@ -234,6 +237,8 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionOverflowWithTracing)
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "overflow"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
   EXPECT_CALL(*child_span_, finishSpan());
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _))
@@ -264,6 +269,9 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeoutWithTracing) 
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "connection_failure"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
+
   EXPECT_CALL(*child_span_, finishSpan());
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _))
@@ -605,6 +613,9 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndEndStreamBeforeResponseWithT
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "protocol_error"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
   EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
+  EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
+
   EXPECT_CALL(*child_span_, finishSpan());
 
   upstream_request->onUpstreamData(test_buffer, true);

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -107,6 +107,7 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       send_xff_(options.send_xff) {
   stream_info_.dynamicMetadata().MergeFrom(options.metadata);
   stream_info_.setIsShadow(options.is_shadow);
+  stream_info_.setUpstreamClusterInfo(parent_.cluster_);
 
   if (options.buffer_body_for_retry) {
     buffered_body_ = std::make_unique<Buffer::OwnedImpl>(account_);

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -218,11 +218,12 @@ void HttpTracerUtility::setCommonTags(Span& span, const StreamInfo::StreamInfo& 
 
   span.setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
 
-  if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-    span.setTag(Tracing::Tags::get().UpstreamCluster,
-                stream_info.upstreamInfo()->upstreamHost()->cluster().name());
+  // Cluster info.
+  if (auto cluster_info = stream_info.upstreamClusterInfo();
+      cluster_info.has_value() && cluster_info.value() != nullptr) {
+    span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info.value()->name());
     span.setTag(Tracing::Tags::get().UpstreamClusterName,
-                stream_info.upstreamInfo()->upstreamHost()->cluster().observabilityName());
+                cluster_info.value()->observabilityName());
   }
 
   // Post response data.

--- a/source/common/tracing/tracer_impl.cc
+++ b/source/common/tracing/tracer_impl.cc
@@ -99,13 +99,16 @@ void TracerUtility::finalizeSpan(Span& span, const TraceContext& trace_context,
     span.setTag(Tracing::Tags::get().PeerAddress, remote_address->asStringView());
   }
 
+  // Cluster info.
+  if (auto cluster_info = stream_info.upstreamClusterInfo();
+      cluster_info.has_value() && cluster_info.value() != nullptr) {
+    span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info.value()->name());
+    span.setTag(Tracing::Tags::get().UpstreamClusterName,
+                cluster_info.value()->observabilityName());
+  }
+
   // Upstream info.
   if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-    span.setTag(Tracing::Tags::get().UpstreamCluster,
-                stream_info.upstreamInfo()->upstreamHost()->cluster().name());
-    span.setTag(Tracing::Tags::get().UpstreamClusterName,
-                stream_info.upstreamInfo()->upstreamHost()->cluster().observabilityName());
-
     auto upstream_address = stream_info.upstreamInfo()->upstreamHost()->address();
 
     span.setTag(Tracing::Tags::get().UpstreamAddress, upstream_address->asStringView());

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -100,6 +100,12 @@ public:
 
 class AsyncClientImplTracingTest : public AsyncClientImplTest {
 public:
+  AsyncClientImplTracingTest() {
+    ON_CALL(stream_info_, upstreamClusterInfo())
+        .WillByDefault(Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(
+            cm_.thread_local_cluster_.cluster_.info_)));
+  }
+
   Tracing::MockSpan parent_span_;
   const std::string child_span_name_{"Test Child Span Name"};
 

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -394,7 +394,11 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
 class RouterTestChildSpan : public RouterTestBase {
 public:
   RouterTestChildSpan()
-      : RouterTestBase(true, false, false, Protobuf::RepeatedPtrField<std::string>{}) {}
+      : RouterTestBase(true, false, false, Protobuf::RepeatedPtrField<std::string>{}) {
+    ON_CALL(callbacks_.stream_info_, upstreamClusterInfo())
+        .WillByDefault(Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(
+            cm_.thread_local_cluster_.cluster_.info_)));
+  }
 };
 
 // Make sure child spans start/inject/finish with a normal flow.

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -45,6 +45,9 @@ protected:
   HttpConnManFinalizerImplTest() {
     Upstream::HostDescriptionConstSharedPtr shared_host(host_);
     stream_info.upstreamInfo()->setUpstreamHost(shared_host);
+    ON_CALL(stream_info, upstreamClusterInfo())
+        .WillByDefault(
+            Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(cluster_info_)));
   }
   struct CustomTagCase {
     std::string custom_tag;
@@ -68,6 +71,8 @@ protected:
   NiceMock<MockSpan> span;
   NiceMock<MockConfig> config;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info_{
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
   Upstream::MockHostDescription* host_{new NiceMock<Upstream::MockHostDescription>()};
 };
 
@@ -171,8 +176,11 @@ TEST_F(HttpConnManFinalizerImplTest, NullRequestHeadersAndNullRouteEntry) {
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
   absl::optional<uint32_t> response_code;
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
+  // No upstream info.
   stream_info.upstreamInfo()->setUpstreamHost(nullptr);
   EXPECT_CALL(stream_info, route()).WillRepeatedly(Return(nullptr));
+  // No cluster info.
+  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
 
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
@@ -248,9 +256,12 @@ TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
   HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
 }
 
-TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
-  host_->cluster_.name_ = "my_upstream_cluster";
-  host_->cluster_.observability_name_ = "my_upstream_cluster_observable";
+TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSetAlthoughNoUpstreamInfo) {
+  // No upstream info.
+  stream_info.upstreamInfo()->setUpstreamHost(nullptr);
+
+  cluster_info_->name_ = "my_upstream_cluster";
+  cluster_info_->observability_name_ = "my_upstream_cluster_observable";
 
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
@@ -261,6 +272,27 @@ TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("my_upstream_cluster")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName),
                            Eq("my_upstream_cluster_observable")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("0")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseSize), Eq("11")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
+
+  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
+}
+
+TEST_F(HttpConnManFinalizerImplTest, NoUpstreamClusterTagSetWhenNoClusterInfo) {
+  // No cluster info.
+  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
+
+  EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
+  EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));
+  absl::optional<uint32_t> response_code;
+  EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
+
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseSize), Eq("11")));
@@ -305,8 +337,8 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
-  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
-  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), "fake_cluster"));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), "observability_name"));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);
@@ -497,8 +529,8 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("UT")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
-  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
-  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), "fake_cluster"));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), "observability_name"));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
                                             &response_trailers, stream_info, config);

--- a/test/common/tracing/tracer_impl_test.cc
+++ b/test/common/tracing/tracer_impl_test.cc
@@ -93,6 +93,9 @@ protected:
   FinalizerImplTest() {
     Upstream::HostDescriptionConstSharedPtr shared_host(host_);
     stream_info.upstreamInfo()->setUpstreamHost(shared_host);
+    ON_CALL(stream_info, upstreamClusterInfo())
+        .WillByDefault(
+            Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(cluster_info_)));
   }
   struct CustomTagCase {
     std::string custom_tag;
@@ -116,6 +119,8 @@ protected:
   NiceMock<MockSpan> span;
   NiceMock<MockConfig> config;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info_{
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
   Upstream::MockHostDescription* host_{new NiceMock<Upstream::MockHostDescription>()};
 };
 
@@ -129,8 +134,8 @@ TEST_F(FinalizerImplTest, TestAll) {
   trace_context.context_protocol_ = "test";
 
   // Set upstream cluster.
-  host_->cluster_.name_ = "my_upstream_cluster";
-  host_->cluster_.observability_name_ = "my_upstream_cluster_observable";
+  cluster_info_->name_ = "my_upstream_cluster_from_cluster_info";
+  cluster_info_->observability_name_ = "my_upstream_cluster_observable_from_cluster_info";
 
   // Enable verbose logs.
   EXPECT_CALL(config, verbose).Times(2).WillRepeatedly(Return(true));
@@ -163,9 +168,10 @@ TEST_F(FinalizerImplTest, TestAll) {
   {
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
-    EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("my_upstream_cluster")));
+    EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster),
+                             Eq("my_upstream_cluster_from_cluster_info")));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName),
-                             Eq("my_upstream_cluster_observable")));
+                             Eq("my_upstream_cluster_observable_from_cluster_info")));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress),
                              Eq("10.0.0.1:443"))); // Upstream address as 'peer.address'
@@ -199,9 +205,10 @@ TEST_F(FinalizerImplTest, TestAll) {
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress),
                              remote_address->asString())); // Downstream address as 'peer.address'
-    EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("my_upstream_cluster")));
+    EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster),
+                             Eq("my_upstream_cluster_from_cluster_info")));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName),
-                             Eq("my_upstream_cluster_observable")));
+                             Eq("my_upstream_cluster_observable_from_cluster_info")));
     EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _));
 
     const auto log_timestamp =
@@ -269,7 +276,12 @@ public:
     tracer_ = std::make_shared<TracerImpl>(std::move(driver_ptr), local_info_);
     Upstream::HostDescriptionConstSharedPtr shared_host(host_);
     stream_info_.upstreamInfo()->setUpstreamHost(shared_host);
+
+    ON_CALL(stream_info_, upstreamClusterInfo())
+        .WillByDefault(
+            Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(cluster_info_)));
   }
+
   Http::TestRequestHeaderMapImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}, {":authority", "test"}};
   Http::TestResponseHeaderMapImpl response_headers_{{":status", "200"},
@@ -282,6 +294,8 @@ public:
   NiceMock<MockConfig> config_;
   NiceMock<MockDriver>* driver_;
   HttpTracerSharedPtr tracer_;
+  std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info_{
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
   Upstream::MockHostDescription* host_{new NiceMock<Upstream::MockHostDescription>()};
 };
 
@@ -341,8 +355,8 @@ TEST_F(TracerImplTest, ChildGrpcUpstreamSpanTest) {
   EXPECT_CALL(stream_info_, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info_, protocol()).WillRepeatedly(ReturnPointee(&protocol));
   EXPECT_CALL(*host_, address()).WillOnce(Return(remote_address));
-  EXPECT_CALL(host_->cluster_, name()).WillOnce(ReturnRef(cluster_name));
-  EXPECT_CALL(host_->cluster_, observabilityName()).WillOnce(ReturnRef(ob_cluster_name));
+  EXPECT_CALL(*cluster_info_, name()).WillOnce(ReturnRef(cluster_name));
+  EXPECT_CALL(*cluster_info_, observabilityName()).WillOnce(ReturnRef(ob_cluster_name));
 
   EXPECT_CALL(*second_span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));


### PR DESCRIPTION


Commit Message: tracing: get cluster name from cluster info rather than upstream info
Additional Description:
See #25887. In the previous impl, we will try to get cluster name from upstream info and set the name in the span. But if there is no valid upstream host, the upstream info will be null and the cluster name will not be set in the span.

In the new impl, we will try to get the cluster name from the cluster info to ensure even there is no valid upstream host, the cluster name will be set in the span.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.