### PR TITLE
http: add runtime value for max requests headers size

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -27,6 +27,11 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: http
+  change: |
+    added Runtime feature ``envoy.reloadable_features.max_request_headers_size_kb`` to override the default value of
+    :ref:`max request headers size
+    <envoy_api_field_config.filter.network.http_connection_manager.v3.HttpConnectionManager.max_request_headers_size_kb>`.
 - area: redis_proxy
   change: |
     added new configuration field :ref:`key_formatter

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,7 +31,7 @@ new_features:
   change: |
     added Runtime feature ``envoy.reloadable_features.max_request_headers_size_kb`` to override the default value of
     :ref:`max request headers size
-    <envoy_api_field_config.filter.network.http_connection_manager.v3.HttpConnectionManager.max_request_headers_size_kb>`.
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.max_request_headers_kb>`.
 - area: redis_proxy
   change: |
     added new configuration field :ref:`key_formatter

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -44,6 +44,8 @@ const char MaxRequestHeadersCountOverrideKey[] =
     "envoy.reloadable_features.max_request_headers_count";
 const char MaxResponseHeadersCountOverrideKey[] =
     "envoy.reloadable_features.max_response_headers_count";
+const char MaxRequestHeadersSizeOverrideKey[] =
+    "envoy.reloadable_features.max_request_headers_size_kb";
 
 class Stream;
 class RequestDecoder;

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -325,7 +325,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
           config.stream_error_on_invalid_http_message(),
           xff_num_trusted_hops_ == 0 && use_remote_address_)),
       max_request_headers_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          config, max_request_headers_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_KB)),
+          config, max_request_headers_kb,
+          context.runtime().snapshot().getInteger(Http::MaxRequestHeadersSizeOverrideKey,
+                                                  Http::DEFAULT_MAX_REQUEST_HEADERS_KB))),
       max_request_headers_count_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config.common_http_protocol_options(), max_headers_count,
           context.runtime().snapshot().getInteger(Http::MaxRequestHeadersCountOverrideKey,

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -795,6 +795,28 @@ TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersKbMaxConfigurable) {
   EXPECT_EQ(8192, config.maxRequestHeadersKb());
 }
 
+TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersKbMaxConfiguredViaRuntime) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF";
+
+  ON_CALL(context_.runtime_loader_.snapshot_,
+          getInteger("envoy.reloadable_features.max_request_headers_size_kb", 60))
+      .WillByDefault(Return(9000));
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_, tracer_manager_,
+                                     filter_config_provider_manager_);
+  EXPECT_EQ(9000, config.maxRequestHeadersKb());
+}
+
 // Validated that an explicit zero stream idle timeout disables.
 TEST_F(HttpConnectionManagerConfigTest, DisabledStreamIdleTimeout) {
   const std::string yaml_string = R"EOF(


### PR DESCRIPTION
Commit Message: add runtime value for max requests headers size
Additional Description: add runtime value for max requests headers size so that the global value can be configured and changed at runtime as needed
Risk Level: Low
Testing: Updated
Docs Changes: N/A
Release Notes: Added

