### PR TITLE
Update substitution_formatter.cc, fix issue 27201

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1888,10 +1888,6 @@ ProtobufWkt::Value GrpcStatusFormatter::formatValue(
   }else{
     return absl::nullopt;
   }
-
-  if (!grpc_status.has_value()) {
-    return unspecifiedValue();
-  }
   
   if (!grpc_status.has_value()) {
     return unspecifiedValue();


### PR DESCRIPTION
For non-grpc request, should not return error grpc_status
Try to fix issue: https://github.com/envoyproxy/envoy/issues/27201

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
