### PR TITLE
stats: allow combining configured tags with custom tags

### DIFF
--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -26,6 +26,7 @@ namespace Stats {
 
 class Sink;
 class SinkPredicates;
+class StatNamePool;
 
 /**
  * Store keeps track of all Scopes created in it, and the Scopes manage
@@ -172,6 +173,13 @@ public:
    * @return a scope of the given name.
    */
   ScopeSharedPtr createScope(const std::string& name) { return rootScope()->createScope(name); }
+
+  /**
+   * Extracts tags from the name and appends them to the provided StatNameTagVector.
+   *     The StatName for the extracted tags will be saved in the provided pool.
+   */
+  virtual void extractAndAppendTags(StatName& name, StatNamePool& pool,
+                                    StatNameTagVector& stat_tags) PURE;
 };
 
 using StorePtr = std::unique_ptr<Store>;

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -177,8 +177,21 @@ public:
   /**
    * Extracts tags from the name and appends them to the provided StatNameTagVector.
    *     The StatName for the extracted tags will be saved in the provided pool.
+   * @param name The stat name.
+   * @param pool The pool to create the tags in.
+   * @param stat_tags The stat name tags vector to append the tags to.
    */
-  virtual void extractAndAppendTags(StatName& name, StatNamePool& pool,
+  virtual void extractAndAppendTags(StatName name, StatNamePool& pool,
+                                    StatNameTagVector& stat_tags) PURE;
+
+  /**
+   * Extracts tags from the name and appends them to the provided StatNameTagVector.
+   *     The StatName for the extracted tags will be saved in the provided pool.
+   * @param name The stat name.
+   * @param pool The pool to create the tags in.
+   * @param stat_tags The stat name tags vector to append the tags to.
+   */
+  virtual void extractAndAppendTags(absl::string_view name, StatNamePool& pool,
                                     StatNameTagVector& stat_tags) PURE;
 };
 

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -235,11 +235,11 @@ public:
   }
 
   void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to function not in use");
+    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
   }
 
   void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to function not in use");
+    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
   }
 
 protected:

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -234,6 +234,8 @@ public:
     return constRootScope()->iterate(fn);
   }
 
