### PR TITLE
dependabot: Run earlier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,251 +13,251 @@ updates:
   directory: "/.github/actions/pr_notifier"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/examples/grpc-bridge/client"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/examples/cache"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/examples/shared/python/aiohttp"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/examples/shared/python/postgres"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/mobile/docs"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/tools/base"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "pip"
   directory: "/tools/code_format"
   schedule:
     interval: "daily"
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/.devcontainer"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/ci"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/ext_authz"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/fault-injection"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/grpc-bridge"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/kafka"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/local_ratelimit"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/mysql"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/opentelemetry"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/redis"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/build"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/echo"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 # TODO(phlax): just use above
 - package-ecosystem: "docker"
   directory: "/examples/shared/echo2"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/golang"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/jaeger"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/node"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/postgres"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/python"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/shared/websocket"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/skywalking"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/udp"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "docker"
   directory: "/examples/zipkin"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/contrib/golang/filters/http/test/test_data/basic"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/contrib/golang/filters/http/test/test_data/dummy"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/contrib/golang/filters/http/test/test_data/echo"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/contrib/golang/filters/http/test/test_data/passthrough"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/contrib/golang/filters/http/test/test_data/routeconfig"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/contrib/golang/router/cluster_specifier/test/test_data/simple"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/examples/ext_authz/auth/grpc-service"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/examples/load-reporting-service"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/examples/grpc-bridge/server"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"
 
 - package-ecosystem: "gomod"
   directory: "/examples/golang/simple"
   schedule:
     interval: daily
-    time: "09:00"
+    time: "06:00"


### PR DESCRIPTION
dependabot takes a while to run, and then triggers a load of CI, and then more if any of the prs are landed

the idea of setting a time was to avoid all this CI during busy times, but atm its running into them

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
