### PR TITLE
tracing: expose stream info to the extended tracing driver

### DIFF
--- a/envoy/tracing/BUILD
+++ b/envoy/tracing/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
     hdrs = ["trace_driver.h"],
     deps = [
         ":trace_config_interface",
+        "//envoy/stream_info:stream_info_interface",
     ],
 )
 

--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "envoy/common/pure.h"
+#include "envoy/stream_info/stream_info.h"
 #include "envoy/tracing/trace_config.h"
 
 namespace Envoy {
@@ -107,8 +108,9 @@ public:
   /**
    * Start driver specific span.
    */
-  virtual SpanPtr startSpan(const Config& config, TraceContext& trace_conext,
-                            const std::string& operation_name, SystemTime start_time,
+  virtual SpanPtr startSpan(const Config& config, TraceContext& trace_context,
+                            const StreamInfo::StreamInfo& stream_info,
+                            const std::string& operation_name,
                             const Tracing::Decision tracing_decision) PURE;
 };
 

--- a/envoy/tracing/tracer.h
+++ b/envoy/tracing/tracer.h
@@ -1,16 +1,11 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <vector>
 
-#include "envoy/access_log/access_log.h"
 #include "envoy/common/pure.h"
+#include "envoy/tracing/trace_context.h"
 #include "envoy/tracing/trace_driver.h"
 #include "envoy/tracing/trace_reason.h"
-
-#include "trace_context.h"
-#include "tracer.h"
 
 namespace Envoy {
 namespace Tracing {

--- a/source/common/tracing/tracer_impl.cc
+++ b/source/common/tracing/tracer_impl.cc
@@ -149,8 +149,8 @@ SpanPtr TracerImpl::startSpan(const Config& config, TraceContext& trace_context,
     span_name.append(std::string(trace_context.host()));
   }
 
-  SpanPtr active_span = driver_->startSpan(config, trace_context, span_name,
-                                           stream_info.startTime(), tracing_decision);
+  SpanPtr active_span =
+      driver_->startSpan(config, trace_context, stream_info, span_name, tracing_decision);
 
   // Set tags related to the local environment
   if (active_span) {

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -153,8 +153,8 @@ OpenTracingDriver::OpenTracingDriver(Stats::Scope& scope)
 
 Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
                                               Tracing::TraceContext& trace_context,
+                                              const StreamInfo::StreamInfo& stream_info,
                                               const std::string& operation_name,
-                                              SystemTime start_time,
                                               const Tracing::Decision tracing_decision) {
   const PropagationMode propagation_mode = this->propagationMode();
   const opentracing::Tracer& tracer = this->tracer();
@@ -196,7 +196,7 @@ Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
   opentracing::StartSpanOptions options;
   options.references.emplace_back(opentracing::SpanReferenceType::ChildOfRef,
                                   parent_span_ctx.get());
-  options.start_system_timestamp = start_time;
+  options.start_system_timestamp = stream_info.startTime();
   if (!tracing_decision.traced) {
     options.tags.emplace_back(opentracing::ext::sampling_priority, 0);
   }

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -64,9 +64,10 @@ class OpenTracingDriver : public Tracing::Driver, protected Logger::Loggable<Log
 public:
   explicit OpenTracingDriver(Stats::Scope& scope);
 
-  // Tracer::TracingDriver
+  // Tracing::Driver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
-                             const std::string& operation_name, SystemTime start_time,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
                              const Tracing::Decision tracing_decision) override;
 
   virtual opentracing::Tracer& tracer() PURE;

--- a/source/extensions/tracers/datadog/tracer.cc
+++ b/source/extensions/tracers/datadog/tracer.cc
@@ -75,7 +75,8 @@ Tracer::Tracer(const std::string& collector_cluster, const std::string& collecto
 // Tracer::TracingDriver
 
 Tracing::SpanPtr Tracer::startSpan(const Tracing::Config&, Tracing::TraceContext& trace_context,
-                                   const std::string& operation_name, SystemTime start_time,
+                                   const StreamInfo::StreamInfo& stream_info,
+                                   const std::string& operation_name,
                                    const Tracing::Decision tracing_decision) {
   ThreadLocalTracer& thread_local_tracer = **thread_local_slot_;
   if (!thread_local_tracer.tracer) {
@@ -86,7 +87,7 @@ Tracing::SpanPtr Tracer::startSpan(const Tracing::Config&, Tracing::TraceContext
   // so we will as well.
   datadog::tracing::SpanConfig span_config;
   span_config.name = operation_name;
-  span_config.start = estimateTime(start_time);
+  span_config.start = estimateTime(stream_info.startTime());
 
   datadog::tracing::Tracer& tracer = *thread_local_tracer.tracer;
   TraceContextReader reader{trace_context};

--- a/source/extensions/tracers/datadog/tracer.h
+++ b/source/extensions/tracers/datadog/tracer.h
@@ -61,27 +61,28 @@ public:
     datadog::tracing::Optional<datadog::tracing::Tracer> tracer;
   };
 
-  // Tracer::TracingDriver
+  // Tracing::Driver
 
   /**
    * Create a Datadog span from the specified \p trace_context, and having the
-   * specified \p operation_name, \p start_time and \p tracing_decision.
+   * specified \p operation_name, \p stream_info and \p tracing_decision.
    * If this tracer encountered an error during initialization, then return a
    * \c Tracing::NullSpan instead.
    * @param config this parameter is ignored
    * @param trace_context possibly contains information about an existing trace
    * that the returned span will be a part of; otherwise, the returned span is
    * the root of a new trace
+   * @param stream_info contains information about the stream.
    * @param operation_name the name of the operation representation by this
    * span, e.g. "handle.request"
-   * @param start_time when the span begins
    * @param tracing_decision the sampling decision made in advance by Envoy for
    * this trace. If the decision is to drop the trace, then this tracer will
    * honor that decision. If the decision is to keep the trace, then this tracer
    * will apply its own sampling logic, which might keep or drop the trace.
    */
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
-                             const std::string& operation_name, SystemTime start_time,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
                              const Tracing::Decision tracing_decision) override;
 
 private:

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -375,10 +375,11 @@ void Driver::applyTraceConfig(const opencensus::proto::trace::v1::TraceConfig& c
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
                                    Tracing::TraceContext& trace_context,
-                                   const std::string& operation_name, SystemTime start_time,
+                                   const StreamInfo::StreamInfo& stream_info,
+                                   const std::string& operation_name,
                                    const Tracing::Decision tracing_decision) {
-  return std::make_unique<Span>(config, oc_config_, trace_context, operation_name, start_time,
-                                tracing_decision);
+  return std::make_unique<Span>(config, oc_config_, trace_context, operation_name,
+                                stream_info.startTime(), tracing_decision);
 }
 
 } // namespace OpenCensus

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
@@ -20,11 +20,10 @@ public:
   Driver(const envoy::config::trace::v3::OpenCensusConfig& oc_config,
          const LocalInfo::LocalInfo& localinfo, Api::Api& api);
 
-  /**
-   * Implements the abstract Driver's startSpan operation.
-   */
+  // Tracing::Driver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
-                             const std::string& operation_name, SystemTime start_time,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
                              const Tracing::Decision tracing_decision) override;
 
 private:

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h
@@ -32,11 +32,10 @@ public:
   Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetry_config,
          Server::Configuration::TracerFactoryContext& context);
 
-  /**
-   * Implements the abstract Driver's startSpan operation.
-   */
+  // Tracing::Driver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
-                             const std::string& operation_name, SystemTime start_time,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
                              const Tracing::Decision tracing_decision) override;
 
 private:

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -45,7 +45,7 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
 }
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config&, Tracing::TraceContext& trace_context,
-                                   const std::string&, Envoy::SystemTime,
+                                   const StreamInfo::StreamInfo&, const std::string&,
                                    const Tracing::Decision decision) {
   auto& tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer();
   TracingContextPtr tracing_context;

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
@@ -24,9 +24,11 @@ public:
   explicit Driver(const envoy::config::trace::v3::SkyWalkingConfig& config,
                   Server::Configuration::TracerFactoryContext& context);
 
+  // Tracing::Driver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
-                             const std::string& operation, Envoy::SystemTime start_time,
-                             const Tracing::Decision decision) override;
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
+                             const Tracing::Decision tracing_decision) override;
 
 private:
   void loadConfig(const envoy::config::trace::v3::ClientConfig& client_config,

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -63,7 +63,8 @@ Driver::Driver(const XRayConfiguration& config,
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
                                    Tracing::TraceContext& trace_context,
-                                   const std::string& operation_name, Envoy::SystemTime start_time,
+                                   const StreamInfo::StreamInfo& stream_info,
+                                   const std::string& operation_name,
                                    const Tracing::Decision tracing_decision) {
   // First thing is to determine whether this request will be sampled or not.
   // if there's a X-Ray header and it has a sampling decision already determined (i.e. Sample=1)
@@ -105,7 +106,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
 
   auto* tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer_.get();
   if (should_trace.value()) {
-    return tracer->startSpan(config, operation_name, start_time,
+    return tracer->startSpan(config, operation_name, stream_info.startTime(),
                              header.has_value() ? absl::optional<XRayHeader>(xray_header)
                                                 : absl::nullopt,
                              trace_context.getByKey(XForwardedForHeader));

--- a/source/extensions/tracers/xray/xray_tracer_impl.h
+++ b/source/extensions/tracers/xray/xray_tracer_impl.h
@@ -17,8 +17,10 @@ public:
   Driver(const XRay::XRayConfiguration& config,
          Server::Configuration::TracerFactoryContext& context);
 
+  // Tracing::Driver
   Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
-                             const std::string& operation_name, Envoy::SystemTime start_time,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
                              const Tracing::Decision tracing_decision) override;
 
 private:

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -123,8 +123,9 @@ public:
    * Thus, this implementation of the virtual function startSpan() ignores the operation name
    * ("ingress" or "egress") passed by the caller.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config&, Tracing::TraceContext& trace_context,
-                             const std::string&, SystemTime start_time,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
+                             const StreamInfo::StreamInfo& stream_info,
+                             const std::string& operation_name,
                              const Tracing::Decision tracing_decision) override;
 
   // Getters to return the ZipkinDriver's key members.

--- a/test/common/tracing/tracer_impl_test.cc
+++ b/test/common/tracing/tracer_impl_test.cc
@@ -303,7 +303,7 @@ TEST_F(TracerImplTest, BasicFunctionalityNullSpan) {
   EXPECT_CALL(config_, operationName()).Times(2);
   EXPECT_CALL(stream_info_, startTime());
   const std::string operation_name = "ingress";
-  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, stream_info_.start_time_, _))
+  EXPECT_CALL(*driver_, startSpan_(_, _, stream_info_, operation_name, _))
       .WillOnce(Return(nullptr));
   tracer_->startSpan(config_, request_headers_, stream_info_, {Reason::Sampling, true});
 }
