### PR TITLE
ci/mobile: Hide CI progress in .bazelrc

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -172,7 +172,7 @@ steps:
       BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
       BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
     ${{ if eq(parameters.rbe, false) }}:
-      BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=ci ${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         BAZEL_REMOTE_INSTANCE_BRANCH: "$(System.PullRequest.TargetBranch)"

--- a/.bazelrc
+++ b/.bazelrc
@@ -333,6 +333,10 @@ build:docker-tsan --config=rbe-toolchain-tsan
 # CI configurations
 build:remote-ci --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote-ci --config=ci
+# Note this config is used by mobile CI also.
+build:ci --noshow_progress
+build:ci --noshow_loading_progress
 
 # Build Event Service
 build:google-bes --bes_backend=grpcs://buildeventservice.googleapis.com

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -115,6 +115,7 @@ jobs:
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             //:android_dist \
         && ./bazelw test \
+            --config=ci \
             --fat_apk_cpu=x86_64 \
             --define=admin_html=enabled \
             --define=envoy_mobile_request_compression=disabled \

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -131,8 +131,6 @@ BAZEL_BUILD_OPTIONS=(
   "--verbose_failures"
   "--experimental_generate_json_trace_profile"
   "--test_output=errors"
-  "--noshow_progress"
-  "--noshow_loading_progress"
   "--action_env=CLANG_FORMAT"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -138,6 +138,7 @@ build:coverage --instrumentation_filter="//library/common[/:]"
 # to add platform-specific options. Avoid using this config directly and
 # instead use a platform-specific config
 #############################################################################
+build:remote-ci-common --config=ci
 build:remote-ci-common --config=remote
 build:remote-ci-common --google_default_credentials=false
 build:remote-ci-common --remote_cache=grpcs://envoy.cluster.engflow.com


### PR DESCRIPTION
This adds a `ci` bazel config target and sets the `noshow...progress` settings there

Both mobile and envoy ci use this target and we can add any more common ci config there

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
