### PR TITLE
TCP Health Check: log parity if TCP HC succeed with no payload.

### DIFF
--- a/source/extensions/health_checkers/tcp/health_checker_impl.cc
+++ b/source/extensions/health_checkers/tcp/health_checker_impl.cc
@@ -108,6 +108,7 @@ void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onEvent(Network::Connect
     // TODO(mattklein123): In the case that a user configured bytes to write, they will not be
     // be written, since we currently have no way to know if the bytes actually get written via
     // the connection interface. We might want to figure out how to handle this better later.
+    ENVOY_CONN_LOG(trace, "healthcheck passed", *client_);
     expect_close_ = true;
     client_->close(Network::ConnectionCloseType::Abort);
     handleSuccess(false);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: TCP Health Check: log parity if TCP HC succeed with no payload.
Additional Description: Already exist if there is payload.
Risk Level: low
Testing: ran test
Docs Changes: na
Release Notes: na
Platform Specific Features: na
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
