### PR TITLE
eds: introducing EDS resources cache

### DIFF
--- a/envoy/upstream/BUILD
+++ b/envoy/upstream/BUILD
@@ -198,3 +198,12 @@ envoy_cc_library(
     deps = [
     ],
 )
+
+envoy_cc_library(
+    name = "eds_resources_cache_interface",
+    hdrs = ["eds_resources_cache.h"],
+    deps = [
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+    ],
+)

--- a/envoy/upstream/eds_resources_cache.h
+++ b/envoy/upstream/eds_resources_cache.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "envoy/common/optref.h"
+#include "envoy/common/pure.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/endpoint/v3/endpoint.pb.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Upstream {
+
+// An interface for cached resource removed callback.
+class EdsResourceRemovalCallback {
+public:
+  virtual ~EdsResourceRemovalCallback() = default;
+
+  // Invoked when a cached resource is removed from the cache.
+  virtual void onCachedResourceRemoved(absl::string_view resource_name) PURE;
+};
+
+// This is an xDS resources cache for EDS subscriptions. It is a multi-level cache,
+// where the first level is a per-ConfigSource cache, and the second level is
+// per resource-name cache. In addition to saving resources in the cache,
+// retrieving them, and removing them, the cache allows attaching watchers to the
+// retrieved resources using ResourceRemovalCallback. The watchers will be notified when
+// the resource is removed from the cache.
+// This cache is needed to allow EDS subscriptions to use previously fetched
+// EDS resources, but only if no new EDS resource arrives. The removal callback
+// is used to ensure resource TTL is working properly.
+// TODO(adisuissa): In the future this can be a per-xDS resource-type cache.
+class EdsResourcesCache {
+public:
+  virtual ~EdsResourcesCache() = default;
+
+  class ConfigSourceResourcesMap {
+  public:
+    virtual ~ConfigSourceResourcesMap() = default;
+
+    /**
+     * Adds or updates a given resource name with its resource.
+     * Any watcher that was previously assigned to the resource will be removed
+     * without any notification.
+     * @param resource_name the name of the resource to add/update.
+     * @param resource the contents of the resource.
+     */
+    virtual void
+    setResource(absl::string_view resource_name,
+                const envoy::config::endpoint::v3::ClusterLoadAssignment& resource) PURE;
+
+    /**
+     * Removes a resource from the resource cache given the resource name.
+     * The watchers for the resource will be notified that the resource is
+     * removed.
+     * @param resource_name the name of the resource that will be removed from
+     *        the cache.
+     */
+    virtual void removeResource(absl::string_view resource_name) PURE;
+
+    /**
+     * Retrieves a resource from the cache, and adds the given callback (if any)
+     * to the resource's removal list. if the resource is removed, all callbacks
+     * for that resource will be invoked.
+     * @param resource_name the name of the resource to fetch.
+     * @param removal_cb an optional callback that will be invoked if the resource is removed
+     *        in the future. Note that setting the resource will also remove the callback.
+     * @return A reference to the cluster load assignment resource, or nullopt if the
+     *         resource doesn't exist.
+     */
+    virtual OptRef<const envoy::config::endpoint::v3::ClusterLoadAssignment>
+    getResource(absl::string_view resource_name, EdsResourceRemovalCallback* removal_cb) PURE;
+
+    /**
+     * Removes a callback for a given resource name (if it was previously added).
+     * @param resource_name the name of the resource for which the callback should be removed.
+     * @param removal_cb a pointer to the callback that needs to be removed.
+     */
+    virtual void removeCallback(absl::string_view resource_name,
+                                EdsResourceRemovalCallback* removal_cb) PURE;
+
+    /**
+     * Returns the number of items in the cache. Only used in tests.
+     * @return the number of items in the cache.
+     */
+    virtual uint32_t cacheSizeForTest() const PURE;
+  };
+
+  /**
+   * Returns a resource map for the given config source (creates if it doesn't exist).
+   * @param config_source the config source for which a resources map will be returned.
+   * @return a resource map for the config source.
+   */
+  virtual ConfigSourceResourcesMap&
+  getConfigSourceResourceMap(const envoy::config::core::v3::ConfigSource& config_source) PURE;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/extensions/clusters/eds/BUILD
+++ b/source/extensions/clusters/eds/BUILD
@@ -64,3 +64,14 @@ envoy_cc_library(
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
     ],
 )
