### PR TITLE
Some ext_proc_integration_tests are timinig out in ASAN test

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1768,8 +1768,8 @@ TEST_P(ExtProcIntegrationTest, PerRouteGrpcService) {
 TEST_P(ExtProcIntegrationTest, RequestAndResponseMessageNewTimeoutWithHeaderMutation) {
   // Set envoy filter timeout to be 200ms.
   proto_config_.mutable_message_timeout()->set_nanos(200000000);
-  // Config max_message_timeout proto to 10s to enable the new timeout API.
-  proto_config_.mutable_max_message_timeout()->set_seconds(10);
+  // Config max_message_timeout proto to 60s to enable the new timeout API.
+  proto_config_.mutable_max_message_timeout()->set_seconds(60);
 
   initializeConfig();
   HttpIntegrationTest::initialize();
@@ -1785,7 +1785,7 @@ TEST_P(ExtProcIntegrationTest, RequestAndResponseMessageNewTimeoutWithHeaderMuta
         EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_request_headers));
 
         // Sending the new timeout API to extend the timeout.
-        serverSendNewTimeout(500);
+        serverSendNewTimeout(60000);
         // ext_proc server stays idle for 300ms.
         timeSystem().advanceTimeWaitImpl(300ms);
         // Server sends back response with the header mutation instructions.
@@ -1811,7 +1811,7 @@ TEST_P(ExtProcIntegrationTest, RequestAndResponseMessageNewTimeoutWithHeaderMuta
         Http::TestRequestHeaderMapImpl expected_response_headers{{":status", "200"}};
         EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_response_headers));
         // Sending the new timeout API to extend the timeout.
-        serverSendNewTimeout(500);
+        serverSendNewTimeout(60000);
         // ext_proc server stays idle for 300ms.
         timeSystem().advanceTimeWaitImpl(300ms);
         return true;
@@ -1824,8 +1824,8 @@ TEST_P(ExtProcIntegrationTest, RequestAndResponseMessageNewTimeoutWithHeaderMuta
 TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutNoMutation) {
   // Set envoy filter timeout to be 200ms.
   proto_config_.mutable_message_timeout()->set_nanos(200000000);
-  // Config max_message_timeout proto to 10s to enable the new timeout API.
-  proto_config_.mutable_max_message_timeout()->set_seconds(10);
+  // Config max_message_timeout proto to 60s to enable the new timeout API.
+  proto_config_.mutable_max_message_timeout()->set_seconds(60);
 
   initializeConfig();
   HttpIntegrationTest::initialize();
@@ -1834,7 +1834,7 @@ TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutNoMutation) {
   processRequestHeadersMessage(*grpc_upstreams_[0], true,
                                [this](const HttpHeaders&, HeadersResponse&) {
                                  // Sending the new timeout API to extend the timeout.
-                                 serverSendNewTimeout(500);
+                                 serverSendNewTimeout(60000);
                                  // ext_proc server stays idle for 300ms before sending back the
                                  // response.
                                  timeSystem().advanceTimeWaitImpl(300ms);
@@ -1856,16 +1856,16 @@ TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutNoMutation) {
 TEST_P(ExtProcIntegrationTest, RequestMessageNoMutationMultipleNewTimeout) {
   // Set envoy filter timeout to be 200ms.
   proto_config_.mutable_message_timeout()->set_nanos(200000000);
-  // Config max_message_timeout proto to 10s to enable the new timeout API.
-  proto_config_.mutable_max_message_timeout()->set_seconds(10);
+  // Config max_message_timeout proto to 60s to enable the new timeout API.
+  proto_config_.mutable_max_message_timeout()->set_seconds(60);
   initializeConfig();
   HttpIntegrationTest::initialize();
   auto response = sendDownstreamRequest(absl::nullopt);
 
   processRequestHeadersMessage(*grpc_upstreams_[0], true,
                                [this](const HttpHeaders&, HeadersResponse&) {
-                                 // Send a 500ms new timeout update first.
-                                 serverSendNewTimeout(500);
+                                 // Send a 60s new timeout update first.
+                                 serverSendNewTimeout(60000);
                                  // Server wait for 100ms.
                                  timeSystem().advanceTimeWaitImpl(100ms);
                                  // Send the 2nd 10ms new timeout update.

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -48,6 +48,10 @@ namespace Envoy {
 
 #if defined(__has_feature) && __has_feature(thread_sanitizer)
 #define TSAN_TIMEOUT_FACTOR 3
+#elif defined(__has_feature) && __has_feature(address_sanitizer)
+#define TSAN_TIMEOUT_FACTOR 3
+#elif defined(__has_feature) && __has_feature(memory_sanitizer)
+#define TSAN_TIMEOUT_FACTOR 3
 #elif defined(ENVOY_CONFIG_COVERAGE)
 #define TSAN_TIMEOUT_FACTOR 3
 #else

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -48,10 +48,6 @@ namespace Envoy {
 
 #if defined(__has_feature) && __has_feature(thread_sanitizer)
 #define TSAN_TIMEOUT_FACTOR 3
-#elif defined(__has_feature) && __has_feature(address_sanitizer)
-#define TSAN_TIMEOUT_FACTOR 3
-#elif defined(__has_feature) && __has_feature(memory_sanitizer)
-#define TSAN_TIMEOUT_FACTOR 3
 #elif defined(ENVOY_CONFIG_COVERAGE)
 #define TSAN_TIMEOUT_FACTOR 3
 #else


### PR DESCRIPTION
Tests are timing out due to waitForHttpConnection() call or waitForNewStream() taking longer in ASAN tests.  Changing the timeout to be 3 times longer.

Also, the timer added for the new time out API tests are too tight. For example, it sends out a new time out as 500ms, then let the ext_proc service idle for 300ms. In normal cases, the response from upstream will be able to be sent back to the downstream client in time, i.e, before that 500ms timer expires.  However, if the CPU is busy in ASAN tests, the timer can fire up causing the test fails.  So, changing the new timeout to be a much larger number, like 60s to largely avoid such timing issue.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
