### PR TITLE
ci: remove unneeded export

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -142,7 +142,7 @@ BAZEL_BUILD_OPTIONS=(
   "--test_env=HEAPCHECK=")
 
 if [[ -z "${ENVOY_RBE}" ]]; then
-    export BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")
+    BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")
     echo "Setting test_tmpdir to ${ENVOY_TEST_TMPDIR}."
 fi
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: append variable, then export
Additional Description: As seen in issue https://github.com/envoyproxy/envoy/issues/26921 exporting and appending in the same line works in @phlax environment. It also works for me in a clean ubuntu image. However, in our company build environment, something is different in the environment where it does not tolerate the the export statement ending in '+'.
So break the line into 2 lines.
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
