### PR TITLE
Add a SystemHelper abstraction for Envoy Mobile

### DIFF
--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -7,14 +7,20 @@ envoy_package()
 envoy_cc_library(
     name = "system_helper_lib",
     srcs = [
-        "default_system_helper.cc",
         "system_helper.cc",
-    ],
+    ] + select({
+        "@envoy//bazel:android": ["default_system_helper_android.cc"],
+        "//conditions:default": ["default_system_helper.cc"],
+    }),
     hdrs = [
         "default_system_helper.h",
         "system_helper.h",
     ],
     repository = "@envoy",
+    deps = select({
+        "@envoy//bazel:android": ["//library/common/jni:android_jni_utility_lib"],
+        "//conditions:default": [],
+    }),
 )
 
 envoy_cc_library(

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -5,6 +5,16 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
+    name = "system_helper_interface_lib",
+    srcs = ["system_helper.cc"],
+    hdrs = ["system_helper.h"],
+    repository = "@envoy",
+    deps = [
+        "//library/common/extensions/cert_validator/platform_bridge:platform_bridge_cert_validator_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "lambda_logger_delegate_lib",
     srcs = ["lambda_logger_delegate.cc"],
     hdrs = ["lambda_logger_delegate.h"],

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -5,13 +5,16 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
-    name = "system_helper_interface_lib",
-    srcs = ["system_helper.cc"],
-    hdrs = ["system_helper.h"],
-    repository = "@envoy",
-    deps = [
-        "//library/common/extensions/cert_validator/platform_bridge:platform_bridge_cert_validator_lib",
+    name = "system_helper_lib",
+    srcs = [
+        "default_system_helper.cc",
+        "system_helper.cc",
     ],
+    hdrs = [
+        "default_system_helper.h",
+        "system_helper.h",
+    ],
+    repository = "@envoy",
 )
 
 envoy_cc_library(

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -2,6 +2,6 @@
 
 namespace Envoy {
 
-bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return false; }
+bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
 } // namespace Envoy

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -2,8 +2,6 @@
 
 namespace Envoy {
 
-bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) {
-  return false;
-}
+bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return false; }
 
-}  // namespace Envoy
+} // namespace Envoy

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -1,0 +1,9 @@
+#include "library/common/common/default_system_helper.h"
+
+namespace Envoy {
+
+bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) {
+  return false;
+}
+
+}  // namespace Envoy

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -9,7 +9,7 @@ namespace Envoy {
  * platform-specific system APIs.
  */
 class DefaultSystemHelper : public SystemHelper {
- public:
+public:
   ~DefaultSystemHelper() override = default;
 
   // SystemHelper:

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "library/common/common/system_helper.h"
+
+namespace Envoy {
+
+/**
+ * Default implementation of SystemHelper which invokes the appropriate
+ * platform-specific system APIs.
+ */
+class DefaultSystemHelper : public SystemHelper {
+ public:
+  ~DefaultSystemHelper() override = default;
+
+  // SystemHelper:
+  bool isCleartextPermitted(absl::string_view hostname) override;
+};
+
+} // namespace Envoy

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -1,5 +1,4 @@
 #include "library/common/common/default_system_helper.h"
-
 #include "library/common/jni/android_jni_utility.h"
 
 namespace Envoy {
@@ -8,4 +7,4 @@ bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
   return is_cleartext_permitted(hostname);
 }
 
-}  // namespace Envoy
+} // namespace Envoy

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -1,0 +1,11 @@
+#include "library/common/common/default_system_helper.h"
+
+#include "library/common/jni/android_jni_utility.h"
+
+namespace Envoy {
+
+bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
+  return is_cleartext_permitted(hostname);
+}
+
+}  // namespace Envoy

--- a/mobile/library/common/common/system_helper.cc
+++ b/mobile/library/common/common/system_helper.cc
@@ -1,30 +1,9 @@
 #include "library/common/common/system_helper.h"
