### PR TITLE
mobile/ci: Add timeout and err handling on hanging jobs

### DIFF
--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -86,7 +86,14 @@ jobs:
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
     - name: 'Check connectivity'
       if: steps.should_run.outputs.run_ci_job == 'true'
-      run: adb logcat -e "received headers with status 301" -m 1
+      run: |
+        timeout 30 adb logcat -e "received headers with status 301" -m 1 || {
+            echo "Failed checking for headers in adb logcat" >&2
+            timeout 30 adb logcat || {
+                echo "Failed dumping adb logcat" >&2
+            }
+            exit 1
+        }
   kotlinhelloworld:
     if: github.repository == 'envoyproxy/envoy'
     name: kotlin_helloworld
@@ -133,7 +140,15 @@ jobs:
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
     - name: 'Check connectivity'
       if: steps.should_run.outputs.run_ci_job == 'true'
-      run: adb logcat -e "received headers with status 200" -m 1
+      run: |
+        timeout 30 adb logcat -e "received headers with status 200" -m 1 || {
+            echo "Failed checking for headers in adb logcat" >&2
+            timeout 30 adb logcat || {
+                echo "Failed dumping adb logcat" >&2
+            }
+            exit 1
+        }
+
   kotlinbaselineapp:
     if: github.repository == 'envoyproxy/envoy'
     name: kotlin_baseline_app
@@ -180,7 +195,14 @@ jobs:
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
     - name: 'Check connectivity'
       if: steps.should_run.outputs.run_ci_job == 'true'
-      run: adb logcat -e "received headers with status 301" -m 1
+      run: |
+        timeout 30 adb logcat -e "received headers with status 301" -m 1 || {
+            echo "Failed checking for headers in adb logcat" >&2
+            timeout 30 adb logcat || {
+                echo "Failed dumping adb logcat" >&2
+            }
+            exit 1
+        }
   kotlinexperimentalapp:
     if: github.repository == 'envoyproxy/envoy'
     name: kotlin_experimental_app
@@ -229,4 +251,11 @@ jobs:
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity
     - name: 'Check connectivity'
       if: steps.should_run.outputs.run_ci_job == 'true'
-      run: adb logcat -e "received headers with status 200" -m 1
+      run: |
+        timeout 30 adb logcat -e "received headers with status 200" -m 1 || {
+            echo "Failed checking for headers in adb logcat" >&2
+            timeout 30 adb logcat || {
+                echo "Failed dumping adb logcat" >&2
+            }
+            exit 1
+        }

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -80,7 +80,7 @@ jobs:
     if: github.repository == 'envoyproxy/envoy'
     name: kotlin_build
     runs-on: macos-12
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
       with:
@@ -103,23 +103,25 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-        $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
-          --fat_apk_cpu=x86_64 \
-          --define=admin_html=enabled \
-          --define=envoy_mobile_request_compression=disabled \
-          --define=envoy_enable_http_datagrams=disabled \
-          --define=google_grpc=disabled \
-          --define=envoy_yaml=disabled \
-          --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-      //:android_dist && ./bazelw test \
-          --fat_apk_cpu=x86_64 \
-          --define=admin_html=enabled \
-          --define=envoy_mobile_request_compression=disabled \
-          --define=envoy_enable_http_datagrams=disabled \
-          --define=google_grpc=disabled \
-          --define=envoy_yaml=disabled \
-          --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-      //test/java/integration:android_engine_socket_tag_test \
-      //test/java/integration:android_engine_start_test \
-      //test/java/io/envoyproxy/envoymobile/utilities:certificate_verification_tests
+        cd mobile \
+        && ./bazelw build \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --fat_apk_cpu=x86_64 \
+            --define=admin_html=enabled \
+            --define=envoy_mobile_request_compression=disabled \
+            --define=envoy_enable_http_datagrams=disabled \
+            --define=google_grpc=disabled \
+            --define=envoy_yaml=disabled \
+            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
+            //:android_dist \
+        && ./bazelw test \
+            --fat_apk_cpu=x86_64 \
+            --define=admin_html=enabled \
+            --define=envoy_mobile_request_compression=disabled \
+            --define=envoy_enable_http_datagrams=disabled \
+            --define=google_grpc=disabled \
+            --define=envoy_yaml=disabled \
+            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
+            //test/java/integration:android_engine_socket_tag_test \
+            //test/java/integration:android_engine_start_test \
+            //test/java/io/envoyproxy/envoymobile/utilities:certificate_verification_tests


### PR DESCRIPTION
Also fixes mobile compile-time-options test broken in #26451 (and increases timeout for job that needs it)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
