### PR TITLE
access_log: remove leftover default access log type parameter

### DIFF
--- a/source/extensions/access_loggers/open_telemetry/access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/access_log_impl.h
@@ -53,8 +53,7 @@ private:
                const Http::ResponseHeaderMap& response_headers,
                const Http::ResponseTrailerMap& response_trailers,
                const StreamInfo::StreamInfo& stream_info,
-               Envoy::AccessLog::AccessLogType access_log_type =
-                   Envoy::AccessLog::AccessLogType::NotSet) override;
+               Envoy::AccessLog::AccessLogType access_log_type) override;
 
   const ThreadLocal::SlotPtr tls_slot_;
   const GrpcAccessLoggerCacheSharedPtr access_logger_cache_;


### PR DESCRIPTION
Commit Message: access_log: remove leftover default access log type parameter
Additional Description: None
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: None 
Platform Specific Features: None