### PR TITLE
bump Envoy-mobile's min macOS version to 10.15

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -18,7 +18,7 @@ build --features=debug_prefix_map_pwd_is_dot
 build --features=swift.cacheable_swiftmodules
 build --features=swift.debug_prefix_map
 build --host_force_python=PY3
-build --macos_minimum_os=10.14
+build --macos_minimum_os=10.15
 build --ios_minimum_os=13.0
 build --ios_simulator_version=16.1
 build --verbose_failures

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -27,7 +27,7 @@ Breaking changes:
 - clusters: removing the base_h3 cluster. If HTTP/3 is enabled, the base cluster will use HTTP/3 instead. (:issue: `#25814 <25814>`).
 - listeners: switched the default listener from Envoy's TCP listener to a lightweight API listener by default. (:issue: `#25899 <25899>`).
 - headers: removed the APIs for protocol based routing, as best available protocol is now automatically selected (:issue:`#25893 <25893>`).
-- building/iOS: the minimum supported iOS version is now 13.0 (:issue: `#24994 <24994>`).
+- build: the minimum supported iOS version is now 13.0 and minimum MacOS version is 10.15 (:issue: `#24994 <24994>`).
 
 Bugfixes:
 


### PR DESCRIPTION
Commit Message: bump Envoy-mobile's min macOS version to 10.15
Risk Level: Low
Testing: Existing tests
Docs Changes: added to pending release note
Release Notes: changed
Platform Specific Features: Apple platforms only.
