### PR TITLE
proto_format: Use char (not text) len when encoding diff

### DIFF
--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -35,11 +35,14 @@ class Git(object):
             nread += len(data)
             hasher.update(data)
         if nread != size:
+            # TODO(phlax): move this to pytooling asap.
+            #     This would not pass type checking `BytesIO` has no `stream.name`
             raise ValueError('%s: expected %u bytes, found %u bytes' % (stream.name, size, nread))
         return hasher.hexdigest()[:10]
 
     def string_hash(self, text):
-        return self.blob_hash(io.BytesIO(text.encode("utf-8")), len(text))
+        chars = text.encode("utf-8")
+        return self.blob_hash(io.BytesIO(chars), len(chars))
 
     def diff(self, t1, t2, path, mode, remove=False):
         fhash = self.string_hash(t1)


### PR DESCRIPTION
Fix #27147 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
