### PR TITLE
mobile: skip SNI matching for empty hostname

### DIFF
--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -78,7 +78,7 @@ ValidationResults PlatformBridgeCertValidator::doVerifyCertChain(
   if (transport_socket_options != nullptr &&
       !transport_socket_options->verifySubjectAltNameListOverride().empty()) {
     subject_alt_names = transport_socket_options->verifySubjectAltNameListOverride();
-  } else {
+  } else if (!hostname.empty()) {
     subject_alt_names = {std::string(hostname)};
   }
 
@@ -115,8 +115,10 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
   }
 
   absl::string_view error_details;
-  // Verify that host name matches leaf cert.
-  success = DefaultCertValidator::verifySubjectAltName(leaf_cert.get(), subject_alt_names);
+  if (!subject_alt_names.empty()) {
+    // Verify that host name matches leaf cert.
+    success = DefaultCertValidator::verifySubjectAltName(leaf_cert.get(), subject_alt_names);
+  }
   if (!success) {
     error_details = "PlatformBridgeCertValidator_verifySubjectAltName failed: SNI mismatch.";
     ENVOY_LOG(debug, error_details);

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -224,11 +224,43 @@ TEST_P(PlatformBridgeCertValidatorTest, ValidCertificate) {
   EXPECT_FALSE(waitForDispatcherToExit());
 }
 
-TEST_P(PlatformBridgeCertValidatorTest, ValidCertificateEmptySocketOptions) {
+TEST_P(PlatformBridgeCertValidatorTest, ValidCertificateEmptySanOverrides) {
   initializeConfig();
   PlatformBridgeCertValidator validator(&config_, stats_, &platform_validator_);
 
   std::string hostname = "server1.example.com";
+  bssl::UniquePtr<STACK_OF(X509)> cert_chain = readCertChainFromFile(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns2_cert.pem"));
+  envoy_cert_validation_result result = {ENVOY_SUCCESS, 0, NULL};
+  EXPECT_CALL(*mock_validator_, validate(_, _, _)).WillOnce(Return(result));
+  EXPECT_CALL(*mock_validator_, cleanup());
+  auto& callback_ref = *callback_;
+  EXPECT_CALL(callback_ref, dispatcher()).WillRepeatedly(ReturnRef(*dispatcher_));
+
+  // Set up transport socket options with an empty SAN list.
+  std::vector<std::string> subject_alt_names;
+  transport_socket_options_ =
+      std::make_shared<Network::TransportSocketOptionsImpl>("", std::move(subject_alt_names));
+
+  ValidationResults results =
+      validator.doVerifyCertChain(*cert_chain, std::move(callback_), transport_socket_options_,
+                                  *ssl_ctx_, validation_context_, is_server_, hostname);
+  EXPECT_EQ(ValidationResults::ValidationStatus::Pending, results.status);
+
+  EXPECT_CALL(callback_ref,
+              onCertValidationResult(true, Envoy::Ssl::ClientValidationStatus::Validated, "", 46))
+      .WillOnce(Invoke([this]() {
+        EXPECT_EQ(main_thread_id_, std::this_thread::get_id());
+        dispatcher_->exit();
+      }));
+  EXPECT_FALSE(waitForDispatcherToExit());
+}
+
+TEST_P(PlatformBridgeCertValidatorTest, ValidCertificateEmptyHostNoOverrides) {
+  initializeConfig();
+  PlatformBridgeCertValidator validator(&config_, stats_, &platform_validator_);
+
+  std::string hostname = "";
   bssl::UniquePtr<STACK_OF(X509)> cert_chain = readCertChainFromFile(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns2_cert.pem"));
   envoy_cert_validation_result result = {ENVOY_SUCCESS, 0, NULL};


### PR DESCRIPTION
Commit Message: stop matching empty hostname to SAN list in the cert.

Risk Level: Low
Testing: New unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: mobile-only