+
+envoy_cc_library(
+    name = "eds_resources_cache_impl_lib",
+    srcs = ["eds_resources_cache_impl.cc"],
+    hdrs = ["eds_resources_cache_impl.h"],
+    deps = [
+        "//envoy/upstream:eds_resources_cache_interface",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/protobuf:utility_lib",
+    ],
+)

--- a/source/extensions/clusters/eds/eds_resources_cache_impl.cc
+++ b/source/extensions/clusters/eds/eds_resources_cache_impl.cc
@@ -1,0 +1,69 @@
+#include "source/extensions/clusters/eds/eds_resources_cache_impl.h"
+
+#include "source/common/common/logger.h"
+
+namespace Envoy {
+namespace Upstream {
+
+void EdsResourcesCacheImpl::ConfigSourceResourcesMapImpl::setResource(
+    absl::string_view resource_name,
+    const envoy::config::endpoint::v3::ClusterLoadAssignment& resource) {
+  ENVOY_LOG_MISC(trace, "Updating resource {} in the xDS resource cache", resource_name);
+  resources_map_.insert_or_assign(resource_name, ResourceData(resource));
+}
+
+void EdsResourcesCacheImpl::ConfigSourceResourcesMapImpl::removeResource(
+    absl::string_view resource_name) {
+  if (const auto& resource_it = resources_map_.find(resource_name);
+      resource_it != resources_map_.end()) {
+    ENVOY_LOG_MISC(trace, "Removing resource {} from the xDS resource cache", resource_name);
+    // Invoke the callbacks, and remove all watchers.
+    for (auto& removal_cb : resource_it->second.removal_cbs_) {
+      removal_cb->onCachedResourceRemoved(resource_name);
+    }
+    resource_it->second.removal_cbs_.clear();
+
+    // Remove the resource entry from the cache.
+    resources_map_.erase(resource_it);
+  }
+}
+
+OptRef<const envoy::config::endpoint::v3::ClusterLoadAssignment>
+EdsResourcesCacheImpl::ConfigSourceResourcesMapImpl::getResource(
+    absl::string_view resource_name, EdsResourceRemovalCallback* removal_cb) {
+  if (const auto& resource_it = resources_map_.find(resource_name);
+      resource_it != resources_map_.end()) {
+    ENVOY_LOG_MISC(trace, "Returning resource {} from the xDS resource cache", resource_name);
+    // Add the removal callback to the list associated with the resource.
+    if (removal_cb != nullptr) {
+      resource_it->second.removal_cbs_.push_back(removal_cb);
+    }
+    return resource_it->second.resource_;
+  }
+  // The resource doesn't exist in the resource map.
+  return {};
+}
+
+void EdsResourcesCacheImpl::ConfigSourceResourcesMapImpl::removeCallback(
+    absl::string_view resource_name, EdsResourceRemovalCallback* removal_cb) {
+  if (const auto& resource_it = resources_map_.find(resource_name);
+      resource_it != resources_map_.end()) {
+    ENVOY_LOG_MISC(trace, "Removing callback for resource {} from the xDS resource cache",
+                   resource_name);
+    resource_it->second.removal_cbs_.remove(removal_cb);
+  }
+}
+
+EdsResourcesCache::ConfigSourceResourcesMap& EdsResourcesCacheImpl::getConfigSourceResourceMap(
+    const envoy::config::core::v3::ConfigSource& config_source) {
+  // Fetch the resource map for the config source. Create it if it doesn't exist.
+  auto it = config_source_map_.find(config_source);
+  if (it == config_source_map_.end()) {
+    it = config_source_map_.emplace(config_source, std::make_unique<ConfigSourceResourcesMapImpl>())
+             .first;
+  }
+  return *(it->second.get());
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/source/extensions/clusters/eds/eds_resources_cache_impl.cc
+++ b/source/extensions/clusters/eds/eds_resources_cache_impl.cc
@@ -62,7 +62,7 @@ EdsResourcesCache::ConfigSourceResourcesMap& EdsResourcesCacheImpl::getConfigSou
     it = config_source_map_.emplace(config_source, std::make_unique<ConfigSourceResourcesMapImpl>())
              .first;
   }
-  return *(it->second.get());
+  return *(it->second);
 }
 
 } // namespace Upstream