+#include "library/common/common/default_system_helper.h"
 
 namespace Envoy {
 
-namespace {
-class DefaultSystemHelper : public SystemHelper {
-  // SystemHelper:
-  bool isCleartextPermitted(absl::string_view /*hostname*/) override {
-    return false;
-  }
-
-  envoy_cert_validation_result validateCertificateChain(const envoy_data* /*certs*/, uint8_t /*size*/,
-                                                        const char* /*host_name*/) override {
-    envoy_cert_validation_result result;
-    result.result = ENVOY_SUCCESS;
-    result.tls_alert = 0;
-    result.error_details = "";
-    return result;
-  }
-
-  void cleanupAfterCertificateValidation() override {
-  }
-
-};
-
-}  // namespace
-std::unique_ptr<SystemHelper> SystemHelper::instance_ = std::make_unique<DefaultSystemHelper>();;
+std::unique_ptr<SystemHelper> SystemHelper::instance_ = std::make_unique<DefaultSystemHelper>();
 
 SystemHelper& SystemHelper::getInstance() {
   return *instance_;

--- a/mobile/library/common/common/system_helper.cc
+++ b/mobile/library/common/common/system_helper.cc
@@ -1,0 +1,33 @@
+#include "library/common/common/system_helper.h"
+
+namespace Envoy {
+
+namespace {
+class DefaultSystemHelper : public SystemHelper {
+  // SystemHelper:
+  bool isCleartextPermitted(absl::string_view /*hostname*/) override {
+    return false;
+  }
+
+  envoy_cert_validation_result validateCertificateChain(const envoy_data* /*certs*/, uint8_t /*size*/,
+                                                        const char* /*host_name*/) override {
+    envoy_cert_validation_result result;
+    result.result = ENVOY_SUCCESS;
+    result.tls_alert = 0;
+    result.error_details = "";
+    return result;
+  }
+
+  void cleanupAfterCertificateValidation() override {
+  }
+
+};
+
+}  // namespace
+std::unique_ptr<SystemHelper> SystemHelper::instance_ = std::make_unique<DefaultSystemHelper>();;
+
+SystemHelper& SystemHelper::getInstance() {
+  return *instance_;
+}
+
+}  // namespace Envoy

--- a/mobile/library/common/common/system_helper.cc
+++ b/mobile/library/common/common/system_helper.cc
@@ -1,12 +1,11 @@
 #include "library/common/common/system_helper.h"
+
 #include "library/common/common/default_system_helper.h"
 
 namespace Envoy {
 
 std::unique_ptr<SystemHelper> SystemHelper::instance_ = std::make_unique<DefaultSystemHelper>();
 
-SystemHelper& SystemHelper::getInstance() {
-  return *instance_;
-}
+SystemHelper& SystemHelper::getInstance() { return *instance_; }
 
-}  // namespace Envoy
+} // namespace Envoy

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <memory>
+
+#include "absl/strings/string_view.h"
+#include "envoy/common/pure.h"
+#include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
+
+namespace Envoy {
+
+/**
+ * This class is used instead of Envoy::MainCommon to customize logic for the Envoy Mobile setting.
+ * It largely leverages Envoy::StrippedMainBase.
+ */
+class SystemHelper {
+public:
+  /**
+   * @return a reference to the current SystemHelper instance.
+   */
+  static SystemHelper& getInstance();
+
+  virtual ~SystemHelper() = default;
+
+  /**
+   * @return true if the system permits cleartext requests.
+   */
+  virtual bool isCleartextPermitted(absl::string_view hostname) PURE;
+
+  /**
+   * Invokes platform APIs to validate certificates.
+   */
+  virtual envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
+                                                        const char* host_name) PURE;
+  /**
+   * Invokes platform APIs to clean up after validation is complete.
+   */
+  virtual void cleanupAfterCertificateValidation() PURE;
+
+private:
+  static std::unique_ptr<SystemHelper> instance_;
+};
+
+} // namespace Envoy

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -4,21 +4,20 @@
 
 #include "absl/strings/string_view.h"
 #include "envoy/common/pure.h"
-#include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 namespace Envoy {
 
+namespace test {
+class SystemHelperPeer;
+}  // namespace test
+
 /**
- * This class is used instead of Envoy::MainCommon to customize logic for the Envoy Mobile setting.
- * It largely leverages Envoy::StrippedMainBase.
+ * SystemHelper provided a platform-agnostic API for interacting with platform-specific
+ * system APIs. The singleton helper is accessible via the `getInstance()` static
+ * method. Tests may override this singleton via `test::SystemHelperPeer` class.
  */
 class SystemHelper {
 public:
-  /**
-   * @return a reference to the current SystemHelper instance.
-   */
-  static SystemHelper& getInstance();
-
   virtual ~SystemHelper() = default;
 
   /**
@@ -27,16 +26,13 @@ public:
   virtual bool isCleartextPermitted(absl::string_view hostname) PURE;
 
   /**
-   * Invokes platform APIs to validate certificates.
+   * @return a reference to the current SystemHelper instance.
    */
-  virtual envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
-                                                        const char* host_name) PURE;
-  /**
-   * Invokes platform APIs to clean up after validation is complete.
-   */
-  virtual void cleanupAfterCertificateValidation() PURE;
+  static SystemHelper& getInstance();
 
 private:
