### PR TITLE
ci: Blow all caches in scheduled runs

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -101,6 +101,8 @@ steps:
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       # sha1sum of `ENVOY_PULL_REQUEST`
       BAZEL_FAKE_SCM_REVISION: e3b4a6e9570da15ac1caffdded17a8bebdc7dfc9
+    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+      BAZEL_FAKE_SCM_REVISION: RANDOM
     ${{ if parameters.rbe }}:
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
       ENVOY_RBE: "1"

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -121,6 +121,11 @@ BAZEL_BUILD_OPTIONS=(
 [[ "${ENVOY_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=(
   "--test_env=HEAPCHECK=")
 
+if [[ "$BAZEL_FAKE_SCM_REVISION" == "RANDOM" ]]; then
+    BAZEL_FAKE_SCM_REVISION="$(tr -dc a-z0-9 </dev/urandom | head -c 43  | sha1sum | cut -d' ' -f1)"
+    export BAZEL_FAKE_SCM_REVISION
+fi
+
 if [[ -z "${ENVOY_RBE}" ]]; then
     export BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")
     echo "Setting test_tmpdir to ${ENVOY_TEST_TMPDIR}."


### PR DESCRIPTION
We might want to revisit this as it will use a lot of resources and caches nothing

I think we do want it for now, partly because we are caching postsubmit tests, so better to use the scheduled run for a full rebuild, also because some jobs can timeout and i think it exposes more flakes - so we want to address those things

Fix #26813 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
