### PR TITLE
owners: update Envoy Mobile owners

### DIFF
--- a/.github/actions/pr_notifier/pr_notifier.py
+++ b/.github/actions/pr_notifier/pr_notifier.py
@@ -39,8 +39,6 @@ MAINTAINERS = {
     'wbpcode': 'U017KF5C0Q6',
     'kyessenov': 'U7KTRAA8M',
     'keith': 'UGS5P90CF',
-    'Augustyniak': 'U017R1YHXGQ',
-    'jpsim': 'U02KAPRELKA',
     'abeyad': 'U03CVM7GPM1',
 }
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -324,7 +324,7 @@ extensions/filters/http/oauth2 @derekargueta @snowp
 /*/extensions/path/uri_template_lib/proto @alyssawilk @yanjunxiang-google
 
 # mobile
-/mobile/ @jpsim @Augustyniak @RyanTheOptimist @alyssawilk @abeyad
+/mobile/ @RyanTheOptimist @alyssawilk @abeyad
 
 # Contrib
 /contrib/exe/ @mattklein123 @lizan

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -52,10 +52,6 @@ routing PRs, questions, etc. to the right place.
 
 The following Envoy maintainers have final say over any changes only affecting /mobile
 
-* JP Simard ([jpsim](https://github.com/jpsim)) (jp@lyft.com)
-  * iOS (swift/objective-c) platform bindings.
-* Rafal Augustyniak ([Augustyniak](https://github.com/Augustyniak)) (raugustyniak@lyft.com)
-  * iOS (swift/objective-c) platform bindings.
 * Ali Beyad ([abeyad](https://github.com/abeyad)) (abeyad@google.com)
   * xDS, C++ integration tests.
 
@@ -112,6 +108,8 @@ contributors to envoy-setec and relevant Slack channels from:
 * Charles Le Borgne ([carloseltuerto](https://github.com/carloseltuerto)) (cleborgne@google.com)
 * William A Rowe Jr ([wrowe](https://github.com/wrowe)) (wrowe@rowe-clan.net)
 * Antonio Vicente ([antoniovicente](https://github.com/antoniovicente)) (avd@google.com)
+* JP Simard ([jpsim](https://github.com/jpsim)) (jp@lyft.com)
+* Rafal Augustyniak ([Augustyniak](https://github.com/Augustyniak)) (raugustyniak@lyft.com)
 
 # Friends of Envoy
 

--- a/mobile/bazel/pom_template.xml
+++ b/mobile/bazel/pom_template.xml
@@ -14,7 +14,7 @@
 
     <name>Envoy Mobile</name>
     <description>Client networking libraries based on the Envoy project.</description>
-    <url>https://github.com/envoyproxy/envoy-mobile</url>
+    <url>https://envoymobile.io</url>
 
     <licenses>
         <license>
@@ -25,25 +25,25 @@
     </licenses>
     <developers>
         <developer>
-            <id>jpsim</id>
-            <name>JP Simard</name>
-            <email>jp@jpsim.com</email>
+            <id>alyssawilk</id>
+            <name>Alyssa Wilk</name>
+            <email>alyssar@google.com</email>
         </developer>
         <developer>
-            <id>goaway</id>
-            <name>Mike Schore</name>
-            <email>mike.schore@gmail.com</email>
+            <id>ryantheoptimist</id>
+            <name>Ryan Hamilton</name>
+            <email>rch@google.com</email>
         </developer>
         <developer>
-            <id>Augustyniak</id>
-            <name>Rafal Augustyniak</name>
-            <email>rafalaugustyniak@gmail.com</email>
+            <id>abeyad</id>
+            <name>Ali Beyad</name>
+            <email>abeyad@google.com</email>
         </developer>
     </developers>
     <scm>
-        <url>https://github.com/envoyproxy/envoy-mobile</url>
-        <connection>scm:git:git@github.com:envoyproxy/envoy-mobile.git</connection>
-        <developerConnection>scm:git:git@github.com:envoyproxy/envoy-mobile.git</developerConnection>
+        <url>https://github.com/envoyproxy/envoy</url>
+        <connection>scm:git:git@github.com:envoyproxy/envoy.git</connection>
+        <developerConnection>scm:git:git@github.com:envoyproxy/envoy.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
Lyft is winding down its involvement in the Envoy Mobile project, and consequently JP and Rafal will no longer be actively maintaining Envoy Mobile.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]