+  friend class test::SystemHelperPeer;
+
   static std::unique_ptr<SystemHelper> instance_;
 };
 

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -2,14 +2,15 @@
 
 #include <memory>
 
-#include "absl/strings/string_view.h"
 #include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 
 namespace test {
 class SystemHelperPeer;
-}  // namespace test
+} // namespace test
 
 /**
  * SystemHelper provided a platform-agnostic API for interacting with platform-specific

--- a/mobile/library/common/http/BUILD
+++ b/mobile/library/common/http/BUILD
@@ -13,7 +13,7 @@ envoy_cc_library(
     deps = [
         "//library/common/bridge:utility_lib",
         "//library/common/buffer:bridge_fragment_lib",
-        "//library/common/common:system_helper_interface_lib",
+        "//library/common/common:system_helper_lib",
         "//library/common/data:utility_lib",
         "//library/common/event:provisional_dispatcher_lib",
         "//library/common/extensions/filters/http/local_error:local_error_filter_lib",

--- a/mobile/library/common/http/BUILD
+++ b/mobile/library/common/http/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     deps = [
         "//library/common/bridge:utility_lib",
         "//library/common/buffer:bridge_fragment_lib",
+        "//library/common/common:system_helper_interface_lib",
         "//library/common/data:utility_lib",
         "//library/common/event:provisional_dispatcher_lib",
         "//library/common/extensions/filters/http/local_error:local_error_filter_lib",

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -487,8 +487,8 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
     // This is largely a check for the android platform: is_cleartext_permitted
     // is a no-op for other platforms.
     if (internal_headers->getSchemeValue() != "https" &&
-        SystemHelper::getInstance().isCleartextPermitted(internal_headers->getHostValue())) {
-      //        !is_cleartext_permitted(internal_headers->getHostValue())) {
+        !SystemHelper::getInstance().isCleartextPermitted(internal_headers->getHostValue())) {
+      std::cout << "not permitted\n";
       direct_stream->request_decoder_->sendLocalReply(
           Http::Code::BadRequest, "Cleartext is not permitted", nullptr, absl::nullopt, "");
       return;

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -488,7 +488,6 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
     // is a no-op for other platforms.
     if (internal_headers->getSchemeValue() != "https" &&
         !SystemHelper::getInstance().isCleartextPermitted(internal_headers->getHostValue())) {
-      std::cout << "not permitted\n";
       direct_stream->request_decoder_->sendLocalReply(
           Http::Code::BadRequest, "Cleartext is not permitted", nullptr, absl::nullopt, "");
       return;

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -10,6 +10,7 @@
 
 #include "library/common/bridge/utility.h"
 #include "library/common/buffer/bridge_fragment.h"
+#include "library/common/common/system_helper.h"
 #include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/http/headers.h"
@@ -486,7 +487,8 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
     // This is largely a check for the android platform: is_cleartext_permitted
     // is a no-op for other platforms.
     if (internal_headers->getSchemeValue() != "https" &&
-        !is_cleartext_permitted(internal_headers->getHostValue())) {
+        SystemHelper::getInstance().isCleartextPermitted(internal_headers->getHostValue())) {
+      //        !is_cleartext_permitted(internal_headers->getHostValue())) {
       direct_stream->request_decoder_->sendLocalReply(
           Http::Code::BadRequest, "Cleartext is not permitted", nullptr, absl::nullopt, "");
       return;

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":base_client_integration_test_lib",
+        "//test/common/mocks/common:common_mocks",
     ],
 )
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -26,6 +26,7 @@ public:
     // TODO(abeyad): Add paramaterized tests for HTTP1, HTTP2, and HTTP3.
     setUpstreamProtocol(Http::CodecType::HTTP1);
     helper_handle_ = test::SystemHelperPeer::replaceSystemHelper();
+    EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).WillRepeatedly(Return(true));
   }
 
   void TearDown() override { BaseClientIntegrationTest::TearDown(); }

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -2,40 +2,15 @@
 
 #include "test/common/integration/base_client_integration_test.h"
 #include "test/integration/autonomous_upstream.h"
+#include "test/common/mocks/common/mocks.h"
 
 #include "library/common/data/utility.h"
 #include "library/common/main_interface.h"
 #include "library/common/network/proxy_settings.h"
 #include "library/common/types/c_types.h"
 
-#include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
-
-namespace {
-// Helper to create a envoy_cert_validation_result.
-envoy_cert_validation_result make_result(envoy_status_t status, uint8_t tls_alert,
-                                         const char* error_details) {
-  envoy_cert_validation_result result;
-  result.result = status;
-  result.tls_alert = tls_alert;
-  result.error_details = error_details;
-  return result;
-}
-
-static envoy_cert_validation_result verify_cert(const envoy_data* /*certs*/, uint8_t /*num_certs*/,
-                                                const char* /*hostname*/) {
-  return make_result(ENVOY_SUCCESS, 0, "");
-}
-
-void register_test_platform_cert_verifier() {
-  envoy_cert_validator* api =
-      static_cast<envoy_cert_validator*>(safe_malloc(sizeof(envoy_cert_validator)));
-  api->validate_cert = verify_cert;
-  api->validation_cleanup = NULL;
-  register_platform_api("platform_cert_validator", api);
-}
-
-}  // namespace
-
+using testing::_;
+using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -50,10 +25,15 @@ public:
     setUpstreamCount(config_helper_.bootstrap().static_resources().clusters_size());
     // TODO(abeyad): Add paramaterized tests for HTTP1, HTTP2, and HTTP3.
     setUpstreamProtocol(Http::CodecType::HTTP1);
