### PR TITLE
ci: run Kotlin tests with signal_trace disabled

### DIFF
--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -45,6 +45,7 @@ jobs:
             --test_output=all \
             --build_tests_only \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --define=signal_trace=disabled \
             //test/kotlin/io/...
   javatestsmac:
     if: github.repository == 'envoyproxy/envoy'
@@ -113,4 +114,5 @@ jobs:
             --build_tests_only \
             --config test-android \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
+            --define=signal_trace=disabled \
             //test/kotlin/...

--- a/mobile/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/mobile/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -40,6 +40,8 @@ class StatFlushIntegrationTest {
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()
   }
 
+  // TODO(abeyad): Fix the test and re-enable.
+  // See https://github.com/envoyproxy/envoy/issues/24657.
   @Ignore
   @Test
   fun `flush flushes to stats sink`() {

--- a/mobile/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/mobile/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -12,9 +12,6 @@ import org.junit.After
 import org.junit.Ignore
 import org.junit.Test
 
-// TODO(abeyad): Fix the test and re-enable.
-// See https://github.com/envoyproxy/envoy/issues/24657.
-@Ignore
 class StatFlushIntegrationTest {
   private var engine: Engine? = null
 
@@ -43,6 +40,7 @@ class StatFlushIntegrationTest {
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()
   }
 
+  @Ignore
   @Test
   fun `flush flushes to stats sink`() {
     val countDownLatch = CountDownLatch(1)


### PR DESCRIPTION
There are several Java tests that fail without the `--define=signal_trace=disabled` flag. The flag is already on for Java tests; this commit turns them on for Kotlin tests on CI as well.

Also, this solves one of the problems with flaky tests in StatsFlushIntegrationTest.kt, as described in
https://github.com/envoyproxy/envoy/issues/24657, so we re-enable the test that now passes. The other StatsFlushIntegrationTest test still fails and will be debugged separately.

Testing: `bazelisk test --config=test-android --define=signal_trace=disabled --test_output=streamed --cache_test_results=no  test/kotlin/integration:stat_flush_integration_test --runs_per_test=100`
