### PR TITLE
bazel: remove pch dep when disabled

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -6,7 +6,7 @@ load(
     "envoy_external_dep_path",
     "envoy_linkstatic",
 )
-load(":envoy_pch.bzl", "envoy_pch_copts")
+load(":envoy_pch.bzl", "envoy_pch_copts", "envoy_pch_deps")
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load(
     "@envoy_build_config//:extensions_build_config.bzl",
@@ -129,12 +129,11 @@ def envoy_cc_library(
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//envoy/common:base_includes",
             repository + "//source/common/common:fmt_lib",
-            repository + "//source/common/common:common_pch",
             envoy_external_dep_path("abseil_flat_hash_map"),
             envoy_external_dep_path("abseil_flat_hash_set"),
             envoy_external_dep_path("abseil_strings"),
             envoy_external_dep_path("fmtlib"),
-        ],
+        ] + envoy_pch_deps(repository, "//source/common/common:common_pch"),
         alwayslink = alwayslink,
         linkstatic = envoy_linkstatic(),
         strip_include_prefix = strip_include_prefix,

--- a/bazel/envoy_pch.bzl
+++ b/bazel/envoy_pch.bzl
@@ -8,6 +8,12 @@ load(
 )
 load(":pch.bzl", "pch")
 
+def envoy_pch_deps(repository, target):
+    return select({
+        repository + "//bazel:clang_pch_build": [repository + target],
+        "//conditions:default": [],
+    })
+
 def envoy_pch_copts(repository, target):
     return select({
         repository + "//bazel:clang_pch_build": [

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -4,7 +4,7 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "fuzzing_decoration")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
-load(":envoy_pch.bzl", "envoy_pch_copts")
+load(":envoy_pch.bzl", "envoy_pch_copts", "envoy_pch_deps")
 load(
     ":envoy_internal.bzl",
     "envoy_copts",
@@ -41,7 +41,7 @@ def _envoy_cc_test_infrastructure_library(
     if disable_pch:
         extra_deps = [envoy_external_dep_path("googletest")]
     else:
-        extra_deps = [repository + "//test:test_pch"]
+        extra_deps = envoy_pch_deps(repository, "//test:test_pch")
         pch_copts = envoy_pch_copts(repository, "//test:test_pch")
 
     native.cc_library(
@@ -176,10 +176,7 @@ def envoy_cc_test(
         deps = envoy_stdlib_deps() + deps + [envoy_external_dep_path(dep) for dep in external_deps + ["googletest"]] + [
             repository + "//test:main",
             repository + "//test/test_common:test_version_linkstamp",
-        ] + select({
-            repository + "//bazel:clang_pch_build": [repository + "//test:test_pch"],
-            "//conditions:default": [],
-        }),
+        ] + envoy_pch_deps(repository, "//test:test_pch"),
         # from https://github.com/google/googletest/blob/6e1970e2376c14bf658eb88f655a054030353f9f/googlemock/src/gmock.cc#L51
         # 2 - by default, mocks act as StrictMocks.
         args = args + ["--gmock_default_mock_behavior=2"],

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -221,6 +221,9 @@ envoy_cc_library(
     name = "base_logger_lib",
     srcs = ["base_logger.cc"],
     hdrs = ["base_logger.h"],
+    external_deps = [
+        "spdlog",
+    ],
 )
 
 envoy_cc_library(

--- a/test/tools/schema_validator/BUILD
+++ b/test/tools/schema_validator/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test_library(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
     ],
 )

--- a/test/tools/schema_validator/validator.cc
+++ b/test/tools/schema_validator/validator.cc
@@ -4,6 +4,7 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.validate.h"
 #include "envoy/config/route/v3/route.pb.h"
 #include "envoy/config/route/v3/route.pb.validate.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 #include "envoy/service/discovery/v3/discovery.pb.validate.h"
 


### PR DESCRIPTION
This should break some unnecessary rebuilding in the case you don't actually use the pch feature.