+    helper_handle_ = test::SystemHelperPeer::replaceSystemHelper();
   }
+
   void TearDown() override { BaseClientIntegrationTest::TearDown(); }
 
   void basicTest();
+
+ protected:
+  std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClientIntegrationTest,
@@ -61,14 +41,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ClientIntegrationTest,
                          TestUtility::ipTestParamsToString);
 
 void ClientIntegrationTest::basicTest() {
-  register_test_platform_cert_verifier();
-  builder_.enablePlatformCertificatesValidation(true);
-
-  //upstream_tls_ = true;
-  //  default_request_headers_.setScheme("https");
-
   initialize();
-  //  default_request_headers_.setScheme("https");
 
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
   default_request_headers_.addCopy(AutonomousStream::EXPECT_REQUEST_SIZE_BYTES,
@@ -106,9 +79,53 @@ void ClientIntegrationTest::basicTest() {
 
 TEST_P(ClientIntegrationTest, Basic) { basicTest(); }
 
-TEST_P(ClientIntegrationTest, BasicNon2xx) {
-  register_test_platform_cert_verifier();
+TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
+  EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).WillRepeatedly(Return(false));
 
+  expect_data_streams_ = false;
+  initialize();
+
+  Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
+  default_request_headers_.addCopy(AutonomousStream::EXPECT_REQUEST_SIZE_BYTES,
+                                   std::to_string(request_data.length()));
+
+  stream_prototype_->setOnData([this](envoy_data c_data, bool end_stream) {
+    if (end_stream) {
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "Cleartext is not permitted");
+    }
+    cc_.on_data_calls++;
+    release_envoy_data(c_data);
+  });
+
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
+  stream_->sendData(c_data);
+
+  Platform::RequestTrailersBuilder builder;
+  std::shared_ptr<Platform::RequestTrailers> trailers =
+      std::make_shared<Platform::RequestTrailers>(builder.build());
+  stream_->close(trailers);
+
+  terminal_callback_.waitReady();
+
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  ASSERT_EQ(cc_.status, "400");
+  ASSERT_EQ(cc_.on_data_calls, 1);
+  ASSERT_EQ(cc_.on_complete_calls, 1);
+
+  EXPECT_EQ(0, cc_.final_intel.stream_start_ms);
+  EXPECT_EQ(0, cc_.final_intel.connect_start_ms);
+  EXPECT_EQ(0, cc_.final_intel.connect_end_ms);
+  EXPECT_EQ(0, cc_.final_intel.sending_start_ms);
+  EXPECT_EQ(0, cc_.final_intel.sending_end_ms);
+  EXPECT_EQ(0, cc_.final_intel.response_start_ms);
+  EXPECT_EQ(0, cc_.final_intel.stream_end_ms);
+  EXPECT_EQ(0, cc_.final_intel.dns_start_ms);
+  EXPECT_EQ(0, cc_.final_intel.dns_end_ms);
+}
+
+TEST_P(ClientIntegrationTest, BasicNon2xx) {
   initialize();
 
   // Set response header status to be non-2xx to test that the correct stats get charged.

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -26,7 +26,8 @@ public:
     // TODO(abeyad): Add paramaterized tests for HTTP1, HTTP2, and HTTP3.
     setUpstreamProtocol(Http::CodecType::HTTP1);
     helper_handle_ = test::SystemHelperPeer::replaceSystemHelper();
-    EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).WillRepeatedly(Return(true));
+    EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_))
+        .WillRepeatedly(Return(true));
   }
 
   void TearDown() override { BaseClientIntegrationTest::TearDown(); }
