### PR TITLE
access_log: use AccessLogType::NotSet instead of default value

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -154,8 +154,7 @@ public:
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info,
-           Envoy::AccessLog::AccessLogType access_log_type =
-               Envoy::AccessLog::AccessLogType::NotSet) override;
+           Envoy::AccessLog::AccessLogType access_log_type) override;
 
   void onStreamComplete() override {}
 

--- a/envoy/access_log/access_log.h
+++ b/envoy/access_log/access_log.h
@@ -96,8 +96,7 @@ public:
   virtual void log(const Http::RequestHeaderMap* request_headers,
                    const Http::ResponseHeaderMap* response_headers,
                    const Http::ResponseTrailerMap* response_trailers,
-                   const StreamInfo::StreamInfo& stream_info,
-                   AccessLogType access_log_type = AccessLogType::NotSet) PURE;
+                   const StreamInfo::StreamInfo& stream_info, AccessLogType access_log_type) PURE;
 };
 
 using InstanceSharedPtr = std::shared_ptr<Instance>;

--- a/source/common/quic/quic_stats_gatherer.cc
+++ b/source/common/quic/quic_stats_gatherer.cc
@@ -25,7 +25,8 @@ void QuicStatsGatherer::maybeDoDeferredLog(bool record_ack_timing) {
   const Http::ResponseHeaderMap* response_headers = response_header_map_.get();
   const Http::ResponseTrailerMap* response_trailers = response_trailer_map_.get();
   for (const AccessLog::InstanceSharedPtr& log_handler : access_log_handlers_) {
-    log_handler->log(request_headers, response_headers, response_trailers, *stream_info_);
+    log_handler->log(request_headers, response_headers, response_trailers, *stream_info_,
+                     AccessLog::AccessLogType::NotSet);
   }
 }
 

--- a/source/extensions/access_loggers/common/access_log_base.h
+++ b/source/extensions/access_loggers/common/access_log_base.h
@@ -30,7 +30,7 @@ public:
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info,
-           AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override;
+           AccessLog::AccessLogType access_log_type) override;
 
 private:
   /**
@@ -41,12 +41,11 @@ private:
    * @param stream_info supplies additional information about the request not
    * contained in the request headers.
    */
-  virtual void
-  emitLog(const Http::RequestHeaderMap& request_headers,
-          const Http::ResponseHeaderMap& response_headers,
-          const Http::ResponseTrailerMap& response_trailers,
-          const StreamInfo::StreamInfo& stream_info,
-          AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) PURE;
+  virtual void emitLog(const Http::RequestHeaderMap& request_headers,
+                       const Http::ResponseHeaderMap& response_headers,
+                       const Http::ResponseTrailerMap& response_trailers,
+                       const StreamInfo::StreamInfo& stream_info,
+                       AccessLog::AccessLogType access_log_type) PURE;
 
   AccessLog::FilterPtr filter_;
 };

--- a/source/extensions/access_loggers/common/file_access_log_impl.h
+++ b/source/extensions/access_loggers/common/file_access_log_impl.h
@@ -19,12 +19,11 @@ public:
 
 private:
   // Common::ImplBase
-  void
-  emitLog(const Http::RequestHeaderMap& request_headers,
-          const Http::ResponseHeaderMap& response_headers,
-          const Http::ResponseTrailerMap& response_trailers,
-          const StreamInfo::StreamInfo& stream_info,
-          AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override;
+  void emitLog(const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers,
+               const StreamInfo::StreamInfo& stream_info,
+               AccessLog::AccessLogType access_log_type) override;
 
   AccessLog::AccessLogFileSharedPtr log_file_;
   Formatter::FormatterPtr formatter_;

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.h
@@ -44,12 +44,11 @@ private:
   };
 
   // Common::ImplBase
-  void
-  emitLog(const Http::RequestHeaderMap& request_headers,
-          const Http::ResponseHeaderMap& response_headers,
-          const Http::ResponseTrailerMap& response_trailers,
-          const StreamInfo::StreamInfo& stream_info,
-          AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override;
+  void emitLog(const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers,
+               const StreamInfo::StreamInfo& stream_info,
+               AccessLog::AccessLogType access_log_type) override;
 
   const HttpGrpcAccessLogConfigConstSharedPtr config_;
   const ThreadLocal::SlotPtr tls_slot_;

--- a/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.h
@@ -43,12 +43,11 @@ private:
   };
 
   // Common::ImplBase
