### PR TITLE
Add metadata to Fault filter.

### DIFF
--- a/api/envoy/extensions/filters/http/fault/v3/BUILD
+++ b/api/envoy/extensions/filters/http/fault/v3/BUILD
@@ -6,9 +6,9 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/core/v3:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/extensions/filters/common/fault/v3:pkg",
-        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/http/fault/v3/BUILD
+++ b/api/envoy/extensions/filters/http/fault/v3/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/config/route/v3:pkg",
         "//envoy/extensions/filters/common/fault/v3:pkg",
+        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -5,6 +5,7 @@ package envoy.extensions.filters.http.fault.v3;
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/filters/common/fault/v3/fault.proto";
 import "envoy/type/v3/percent.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 
 import "google/protobuf/wrappers.proto";
 
@@ -55,7 +56,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.HTTPFault";
@@ -148,4 +149,10 @@ message HTTPFault {
   // If set to false, dynamic stats storage will be allocated for the downstream cluster name.
   // Default value is false.
   bool disable_downstream_cluster_stats = 15;
+  
+  // [#not-implemented-hide:]
+  // The Metadata field can be used to provide additional information
+  // about the fault. It can be used for configuration, stats, and logging.
+  // The metadata should go under the filter namespace that will need it.
+  core.v3.Metadata metadata = 16;
 }

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.fault.v3;
 
+import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/filters/common/fault/v3/fault.proto";
 import "envoy/type/v3/percent.proto";
-import "envoy/type/metadata/v3/metadata.proto";
 
 import "google/protobuf/wrappers.proto";
 
@@ -149,10 +149,10 @@ message HTTPFault {
   // If set to false, dynamic stats storage will be allocated for the downstream cluster name.
   // Default value is false.
   bool disable_downstream_cluster_stats = 15;
-  
+
   // [#not-implemented-hide:]
   // The Metadata field can be used to provide additional information
   // about the fault. It can be used for configuration, stats, and logging.
   // The metadata should go under the filter namespace that will need it.
-  core.v3.Metadata metadata = 16;
+  config.core.v3.Metadata metadata = 16;
 }

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -150,9 +150,10 @@ message HTTPFault {
   // Default value is false.
   bool disable_downstream_cluster_stats = 15;
 
-  // [#not-implemented-hide:]
-  // The Metadata field can be used to provide additional information
-  // about the fault. It can be used for configuration, stats, and logging.
-  // The metadata should go under the filter namespace that will need it.
+  // When an abort or delay fault is executed, the metadata provided here will be added to the
+  // request's dynamic metadata. The metadata must be set under the filter namespace that will use it.
+  // This data can be logged as part of Access Logs using the :ref:`command operator
+  // <config_access_log_command_operators>` %DYNAMIC_METADATA(NAMESPACE)%, where NAMESPACE is the filter
+  // namespace used when setting the metadata.
   config.core.v3.Metadata metadata = 16;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -158,6 +158,11 @@ new_features:
     added new field :ref:`connection_rate_limit
     <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.ConnPoolSettings.connection_rate_limit>`
     to limit reconnection rate to redis server to avoid reconnection storm.
+- area: fault
+  change: |
+    added new field :ref:`metadata
+    <envoy_v3_api_field_extensions.filters.http.fault.v3.HTTPFault.metadata>` to aid in logging.
+    This metadata can be accessed from StreamInfo's dynamicMetadata().
 
 deprecated:
 - area: access_log

--- a/source/extensions/filters/http/fault/BUILD
+++ b/source/extensions/filters/http/fault/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
         "//source/common/stats:utility_lib",
         "//source/extensions/filters/common/fault:fault_config_lib",
         "//source/extensions/filters/http/common:stream_rate_limiter_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/fault/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -50,7 +50,8 @@ FaultSettings::FaultSettings(const envoy::extensions::filters::http::fault::v3::
       response_rate_limit_percent_runtime_(
           PROTOBUF_GET_STRING_OR_DEFAULT(fault, response_rate_limit_percent_runtime,
                                          RuntimeKeys::get().ResponseRateLimitPercentKey)),
-      disable_downstream_cluster_stats_(fault.disable_downstream_cluster_stats()) {
+      disable_downstream_cluster_stats_(fault.disable_downstream_cluster_stats()),
+      metadata_(fault.metadata()) {
   if (fault.has_abort()) {
     request_abort_config_ =
         std::make_unique<Filters::Common::Fault::FaultAbortConfig>(fault.abort());
@@ -169,6 +170,7 @@ bool FaultFilter::maybeSetupDelay(const Http::RequestHeaderMap& request_headers)
     delay_timer_->enableTimer(duration.value(), &decoder_callbacks_->scope());
     recordDelaysInjectedStats();
     decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DelayInjected);
+    decoder_callbacks_->streamInfo().dynamicMetadata().MergeFrom(fault_settings_->metadata());
     return true;
   }
   return false;
@@ -467,6 +469,7 @@ void FaultFilter::abortWithStatus(Http::Code http_status_code,
                                   absl::optional<Grpc::Status::GrpcStatus> grpc_status) {
   recordAbortsInjectedStats();
   decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FaultInjected);
+  decoder_callbacks_->streamInfo().dynamicMetadata().MergeFrom(fault_settings_->metadata());
   decoder_callbacks_->sendLocalReply(http_status_code, "fault filter abort", nullptr, grpc_status,
                                      RcDetails::get().FaultAbort);
 }

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/extensions/filters/http/fault/v3/fault.pb.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
@@ -74,6 +75,7 @@ public:
     return response_rate_limit_percent_runtime_;
   }
   bool disableDownstreamClusterStats() const { return disable_downstream_cluster_stats_; }
