### PR TITLE
fix network local ratelimit connection close without reason

### DIFF
--- a/source/extensions/filters/network/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/network/local_ratelimit/local_ratelimit.cc
@@ -108,7 +108,8 @@ Network::FilterStatus Filter::onNewConnection() {
                    read_callbacks_->connection());
     read_callbacks_->connection().streamInfo().setResponseFlag(
         StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded);
-    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush,
+                                        "local_ratelimit_close_over_limit");
     return Network::FilterStatus::StopIteration;
   }
 

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
@@ -94,7 +94,8 @@ token_bucket:
   ActiveFilter active_filter2(config_);
   EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded));
-  EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_, close(_, _));
+  EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::NoFlush, "local_ratelimit_close_over_limit"));
   EXPECT_EQ(Network::FilterStatus::StopIteration, active_filter2.filter_.onNewConnection());
   EXPECT_EQ(1, TestUtility::findCounter(stats_store_,
                                         "local_rate_limit.local_rate_limit_stats.rate_limited")

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
@@ -94,7 +94,7 @@ token_bucket:
   ActiveFilter active_filter2(config_);
   EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded));
-  EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_, close(_));
+  EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_, close(_, _));
   EXPECT_EQ(Network::FilterStatus::StopIteration, active_filter2.filter_.onNewConnection());
   EXPECT_EQ(1, TestUtility::findCounter(stats_store_,
                                         "local_rate_limit.local_rate_limit_stats.rate_limited")


### PR DESCRIPTION
Commit Message: fix network local ratelimit connection close without reason
Additional Description: N/A
Risk Level: low
Testing: ut
Docs Changes: N/A
Release Notes: N/A