-  void
-  emitLog(const Http::RequestHeaderMap& request_headers,
-          const Http::ResponseHeaderMap& response_headers,
-          const Http::ResponseTrailerMap& response_trailers,
-          const StreamInfo::StreamInfo& stream_info,
-          AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override;
+  void emitLog(const Http::RequestHeaderMap& request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap& response_trailers,
+               const StreamInfo::StreamInfo& stream_info,
+               AccessLog::AccessLogType access_log_type) override;
 
   const TcpGrpcAccessLogConfigConstSharedPtr config_;
   const ThreadLocal::SlotPtr tls_slot_;

--- a/source/extensions/access_loggers/wasm/wasm_access_log_impl.h
+++ b/source/extensions/access_loggers/wasm/wasm_access_log_impl.h
@@ -23,7 +23,8 @@ public:
   void log(const Http::RequestHeaderMap* request_headers,
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
-           const StreamInfo::StreamInfo& stream_info, AccessLog::AccessLogType) override {
+           const StreamInfo::StreamInfo& stream_info,
+           AccessLog::AccessLogType access_log_type) override {
     if (filter_ && request_headers && response_headers && response_trailers) {
       if (!filter_->evaluate(stream_info, *request_headers, *response_headers,
                              *response_trailers)) {
@@ -40,7 +41,7 @@ public:
     }
     if (handle->wasmHandle()) {
       handle->wasmHandle()->wasm()->log(plugin_, request_headers, response_headers,
-                                        response_trailers, stream_info);
+                                        response_trailers, stream_info, access_log_type);
     }
   }
 

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -152,7 +152,7 @@ public:
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info,
-           AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override;
+           AccessLog::AccessLogType access_log_type) override;
 
   uint32_t getLogLevel() override;
 

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -229,10 +229,10 @@ ContextBase* Wasm::createVmContext() { return new Context(this); }
 void Wasm::log(const PluginSharedPtr& plugin, const Http::RequestHeaderMap* request_headers,
                const Http::ResponseHeaderMap* response_headers,
                const Http::ResponseTrailerMap* response_trailers,
-               const StreamInfo::StreamInfo& stream_info) {
+               const StreamInfo::StreamInfo& stream_info,
+               AccessLog::AccessLogType access_log_type) {
   auto context = getRootContext(plugin, true);
-  context->log(request_headers, response_headers, response_trailers, stream_info,
-               AccessLog::AccessLogType::NotSet);
+  context->log(request_headers, response_headers, response_trailers, stream_info, access_log_type);
 }
 
 void Wasm::onStatsUpdate(const PluginSharedPtr& plugin, Envoy::Stats::MetricSnapshot& snapshot) {

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -231,7 +231,8 @@ void Wasm::log(const PluginSharedPtr& plugin, const Http::RequestHeaderMap* requ
                const Http::ResponseTrailerMap* response_trailers,
                const StreamInfo::StreamInfo& stream_info) {
   auto context = getRootContext(plugin, true);
-  context->log(request_headers, response_headers, response_trailers, stream_info);
+  context->log(request_headers, response_headers, response_trailers, stream_info,
+               AccessLog::AccessLogType::NotSet);
 }
 
 void Wasm::onStatsUpdate(const PluginSharedPtr& plugin, Envoy::Stats::MetricSnapshot& snapshot) {

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -69,7 +69,7 @@ public:
   void log(const PluginSharedPtr& plugin, const Http::RequestHeaderMap* request_headers,
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
-           const StreamInfo::StreamInfo& stream_info);
+           const StreamInfo::StreamInfo& stream_info, AccessLog::AccessLogType access_log_type);
 
   void onStatsUpdate(const PluginSharedPtr& plugin, Envoy::Stats::MetricSnapshot& snapshot);
 

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -71,7 +71,7 @@ public:
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info,
-           AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override {
+           AccessLog::AccessLogType access_log_type) override {
     for (const auto& log : access_loggers_) {
       log->log(request_headers, response_headers, response_trailers, stream_info, access_log_type);
     }

--- a/source/extensions/filters/http/tap/tap_filter.h
+++ b/source/extensions/filters/http/tap/tap_filter.h
@@ -111,7 +111,7 @@ public:
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info,
-           AccessLog::AccessLogType access_log_type = AccessLog::AccessLogType::NotSet) override;
+           AccessLog::AccessLogType access_log_type) override;
 
 private:
   FilterConfigSharedPtr config_;

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -55,7 +55,8 @@ void ConnectionManager::emitLogEntry(const Http::RequestHeaderMap* request_heade
                                      const Http::ResponseHeaderMap* response_headers,
                                      const StreamInfo::StreamInfo& stream_info) {
   for (const auto& access_log : config_.accessLogs()) {
-    access_log->log(request_headers, response_headers, nullptr, stream_info);
+    access_log->log(request_headers, response_headers, nullptr, stream_info,
+                    AccessLog::AccessLogType::NotSet);
   }
 }
 

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -30,7 +30,8 @@ UdpProxyFilter::~UdpProxyFilter() {
   if (!config_->proxyAccessLogs().empty()) {
     fillProxyStreamInfo();
     for (const auto& access_log : config_->proxyAccessLogs()) {
-      access_log->log(nullptr, nullptr, nullptr, udp_proxy_stats_.value());
+      access_log->log(nullptr, nullptr, nullptr, udp_proxy_stats_.value(),
+                      AccessLog::AccessLogType::NotSet);
     }
   }
 }
