### PR TITLE
ci: Set a timeout on docker publish job

### DIFF
--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -657,7 +657,11 @@ stages:
         cp -a $(Build.StagingDirectory)/bazel.release.arm64/bin/release.tar.zst linux/arm64/release.tar.zst
         cp -a $(Build.StagingDirectory)/bazel.release.arm64/bin/schema_validator_tool linux/arm64/schema_validator_tool
 
+        # Debug what files appear to have been downloaded
+        find linux -type f -name "*" | xargs ls -l
+
         ci/docker_ci.sh
+      timeoutInMinutes: 40
       workingDirectory: $(Build.SourcesDirectory)
       env:
         AZP_BRANCH: $(Build.SourceBranch)


### PR DESCRIPTION
Currently there is an issue where using an injected tarball with Docker can hang

This is (hopeful) workaround to just limit the time

Also adds some debugging so we can see what it has downloaded

Related to #26634 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
