### PR TITLE
ci: Fix clang-tidy-diff (again)

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -19,6 +19,7 @@ DIFF_TARGET_REMOTE="${DIFF_TARGET_REMOTE:-origin}"
 DIFF_TARGET_BRANCH="${DIFF_TARGET_BRANCH:-${AZP_TARGET_BRANCH:-origin/main}}"
 # Exclude merges for finding merge base if required
 DIFF_HEAD="$(git rev-list --no-merges HEAD -n1)"
+MERGE_HEAD="$(git rev-list HEAD -n1)"
 
 # Quick syntax check of .clang-tidy.
 ${CLANG_TIDY} -dump-config > /dev/null 2> clang-tidy-config-errors.txt
@@ -102,16 +103,18 @@ function run_clang_tidy() {
 
 function run_clang_tidy_diff() {
   local diff
-  diff="$(git diff "${1}")"
+  diff="$(git diff "${1}" | filter_excludes)"
   if [[ -z "$diff" ]]; then
     echo "No changes detected, skipping clang_tidy_diff"
     return 0
   fi
-  echo "$diff" | filter_excludes | \
+
+  echo "$diff" | \
     python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary="${CLANG_TIDY}" \
       -export-fixes="${FIX_YAML}" -j "${NUM_CPUS:-0}" -p 1 -quiet
 }
+
 
 if [[ $# -gt 0 ]]; then
   echo "Running clang-tidy on: $*"
@@ -126,15 +129,9 @@ else
             DIFF_REF="HEAD^"
         # Presubmit/PR
         elif [[ -n "${BUILD_REASON}" ]]; then
-            # Common ancestor commit
-            if "$(git rev-parse --is-shallow-repository)"; then
-                # Ideally we always want to fetch here, but this can
-                # fail depending on how the repository is checked out.
-                # If the repo is shallow (ie CI) then we have to unshallow it.
-                git fetch "${DIFF_TARGET_REMOTE}"
-                git fetch --unshallow
-            fi
-            DIFF_REF="$(git merge-base "${DIFF_HEAD}" "${DIFF_TARGET_BRANCH}")"
+            # Common ancestor commit - we only want the changes between the merged commit
+            #   and the common ancestor - ie the changes in this PR
+            DIFF_REF="$(git merge-base "${MERGE_HEAD}" "${DIFF_TARGET_BRANCH}")"
         else
             # TODO(phlax): this is the path used for local CI. Make this work
             #    similar to above, allow the `remote` to be configurable, and


### PR DESCRIPTION
the cause of the issue addressed here is that when we were checking out with a shallow checkout github creates a "merge" commit, so the comparison algo worked - it compared against the merge commit.

Switching to non-shallow checkout (to make clang-tidy work more generally and to avoid needing to unshallow in this case) meant that instead the comparison commit was the actual unmerged commit in a given PR - hence a lot more change

Fix #26743

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
