### PR TITLE
access_log: pass access log type parameter to evaluate function

### DIFF
--- a/envoy/access_log/access_log.h
+++ b/envoy/access_log/access_log.h
@@ -71,7 +71,8 @@ public:
   virtual bool evaluate(const StreamInfo::StreamInfo& info,
                         const Http::RequestHeaderMap& request_headers,
                         const Http::ResponseHeaderMap& response_headers,
-                        const Http::ResponseTrailerMap& response_trailers) const PURE;
+                        const Http::ResponseTrailerMap& response_trailers,
+                        AccessLogType access_log_type) const PURE;
 };
 
 using FilterPtr = std::unique_ptr<Filter>;

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -96,14 +96,14 @@ FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLog
 
 bool TraceableRequestFilter::evaluate(const StreamInfo::StreamInfo& info,
                                       const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
-                                      const Http::ResponseTrailerMap&) const {
+                                      const Http::ResponseTrailerMap&, AccessLogType) const {
   const Tracing::Decision decision = Tracing::TracerUtility::shouldTraceRequest(info);
   return decision.traced && decision.reason == Tracing::Reason::ServiceForced;
 }
 
 bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                                const Http::ResponseHeaderMap&,
-                                const Http::ResponseTrailerMap&) const {
+                                const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
+                                AccessLogType) const {
   if (!info.responseCode()) {
     return compareAgainstValue(0ULL);
   }
@@ -112,8 +112,8 @@ bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::
 }
 
 bool DurationFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                              const Http::ResponseHeaderMap&,
