### PR TITLE
ci: Make repo checkout configurable and fix clang-tidy

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -24,8 +24,20 @@ parameters:
   displayName: "Cache test results"
   type: boolean
   default: true
+# Unfortunately, AZP is an unmittigated and undocumented disaster.
+# The definition of primitive types is close to pointless, as depending
+# on where things are set, azp just turns them into strings anyway.
+- name: repoFetchDepth
+  type: string
+  default: 1
+- name: repoFetchTags
+  type: string
+  default: false
 
 steps:
+- checkout: self
+  fetchDepth: ${{ parameters.repoFetchDepth }}
+  fetchTags: ${{ parameters.repoFetchTags }}
 # Set up tmpfs directories for self-hosted agents which have a surplus of mem.
 #
 # NB: Do not add any directory that grow larger than spare memory capacity!

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -512,6 +512,9 @@ stages:
     dependsOn: []
     # Skip checks if only mobile/ or docs/ have changed.
     condition: and(not(canceled()), or(succeeded(), eq(variables['PostSubmit'], true)), ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.docsOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.examplesOnly'], 'true'))
+    variables:
+      REPO_FETCH_DEPTH: 1
+      REPO_FETCH_TAGS: false
     strategy:
       maxParallel: ${{ parameters.checksConcurrency }}
       matrix:
@@ -534,6 +537,8 @@ stages:
           ENVOY_FILTER_EXAMPLE: true
         clang_tidy:
           CI_TARGET: "bazel.clang_tidy"
+          REPO_FETCH_DEPTH: 0
+          REPO_FETCH_TAGS: true
         api:
           CI_TARGET: "bazel.api"
     timeoutInMinutes: 120
@@ -545,6 +550,8 @@ stages:
         ciTarget: $(CI_TARGET)
         envoyBuildFilterExample: $(ENVOY_FILTER_EXAMPLE)
         cacheTestResults: ${{ parameters.cacheTestResults }}
+        repoFetchDepth: $(REPO_FETCH_DEPTH)
+        repoFetchTags: $(REPO_FETCH_TAGS)
 
   - job: coverage
     displayName: "Linux x64"


### PR DESCRIPTION
Currently the clang-tidy script uses git to determine what to compare using clang-tidy-diff

This requires either a full repo checkout or unshallowing it in the script (which it does in some circumstances)

This breaks in cache-warming CI runs (or any non-PR run on presubmit) currently

This PR fixes that by ensuring that clang-tidy always has a full checkout in CI 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