+  const envoy::config::core::v3::Metadata& metadata() const { return metadata_; }
 
 private:
   class RuntimeKeyValues {
@@ -106,6 +108,8 @@ private:
   const std::string max_active_faults_runtime_;
   const std::string response_rate_limit_percent_runtime_;
   const bool disable_downstream_cluster_stats_;
+
+  const envoy::config::core::v3::Metadata metadata_;
 };
 
 /**

--- a/test/extensions/filters/http/fault/config_test.cc
+++ b/test/extensions/filters/http/fault/config_test.cc
@@ -28,6 +28,10 @@ TEST(FaultFilterConfigTest, ValidateFail) {
 
 TEST(FaultFilterConfigTest, FaultFilterCorrectJson) {
   const std::string yaml_string = R"EOF(
+  metadata:
+    filter_metadata:
+      com.scooby.doo:
+        hello: "world"
   delay:
     percentage:
       numerator: 100

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -62,6 +62,10 @@ public:
       numerator: 100
       denominator: HUNDRED
     fixed_delay: 5s
+  metadata:
+    filter_metadata:
+      com.scooby.doo:
+        hello: "world"
   )EOF";
 
   const std::string fixed_delay_only_disable_stats_yaml = R"EOF(
@@ -79,6 +83,10 @@ public:
       numerator: 100
       denominator: HUNDRED
     http_status: 429
+  metadata:
+    filter_metadata:
+      com.scooby.doo:
+        hello: "world"
   )EOF";
 
   const std::string fixed_delay_and_abort_yaml = R"EOF(
@@ -92,6 +100,10 @@ public:
       numerator: 100
       denominator: HUNDRED
     http_status: 503
+  metadata:
+    filter_metadata:
+      com.scooby.doo:
+        hello: "world"
   )EOF";
 
   const std::string header_abort_only_yaml = R"EOF(
@@ -230,12 +242,15 @@ TEST(FaultFilterBadConfigTest, MissingDelayDuration) {
 }
 
 TEST_F(FaultFilterTest, AbortWithHttpStatus) {
-  envoy::extensions::filters::http::fault::v3::HTTPFault fault;
-  fault.mutable_abort()->mutable_percentage()->set_numerator(100);
-  fault.mutable_abort()->mutable_percentage()->set_denominator(
-      envoy::type::v3::FractionalPercent::HUNDRED);
-  fault.mutable_abort()->set_http_status(429);
-  setUpTest(fault);
+  setUpTest(abort_only_yaml);
+
+  envoy::config::core::v3::Metadata dynamic_metadata;
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
+      .WillOnce(ReturnRef(dynamic_metadata));
+
+  envoy::config::core::v3::Metadata expected_metadata;
+  auto& filter_metadata = *expected_metadata.mutable_filter_metadata();
+  (*filter_metadata["com.scooby.doo"].mutable_fields())["hello"].set_string_value("world");
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -264,6 +279,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+  EXPECT_THAT(dynamic_metadata, ProtoEq(expected_metadata));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -501,6 +517,7 @@ TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_, setResponseFlag(_)).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata()).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
 
   // Expect filter to continue execution when delay is 0ms
@@ -529,7 +546,7 @@ TEST_F(FaultFilterTest, Overflow) {
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
       .WillOnce(Return(0));
-
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata()).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
 
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
@@ -597,6 +614,11 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
 // Verifies that 2 consecutive delay faults be allowed with the max number of faults set to 1.
 TEST_F(FaultFilterTest, ConsecutiveDelayFaults) {
   setUpTest(fixed_delay_only_yaml);
+  envoy::config::core::v3::Metadata dynamic_metadata;
+
+  envoy::config::core::v3::Metadata expected_metadata;
+  auto& filter_metadata = *expected_metadata.mutable_filter_metadata();
+  (*filter_metadata["com.scooby.doo"].mutable_fields())["hello"].set_string_value("world");
 
   // Set the max number of faults to 1.
   EXPECT_CALL(runtime_.snapshot_,
@@ -622,6 +644,9 @@ TEST_F(FaultFilterTest, ConsecutiveDelayFaults) {
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
       .Times(2);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
+      .WillOnce(ReturnRef(dynamic_metadata))
+      .WillOnce(ReturnRef(dynamic_metadata));
 
   // Start request 1 with a fault delay.
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -649,6 +674,7 @@ TEST_F(FaultFilterTest, ConsecutiveDelayFaults) {
   // Should stop counting as active fault after delay elapsed.
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
   EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
+  EXPECT_THAT(dynamic_metadata, ProtoEq(expected_metadata));
 
   // Prep up request 2, with setups and expectations same as request 1.
   setUpTest(fixed_delay_only_yaml);
@@ -667,6 +693,7 @@ TEST_F(FaultFilterTest, ConsecutiveDelayFaults) {
 
   // Have the fault delay of request 2 kick in, which should be delayed with success.
   timer_->invokeCallback();
+  EXPECT_THAT(dynamic_metadata, ProtoEq(config_->settings()->metadata()));
   filter_->onDestroy();
 
   EXPECT_EQ(2UL, config_->stats().delays_injected_.value());
@@ -775,6 +802,14 @@ TEST_F(FaultFilterTest, DelayForDownstreamClusterDisableTracing) {
 TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   setUpTest(fixed_delay_and_abort_yaml);
 
+  envoy::config::core::v3::Metadata dynamic_metadata;
+  ON_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
+      .WillByDefault(ReturnRef(dynamic_metadata));
+
+  envoy::config::core::v3::Metadata expected_metadata;
+  auto& filter_metadata = *expected_metadata.mutable_filter_metadata();
+  (*filter_metadata["com.scooby.doo"].mutable_fields())["hello"].set_string_value("world");
+
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
       .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
@@ -829,6 +864,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_EQ(1UL, config_->stats().active_faults_.value());
+  EXPECT_THAT(dynamic_metadata, ProtoEq(expected_metadata));
   filter_->onDestroy();
 
   EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
@@ -1358,8 +1394,14 @@ TEST_F(FaultFilterRateLimitTest, DelayWithResponseRateLimitEnabled) {
 }
 
 TEST_F(FaultFilterRateLimitTest, ResponseRateLimitEnabled) {
-  setupRateLimitTest(true);
+  // Set metadata in fault. Ensure that it does not get reflected in stream info.
+  envoy::extensions::filters::http::fault::v3::HTTPFault fault;
+  auto& filter_metadata = *fault.mutable_metadata()->mutable_filter_metadata();
+  (*filter_metadata["com.scooby.doo"].mutable_fields())["hello"].set_string_value("world");
 
+  setupRateLimitTest(fault);
+
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata()).Times(0);
   ON_CALL(encoder_filter_callbacks_, encoderBufferLimit()).WillByDefault(Return(1100));
   Event::MockTimer* token_timer =
       new NiceMock<Event::MockTimer>(&decoder_filter_callbacks_.dispatcher_);

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -294,7 +294,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
 
   envoy::config::core::v3::Metadata dynamic_metadata;
   ON_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
-          .WillByDefault(ReturnRef(dynamic_metadata));
+      .WillByDefault(ReturnRef(dynamic_metadata));
 
   envoy::config::core::v3::Metadata expected_metadata;
   auto& filter_metadata = *expected_metadata.mutable_filter_metadata();
@@ -328,7 +328,6 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
   EXPECT_THAT(dynamic_metadata, ProtoEq(expected_metadata));
-
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -83,10 +83,6 @@ public:
       numerator: 100
       denominator: HUNDRED
     http_status: 429
-  metadata:
-    filter_metadata:
-      com.scooby.doo:
-        hello: "world"
   )EOF";
 
   const std::string fixed_delay_and_abort_yaml = R"EOF(
@@ -107,6 +103,10 @@ public:
   )EOF";
 
   const std::string header_abort_only_yaml = R"EOF(
+  metadata:
+    filter_metadata:
+      com.scooby.doo:
+        hello: "world"
   abort:
     header_abort: {}
     percentage:
@@ -244,9 +244,57 @@ TEST(FaultFilterBadConfigTest, MissingDelayDuration) {
 TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   setUpTest(abort_only_yaml);
 
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+      .Times(0);
+
+  // Abort related calls
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("fault.http.abort.abort_percent",
+                     testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
+      .WillOnce(Return(429));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
+  EXPECT_CALL(decoder_filter_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
+  EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
+
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+  Http::MetadataMap metadata_map{{"metadata", "metadata"}};
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
+  EXPECT_EQ(1UL, config_->stats().active_faults_.value());
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+  filter_->onDestroy();
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().active_faults_.value());
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
+}
+
+TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
+  setUpTest(header_abort_only_yaml);
+
+  request_headers_.addCopy("x-envoy-fault-abort-request", "429");
+
   envoy::config::core::v3::Metadata dynamic_metadata;
-  EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
-      .WillOnce(ReturnRef(dynamic_metadata));
+  ON_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
+          .WillByDefault(ReturnRef(dynamic_metadata));
 
   envoy::config::core::v3::Metadata expected_metadata;
   auto& filter_metadata = *expected_metadata.mutable_filter_metadata();
@@ -281,53 +329,6 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
               setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
   EXPECT_THAT(dynamic_metadata, ProtoEq(expected_metadata));
 
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(request_headers_, false));
-  Http::MetadataMap metadata_map{{"metadata", "metadata"}};
-  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
-  EXPECT_EQ(1UL, config_->stats().active_faults_.value());
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
-  filter_->onDestroy();
-
-  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
-  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
-  EXPECT_EQ(0UL, config_->stats().active_faults_.value());
-  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
-}
-
-TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
-  setUpTest(header_abort_only_yaml);
-
-  request_headers_.addCopy("x-envoy-fault-abort-request", "429");
-
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
-
-  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
-  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
-      .Times(0);
-
-  // Abort related calls
-  EXPECT_CALL(
-      runtime_.snapshot_,
-      featureEnabled("fault.http.abort.abort_percent",
-                     testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
-      .WillOnce(Return(true));
-
-  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
-      .WillOnce(Return(429));
-
-  Http::TestResponseHeaderMapImpl response_headers{
-      {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
-  EXPECT_CALL(decoder_filter_callbacks_,
-              encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
-  EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
-
-  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));


### PR DESCRIPTION
Commit Message: Add metadata field to fault filter to aid logging. 
Additional Description: This metadata will be available as part of StreamInfo's dynamicMetadata().
Risk Level: Low
Testing: Unit tests
Docs Changes: Not Yet
Release Notes: Add metadata field to fault filter to aid logging.
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
