### PR TITLE
http headers: add the rfc 9211 cache-status standard header constant

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -68,6 +68,7 @@ public:
   const LowerCaseString Authentication{"authentication"};
   const LowerCaseString Authorization{"authorization"};
   const LowerCaseString CacheControl{"cache-control"};
+  const LowerCaseString CacheStatus{"cache-status"};
   const LowerCaseString CdnLoop{"cdn-loop"};
   const LowerCaseString ContentEncoding{"content-encoding"};
   const LowerCaseString ConnectAcceptEncoding{"connect-accept-encoding"};


### PR DESCRIPTION
Signed-off-by: Hiram Silvey [hiramj@google.com](mailto:hiramj@google.com)

Commit Message: Adds the RFC 9211 `Cache-Status` standard header constant to headers.h.
Additional Description: This allows clients of Envoy to easily populate the header using an Envoy-defined constant rather than creating their own constants.
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A