### PR TITLE
Deflake TcpProxyManyConnections test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1570,6 +1570,9 @@ envoy_cc_test(
         "tcp_proxy_many_connections_test.cc",
     ],
     shard_count = 1,
+    tags = [
+        "cpu:4",
+    ],
     deps = [
         ":integration_lib",
         "//source/common/config:api_version_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1564,6 +1564,33 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "tcp_proxy_many_connections_test",
+    size = "large",
+    srcs = [
+        "tcp_proxy_many_connections_test.cc",
+    ],
+    shard_count = 1,
+    deps = [
+        ":integration_lib",
+        "//source/common/config:api_version_lib",
+        "//source/common/event:dispatcher_includes",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:utility_lib",
+        "//source/extensions/access_loggers/file:config",
+        "//source/extensions/filters/network/common:factory_base_lib",
+        "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/load_balancing_policies/subset:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//source/extensions/transport_sockets/tls:context_config_lib",
+        "//source/extensions/transport_sockets/tls:context_lib",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/secret:secret_mocks",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "tcp_tunneling_integration_test",
     size = "large",
     srcs = [

--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -109,12 +109,17 @@ void IntegrationTcpClient::waitForDisconnect(bool ignore_spurious_events) {
 }
 
 void IntegrationTcpClient::waitForHalfClose(bool ignore_spurious_events) {
+  waitForHalfClose(TestUtility::DefaultTimeout, ignore_spurious_events);
+}
+
+void IntegrationTcpClient::waitForHalfClose(std::chrono::milliseconds timeout,
+                                            bool ignore_spurious_events) {
   if (payload_reader_->readLastByte()) {
     return;
   }
   Event::TimerPtr timeout_timer =
       connection_->dispatcher().createTimer([this]() -> void { connection_->dispatcher().exit(); });
-  timeout_timer->enableTimer(TestUtility::DefaultTimeout);
+  timeout_timer->enableTimer(timeout);
 
   if (ignore_spurious_events) {
     while (!payload_reader_->readLastByte() && timeout_timer->enabled()) {

--- a/test/integration/integration_tcp_client.h
+++ b/test/integration/integration_tcp_client.h
@@ -39,6 +39,7 @@ public:
   waitForData(size_t length, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
   void waitForDisconnect(bool ignore_spurious_events = false);
   void waitForHalfClose(bool ignore_spurious_events = false);
+  void waitForHalfClose(std::chrono::milliseconds timeout, bool ignore_spurious_events = false);
   void readDisable(bool disabled);
   ABSL_MUST_USE_RESULT AssertionResult
   write(const std::string& data, bool end_stream = false, bool verify = true,

--- a/test/integration/tcp_proxy_many_connections_test.cc
+++ b/test/integration/tcp_proxy_many_connections_test.cc
@@ -1,0 +1,75 @@
+#include <memory>
+#include <string>
+
+#include "source/common/network/utility.h"
+
+#include "test/integration/integration.h"
+#include "test/integration/utility.h"
+#include "test/test_common/registry.h"
+
+#include "gtest/gtest.h"
+
+using testing::HasSubstr;
+
+namespace Envoy {
+
+class TcpProxyManyConnectionsTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                    public BaseIntegrationTest {
+public:
+  TcpProxyManyConnectionsTest() : BaseIntegrationTest(GetParam(), ConfigHelper::tcpProxyConfig()) {
+    enableHalfClose(true);
+  }
+
+  void initialize() override {
+    config_helper_.renameListener("tcp_proxy");
+    BaseIntegrationTest::initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, TcpProxyManyConnectionsTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(TcpProxyManyConnectionsTest, TcpProxyManyConnections) {
+  autonomous_upstream_ = true;
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* static_resources = bootstrap.mutable_static_resources();
+    for (int i = 0; i < static_resources->clusters_size(); ++i) {
+      auto* cluster = static_resources->mutable_clusters(i);
+      cluster->mutable_connect_timeout()->set_seconds(20);
+      auto* thresholds = cluster->mutable_circuit_breakers()->add_thresholds();
+      thresholds->mutable_max_connections()->set_value(1027);
+      thresholds->mutable_max_pending_requests()->set_value(1027);
+    }
+  });
+  initialize();
+// The large number of connection is meant to regression test
+// https://github.com/envoyproxy/envoy/issues/19033 but fails on apple CI
+// TODO(alyssawilk) debug.
+#if defined(__APPLE__)
+  const int num_connections = 50;
+#else
+  const int num_connections = 1026;
+#endif
+  std::vector<IntegrationTcpClientPtr> clients(num_connections);
+
+  for (int i = 0; i < num_connections; ++i) {
+    clients[i] = makeTcpConnection(lookupPort("tcp_proxy"));
+    test_server_->waitForGaugeGe("cluster.cluster_0.upstream_cx_active", i,
+                                 TestUtility::DefaultTimeout * 20);
+  }
+  for (int i = 0; i < num_connections; ++i) {
+    IntegrationTcpClientPtr& tcp_client = clients[i];
+    // The autonomous upstream is an HTTP upstream, so send raw HTTP.
+    // This particular request will result in the upstream sending a response,
+    // and flush-closing due to the 'close_after_response' header.
+    ASSERT_TRUE(tcp_client->write(
+        "GET / HTTP/1.1\r\nHost: foo\r\nclose_after_response: yes\r\ncontent-length: 0\r\n\r\n",
+        false));
+    tcp_client->waitForHalfClose(TestUtility::DefaultTimeout * 20);
+    tcp_client->close();
+    EXPECT_THAT(tcp_client->data(), HasSubstr("aaaaaaaaaa"));
+  }
+}
+
+} // namespace Envoy


### PR DESCRIPTION
Additional Description:
The reason for flakes is that integration tests oversubscribe CPU by a factor of 4 or 5. This causes timing issues, especially for CPU heavy builds (i.e. sanitizers), or builds that do not run on RBE/EngFlow (coverage, arm).

TcpProxyManyConnections fails in two places when starved for CPU. Creating autonomous upstreams (which is less likely) and then exchanging data over the connections (more likely). Stretching timeouts decreases probability of failure significantly, but does not eliminate it.

Splitting it from the TcpProxyIntegrationTest suite deflakes the tests in the TcpProxyIntegrationTest suite completely in my tests.

If the TcpProxyManyConnections continues to fail, the next step is to eliminate the data exchange step, as the only condition it tests is ability to establish more than 1024 connections, it does not actually need to send any data at all.

Also reserved 4 cores for running the TcpProxyManyConnections test. We may consider reserving more cores for all integration tests to avoid oversubscribing CPU too much.

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
