### PR TITLE
Route level config support for AWS request signing filter

### DIFF
--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
@@ -65,7 +65,6 @@ message AwsRequestSigning {
   repeated type.matcher.v3.StringMatcher match_excluded_headers = 5;
 }
 
-
 message AwsRequestSigningPerRoute {
   // Override the global configuration of the filter with this new config.
   AwsRequestSigning aws_request_signing = 1;
@@ -73,4 +72,3 @@ message AwsRequestSigningPerRoute {
   // The human readable prefix to use when emitting stats.
   string stat_prefix = 2 [(validate.rules).string = {min_len: 1}];
 }
-

--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
@@ -64,3 +64,16 @@ message AwsRequestSigning {
   // When applied, all headers that start with "x-envoy" and headers "foo" and "bar" will not be signed.
   repeated type.matcher.v3.StringMatcher match_excluded_headers = 5;
 }
+
+
+message AwsRequestSigningPerRoute {
+  option (udpa.annotations.versioning).previous_message_type =
+    "envoy.config.filter.http.aws_request_signing.v2alpha.AwsRequestSigningPerRoute";
+
+  // Override the global configuration of the filter with this new config.
+  AwsRequestSigning aws_request_signing = 1;
+
+  // The human readable prefix to use when emitting stats.
+  string stat_prefix = 2 [(validate.rules).string = {min_len: 1}];
+}
+

--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
@@ -67,9 +67,6 @@ message AwsRequestSigning {
 
 
 message AwsRequestSigningPerRoute {
-  option (udpa.annotations.versioning).previous_message_type =
-    "envoy.config.filter.http.aws_request_signing.v2alpha.AwsRequestSigningPerRoute";
-
   // Override the global configuration of the filter with this new config.
   AwsRequestSigning aws_request_signing = 1;
 

--- a/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
+++ b/api/envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.proto
@@ -67,6 +67,7 @@ message AwsRequestSigning {
 
 message AwsRequestSigningPerRoute {
   // Override the global configuration of the filter with this new config.
+  // This overrides the entire message of AwsRequestSigning and not at field level.
   AwsRequestSigning aws_request_signing = 1;
 
   // The human readable prefix to use when emitting stats.

--- a/docs/root/configuration/http/http_filters/_include/aws-request-signing-filter-route-level-override.yaml
+++ b/docs/root/configuration/http/http_filters/_include/aws-request-signing-filter-route-level-override.yaml
@@ -1,0 +1,66 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: app
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: versioned-cluster
+                typed_per_filter_config:
+                  envoy.filters.http.aws_request_signing:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigningPerRoute
+                    aws_request_signing:
+                      service_name: s3
+                      region: us-west-1
+                      use_unsigned_payload: true
+                      host_rewrite: new-host
+                      match_excluded_headers:
+                      - prefix: x-envoy
+                      - prefix: x-forwarded
+                      - exact: x-amzn-trace-id
+                    stat_prefix: some-prefix
+          http_filters:
+          - name: envoy.filters.http.aws_request_signing
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning
+              service_name: s3
+              region: us-west-2
+              use_unsigned_payload: true
+              host_rewrite: default-host
+              match_excluded_headers:
+              - prefix: x-envoy
+              - prefix: x-forwarded
+              - exact: x-amzn-trace-id
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+  - name: versioned-cluster
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: versioned-cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8080

--- a/docs/root/configuration/http/http_filters/_include/aws-request-signing-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/aws-request-signing-filter.yaml
@@ -1,0 +1,52 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: app
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: versioned-cluster
+          http_filters:
+          - name: envoy.filters.http.aws_request_signing
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning
+              service_name: s3
+              region: us-west-2
+              use_unsigned_payload: true
+              match_excluded_headers:
+              - prefix: x-envoy
+              - prefix: x-forwarded
+              - exact: x-amzn-trace-id
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+  - name: versioned-cluster
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: versioned-cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8080

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -64,13 +64,15 @@ Note that this filter also supports per route configuration:
         typed_per_filter_config:
           envoy.filters.http.aws_request_signing:
             "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigningPerRoute
-            service_name: s3
-            region: us-west-2
-            use_unsigned_payload: true
-            match_excluded_headers:
-            - prefix: x-envoy
-            - prefix: x-forwarded
-            - exact: x-amzn-trace-id
+            aws_request_signing:
+              service_name: s3
+              region: us-west-2
+              use_unsigned_payload: true
+              match_excluded_headers:
+              - prefix: x-envoy
+              - prefix: x-forwarded
+              - exact: x-amzn-trace-id
+            stat_prefix: some-prefix
 
 This can be used to either override the global configuration
 

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -50,6 +50,30 @@ Example filter configuration:
 
 .. include:: _include/aws_credentials.rst
 
+Note that this filter also supports per route configuration:
+
+.. code-block:: yaml
+  route_config:
+    name: local_route
+    virtual_hosts:
+    - name: local_service
+      domains: ["*"]
+      routes:
+      - match: { prefix: "/some-route-match" }
+        route: { cluster: service }
+        typed_per_filter_config:
+          envoy.filters.http.aws_request_signing:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigningPerRoute
+            service_name: s3
+            region: us-west-2
+            use_unsigned_payload: true
+            match_excluded_headers:
+            - prefix: x-envoy
+            - prefix: x-forwarded
+            - exact: x-amzn-trace-id
+
+This can be used to either override the global configuration
+
 Statistics
 ----------
 

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -39,7 +39,7 @@ Example filter configuration:
     :lines: 25-35
     :lineno-start: 25
     :linenos:
-    :caption: :download:`aws-request-signing-filter.yaml <_include/aws-request-signing-filter.yaml>`\
+    :caption: :download:`aws-request-signing-filter.yaml <_include/aws-request-signing-filter.yaml>`
 
 Note that this filter also supports per route configuration:
 

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -34,32 +34,14 @@ Example configuration
 
 Example filter configuration:
 
-.. code-block:: yaml
-
-  name: envoy.filters.http.aws_request_signing
-  typed_config:
-    "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning
-    service_name: s3
-    region: us-west-2
-    use_unsigned_payload: true
-    match_excluded_headers:
-    - prefix: x-envoy
-    - prefix: x-forwarded
-    - exact: x-amzn-trace-id
-
 .. literalinclude:: _include/aws-request-signing-filter.yaml
     :language: yaml
     :lines: 25-35
     :lineno-start: 25
     :linenos:
-    :caption: :download:`aws-request-signing-filter.yaml <_include/aws-request-signing-filter.yaml>`
-
-
-.. include:: _include/aws_credentials.rst
+    :caption: :download:`aws-request-signing-filter.yaml <_include/aws-request-signing-filter.yaml>`\
 
 Note that this filter also supports per route configuration:
-
-.. code-block:: yaml
 
 .. literalinclude:: _include/aws-request-signing-filter-route-level-override.yaml
     :language: yaml
@@ -69,6 +51,8 @@ Note that this filter also supports per route configuration:
     :caption: :download:`aws-request-signing-filter-route-level-override.yaml <_include/aws-request-signing-filter-route-level-override.yaml>`
 
 Above shows an example of route-level config overriding the config on the virutal-host level.
+
+.. include:: _include/aws_credentials.rst
 
 Statistics
 ----------

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -47,6 +47,13 @@ Example filter configuration:
     - prefix: x-forwarded
     - exact: x-amzn-trace-id
 
+.. literalinclude:: _include/aws-request-signing-filter.yaml
+    :language: yaml
+    :lines: 25-35
+    :lineno-start: 25
+    :linenos:
+    :caption: :download:`aws-request-signing-filter.yaml <_include/aws-request-signing-filter.yaml>`
+
 
 .. include:: _include/aws_credentials.rst
 
@@ -54,28 +61,14 @@ Note that this filter also supports per route configuration:
 
 .. code-block:: yaml
 
-  route_config:
-    name: local_route
-    virtual_hosts:
-    - name: local_service
-      domains: ["*"]
-      routes:
-      - match: { prefix: "/some-route-match" }
-        route: { cluster: service }
-        typed_per_filter_config:
-          envoy.filters.http.aws_request_signing:
-            "@type": type.googleapis.com/envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigningPerRoute
-            aws_request_signing:
-              service_name: s3
-              region: us-west-2
-              use_unsigned_payload: true
-              match_excluded_headers:
-              - prefix: x-envoy
-              - prefix: x-forwarded
-              - exact: x-amzn-trace-id
-            stat_prefix: some-prefix
+.. literalinclude:: _include/aws-request-signing-filter-route-level-override.yaml
+    :language: yaml
+    :lines: 20-37
+    :lineno-start: 20
+    :linenos:
+    :caption: :download:`aws-request-signing-filter-route-level-override.yaml <_include/aws-request-signing-filter-route-level-override.yaml>`
 
-This can be used to either override the global configuration
+Above shows an example of route-level config overriding the config on the virutal-host level.
 
 Statistics
 ----------

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -53,6 +53,7 @@ Example filter configuration:
 Note that this filter also supports per route configuration:
 
 .. code-block:: yaml
+
   route_config:
     name: local_route
     virtual_hosts:

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -50,7 +50,7 @@ Note that this filter also supports per route configuration:
     :linenos:
     :caption: :download:`aws-request-signing-filter-route-level-override.yaml <_include/aws-request-signing-filter-route-level-override.yaml>`
 
-Above shows an example of route-level config overriding the config on the virutal-host level.
+Above shows an example of route-level config overriding the config on the virtual-host level.
 
 .. include:: _include/aws_credentials.rst
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -208,6 +208,7 @@ envoy.filters.http.aws_request_signing:
   status: alpha
   type_urls:
   - envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigning
+  - envoy.extensions.filters.http.aws_request_signing.v3.AwsRequestSigningPerRoute
 envoy.filters.http.bandwidth_limit:
   categories:
   - envoy.filters.http

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
@@ -4,6 +4,7 @@
 
 #include "source/common/common/hex.h"
 #include "source/common/crypto/utility.h"
+#include "source/common/http/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -31,8 +32,10 @@ FilterStats Filter::generateStats(const std::string& prefix, Stats::Scope& scope
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
-  const auto& host_rewrite = config_->hostRewrite();
-  const bool use_unsigned_payload = config_->useUnsignedPayload();
+  auto& config = getConfig();
+
+  const auto& host_rewrite = config.hostRewrite();
+  const bool use_unsigned_payload = config.useUnsignedPayload();
 
   if (!host_rewrite.empty()) {
     headers.setHost(host_rewrite);
@@ -47,22 +50,24 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     ENVOY_LOG(debug, "aws request signing from decodeHeaders use_unsigned_payload: {}",
               use_unsigned_payload);
     if (use_unsigned_payload) {
-      config_->signer().signUnsignedPayload(headers);
+      config.signer().signUnsignedPayload(headers);
     } else {
-      config_->signer().signEmptyPayload(headers);
+      config.signer().signEmptyPayload(headers);
     }
-    config_->stats().signing_added_.inc();
+    config.stats().signing_added_.inc();
   } catch (const EnvoyException& e) {
     // TODO: sign should not throw to avoid exceptions in the request path
     ENVOY_LOG(debug, "signing failed: {}", e.what());
-    config_->stats().signing_failed_.inc();
+    config.stats().signing_failed_.inc();
   }
 
   return Http::FilterHeadersStatus::Continue;
 }
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
-  if (config_->useUnsignedPayload()) {
+  auto& config = getConfig();
+
+  if (config.useUnsignedPayload()) {
     return Http::FilterDataStatus::Continue;
   }
 
@@ -80,17 +85,26 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
   try {
     ENVOY_LOG(debug, "aws request signing from decodeData");
     ASSERT(request_headers_ != nullptr);
-    config_->signer().sign(*request_headers_, hash);
-    config_->stats().signing_added_.inc();
-    config_->stats().payload_signing_added_.inc();
+    config.signer().sign(*request_headers_, hash);
+    config.stats().signing_added_.inc();
+    config.stats().payload_signing_added_.inc();
   } catch (const EnvoyException& e) {
     // TODO: sign should not throw to avoid exceptions in the request path
     ENVOY_LOG(debug, "signing failed: {}", e.what());
-    config_->stats().signing_failed_.inc();
-    config_->stats().payload_signing_failed_.inc();
+    config.stats().signing_failed_.inc();
+    config.stats().payload_signing_failed_.inc();
   }
 
   return Http::FilterDataStatus::Continue;
+}
+
+FilterConfig& Filter::getConfig() const {
+  auto* config =
+      const_cast<FilterConfig*>(Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(decoder_callbacks_));
+  if (config) {
+    return *config;
+  }
+  return *config_;
 }
 
 } // namespace AwsRequestSigningFilter

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
@@ -99,8 +99,8 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
 }
 
 FilterConfig& Filter::getConfig() const {
-  auto* config =
-      const_cast<FilterConfig*>(Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(decoder_callbacks_));
+  auto* config = const_cast<FilterConfig*>(
+      Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(decoder_callbacks_));
   if (config) {
     return *config;
   }

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
@@ -34,7 +34,7 @@ struct FilterStats {
 /**
  * Abstract filter configuration.
  */
-class FilterConfig: public Router::RouteSpecificFilterConfig {
+class FilterConfig : public Router::RouteSpecificFilterConfig {
 public:
   virtual ~FilterConfig() = default;
 

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
@@ -34,7 +34,7 @@ struct FilterStats {
 /**
  * Abstract filter configuration.
  */
-class FilterConfig {
+class FilterConfig: public Router::RouteSpecificFilterConfig {
 public:
   virtual ~FilterConfig() = default;
 
@@ -95,6 +95,8 @@ public:
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
 
 private:
+  FilterConfig& getConfig() const;
+
   std::shared_ptr<FilterConfig> config_;
   Http::RequestHeaderMap* request_headers_{};
 };

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
@@ -36,7 +36,7 @@ struct FilterStats {
  */
 class FilterConfig : public Router::RouteSpecificFilterConfig {
 public:
-  virtual ~FilterConfig() = default;
+  ~FilterConfig() override = default;
 
   /**
    * @return the config's signer.

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -38,22 +38,22 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 Router::RouteSpecificFilterConfigConstSharedPtr
 AwsRequestSigningFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute&
-        perRouteConfig,
+        per_route_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
           context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
   const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
-      perRouteConfig.aws_request_signing().match_excluded_headers().begin(),
-      perRouteConfig.aws_request_signing().match_excluded_headers().end());
+      per_route_config.aws_request_signing().match_excluded_headers().begin(),
+      per_route_config.aws_request_signing().match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(
-      perRouteConfig.aws_request_signing().service_name(),
-      perRouteConfig.aws_request_signing().region(), credentials_provider,
+      per_route_config.aws_request_signing().service_name(),
+      per_route_config.aws_request_signing().region(), credentials_provider,
       context.mainThreadDispatcher().timeSource(), matcher_config);
   return std::make_shared<const FilterConfigImpl>(
-      std::move(signer), perRouteConfig.stat_prefix(), context.scope(),
-      perRouteConfig.aws_request_signing().host_rewrite(),
-      perRouteConfig.aws_request_signing().use_unsigned_payload());
+      std::move(signer), per_route_config.stat_prefix(), context.scope(),
+      per_route_config.aws_request_signing().host_rewrite(),
+      per_route_config.aws_request_signing().use_unsigned_payload());
 }
 
 /**

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -37,18 +37,23 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 
 Router::RouteSpecificFilterConfigConstSharedPtr
 AwsRequestSigningFilterFactory::createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute& perRouteConfig,
+    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute&
+        perRouteConfig,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
           context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
   const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
-      perRouteConfig.aws_request_signing().match_excluded_headers().begin(), perRouteConfig.aws_request_signing().match_excluded_headers().end());
+      perRouteConfig.aws_request_signing().match_excluded_headers().begin(),
+      perRouteConfig.aws_request_signing().match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(
-      perRouteConfig.aws_request_signing().service_name(), perRouteConfig.aws_request_signing().region(), credentials_provider,
+      perRouteConfig.aws_request_signing().service_name(),
+      perRouteConfig.aws_request_signing().region(), credentials_provider,
       context.mainThreadDispatcher().timeSource(), matcher_config);
-  return std::make_shared<const FilterConfigImpl>(std::move(signer), perRouteConfig.stat_prefix(), context.scope(),
-                                         perRouteConfig.aws_request_signing().host_rewrite(), perRouteConfig.aws_request_signing().use_unsigned_payload());
+  return std::make_shared<const FilterConfigImpl>(
+      std::move(signer), perRouteConfig.stat_prefix(), context.scope(),
+      perRouteConfig.aws_request_signing().host_rewrite(),
+      perRouteConfig.aws_request_signing().use_unsigned_payload());
 }
 
 /**

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -15,7 +15,7 @@ namespace HttpFilters {
 namespace AwsRequestSigningFilter {
 
 Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning& config,
+    const AwsRequestSigningProtoConfig& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
 
   auto credentials_provider =
@@ -37,8 +37,7 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 
 Router::RouteSpecificFilterConfigConstSharedPtr
 AwsRequestSigningFilterFactory::createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute&
-        per_route_config,
+    const AwsRequestSigningProtoPerRouteConfig& per_route_config,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -37,18 +37,18 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
 
 Router::RouteSpecificFilterConfigConstSharedPtr
 AwsRequestSigningFilterFactory::createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning& config,
+    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute& perRouteConfig,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
           context.api(), Extensions::Common::Aws::Utility::fetchMetadata);
   const auto matcher_config = Extensions::Common::Aws::AwsSigV4HeaderExclusionVector(
-      config.match_excluded_headers().begin(), config.match_excluded_headers().end());
+      perRouteConfig.aws_request_signing().match_excluded_headers().begin(), perRouteConfig.aws_request_signing().match_excluded_headers().end());
   auto signer = std::make_unique<Extensions::Common::Aws::SignerImpl>(
-      config.service_name(), config.region(), credentials_provider,
+      perRouteConfig.aws_request_signing().service_name(), perRouteConfig.aws_request_signing().region(), credentials_provider,
       context.mainThreadDispatcher().timeSource(), matcher_config);
-  return std::make_shared<const FilterConfigImpl>(std::move(signer), stats_prefix, context.scope(),
-                                         config.host_rewrite(), config.use_unsigned_payload());
+  return std::make_shared<const FilterConfigImpl>(std::move(signer), perRouteConfig.stat_prefix(), context.scope(),
+                                         perRouteConfig.aws_request_signing().host_rewrite(), perRouteConfig.aws_request_signing().use_unsigned_payload());
 }
 
 /**

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -15,8 +15,8 @@ namespace HttpFilters {
 namespace AwsRequestSigningFilter {
 
 Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
-    const AwsRequestSigningProtoConfig& config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    const AwsRequestSigningProtoConfig& config, const std::string& stats_prefix,
+    Server::Configuration::FactoryContext& context) {
 
   auto credentials_provider =
       std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -10,24 +10,27 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AwsRequestSigningFilter {
 
+using AwsRequestSigningProtoConfig =
+    envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning;
+
+using AwsRequestSigningProtoPerRouteConfig =
+    envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute;
+
 /**
  * Config registration for the AWS request signing filter.
  */
 class AwsRequestSigningFilterFactory
-    : public Common::FactoryBase<
-          envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning,
-          envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute> {
+    : public Common::FactoryBase<AwsRequestSigningProtoConfig, AwsRequestSigningProtoPerRouteConfig> {
 public:
   AwsRequestSigningFilterFactory() : FactoryBase("envoy.filters.http.aws_request_signing") {}
 
 private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning&
-          proto_config,
+      const AwsRequestSigningProtoConfig& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute& perRouteConfig,
+    const AwsRequestSigningProtoPerRouteConfig& perRouteConfig,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) override;
 };
 

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -24,6 +24,10 @@ private:
       const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning&
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning& config,
+    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) override;
 };
 
 } // namespace AwsRequestSigningFilter

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -15,7 +15,8 @@ namespace AwsRequestSigningFilter {
  */
 class AwsRequestSigningFilterFactory
     : public Common::FactoryBase<
-          envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning> {
+          envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning,
+          envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute> {
 public:
   AwsRequestSigningFilterFactory() : FactoryBase("envoy.filters.http.aws_request_signing") {}
 
@@ -26,7 +27,7 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning& config,
+    const envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute& perRouteConfig,
     Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) override;
 };
 

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -20,18 +20,21 @@ using AwsRequestSigningProtoPerRouteConfig =
  * Config registration for the AWS request signing filter.
  */
 class AwsRequestSigningFilterFactory
-    : public Common::FactoryBase<AwsRequestSigningProtoConfig, AwsRequestSigningProtoPerRouteConfig> {
+    : public Common::FactoryBase<AwsRequestSigningProtoConfig,
+                                 AwsRequestSigningProtoPerRouteConfig> {
 public:
   AwsRequestSigningFilterFactory() : FactoryBase("envoy.filters.http.aws_request_signing") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
-      const AwsRequestSigningProtoConfig& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  Http::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const AwsRequestSigningProtoConfig& proto_config,
+                                    const std::string& stats_prefix,
+                                    Server::Configuration::FactoryContext& context) override;
 
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
-    const AwsRequestSigningProtoPerRouteConfig& perRouteConfig,
-    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) override;
+  Router::RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfigTyped(const AwsRequestSigningProtoPerRouteConfig& perRouteConfig,
+                                       Server::Configuration::ServerFactoryContext& context,
+                                       ProtobufMessage::ValidationVisitor&) override;
 };
 
 } // namespace AwsRequestSigningFilter

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -32,7 +32,7 @@ private:
                                     Server::Configuration::FactoryContext& context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr
-  createRouteSpecificFilterConfigTyped(const AwsRequestSigningProtoPerRouteConfig& perRouteConfig,
+  createRouteSpecificFilterConfigTyped(const AwsRequestSigningProtoPerRouteConfig& per_route_config,
                                        Server::Configuration::ServerFactoryContext& context,
                                        ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -144,7 +144,7 @@ void TcpStatsSocket::recordStats() {
   update_counter(config_->stats_.cx_rx_bytes_received_, last_cx_rx_bytes_received_,
                  tcp_info->tcpi_bytes_received);
   update_counter(config_->stats_.cx_tx_bytes_sent_, last_cx_tx_bytes_sent_,
-                 tcp_info->tcpi_bytes_acked);
+                 tcp_info->tcpi_bytes_sent);
 
   update_gauge(config_->stats_.cx_tx_unsent_bytes_, last_cx_tx_unsent_bytes_,
                tcp_info->tcpi_notsent_bytes);

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -144,7 +144,7 @@ void TcpStatsSocket::recordStats() {
   update_counter(config_->stats_.cx_rx_bytes_received_, last_cx_rx_bytes_received_,
                  tcp_info->tcpi_bytes_received);
   update_counter(config_->stats_.cx_tx_bytes_sent_, last_cx_tx_bytes_sent_,
-                 tcp_info->tcpi_bytes_sent);
+                 tcp_info->tcpi_bytes_acked);
 
   update_gauge(config_->stats_.cx_tx_unsent_bytes_, last_cx_tx_unsent_bytes_,
                tcp_info->tcpi_notsent_bytes);

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
@@ -205,10 +205,10 @@ TEST_F(AwsRequestSigningFilterTest, PerRouteConfigSignWithHostRewrite) {
 
   Stats::IsolatedStoreImpl stats;
   auto signer = std::make_unique<Common::Aws::MockSigner>();
-  EXPECT_CALL(*(signer),
-              signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
+  EXPECT_CALL(*(signer), signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
 
-  FilterConfigImpl per_route_config(std::move(signer), "prefix", *stats.rootScope(), "overridden-host", false);
+  FilterConfigImpl per_route_config(std::move(signer), "prefix", *stats.rootScope(),
+                                    "overridden-host", false);
   ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
       .WillByDefault(Return(&per_route_config));
 

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
@@ -198,6 +198,25 @@ TEST_F(AwsRequestSigningFilterTest, FilterConfigImplGetters) {
   EXPECT_EQ(true, config.useUnsignedPayload());
 }
 
+// Verify filter functionality when a host rewrite happens on route-level config.
+TEST_F(AwsRequestSigningFilterTest, PerRouteConfigSignWithHostRewrite) {
+  setup();
+  filter_config_->host_rewrite_ = "original-host";
+
+  Stats::IsolatedStoreImpl stats;
+  auto signer = std::make_unique<Common::Aws::MockSigner>();
+  EXPECT_CALL(*(signer),
+              signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
+
+  FilterConfigImpl per_route_config(std::move(signer), "prefix", *stats.rootScope(), "overridden-host", false);
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillByDefault(Return(&per_route_config));
+
+  Http::TestRequestHeaderMapImpl headers;
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
+  EXPECT_EQ("overridden-host", headers.getHostValue());
+}
+
 } // namespace
 } // namespace AwsRequestSigningFilter
 } // namespace HttpFilters

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.pb.h"
 #include "envoy/extensions/filters/http/aws_request_signing/v3/aws_request_signing.pb.validate.h"
 
+#include "source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h"
 #include "source/extensions/filters/http/aws_request_signing/config.h"
 
 #include "test/mocks/server/factory_context.h"
@@ -16,6 +17,9 @@ namespace AwsRequestSigningFilter {
 
 using AwsRequestSigningProtoConfig =
     envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning;
+
+using AwsRequestSigningProtoPerRouteConfig =
+    envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute;
 
 TEST(AwsRequestSigningFilterConfigTest, SimpleConfig) {
   const std::string yaml = R"EOF(
@@ -49,6 +53,29 @@ match_excluded_headers:
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);
+}
+
+TEST(AwsRequestSigningFilterConfigTest, RouteSpecificFilterConfig) {
+  const std::string yaml = R"EOF(
+aws_request_signing:
+  service_name: s3
+  region: us-west-2
+  match_excluded_headers:
+    - prefix: x-envoy
+    - exact: foo
+    - exact: bar
+stat_prefix: foo_prefix
+  )EOF";
+
+  AwsRequestSigningProtoPerRouteConfig proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  AwsRequestSigningFilterFactory factory;
+
+  const auto route_config = factory.createRouteSpecificFilterConfig(
+      proto_config, context, ProtobufMessage::getNullValidationVisitor());
+  ASSERT_NE(route_config, nullptr);
 }
 
 } // namespace AwsRequestSigningFilter

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -15,12 +15,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AwsRequestSigningFilter {
 
-using AwsRequestSigningProtoConfig =
-    envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigning;
-
-using AwsRequestSigningProtoPerRouteConfig =
-    envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute;
-
 TEST(AwsRequestSigningFilterConfigTest, SimpleConfig) {
   const std::string yaml = R"EOF(
 service_name: s3

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -19,6 +19,7 @@ TEST(AwsRequestSigningFilterConfigTest, SimpleConfig) {
   const std::string yaml = R"EOF(
 service_name: s3
 region: us-west-2
+host_rewrite: new-host
 match_excluded_headers:
   - prefix: x-envoy
   - exact: foo
@@ -31,6 +32,7 @@ match_excluded_headers:
   AwsRequestSigningProtoConfig expected_config;
   expected_config.set_service_name("s3");
   expected_config.set_region("us-west-2");
+  expected_config.set_host_rewrite("new-host");
   expected_config.add_match_excluded_headers()->set_prefix("x-envoy");
   expected_config.add_match_excluded_headers()->set_exact("foo");
   expected_config.add_match_excluded_headers()->set_exact("bar");
@@ -54,6 +56,7 @@ TEST(AwsRequestSigningFilterConfigTest, RouteSpecificFilterConfig) {
 aws_request_signing:
   service_name: s3
   region: us-west-2
+  host_rewrite: new-host
   match_excluded_headers:
     - prefix: x-envoy
     - exact: foo


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add route-level config for AWS request signing filter.
Additional Description: If route-level config is specified then it overrides the configuration on the virtual host level if set. Route-level sets a stats prefix so more granular stats may be exposed.
Risk Level: Low
Testing: Unit tests
Docs Changes: included
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue] #21541
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