+  void extractAndAppendTags(StatName&, StatNamePool&, StatNameTagVector&) override {}
+
 protected:
   /**
    * Provides a hook for sub-classes to define how to create new scopes. When

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -234,7 +234,13 @@ public:
     return constRootScope()->iterate(fn);
   }
 
-  void extractAndAppendTags(StatName&, StatNamePool&, StatNameTagVector&) override {}
+  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {
+    IS_ENVOY_BUG("Unexpected call to function not in use");
+  }
+
+  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {
+    IS_ENVOY_BUG("Unexpected call to function not in use");
+  }
 
 protected:
   /**

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -1075,10 +1075,15 @@ void ThreadLocalStoreImpl::setSinkPredicates(std::unique_ptr<SinkPredicates>&& s
   }
 }
 
-void ThreadLocalStoreImpl::extractAndAppendTags(StatName& name, StatNamePool& pool,
+void ThreadLocalStoreImpl::extractAndAppendTags(StatName name, StatNamePool& pool,
+                                                StatNameTagVector& stat_tags) {
+  extractAndAppendTags(symbolTable().toString(name), pool, stat_tags);
+}
+
+void ThreadLocalStoreImpl::extractAndAppendTags(absl::string_view name, StatNamePool& pool,
                                                 StatNameTagVector& stat_tags) {
   TagVector tags;
-  tagProducer().produceTags(symbolTable().toString(name), tags);
+  tagProducer().produceTags(name, tags);
   for (const auto& tag : tags) {
     stat_tags.emplace_back(pool.add(tag.name_), pool.add(tag.value_));
   }

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -1075,5 +1075,14 @@ void ThreadLocalStoreImpl::setSinkPredicates(std::unique_ptr<SinkPredicates>&& s
   }
 }
 
+void ThreadLocalStoreImpl::extractAndAppendTags(StatName& name, StatNamePool& pool,
+                                                StatNameTagVector& stat_tags) {
+  TagVector tags;
+  tagProducer().produceTags(symbolTable().toString(name), tags);
+  for (const auto& tag : tags) {
+    stat_tags.emplace_back(pool.add(tag.name_), pool.add(tag.value_));
+  }
+}
+
 } // namespace Stats
 } // namespace Envoy

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -211,7 +211,9 @@ public:
   void releaseHistogramCrossThread(uint64_t histogram_id);
 
   const TagProducer& tagProducer() const { return *tag_producer_; }
-  void extractAndAppendTags(StatName& name, StatNamePool& pool, StatNameTagVector& tags) override;
+  void extractAndAppendTags(StatName name, StatNamePool& pool, StatNameTagVector& tags) override;
+  void extractAndAppendTags(absl::string_view name, StatNamePool& pool,
+                            StatNameTagVector& tags) override;
 
 private:
   friend class ThreadLocalStoreTestingPeer;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -211,6 +211,8 @@ public:
   void releaseHistogramCrossThread(uint64_t histogram_id);
 
   const TagProducer& tagProducer() const { return *tag_producer_; }
+  void extractAndAppendTags(StatName& name, StatNamePool& pool,
+                            StatNameTagVector& tags) override;
 
 private:
   friend class ThreadLocalStoreTestingPeer;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -211,8 +211,7 @@ public:
   void releaseHistogramCrossThread(uint64_t histogram_id);
 
   const TagProducer& tagProducer() const { return *tag_producer_; }
-  void extractAndAppendTags(StatName& name, StatNamePool& pool,
-                            StatNameTagVector& tags) override;
+  void extractAndAppendTags(StatName& name, StatNamePool& pool, StatNameTagVector& tags) override;
 
 private:
   friend class ThreadLocalStoreTestingPeer;

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -848,6 +848,27 @@ TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexValueWithMatch) {
   EXPECT_EQ("bar", symbol_table_.toString(tags[1].second));
 }
 
+TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexBuiltinExpression) {
+  store_->initializeThreading(main_thread_dispatcher_, tls_);
+
+  envoy::config::metrics::v3::StatsConfig stats_config;
+  store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
+
+  StatNamePool pool(symbol_table_);
+  StatName name = pool.add("cluster.foo.bar");
+  StatName tag_key = pool.add("a");
+  StatName tag_val = pool.add("b");
+
+  StatNameTagVector tags{{tag_key, tag_val}};
+  store_->extractAndAppendTags(name, pool, tags);
+
+  EXPECT_EQ(2, tags.size());
+  EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
+  EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
+  EXPECT_EQ("envoy.cluster_name", symbol_table_.toString(tags[1].first));
+  EXPECT_EQ("foo", symbol_table_.toString(tags[1].second));
+}
+
 class LookupWithStatNameTest : public ThreadLocalStoreNoMocksMixin, public testing::Test {};
 
 TEST_F(LookupWithStatNameTest, All) {

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -786,14 +786,10 @@ TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsFixedValue) {
   store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
 
   StatNamePool pool(symbol_table_);
-  StatName name = pool.add("c1");
-  StatName tag_key = pool.add("a");
-  StatName tag_val = pool.add("b");
+  StatNameTagVector tags{{pool.add("a"), pool.add("b")}};
+  store_->extractAndAppendTags(pool.add("c1"), pool, tags);
 
-  StatNameTagVector tags{{tag_key, tag_val}};
-  store_->extractAndAppendTags(name, pool, tags);
-
-  EXPECT_EQ(2, tags.size());
+  ASSERT_EQ(2, tags.size());
   EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
   EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
   EXPECT_EQ("foo", symbol_table_.toString(tags[1].first));
@@ -811,14 +807,10 @@ TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexValueNoMatch) {
   store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
 
   StatNamePool pool(symbol_table_);
-  StatName name = pool.add("c1");
-  StatName tag_key = pool.add("a");
-  StatName tag_val = pool.add("b");
+  StatNameTagVector tags{{pool.add("a"), pool.add("b")}};
+  store_->extractAndAppendTags(pool.add("c1"), pool, tags);
 
-  StatNameTagVector tags{{tag_key, tag_val}};
-  store_->extractAndAppendTags(name, pool, tags);
-
-  EXPECT_EQ(1, tags.size());
+  ASSERT_EQ(1, tags.size());
   EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
   EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
 }
@@ -834,14 +826,10 @@ TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexValueWithMatch) {
   store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
 
   StatNamePool pool(symbol_table_);
-  StatName name = pool.add("foo.bar");
-  StatName tag_key = pool.add("a");
-  StatName tag_val = pool.add("b");
+  StatNameTagVector tags{{pool.add("a"), pool.add("b")}};
+  store_->extractAndAppendTags(pool.add("foo.bar"), pool, tags);
 
-  StatNameTagVector tags{{tag_key, tag_val}};
-  store_->extractAndAppendTags(name, pool, tags);
-
-  EXPECT_EQ(2, tags.size());
+  ASSERT_EQ(2, tags.size());
   EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
   EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
   EXPECT_EQ("foo_tag", symbol_table_.toString(tags[1].first));
@@ -855,14 +843,10 @@ TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexBuiltinExpression) {
   store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
 
   StatNamePool pool(symbol_table_);
-  StatName name = pool.add("cluster.foo.bar");
-  StatName tag_key = pool.add("a");
-  StatName tag_val = pool.add("b");
+  StatNameTagVector tags{{pool.add("a"), pool.add("b")}};
+  store_->extractAndAppendTags(pool.add("cluster.foo.bar"), pool, tags);
 
-  StatNameTagVector tags{{tag_key, tag_val}};
-  store_->extractAndAppendTags(name, pool, tags);
-
-  EXPECT_EQ(2, tags.size());
+  ASSERT_EQ(2, tags.size());
   EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
   EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
   EXPECT_EQ("envoy.cluster_name", symbol_table_.toString(tags[1].first));

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -775,6 +775,79 @@ TEST_F(StatsThreadLocalStoreTest, SharedScopes) {
   tls_.shutdownThread();
 }
 
+TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsFixedValue) {
+  store_->initializeThreading(main_thread_dispatcher_, tls_);
+
+  envoy::config::metrics::v3::StatsConfig stats_config;
+  auto* tag_specifier = stats_config.add_stats_tags();
+  tag_specifier->set_tag_name("foo");
+  tag_specifier->set_fixed_value("bar");
+
+  store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
+
+  StatNamePool pool(symbol_table_);
+  StatName name = pool.add("c1");
+  StatName tag_key = pool.add("a");
+  StatName tag_val = pool.add("b");
+
+  StatNameTagVector tags{{tag_key, tag_val}};
+  store_->extractAndAppendTags(name, pool, tags);
+
+  EXPECT_EQ(2, tags.size());
+  EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
+  EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
+  EXPECT_EQ("foo", symbol_table_.toString(tags[1].first));
+  EXPECT_EQ("bar", symbol_table_.toString(tags[1].second));
+}
+
+TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexValueNoMatch) {
+  store_->initializeThreading(main_thread_dispatcher_, tls_);
+
+  envoy::config::metrics::v3::StatsConfig stats_config;
+  auto* tag_specifier = stats_config.add_stats_tags();
+  tag_specifier->set_tag_name("foo");
+  tag_specifier->set_regex("bar");
+
+  store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
+
+  StatNamePool pool(symbol_table_);
+  StatName name = pool.add("c1");
+  StatName tag_key = pool.add("a");
+  StatName tag_val = pool.add("b");
+
+  StatNameTagVector tags{{tag_key, tag_val}};
+  store_->extractAndAppendTags(name, pool, tags);
+
+  EXPECT_EQ(1, tags.size());
+  EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
+  EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
+}
+
+TEST_F(StatsThreadLocalStoreTest, ExtractAndAppendTagsRegexValueWithMatch) {
+  store_->initializeThreading(main_thread_dispatcher_, tls_);
+
+  envoy::config::metrics::v3::StatsConfig stats_config;
+  auto* tag_specifier = stats_config.add_stats_tags();
+  tag_specifier->set_tag_name("foo_tag");
+  tag_specifier->set_regex("^foo.(.+)");
+
+  store_->setTagProducer(std::make_unique<TagProducerImpl>(stats_config));
+
+  StatNamePool pool(symbol_table_);
+  StatName name = pool.add("foo.bar");
+  StatName tag_key = pool.add("a");
+  StatName tag_val = pool.add("b");
+
+  StatNameTagVector tags{{tag_key, tag_val}};
+  store_->extractAndAppendTags(name, pool, tags);
+
+  EXPECT_EQ(2, tags.size());
+  EXPECT_EQ("a", symbol_table_.toString(tags[0].first));
+  EXPECT_EQ("b", symbol_table_.toString(tags[0].second));
+  EXPECT_EQ("foo_tag", symbol_table_.toString(tags[1].first));
+  EXPECT_EQ("bar", symbol_table_.toString(tags[1].second));
+}
+
 class LookupWithStatNameTest : public ThreadLocalStoreNoMocksMixin, public testing::Test {};
 
 TEST_F(LookupWithStatNameTest, All) {

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -357,7 +357,7 @@ public:
   bool iterate(const IterateFn<Histogram>& fn) const override { return store_.iterate(fn); }
   bool iterate(const IterateFn<TextReadout>& fn) const override { return store_.iterate(fn); }
 
-  void extractAndAppendTags(StatName&, StatNamePool&, StatNameTagVector&) override {};
+  void extractAndAppendTags(StatName&, StatNamePool&, StatNameTagVector&) override{};
 
   // Stats::StoreRoot
   void addSink(Sink&) override {}

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -357,6 +357,8 @@ public:
   bool iterate(const IterateFn<Histogram>& fn) const override { return store_.iterate(fn); }
   bool iterate(const IterateFn<TextReadout>& fn) const override { return store_.iterate(fn); }
 
+  void extractAndAppendTags(StatName&, StatNamePool&, StatNameTagVector&) override {};
+
   // Stats::StoreRoot
   void addSink(Sink&) override {}
   void setTagProducer(TagProducerPtr&&) override {}

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -357,7 +357,13 @@ public:
   bool iterate(const IterateFn<Histogram>& fn) const override { return store_.iterate(fn); }
   bool iterate(const IterateFn<TextReadout>& fn) const override { return store_.iterate(fn); }
 
-  void extractAndAppendTags(StatName&, StatNamePool&, StatNameTagVector&) override{};
+  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {
+    IS_ENVOY_BUG("Unexpected call to function not in use");
+  };
+
+  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {
+    IS_ENVOY_BUG("Unexpected call to function not in use");
+  };
 
   // Stats::StoreRoot
   void addSink(Sink&) override {}

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -358,11 +358,11 @@ public:
   bool iterate(const IterateFn<TextReadout>& fn) const override { return store_.iterate(fn); }
 
   void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to function not in use");
+    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
   };
 
   void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to function not in use");
+    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
   };
 
   // Stats::StoreRoot


### PR DESCRIPTION
Commit Message: stats: allow combining configured tags with custom tags
Additional Description: Adds a way to create a StatNameTagVector that contains extracted tags names from both the configured and well defined tags, and custom provided tags. Resolves #27030.
Risk Level: Low
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None