### PR TITLE
ci: Consolidate artifact targets

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -220,6 +220,6 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     pathtoPublish: "$(Build.StagingDirectory)/envoy"
-    artifactName: ${{ parameters.ciTarget }}${{ parameters.artifactSuffix }}
+    artifactName: ${{ parameters.ciTarget }}
   timeoutInMinutes: 10
   condition: eq('${{ parameters.publishEnvoy }}', 'true')

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -95,13 +95,7 @@ jobs:
     inputs:
       buildType: current
       artifactName: "bazel.release"
-      itemPattern: "bazel.release/bin/*"
-      targetPath: $(Build.StagingDirectory)
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      buildType: current
-      artifactName: "bazel.release.arm64"
-      itemPattern: "bazel.release.arm64/bin/*"
+      itemPattern: "bazel.release/**/bin/*"
       targetPath: $(Build.StagingDirectory)
   - bash: |
       set -e
@@ -109,12 +103,12 @@ jobs:
       mkdir -p linux/amd64 linux/arm64
 
       # x64
-      cp -a $(Build.StagingDirectory)/bazel.release/bin/release.tar.zst linux/amd64/release.tar.zst
-      cp -a $(Build.StagingDirectory)/bazel.release/bin/schema_validator_tool linux/amd64/schema_validator_tool
+      cp -a $(Build.StagingDirectory)/bazel.release/x64/bin/release.tar.zst linux/amd64/release.tar.zst
+      cp -a $(Build.StagingDirectory)/bazel.release/x64/bin/schema_validator_tool linux/amd64/schema_validator_tool
 
       # arm64
-      cp -a $(Build.StagingDirectory)/bazel.release.arm64/bin/release.tar.zst linux/arm64/release.tar.zst
-      cp -a $(Build.StagingDirectory)/bazel.release.arm64/bin/schema_validator_tool linux/arm64/schema_validator_tool
+      cp -a $(Build.StagingDirectory)/bazel.release/arm64/bin/release.tar.zst linux/arm64/release.tar.zst
+      cp -a $(Build.StagingDirectory)/bazel.release/arm64/bin/schema_validator_tool linux/arm64/schema_validator_tool
 
       # Debug what files appear to have been downloaded
       find linux -type f -name "*" | xargs ls -l
@@ -156,7 +150,7 @@ jobs:
     inputs:
       buildType: current
       artifactName: "bazel.release"
-      itemPattern: "bazel.release/bin/*"
+      itemPattern: "bazel.release/x64/bin/*"
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:
@@ -173,8 +167,8 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.release.arm64"
-      itemPattern: "bazel.release.arm64/bin/*"
+      artifactName: "bazel.release"
+      itemPattern: "bazel.release/arm64/bin/*"
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:

--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -38,7 +38,7 @@ jobs:
     inputs:
       buildType: current
       artifactName: "bazel.distribution"
-      itemPattern: "bazel.distribution/packages.x64.tar.gz"
+      itemPattern: "bazel.distribution/x64/packages.x64.tar.gz"
       downloadType: single
       targetPath: $(Build.StagingDirectory)
   - script: ci/run_envoy_docker.sh 'ci/do_ci.sh verify_distro'
@@ -60,8 +60,8 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.distribution.arm64"
-      itemPattern: "bazel.distribution.arm64/packages.arm64.tar.gz"
+      artifactName: "bazel.distribution"
+      itemPattern: "bazel.distribution/arm64/packages.arm64.tar.gz"
       downloadType: single
       targetPath: $(Build.StagingDirectory)
   - script: ci/run_envoy_docker.sh 'ci/do_ci.sh verify_distro'

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -161,9 +161,14 @@ fi
 
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && bazel clean "${BAZEL_BUILD_OPTIONS[@]}" --expunge
 
+if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
+    ENVOY_BUILD_DIR="${BUILD_DIR}/envoy/x64"
+else
+    ENVOY_BUILD_DIR="${BUILD_DIR}/envoy/arm64"
+fi
 
 # Also setup some space for building Envoy standalone.
-export ENVOY_BUILD_DIR="${BUILD_DIR}"/envoy
+export ENVOY_BUILD_DIR
 mkdir -p "${ENVOY_BUILD_DIR}"
 
 # This is where we copy build deliverables to.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -253,9 +253,9 @@ case $CI_TARGET in
         # Extract the Envoy binary from the tarball
         mkdir -p distribution/custom
         if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
-            ENVOY_RELEASE_TARBALL="/build/bazel.release/bin/release.tar.zst"
+            ENVOY_RELEASE_TARBALL="/build/bazel.release/x64/bin/release.tar.zst"
         else
-            ENVOY_RELEASE_TARBALL="/build/bazel.release.arm64/bin/release.tar.zst"
+            ENVOY_RELEASE_TARBALL="/build/bazel.release/arm64/bin/release.tar.zst"
         fi
         bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- --stdout -d "$ENVOY_RELEASE_TARBALL" | tar xfO - envoy > distribution/custom/envoy
 
@@ -564,9 +564,9 @@ case $CI_TARGET in
         ;;
     verify_distro)
         if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
-            PACKAGE_BUILD=/build/bazel.distribution/packages.x64.tar.gz
+            PACKAGE_BUILD=/build/bazel.distribution/x64/packages.x64.tar.gz
         else
-            PACKAGE_BUILD=/build/bazel.distribution.arm64/packages.arm64.tar.gz
+            PACKAGE_BUILD=/build/bazel.distribution/arm64/packages.arm64.tar.gz
         fi
         bazel run "${BAZEL_BUILD_OPTIONS[@]}" //distribution:verify_packages "$PACKAGE_BUILD"
         ;;


### PR DESCRIPTION
Currently we publish to quite a few artifact targets

This means that pulling artifacts often requires pulling from several targets, and doing so sequentially

This consolidates some of the targets and should optimize CI a little, and allow more/easier use of the artifacts

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