@@ -315,8 +315,7 @@ TEST_F(TracerImplTest, BasicFunctionalityNodeSet) {
 
   NiceMock<MockSpan>* span = new NiceMock<MockSpan>();
   const std::string operation_name = "egress test";
-  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, stream_info_.start_time_, _))
-      .WillOnce(Return(span));
+  EXPECT_CALL(*driver_, startSpan_(_, _, stream_info_, operation_name, _)).WillOnce(Return(span));
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag(Eq(Tracing::Tags::get().NodeId), Eq("node_name")));
 
@@ -330,8 +329,7 @@ TEST_F(TracerImplTest, ChildGrpcUpstreamSpanTest) {
 
   NiceMock<MockSpan>* span = new NiceMock<MockSpan>();
   const std::string operation_name = "egress test";
-  EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, stream_info_.start_time_, _))
-      .WillOnce(Return(span));
+  EXPECT_CALL(*driver_, startSpan_(_, _, stream_info_, operation_name, _)).WillOnce(Return(span));
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag(Eq(Tracing::Tags::get().NodeId), Eq("node_name")));
 

--- a/test/extensions/tracers/common/ot/BUILD
+++ b/test/extensions/tracers/common/ot/BUILD
@@ -23,6 +23,7 @@ envoy_extension_cc_test(
         "//source/extensions/tracers/dynamic_ot:dynamic_opentracing_driver_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "@io_opentracing_cpp//mocktracer",
     ],

