### PR TITLE
thrift_proxy: add access log support for local reply

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -106,10 +106,11 @@ void ConnectionManager::dispatch() {
   resetAllRpcs(true);
 }
 
-void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectResponse& response,
-                                       bool end_stream) {
+absl::optional<DirectResponse::ResponseType>
+ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectResponse& response,
+                                  bool end_stream) {
   if (read_callbacks_->connection().state() == Network::Connection::State::Closed) {
-    return;
+    return absl::nullopt;
   }
 
   DirectResponse::ResponseType result = DirectResponse::ResponseType::Exception;
@@ -139,6 +140,7 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectRe
     stats_.response_exception_.inc();
     break;
   }
+  return result;
 }
 
 void ConnectionManager::continueDecoding() {
@@ -356,20 +358,7 @@ FilterStatus ConnectionManager::ResponseDecoder::messageBegin(MessageMetadataSha
     }
   }
 
-  ProtobufWkt::Struct stats_obj;
-  auto& fields_map = *stats_obj.mutable_fields();
-  auto& response_fields_map = *fields_map["response"].mutable_struct_value()->mutable_fields();
-
-  response_fields_map["transport_type"] =
-      ValueUtil::stringValue(TransportNames::get().fromType(decoder_->transportType()));
-  response_fields_map["protocol_type"] =
-      ValueUtil::stringValue(ProtocolNames::get().fromType(decoder_->protocolType()));
-  response_fields_map["message_type"] = ValueUtil::stringValue(
-      metadata->hasMessageType() ? MessageTypeNames::get().fromType(metadata->messageType()) : "-");
-  response_fields_map["reply_type"] = ValueUtil::stringValue(
-      metadata->hasReplyType() ? ReplyTypeNames::get().fromType(metadata->replyType()) : "-");
-
-  parent_.streamInfo().setDynamicMetadata("thrift.proxy", stats_obj);
+  parent_.recordResponseAccessLog(metadata);
 
   return parent_.applyEncoderFilters(DecoderEvent::MessageBegin, metadata, protocol_converter_);
 }
@@ -816,6 +805,43 @@ bool ConnectionManager::ActiveRpc::passthroughSupported() const {
   return true;
 }
 
