### PR TITLE
minor fix: eliminate the gmock warning of ssl sock test

### DIFF
--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -5924,7 +5924,7 @@ protected:
     EXPECT_CALL(*client_write_buffer, move(_))
         .WillRepeatedly(DoAll(AddBufferToStringWithoutDraining(&data_written),
                               Invoke(client_write_buffer, &MockWatermarkBuffer::baseMove)));
-    EXPECT_CALL(*client_write_buffer, drain(_)).Times(2).WillOnce(Invoke([&](uint64_t n) -> void {
+    EXPECT_CALL(*client_write_buffer, drain(_)).Times(2).WillRepeatedly(Invoke([&](uint64_t n) -> void {
       client_write_buffer->baseDrain(n);
       dispatcher_->exit();
     }));

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -5924,10 +5924,12 @@ protected:
     EXPECT_CALL(*client_write_buffer, move(_))
         .WillRepeatedly(DoAll(AddBufferToStringWithoutDraining(&data_written),
                               Invoke(client_write_buffer, &MockWatermarkBuffer::baseMove)));
-    EXPECT_CALL(*client_write_buffer, drain(_)).Times(2).WillRepeatedly(Invoke([&](uint64_t n) -> void {
-      client_write_buffer->baseDrain(n);
-      dispatcher_->exit();
-    }));
+    EXPECT_CALL(*client_write_buffer, drain(_))
+        .Times(2)
+        .WillRepeatedly(Invoke([&](uint64_t n) -> void {
+          client_write_buffer->baseDrain(n);
+          dispatcher_->exit();
+        }));
     client_connection_->write(buffer_to_write, false);
     dispatcher_->run(Event::Dispatcher::RunType::Block);
     EXPECT_EQ(data_to_write, data_written);


### PR DESCRIPTION


Commit Message: minor fix: eliminate the gmock warning of ssl sock test
Additional Description:

```
2023-05-05T02:43:10.9572063Z [ RUN      ] IpVersions/SslReadBufferLimitTest.WritesLargerThanBufferLimit/IPv4_with_custom_cert_validation
2023-05-05T02:43:10.9572308Z 
2023-05-05T02:43:10.9572560Z GMOCK WARNING:
2023-05-05T02:43:10.9572930Z test/extensions/transport_sockets/tls/ssl_socket_test.cc:5925: Too few actions specified in EXPECT_CALL(*client_write_buffer, drain(_))...
2023-05-05T02:43:10.9573326Z Expected to be called twice, but has only 1 WillOnce().
2023-05-05T02:43:10.9573619Z GMOCK WARNING:
2023-05-05T02:43:10.9573956Z test/extensions/transport_sockets/tls/ssl_socket_test.cc:5925: Actions ran out in EXPECT_CALL(*client_write_buffer, drain(_))...
2023-05-05T02:43:10.9574481Z Called 2 times, but only 1 WillOnce() is specified - returning directly.
2023-05-05T02:43:10.9574810Z Stack trace:
2023-05-05T02:43:10.9575136Z   0x4dccb68: testing::internal::TypedExpectation<>::GetActionForArguments()
2023-05-05T02:43:10.9575529Z   0x4dcaaac: testing::internal::FunctionMocker<>::UntypedFindMatchingExpectation()
2023-05-05T02:43:10.9575936Z   0xaa5649a: testing::internal::UntypedFunctionMockerBase::UntypedInvokeWith()
2023-05-05T02:43:10.9576320Z   0x385b532: testing::internal::FunctionMocker<>::Invoke()
2023-05-05T02:43:10.9576647Z   0x38c9d80: Envoy::MockBufferBase<>::drain()
2023-05-05T02:43:10.9576987Z   0x7900baf: Envoy::Network::ConnectionImpl::closeSocket()
2023-05-05T02:43:10.9577335Z   0x78fd3f8: Envoy::Network::ConnectionImpl::close()
2023-05-05T02:43:10.9577859Z   0x78ff853: Envoy::Network::ConnectionImpl::close()
2023-05-05T02:43:10.9578238Z   0x375ce35: Envoy::Extensions::TransportSockets::Tls::SslReadBufferLimitTest::disconnect()
2023-05-05T02:43:10.9578653Z   0x3758296: Envoy::Extensions::TransportSockets::Tls::SslReadBufferLimitTest::singleWriteTest()
2023-05-05T02:43:10.9579101Z   0x36b0faa: Envoy::Extensions::TransportSockets::Tls::SslReadBufferLimitTest_WritesLargerThanBufferLimit_Test::TestBody()
2023-05-05T02:43:10.9579882Z   0xaae6095: testing::internal::HandleExceptionsInMethodIfSupported<>()
2023-05-05T02:43:10.9580246Z   0xaaad933: testing::Test::Run()
2023-05-05T02:43:10.9580559Z   0xaaaf498: testing::TestInfo::Run()
2023-05-05T02:43:10.9580866Z ... Google Test internal frames ...
2023-05-05T02:43:10.9581248Z [external/com_google_absl/absl/flags/internal/flag.cc : 115] RAW: Restore saved value of envoy_reloadable_features_tls_async_cert_validation to: true
2023-05-05T02:43:10.9582035Z [       OK ] IpVersions/SslReadBufferLimitTest.WritesLargerThanBufferLimit/IPv4_with_custom_cert_validation (392 ms)

```
Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.