### PR TITLE
Redirect trace log output to /dev/null for coverage tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -195,6 +195,7 @@ build:coverage --collect_code_coverage
 build:coverage --test_tag_filters=-nocoverage
 build:coverage --instrumentation_filter="//source(?!/common/quic/platform)[/:],//envoy[/:],//contrib(?!/.*/test)[/:]"
 build:test-coverage --test_arg="-l trace"
+build:test-coverage --test_arg="--log-path /dev/null"
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
 

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -120,6 +120,7 @@ public:
 
   void expectLogMessage(const std::string& pattern, const std::string& message,
                         const std::string& expected) {
+    StderrSinkDelegate stacked(Envoy::Logger::Registry::getSink());
     auto formatter = std::make_unique<spdlog::pattern_formatter>();
     formatter
         ->add_flag<CustomFlagFormatter::EscapeMessageNewLine>(

--- a/test/test_runner.cc
+++ b/test/test_runner.cc
@@ -64,9 +64,19 @@ public:
   bool disable_;
 };
 
+bool isDeathTestChild(int argc, char** argv) {
+  for (int i = 0; i < argc; ++i) {
+    if (absl::StartsWith(argv[i], "--gtest_internal_run_death_test")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace
 
 int TestRunner::RunTests(int argc, char** argv) {
+  const bool is_death_test_child = isDeathTestChild(argc, argv);
   ::testing::InitGoogleMock(&argc, argv);
   // We hold on to process_wide to provide RAII cleanup of process-wide
   // state.
@@ -140,7 +150,9 @@ int TestRunner::RunTests(int argc, char** argv) {
   std::unique_ptr<Logger::FileSinkDelegate> file_logger;
 
   // Redirect all logs to fake file when --log-path arg is specified in command line.
-  if (!TestEnvironment::getOptions().logPath().empty()) {
+  // However do not redirect to file from death test children as the parent typically
+  // looks for specific output in stderr
+  if (!TestEnvironment::getOptions().logPath().empty() && !is_death_test_child) {
     file_logger = std::make_unique<Logger::FileSinkDelegate>(
         TestEnvironment::getOptions().logPath(), access_log_manager, Logger::Registry::getSink());
   }


### PR DESCRIPTION
Risk Level: Low, test only
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
