### PR TITLE
Ldamata/fix least request lb not fair

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -475,6 +475,11 @@ message Cluster {
     // Configuration for slow start mode.
     // If this configuration is not set, slow start will not be not enabled.
     SlowStartConfig slow_start_config = 3;
+
+    // Configuration for performing full scan on the list of hosts.
+    // If this configuration is set, when selecting the host a full scan on the list hosts will be
+    // used to select the one with least requests instead of using random choices.
+    google.protobuf.BoolValue full_scan_hosts = 4;
   }
 
   // Specific configuration for the :ref:`RingHash<arch_overview_load_balancing_types_ring_hash>`

--- a/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
+++ b/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
@@ -58,4 +58,9 @@ message LeastRequest {
 
   // Configuration for local zone aware load balancing or locality weighted load balancing.
   common.v3.LocalityLbConfig locality_lb_config = 4;
+
+  // Configuration for performing full scan on the list of hosts.
+  // If this configuration is set, when selecting the host a full scan on the list hosts will be
+  // used to select the one with least requests instead of using random choices.
+  google.protobuf.BoolValue full_scan_hosts = 5;
 }

--- a/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
+++ b/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
@@ -22,6 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // This configuration allows the built-in LEAST_REQUEST LB policy to be configured via the LB policy
 // extension point. See the :ref:`load balancing architecture overview
 // <arch_overview_load_balancing_types>` for more information.
+// [#next-free-field: 6]
 message LeastRequest {
   // The number of random healthy hosts from which the host with the fewest active requests will
   // be chosen. Defaults to 2 so that we perform two-choice selection if the field is not set.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1589,7 +1589,6 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
       lb_ = lb_factory_->create({priority_set_, parent_.local_priority_set_});
       break;
     }
-    }
   }
 }
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1079,7 +1079,6 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
   for (uint32_t choice_idx = 0; choice_idx < choice_count_; ++choice_idx) {
     const int rand_idx = random_.random() % hosts_to_use_current_size;
     const HostSharedPtr& sampled_host = hosts->at(rand_idx);
-    std::cout <<"pick: " << sampled_host->address()->asString() << "\n";
 
     // Swap selected host with latest one and skip latest one  on next iteration 
     // so we don't repeat the selection when there are enough hosts.
@@ -1091,10 +1090,6 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
       --hosts_to_use_current_size;
     
       hosts->at(rand_idx) = hosts->at(last_host_idx);
-      std::cout << "Modified\n";
-      for (auto& it : *hosts) {
-        std::cout << it->address()->asString() << "\n";
-      }
     }
 
     if (candidate_host == nullptr) {
@@ -1111,8 +1106,6 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
     }
   }
 
-
-  std::cout << "CHOSEN " << candidate_host->address()->asString() << "\n";
   return candidate_host;
 }
 

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1056,39 +1056,39 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
   HostSharedPtr candidate_host = nullptr;
 
   // We do a full scan if the number of choices is equal to the size.