--- a/test/extensions/tracers/datadog/BUILD
+++ b/test/extensions/tracers/datadog/BUILD
@@ -49,6 +49,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:tracer_factory_context_mocks",
         "//test/mocks/server:tracer_factory_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -82,9 +82,9 @@ public:
   const std::string operation_name_{"test"};
   Http::TestRequestHeaderMapImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
-  SystemTime start_time_;
 
   NiceMock<ThreadLocal::MockInstance> tls_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   NiceMock<Event::MockTimer>* timer_;
   Stats::TestUtil::TestStore stats_;
   NiceMock<Upstream::MockClusterManager> cm_;
@@ -173,8 +173,8 @@ TEST_F(DatadogConfigTest, CollectorHostname) {
             return &request;
           }));
 
-  Tracing::SpanPtr span = tracer_->startSpan(config_, request_headers_, operation_name_,
-                                             start_time_, {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = tracer_->startSpan(config_, request_headers_, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
   // Timer should be re-enabled.

--- a/test/extensions/tracers/datadog/tracer_test.cc
+++ b/test/extensions/tracers/datadog/tracer_test.cc
@@ -4,6 +4,7 @@
 #include "source/extensions/tracers/datadog/span.h"
 #include "source/extensions/tracers/datadog/tracer.h"
 
+#include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/test_common/simulated_time_system.h"
@@ -35,6 +36,7 @@ protected:
   Stats::TestUtil::TestStore store_;
   NiceMock<ThreadLocal::MockInstance> thread_local_slot_allocator_;
   Event::SimulatedTimeSystem time_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 };
 
 TEST_F(DatadogTracerTest, Breathing) {
@@ -71,9 +73,10 @@ TEST_F(DatadogTracerTest, NoOpMode) {
 
   const std::string operation_name = "do.thing";
   const SystemTime start = time_.timeSystem().systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(testing::Return(start));
 
   const Tracing::SpanPtr span =
-      tracer.startSpan(Tracing::MockConfig{}, context, operation_name, start, decision);
+      tracer.startSpan(Tracing::MockConfig{}, context, stream_info_, operation_name, decision);
   ASSERT_TRUE(span);
   const auto as_null_span = dynamic_cast<Tracing::NullSpan*>(span.get());
   EXPECT_NE(nullptr, as_null_span);
@@ -100,9 +103,10 @@ TEST_F(DatadogTracerTest, SpanProperties) {
 
   const std::string operation_name = "do.thing";
   const SystemTime start = time_.timeSystem().systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(testing::Return(start));
 
   const Tracing::SpanPtr span =
-      tracer.startSpan(Tracing::MockConfig{}, context, operation_name, start, decision);
+      tracer.startSpan(Tracing::MockConfig{}, context, stream_info_, operation_name, decision);
   ASSERT_TRUE(span);
   const auto as_dd_span_wrapper = dynamic_cast<Span*>(span.get());
   EXPECT_NE(nullptr, as_dd_span_wrapper);
@@ -139,12 +143,14 @@ TEST_F(DatadogTracerTest, ExtractionSuccess) {
 
   const std::string operation_name = "do.thing";
   const SystemTime start = time_.timeSystem().systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(testing::Return(start));
+
   // trace context in the Datadog style
   Tracing::TestTraceContextImpl context{{"x-datadog-trace-id", "1234"},
                                         {"x-datadog-parent-id", "5678"}};
 
   const Tracing::SpanPtr span =
-      tracer.startSpan(Tracing::MockConfig{}, context, operation_name, start, decision);
+      tracer.startSpan(Tracing::MockConfig{}, context, stream_info_, operation_name, decision);
   ASSERT_TRUE(span);
   const auto as_dd_span_wrapper = dynamic_cast<Span*>(span.get());
   EXPECT_NE(nullptr, as_dd_span_wrapper);
@@ -176,12 +182,14 @@ TEST_F(DatadogTracerTest, ExtractionFailure) {
 
   const std::string operation_name = "do.thing";
   const SystemTime start = time_.timeSystem().systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(testing::Return(start));
+
   // invalid trace context in the Datadog style
   Tracing::TestTraceContextImpl context{{"x-datadog-trace-id", "nope"},
                                         {"x-datadog-parent-id", "nice try"}};
 
   const Tracing::SpanPtr span =
-      tracer.startSpan(Tracing::MockConfig{}, context, operation_name, start, decision);
+      tracer.startSpan(Tracing::MockConfig{}, context, stream_info_, operation_name, decision);
   ASSERT_TRUE(span);
   const auto as_dd_span_wrapper = dynamic_cast<Span*>(span.get());
   EXPECT_NE(nullptr, as_dd_span_wrapper);

--- a/test/extensions/tracers/dynamic_ot/BUILD
+++ b/test/extensions/tracers/dynamic_ot/BUILD
@@ -27,6 +27,7 @@ envoy_extension_cc_test(
         "//source/extensions/tracers/dynamic_ot:dynamic_opentracing_driver_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/test_common:environment_lib",
     ],

--- a/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
@@ -5,6 +5,7 @@
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/environment.h"
 
@@ -42,8 +43,9 @@ public:
   const std::string operation_name_{"test"};
   Http::TestRequestHeaderMapImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
-  SystemTime start_time_;
+
   NiceMock<Tracing::MockConfig> config_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 };
 
 TEST_F(DynamicOpenTracingDriverTest, FormatErrorMessage) {
@@ -77,8 +79,9 @@ TEST_F(DynamicOpenTracingDriverTest, FlushSpans) {
   setupValidDriver();
 
   {
-    Tracing::SpanPtr first_span = driver_->startSpan(
-        config_, request_headers_, operation_name_, start_time_, {Tracing::Reason::Sampling, true});
+    Tracing::SpanPtr first_span =
+        driver_->startSpan(config_, request_headers_, stream_info_, operation_name_,
+                           {Tracing::Reason::Sampling, true});
     first_span->finishSpan();
     driver_->tracer().Close();
   }

--- a/test/extensions/tracers/opencensus/BUILD
+++ b/test/extensions/tracers/opencensus/BUILD
@@ -21,6 +21,7 @@ envoy_extension_cc_test(
         "//source/extensions/tracers/opencensus:opencensus_tracer_impl",
         "//test/mocks/http:http_mocks",
         "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
     ],

--- a/test/extensions/tracers/opentelemetry/BUILD
+++ b/test/extensions/tracers/opentelemetry/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:tracer_factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -8,6 +8,7 @@
 #include "test/mocks/common.h"
 #include "test/mocks/server/tracer_factory_context.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/utility.h"
 
@@ -63,6 +64,7 @@ protected:
   const std::string operation_name_{"test"};
   NiceMock<Envoy::Server::Configuration::MockTracerFactoryContext> context_;
   NiceMock<Envoy::Tracing::MockConfig> mock_tracing_config_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   Event::SimulatedTimeSystem time_system_;
   std::unique_ptr<NiceMock<Grpc::MockAsyncStream>> mock_stream_ptr_{nullptr};
   envoy::config::trace::v3::OpenTelemetryConfig config_;
@@ -107,9 +109,8 @@ TEST_F(OpenTelemetryDriverTest, ParseSpanContextFromHeadersTest) {
       context_.server_factory_context_.api_.random_;
   ON_CALL(mock_random_generator_, random()).WillByDefault(Return(new_span_id));
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
 
   EXPECT_EQ(span->getTraceIdAsHex(), trace_id_hex);
 
@@ -146,6 +147,8 @@ resource_spans:
   )";
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
   SystemTime timestamp = time_system_.systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(Return(timestamp));
+
   int64_t timestamp_ns = std::chrono::nanoseconds(timestamp.time_since_epoch()).count();
   TestUtility::loadFromYaml(fmt::format(request_yaml, timestamp_ns, timestamp_ns), request_proto);
   auto* expected_span =
@@ -187,9 +190,8 @@ TEST_F(OpenTelemetryDriverTest, GenerateSpanContextWithoutHeadersTest) {
     EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(new_span_id));
   }
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
 
   // Remove headers, then inject context into header from the span.
   request_headers.remove(OpenTelemetryConstants::get().TRACE_PARENT);
@@ -212,9 +214,8 @@ TEST_F(OpenTelemetryDriverTest, NullSpanWithPropagationHeaderError) {
   request_headers.addReferenceKey(OpenTelemetryConstants::get().TRACE_PARENT,
                                   "invalid00-0000000000000003-01");
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
 
   auto& null_span = *span;
   EXPECT_EQ(typeid(null_span).name(), typeid(Tracing::NullSpan).name());
@@ -226,9 +227,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpan) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   // Test baggage noop and other noop calls.
@@ -254,9 +254,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithBuffer) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   // Flush after two spans.
@@ -267,8 +266,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithBuffer) {
   span->finishSpan();
   // Once we create a
   Tracing::SpanPtr second_span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+      driver_->startSpan(mock_tracing_config_, request_headers, stream_info_, operation_name_,
+                         {Tracing::Reason::Sampling, true});
   EXPECT_NE(second_span.get(), nullptr);
   // Only now should we see the span exported.
   EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
@@ -287,9 +286,8 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithFlushTimeout) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   // Set it to flush after 2 spans so that the span will only be flushed by timeout.
@@ -329,9 +327,8 @@ TEST_F(OpenTelemetryDriverTest, SpawnChildSpan) {
     EXPECT_CALL(mock_random_generator_, random()).WillOnce(Return(parent_span_id));
   }
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   // The child should only generate a span ID for itself; the trace id should come from the parent..
@@ -359,9 +356,10 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithAttributes) {
   int64_t generated_int = 1;
   EXPECT_CALL(mock_random_generator_, random()).Times(3).WillRepeatedly(Return(generated_int));
   SystemTime timestamp = time_system_.systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(Return(timestamp));
 
-  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                                             timestamp, {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   span->setTag("first_tag_name", "first_tag_value");
@@ -418,9 +416,8 @@ TEST_F(OpenTelemetryDriverTest, IgnoreNotSampledSpan) {
   setupValidDriver();
   Http::TestRequestHeaderMapImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   span->setSampled(false);
@@ -440,9 +437,8 @@ TEST_F(OpenTelemetryDriverTest, NoExportWithoutGrpcService) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
-  Tracing::SpanPtr span =
-      driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                         time_system_.systemTime(), {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   // Flush after a single span.
@@ -474,9 +470,10 @@ TEST_F(OpenTelemetryDriverTest, ExportSpanWithCustomServiceName) {
   int64_t generated_int = 1;
   EXPECT_CALL(mock_random_generator_, random()).Times(3).WillRepeatedly(Return(generated_int));
   SystemTime timestamp = time_system_.systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(Return(timestamp));
 
-  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, operation_name_,
-                                             timestamp, {Tracing::Reason::Sampling, true});
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
   const std::string request_yaml = R"(

--- a/test/extensions/tracers/skywalking/BUILD
+++ b/test/extensions/tracers/skywalking/BUILD
@@ -85,6 +85,7 @@ envoy_extension_cc_test(
         "//test/mocks/grpc:grpc_mocks",
         "//test/mocks/server:tracer_factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
+++ b/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
@@ -3,6 +3,7 @@
 #include "test/extensions/tracers/skywalking/skywalking_test_helper.h"
 #include "test/mocks/common.h"
 #include "test/mocks/server/tracer_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/utility.h"
 
@@ -49,7 +50,7 @@ public:
 protected:
   NiceMock<Envoy::Server::Configuration::MockTracerFactoryContext> context_;
   NiceMock<Envoy::Tracing::MockConfig> mock_tracing_config_;
-  Event::SimulatedTimeSystem time_system_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   std::unique_ptr<NiceMock<Grpc::MockAsyncStream>> mock_stream_ptr_{nullptr};
   envoy::config::trace::v3::SkyWalkingConfig config_;
   std::string test_string = "ABCDEFGHIJKLMN";
@@ -83,8 +84,8 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
     ON_CALL(mock_tracing_config_, operationName())
         .WillByDefault(Return(Tracing::OperationName::Ingress));
 
-    Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, request_headers, "TEST_OP",
-                                                   time_system_.systemTime(), decision);
+    Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, request_headers,
+                                                   stream_info_, "TEST_OP", decision);
     EXPECT_NE(nullptr, org_span.get());
 
     Span* span = dynamic_cast<Span*>(org_span.get());
@@ -112,8 +113,8 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
     Http::TestRequestHeaderMapImpl new_request_headers{
         {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
-    Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, new_request_headers, "",
-                                                   time_system_.systemTime(), decision);
+    Tracing::SpanPtr org_span =
+        driver_->startSpan(mock_tracing_config_, new_request_headers, stream_info_, "", decision);
 
     Span* span = dynamic_cast<Span*>(org_span.get());
     ASSERT(span);
@@ -137,7 +138,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
         {":authority", "test.com"},
         {"sw8", "xxxxxx-error-propagation-header"}};
     Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, error_request_headers,
-                                                   "TEST_OP", time_system_.systemTime(), decision);
+                                                   stream_info_, "TEST_OP", decision);
     Span* span = dynamic_cast<Span*>(org_span.get());
     ASSERT(span);
 
@@ -160,7 +161,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
         {":authority", "test.com"},
         {"sw8", "1-x-x-x-x-x-x-x"}}; // The first field is legal and fourth field is illegal.
     Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, error_request_headers,
-                                                   "TEST_OP", time_system_.systemTime(), decision);
+                                                   stream_info_, "TEST_OP", decision);
 
     Span* span = dynamic_cast<Span*>(org_span.get());
     ASSERT(span);
@@ -181,8 +182,8 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
     decision.traced = false;
     Http::TestRequestHeaderMapImpl request_headers{
         {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
-    Tracing::SpanPtr org_null_span = driver_->startSpan(
-        mock_tracing_config_, request_headers, "TEST_OP", time_system_.systemTime(), decision);
+    Tracing::SpanPtr org_null_span = driver_->startSpan(mock_tracing_config_, request_headers,
+                                                        stream_info_, "TEST_OP", decision);
 
     EXPECT_EQ(nullptr, dynamic_cast<Span*>(org_null_span.get()));
 
@@ -198,9 +199,8 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
         {":method", "GET"},
         {":authority", "test.com"},
         {"sw8", "xxxxxx-error-propagation-header"}};
-    Tracing::SpanPtr org_null_span =
-        driver_->startSpan(mock_tracing_config_, error_request_headers, "TEST_OP",
-                           time_system_.systemTime(), decision);
+    Tracing::SpanPtr org_null_span = driver_->startSpan(mock_tracing_config_, error_request_headers,
+                                                        stream_info_, "TEST_OP", decision);
 
     EXPECT_EQ(nullptr, dynamic_cast<Span*>(org_null_span.get()));
 
@@ -216,9 +216,8 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
         {":method", "GET"},
         {":authority", "test.com"},
         {"sw8", "1-x-x-x-x-x-x-x"}}; // The first field is legal and fourth field is illegal.
-    Tracing::SpanPtr org_null_span =
-        driver_->startSpan(mock_tracing_config_, error_request_headers, "TEST_OP",
-                           time_system_.systemTime(), decision);
+    Tracing::SpanPtr org_null_span = driver_->startSpan(mock_tracing_config_, error_request_headers,
+                                                        stream_info_, "TEST_OP", decision);
 
     EXPECT_EQ(nullptr, dynamic_cast<Span*>(org_null_span.get()));
 
@@ -243,8 +242,8 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestNoClientConfig) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
-  Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, request_headers, "TEST_OP",
-                                                 time_system_.systemTime(), decision);
+  Tracing::SpanPtr org_span =
+      driver_->startSpan(mock_tracing_config_, request_headers, stream_info_, "TEST_OP", decision);
   EXPECT_NE(nullptr, org_span.get());
 
   Span* span = dynamic_cast<Span*>(org_span.get());