@@ -297,7 +298,8 @@ UdpProxyFilter::ActiveSession::~ActiveSession() {
   if (!cluster_.filter_.config_->sessionAccessLogs().empty()) {
     fillSessionStreamInfo();
     for (const auto& access_log : cluster_.filter_.config_->sessionAccessLogs()) {
-      access_log->log(nullptr, nullptr, nullptr, udp_session_stats_.value());
+      access_log->log(nullptr, nullptr, nullptr, udp_session_stats_.value(),
+                      AccessLog::AccessLogType::NotSet);
     }
   }
 }

--- a/source/extensions/listener_managers/listener_manager/active_stream_listener_base.cc
+++ b/source/extensions/listener_managers/listener_manager/active_stream_listener_base.cc
@@ -20,7 +20,7 @@ void ActiveStreamListenerBase::emitLogs(Network::ListenerConfig& config,
                                         StreamInfo::StreamInfo& stream_info) {
   stream_info.onRequestComplete();
   for (const auto& access_log : config.accessLogs()) {
-    access_log->log(nullptr, nullptr, nullptr, stream_info);
+    access_log->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 }
 

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -92,7 +92,8 @@ typed_config:
   request_headers_.addCopy(Http::Headers::get().Host, "host");
   request_headers_.addCopy(Http::Headers::get().ForwardedFor, "x.x.x.x");
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 UF 1 2 3 - \"x.x.x.x\" "
             "\"user-agent-set\" \"id\" \"host\" \"-\"\n",
             output_);
@@ -115,7 +116,8 @@ typed_config:
       Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime()));
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamConnectionTermination);
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 DC 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"10.0.0.5:1234\"\n",
             output_);
@@ -142,7 +144,8 @@ typed_config:
   request_headers_.addCopy(Http::Headers::get().Host, "host");
   request_headers_.addCopy(Http::Headers::get().ForwardedFor, "x.x.x.x");
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 UF route-test-name 1 2 0 0 3 - "
             "\"x.x.x.x\" "
@@ -179,7 +182,8 @@ typed_config:
   // response trailers:
   // response_trailer_key: response_trailer_val
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_EQ(output_, "52 38 40");
 }
@@ -197,7 +201,8 @@ typed_config:
   EXPECT_CALL(*file_, write(_));
   response_headers_.addCopy(Http::Headers::get().EnvoyUpstreamServiceTime, "999");
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 999 \"-\" \"-\" \"-\" \"-\" "
             "\"-\"\n",
             output_);
@@ -214,7 +219,8 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
   EXPECT_EQ(
       "[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" \"-\"\n",
       output_);
@@ -235,7 +241,8 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"10.0.0.5:1234\"\n",
             output_);
@@ -267,10 +274,12 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.response_code_ = 200;
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, WithFilterHit) {
@@ -305,15 +314,18 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(3);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.response_code_ = 500;
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.response_code_ = 200;
   stream_info_.end_time_ =
       stream_info_.startTimeMonotonic() + std::chrono::microseconds(1001000000000000);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, RuntimeFilter) {
@@ -335,25 +347,29 @@ typed_config:
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 42, 100))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 43, 100))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.stream_id_provider_ =
       std::make_shared<StreamInfo::StreamIdProviderImpl>("000000ff-0000-0000-0000-000000000000");
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 55, 100))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 55, 100))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2) {
@@ -378,25 +394,29 @@ typed_config:
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 42, 10000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 43, 10000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.stream_id_provider_ =
       std::make_shared<StreamInfo::StreamIdProviderImpl>("000000ff-0000-0000-0000-000000000000");
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 255, 10000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 255, 10000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, RuntimeFilterV2IndependentRandomness) {
@@ -422,13 +442,15 @@ typed_config:
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 42, 1000000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 43, 1000000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, PathRewrite) {
@@ -444,7 +466,8 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET /bar HTTP/1.1\" 0 - 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
             "\"-\"\n",
             output_);
@@ -466,7 +489,8 @@ typed_config:
   stream_info_.health_check_request_ = true;
   EXPECT_CALL(*file_, write(_)).Times(0);
 
