### PR TITLE
[fuzz] Address various issues in the health_check_fuzz_test

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -991,8 +991,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getDownstreamBytesMeter()
-                                        ->wireBytesReceived();
+                                    auto bytes_meter = stream_info.getDownstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->wireBytesReceived() : 0;
                                   });
                             }}},
                           {"DOWNSTREAM_HEADER_BYTES_RECEIVED",
@@ -1000,8 +1000,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getDownstreamBytesMeter()
-                                        ->headerBytesReceived();
+                                    auto bytes_meter = stream_info.getDownstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->headerBytesReceived() : 0;
                                   });
                             }}},
                           {"PROTOCOL",
@@ -1077,7 +1077,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getDownstreamBytesMeter()->wireBytesSent();
+                                    auto bytes_meter = stream_info.getDownstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->wireBytesSent() : 0;
                                   });
                             }}},
                           {"DOWNSTREAM_HEADER_BYTES_SENT",
@@ -1085,7 +1086,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getDownstreamBytesMeter()->headerBytesSent();
+                                    auto bytes_meter = stream_info.getDownstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->headerBytesSent() : 0;
                                   });
                             }}},
                           {"DURATION",

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -511,8 +511,8 @@ void GrpcHealthCheckFuzz::expectClientCreate() {
 void GrpcHealthCheckFuzz::expectStreamCreate() {
   test_session_->request_encoder_.stream_.callbacks_.clear();
   EXPECT_CALL(*test_session_->codec_, newStream(_))
-      .WillOnce(DoAll(SaveArgAddress(&test_session_->stream_response_callbacks_),
-                      ReturnRef(test_session_->request_encoder_)));
+      .WillRepeatedly(DoAll(SaveArgAddress(&test_session_->stream_response_callbacks_),
+                            ReturnRef(test_session_->request_encoder_)));
 }
 
 Network::ConnectionEvent

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -301,7 +301,12 @@ void TcpHealthCheckFuzz::raiseEvent(const Network::ConnectionEvent& event_type, 
   // set by multiple code paths. handleFailure() turns on interval and turns off timeout. However,
   // other action of the fuzzer account for this by explicitly invoking a client after
   // expect_close_ gets set to true, turning expect_close_ back to false.
-  connection_->raiseEvent(event_type);
+  if (event_type == Network::ConnectionEvent::Connected &&
+      connection_->state() != Network::Connection::State::Open) {
+    ENVOY_LOG_MISC(trace, "Event CONNECTED on closed connection; ignoring");
+  } else {
+    connection_->raiseEvent(event_type);
+  }
   if (!last_action && event_type != Network::ConnectionEvent::Connected) {
     if (!interval_timer_->enabled_) {
       return;

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -172,6 +172,10 @@ void HttpHealthCheckFuzz::triggerIntervalTimer(bool expect_client_create) {
   }
   if (expect_client_create) {
     expectClientCreate(0);
+  } else if (test_sessions_[0]->client_connection_->state() != Network::Connection::State::Open) {
+    // No client connection to reuse.
+    ENVOY_LOG_MISC(trace, "Interval timer on closed connection; ignored.");
+    return;
   }
   expectStreamCreate(0);
   ENVOY_LOG_MISC(trace, "Triggered interval timer");
@@ -269,6 +273,10 @@ void TcpHealthCheckFuzz::triggerIntervalTimer(bool expect_client_create) {
   if (expect_client_create) {
     ENVOY_LOG_MISC(trace, "Creating client");
     expectClientCreate();
+  } else if (connection_->state() != Network::Connection::State::Open) {
+    // Without a client no interval timer possible.
+    ENVOY_LOG_MISC(trace, "Interval timer on closed connection; ignored.");
+    return;
   }
   ENVOY_LOG_MISC(trace, "Triggered interval timer");
   interval_timer_->invokeCallback();
@@ -447,6 +455,10 @@ void GrpcHealthCheckFuzz::triggerIntervalTimer(bool expect_client_create) {
   if (expect_client_create) {
     expectClientCreate();
     ENVOY_LOG_MISC(trace, "Created client");
+  } else if (test_session_->client_connection_->state() != Network::Connection::State::Open) {
+    // No client connection to reuse.
+    ENVOY_LOG_MISC(trace, "Interval timer on closed connection; ignored.");
+    return;
   }
   expectStreamCreate();
   ENVOY_LOG_MISC(trace, "Created stream");


### PR DESCRIPTION
Commit Message: [fuzz] Address various issues in the health_check_fuzz_test
Additional Description:
Fix some issues in the health_check_fuzz_test where:
* EXPECT_CALL had willOnce but was called multiple times
* Interval timer trigger was applied to a closed connection
* an action event CONNECTED was applied multiple time consecutively
* header substitution for DOWNSTREAM_* was applied with no downstream connection

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
