### PR TITLE
[release/v1.25] fips: fix Wasm extensions to comply with FIPS

### DIFF
--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -1,0 +1,13 @@
+diff --git a/BUILD b/BUILD
+index 69c9bda..d293092 100644
+--- a/BUILD
++++ b/BUILD
+@@ -88,7 +88,7 @@ cc_library(
+         ":headers",
+     ] + select({
+         "//bazel:crypto_system": [],
+-        "//conditions:default": ["@boringssl//:crypto"],
++        "//conditions:default": ["@envoy//bazel:boringcrypto"],
+     }),
+     alwayslink = 1,
+ )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1069,7 +1069,13 @@ def _proxy_wasm_cpp_sdk():
     external_http_archive(name = "proxy_wasm_cpp_sdk")
 
 def _proxy_wasm_cpp_host():
-    external_http_archive(name = "proxy_wasm_cpp_host")
+    external_http_archive(
+        name = "proxy_wasm_cpp_host",
+        patch_args = ["-p1"],
+        patches = [
+            "@envoy//bazel:proxy_wasm_cpp_host.patch",
+        ],
+    )
 
 def _emsdk():
     external_http_archive(

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: tls
+  change: |
+    Fix build FIPS compliance when using both FIPS mode and Wasm extensions (``--define boringssl=fips`` and ``--define wasm=v8``).
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -65,6 +65,7 @@ envoy_cc_library(
         ],
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     ),
+    external_deps = ["ssl"],
     deps = [
         ":version_includes",
         "//source/common/common:macros",

--- a/source/common/version/version.cc
+++ b/source/common/version/version.cc
@@ -12,6 +12,10 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 
+#ifdef ENVOY_SSL_FIPS
+#include "openssl/crypto.h"
+#endif
+
 extern const char build_scm_revision[];
 extern const char build_scm_status[];
 
@@ -38,6 +42,7 @@ const envoy::config::core::v3::BuildVersion& VersionInfo::buildVersion() {
 
 bool VersionInfo::sslFipsCompliant() {
 #ifdef ENVOY_SSL_FIPS
+  RELEASE_ASSERT(FIPS_mode() == 1, "FIPS mode must be enabled in Envoy FIPS configuration.");
   return true;
 #else
   return false;


### PR DESCRIPTION
Commit Message: Fixes a build issue with Wasm extensions triggering a non-FIPS mode when included into Envoy.
Risk Level: low
Testing: yes
Docs Changes: none
Release Notes: yes