--- a/source/extensions/clusters/eds/eds_resources_cache_impl.h
+++ b/source/extensions/clusters/eds/eds_resources_cache_impl.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "envoy/upstream/eds_resources_cache.h"
+
+#include "source/common/protobuf/utility.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Upstream {
+
+// This is an xDS resources cache for EDS subscriptions. It is a multi-level cache,
+// where the first level is a per-ConfigSource cache, and the second level is
+// per resource-name cache. In addition to saving resources in the cache,
+// retrieving them, and removing them, the cache allows attaching watchers to the
+// retrieved resources using ResourceRemovalCallback. The watchers will be notified when
+// the resource is removed from the cache.
+class EdsResourcesCacheImpl : public EdsResourcesCache {
+public:
+  // A resource-name to resource data map for a specific config source.
+  class ConfigSourceResourcesMapImpl : public EdsResourcesCache::ConfigSourceResourcesMap {
+  public:
+    void setResource(absl::string_view resource_name,
+                     const envoy::config::endpoint::v3::ClusterLoadAssignment& resource) override;
+
+    void removeResource(absl::string_view resource_name) override;
+
+    OptRef<const envoy::config::endpoint::v3::ClusterLoadAssignment>
+    getResource(absl::string_view resource_name, EdsResourceRemovalCallback* removal_cb) override;
+
+    void removeCallback(absl::string_view resource_name,
+                        EdsResourceRemovalCallback* removal_cb) override;
+
+    uint32_t cacheSizeForTest() const override { return resources_map_.size(); }
+
+  private:
+    // The value of the map, holds the resource and the removal callbacks.
+    struct ResourceData {
+      envoy::config::endpoint::v3::ClusterLoadAssignment resource_;
+      std::list<EdsResourceRemovalCallback*> removal_cbs_;
+
+      ResourceData(const envoy::config::endpoint::v3::ClusterLoadAssignment& resource) {
+        resource_.CopyFrom(resource);
+      }
+    };
+    // A map between a resource name and its ResourceData.
+    absl::flat_hash_map<std::string, ResourceData> resources_map_;
+  };
+
+  // The first level cache for a given ConfigSource.
+  ConfigSourceResourcesMap&
+  getConfigSourceResourceMap(const envoy::config::core::v3::ConfigSource& config_source) override;
+
+private:
+  using ConfigSourceResourcesMapPtr = std::unique_ptr<ConfigSourceResourcesMap>;
+
+  // A type for the first-level cache that maps a ConfigSource to the
+  // second-level cache.
+  using ConfigSourceMap =
+      absl::flat_hash_map<envoy::config::core::v3::ConfigSource, ConfigSourceResourcesMapPtr,
+                          MessageUtil, MessageUtil>;
+
+  // The first-level cache, maps a ConfigSource to the second-level cache.
+  ConfigSourceMap config_source_map_;
+};
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/extensions/clusters/eds/BUILD
+++ b/test/extensions/clusters/eds/BUILD
@@ -99,3 +99,12 @@ envoy_cc_test(
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
     ],
 )
