### PR TITLE
Mobile: Ifdef escape some test code which isn't supported on iOS

### DIFF
--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -631,7 +631,10 @@ TEST_P(ClientTest, Encode100Continue) {
 
   // Encode 100 continue should blow up.
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+// Death tests are not supported on iOS.
+#ifndef TARGET_OS_IOS
   EXPECT_DEATH(response_encoder_->encode1xxHeaders(response_headers), "panic: not implemented");
+#endif
 }
 
 TEST_P(ClientTest, EncodeMetadata) {
@@ -658,7 +661,10 @@ TEST_P(ClientTest, EncodeMetadata) {
   MetadataMapPtr metadata_map_ptr = std::make_unique<MetadataMap>(metadata_map);
   MetadataMapVector metadata_map_vector;
   metadata_map_vector.push_back(std::move(metadata_map_ptr));
+// Death tests are not supported on iOS.
+#ifndef TARGET_OS_IOS
   EXPECT_DEATH(response_encoder_->encodeMetadata(metadata_map_vector), "panic: not implemented");
+#endif
 }
 
 TEST_P(ClientTest, NullAccessors) {

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -401,6 +401,8 @@ Json::ObjectSharedPtr TestEnvironment::jsonLoadFromString(const std::string& jso
   return Json::Factory::loadFromString(substitute(json, version));
 }
 
+// This function is not used for Envoy Mobile tests, and ::system() is not supported on iOS.
+#ifndef TARGET_OS_IOS
 void TestEnvironment::exec(const std::vector<std::string>& args) {
   std::stringstream cmd;
   // Symlinked args[0] can confuse Python when importing module relative, so we let Python know
@@ -415,6 +417,7 @@ void TestEnvironment::exec(const std::vector<std::string>& args) {
     RELEASE_ASSERT(false, "");
   }
 }
+#endif
 
 std::string TestEnvironment::writeStringToFileForTest(const std::string& filename,
                                                       const std::string& contents,

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -195,11 +195,15 @@ public:
   jsonLoadFromString(const std::string& json,
                      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
+// This function is not used for Envoy Mobile tests, and ::system() is not supported on iOS.
+#ifndef TARGET_OS_IOS
   /**
    * Execute a program under ::system. Any failure is fatal.
    * @param args program path and arguments.
    */
+
   static void exec(const std::vector<std::string>& args);
+#endif
 
   /**
    * Dumps the contents of the string into a temporary file from temporaryDirectory() + filename.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -195,7 +195,6 @@ public:
   jsonLoadFromString(const std::string& json,
                      Network::Address::IpVersion version = Network::Address::IpVersion::v4);
 
-// This function is not used for Envoy Mobile tests, and ::system() is not supported on iOS.
 #ifndef TARGET_OS_IOS
   /**
    * Execute a program under ::system. Any failure is fatal.


### PR DESCRIPTION
We'd like to run common and cc tests on the iOS simulator inside Google.  The ::system and EXPECT_DEATH calls are not supported on iOS, so I have ifdeffed them out.

I've already made this change internally and enabled iOS tests!