### PR TITLE
golang filter: fix segfault: should check filter expired before touch mutex_ lock.

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -750,7 +750,7 @@ CAPIStatus Filter::removeHeader(absl::string_view key) {
 }
 
 CAPIStatus Filter::copyBuffer(Buffer::Instance* buffer, char* data) {
-  if (has_destroyed_ {
+  if (has_destroyed_) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -640,7 +640,6 @@ CAPIStatus Filter::copyHeaders(GoString* go_strs, char* go_buf) {
 // It won't take affect immidiately while it's invoked from a Go thread, instead, it will post a
 // callback to run in the envoy worker thread.
 CAPIStatus Filter::setHeader(absl::string_view key, absl::string_view value, headerAction act) {
-  // lock until this function return since it may running in a Go thread.
   Thread::LockGuard lock(mutex_);
   if (has_destroyed_) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
@@ -750,6 +749,8 @@ CAPIStatus Filter::removeHeader(absl::string_view key) {
 }
 
 CAPIStatus Filter::copyBuffer(Buffer::Instance* buffer, char* data) {
+  // lock until this function return since it may running in a Go thread.
+  Thread::LockGuard lock(mutex_);
   if (has_destroyed_) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
@@ -839,6 +840,7 @@ CAPIStatus Filter::setTrailer(absl::string_view key, absl::string_view value) {
 }
 
 CAPIStatus Filter::getIntegerValue(int id, uint64_t* value) {
+  // lock until this function return since it may running in a Go thread.
   Thread::LockGuard lock(mutex_);
   if (has_destroyed_) {
     ENVOY_LOG(debug, "golang filter has been destroyed");

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -598,12 +598,12 @@ void copyHeaderMapToGo(Http::HeaderMap& m, GoString* go_strs, char* go_buf) {
     auto value = std::string(header.value().getStringView());
 
     auto len = key.length();
-    // go_strs is the heap memory of go, and the length is twice the number of headers. So range
-    // it is safe.
+    // go_strs is the heap memory of go, and the length is twice the number of headers. So range it
+    // is safe.
     go_strs[i].n = len;
     go_strs[i].p = go_buf;
-    // go_buf is the heap memory of go, and the length is the total length of all keys and values
-    // in the header. So use memcpy is safe.
+    // go_buf is the heap memory of go, and the length is the total length of all keys and values in
+    // the header. So use memcpy is safe.
     memcpy(go_buf, key.data(), len); // NOLINT(safe-memcpy)
     go_buf += len;
     i++;
@@ -679,8 +679,8 @@ CAPIStatus Filter::setHeader(absl::string_view key, absl::string_view value, hea
 
     auto weak_ptr = weak_from_this();
     // dispatch a callback to write header in the envoy safe thread, to make the write operation
-    // safety. otherwise, there might be race between reading in the envoy worker thread and
-    // writing in the Go thread.
+    // safety. otherwise, there might be race between reading in the envoy worker thread and writing
+    // in the Go thread.
     state.getDispatcher().post([this, weak_ptr, key_str, value_str, act] {
       if (!weak_ptr.expired() && !hasDestroyed()) {
         Thread::LockGuard lock(mutex_);
@@ -734,8 +734,8 @@ CAPIStatus Filter::removeHeader(absl::string_view key) {
 
     auto weak_ptr = weak_from_this();
     // dispatch a callback to write header in the envoy safe thread, to make the write operation
-    // safety. otherwise, there might be race between reading in the envoy worker thread and
-    // writing in the Go thread.
+    // safety. otherwise, there might be race between reading in the envoy worker thread and writing
+    // in the Go thread.
     state.getDispatcher().post([this, weak_ptr, key_str] {
       if (!weak_ptr.expired() && !hasDestroyed()) {
         Thread::LockGuard lock(mutex_);
@@ -764,8 +764,8 @@ CAPIStatus Filter::copyBuffer(Buffer::Instance* buffer, char* data) {
     return CAPIStatus::CAPIInvalidPhase;
   }
   for (const Buffer::RawSlice& slice : buffer->getRawSlices()) {
-    // data is the heap memory of go, and the length is the total length of buffer. So use memcpy
-    // is safe.
+    // data is the heap memory of go, and the length is the total length of buffer. So use memcpy is
+    // safe.
     memcpy(data, static_cast<const char*>(slice.mem_), slice.len_); // NOLINT(safe-memcpy)
     data += slice.len_;
   }

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -180,6 +180,10 @@ public:
   CAPIStatus setDynamicMetadata(std::string filter_name, std::string key, absl::string_view buf);
 
 private:
+  bool hasDestroyed() {
+    Thread::LockGuard lock(mutex_);
+    return has_destroyed_;
+  };
   ProcessorState& getProcessorState();
 
   bool doHeaders(ProcessorState& state, Http::RequestOrResponseHeaderMap& headers, bool end_stream);


### PR DESCRIPTION
Otherwise, might lead to segfault.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