-  log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, HealthCheckFalse) {
@@ -484,7 +508,8 @@ typed_config:
   Http::TestRequestHeaderMapImpl header_map{};
   EXPECT_CALL(*file_, write(_));
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, RequestTracing) {
@@ -504,19 +529,22 @@ typed_config:
   {
     stream_info_.setTraceReason(Tracing::Reason::ServiceForced);
     EXPECT_CALL(*file_, write(_));
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 
   {
     stream_info_.setTraceReason(Tracing::Reason::NotTraceable);
     EXPECT_CALL(*file_, write(_)).Times(0);
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 
   {
     stream_info_.setTraceReason(Tracing::Reason::Sampling);
     EXPECT_CALL(*file_, write(_)).Times(0);
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -577,14 +605,16 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
     Http::TestRequestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
 
-    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 
   {
     EXPECT_CALL(*file_, write(_)).Times(0);
     Http::TestRequestHeaderMapImpl header_map{};
     stream_info_.health_check_request_ = true;
-    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -613,13 +643,15 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
     Http::TestRequestHeaderMapImpl header_map{{"user-agent", "NOT/Envoy/HC"}};
 
-    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 
   {
     EXPECT_CALL(*file_, write(_));
     Http::TestRequestHeaderMapImpl header_map{{"user-agent", "Envoy/HC"}};
-    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -656,7 +688,8 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
     Http::TestRequestHeaderMapImpl header_map{};
 
-    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 
   {
@@ -664,7 +697,8 @@ typed_config:
     Http::TestRequestHeaderMapImpl header_map{};
     stream_info_.health_check_request_ = true;
 
-    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&header_map, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -791,12 +825,14 @@ typed_config:
   stream_info_.response_code_ = 499;
   EXPECT_CALL(runtime_.snapshot_, getInteger("hello", 499)).WillOnce(Return(499));
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.response_code_ = 500;
   EXPECT_CALL(runtime_.snapshot_, getInteger("hello", 499)).WillOnce(Return(499));
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, HeaderPresence) {
@@ -814,11 +850,13 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.addCopy("test-header", "present");
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, HeaderExactMatch) {
@@ -839,16 +877,19 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.addCopy("test-header", "exact-match-value");
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "not-exact-match-value");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, HeaderRegexMatch) {
@@ -869,21 +910,25 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.addCopy("test-header", "123");
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "1234");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "123.456");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, HeaderRangeMatch) {
@@ -904,31 +949,37 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.addCopy("test-header", "-1");
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "0");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "somestring");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "10.9");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("test-header");
   request_headers_.addCopy("test-header", "-1somestring");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterAnyFlag) {
@@ -944,11 +995,13 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterSpecificFlag) {
@@ -966,15 +1019,18 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterSeveralFlags) {
@@ -993,15 +1049,18 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 
   stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, ResponseFlagFilterAllFlagsInPGV) {
@@ -1050,7 +1109,8 @@ typed_config:
     TestStreamInfo stream_info(time_source_);
     stream_info.setResponseFlag(response_flag);
     EXPECT_CALL(*file_, write(_));
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info,
+             AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -1154,7 +1214,8 @@ typed_config:
   {
     EXPECT_CALL(*file_, write(_));
     response_trailers_.addCopy(Http::Headers::get().GrpcStatus, "0");
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
     EXPECT_EQ("OK 0 OK OK OK 0\n", output_);
     response_trailers_.remove(Http::Headers::get().GrpcStatus);
   }
@@ -1162,7 +1223,8 @@ typed_config:
     InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
     EXPECT_CALL(*file_, write(_));
     response_headers_.addCopy(Http::Headers::get().GrpcStatus, "1");
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
     EXPECT_EQ("Canceled 1 Canceled Canceled CANCELLED 1\n", output_);
     response_headers_.remove(Http::Headers::get().GrpcStatus);
   }
@@ -1170,7 +1232,8 @@ typed_config:
     InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
     EXPECT_CALL(*file_, write(_));
     response_headers_.addCopy(Http::Headers::get().GrpcStatus, "-1");
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
     EXPECT_EQ("-1 -1 -1 -1 -1 -1\n", output_);
     response_headers_.remove(Http::Headers::get().GrpcStatus);
   }
@@ -1202,7 +1265,8 @@ typed_config:
     EXPECT_CALL(*file_, write(_));
 
     response_trailers_.addCopy(Http::Headers::get().GrpcStatus, std::to_string(i));
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
     response_trailers_.remove(Http::Headers::get().GrpcStatus);
   }
 }
@@ -1241,7 +1305,8 @@ typed_config:
   response_trailers_.addCopy(Http::Headers::get().GrpcStatus, "1");
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHttpCodes) {
@@ -1272,7 +1337,8 @@ typed_config:
         parseAccessLogFromV3Yaml(fmt::format(yaml_template, response_string)), context_);
 
     EXPECT_CALL(*file_, write(_));
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -1292,7 +1358,8 @@ typed_config:
       AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterExclude) {
@@ -1315,7 +1382,8 @@ typed_config:
     EXPECT_CALL(*file_, write(_)).Times(i == 0 ? 0 : 1);
 
     response_trailers_.addCopy(Http::Headers::get().GrpcStatus, std::to_string(i));
-    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+             AccessLog::AccessLogType::NotSet);
     response_trailers_.remove(Http::Headers::get().GrpcStatus);
   }
 }
@@ -1339,7 +1407,8 @@ typed_config:
   response_trailers_.addCopy(Http::Headers::get().GrpcStatus, "0");
 
   EXPECT_CALL(*file_, write(_));
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHeader) {
@@ -1360,7 +1429,8 @@ typed_config:
   EXPECT_CALL(*file_, write(_));
 
   response_headers_.addCopy(Http::Headers::get().GrpcStatus, "0");
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, MetadataFilter) {
@@ -1398,7 +1468,8 @@ typed_config:
 
   EXPECT_CALL(*file_, write(_));
 
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info,
+           AccessLog::AccessLogType::NotSet);
   fields_c["c"].set_bool_value(false);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
@@ -1427,7 +1498,8 @@ typed_config:
 
   // If no matcher is set, then expect no logs.
   EXPECT_CALL(*file_, write(_)).Times(0);
