### PR TITLE
ci: Compress coverage tarballs more

### DIFF
--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -82,7 +82,7 @@ if [[ -n "${ENVOY_BUILD_DIR}" ]]; then
     find bazel-testlogs/ -name test.log \
         | tar cf - -T - \
         | bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
-                - -T0 --fast -o "${ENVOY_BUILD_DIR}/testlogs.tar.zst"
+                - -T0 -o "${ENVOY_BUILD_DIR}/testlogs.tar.zst"
     echo "Profile/testlogs collected: ${ENVOY_BUILD_DIR}/testlogs.tar.zst"
 fi
 
@@ -113,12 +113,12 @@ if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
     if [[ -n "${ENVOY_FUZZ_COVERAGE_ARTIFACT}" ]]; then
         tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./fuzz_coverage/' . \
             | bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
-                    - -T0 --fast -o "${ENVOY_FUZZ_COVERAGE_ARTIFACT}"
+                    - -T0 -o "${ENVOY_FUZZ_COVERAGE_ARTIFACT}"
     fi
 elif [[ -n "${ENVOY_COVERAGE_ARTIFACT}" ]]; then
      tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./coverage/' . \
          | bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
-                 - -T0 --fast -o "${ENVOY_COVERAGE_ARTIFACT}"
+                 - -T0 -o "${ENVOY_COVERAGE_ARTIFACT}"
 fi
 
 if [[ "$VALIDATE_COVERAGE" == "true" ]]; then


### PR DESCRIPTION
The self-hosted machines used to run coverage are far from the azp artefact upload, and these machines have lots of cores so compressing more is beneficial.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
