### PR TITLE
ci: Fix for setting `test_tmpdir` in non-RBE

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -121,6 +121,11 @@ BAZEL_BUILD_OPTIONS=(
 [[ "${ENVOY_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=(
   "--test_env=HEAPCHECK=")
 
+if [[ -z "${ENVOY_RBE}" ]]; then
+    export BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")
+    echo "Setting test_tmpdir to ${ENVOY_TEST_TMPDIR}."
+fi
+
 _bazel="$(which bazel)"
 
 bazel () {

--- a/ci/setup_cache.sh
+++ b/ci/setup_cache.sh
@@ -40,7 +40,7 @@ if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
     fi
 
     if [[ -z "${ENVOY_RBE}" ]]; then
-        export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.99 --remote_timeout=600 --test_tmpdir=${ENVOY_TEST_TMPDIR}"
+        export BAZEL_BUILD_EXTRA_OPTIONS+=" --jobs=HOST_CPUS*.99 --remote_timeout=600"
         echo "using local build cache."
     fi
 else


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
