### PR TITLE
Stats: Do not import for gauges in Overload Manager.

### DIFF
--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -263,9 +263,9 @@ OverloadAction::OverloadAction(const envoy::config::overload::v3::OverloadAction
                                Stats::Scope& stats_scope)
     : state_(OverloadActionState::inactive()),
       active_gauge_(
-          makeGauge(stats_scope, config.name(), "active", Stats::Gauge::ImportMode::Accumulate)),
+          makeGauge(stats_scope, config.name(), "active", Stats::Gauge::ImportMode::NeverImport)),
       scale_percent_gauge_(makeGauge(stats_scope, config.name(), "scale_percent",
-                                     Stats::Gauge::ImportMode::Accumulate)) {
+                                     Stats::Gauge::ImportMode::NeverImport)) {
   for (const auto& trigger_config : config.triggers()) {
     if (!triggers_.try_emplace(trigger_config.name(), createTriggerFromConfig(trigger_config))
              .second) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Stats: Do not import for gauges in Overload Manager.
Additional Description:  It doesn't make sense to accumulate the current reading of an Overload Action across hot restarts; instead they should start from 0.
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:

