### PR TITLE
Bump MACOSX_DEPLOYMENT_TARGET to 10.8

### DIFF
--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -149,7 +149,7 @@ index 00000000..1201542c
 +    shutil.copytree(src_dir, os.path.basename(src_dir))
 +    os.chdir(os.path.basename(src_dir))
 +
-+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
++    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.8"
 +    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
 +    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"


### PR DESCRIPTION
Commit Message:
Failing to build `luajit` on Macos with the current target. Thus bumping it up.

```
lj_err.c:716:8: error: thread-local storage is not supported for the current target
static __thread struct {
       ^
1 error generated.
make[1]: *** [lj_err.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```


Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
