### PR TITLE
header formatter: handling out of bounds protos consistently

### DIFF
--- a/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.cc
+++ b/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.cc
@@ -13,6 +13,7 @@ PreserveCaseHeaderFormatter::PreserveCaseHeaderFormatter(
     : forward_reason_phrase_(forward_reason_phrase),
       formatter_type_on_envoy_headers_(formatter_type_on_envoy_headers) {
   switch (formatter_type_on_envoy_headers_) {
+    PANIC_ON_PROTO_ENUM_SENTINEL_VALUES;
   case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
       DEFAULT:
     header_key_formatter_on_enovy_headers_ = Envoy::Http::HeaderKeyFormatterConstPtr();
@@ -22,9 +23,6 @@ PreserveCaseHeaderFormatter::PreserveCaseHeaderFormatter(
     header_key_formatter_on_enovy_headers_ =
         std::make_unique<Envoy::Http::Http1::ProperCaseHeaderKeyFormatter>();
     break;
-  default:
-    throw EnvoyException(fmt::format("Not supported FormatterTypeOnEnvoyHeaders: {}.",
-                                     formatter_type_on_envoy_headers_));
   }
 }
 

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
@@ -86,14 +86,6 @@ TEST(PreserveCaseFormatterTest, DefaultFormatterOnEnvoyHeadersEnabled) {
   EXPECT_EQ(false, formatter.formatterOnEnvoyHeaders().has_value());
 }
 
-TEST(PreserveCaseFormatterTest, InvalidFormatterOnEnvoyHeaders) {
-  EXPECT_THROW_WITH_REGEX(
-      PreserveCaseHeaderFormatter formatter(
-          false, static_cast<envoy::extensions::http::header_formatters::preserve_case::v3::
-                                 PreserveCaseFormatterConfig::FormatterTypeOnEnvoyHeaders>(-1)),
-      EnvoyException, "Not supported FormatterTypeOnEnvoyHeaders:.*");
-}
-
 } // namespace PreserveCase
 } // namespace HeaderFormatters
 } // namespace Http


### PR DESCRIPTION
We prefer having explicit failure on out-of-bounds protos to having defaults in switch statements which are often missed when protos are extended.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a