-  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info,
+           AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, MetadataFilterNoKey) {
@@ -1478,13 +1550,15 @@ typed_config:
       AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(default_false_yaml), context_);
   EXPECT_CALL(*file_, write(_)).Times(0);
 
-  default_false_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+  default_false_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info,
+                         AccessLog::AccessLogType::NotSet);
 
   const InstanceSharedPtr default_true_log =
       AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(default_true_yaml), context_);
   EXPECT_CALL(*file_, write(_));
 
-  default_true_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+  default_true_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info,
+                        AccessLog::AccessLogType::NotSet);
 }
 
 class TestHeaderFilterFactory : public ExtensionFilterFactory {
@@ -1529,11 +1603,13 @@ typed_config:
   InstanceSharedPtr logger = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
 
   request_headers_.addCopy("test-header", "foo/bar");
   EXPECT_CALL(*file_, write(_));
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
 }
 
 /**
@@ -1606,13 +1682,16 @@ typed_config:
   InstanceSharedPtr logger = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
   // For rate=5 expect 1st request to be recorded, 2nd-5th skipped, and 6th recorded.
   EXPECT_CALL(*file_, write(_));
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
   for (int i = 0; i <= 3; ++i) {
     EXPECT_CALL(*file_, write(_)).Times(0);
-    logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+                AccessLog::AccessLogType::NotSet);
   }
   EXPECT_CALL(*file_, write(_));
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, UnregisteredExtensionFilter) {
@@ -1671,11 +1750,13 @@ typed_config:
   request_headers_.addCopy("log", "true");
   stream_info_.response_code_ = 404;
   EXPECT_CALL(*file_, write(_));
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
 
   request_headers_.remove("log");
   EXPECT_CALL(*file_, write(_)).Times(0);
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, CelExtensionFilterExpressionError) {
@@ -1695,7 +1776,8 @@ typed_config:
   InstanceSharedPtr logger = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_)).Times(0);
-  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+  logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+              AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(AccessLogImplTest, CelExtensionFilterExpressionUnparsable) {

--- a/test/extensions/access_loggers/common/access_log_base_test.cc
+++ b/test/extensions/access_loggers/common/access_log_base_test.cc
@@ -25,7 +25,7 @@ public:
 private:
   void emitLog(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
                const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&,
-               AccessLog::AccessLogType = AccessLog::AccessLogType::NotSet) override {
+               AccessLog::AccessLogType) override {
     count_++;
   }
 
@@ -36,7 +36,7 @@ TEST(AccessLogBaseTest, NoFilter) {
   StreamInfo::MockStreamInfo stream_info;
   TestImpl logger(nullptr);
   EXPECT_EQ(logger.count(), 0);
-  logger.log(nullptr, nullptr, nullptr, stream_info);
+  logger.log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   EXPECT_EQ(logger.count(), 1);
 }
 
@@ -47,7 +47,7 @@ TEST(AccessLogBaseTest, FilterReject) {
   EXPECT_CALL(*filter, evaluate(_, _, _, _)).WillOnce(Return(false));
   TestImpl logger(std::move(filter));
   EXPECT_EQ(logger.count(), 0);
-  logger.log(nullptr, nullptr, nullptr, stream_info);
+  logger.log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   EXPECT_EQ(logger.count(), 0);
 }
 

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -73,7 +73,8 @@ public:
         EXPECT_EQ(got, expected);
       }
     }));
-    logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+                AccessLog::AccessLogType::NotSet);
   }
 
   Http::TestRequestHeaderMapImpl request_headers_{{":method", "GET"}, {":path", "/bar/foo"}};

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -155,7 +155,8 @@ request:
 response: {{}}
     )EOF",
                           request_method, request_method.length() + 7));
-    access_log_->log(&request_headers, nullptr, nullptr, stream_info);
+    access_log_->log(&request_headers, nullptr, nullptr, stream_info,
+                     AccessLog::AccessLogType::NotSet);
   }
 
   Stats::IsolatedStoreImpl scope_;
@@ -247,7 +248,7 @@ common_properties:
 request: {}
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 
   {
@@ -285,7 +286,7 @@ common_properties:
 request: {}
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 
   {
@@ -404,7 +405,8 @@ response:
   response_body_bytes: 20
   response_code_details: "via_upstream"
 )EOF");
-    access_log_->log(&request_headers, &response_headers, nullptr, stream_info);
+    access_log_->log(&request_headers, &response_headers, nullptr, stream_info,
+                     AccessLog::AccessLogType::NotSet);
   }
 
   {
@@ -445,7 +447,8 @@ request:
   request_headers_bytes: 16
 response: {}
 )EOF");
-    access_log_->log(&request_headers, nullptr, nullptr, stream_info);
+    access_log_->log(&request_headers, nullptr, nullptr, stream_info,
+                     AccessLog::AccessLogType::NotSet);
   }
 
   {
@@ -517,7 +520,8 @@ request:
   request_headers_bytes: 16
 response: {}
 )EOF");
-    access_log_->log(&request_headers, nullptr, nullptr, stream_info);
+    access_log_->log(&request_headers, nullptr, nullptr, stream_info,
+                     AccessLog::AccessLogType::NotSet);
   }
 
   // TLSv1.2
@@ -573,7 +577,7 @@ request:
   request_method: "METHOD_UNSPECIFIED"
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 
   // TLSv1.1
@@ -629,7 +633,7 @@ request:
   request_method: "METHOD_UNSPECIFIED"
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 
   // TLSv1
@@ -685,7 +689,7 @@ request:
   request_method: "METHOD_UNSPECIFIED"
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 
   // Unknown TLS version (TLSv1.4)
@@ -741,7 +745,7 @@ request:
   request_method: "METHOD_UNSPECIFIED"
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 
   // Intermediate log entry.
@@ -809,7 +813,7 @@ common_properties:
 request: {}
 response: {}
 )EOF");
-    access_log_->log(nullptr, nullptr, nullptr, stream_info);
+    access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -905,7 +909,8 @@ response:
     "x-logged-trailer": "value,response_trailer_value"
     "x-empty-trailer": ""
 )EOF");
-    access_log_->log(&request_headers, &response_headers, &response_trailers, stream_info);
+    access_log_->log(&request_headers, &response_headers, &response_trailers, stream_info,
+                     AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -988,7 +993,8 @@ response:
     "x-trailer": "{0},{0}"
 )EOF",
                           "prefix!!suffix"));
-    access_log_->log(&request_headers, &response_headers, &response_trailers, stream_info);
+    access_log_->log(&request_headers, &response_headers, &response_trailers, stream_info,
+                     AccessLog::AccessLogType::NotSet);
   }
 }
 
@@ -1050,7 +1056,7 @@ common_properties:
 request: {}
 response: {}
 )EOF");
-  access_log_->log(nullptr, nullptr, nullptr, stream_info);
+  access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(HttpGrpcAccessLogTest, CustomTagTestMetadata) {
@@ -1109,7 +1115,7 @@ common_properties:
 request: {}
 response: {}
 )EOF");
-  access_log_->log(nullptr, nullptr, nullptr, stream_info);
+  access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
 }
 
 TEST_F(HttpGrpcAccessLogTest, CustomTagTestMetadataDefaultValue) {
@@ -1165,7 +1171,7 @@ common_properties:
 request: {}
 response: {}
 )EOF");
-  access_log_->log(nullptr, nullptr, nullptr, stream_info);
+  access_log_->log(nullptr, nullptr, nullptr, stream_info, AccessLog::AccessLogType::NotSet);
 }
 
 } // namespace

--- a/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
@@ -145,7 +145,8 @@ TEST_F(AccessLogTest, Marshalling) {
           value:
             string_value: "10"
     )EOF");
-  access_log->log(&request_headers, &response_headers, nullptr, stream_info);
+  access_log->log(&request_headers, &response_headers, nullptr, stream_info,
+                  Envoy::AccessLog::AccessLogType::NotSet);
 }
 
 // Test log with empty config.
@@ -159,7 +160,8 @@ TEST_F(AccessLogTest, EmptyConfig) {
   expectLog(R"EOF(
       time_unix_nano: 3600000000000
     )EOF");
-  access_log->log(&request_headers, &response_headers, nullptr, stream_info);
+  access_log->log(&request_headers, &response_headers, nullptr, stream_info,
+                  Envoy::AccessLog::AccessLogType::NotSet);
 }
 
 } // namespace

--- a/test/extensions/access_loggers/stream/stream_test_base.h
+++ b/test/extensions/access_loggers/stream/stream_test_base.h
@@ -52,7 +52,8 @@ protected:
         EXPECT_EQ(got, expected);
       }
     }));
-    logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
+    logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
+                AccessLog::AccessLogType::NotSet);
   }
 
   Http::TestRequestHeaderMapImpl request_headers_{{":method", "GET"}, {":path", "/bar/foo"}};

--- a/test/extensions/access_loggers/wasm/config_test.cc
+++ b/test/extensions/access_loggers/wasm/config_test.cc
@@ -121,12 +121,14 @@ TEST_P(WasmAccessLogConfigTest, CreateWasmFromWASM) {
   Http::TestRequestHeaderMapImpl request_header;
   Http::TestResponseHeaderMapImpl response_header;
   Http::TestResponseTrailerMapImpl response_trailer;
-  instance->log(&request_header, &response_header, &response_trailer, log_stream_info_);
+  instance->log(&request_header, &response_header, &response_trailer, log_stream_info_,
+                AccessLog::AccessLogType::NotSet);
 
   filter = std::make_unique<NiceMock<AccessLog::MockFilter>>();
   AccessLog::InstanceSharedPtr filter_instance =
       factory->createAccessLogInstance(config, std::move(filter), context_);
-  filter_instance->log(&request_header, &response_header, &response_trailer, log_stream_info_);
+  filter_instance->log(&request_header, &response_header, &response_trailer, log_stream_info_,
+                       AccessLog::AccessLogType::NotSet);
 }
 
 TEST_P(WasmAccessLogConfigTest, YamlLoadFromFileWasmInvalidConfig) {
@@ -180,7 +182,8 @@ TEST_P(WasmAccessLogConfigTest, YamlLoadFromFileWasmInvalidConfig) {
   AccessLog::InstanceSharedPtr filter_instance =
       factory->createAccessLogInstance(proto_config, nullptr, context_);
   filter_instance = factory->createAccessLogInstance(proto_config, nullptr, context_);
-  filter_instance->log(nullptr, nullptr, nullptr, log_stream_info_);
+  filter_instance->log(nullptr, nullptr, nullptr, log_stream_info_,
+                       AccessLog::AccessLogType::NotSet);
 }
 
 TEST_P(WasmAccessLogConfigTest, YamlLoadFromRemoteWasmCreateFilter) {
@@ -225,7 +228,8 @@ TEST_P(WasmAccessLogConfigTest, YamlLoadFromRemoteWasmCreateFilter) {
           }));
   AccessLog::InstanceSharedPtr filter_instance =
       factory.createAccessLogInstance(proto_config, nullptr, context_);
-  filter_instance->log(nullptr, nullptr, nullptr, log_stream_info_);
+  filter_instance->log(nullptr, nullptr, nullptr, log_stream_info_,
+                       AccessLog::AccessLogType::NotSet);
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   auto response = Http::ResponseMessagePtr{new Http::ResponseMessageImpl(
@@ -233,7 +237,8 @@ TEST_P(WasmAccessLogConfigTest, YamlLoadFromRemoteWasmCreateFilter) {
   response->body().add(code);
   async_callbacks->onSuccess(request, std::move(response));
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
-  filter_instance->log(nullptr, nullptr, nullptr, log_stream_info_);
+  filter_instance->log(nullptr, nullptr, nullptr, log_stream_info_,
+                       AccessLog::AccessLogType::NotSet);
 }
 
 TEST_P(WasmAccessLogConfigTest, FailedToGetThreadLocalPlugin) {
@@ -274,11 +279,13 @@ TEST_P(WasmAccessLogConfigTest, FailedToGetThreadLocalPlugin) {
   Http::TestResponseHeaderMapImpl response_header;
   Http::TestResponseTrailerMapImpl response_trailer;
 
-  filter_instance->log(&request_header, &response_header, &response_trailer, log_stream_info_);
+  filter_instance->log(&request_header, &response_header, &response_trailer, log_stream_info_,
+                       AccessLog::AccessLogType::NotSet);
   // Even if the thread local plugin handle returns nullptr, `log` should not raise error or
   // exception.
   threadlocal.data_[0] = std::make_shared<PluginHandleSharedPtrThreadLocal>(nullptr);
-  filter_instance->log(&request_header, &response_header, &response_trailer, log_stream_info_);
+  filter_instance->log(&request_header, &response_header, &response_trailer, log_stream_info_,
+                       AccessLog::AccessLogType::NotSet);
 }
 
 } // namespace Wasm

--- a/test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h
+++ b/test/extensions/filters/http/common/fuzz/http_filter_fuzzer.h
@@ -38,7 +38,8 @@ public:
   // This executes the access logger with the fuzzed headers/trailers.
   void accessLog(AccessLog::Instance* access_logger, const StreamInfo::StreamInfo& stream_info) {
     ENVOY_LOG_MISC(debug, "Access logging");
-    access_logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+    access_logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info,
+                       AccessLog::AccessLogType::NotSet);
   }
 
   // Fuzzed headers and trailers are needed for access logging, reset the data and destroy filters.

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -226,7 +226,8 @@ TEST_F(FilterTest, StreamFilterDelegationMultipleAccessLoggers) {
 
   EXPECT_CALL(*access_log_1, log(_, _, _, _, _));
   EXPECT_CALL(*access_log_2, log(_, _, _, _, _));
-  filter_.log(nullptr, nullptr, nullptr, StreamInfo::MockStreamInfo());
+  filter_.log(nullptr, nullptr, nullptr, StreamInfo::MockStreamInfo(),
+              AccessLog::AccessLogType::NotSet);
 }
 
 } // namespace

--- a/test/extensions/filters/http/tap/tap_filter_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_test.cc
@@ -89,7 +89,8 @@ TEST_F(TapFilterTest, NoConfig) {
   Http::MetadataMap metadata;
   EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->encodeMetadata(metadata));
 
-  filter_->log(&request_headers, &response_headers, &response_trailers, stream_info_);
+  filter_->log(&request_headers, &response_headers, &response_trailers, stream_info_,
+               AccessLog::AccessLogType::NotSet);
 }
 
 // Verify filter functionality when there is a tap config.
@@ -119,7 +120,8 @@ TEST_F(TapFilterTest, Config) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
 
   EXPECT_CALL(*http_per_request_tapper_, onDestroyLog()).WillOnce(Return(true));
-  filter_->log(&request_headers, &response_headers, &response_trailers, stream_info_);
+  filter_->log(&request_headers, &response_headers, &response_trailers, stream_info_,
+               AccessLog::AccessLogType::NotSet);
   EXPECT_EQ(1UL, filter_config_->stats_.rq_tapped_.value());
 
   // Workaround InSequence/shared_ptr mock leak.

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -678,7 +678,8 @@ TEST_P(WasmHttpFilterTest, AccessLog) {
   StreamInfo::MockStreamInfo log_stream_info;
   EXPECT_CALL(log_stream_info, requestComplete())
       .WillRepeatedly(testing::Return(std::chrono::milliseconds(30)));
-  filter().log(&request_headers, &response_headers, &response_trailers, log_stream_info);
+  filter().log(&request_headers, &response_headers, &response_trailers, log_stream_info,
+               AccessLog::AccessLogType::NotSet);
   filter().onDestroy();
 }
 
@@ -697,7 +698,8 @@ TEST_P(WasmHttpFilterTest, AccessLogClientDisconnected) {
   StreamInfo::MockStreamInfo log_stream_info;
   EXPECT_CALL(log_stream_info, requestComplete())
       .WillRepeatedly(testing::Return(std::chrono::milliseconds(30)));
-  filter().log(&request_headers, nullptr, nullptr, log_stream_info);
+  filter().log(&request_headers, nullptr, nullptr, log_stream_info,
+               AccessLog::AccessLogType::NotSet);
   filter().onDestroy();
 }
 
@@ -714,7 +716,8 @@ TEST_P(WasmHttpFilterTest, AccessLogDisabledForIncompleteStream) {
 
   StreamInfo::MockStreamInfo log_stream_info;
   EXPECT_CALL(log_stream_info, requestComplete()).WillRepeatedly(testing::Return(absl::nullopt));
-  filter().log(&request_headers, nullptr, nullptr, log_stream_info);
+  filter().log(&request_headers, nullptr, nullptr, log_stream_info,
+               AccessLog::AccessLogType::NotSet);
   filter().onDestroy();
 }
 
@@ -730,7 +733,8 @@ TEST_P(WasmHttpFilterTest, AccessLogCreate) {
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   Http::TestResponseTrailerMapImpl response_trailers{};
-  filter().log(&request_headers, &response_headers, &response_trailers, log_stream_info);
+  filter().log(&request_headers, &response_headers, &response_trailers, log_stream_info,
+               AccessLog::AccessLogType::NotSet);
   filter().onDestroy();
 }
 
@@ -1759,7 +1763,8 @@ TEST_P(WasmHttpFilterTest, Metadata) {
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
 
-  filter().log(&request_headers, nullptr, nullptr, request_stream_info_);
+  filter().log(&request_headers, nullptr, nullptr, request_stream_info_,
+               AccessLog::AccessLogType::NotSet);
 
   const auto* result =
       request_stream_info_.filterState()->getDataReadOnly<Filters::Common::Expr::CelState>(
@@ -1826,7 +1831,8 @@ TEST_P(WasmHttpFilterTest, Property) {
   request_stream_info_.upstreamInfo()->setUpstreamHost(host_description);
   EXPECT_CALL(request_stream_info_, requestComplete())
       .WillRepeatedly(Return(std::chrono::milliseconds(30)));
-  filter().log(&request_headers, nullptr, nullptr, request_stream_info_);
+  filter().log(&request_headers, nullptr, nullptr, request_stream_info_,
+               AccessLog::AccessLogType::NotSet);
 }
 
 TEST_P(WasmHttpFilterTest, ClusterMetadata) {
@@ -1857,14 +1863,16 @@ TEST_P(WasmHttpFilterTest, ClusterMetadata) {
   request_stream_info_.upstreamInfo()->setUpstreamHost(host_description);
   EXPECT_CALL(request_stream_info_, requestComplete)
       .WillRepeatedly(Return(std::chrono::milliseconds(30)));
-  filter().log(&request_headers, nullptr, nullptr, request_stream_info_);
+  filter().log(&request_headers, nullptr, nullptr, request_stream_info_,
+               AccessLog::AccessLogType::NotSet);
 
   // If upstream host is empty, fallback to upstream cluster info for cluster metadata.
   request_stream_info_.upstreamInfo()->setUpstreamHost(nullptr);
   EXPECT_CALL(request_stream_info_, upstreamClusterInfo()).WillRepeatedly(Return(cluster));
   EXPECT_CALL(filter(),
               log_(spdlog::level::warn, Eq(absl::string_view("cluster metadata: cluster"))));
-  filter().log(&request_headers, nullptr, nullptr, request_stream_info_);
+  filter().log(&request_headers, nullptr, nullptr, request_stream_info_,
+               AccessLog::AccessLogType::NotSet);
 }
 
 TEST_P(WasmHttpFilterTest, SharedData) {


### PR DESCRIPTION
Commit Message: access_log: use AccessLogType::NotSet instead of default value
Additional Description: Remove default value for the access_log_type parameter in any log function and instead call log() with AccessLogType::NotSet to explicitly indicate that the access log type is irrelevant or not handled
Risk Level: Low
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None