### PR TITLE
ci: Add retry on flaky Docker tag command

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -279,7 +279,11 @@ tag_image () {
 
     if [[ -z "$DOCKER_CI_DRYRUN" ]]; then
         echo "..."
-        docker "${docker_tag_args[@]}"
+        docker "${docker_tag_args[@]}" || {
+            echo "Retry Docker tag in 5s ..." >&2
+            sleep 5
+            docker "${docker_tag_args[@]}"
+        }
     fi
 }
 


### PR DESCRIPTION
Workaround/~ fix #26338

This is a docker bug that seems to be triggered by some kinda transient network issue

Not sure how well this will work, but there are not many other options atm

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