--- a/test/extensions/tracers/xray/BUILD
+++ b/test/extensions/tracers/xray/BUILD
@@ -30,6 +30,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:instance_mocks",
         "//test/mocks/server:tracer_factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/test_common:environment_lib",

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -5,6 +5,7 @@
 #include "source/extensions/tracers/xray/xray_tracer_impl.h"
 
 #include "test/mocks/server/tracer_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/utility.h"
@@ -22,6 +23,7 @@ namespace {
 class XRayDriverTest : public ::testing::Test {
 public:
   const std::string operation_name_ = "test_operation_name";
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   absl::flat_hash_map<std::string, ProtobufWkt::Value> aws_metadata_;
   NiceMock<Server::Configuration::MockTracerFactoryContext> context_;
   NiceMock<ThreadLocal::MockInstance> tls_;
@@ -38,8 +40,8 @@ TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
   ASSERT_NE(span, nullptr);
   auto* xray_span = static_cast<XRay::Span*>(span.get());
@@ -54,8 +56,8 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
   ASSERT_NE(span, nullptr);
 }
@@ -68,8 +70,8 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
   // sampling should fall back to the default manifest since:
   // a) there is no valid sampling decision in the X-Ray header
@@ -94,8 +96,8 @@ TEST_F(XRayDriverTest, XRayTraceHeaderWithoutSamplingDecision) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
   // sampling will not be done since:
   // a) there is no sampling decision in the X-Ray header
@@ -111,8 +113,8 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
   // sampling should fall back to the default manifest since:
   // a) there is no X-Ray header to determine the sampling decision
@@ -128,8 +130,8 @@ TEST_F(XRayDriverTest, XForwardedForHeaderSet) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
 
   ASSERT_NE(span, nullptr);
@@ -144,8 +146,8 @@ TEST_F(XRayDriverTest, XForwardedForHeaderNotSet) {
   Driver driver(config, context_);
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
-  Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+
+  auto span = driver.startSpan(tracing_config_, request_headers_, stream_info_, operation_name_,
                                tracing_decision);
 
   ASSERT_NE(span, nullptr);

--- a/test/extensions/tracers/zipkin/BUILD
+++ b/test/extensions/tracers/zipkin/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test(
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -76,14 +76,16 @@ public:
   ~MockDriver() override;
 
   SpanPtr startSpan(const Config& config, TraceContext& trace_context,
-                    const std::string& operation_name, SystemTime start_time,
+                    const StreamInfo::StreamInfo& stream_info, const std::string& operation_name,
                     const Tracing::Decision tracing_decision) override {
-    return SpanPtr{startSpan_(config, trace_context, operation_name, start_time, tracing_decision)};
+    return SpanPtr{
+        startSpan_(config, trace_context, stream_info, operation_name, tracing_decision)};
   }
 
   MOCK_METHOD(Span*, startSpan_,
-              (const Config& config, TraceContext& trace_context, const std::string& operation_name,
-               SystemTime start_time, const Tracing::Decision tracing_decision));
+              (const Config& config, TraceContext& trace_context,
+               const StreamInfo::StreamInfo& stream_info, const std::string& operation_name,
+               const Tracing::Decision tracing_decision));
 };
 
 class MockTracerManager : public TracerManager {


### PR DESCRIPTION

Commit Message: tracing: expose stream info to the extended tracing driver
Additional Description:

To close https://github.com/envoyproxy/envoy/issues/26229.

By this PR, the extended tracing driver could access stream info directly and they can get related attributes from the stream info and set them into the extended span according to their requirements.

Risk Level: Low. Interface only change.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.