### PR TITLE
change Envoy Mobile min ios version from 12.0 to 13.0

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -19,7 +19,7 @@ build --features=swift.cacheable_swiftmodules
 build --features=swift.debug_prefix_map
 build --host_force_python=PY3
 build --macos_minimum_os=10.14
-build --ios_minimum_os=12.0
+build --ios_minimum_os=13.0
 build --ios_simulator_version=16.1
 build --verbose_failures
 build --workspace_status_command=../bazel/get_workspace_status

--- a/mobile/.swiftlint.yml
+++ b/mobile/.swiftlint.yml
@@ -140,7 +140,7 @@ modifier_order:
   - dynamic
   - convenience
 deployment_target:
-  iOS_deployment_target: 12.0
+  iOS_deployment_target: 13.0
 
 custom_rules:
   newline_after_brace:

--- a/mobile/bazel/config.bzl
+++ b/mobile/bazel/config.bzl
@@ -1,3 +1,3 @@
 """Shared configuration for things we don't want to duplicate"""
 
-MINIMUM_IOS_VERSION = "12.0"
+MINIMUM_IOS_VERSION = "13.0"

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -26,6 +26,7 @@ Breaking changes:
 - clusters: removing the base_h3 cluster. If HTTP/3 is enabled, the base cluster will use HTTP/3 instead. (:issue: `#25814 <25814>`).
 - listeners: switched the default listener from Envoy's TCP listener to a lightweight API listener by default. (:issue: `#25899 <25899>`).
 - headers: removed the APIs for protocol based routing, as best available protocol is now automatically selected (:issue:`#25893 <25893>`).
+- building/iOS: the minimum supported iOS version is now 13.0
 
 Bugfixes:
 

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -26,7 +26,7 @@ Breaking changes:
 - clusters: removing the base_h3 cluster. If HTTP/3 is enabled, the base cluster will use HTTP/3 instead. (:issue: `#25814 <25814>`).
 - listeners: switched the default listener from Envoy's TCP listener to a lightweight API listener by default. (:issue: `#25899 <25899>`).
 - headers: removed the APIs for protocol based routing, as best available protocol is now automatically selected (:issue:`#25893 <25893>`).
-- building/iOS: the minimum supported iOS version is now 13.0
+- building/iOS: the minimum supported iOS version is now 13.0 (:issue: `#24994 <24994>`).
 
 Bugfixes:
 

--- a/mobile/docs/root/start/building/building.rst
+++ b/mobile/docs/root/start/building/building.rst
@@ -59,7 +59,7 @@ iOS requirements
 ----------------
 
 - Xcode 14.1
-- iOS 12.0 or later
+- iOS 13.0 or later
 - Note: Requirements are listed in the :repo:`.bazelrc file <.bazelrc>` and CI scripts
 
 .. _android_aar:


### PR DESCRIPTION
Commit Message: change Envoy Mobile min ios version from 12.0 to 13.0
Risk Level: Low
Testing: Existing tests
Docs Changes: version history is updated
Release Notes: added this change in the pending release note.
Platform Specific Features: ios only