+void ConnectionManager::ActiveRpc::recordResponseAccessLog(
+    DirectResponse::ResponseType direct_response_type, const MessageMetadataSharedPtr& metadata) {
+  if (direct_response_type == DirectResponse::ResponseType::Exception) {
+    recordResponseAccessLog(MessageTypeNames::get().fromType(MessageType::Exception), "-");
+    return;
+  }
+  const std::string& message_type_name =
+      metadata->hasMessageType() ? MessageTypeNames::get().fromType(metadata->messageType()) : "-";
+  const std::string& reply_type_name = ReplyTypeNames::get().fromType(
+      direct_response_type == DirectResponse::ResponseType::SuccessReply ? ReplyType::Success
+                                                                         : ReplyType::Error);
+  recordResponseAccessLog(message_type_name, reply_type_name);
+}
+
+void ConnectionManager::ActiveRpc::recordResponseAccessLog(
+    const MessageMetadataSharedPtr& metadata) {
+  recordResponseAccessLog(
+      metadata->hasMessageType() ? MessageTypeNames::get().fromType(metadata->messageType()) : "-",
+      metadata->hasReplyType() ? ReplyTypeNames::get().fromType(metadata->replyType()) : "-");
+}
+
+void ConnectionManager::ActiveRpc::recordResponseAccessLog(const std::string& message_type,
+                                                           const std::string& reply_type) {
+  ProtobufWkt::Struct stats_obj;
+  auto& fields_map = *stats_obj.mutable_fields();
+  auto& response_fields_map = *fields_map["response"].mutable_struct_value()->mutable_fields();
+
+  response_fields_map["transport_type"] =
+      ValueUtil::stringValue(TransportNames::get().fromType(downstreamTransportType()));
+  response_fields_map["protocol_type"] =
+      ValueUtil::stringValue(ProtocolNames::get().fromType(downstreamProtocolType()));
+  response_fields_map["message_type"] = ValueUtil::stringValue(message_type);
+  response_fields_map["reply_type"] = ValueUtil::stringValue(reply_type);
+
+  streamInfo().setDynamicMetadata("thrift.proxy", stats_obj);
+}
+
 FilterStatus ConnectionManager::ActiveRpc::passthroughData(Buffer::Instance& data) {
   passthrough_ = true;
   return applyDecoderFilters(DecoderEvent::PassthroughData, &data);
@@ -875,7 +901,7 @@ FilterStatus ConnectionManager::ActiveRpc::messageBegin(MessageMetadataSharedPtr
   request_fields_map["transport_type"] =
       ValueUtil::stringValue(TransportNames::get().fromType(downstreamTransportType()));
   request_fields_map["protocol_type"] =
-      ValueUtil::stringValue(ProtocolNames::get().fromType(parent_.decoder_->protocolType()));
+      ValueUtil::stringValue(ProtocolNames::get().fromType(downstreamProtocolType()));
   request_fields_map["message_type"] = ValueUtil::stringValue(
       metadata->hasMessageType() ? MessageTypeNames::get().fromType(metadata->messageType()) : "-");
 
@@ -1025,7 +1051,11 @@ void ConnectionManager::ActiveRpc::sendLocalReply(const DirectResponse& response
     cm.stats_.downstream_response_drain_close_.inc();
   }
 
-  parent_.sendLocalReply(*localReplyMetadata_, response, end_stream);
+  auto result = parent_.sendLocalReply(*localReplyMetadata_, response, end_stream);
+  // Only report while the local reply is successfully written.
+  if (result.has_value()) {
+    recordResponseAccessLog(*result, localReplyMetadata_);
+  }
 
   if (end_stream) {
     return;

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -324,6 +324,11 @@ private:
 
     bool passthroughSupported() const;
 
+    void recordResponseAccessLog(const MessageMetadataSharedPtr& metadata);
+    void recordResponseAccessLog(DirectResponse::ResponseType direct_response_type,
+                                 const MessageMetadataSharedPtr& metadata);
+    void recordResponseAccessLog(const std::string& message_type, const std::string& reply_type);
+
     // Apply filters to the decoder_event.
     // @param filter    the last filter which is already applied to the decoder_event.
     //                  nullptr indicates none is applied and the decoder_event is applied from the
@@ -372,7 +377,8 @@ private:
 
   void continueDecoding();
   void dispatch();
-  void sendLocalReply(MessageMetadata& metadata, const DirectResponse& response, bool end_stream);
+  absl::optional<DirectResponse::ResponseType>
+  sendLocalReply(MessageMetadata& metadata, const DirectResponse& response, bool end_stream);
   void doDeferredRpcDestroy(ActiveRpc& rpc);
   void resetAllRpcs(bool local_reset);
   void emitLogEntry(const Http::RequestHeaderMap* request_headers,

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -852,8 +852,8 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0U, stats_.request_active_.value());
-  EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call framed binary exception - 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed "
+                              "binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolErrorDuringMessageBegin) {
@@ -1358,7 +1358,8 @@ TEST_F(ThriftConnectionManagerTest, RequestAndResponseProtocolError) {
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
   EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
 
-  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed binary exception - 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed "
+                              "binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, RequestAndTransportApplicationException) {
@@ -1402,8 +1403,8 @@ TEST_F(ThriftConnectionManagerTest, RequestAndTransportApplicationException) {
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
   EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
 
-  EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false header binary call header binary exception - 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false header binary call header "
+                              "binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, BadFunctionCallExceptionHandling) {
@@ -1466,8 +1467,8 @@ TEST_F(ThriftConnectionManagerTest, RequestAndGarbageResponse) {
   EXPECT_EQ(0U, store_.counter("test.response_success").value());
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
 
-  EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call framed binary exception - 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed "
+                              "binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, PipelinedRequestAndResponse) {
@@ -1954,8 +1955,8 @@ TEST_F(ThriftConnectionManagerTest, OnDataWithFilterSendsLocalReply) {
   EXPECT_EQ(0U, stats_.request_active_.value());
   EXPECT_EQ(1U, store_.counter("test.response_success").value());
 
-  EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call framed binary call success 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed "
+                              "binary call success 0 0 0 -\n");
 }
 
 // Tests multiple filters where one invokes sendLocalReply with an error reply.
@@ -2008,8 +2009,8 @@ TEST_F(ThriftConnectionManagerTest, OnDataWithFilterSendsLocalErrorReply) {
   EXPECT_EQ(0U, stats_.request_active_.value());
   EXPECT_EQ(1U, store_.counter("test.response_error").value());
 
-  EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call framed binary call error 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed "
+                              "binary call error 0 0 0 -\n");
 }
 
 // sendLocalReply does nothing, when the remote closed the connection.

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -852,9 +852,8 @@ TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolError) {
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
   EXPECT_EQ(0U, stats_.request_active_.value());
-
   EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call - - - - 0 0 0 -\n");
+            "name cluster passthrough_enabled=false framed binary call framed binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, OnDataHandlesProtocolErrorDuringMessageBegin) {
@@ -1359,8 +1358,7 @@ TEST_F(ThriftConnectionManagerTest, RequestAndResponseProtocolError) {
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
   EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
 
-  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed "
-                              "binary reply success 0 0 0 -\n");
+  EXPECT_EQ(access_log_data_, "name cluster passthrough_enabled=false framed binary call framed binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, RequestAndTransportApplicationException) {
@@ -1405,7 +1403,7 @@ TEST_F(ThriftConnectionManagerTest, RequestAndTransportApplicationException) {
   EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
 
   EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false header binary call - - - - 0 0 0 -\n");
+            "name cluster passthrough_enabled=false header binary call header binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, BadFunctionCallExceptionHandling) {
@@ -1469,7 +1467,7 @@ TEST_F(ThriftConnectionManagerTest, RequestAndGarbageResponse) {
   EXPECT_EQ(0U, store_.counter("test.response_error").value());
 
   EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call - - - - 0 0 0 -\n");
+            "name cluster passthrough_enabled=false framed binary call framed binary exception - 0 0 0 -\n");
 }
 
 TEST_F(ThriftConnectionManagerTest, PipelinedRequestAndResponse) {
@@ -1957,7 +1955,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataWithFilterSendsLocalReply) {
   EXPECT_EQ(1U, store_.counter("test.response_success").value());
 
   EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call - - - - 0 0 0 -\n");
+            "name cluster passthrough_enabled=false framed binary call framed binary call success 0 0 0 -\n");
 }
 
 // Tests multiple filters where one invokes sendLocalReply with an error reply.
@@ -2011,7 +2009,7 @@ TEST_F(ThriftConnectionManagerTest, OnDataWithFilterSendsLocalErrorReply) {
   EXPECT_EQ(1U, store_.counter("test.response_error").value());
 
   EXPECT_EQ(access_log_data_,
-            "name cluster passthrough_enabled=false framed binary call - - - - 0 0 0 -\n");
+            "name cluster passthrough_enabled=false framed binary call framed binary call error 0 0 0 -\n");
 }
 
 // sendLocalReply does nothing, when the remote closed the connection.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Currently we don't have reply information access log for local replies. 

Additional Description:
Risk Level: low
Testing: unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
