### PR TITLE
mobile: remove GRPCStream's close method

### DIFF
--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -13,6 +13,7 @@ Breaking changes:
 - Envoy Mobile's release builds compile without admin support by default. (``--define=admin_functionality=disabled``) (:issue`#2693 <2693>`)
 - swift/kotlin: remove `gauge`, `timer`, and `distribution` methods from the PulseClient.
 - swift/kotlin: add `cancel` method to `GRPCStream`` type (:issue:`#24780 <24780>`).
+- swift/kotlin: Replace `close` method of `GRPCStream` with `cancel` method (:issue:`#24780 <24780>` :issue:`#26683 <26683>`).
 - all: enable HTTP/3 by default in Engine builders.
 - api: remove ``extendKeepaliveTimeout`` method from engine builders.
 - java: moved the Java builder to use the C++ builder's generated bootstrap, rather than doing YAML string manipulation (:issue: `#25392 <25392>`)

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
@@ -53,15 +53,6 @@ open class Stream(
   }
 
   /**
-   * Close the stream with trailers.
-   *
-   * @param trailers Trailers with which to close the stream.
-   */
-  open fun close(trailers: RequestTrailers) {
-    underlyingStream.sendTrailers(trailers.caseSensitiveHeaders())
-  }
-
-  /**
    * Close the stream with a data frame. By default, the length sent is the
    * **[ByteBuffer.capacity]**. However, the length will rather be **[ByteBuffer.position]**
    * if the Stream was configured to do so - see **[StreamPrototype.useByteBufferPosition]**.

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
@@ -53,6 +53,15 @@ open class Stream(
   }
 
   /**
+   * Close the stream with trailers.
+   *
+   * @param trailers Trailers with which to close the stream.
+   */
+  open fun close(trailers: RequestTrailers) {
+    underlyingStream.sendTrailers(trailers.caseSensitiveHeaders())
+  }
+
+  /**
    * Close the stream with a data frame. By default, the length sent is the
    * **[ByteBuffer.capacity]**. However, the length will rather be **[ByteBuffer.position]**
    * if the Stream was configured to do so - see **[StreamPrototype.useByteBufferPosition]**.

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStream.kt
@@ -51,20 +51,6 @@ class GRPCStream(
   }
 
   /**
-   * Close stream by sending the "end stream" signal to the peer and
-   * then waiting for the peer to finish before actually closing the stream.
-   */
-  fun close() {
-    // TODO(Augustyniak): Remove the method once `cancel` method is proved
-    // to work fine.
-
-    // The gRPC protocol requires the client stream to close with a DATA frame.
-    // More information here:
-    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
-    underlyingStream.close(ByteBuffer.allocate(0))
-  }
-
-  /**
    * Cancel the stream forcefully regardless of whether the peer has more data to send.
    */
   fun cancel() {

--- a/mobile/library/swift/grpc/GRPCStream.swift
+++ b/mobile/library/swift/grpc/GRPCStream.swift
@@ -61,18 +61,6 @@ public final class GRPCStream: NSObject {
     return self
   }
 
-  /// Close stream by sending the "end stream" signal to the peer and
-  /// then waiting for the peer to finish before actually closing the stream.
-  public func close() {
-    // TODO(Augustyniak): Remove the method once `cancel` method is proved
-    // to work fine.
-
-    // The gRPC protocol requires the client stream to close with a DATA frame.
-    // More information here:
-    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
-    self.underlyingStream.close(data: Data())
-  }
-
   /// Cancel the stream forcefully regardless of whether the peer has more data to send.
   public func cancel() {
     self.underlyingStream.cancel()

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
@@ -76,24 +76,6 @@ class GRPCStreamTest {
   }
 
   @Test
-  fun `close is called with empty data frame`() {
-    var closedData: ByteBuffer? = null
-    val streamClient = MockStreamClient { stream ->
-      stream.onRequestData = { data, endStream ->
-        assertThat(endStream).isTrue()
-        closedData = data
-      }
-    }
-
-    GRPCClient(streamClient)
-      .newGRPCStreamPrototype()
-      .start(Executor {})
-      .close()
-
-    assertThat(closedData).isEqualTo(ByteBuffer.allocate(0))
-  }
-
-  @Test
   fun `cancel calls a stream callback`() {
     val countDownLatch = CountDownLatch(1)
     val streamClient = MockStreamClient { stream ->

--- a/mobile/test/swift/GRPCStreamTests.swift
+++ b/mobile/test/swift/GRPCStreamTests.swift
@@ -66,23 +66,6 @@ final class GRPCStreamTests: XCTestCase {
     XCTAssertEqual(kMessage1, sentData.subdata(in: 5..<sentData.count))
   }
 
-  func testCloseIsCalledWithEmptyDataFrame() {
-    var closedData: Data?
-    let streamClient = MockStreamClient { stream in
-      stream.onRequestData = { data, endStream in
-        XCTAssertTrue(endStream)
-        closedData = data
-      }
-    }
-
-    GRPCClient(streamClient: streamClient)
-      .newGRPCStreamPrototype()
-      .start()
-      .close()
-
-    XCTAssertEqual(Data(), closedData)
-  }
-
   func testCancelCallsStreamCallback() {
     let expectation = self.expectation(description: "onCancel callback is called")
     let streamClient = MockStreamClient { stream in


### PR DESCRIPTION
Commit Message: `GRPCStream` should be closed using `cancel` and not a `close` method. Both manual testing and A/B experimentation confirm that the latter results in desired (and better in comparison) perf characteristics.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