@@ -124,6 +125,7 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
   EXPECT_EQ(0, cc_.final_intel.stream_end_ms);
   EXPECT_EQ(0, cc_.final_intel.dns_start_ms);
   EXPECT_EQ(0, cc_.final_intel.dns_end_ms);
+  release_envoy_data(c_data);
 }
 
 TEST_P(ClientIntegrationTest, BasicNon2xx) {

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -1,8 +1,8 @@
 #include "source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
 #include "test/common/integration/base_client_integration_test.h"
-#include "test/integration/autonomous_upstream.h"
 #include "test/common/mocks/common/mocks.h"
+#include "test/integration/autonomous_upstream.h"
 
 #include "library/common/data/utility.h"
 #include "library/common/main_interface.h"
@@ -32,7 +32,7 @@ public:
 
   void basicTest();
 
- protected:
+protected:
   std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
 };
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -99,15 +99,7 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
     release_envoy_data(c_data);
   });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
-
-  envoy_data c_data = Data::Utility::toBridgeData(request_data);
-  stream_->sendData(c_data);
-
-  Platform::RequestTrailersBuilder builder;
-  std::shared_ptr<Platform::RequestTrailers> trailers =
-      std::make_shared<Platform::RequestTrailers>(builder.build());
-  stream_->close(trailers);
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
 
   terminal_callback_.waitReady();
 
@@ -125,7 +117,6 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
   EXPECT_EQ(0, cc_.final_intel.stream_end_ms);
   EXPECT_EQ(0, cc_.final_intel.dns_start_ms);
   EXPECT_EQ(0, cc_.final_intel.dns_end_ms);
-  release_envoy_data(c_data);
 }
 
 TEST_P(ClientIntegrationTest, BasicNon2xx) {

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -107,16 +107,6 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
   ASSERT_EQ(cc_.status, "400");
   ASSERT_EQ(cc_.on_data_calls, 1);
   ASSERT_EQ(cc_.on_complete_calls, 1);
-
-  EXPECT_EQ(0, cc_.final_intel.stream_start_ms);
-  EXPECT_EQ(0, cc_.final_intel.connect_start_ms);
-  EXPECT_EQ(0, cc_.final_intel.connect_end_ms);
-  EXPECT_EQ(0, cc_.final_intel.sending_start_ms);
-  EXPECT_EQ(0, cc_.final_intel.sending_end_ms);
-  EXPECT_EQ(0, cc_.final_intel.response_start_ms);
-  EXPECT_EQ(0, cc_.final_intel.stream_end_ms);
-  EXPECT_EQ(0, cc_.final_intel.dns_start_ms);
-  EXPECT_EQ(0, cc_.final_intel.dns_end_ms);
 }
 
 TEST_P(ClientIntegrationTest, BasicNon2xx) {

--- a/mobile/test/common/mocks/common/BUILD
+++ b/mobile/test/common/mocks/common/BUILD
@@ -1,0 +1,19 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_mock",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_mock(
+    name = "common_mocks",
+    srcs = ["mocks.cc"],
+    hdrs = ["mocks.h"],
+    repository = "@envoy",
+    deps = [
+        "//library/common/common:system_helper_lib",
+    ],
+)