+
+envoy_cc_test(
+    name = "eds_resources_cache_impl_test",
+    srcs = ["eds_resources_cache_impl_test.cc"],
+    deps = [
+        "//source/extensions/clusters/eds:eds_resources_cache_impl_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/clusters/eds/eds_resources_cache_impl_test.cc
+++ b/test/extensions/clusters/eds/eds_resources_cache_impl_test.cc
@@ -1,0 +1,284 @@
+#include "source/extensions/clusters/eds/eds_resources_cache_impl.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Upstream {
+
+class EdsResourcesCacheImplTest : public testing::Test {
+public:
+  using ResourceType = envoy::config::endpoint::v3::ClusterLoadAssignment;
+
+  EdsResourcesCacheImplTest() {
+    TestUtility::loadFromYaml(R"EOF(
+      resource_api_version: V3
+      api_config_source:
+        api_type: DELTA_GRPC
+        transport_api_version: V3
+        grpc_services:
+          envoy_grpc:
+            cluster_name: xds_cluster
+      )EOF",
+                              default_config_source_);
+  }
+
+  // An implementation of EdsResourceRemovalCallback that tracks calls with using a counter.
+  struct ResourceRemovalCallbackCounter : public EdsResourceRemovalCallback {
+    void onCachedResourceRemoved(absl::string_view resource_name) override {
+      auto& resource_calls_counter = calls_counter_map_[resource_name];
+      resource_calls_counter++;
+    }
+
+    absl::flat_hash_map<std::string, uint32_t> calls_counter_map_;
+  };
+
+  envoy::config::core::v3::ConfigSource default_config_source_;
+
+  EdsResourcesCacheImpl cache_;
+};
+
+// Validates that simple addition works.
+TEST_F(EdsResourcesCacheImplTest, AddSuccess) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+
+  // Add a resource.
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+}
+
+// Validates that simple addition and update works.
+TEST_F(EdsResourcesCacheImplTest, AddAndSetSuccess) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+
+  // Add a resource.
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Add a new resource.
+  ResourceType new_resource;
+  new_resource.set_cluster_name("new_foo");
+  resources_cache.setResource("new_foo_cla", new_resource);
+  EXPECT_EQ(2, resources_cache.cacheSizeForTest());
+
+  // Update the first resource.
+  ResourceType resource_update;
+  resource_update.set_cluster_name("foo_update");
+  resources_cache.setResource("foo_cla", resource_update);
+  EXPECT_EQ(2, resources_cache.cacheSizeForTest());
+}
+
+// Validates simple addition and fetching works.
+TEST_F(EdsResourcesCacheImplTest, AddAndFetchSuccess) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", nullptr);
+  EXPECT_TRUE(fetched_resource.has_value());
+  EXPECT_EQ("foo", fetched_resource->cluster_name());
+}
+
+// Validates simple addition, update and fetching works.
+TEST_F(EdsResourcesCacheImplTest, AddUpdateAndFetchSuccess) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", nullptr);
+  EXPECT_TRUE(fetched_resource.has_value());
+  EXPECT_EQ("foo", fetched_resource->cluster_name());
+
+  // Update the resource.
+  ResourceType resource_update;
+  resource_update.set_cluster_name("foo_update");
+  resources_cache.setResource("foo_cla", resource_update);
+
+  const auto& fetched_resource2 = resources_cache.getResource("foo_cla", nullptr);
+  EXPECT_TRUE(fetched_resource2.has_value());
+  EXPECT_EQ("foo_update", fetched_resource2->cluster_name());
+}
+
+// Validates that adding and fetching a different resource returns nullopt.
+TEST_F(EdsResourcesCacheImplTest, AddAndFetchNonExistent) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Fetch non-existent resource name.
+  const auto& fetched_resource = resources_cache.getResource("non_existent", nullptr);
+  EXPECT_FALSE(fetched_resource.has_value());
+}
+
+// Validates that fetching from an empty map returns nullopt.
+TEST_F(EdsResourcesCacheImplTest, FetchEmpty) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", nullptr);
+  EXPECT_FALSE(fetched_resource.has_value());
+}
+
+// Validates that adding and removing works.
+TEST_F(EdsResourcesCacheImplTest, AddRemoveThenFetchEmpty) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Remove the resource.
+  resources_cache.removeResource("foo_cla");
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+
+  // Fetch the removed resource name.
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", nullptr);
+  EXPECT_FALSE(fetched_resource.has_value());
+}
+
+// Validates that adding and removing a non-existent resource works.
+TEST_F(EdsResourcesCacheImplTest, AddAndRemoveNonExistent) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Remove the resource.
+  resources_cache.removeResource("non_existent");
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+}
+
+// Validates that the removal from an empty map works.
+TEST_F(EdsResourcesCacheImplTest, RemoveEmpty) {
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+  resources_cache.removeResource("non_existent");
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+}
+
+// Validate removal callback gets notified.
+TEST_F(EdsResourcesCacheImplTest, RemoveCallbackCalled) {
+  ResourceRemovalCallbackCounter callback;
+
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Fetch the resource and register a callback.
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", &callback);
+  EXPECT_TRUE(fetched_resource.has_value());
+  EXPECT_EQ("foo", fetched_resource->cluster_name());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
+
+  // Remove the resource.
+  resources_cache.removeResource("foo_cla");
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+  EXPECT_EQ(1, callback.calls_counter_map_["foo_cla"]);
+}
+
+// Validate removal callback isn't invoked after update.
+TEST_F(EdsResourcesCacheImplTest, RemoveCallbackNotCalledAfterUpdate) {
+  ResourceRemovalCallbackCounter callback;
+
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Fetch the resource and register a callback.
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", &callback);
+  EXPECT_TRUE(fetched_resource.has_value());
+  EXPECT_EQ("foo", fetched_resource->cluster_name());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
+
+  // Update the resource.
+  ResourceType resource_update;
+  resource_update.set_cluster_name("foo_update");
+  resources_cache.setResource("foo_cla", resource_update);
+
+  // Remove the resource.
+  resources_cache.removeResource("foo_cla");
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
+}
+
+// Validate correct removal callback gets notified when multiple resources are used.
+TEST_F(EdsResourcesCacheImplTest, MultipleResourcesRemoveCallbackCalled) {
+  ResourceRemovalCallbackCounter callback;
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+
+  // Add first resource.
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Fetch the resource and register a callback.
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", &callback);
+  EXPECT_TRUE(fetched_resource.has_value());
+  EXPECT_EQ("foo", fetched_resource->cluster_name());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
+
+  // Add second resource.
+  ResourceType resource2;
+  resource2.set_cluster_name("foo2");
+  resources_cache.setResource("foo2_cla", resource2);
+  EXPECT_EQ(2, resources_cache.cacheSizeForTest());
+
+  // Fetch the resource and register a callback.
+  const auto& fetched_resource2 = resources_cache.getResource("foo2_cla", &callback);
+  EXPECT_TRUE(fetched_resource2.has_value());
+  EXPECT_EQ("foo2", fetched_resource2->cluster_name());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo2_cla"]);
+
+  // Remove the first resource.
+  resources_cache.removeResource("foo_cla");
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+  EXPECT_EQ(1, callback.calls_counter_map_["foo_cla"]);
+  EXPECT_EQ(0, callback.calls_counter_map_["foo2_cla"]);
+
+  // Remove the second resource.
+  resources_cache.removeResource("foo2_cla");
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+  EXPECT_EQ(1, callback.calls_counter_map_["foo_cla"]);
+  EXPECT_EQ(1, callback.calls_counter_map_["foo2_cla"]);
+}
+
+// Validate first-level cache is different depending on the ConfigSource.
+TEST_F(EdsResourcesCacheImplTest, SameConfigSourceCache) {
+  auto& resources_cache1 = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache1.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache1.cacheSizeForTest());
+
+  // Use cache with the same ConfigSource.
+  auto& resources_cache_same = cache_.getConfigSourceResourceMap(default_config_source_);
+  EXPECT_EQ(1, resources_cache_same.cacheSizeForTest());
+
+  // Use cache with a different ConfigSource.
+  envoy::config::core::v3::ConfigSource config_source2 = default_config_source_;
+  config_source2.mutable_api_config_source()
+      ->mutable_grpc_services(0)
+      ->mutable_envoy_grpc()
+      ->set_cluster_name("xds_cluster2");
+  auto& resources_cache_different = cache_.getConfigSourceResourceMap(config_source2);
+  EXPECT_EQ(0, resources_cache_different.cacheSizeForTest());
+}
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/extensions/clusters/eds/eds_resources_cache_impl_test.cc
+++ b/test/extensions/clusters/eds/eds_resources_cache_impl_test.cc
@@ -216,6 +216,31 @@ TEST_F(EdsResourcesCacheImplTest, RemoveCallbackNotCalledAfterUpdate) {
   EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
 }
 
