### PR TITLE
Harmonize UHV interface names

### DIFF
--- a/envoy/http/header_validator.h
+++ b/envoy/http/header_validator.h
@@ -11,11 +11,10 @@ namespace Http {
 
 /**
  * Common interface for server and client header validators.
- * TODO(yanavlasov): rename interfaces in the next PR to `HeaderValidator`
  */
-class HeaderValidatorBase {
+class HeaderValidator {
 public:
-  virtual ~HeaderValidatorBase() = default;
+  virtual ~HeaderValidator() = default;
 
   // A class that holds either success condition or an error condition with tuple of
   // action and error details.
@@ -78,11 +77,10 @@ public:
 
 /**
  * Interface for server header validators.
- * TODO(yanavlasov): rename interfaces in the next PR to `ServerHeaderValidator`
  */
-class HeaderValidator : public HeaderValidatorBase {
+class ServerHeaderValidator : public HeaderValidator {
 public:
-  ~HeaderValidator() override = default;
+  ~ServerHeaderValidator() override = default;
 
   /**
    * Transform the entire request header map.
@@ -127,7 +125,7 @@ public:
 /**
  * Interface for server header validators.
  */
-class ClientHeaderValidator : public HeaderValidatorBase {
+class ClientHeaderValidator : public HeaderValidator {
 public:
   ~ClientHeaderValidator() override = default;
 
@@ -161,7 +159,7 @@ public:
   virtual TransformationResult transformResponseHeaders(ResponseHeaderMap& header_map) PURE;
 };
 
-using HeaderValidatorPtr = std::unique_ptr<HeaderValidator>;
+using ServerHeaderValidatorPtr = std::unique_ptr<ServerHeaderValidator>;
 using ClientHeaderValidatorPtr = std::unique_ptr<ClientHeaderValidator>;
 
 /**
@@ -187,8 +185,8 @@ public:
   /**
    * Create a new header validator for the specified protocol.
    */
-  virtual HeaderValidatorPtr createServerHeaderValidator(Protocol protocol,
-                                                         HeaderValidatorStats& stats) PURE;
+  virtual ServerHeaderValidatorPtr createServerHeaderValidator(Protocol protocol,
+                                                               HeaderValidatorStats& stats) PURE;
   virtual ClientHeaderValidatorPtr createClientHeaderValidator(Protocol protocol,
                                                                HeaderValidatorStats& stats) PURE;
 };

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -513,7 +513,7 @@ public:
    * @return pointer to the header validator.
    *         If nullptr, header validation will not be done.
    */
-  virtual HeaderValidatorPtr makeHeaderValidator(Protocol protocol) PURE;
+  virtual ServerHeaderValidatorPtr makeHeaderValidator(Protocol protocol) PURE;
 
   /**
    * @return whether to append the x-forwarded-port header.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -948,7 +948,7 @@ bool ConnectionManagerImpl::ActiveStream::validateHeaders() {
       auto transformation_result = header_validator_->transformRequestHeaders(*request_headers_);
       failure = !transformation_result.ok();
       redirect = transformation_result.action() ==
-                 Http::HeaderValidator::RequestHeadersTransformationResult::Action::Redirect;
+                 Http::ServerHeaderValidator::RequestHeadersTransformationResult::Action::Redirect;
       failure_details = std::string(transformation_result.details());
     }
     if (failure) {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -491,7 +491,7 @@ private:
     const std::string* decorated_operation_{nullptr};
     std::unique_ptr<RdsRouteConfigUpdateRequester> route_config_update_requester_;
     std::unique_ptr<Tracing::CustomTagMap> tracing_custom_tags_{nullptr};
-    Http::HeaderValidatorPtr header_validator_;
+    Http::ServerHeaderValidatorPtr header_validator_;
 
     friend FilterManager;
 

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -243,7 +243,8 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  Http::HeaderValidatorPtr makeHeaderValidator([[maybe_unused]] Http::Protocol protocol) override {
+  Http::ServerHeaderValidatorPtr
+  makeHeaderValidator([[maybe_unused]] Http::Protocol protocol) override {
 #ifdef ENVOY_ENABLE_UHV
     return header_validator_factory_ ? header_validator_factory_->createServerHeaderValidator(
                                            protocol, getHeaderValidatorStats(protocol))

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -518,7 +518,7 @@ HeaderValidator::HeaderEntryValidationResult HeaderValidator::validateGenericReq
 // For H/1 the codec will never produce H/2 pseudo headers and per
 // https://www.rfc-editor.org/rfc/rfc9110#section-6.5 there are no other prohibitions.
 // As a result this common function can cover trailer validation for all protocols.
-::Envoy::Http::HeaderValidatorBase::ValidationResult
+::Envoy::Http::HeaderValidator::ValidationResult
 HeaderValidator::validateTrailers(const ::Envoy::Http::HeaderMap& trailers) {
   std::string reject_details;
   trailers.iterate([this, &reject_details](const ::Envoy::Http::HeaderEntry& header_entry)
@@ -541,10 +541,10 @@ HeaderValidator::validateTrailers(const ::Envoy::Http::HeaderMap& trailers) {
   });
 
   if (!reject_details.empty()) {
-    return {::Envoy::Http::HeaderValidatorBase::ValidationResult::Action::Reject, reject_details};
+    return {::Envoy::Http::HeaderValidator::ValidationResult::Action::Reject, reject_details};
   }
 
-  return ::Envoy::Http::HeaderValidatorBase::ValidationResult::success();
+  return ::Envoy::Http::HeaderValidator::ValidationResult::success();
 }
 
 void HeaderValidator::sanitizeHeadersWithUnderscores(::Envoy::Http::HeaderMap& header_map) {

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -89,7 +89,7 @@ protected:
    */
   class HostHeaderValidationResult {
   public:
-    using RejectAction = ::Envoy::Http::HeaderValidatorBase::RejectAction;
+    using RejectAction = ::Envoy::Http::HeaderValidator::RejectAction;
     HostHeaderValidationResult(RejectAction action, absl::string_view details,
                                absl::string_view address, absl::string_view port)
         : result_(action, details, address, port) {

--- a/source/extensions/http/header_validators/envoy_default/header_validator_factory.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator_factory.cc
@@ -15,7 +15,7 @@ using ::Envoy::Http::Protocol;
 HeaderValidatorFactory::HeaderValidatorFactory(const HeaderValidatorConfig& config)
     : config_(config) {}
 
-::Envoy::Http::HeaderValidatorPtr
+::Envoy::Http::ServerHeaderValidatorPtr
 HeaderValidatorFactory::createServerHeaderValidator(Protocol protocol,
                                                     ::Envoy::Http::HeaderValidatorStats& stats) {
   switch (protocol) {

--- a/source/extensions/http/header_validators/envoy_default/header_validator_factory.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator_factory.h
@@ -15,7 +15,7 @@ public:
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&
           config);
 
-  ::Envoy::Http::HeaderValidatorPtr
+  ::Envoy::Http::ServerHeaderValidatorPtr
   createServerHeaderValidator(::Envoy::Http::Protocol protocol,
                               ::Envoy::Http::HeaderValidatorStats& stats) override;
 

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -22,7 +22,7 @@ using ::Envoy::Http::LowerCaseString;
 using ::Envoy::Http::Protocol;
 using ::Envoy::Http::RequestHeaderMap;
 using ::Envoy::Http::UhvResponseCodeDetail;
-using ValidationResult = ::Envoy::Http::HeaderValidatorBase::ValidationResult;
+using ValidationResult = ::Envoy::Http::HeaderValidator::ValidationResult;
 
 struct Http1ResponseCodeDetailValues {
   const std::string InvalidTransferEncoding = "uhv.http1.invalid_transfer_encoding";
@@ -295,7 +295,7 @@ void Http1HeaderValidator::sanitizeContentLength(::Envoy::Http::RequestHeaderMap
   }
 }
 
-::Envoy::Http::HeaderValidator::RequestHeadersTransformationResult
+::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult
 ServerHttp1HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeaderMap& header_map) {
   sanitizeContentLength(header_map);
   sanitizeHeadersWithUnderscores(header_map);
@@ -305,7 +305,7 @@ ServerHttp1HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeader
       return path_result;
     }
   }
-  return ::Envoy::Http::HeaderValidator::RequestHeadersTransformationResult::success();
+  return ::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult::success();
 }
 
 ValidationResult

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.h
@@ -15,16 +15,16 @@ public:
           config,
       ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateRequestHeaders(const ::Envoy::Http::RequestHeaderMap& header_map);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateResponseHeaders(const ::Envoy::Http::ResponseHeaderMap& header_map);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateRequestTrailers(const ::Envoy::Http::RequestTrailerMap& trailer_map);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateResponseTrailers(const ::Envoy::Http::ResponseTrailerMap& trailer_map);
 
 protected:
@@ -56,7 +56,7 @@ private:
 };
 
 class ServerHttp1HeaderValidator : public Http1HeaderValidator,
-                                   public ::Envoy::Http::HeaderValidator {
+                                   public ::Envoy::Http::ServerHeaderValidator {
 public:
   ServerHttp1HeaderValidator(
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -26,7 +26,7 @@ using ::Envoy::Http::HeaderUtility;
 using ::Envoy::Http::Protocol;
 using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::UhvResponseCodeDetail;
-using ValidationResult = ::Envoy::Http::HeaderValidatorBase::ValidationResult;
+using ValidationResult = ::Envoy::Http::HeaderValidator::ValidationResult;
 
 struct Http2ResponseCodeDetailValues {
   const std::string InvalidTE = "uhv.http2.invalid_te";
@@ -425,7 +425,7 @@ ValidationResult Http2HeaderValidator::validateResponseTrailers(
   return result;
 }
 
-::Envoy::Http::HeaderValidator::RequestHeadersTransformationResult
+::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult
 ServerHttp2HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeaderMap& header_map) {
   sanitizeHeadersWithUnderscores(header_map);
   if (!config_.uri_path_normalization_options().skip_path_normalization()) {
@@ -440,10 +440,10 @@ ServerHttp2HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeader
   if (::Envoy::Http::Utility::isH2UpgradeRequest(header_map)) {
     ::Envoy::Http::Utility::transformUpgradeRequestFromH2toH1(header_map);
   }
-  return ::Envoy::Http::HeaderValidator::RequestHeadersTransformationResult::success();
+  return ::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult::success();
 }
 
-::Envoy::Http::HeaderValidator::ResponseHeadersTransformationResult
+::Envoy::Http::ServerHeaderValidator::ResponseHeadersTransformationResult
 ServerHttp2HeaderValidator::transformResponseHeaders(
     const ::Envoy::Http::ResponseHeaderMap& header_map) {
   // Check if the response is for the the H/1 UPGRADE and transform it to the H/2 extended CONNECT

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.h
@@ -15,16 +15,16 @@ public:
           config,
       ::Envoy::Http::Protocol protocol, ::Envoy::Http::HeaderValidatorStats& stats);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateRequestHeaders(const ::Envoy::Http::RequestHeaderMap& header_map);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateResponseHeaders(const ::Envoy::Http::ResponseHeaderMap& header_map);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateRequestTrailers(const ::Envoy::Http::RequestTrailerMap& trailer_map);
 
-  ::Envoy::Http::HeaderValidatorBase::ValidationResult
+  ::Envoy::Http::HeaderValidator::ValidationResult
   validateResponseTrailers(const ::Envoy::Http::ResponseTrailerMap& trailer_map);
 
 private:
@@ -56,7 +56,7 @@ private:
 };
 
 class ServerHttp2HeaderValidator : public Http2HeaderValidator,
-                                   public ::Envoy::Http::HeaderValidator {
+                                   public ::Envoy::Http::ServerHeaderValidator {
 public:
   ServerHttp2HeaderValidator(
       const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -217,7 +217,7 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  Http::HeaderValidatorPtr makeHeaderValidator(Http::Protocol) override {
+  Http::ServerHeaderValidatorPtr makeHeaderValidator(Http::Protocol) override {
     // TODO(yanavlasov): admin interface should use the default validator
     return nullptr;
   }

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -389,8 +389,8 @@ TEST_F(CodecClientTest, ResponseHeaderValidationFails) {
   EXPECT_OK(request_encoder.encodeHeaders(request_headers, true));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   EXPECT_CALL(*header_validator_, validateResponseHeaders(_))
-      .WillOnce(Return(HeaderValidatorBase::ValidationResult{
-          HeaderValidatorBase::ValidationResult::Action::Reject, "some error"}));
+      .WillOnce(Return(HeaderValidator::ValidationResult{
+          HeaderValidator::ValidationResult::Action::Reject, "some error"}));
   // Invalid response should cause stream reset
   EXPECT_CALL(inner_encoder.stream_, resetStream(StreamResetReason::ProtocolError));
   inner_decoder->decodeHeaders(std::move(response_headers), true);
@@ -444,8 +444,8 @@ TEST_F(CodecClientTest, ResponseHeaderValidationFailsWithConnectionClosure) {
   EXPECT_OK(request_encoder.encodeHeaders(request_headers, true));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   EXPECT_CALL(*header_validator_, validateResponseHeaders(_))
-      .WillOnce(Return(HeaderValidatorBase::ValidationResult{
-          HeaderValidatorBase::ValidationResult::Action::Reject, "some error"}));
+      .WillOnce(Return(HeaderValidator::ValidationResult{
+          HeaderValidator::ValidationResult::Action::Reject, "some error"}));
   // By default H/2 and H/3 connections are disconnected on protocol errors
   EXPECT_CALL(*connection_, close(_));
   inner_decoder->decodeHeaders(std::move(response_headers), true);

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -225,7 +225,7 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  Http::HeaderValidatorPtr makeHeaderValidator(Protocol) override {
+  Http::ServerHeaderValidatorPtr makeHeaderValidator(Protocol) override {
     // TODO(yanavlasov): fuzz test interface should use the default validator, although this could
     // be changed too
     return nullptr;

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -3355,7 +3355,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp1) {
   setup(false, "");
   expectUhvHeaderCheck(HeaderValidator::ValidationResult(
                            HeaderValidator::ValidationResult::Action::Reject, "bad_header_map"),
-                       HeaderValidator::RequestHeadersTransformationResult::success());
+                       ServerHeaderValidator::RequestHeadersTransformationResult::success());
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     decoder_ = &conn_manager_->newStream(response_encoder_);
@@ -3401,7 +3401,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp2) {
   setup(false, "");
   expectUhvHeaderCheck(HeaderValidator::ValidationResult(
                            HeaderValidator::ValidationResult::Action::Reject, "bad_header_map"),
-                       HeaderValidator::RequestHeadersTransformationResult::success());
+                       ServerHeaderValidator::RequestHeadersTransformationResult::success());
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     decoder_ = &conn_manager_->newStream(response_encoder_);
@@ -3430,7 +3430,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectGrpcRequest) {
   setup(false, "");
   expectUhvHeaderCheck(HeaderValidator::ValidationResult(
                            HeaderValidator::ValidationResult::Action::Reject, "bad_header_map"),
-                       HeaderValidator::RequestHeadersTransformationResult::success());
+                       ServerHeaderValidator::RequestHeadersTransformationResult::success());
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     decoder_ = &conn_manager_->newStream(response_encoder_);
@@ -3460,8 +3460,9 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRedirect) {
   setup(false, "");
   expectUhvHeaderCheck(
       HeaderValidator::ValidationResult::success(),
-      HeaderValidator::RequestHeadersTransformationResult(
-          HeaderValidator::RequestHeadersTransformationResult::Action::Redirect, "bad_header_map"));
+      ServerHeaderValidator::RequestHeadersTransformationResult(
+          ServerHeaderValidator::RequestHeadersTransformationResult::Action::Redirect,
+          "bad_header_map"));
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     decoder_ = &conn_manager_->newStream(response_encoder_);
@@ -3489,8 +3490,9 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRedirectGrpcRequest) {
   setup(false, "");
   expectUhvHeaderCheck(
       HeaderValidator::ValidationResult::success(),
-      HeaderValidator::RequestHeadersTransformationResult(
-          HeaderValidator::RequestHeadersTransformationResult::Action::Redirect, "bad_header_map"));
+      ServerHeaderValidator::RequestHeadersTransformationResult(
+          ServerHeaderValidator::RequestHeadersTransformationResult::Action::Redirect,
+          "bad_header_map"));
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     decoder_ = &conn_manager_->newStream(response_encoder_);
@@ -3644,7 +3646,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectTrailersAfterResponse
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorAccept) {
   setup(false, "");
   expectUhvHeaderCheck(HeaderValidator::ValidationResult::success(),
-                       HeaderValidator::RequestHeadersTransformationResult::success());
+                       ServerHeaderValidator::RequestHeadersTransformationResult::success());
 
   // Store the basic request encoder during filter chain setup.
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -311,10 +311,10 @@ void HttpConnectionManagerImplMixin::testPathNormalization(
 
 void HttpConnectionManagerImplMixin::expectUhvHeaderCheck(
     HeaderValidator::ValidationResult validation_result,
-    HeaderValidator::RequestHeadersTransformationResult transformation_result) {
+    ServerHeaderValidator::RequestHeadersTransformationResult transformation_result) {
   EXPECT_CALL(header_validator_factory_, createServerHeaderValidator(codec_->protocol_, _))
       .WillOnce(InvokeWithoutArgs([validation_result, transformation_result]() {
-        auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
+        auto header_validator = std::make_unique<testing::StrictMock<MockServerHeaderValidator>>();
         EXPECT_CALL(*header_validator, validateRequestHeaders(_))
             .WillOnce(InvokeWithoutArgs([validation_result]() { return validation_result; }));
 
@@ -322,7 +322,7 @@ void HttpConnectionManagerImplMixin::expectUhvHeaderCheck(
           EXPECT_CALL(*header_validator, transformRequestHeaders(_))
               .WillOnce(Invoke([transformation_result](RequestHeaderMap& headers) {
                 if (transformation_result.action() ==
-                    HeaderValidator::RequestHeadersTransformationResult::Action::Redirect) {
+                    ServerHeaderValidator::RequestHeadersTransformationResult::Action::Redirect) {
                   headers.setPath("/some/new/path");
                 }
                 return transformation_result;
@@ -330,8 +330,9 @@ void HttpConnectionManagerImplMixin::expectUhvHeaderCheck(
         }
 
         EXPECT_CALL(*header_validator, transformResponseHeaders(_))
-            .WillOnce(InvokeWithoutArgs(
-                []() { return HeaderValidator::ResponseHeadersTransformationResult::success(); }));
+            .WillOnce(InvokeWithoutArgs([]() {
+              return ServerHeaderValidator::ResponseHeadersTransformationResult::success();
+            }));
 
         return header_validator;
       }));
@@ -342,13 +343,13 @@ void HttpConnectionManagerImplMixin::expectUhvTrailerCheck(
     HeaderValidator::TransformationResult transformation_result, bool expect_response) {
   EXPECT_CALL(header_validator_factory_, createServerHeaderValidator(codec_->protocol_, _))
       .WillOnce(InvokeWithoutArgs([validation_result, transformation_result, expect_response]() {
-        auto header_validator = std::make_unique<testing::StrictMock<MockHeaderValidator>>();
+        auto header_validator = std::make_unique<testing::StrictMock<MockServerHeaderValidator>>();
         EXPECT_CALL(*header_validator, validateRequestHeaders(_)).WillOnce(InvokeWithoutArgs([]() {
           return HeaderValidator::ValidationResult::success();
         }));
 
         EXPECT_CALL(*header_validator, transformRequestHeaders(_)).WillOnce(InvokeWithoutArgs([]() {
-          return HeaderValidator::RequestHeadersTransformationResult::success();
+          return ServerHeaderValidator::RequestHeadersTransformationResult::success();
         }));
 
         EXPECT_CALL(*header_validator, validateRequestTrailers(_))
@@ -361,7 +362,7 @@ void HttpConnectionManagerImplMixin::expectUhvTrailerCheck(
         if (expect_response) {
           EXPECT_CALL(*header_validator, transformResponseHeaders(_))
               .WillOnce(InvokeWithoutArgs([]() {
-                return HeaderValidator::ResponseHeadersTransformationResult::success();
+                return ServerHeaderValidator::ResponseHeadersTransformationResult::success();
               }));
         }
         return header_validator;

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -159,7 +159,7 @@ public:
   const HttpConnectionManagerProto::ProxyStatusConfig* proxyStatusConfig() const override {
     return proxy_status_config_.get();
   }
-  HeaderValidatorPtr makeHeaderValidator(Protocol protocol) override {
+  ServerHeaderValidatorPtr makeHeaderValidator(Protocol protocol) override {
     return header_validator_factory_.createServerHeaderValidator(protocol, header_validator_stats_);
   }
   bool appendXForwardedPort() const override { return false; }
@@ -186,9 +186,9 @@ public:
       callbacks.addAccessLogHandler(handler);
     };
   }
-  void
-  expectUhvHeaderCheck(HeaderValidatorBase::ValidationResult validation_result,
-                       HeaderValidator::RequestHeadersTransformationResult transformation_result);
+  void expectUhvHeaderCheck(
+      HeaderValidator::ValidationResult validation_result,
+      ServerHeaderValidator::RequestHeadersTransformationResult transformation_result);
   void expectUhvTrailerCheck(HeaderValidator::ValidationResult validation_result,
                              HeaderValidator::TransformationResult transformation_result,
                              bool expect_response = true);

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -93,14 +93,14 @@ struct HTTPStringTestCase {
 // validation fails it calls the `sendLocalReply` on the decoder, indicating validation error.
 class MockRequestDecoderShimWithUhv : public Http::MockRequestDecoder {
 public:
-  MockRequestDecoderShimWithUhv(Http::HeaderValidator* header_validator,
+  MockRequestDecoderShimWithUhv(Http::ServerHeaderValidator* header_validator,
                                 Network::MockConnection& connection)
       : header_validator_(header_validator), connection_(connection) {}
 
   void setResponseEncoder(Http::ResponseEncoder* response_encoder) {
     response_encoder_ = response_encoder;
   }
-  void setHeaderValidator(Http::HeaderValidator* header_validator) {
+  void setHeaderValidator(Http::ServerHeaderValidator* header_validator) {
     header_validator_ = header_validator;
   }
   void decodeHeaders(Http::RequestHeaderMapSharedPtr&& headers, bool end_stream) override {
@@ -129,7 +129,7 @@ public:
   }
 
 private:
-  Http::HeaderValidator* header_validator_;
+  Http::ServerHeaderValidator* header_validator_;
   Network::MockConnection& connection_;
   Http::ResponseEncoder* response_encoder_{nullptr};
 };
@@ -232,7 +232,7 @@ protected:
       headers_with_underscores_action_{envoy::config::core::v3::HttpProtocolOptions::ALLOW};
   envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       header_validator_config_;
-  HeaderValidatorPtr header_validator_;
+  ServerHeaderValidatorPtr header_validator_;
 };
 
 void Http1ServerConnectionImplTest::expect400(Buffer::OwnedImpl& buffer,

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -75,7 +75,7 @@ public:
   void setResponseEncoder(Http::ResponseEncoder* response_encoder) {
     response_encoder_ = response_encoder;
   }
-  void setHeaderValidator(Http::HeaderValidator* header_validator) {
+  void setHeaderValidator(Http::ServerHeaderValidator* header_validator) {
     header_validator_ = header_validator;
   }
   void decodeHeaders(Http::RequestHeaderMapSharedPtr&& headers, bool end_stream) override {
@@ -106,7 +106,7 @@ public:
   }
 
 private:
-  Http::HeaderValidator* header_validator_{nullptr};
+  Http::ServerHeaderValidator* header_validator_{nullptr};
   Http::ResponseEncoder* response_encoder_{nullptr};
 };
 } // namespace
@@ -457,7 +457,7 @@ public:
       headers_with_underscores_action_{envoy::config::core::v3::HttpProtocolOptions::ALLOW};
   envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       header_validator_config_;
-  HeaderValidatorPtr header_validator_;
+  ServerHeaderValidatorPtr header_validator_;
 };
 
 class Http2CodecImplTest : public ::testing::TestWithParam<Http2SettingsTestParam>,

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -36,9 +36,9 @@ TEST(EnvoyQuicUtilsTest, ConversionBetweenQuicAddressAndEnvoyAddress) {
   EXPECT_FALSE(envoyIpAddressToQuicSocketAddress(nullptr).IsInitialized());
 }
 
-class MockHeaderValidator : public HeaderValidator {
+class MockServerHeaderValidator : public HeaderValidator {
 public:
-  ~MockHeaderValidator() override = default;
+  ~MockServerHeaderValidator() override = default;
   MOCK_METHOD(Http::HeaderUtility::HeaderValidationResult, validateHeader,
               (absl::string_view header_name, absl::string_view header_value));
 };
@@ -55,7 +55,7 @@ TEST(EnvoyQuicUtilsTest, HeadersConversion) {
   headers_block.AppendValueOrAddHeader("key1", "value1");
   headers_block.AppendValueOrAddHeader("key1", "");
   headers_block.AppendValueOrAddHeader("key1", "value2");
-  NiceMock<MockHeaderValidator> validator;
+  NiceMock<MockServerHeaderValidator> validator;
   absl::string_view details;
   quic::QuicRstStreamErrorCode rst = quic::QUIC_REFUSED_STREAM;
   auto envoy_headers = http2HeaderBlockToEnvoyTrailers<Http::RequestHeaderMapImpl>(
@@ -126,7 +126,7 @@ TEST(EnvoyQuicUtilsTest, HeadersSizeBounds) {
   headers_block["foo"] = std::string("bar\0eep\0baz", 11);
   absl::string_view details;
   // 6 headers are allowed.
-  NiceMock<MockHeaderValidator> validator;
+  NiceMock<MockServerHeaderValidator> validator;
   quic::QuicRstStreamErrorCode rst = quic::QUIC_REFUSED_STREAM;
   EXPECT_NE(nullptr, http2HeaderBlockToEnvoyTrailers<Http::RequestHeaderMapImpl>(
                          headers_block, 6, validator, details, rst));
@@ -146,7 +146,7 @@ TEST(EnvoyQuicUtilsTest, TrailersSizeBounds) {
   headers_block[":scheme"] = "https";
   headers_block["foo"] = std::string("bar\0eep\0baz", 11);
   absl::string_view details;
-  NiceMock<MockHeaderValidator> validator;
+  NiceMock<MockServerHeaderValidator> validator;
   quic::QuicRstStreamErrorCode rst = quic::QUIC_REFUSED_STREAM;
   EXPECT_NE(nullptr, http2HeaderBlockToEnvoyTrailers<Http::RequestHeaderMapImpl>(
                          headers_block, 6, validator, details, rst));
@@ -164,7 +164,7 @@ TEST(EnvoyQuicUtilsTest, TrailerCharacters) {
   headers_block[":path"] = "/index.hml";
   headers_block[":scheme"] = "https";
   absl::string_view details;
-  NiceMock<MockHeaderValidator> validator;
+  NiceMock<MockServerHeaderValidator> validator;
   EXPECT_CALL(validator, validateHeader(_, _))
       .WillRepeatedly(Return(Http::HeaderUtility::HeaderValidationResult::REJECT));
   quic::QuicRstStreamErrorCode rst = quic::QUIC_REFUSED_STREAM;

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -2967,7 +2967,7 @@ public:
     auto header_validator = std::make_unique<StrictMock<Http::MockHeaderValidatorFactory>>();
     EXPECT_CALL(*header_validator, createServerHeaderValidator(Http::Protocol::Http2, _))
         .WillOnce(InvokeWithoutArgs(
-            []() { return std::make_unique<StrictMock<Http::MockHeaderValidator>>(); }));
+            []() { return std::make_unique<StrictMock<Http::MockServerHeaderValidator>>(); }));
     return header_validator;
   }
 };
@@ -3002,7 +3002,7 @@ public:
     auto header_validator = std::make_unique<StrictMock<Http::MockHeaderValidatorFactory>>();
     EXPECT_CALL(*header_validator, createServerHeaderValidator(Http::Protocol::Http2, _))
         .WillOnce(InvokeWithoutArgs(
-            []() { return std::make_unique<StrictMock<Http::MockHeaderValidator>>(); }));
+            []() { return std::make_unique<StrictMock<Http::MockServerHeaderValidator>>(); }));
     return header_validator;
   }
 

--- a/test/extensions/http/header_validators/envoy_default/header_validator_factory_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_factory_test.cc
@@ -23,7 +23,7 @@ using ::testing::NiceMock;
 
 class HeaderValidatorFactoryTest : public testing::Test {
 protected:
-  ::Envoy::Http::HeaderValidatorPtr create(absl::string_view config_yaml, Protocol protocol) {
+  ::Envoy::Http::ServerHeaderValidatorPtr create(absl::string_view config_yaml, Protocol protocol) {
     auto* factory =
         Registry::FactoryRegistry<Envoy::Http::HeaderValidatorFactoryConfig>::getFactory(
             "envoy.http.header_validators.envoy_default");

--- a/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_test.cc
@@ -18,11 +18,11 @@ using ::Envoy::Http::Protocol;
 using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
-using HeaderValidatorPtr = std::unique_ptr<HeaderValidator>;
+using ServerHeaderValidatorPtr = std::unique_ptr<HeaderValidator>;
 
 class BaseHeaderValidatorTest : public HeaderValidatorTest, public testing::Test {
 protected:
-  HeaderValidatorPtr createBase(absl::string_view config_yaml) {
+  ServerHeaderValidatorPtr createBase(absl::string_view config_yaml) {
     envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -595,8 +595,9 @@ TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderMapRedirectPath) {
   auto uhv = createH1(redirect_encoded_slash_config);
   EXPECT_TRUE(uhv->validateRequestHeaders(headers).ok());
   auto result = uhv->transformRequestHeaders(headers);
-  EXPECT_EQ(result.action(),
-            ::Envoy::Http::HeaderValidator::RequestHeadersTransformationResult::Action::Redirect);
+  EXPECT_EQ(
+      result.action(),
+      ::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult::Action::Redirect);
   EXPECT_EQ(result.details(), "uhv.path_noramlization_redirect");
   EXPECT_EQ(headers.path(), "/dir1/dir2");
 }

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -25,7 +25,7 @@ using ::Envoy::Http::UhvResponseCodeDetail;
 
 class Http2HeaderValidatorTest : public HeaderValidatorTest, public testing::Test {
 protected:
-  ::Envoy::Http::HeaderValidatorPtr createH2ServerUhv(absl::string_view config_yaml) {
+  ::Envoy::Http::ServerHeaderValidatorPtr createH2ServerUhv(absl::string_view config_yaml) {
     envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);
@@ -689,8 +689,9 @@ TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMapRedirectPath) {
   EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
   // Path normalization should result in redirect
   auto result = uhv->transformRequestHeaders(headers);
-  EXPECT_EQ(result.action(),
-            ::Envoy::Http::HeaderValidator::RequestHeadersTransformationResult::Action::Redirect);
+  EXPECT_EQ(
+      result.action(),
+      ::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult::Action::Redirect);
   EXPECT_EQ(result.details(), "uhv.path_noramlization_redirect");
   EXPECT_EQ(headers.path(), "/dir1/dir2");
 }

--- a/test/extensions/http/header_validators/envoy_default/http_common_validation_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http_common_validation_test.cc
@@ -21,7 +21,7 @@ using ::Envoy::Http::TestRequestHeaderMapImpl;
 class HttpCommonValidationTest : public HeaderValidatorTest,
                                  public testing::TestWithParam<Protocol> {
 protected:
-  ::Envoy::Http::HeaderValidatorPtr createUhv(absl::string_view config_yaml) {
+  ::Envoy::Http::ServerHeaderValidatorPtr createUhv(absl::string_view config_yaml) {
     envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -441,7 +441,7 @@ Http::Protocol codeTypeToProtocol(Http::CodecType codec_type) {
 }
 } // namespace
 
-Http::HeaderValidatorPtr FakeHttpConnection::makeHeaderValidator() {
+Http::ServerHeaderValidatorPtr FakeHttpConnection::makeHeaderValidator() {
   return header_validator_factory_ ? header_validator_factory_->createServerHeaderValidator(
                                          codeTypeToProtocol(type_), header_validator_stats_)
                                    : nullptr;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -267,7 +267,7 @@ private:
   std::list<AccessLog::InstanceSharedPtr> access_log_handlers_;
   bool received_data_{false};
   bool grpc_stream_started_{false};
-  Http::HeaderValidatorPtr header_validator_;
+  Http::ServerHeaderValidatorPtr header_validator_;
 };
 
 using FakeStreamPtr = std::unique_ptr<FakeStream>;
@@ -496,7 +496,7 @@ public:
   void writeRawData(absl::string_view data);
   ABSL_MUST_USE_RESULT AssertionResult postWriteRawData(std::string data);
 
-  Http::HeaderValidatorPtr makeHeaderValidator();
+  Http::ServerHeaderValidatorPtr makeHeaderValidator();
 
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {

--- a/test/mocks/http/header_validator.h
+++ b/test/mocks/http/header_validator.h
@@ -7,9 +7,9 @@
 namespace Envoy {
 namespace Http {
 
-class MockHeaderValidator : public HeaderValidator {
+class MockServerHeaderValidator : public ServerHeaderValidator {
 public:
-  ~MockHeaderValidator() override = default;
+  ~MockServerHeaderValidator() override = default;
   MOCK_METHOD(ValidationResult, validateRequestHeaders, (const RequestHeaderMap& header_map));
   MOCK_METHOD(ValidationResult, validateResponseHeaders, (const ResponseHeaderMap& header_map));
   MOCK_METHOD(ValidationResult, validateRequestTrailers, (const RequestTrailerMap& header_map));
@@ -42,7 +42,7 @@ public:
 
 class MockHeaderValidatorFactory : public HeaderValidatorFactory {
 public:
-  MOCK_METHOD(HeaderValidatorPtr, createServerHeaderValidator,
+  MOCK_METHOD(ServerHeaderValidatorPtr, createServerHeaderValidator,
               (Protocol protocol, HeaderValidatorStats& stats));
   MOCK_METHOD(ClientHeaderValidatorPtr, createClientHeaderValidator,
               (Protocol protocol, HeaderValidatorStats& stats));

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -660,7 +660,7 @@ public:
   }
   MOCK_METHOD(uint64_t, maxRequestsPerConnection, (), (const));
   MOCK_METHOD(const HttpConnectionManagerProto::ProxyStatusConfig*, proxyStatusConfig, (), (const));
-  MOCK_METHOD(HeaderValidatorPtr, makeHeaderValidator, (Protocol protocol));
+  MOCK_METHOD(ServerHeaderValidatorPtr, makeHeaderValidator, (Protocol protocol));
   MOCK_METHOD(bool, appendXForwardedPort, (), (const));
   MOCK_METHOD(bool, addProxyProtocolConnectionState, (), (const));
 


### PR DESCRIPTION
Additional Description:
This is safe commit that renames `HeaderValidator` interface to `ServerHeaderValidator` to make it consistent with existing `ClientHeaderValidator`.

Risk Level: Low, build flag protected
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