--- a/mobile/test/common/mocks/common/mocks.cc
+++ b/mobile/test/common/mocks/common/mocks.cc
@@ -1,0 +1,13 @@
+#include "test/common/mocks/common/mocks.h"
+
+namespace Envoy {
+namespace test {
+
+using testing::_;
+
+MockSystemHelper::MockSystemHelper() {
+  ON_CALL(*this, isCleartextPermitted(_)).WillByDefault(testing::Return(true));
+}
+
+} // namespace test
+} // namespace Envoy

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -10,7 +10,7 @@ public:
   MockSystemHelper();
 
   // SystemHelper:
-  MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view /*hostname*/));
+  MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view hostname));
 };
 
 // SystemHelperPeer allows the replacement of the SystemHelper singleton

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -1,13 +1,12 @@
-#include "library/common/common/system_helper.h"
-
 #include "gmock/gmock.h"
+#include "library/common/common/system_helper.h"
 
 namespace Envoy {
 namespace test {
 
 // Mock implementation of SystemHelper.
 class MockSystemHelper : public SystemHelper {
- public:
+public:
   MockSystemHelper();
 
   // SystemHelper:
@@ -17,39 +16,34 @@ class MockSystemHelper : public SystemHelper {
 // SystemHelperPeer allows the replacement of the SystemHelper singleton
 // with a MockSystemHelper.
 class SystemHelperPeer {
- public:
+public:
   class Handle;
 
   // Replaces the SystemHelper singleton with a new MockSystemHelper which is
   // wrapped in a Handle. The MockSystemHelper can be accessed via the
   // Handle's `mock_helper()` accessor.
-  static std::unique_ptr<Handle> replaceSystemHelper() {
-    return std::make_unique<Handle>();
-  }
+  static std::unique_ptr<Handle> replaceSystemHelper() { return std::make_unique<Handle>(); }
 
   // RAII type for replacing the SystemHelper singleton with a the MockSystemHelper.
   // When this object is destroyed, it resets the SystemHelper singleton back
   // to the previous state.
   class Handle {
-   public:
+  public:
     Handle() {
       previous_ = std::make_unique<test::MockSystemHelper>();
       SystemHelper::instance_.swap(previous_);
     }
 
-    ~Handle() {
-      SystemHelper::instance_ = std::move(previous_);
-    }
+    ~Handle() { SystemHelper::instance_ = std::move(previous_); }
 
     test::MockSystemHelper& mock_helper() {
       return *static_cast<test::MockSystemHelper*>(SystemHelper::instance_.get());
     }
 
-   private:
+  private:
     std::unique_ptr<SystemHelper> previous_;
   };
 };
 
-
-}  // namespace test
-}  // namespace Envoy
+} // namespace test
+} // namespace Envoy

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -1,0 +1,55 @@
+#include "library/common/common/system_helper.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace test {
+
+// Mock implementation of SystemHelper.
+class MockSystemHelper : public SystemHelper {
+ public:
+  MockSystemHelper();
+
+  // SystemHelper:
+  MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view /*hostname*/));
+};
+
+// SystemHelperPeer allows the replacement of the SystemHelper singleton
+// with a MockSystemHelper.
+class SystemHelperPeer {
+ public:
+  class Handle;
+
+  // Replaces the SystemHelper singleton with a new MockSystemHelper which is
+  // wrapped in a Handle. The MockSystemHelper can be accessed via the
+  // Handle's `mock_helper()` accessor.
+  static std::unique_ptr<Handle> replaceSystemHelper() {
+    return std::make_unique<Handle>();
+  }
+
+  // RAII type for replacing the SystemHelper singleton with a the MockSystemHelper.
+  // When this object is destroyed, it resets the SystemHelper singleton back
+  // to the previous state.
+  class Handle {
+   public:
+    Handle() {
+      previous_ = std::make_unique<test::MockSystemHelper>();
+      SystemHelper::instance_.swap(previous_);
+    }
+
+    ~Handle() {
+      SystemHelper::instance_ = std::move(previous_);
+    }
+
+    test::MockSystemHelper& mock_helper() {
+      return *static_cast<test::MockSystemHelper*>(SystemHelper::instance_.get());
+    }
+
+   private:
+    std::unique_ptr<SystemHelper> previous_;
+  };
+};
+
+
+}  // namespace test
+}  // namespace Envoy


### PR DESCRIPTION
Add a SystemHelper abstraction for Envoy Mobile which provides
a platform-agnostic API for platform-specific system services in 
a manner that can be swapped out in tests.

Risk Level: Low
Testing: New unit tests
Docs Changes: N/A
Release Notes: N/A