-  if ((hosts_to_use.size() <= choice_count_ )|| full_scan_hosts_) {
+  if ((hosts_to_use.size() <= choice_count_) || full_scan_hosts_) {
     for (auto& sampled_host : hosts_to_use) {
-     if (candidate_host == nullptr) {
-      // Make a first choice to start the comparisons.
-      candidate_host = sampled_host;
-      continue;
+      if (candidate_host == nullptr) {
+        // Make a first choice to start the comparisons.
+        candidate_host = sampled_host;
+        continue;
       }
 
       const auto candidate_active_rq = candidate_host->stats().rq_active_.value();
       const auto sampled_active_rq = sampled_host->stats().rq_active_.value();
       if (sampled_active_rq < candidate_active_rq) {
-          candidate_host = sampled_host;
-        }
+        candidate_host = sampled_host;
+      }
     }
     return candidate_host;
   }
-  
+
   uint32_t hosts_to_use_current_size = hosts_to_use.size();
-  HostVectorSharedPtr hosts( new HostVector(hosts_to_use));
+  HostVectorSharedPtr hosts(new HostVector(hosts_to_use));
 
   for (uint32_t choice_idx = 0; choice_idx < choice_count_; ++choice_idx) {
     const int rand_idx = random_.random() % hosts_to_use_current_size;
     const HostSharedPtr& sampled_host = hosts->at(rand_idx);
 
-    // Swap selected host with latest one and skip latest one  on next iteration 
+    // Swap selected host with latest one and skip latest one  on next iteration
     // so we don't repeat the selection when there are enough hosts.
     // This will prevent use to choose the same host on our selection since there
     // is a higher chance of selecting the same host when the number of hosts is
     // too big.
-    uint32_t last_host_idx = hosts_to_use_current_size-1;
-    if ( hosts_to_use.size() > choice_count_ ) {
+    uint32_t last_host_idx = hosts_to_use_current_size - 1;
+    if (hosts_to_use.size() > choice_count_) {
       --hosts_to_use_current_size;
-    
+
       hosts->at(rand_idx) = hosts->at(last_host_idx);
     }
 

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -642,11 +642,16 @@ public:
             least_request_config.has_value()
                 ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(least_request_config.ref(), choice_count, 2)
                 : 2),
+        
         active_request_bias_runtime_(
             least_request_config.has_value() && least_request_config->has_active_request_bias()
                 ? absl::optional<Runtime::Double>(
                       {least_request_config->active_request_bias(), runtime})
-                : absl::nullopt) {
+                : absl::nullopt),
+                full_scan_hosts_(
+          least_request_config.has_value()
+            ? least_request_config->full_scan_hosts().value()
+            : false) {
     initialize();
   }
 
@@ -661,11 +666,15 @@ public:
             LoadBalancerConfigHelper::localityLbConfigFromProto(least_request_config),
             LoadBalancerConfigHelper::slowStartConfigFromProto(least_request_config), time_source),
         choice_count_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(least_request_config, choice_count, 2)),
+
         active_request_bias_runtime_(
             least_request_config.has_active_request_bias()
                 ? absl::optional<Runtime::Double>(
                       {least_request_config.active_request_bias(), runtime})
-                : absl::nullopt) {
+                : absl::nullopt),
+                         full_scan_hosts_(
+          least_request_config.has_full_scan_hosts() ? least_request_config.full_scan_hosts().value()
+            : false) {
     initialize();
   }
 
@@ -701,6 +710,7 @@ private:
   double active_request_bias_{};
 
   const absl::optional<Runtime::Double> active_request_bias_runtime_;
