### PR TITLE
Make envoy compile at least with GCC 11.3.x on RHEL9 and derivatives

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -68,7 +68,7 @@ def envoy_copts(repository, test = False):
                    "-Wc++2a-extensions",
                    "-Wrange-loop-analysis",
                ],
-               repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
+               repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized", "-Wno-error=uninitialized"],
                # Allow 'nodiscard' function results values to be discarded for test code only
                # TODO(envoyproxy/windows-dev): Replace /Zc:preprocessor with /experimental:preprocessor
                # for msvc versions between 15.8 through 16.4.x. see


### PR DESCRIPTION
Commit Message:
By default, warnings are treated as errors as -Werror is set. Because of the use of uninitialized structures, some versions of GCC seem to become unhappy. If we treat them as warnings compilation will work. See discussion in envoyproxy/envoy#23783

Additional Description: N/A
Risk Level: Low
Testing: Compiles now ;)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #23783 
