### PR TITLE
http: Allow grpc_http1_reverse_bridge to translate 201.

### DIFF
--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -41,7 +41,7 @@ Grpc::Status::GrpcStatus grpcStatusFromHeaders(Http::ResponseHeaderMap& headers)
   // Notably, we treat an upstream 200 as a successful response. This differs
   // from the standard but is key in being able to transform a successful
   // upstream HTTP response into a gRPC response.
-  if (http_response_status == 200) {
+  if (http_response_status == 200 || http_response_status == 201) {
     return Grpc::Status::WellKnownGrpcStatus::Ok;
   } else {
     return Grpc::Utility::httpToGrpcStatus(http_response_status);


### PR DESCRIPTION
When using the grpc_http1_reverse_bridge filter, one will encounter HTTP services that return 201 instead of 200 when the request resulted in creating a new resource.

Previously, these 201 return codes will turn into gRPC status UNKNOWN, crashing gRPC clients.

This commit updates the filter to also translate the 201 code into a gRPC OK status.