+// Validate explicit callback removal does not get notification.
+TEST_F(EdsResourcesCacheImplTest, ExplicitRemoveCallback) {
+  ResourceRemovalCallbackCounter callback;
+
+  auto& resources_cache = cache_.getConfigSourceResourceMap(default_config_source_);
+  ResourceType resource;
+  resource.set_cluster_name("foo");
+  resources_cache.setResource("foo_cla", resource);
+  EXPECT_EQ(1, resources_cache.cacheSizeForTest());
+
+  // Fetch the resource and register a callback.
+  const auto& fetched_resource = resources_cache.getResource("foo_cla", &callback);
+  EXPECT_TRUE(fetched_resource.has_value());
+  EXPECT_EQ("foo", fetched_resource->cluster_name());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
+
+  // Remove the callback.
+  resources_cache.removeCallback("foo_cla", &callback);
+
+  // Remove the resource.
+  resources_cache.removeResource("foo_cla");
+  EXPECT_EQ(0, resources_cache.cacheSizeForTest());
+  EXPECT_EQ(0, callback.calls_counter_map_["foo_cla"]);
+}
+
 // Validate correct removal callback gets notified when multiple resources are used.
 TEST_F(EdsResourcesCacheImplTest, MultipleResourcesRemoveCallbackCalled) {
   ResourceRemovalCallbackCounter callback;


### PR DESCRIPTION
Commit Message: introducing EDS resources cache
Additional Description:

Currently after an EDS-cluster update, Envoy waits for an EDS response. If a timeout occurs, the EDS-cluster will be used without endpoints.
This PR introduces a cache to store EDS resources (ClusterLoadAssignments), that allows invoking a callback when a resource is removed.
This will be followed up by 2 PRs:
- Plumbing the cache in the cluster-manager.
- Modifying the EdsClusterImpl class to use the cache.

Risk Level: low - introducing a new component which isn't used anywhere.
Testing: Adding a unit test for the class.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
Part of #26749