### PR TITLE
doc: `google_re2` for type type.matcher.v3.RegexMatcher is not required any more

### DIFF
--- a/api/envoy/type/matcher/v3/regex.proto
+++ b/api/envoy/type/matcher/v3/regex.proto
@@ -57,11 +57,8 @@ message RegexMatcher {
 
   oneof engine_type {
     // Google's RE2 regex engine.
-    GoogleRE2 google_re2 = 1 [
-      deprecated = true,
-      (validate.rules).message = {required: true},
-      (envoy.annotations.deprecated_at_minor_version) = "3.0"
-    ];
+    GoogleRE2 google_re2 = 1
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   // The regex match string. The string must be supported by the configured engine. The regex is matched


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Correction of a proto model to fix the actual state in envoy. The field was both required & deprecated. During execution, it was not required anymore. 
Additional Description: 
Risk Level: Low
Testing: None
Docs Changes: Correction of a proto model to fix the actual state in envoy. The field was both required & deprecated. During execution, it was not required anymore.
Release Notes: None
Platform Specific Features: None
Fixes https://github.com/envoyproxy/envoy/issues/26875