-                              const Http::ResponseTrailerMap&) const {
+                              const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
+                              AccessLogType) const {
   absl::optional<std::chrono::nanoseconds> duration = info.currentDuration();
   if (!duration.has_value()) {
     return false;
@@ -131,7 +131,7 @@ RuntimeFilter::RuntimeFilter(const envoy::config::accesslog::v3::RuntimeFilter& 
 
 bool RuntimeFilter::evaluate(const StreamInfo::StreamInfo& stream_info,
                              const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
-                             const Http::ResponseTrailerMap&) const {
+                             const Http::ResponseTrailerMap&, AccessLogType) const {
   // This code is verbose to avoid preallocating a random number that is not needed.
   uint64_t random_value;
   if (use_independent_randomness_) {
@@ -179,10 +179,12 @@ AndFilter::AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
 bool OrFilter::evaluate(const StreamInfo::StreamInfo& info,
                         const Http::RequestHeaderMap& request_headers,
                         const Http::ResponseHeaderMap& response_headers,
-                        const Http::ResponseTrailerMap& response_trailers) const {
+                        const Http::ResponseTrailerMap& response_trailers,
+                        AccessLogType access_log_type) const {
   bool result = false;
   for (auto& filter : filters_) {
-    result |= filter->evaluate(info, request_headers, response_headers, response_trailers);
+    result |= filter->evaluate(info, request_headers, response_headers, response_trailers,
+                               access_log_type);
 
     if (result) {
       break;
@@ -195,10 +197,12 @@ bool OrFilter::evaluate(const StreamInfo::StreamInfo& info,
 bool AndFilter::evaluate(const StreamInfo::StreamInfo& info,
                          const Http::RequestHeaderMap& request_headers,
                          const Http::ResponseHeaderMap& response_headers,
-                         const Http::ResponseTrailerMap& response_trailers) const {
+                         const Http::ResponseTrailerMap& response_trailers,
+                         AccessLogType access_log_type) const {
   bool result = true;
   for (auto& filter : filters_) {
-    result &= filter->evaluate(info, request_headers, response_headers, response_trailers);
+    result &= filter->evaluate(info, request_headers, response_headers, response_trailers,
+                               access_log_type);
 
     if (!result) {
       break;
@@ -210,7 +214,7 @@ bool AndFilter::evaluate(const StreamInfo::StreamInfo& info,
 
 bool NotHealthCheckFilter::evaluate(const StreamInfo::StreamInfo& info,
                                     const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
-                                    const Http::ResponseTrailerMap&) const {
+                                    const Http::ResponseTrailerMap&, AccessLogType) const {
   return !info.healthCheck();
 }
 
@@ -219,7 +223,8 @@ HeaderFilter::HeaderFilter(const envoy::config::accesslog::v3::HeaderFilter& con
 
 bool HeaderFilter::evaluate(const StreamInfo::StreamInfo&,
                             const Http::RequestHeaderMap& request_headers,
-                            const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) const {
+                            const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
+                            AccessLogType) const {
   return Http::HeaderUtility::matchHeaders(request_headers, *header_data_);
 }
 
@@ -235,8 +240,8 @@ ResponseFlagFilter::ResponseFlagFilter(
 }
 
 bool ResponseFlagFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                                  const Http::ResponseHeaderMap&,
-                                  const Http::ResponseTrailerMap&) const {
+                                  const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
+                                  AccessLogType) const {
   if (configured_flags_ != 0) {
     return info.intersectResponseFlags(configured_flags_);
   }
@@ -253,7 +258,8 @@ GrpcStatusFilter::GrpcStatusFilter(const envoy::config::accesslog::v3::GrpcStatu
 
 bool GrpcStatusFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
                                 const Http::ResponseHeaderMap& response_headers,
-                                const Http::ResponseTrailerMap& response_trailers) const {
+                                const Http::ResponseTrailerMap& response_trailers,
+                                AccessLogType) const {
 
   Grpc::Status::GrpcStatus status = Grpc::Status::WellKnownGrpcStatus::Unknown;
   const auto& optional_status =
@@ -294,8 +300,8 @@ MetadataFilter::MetadataFilter(const envoy::config::accesslog::v3::MetadataFilte
 }
 
 bool MetadataFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                              const Http::ResponseHeaderMap&,
-                              const Http::ResponseTrailerMap&) const {
+                              const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
+                              AccessLogType) const {
   const auto& value =
       Envoy::Config::Metadata::metadataValue(&info.dynamicMetadata(), filter_, path_);
   // If the key corresponds to a set value in dynamic metadata, return true if the value matches the

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -62,7 +62,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 };
 
 /**
@@ -77,7 +77,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 };
 
 /**
@@ -106,7 +106,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 };
 
 /**
@@ -120,7 +120,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 };
 
 /**
@@ -133,7 +133,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 };
 
 /**
@@ -144,7 +144,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 };
 
 /**
@@ -158,7 +158,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 
 private:
   Runtime::Loader& runtime_;
@@ -178,7 +178,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 
 private:
   const Http::HeaderUtility::HeaderDataPtr header_data_;
@@ -194,7 +194,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 
 private:
   uint64_t configured_flags_{};
@@ -215,7 +215,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 
 private:
   GrpcStatusHashSet statuses_;
@@ -238,7 +238,7 @@ public:
 
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers, AccessLogType) const override;
 
 private:
   Matchers::ValueMatcherConstSharedPtr present_matcher_;

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -80,7 +80,8 @@ public:
                        BodyFormatter*& final_formatter) const {
     // If not matched, just bail out.
     if (filter_ == nullptr ||
-        !filter_->evaluate(stream_info, request_headers, response_headers, response_trailers)) {
+        !filter_->evaluate(stream_info, request_headers, response_headers, response_trailers,
+                           AccessLog::AccessLogType::NotSet)) {
       return false;
     }
 

--- a/source/extensions/access_loggers/common/access_log_base.cc
+++ b/source/extensions/access_loggers/common/access_log_base.cc
@@ -22,8 +22,8 @@ void ImplBase::log(const Http::RequestHeaderMap* request_headers,
   if (!response_trailers) {
     response_trailers = Http::StaticEmptyHeaders::get().response_trailers.get();
   }
-  if (filter_ &&
-      !filter_->evaluate(stream_info, *request_headers, *response_headers, *response_trailers)) {
+  if (filter_ && !filter_->evaluate(stream_info, *request_headers, *response_headers,
+                                    *response_trailers, access_log_type)) {
     return;
   }
   return emitLog(*request_headers, *response_headers, *response_trailers, stream_info,

--- a/source/extensions/access_loggers/filters/cel/cel.cc
+++ b/source/extensions/access_loggers/filters/cel/cel.cc
@@ -14,10 +14,11 @@ CELAccessLogExtensionFilter::CELAccessLogExtensionFilter(
   compiled_expr_ = Expr::createExpression(builder, parsed_expr_);
 }
 
-bool CELAccessLogExtensionFilter::evaluate(
-    const StreamInfo::StreamInfo& stream_info, const Http::RequestHeaderMap& request_headers,
-    const Http::ResponseHeaderMap& response_headers,
-    const Http::ResponseTrailerMap& response_trailers) const {
+bool CELAccessLogExtensionFilter::evaluate(const StreamInfo::StreamInfo& stream_info,
+                                           const Http::RequestHeaderMap& request_headers,
+                                           const Http::ResponseHeaderMap& response_headers,
+                                           const Http::ResponseTrailerMap& response_trailers,
+                                           AccessLog::AccessLogType) const {
   Protobuf::Arena arena;
   auto eval_status = Expr::evaluate(*compiled_expr_, arena, stream_info, &request_headers,
                                     &response_headers, &response_trailers);

--- a/source/extensions/access_loggers/filters/cel/cel.h
+++ b/source/extensions/access_loggers/filters/cel/cel.h
@@ -22,7 +22,8 @@ public:
 
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) const override;
+                const Http::ResponseTrailerMap& response_trailers,
+                AccessLog::AccessLogType access_log_type) const override;
 
 private:
   const google::api::expr::v1alpha1::Expr parsed_expr_;

--- a/source/extensions/access_loggers/wasm/wasm_access_log_impl.h
+++ b/source/extensions/access_loggers/wasm/wasm_access_log_impl.h
@@ -23,10 +23,11 @@ public:
   void log(const Http::RequestHeaderMap* request_headers,
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
-           const StreamInfo::StreamInfo& stream_info, AccessLog::AccessLogType) override {
+           const StreamInfo::StreamInfo& stream_info,
+           AccessLog::AccessLogType access_log_type) override {
     if (filter_ && request_headers && response_headers && response_trailers) {
-      if (!filter_->evaluate(stream_info, *request_headers, *response_headers,
-                             *response_trailers)) {
+      if (!filter_->evaluate(stream_info, *request_headers, *response_headers, *response_trailers,
+                             access_log_type)) {
         return;
       }
     }

--- a/test/extensions/access_loggers/common/access_log_base_test.cc
+++ b/test/extensions/access_loggers/common/access_log_base_test.cc
@@ -44,7 +44,7 @@ TEST(AccessLogBaseTest, FilterReject) {
   StreamInfo::MockStreamInfo stream_info;
 
   std::unique_ptr<MockFilter> filter = std::make_unique<MockFilter>();
-  EXPECT_CALL(*filter, evaluate(_, _, _, _)).WillOnce(Return(false));
+  EXPECT_CALL(*filter, evaluate(_, _, _, _, _)).WillOnce(Return(false));
   TestImpl logger(std::move(filter));
   EXPECT_EQ(logger.count(), 0);
   logger.log(nullptr, nullptr, nullptr, stream_info);

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -83,7 +83,7 @@ TEST(HttpGrpcAccessLog, TlsLifetimeCheck) {
 class HttpGrpcAccessLogTest : public testing::Test {
 public:
   void init() {
-    ON_CALL(*filter_, evaluate(_, _, _, _)).WillByDefault(Return(true));
+    ON_CALL(*filter_, evaluate(_, _, _, _, _)).WillByDefault(Return(true));
     config_.mutable_common_config()->set_log_name("hello_log");
     config_.mutable_common_config()->add_filter_state_objects_to_log("string_accessor");
     config_.mutable_common_config()->add_filter_state_objects_to_log("uint32_accessor");

--- a/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
@@ -64,7 +64,7 @@ public:
 class AccessLogTest : public testing::Test {
 public:
   AccessLogPtr makeAccessLog(const AnyValue& body_config, const KeyValueList& attributes_config) {
-    ON_CALL(*filter_, evaluate(_, _, _, _)).WillByDefault(Return(true));
+    ON_CALL(*filter_, evaluate(_, _, _, _, _)).WillByDefault(Return(true));
     *config_.mutable_body() = body_config;
     *config_.mutable_attributes() = attributes_config;
     config_.mutable_common_config()->set_log_name("test_log");

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -30,7 +30,7 @@ public:
   MOCK_METHOD(bool, evaluate,
               (const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                const Http::ResponseHeaderMap& response_headers,
-               const Http::ResponseTrailerMap& response_trailers),
+               const Http::ResponseTrailerMap& response_trailers, AccessLogType access_log_type),
               (const));
 };
 


### PR DESCRIPTION
Commit Message: access_log: pass access log type parameter to evaluate function
Additional Description: This change is a no-op, a follow up PR will add a new feature to filter access logs based on ``AccessLogType`` (#26755)
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None