+  const bool full_scan_hosts_;
 };
 
 /**

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -642,16 +642,15 @@ public:
             least_request_config.has_value()
                 ? PROTOBUF_GET_WRAPPED_OR_DEFAULT(least_request_config.ref(), choice_count, 2)
                 : 2),
-        
+
         active_request_bias_runtime_(
             least_request_config.has_value() && least_request_config->has_active_request_bias()
                 ? absl::optional<Runtime::Double>(
                       {least_request_config->active_request_bias(), runtime})
                 : absl::nullopt),
-                full_scan_hosts_(
-          least_request_config.has_value()
-            ? least_request_config->full_scan_hosts().value()
-            : false) {
+        full_scan_hosts_(least_request_config.has_value()
+                             ? least_request_config->full_scan_hosts().value()
+                             : false) {
     initialize();
   }
 
@@ -672,9 +671,9 @@ public:
                 ? absl::optional<Runtime::Double>(
                       {least_request_config.active_request_bias(), runtime})
                 : absl::nullopt),
-                         full_scan_hosts_(
-          least_request_config.has_full_scan_hosts() ? least_request_config.full_scan_hosts().value()
-            : false) {
+        full_scan_hosts_(least_request_config.has_full_scan_hosts()
+                             ? least_request_config.full_scan_hosts().value()
+                             : false) {
     initialize();
   }
 

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -2045,8 +2045,11 @@ TEST_P(LeastRequestLoadBalancerTest, PNC) {
   lr_lb_config.mutable_choice_count()->set_value(2);
   LeastRequestLoadBalancer lb_2{priority_set_, nullptr,        stats_,       runtime_,
                                 random_,       common_config_, lr_lb_config, simTime()};
-  lr_lb_config.mutable_choice_count()->set_value(5);
-  LeastRequestLoadBalancer lb_5{priority_set_, nullptr,        stats_,       runtime_,
+  lr_lb_config.mutable_choice_count()->set_value(3);
+  LeastRequestLoadBalancer lb_3{priority_set_, nullptr,        stats_,       runtime_,
+                                random_,       common_config_, lr_lb_config, simTime()};
+  lr_lb_config.mutable_choice_count()->set_value(4);
+  LeastRequestLoadBalancer lb_4{priority_set_, nullptr,        stats_,       runtime_,
                                 random_,       common_config_, lr_lb_config, simTime()};
 
   // Verify correct number of choices.
@@ -2059,20 +2062,21 @@ TEST_P(LeastRequestLoadBalancerTest, PNC) {
   EXPECT_CALL(random_, random()).Times(3).WillRepeatedly(Return(0));
   EXPECT_EQ(hostSet().healthy_hosts_[3], lb_2.chooseHost(nullptr));
 
-  // 5 choices configured results in P5C.
-  EXPECT_CALL(random_, random()).Times(6).WillRepeatedly(Return(0));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_5.chooseHost(nullptr));
 
-  // Verify correct host chosen in P5C scenario.
+  // Verify correct host chosen in P3C scenario.
   EXPECT_CALL(random_, random())
-      .Times(6)
+      .Times(3)
       .WillOnce(Return(0))
       .WillOnce(Return(3))
-      .WillOnce(Return(0))
-      .WillOnce(Return(3))
-      .WillOnce(Return(2))
       .WillOnce(Return(1));
-  EXPECT_EQ(hostSet().healthy_hosts_[3], lb_5.chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[3], lb_3.chooseHost(nullptr));
+
+
+  // When the number of hosts is smaller or equal to the number of choices we don't call
+  // random() since we do a full table scan.
+  EXPECT_CALL(random_, random()).Times(0);
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_4.chooseHost(nullptr));
+
 }
 
 TEST_P(LeastRequestLoadBalancerTest, WeightImbalance) {

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -2053,11 +2053,11 @@ TEST_P(LeastRequestLoadBalancerTest, PNC) {
 
   // 0 choices configured should default to P2C.
   EXPECT_CALL(random_, random()).Times(3).WillRepeatedly(Return(0));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_.chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[3], lb_.chooseHost(nullptr));
 
   // 2 choices configured results in P2C.
   EXPECT_CALL(random_, random()).Times(3).WillRepeatedly(Return(0));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[3], lb_2.chooseHost(nullptr));
 
   // 5 choices configured results in P5C.
   EXPECT_CALL(random_, random()).Times(6).WillRepeatedly(Return(0));

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -2062,7 +2062,6 @@ TEST_P(LeastRequestLoadBalancerTest, PNC) {
   EXPECT_CALL(random_, random()).Times(3).WillRepeatedly(Return(0));
   EXPECT_EQ(hostSet().healthy_hosts_[3], lb_2.chooseHost(nullptr));
 
-
   // Verify correct host chosen in P3C scenario.
   EXPECT_CALL(random_, random())
       .Times(3)
@@ -2071,12 +2070,10 @@ TEST_P(LeastRequestLoadBalancerTest, PNC) {
       .WillOnce(Return(1));
   EXPECT_EQ(hostSet().healthy_hosts_[3], lb_3.chooseHost(nullptr));
 
-
   // When the number of hosts is smaller or equal to the number of choices we don't call
   // random() since we do a full table scan.
   EXPECT_CALL(random_, random()).Times(0);
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_4.chooseHost(nullptr));
-
 }
 
 TEST_P(LeastRequestLoadBalancerTest, WeightImbalance) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
This PR fixes the behaviour when the number of hosts used for selecting the one with least requests are small and the chances of choosing the same host is very high. This is described on the issue #11004. 

This PR also adds a new option for the least request LB to allow it to make a full scan on the list of hosts to select the one with least amount of requests.  This new option will help people that have a small number of hosts but have specific needs to choose the one with least requests.
 
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
