### PR TITLE
Add cert verification support to the mobile SystemHelper

### DIFF
--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -82,6 +82,7 @@ jobs:
             --define envoy_mobile_listener=enabled \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --define=signal_trace=disabled \
+            --define=system-helper=android \
             //test/java/...
   kotlintestslinux:
     if: github.repository == 'envoyproxy/envoy'

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -645,6 +645,11 @@ config_setting(
 )
 
 config_setting(
+    name = "android_system_helper",
+    values = {"define": "system-helper=android"},
+)
+
+config_setting(
     name = "libfuzzer_coverage",
     define_values = {
         "FUZZING_ENGINE": "libfuzzer",

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -106,7 +106,8 @@ def envoy_cc_library(
         include_prefix = None,
         textual_hdrs = None,
         alwayslink = None,
-        defines = []):
+        defines = [],
+        linkopts = []):
     if tcmalloc_dep:
         deps += tcmalloc_external_deps(repository)
 
@@ -123,6 +124,7 @@ def envoy_cc_library(
         srcs = srcs,
         hdrs = hdrs,
         copts = envoy_copts(repository) + envoy_pch_copts(repository, "//source/common/common:common_pch") + copts,
+        linkopts = linkopts,
         visibility = visibility,
         tags = tags,
         textual_hdrs = textual_hdrs,

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -10,6 +10,7 @@ envoy_cc_library(
         "system_helper.cc",
     ] + select({
         "@envoy//bazel:android": ["default_system_helper_android.cc"],
+        "@envoy//bazel:apple": ["default_system_helper_apple.cc"],
         "//conditions:default": ["default_system_helper.cc"],
     }),
     hdrs = [
@@ -23,6 +24,9 @@ envoy_cc_library(
         "@envoy//bazel:android": [
             "//library/common/jni:android_jni_utility_lib",
             "//library/common/jni:android_network_utility_lib",
+        ],
+        "@envoy//bazel:apple": [
+            "//library/common/network:apple_platform_cert_verifier",
         ],
         "//conditions:default": [],
     }),

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -1,40 +1,55 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+selects.config_setting_group(
+    name = "use_android_system_helper",
+    match_any = ["@envoy//bazel:android_system_helper", "@envoy//bazel:android"],
+)
+
 envoy_cc_library(
     name = "system_helper_lib",
     srcs = [
         "system_helper.cc",
-    ] + select({
-        "@envoy//bazel:android_system_helper": ["default_system_helper_android.cc"],
-        "@envoy//bazel:android": ["default_system_helper_android.cc"],
-        "@envoy//bazel:apple": ["default_system_helper_apple.cc"],
-        "//conditions:default": ["default_system_helper.cc"],
-    }),
+    ],
     hdrs = [
-        "default_system_helper.h",
         "system_helper.h",
     ],
+    copts = select({
+        ":use_android_system_helper": ["-DUSE_ANDROID_SYSTEM_HELPER"],
+        "//conditions:default": [],
+    }),
     repository = "@envoy",
     deps = [
         "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
+        ":default_system_helper_lib",
     ] + select({
-        "@envoy//bazel:android_system_helper": [
+        ":use_android_system_helper": [
             "//library/common/jni:android_jni_utility_lib",
             "//library/common/jni:android_network_utility_lib",
-        ],
-        "@envoy//bazel:android": [
-            "//library/common/jni:android_jni_utility_lib",
-            "//library/common/jni:android_network_utility_lib",
-        ],
+        ]
+    }) + select({
         "@envoy//bazel:apple": [
             "//library/common/network:apple_platform_cert_verifier",
         ],
         "//conditions:default": [],
     }),
+)
+
+envoy_cc_library(
+    name = "default_system_helper_lib",
+    hdrs = [
+        "default_system_helper.h",
+        "default_system_helper_android.cc",
+        "default_system_helper_apple.cc",
+        "default_system_helper.cc",
+    ],
+    repository = "@envoy",
+    srcs = [],
+    deps = [],
 )
 
 envoy_cc_library(

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -17,7 +17,9 @@ envoy_cc_library(
         "system_helper.h",
     ],
     repository = "@envoy",
-    deps = select({
+    deps = [
+        "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
+    ] + select({
         "@envoy//bazel:android": ["//library/common/jni:android_jni_utility_lib"],
         "//conditions:default": [],
     }),

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
             "//library/common/jni:android_jni_utility_lib",
             "//library/common/jni:android_network_utility_lib",
         ],
+        "//conditions:default": [],
     }) + select({
         "@envoy//bazel:apple": [
             "//library/common/network:apple_platform_cert_verifier",

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -7,7 +7,10 @@ envoy_package()
 
 selects.config_setting_group(
     name = "use_android_system_helper",
-    match_any = ["@envoy//bazel:android_system_helper", "@envoy//bazel:android"],
+    match_any = [
+        "@envoy//bazel:android_system_helper",
+        "@envoy//bazel:android",
+    ],
 )
 
 envoy_cc_library(
@@ -24,13 +27,13 @@ envoy_cc_library(
     }),
     repository = "@envoy",
     deps = [
-        "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
         ":default_system_helper_lib",
+        "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
     ] + select({
         ":use_android_system_helper": [
             "//library/common/jni:android_jni_utility_lib",
             "//library/common/jni:android_network_utility_lib",
-        ]
+        ],
     }) + select({
         "@envoy//bazel:apple": [
             "//library/common/network:apple_platform_cert_verifier",
@@ -41,14 +44,14 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "default_system_helper_lib",
+    srcs = [],
     hdrs = [
+        "default_system_helper.cc",
         "default_system_helper.h",
         "default_system_helper_android.cc",
         "default_system_helper_apple.cc",
-        "default_system_helper.cc",
     ],
     repository = "@envoy",
-    srcs = [],
     deps = [],
 )
 

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -9,6 +9,7 @@ envoy_cc_library(
     srcs = [
         "system_helper.cc",
     ] + select({
+        "@envoy//bazel:android_system_helper": ["default_system_helper_android.cc"],
         "@envoy//bazel:android": ["default_system_helper_android.cc"],
         "@envoy//bazel:apple": ["default_system_helper_apple.cc"],
         "//conditions:default": ["default_system_helper.cc"],
@@ -21,6 +22,10 @@ envoy_cc_library(
     deps = [
         "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
     ] + select({
+        "@envoy//bazel:android_system_helper": [
+            "//library/common/jni:android_jni_utility_lib",
+            "//library/common/jni:android_network_utility_lib",
+        ],
         "@envoy//bazel:android": [
             "//library/common/jni:android_jni_utility_lib",
             "//library/common/jni:android_network_utility_lib",

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -20,7 +20,10 @@ envoy_cc_library(
     deps = [
         "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
     ] + select({
-        "@envoy//bazel:android": ["//library/common/jni:android_jni_utility_lib"],
+        "@envoy//bazel:android": [
+            "//library/common/jni:android_jni_utility_lib",
+            "//library/common/jni:android_network_utility_lib",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -43,6 +43,12 @@ envoy_cc_library(
     }),
 )
 
+# Ideally, Bazel select() would choose the appropriate implementation to use.
+# It would use the Android implementation on Android, or when the config
+# android_system_helper is set. Otherwise, it would use the Apple implementation
+# on Apple platforms, or the default otherwise. However, Bazel select() doesn't
+# have a good way to express this. Instead, system_helper.cc uses "#if defined"
+# and "#include" to select the correct implementation.
 envoy_cc_library(
     name = "default_system_helper_lib",
     srcs = [],

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -4,11 +4,12 @@ namespace Envoy {
 
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* /*certs*/, uint8_t /*size*/,
-                                                      const char* /*host_name*/) {
+envoy_cert_validation_result
+DefaultSystemHelper::validateCertificateChain(const envoy_data* /*certs*/, uint8_t /*size*/,
+                                              const char* /*host_name*/) {
   envoy_cert_validation_result result;
   result.result = ENVOY_FAILURE;
-  result.tls_alert = 80;  // internal error
+  result.tls_alert = 80; // internal error
   result.error_details = "Certifcate verification not implemented ";
   return result;
 }

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -4,4 +4,15 @@ namespace Envoy {
 
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* /*certs*/, uint8_t /*size*/,
+                                                      const char* /*host_name*/) {
+  envoy_cert_validation_result result;
+  result.result = ENVOY_FAILURE;
+  result.tls_alert = 80;  // internal error
+  result.error_details = "Certifcate verification not implemented ";
+  return result;
+}
+
+void DefaultSystemHelper::cleanupAfterCertificateValidation() {}
+
 } // namespace Envoy

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -8,12 +8,9 @@ envoy_cert_validation_result
 DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& /*certs*/,
                                               absl::string_view /*hostname*/) {
   envoy_cert_validation_result result;
-  // result.result = ENVOY_FAILURE;
-  // result.tls_alert = 80; // internal error
-  // result.error_details = "Certifcate verification not implemented ";
-  result.result = ENVOY_SUCCESS;
-  result.tls_alert = 0;
-  result.error_details = "";
+  result.result = ENVOY_FAILURE;
+  result.tls_alert = 80; // internal error
+  result.error_details = "Certifcate verification not implemented ";
   return result;
 }
 

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -5,8 +5,7 @@ namespace Envoy {
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
 envoy_cert_validation_result
-DefaultSystemHelper::validateCertificateChain(const envoy_data* /*certs*/, uint8_t /*size*/,
-                                              const char* /*host_name*/) {
+DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> /*certs*/, absl::string_view /*hostname*/) {
   envoy_cert_validation_result result;
   result.result = ENVOY_FAILURE;
   result.tls_alert = 80; // internal error

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -8,9 +8,12 @@ envoy_cert_validation_result
 DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& /*certs*/,
                                               absl::string_view /*hostname*/) {
   envoy_cert_validation_result result;
-  result.result = ENVOY_FAILURE;
-  result.tls_alert = 80; // internal error
-  result.error_details = "Certifcate verification not implemented ";
+  // result.result = ENVOY_FAILURE;
+  // result.tls_alert = 80; // internal error
+  // result.error_details = "Certifcate verification not implemented ";
+  result.result = ENVOY_SUCCESS;
+  result.tls_alert = 0;
+  result.error_details = "";
   return result;
 }
 

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -5,7 +5,8 @@ namespace Envoy {
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
 envoy_cert_validation_result
-DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> /*certs*/, absl::string_view /*hostname*/) {
+DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> /*certs*/,
+                                              absl::string_view /*hostname*/) {
   envoy_cert_validation_result result;
   result.result = ENVOY_FAILURE;
   result.tls_alert = 80; // internal error

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -10,7 +10,7 @@ DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& /*
   envoy_cert_validation_result result;
   result.result = ENVOY_FAILURE;
   result.tls_alert = 80; // internal error
-  result.error_details = "Certifcate verification not implemented ";
+  result.error_details = "Certificate verification not implemented.";
   return result;
 }
 

--- a/mobile/library/common/common/default_system_helper.cc
+++ b/mobile/library/common/common/default_system_helper.cc
@@ -5,7 +5,7 @@ namespace Envoy {
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
 envoy_cert_validation_result
-DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> /*certs*/,
+DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& /*certs*/,
                                               absl::string_view /*hostname*/) {
   envoy_cert_validation_result result;
   result.result = ENVOY_FAILURE;

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -14,8 +14,7 @@ public:
 
   // SystemHelper:
   bool isCleartextPermitted(absl::string_view hostname) override;
-  envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
-                                                        const char* host_name) override;
+  envoy_cert_validation_result validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) override;
   void cleanupAfterCertificateValidation() override;
 };
 

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -14,6 +14,11 @@ public:
 
   // SystemHelper:
   bool isCleartextPermitted(absl::string_view hostname) override;
+
+  envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
+                                                        const char* host_name) override;
+
+  void cleanupAfterCertificateValidation() override;
 };
 
 } // namespace Envoy

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -14,7 +14,8 @@ public:
 
   // SystemHelper:
   bool isCleartextPermitted(absl::string_view hostname) override;
-  envoy_cert_validation_result validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) override;
+  envoy_cert_validation_result validateCertificateChain(absl::Span<const absl::string_view> certs,
+                                                        absl::string_view hostname) override;
   void cleanupAfterCertificateValidation() override;
 };
 

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -14,10 +14,8 @@ public:
 
   // SystemHelper:
   bool isCleartextPermitted(absl::string_view hostname) override;
-
   envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
                                                         const char* host_name) override;
-
   void cleanupAfterCertificateValidation() override;
 };
 

--- a/mobile/library/common/common/default_system_helper.h
+++ b/mobile/library/common/common/default_system_helper.h
@@ -14,7 +14,7 @@ public:
 
   // SystemHelper:
   bool isCleartextPermitted(absl::string_view hostname) override;
-  envoy_cert_validation_result validateCertificateChain(absl::Span<const absl::string_view> certs,
+  envoy_cert_validation_result validateCertificateChain(const std::vector<std::string>& certs,
                                                         absl::string_view hostname) override;
   void cleanupAfterCertificateValidation() override;
 };

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -8,10 +8,9 @@ bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
   return is_cleartext_permitted(hostname);
 }
 
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs,
-                                                                           uint8_t size,
-                                                                           const char* hostname) {
-  return verify_x509_cert_chain(certs, size, hostname);
+
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) {
+  return verify_x509_cert_chain(certs, hostname);
 }
 
 void DefaultSystemHelper::cleanupAfterCertificateValidation() { jvm_detach_thread(); }

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -1,10 +1,21 @@
 #include "library/common/common/default_system_helper.h"
 #include "library/common/jni/android_jni_utility.h"
+#include "library/common/jni/android_network_utility.h"
 
 namespace Envoy {
 
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
   return is_cleartext_permitted(hostname);
 }
+
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs, uint8_t size,
+                                                      const char* hostname) {
+  return verify_x509_cert_chain(certs, size, hostname);
+}
+
+void DefaultSystemHelper::cleanupAfterCertificateValidation() {
+  jvm_detach_thread();
+}
+
 
 } // namespace Envoy

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -8,14 +8,12 @@ bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
   return is_cleartext_permitted(hostname);
 }
 
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs, uint8_t size,
-                                                      const char* hostname) {
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs,
+                                                                           uint8_t size,
+                                                                           const char* hostname) {
   return verify_x509_cert_chain(certs, size, hostname);
 }
 
-void DefaultSystemHelper::cleanupAfterCertificateValidation() {
-  jvm_detach_thread();
-}
-
+void DefaultSystemHelper::cleanupAfterCertificateValidation() { jvm_detach_thread(); }
 
 } // namespace Envoy

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -8,8 +8,9 @@ bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
   return is_cleartext_permitted(hostname);
 }
 
-
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) {
+envoy_cert_validation_result
+DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs,
+                                              absl::string_view hostname) {
   return verify_x509_cert_chain(certs, hostname);
 }
 

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -9,7 +9,7 @@ bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
 }
 
 envoy_cert_validation_result
-DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs,
+DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& certs,
                                               absl::string_view hostname) {
   return verify_x509_cert_chain(certs, hostname);
 }

--- a/mobile/library/common/common/default_system_helper_apple.cc
+++ b/mobile/library/common/common/default_system_helper_apple.cc
@@ -1,0 +1,18 @@
+#include "library/common/common/default_system_helper.h"
+#include "library/common/network/apple_platform_cert_verifier.h"
+
+namespace Envoy {
+
+bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) {
+  return true;
+}
+
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs, uint8_t size,
+                                                      const char* hostname) {
+  return verify_cert(certs, size, hostname);
+}
+
+void DefaultSystemHelper::cleanupAfterCertificateValidation() {}
+
+
+} // namespace Envoy

--- a/mobile/library/common/common/default_system_helper_apple.cc
+++ b/mobile/library/common/common/default_system_helper_apple.cc
@@ -5,7 +5,9 @@ namespace Envoy {
 
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) {
+envoy_cert_validation_result
+DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs,
+                                              absl::string_view hostname) {
   return verify_cert(certs, hostname);
 }
 

--- a/mobile/library/common/common/default_system_helper_apple.cc
+++ b/mobile/library/common/common/default_system_helper_apple.cc
@@ -6,7 +6,7 @@ namespace Envoy {
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
 envoy_cert_validation_result
-DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs,
+DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& certs,
                                               absl::string_view hostname) {
   return verify_cert(certs, hostname);
 }

--- a/mobile/library/common/common/default_system_helper_apple.cc
+++ b/mobile/library/common/common/default_system_helper_apple.cc
@@ -3,16 +3,14 @@
 
 namespace Envoy {
 
-bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) {
-  return true;
-}
+bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs, uint8_t size,
-                                                      const char* hostname) {
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs,
+                                                                           uint8_t size,
+                                                                           const char* hostname) {
   return verify_cert(certs, size, hostname);
 }
 
 void DefaultSystemHelper::cleanupAfterCertificateValidation() {}
-
 
 } // namespace Envoy

--- a/mobile/library/common/common/default_system_helper_apple.cc
+++ b/mobile/library/common/common/default_system_helper_apple.cc
@@ -5,10 +5,8 @@ namespace Envoy {
 
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view /*hostname*/) { return true; }
 
-envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(const envoy_data* certs,
-                                                                           uint8_t size,
-                                                                           const char* hostname) {
-  return verify_cert(certs, size, hostname);
+envoy_cert_validation_result DefaultSystemHelper::validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) {
+  return verify_cert(certs, hostname);
 }
 
 void DefaultSystemHelper::cleanupAfterCertificateValidation() {}

--- a/mobile/library/common/common/system_helper.cc
+++ b/mobile/library/common/common/system_helper.cc
@@ -2,6 +2,14 @@
 
 #include "library/common/common/default_system_helper.h"
 
+#if defined(USE_ANDROID_SYSTEM_HELPER)
+#include "library/common/common/default_system_helper_android.cc"
+#elif defined(__APPLE__)
+#include "library/common/common/default_system_helper_apple.cc"
+#else
+#include "library/common/common/default_system_helper.cc"
+#endif
+
 namespace Envoy {
 
 std::unique_ptr<SystemHelper> SystemHelper::instance_ = std::make_unique<DefaultSystemHelper>();

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "envoy/common/pure.h"
 
 #include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 namespace Envoy {
@@ -32,7 +32,7 @@ public:
    * Invokes platform APIs to validate certificates.
    */
   virtual envoy_cert_validation_result
-  validateCertificateChain(absl::Span<const absl::string_view> certs,
+  validateCertificateChain(const std::vector<std::string>& certs,
                            absl::string_view hostname) PURE;
   /**
    * Invokes platform APIs to clean up after validation is complete.

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -32,8 +32,7 @@ public:
    * Invokes platform APIs to validate certificates.
    */
   virtual envoy_cert_validation_result
-  validateCertificateChain(const std::vector<std::string>& certs,
-                           absl::string_view hostname) PURE;
+  validateCertificateChain(const std::vector<std::string>& certs, absl::string_view hostname) PURE;
   /**
    * Invokes platform APIs to clean up after validation is complete.
    */

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -32,7 +32,8 @@ public:
    * Invokes platform APIs to validate certificates.
    */
   virtual envoy_cert_validation_result
-  validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) PURE;
+  validateCertificateChain(absl::Span<const absl::string_view> certs,
+                           absl::string_view hostname) PURE;
   /**
    * Invokes platform APIs to clean up after validation is complete.
    */

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -2,9 +2,9 @@
 
 #include <memory>
 
-#include "envoy/common/pure.h"
-
 #include "absl/strings/string_view.h"
+#include "envoy/common/pure.h"
+#include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 namespace Envoy {
 
@@ -25,6 +25,16 @@ public:
    * @return true if the system permits cleartext requests.
    */
   virtual bool isCleartextPermitted(absl::string_view hostname) PURE;
+
+  /**
+   * Invokes platform APIs to validate certificates.
+   */
+  virtual envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
+                                                        const char* host_name) PURE;
+  /**
+   * Invokes platform APIs to clean up after validation is complete.
+   */
+  virtual void cleanupAfterCertificateValidation() PURE;
 
   /**
    * @return a reference to the current SystemHelper instance.

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -33,6 +33,7 @@ public:
    */
   virtual envoy_cert_validation_result
   validateCertificateChain(const std::vector<std::string>& certs, absl::string_view hostname) PURE;
+
   /**
    * Invokes platform APIs to clean up after validation is complete.
    */

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -2,8 +2,9 @@
 
 #include <memory>
 
-#include "absl/strings/string_view.h"
 #include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 namespace Envoy {
@@ -29,8 +30,8 @@ public:
   /**
    * Invokes platform APIs to validate certificates.
    */
-  virtual envoy_cert_validation_result validateCertificateChain(const envoy_data* certs, uint8_t size,
-                                                        const char* host_name) PURE;
+  virtual envoy_cert_validation_result
+  validateCertificateChain(const envoy_data* certs, uint8_t size, const char* host_name) PURE;
   /**
    * Invokes platform APIs to clean up after validation is complete.
    */

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -5,6 +5,7 @@
 #include "envoy/common/pure.h"
 
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 namespace Envoy {
@@ -31,7 +32,7 @@ public:
    * Invokes platform APIs to validate certificates.
    */
   virtual envoy_cert_validation_result
-  validateCertificateChain(const envoy_data* certs, uint8_t size, const char* host_name) PURE;
+  validateCertificateChain(absl::Span<const absl::string_view> certs, absl::string_view hostname) PURE;
   /**
    * Invokes platform APIs to clean up after validation is complete.
    */

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/BUILD
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
     deps = [
         ":c_types_lib",
         ":platform_bridge_cc_proto",
+        "//library/common/common:system_helper_lib",
         "@envoy//source/extensions/transport_sockets/tls/cert_validator:cert_validator_lib",
     ],
 )

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/c_types.h
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/c_types.h
@@ -13,30 +13,3 @@ typedef struct {
   uint8_t tls_alert;
   const char* error_details;
 } envoy_cert_validation_result;
-
-#ifdef __cplusplus
-extern "C" { // function pointers
-#endif
-
-/**
- * Function signature for calling into platform APIs to validate certificates.
- */
-typedef envoy_cert_validation_result (*envoy_validate_cert_f)(const envoy_data* certs, uint8_t size,
-                                                              const char* host_name);
-
-/**
- * Function signature for calling into platform APIs to clean up after validation is complete.
- */
-typedef void (*envoy_validation_cleanup_f)();
-
-#ifdef __cplusplus
-} // function pointers
-#endif
-
-/**
- * A bag of function pointers to be registered in the platform registry.
- */
-typedef struct {
-  envoy_validate_cert_f validate_cert;
-  envoy_validation_cleanup_f validation_cleanup;
-} envoy_cert_validator;

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/config.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/config.cc
@@ -10,11 +10,7 @@ namespace Tls {
 CertValidatorPtr PlatformBridgeCertValidatorFactory::createCertValidator(
     const Envoy::Ssl::CertificateValidationContextConfig* config, SslStats& stats,
     TimeSource& /*time_source*/) {
-  if (platform_validator_ == nullptr) {
-    platform_validator_ =
-        static_cast<envoy_cert_validator*>(Api::External::retrieveApi("platform_cert_validator"));
-  }
-  return std::make_unique<PlatformBridgeCertValidator>(config, stats, platform_validator_);
+  return std::make_unique<PlatformBridgeCertValidator>(config, stats);
 }
 
 REGISTER_FACTORY(PlatformBridgeCertValidatorFactory, CertValidatorFactory);

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/config.h
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/config.h
@@ -24,9 +24,6 @@ public:
         envoy_mobile::extensions::cert_validator::platform_bridge::PlatformBridgeCertValidator>();
   }
   std::string category() const override { return "envoy.tls.cert_validator"; }
-
-private:
-  const envoy_cert_validator* platform_validator_ = nullptr;
 };
 
 DECLARE_FACTORY(PlatformBridgeCertValidatorFactory);

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -4,8 +4,8 @@
 #include <memory>
 #include <type_traits>
 
-#include "library/common/data/utility.h"
 #include "library/common/common/system_helper.h"
+#include "library/common/data/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -84,9 +84,9 @@ ValidationResults PlatformBridgeCertValidator::doVerifyCertChain(
 
   ValidationJob job;
   job.result_callback_ = std::move(callback);
-  job.validation_thread_ = std::thread(&verifyCertChainByPlatform,
-                                       &(job.result_callback_->dispatcher()), std::move(certs),
-                                       std::string(host), std::move(subject_alt_names), this);
+  job.validation_thread_ =
+      std::thread(&verifyCertChainByPlatform, &(job.result_callback_->dispatcher()),
+                  std::move(certs), std::string(host), std::move(subject_alt_names), this);
   std::thread::id thread_id = job.validation_thread_.get_id();
   validation_jobs_[thread_id] = std::move(job);
   return {ValidationResults::ValidationStatus::Pending,
@@ -94,8 +94,7 @@ ValidationResults PlatformBridgeCertValidator::doVerifyCertChain(
 }
 
 void PlatformBridgeCertValidator::verifyCertChainByPlatform(
-    Event::Dispatcher* dispatcher,
-    std::vector<envoy_data> cert_chain, std::string hostname,
+    Event::Dispatcher* dispatcher, std::vector<envoy_data> cert_chain, std::string hostname,
     std::vector<std::string> subject_alt_names, PlatformBridgeCertValidator* parent) {
   ASSERT(!cert_chain.empty());
   ENVOY_LOG(trace, "Start verifyCertChainByPlatform for host {}", hostname);
@@ -103,8 +102,8 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
   envoy_data leaf_cert_der = cert_chain[0];
   bssl::UniquePtr<X509> leaf_cert(d2i_X509(
       nullptr, const_cast<const unsigned char**>(&leaf_cert_der.bytes), leaf_cert_der.length));
-  envoy_cert_validation_result result =
-      SystemHelper::getInstance().validateCertificateChain(cert_chain.data(), cert_chain.size(), hostname.c_str());
+  envoy_cert_validation_result result = SystemHelper::getInstance().validateCertificateChain(
+      cert_chain.data(), cert_chain.size(), hostname.c_str());
   bool success = result.result == ENVOY_SUCCESS;
   if (!success) {
     ENVOY_LOG(debug, result.error_details);
@@ -126,14 +125,16 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
     return;
   }
   postVerifyResultAndCleanUp(success, std::move(hostname), error_details,
-                             SSL_AD_CERTIFICATE_UNKNOWN, ValidationFailureType::SUCCESS,
-                             dispatcher, parent);
+                             SSL_AD_CERTIFICATE_UNKNOWN, ValidationFailureType::SUCCESS, dispatcher,
+                             parent);
 }
 
-void PlatformBridgeCertValidator::postVerifyResultAndCleanUp(
-    bool success, std::string hostname, absl::string_view error_details, uint8_t tls_alert,
-    ValidationFailureType failure_type,
-    Event::Dispatcher* dispatcher, PlatformBridgeCertValidator* parent) {
+void PlatformBridgeCertValidator::postVerifyResultAndCleanUp(bool success, std::string hostname,
+                                                             absl::string_view error_details,
+                                                             uint8_t tls_alert,
+                                                             ValidationFailureType failure_type,
+                                                             Event::Dispatcher* dispatcher,
+                                                             PlatformBridgeCertValidator* parent) {
   ENVOY_LOG(trace,
             "Finished platform cert validation for {}, post result callback to network thread",
             hostname);

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -106,8 +106,8 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
   for (const envoy_data data : cert_chain) {
     certs.push_back(absl::string_view(reinterpret_cast<const char*>(data.bytes), data.length));
   }
-  envoy_cert_validation_result result = SystemHelper::getInstance().validateCertificateChain(
-      certs, hostname);
+  envoy_cert_validation_result result =
+      SystemHelper::getInstance().validateCertificateChain(certs, hostname);
   bool success = result.result == ENVOY_SUCCESS;
   if (!success) {
     ENVOY_LOG(debug, result.error_details);

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -102,8 +102,12 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
   envoy_data leaf_cert_der = cert_chain[0];
   bssl::UniquePtr<X509> leaf_cert(d2i_X509(
       nullptr, const_cast<const unsigned char**>(&leaf_cert_der.bytes), leaf_cert_der.length));
+  std::vector<absl::string_view> certs;
+  for (const envoy_data data : cert_chain) {
+    certs.push_back(absl::string_view(reinterpret_cast<const char*>(data.bytes), data.length));
+  }
   envoy_cert_validation_result result = SystemHelper::getInstance().validateCertificateChain(
-      cert_chain.data(), cert_chain.size(), hostname.c_str());
+      certs, hostname);
   bool success = result.result == ENVOY_SUCCESS;
   if (!success) {
     ENVOY_LOG(debug, result.error_details);

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -100,9 +100,9 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
   ENVOY_LOG(trace, "Start verifyCertChainByPlatform for host {}", hostname);
   // This is running in a stand alone thread other than the engine thread.
   const std::string& leaf_cert_der = cert_chain[0];
-  const unsigned char* leaf_cert_data = reinterpret_cast<const unsigned char*>(leaf_cert_der.data());
-  bssl::UniquePtr<X509> leaf_cert(d2i_X509(
-      nullptr, &leaf_cert_data, leaf_cert_der.length()));
+  const unsigned char* leaf_cert_data =
+      reinterpret_cast<const unsigned char*>(leaf_cert_der.data());
+  bssl::UniquePtr<X509> leaf_cert(d2i_X509(nullptr, &leaf_cert_data, leaf_cert_der.length()));
   envoy_cert_validation_result result =
       SystemHelper::getInstance().validateCertificateChain(cert_chain, hostname);
   bool success = result.result == ENVOY_SUCCESS;

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -74,7 +74,7 @@ private:
   // thread to trigger callback and update verify stats.
   // Must be called on the validation thread.
   static void verifyCertChainByPlatform(Event::Dispatcher* dispatcher,
-                                        std::vector<envoy_data> cert_chain, std::string hostname,
+                                        std::vector<std::string> cert_chain, std::string hostname,
                                         std::vector<std::string> subject_alt_names,
                                         PlatformBridgeCertValidator* parent);
 

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -19,7 +19,7 @@ namespace Tls {
 class PlatformBridgeCertValidator : public CertValidator, Logger::Loggable<Logger::Id::connection> {
 public:
   PlatformBridgeCertValidator(const Envoy::Ssl::CertificateValidationContextConfig* config,
-                              SslStats& stats, const envoy_cert_validator* platform_validator);
+                              SslStats& stats);
 
   ~PlatformBridgeCertValidator() override;
 
@@ -73,8 +73,7 @@ private:
   // Once the validation is done, the result will be posted back to the current
   // thread to trigger callback and update verify stats.
   // Must be called on the validation thread.
-  static void verifyCertChainByPlatform(const envoy_cert_validator* platform_validator,
-                                        Event::Dispatcher* dispatcher,
+  static void verifyCertChainByPlatform(Event::Dispatcher* dispatcher,
                                         std::vector<envoy_data> cert_chain, std::string hostname,
                                         std::vector<std::string> subject_alt_names,
                                         PlatformBridgeCertValidator* parent);
@@ -83,7 +82,6 @@ private:
   static void postVerifyResultAndCleanUp(bool success, std::string hostname,
                                          absl::string_view error_details, uint8_t tls_alert,
                                          ValidationFailureType failure_type,
-                                         const envoy_cert_validator* platform_validator,
                                          Event::Dispatcher* dispatcher,
                                          PlatformBridgeCertValidator* parent);
 
@@ -98,7 +96,6 @@ private:
   };
 
   const bool allow_untrusted_certificate_;
-  const envoy_cert_validator* platform_validator_;
   SslStats& stats_;
   absl::flat_hash_map<std::thread::id, ValidationJob> validation_jobs_;
   std::shared_ptr<size_t> alive_indicator_{new size_t(1)};

--- a/mobile/library/common/jni/android_jni_interface.cc
+++ b/mobile/library/common/jni/android_jni_interface.cc
@@ -13,6 +13,5 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
                                                                    jclass, // class
                                                                    jobject class_loader) {
   set_class_loader(env->NewGlobalRef(class_loader));
-  // At this point, we know Android APIs are available. Register cert chain validation JNI calls.
-  return register_platform_api(cert_validator_name, get_android_cert_validator_api());
+  return ENVOY_SUCCESS;
 }

--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -109,7 +109,7 @@ static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chai
 }
 
 envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uint8_t size,
-                                                           const char* host_name) {
+                                                    const char* host_name) {
   jni_log("[Envoy]", "verify_x509_cert_chain");
 
   envoy_cert_verify_status_t result;

--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -108,7 +108,7 @@ static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chai
   env->DeleteLocalRef(result);
 }
 
-static envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uint8_t size,
+envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uint8_t size,
                                                            const char* host_name) {
   jni_log("[Envoy]", "verify_x509_cert_chain");
 

--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -109,7 +109,7 @@ static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chai
   env->DeleteLocalRef(result);
 }
 
-envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs,
+envoy_cert_validation_result verify_x509_cert_chain(const std::vector<std::string>& certs,
                                                     absl::string_view hostname) {
   jni_log("[Envoy]", "verify_x509_cert_chain");
 

--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -77,7 +77,8 @@ jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::stri
   Envoy::JNI::Exception::checkAndClear("call_jvm_verify_x509_cert_chain:GetStaticMethodID");
   jobjectArray chain_byte_array = ToJavaArrayOfByteArray(env, cert_chain);
   jbyteArray auth_string = ToJavaByteArray(env, auth_type);
-  jbyteArray host_string = ToJavaByteArray(env, reinterpret_cast<const uint8_t *>(hostname.data()), hostname.length());
+  jbyteArray host_string =
+      ToJavaByteArray(env, reinterpret_cast<const uint8_t*>(hostname.data()), hostname.length());
   jobject result =
       env->CallStaticObjectMethod(jcls_AndroidNetworkLibrary, jmid_verifyServerCertificates,
                                   chain_byte_array, auth_string, host_string);
@@ -108,7 +109,8 @@ static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chai
   env->DeleteLocalRef(result);
 }
 
-envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs, absl::string_view hostname) {
+envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs,
+                                                    absl::string_view hostname) {
   jni_log("[Envoy]", "verify_x509_cert_chain");
 
   envoy_cert_verify_status_t result;

--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -152,10 +152,3 @@ envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uin
 }
 
 void jvm_detach_thread() { Envoy::JNI::JavaVirtualMachine::detachCurrentThread(); }
-
-envoy_cert_validator* get_android_cert_validator_api() {
-  envoy_cert_validator* api = (envoy_cert_validator*)safe_malloc(sizeof(envoy_cert_validator));
-  api->validate_cert = verify_x509_cert_chain;
-  api->validation_cleanup = jvm_detach_thread;
-  return api;
-}

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -3,6 +3,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+
 #include "library/common/api/c_types.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 #include "library/common/jni/import/jni_import.h"
@@ -12,9 +15,8 @@
 /* Calls up through JNI to validate given certificates.
  */
 jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::string>& cert_chain,
-                                        std::string auth_type, std::string host);
+                                        std::string auth_type, absl::string_view hostname);
 
-envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uint8_t size,
-                                                    const char* host_name);
+envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs, absl::string_view hostname);
 
 void jvm_detach_thread();

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -5,7 +5,6 @@
 
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-
 #include "library/common/api/c_types.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 #include "library/common/jni/import/jni_import.h"
@@ -17,6 +16,7 @@
 jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::string>& cert_chain,
                                         std::string auth_type, absl::string_view hostname);
 
-envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs, absl::string_view hostname);
+envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs,
+                                                    absl::string_view hostname);
 
 void jvm_detach_thread();

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 #include "library/common/api/c_types.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 #include "library/common/jni/import/jni_import.h"
@@ -16,7 +15,7 @@
 jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::string>& cert_chain,
                                         std::string auth_type, absl::string_view hostname);
 
-envoy_cert_validation_result verify_x509_cert_chain(absl::Span<const absl::string_view> certs,
+envoy_cert_validation_result verify_x509_cert_chain(const std::vector<std::string>& certs,
                                                     absl::string_view hostname);
 
 void jvm_detach_thread();

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -14,6 +14,12 @@
 jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::string>& cert_chain,
                                         std::string auth_type, std::string host);
 
+
+envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uint8_t size,
+                                                    const char* host_name);
+
+void jvm_detach_thread();
+
 /* Returns a group of C functions to do certificates validation using AndroidNetworkLibrary.
  */
 envoy_cert_validator* get_android_cert_validator_api();

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -19,9 +19,3 @@ envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uin
                                                     const char* host_name);
 
 void jvm_detach_thread();
-
-/* Returns a group of C functions to do certificates validation using AndroidNetworkLibrary.
- */
-envoy_cert_validator* get_android_cert_validator_api();
-
-static constexpr const char* cert_validator_name = "platform_cert_validator";

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -14,7 +14,6 @@
 jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::string>& cert_chain,
                                         std::string auth_type, std::string host);
 
-
 envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* certs, uint8_t size,
                                                     const char* host_name);
 

--- a/mobile/library/common/network/BUILD
+++ b/mobile/library/common/network/BUILD
@@ -74,6 +74,10 @@ envoy_cc_library(
         "@envoy//bazel:apple": ["apple_platform_cert_verifier.h"],
         "//conditions:default": [],
     }),
+    linkopts = select({
+        "@envoy//bazel:apple": ["-framework Security"],
+        "//conditions:default": [],
+    }),
     repository = "@envoy",
     deps = select({
         "@envoy//bazel:apple": [

--- a/mobile/library/common/network/BUILD
+++ b/mobile/library/common/network/BUILD
@@ -77,7 +77,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = select({
         "@envoy//bazel:apple": [
-            "//library/common:envoy_main_interface_lib",
             "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
             "@envoy//bazel:boringssl",
         ],

--- a/mobile/library/common/network/apple_platform_cert_verifier.cc
+++ b/mobile/library/common/network/apple_platform_cert_verifier.cc
@@ -7,7 +7,6 @@
 #include <Security/SecTrust.h>
 
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
-#include "library/common/main_interface.h"
 #include "openssl/ssl.h"
 
 // NOLINT(namespace-envoy)
@@ -70,7 +69,7 @@ envoy_cert_validation_result make_result(envoy_status_t status, uint8_t tls_aler
   return result;
 }
 
-static envoy_cert_validation_result verify_cert(const envoy_data* certs, uint8_t num_certs,
+envoy_cert_validation_result verify_cert(const envoy_data* certs, uint8_t num_certs,
                                                 const char* /*hostname*/) {
   CFArrayRef trust_policies = CreateTrustPolicies();
   if (!trust_policies) {
@@ -103,19 +102,3 @@ static envoy_cert_validation_result verify_cert(const envoy_data* certs, uint8_t
   }
   return make_result(ENVOY_SUCCESS, 0, "");
 }
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void register_apple_platform_cert_verifier() {
-  envoy_cert_validator* api =
-      static_cast<envoy_cert_validator*>(safe_malloc(sizeof(envoy_cert_validator)));
-  api->validate_cert = verify_cert;
-  api->validation_cleanup = NULL;
-  register_platform_api("platform_cert_validator", api);
-}
-
-#ifdef __cplusplus
-}
-#endif

--- a/mobile/library/common/network/apple_platform_cert_verifier.cc
+++ b/mobile/library/common/network/apple_platform_cert_verifier.cc
@@ -34,7 +34,7 @@ CFMutableArrayRef CreateTrustPolicies() {
 // Returns a new CFMutableArrayRef containing the specified certificates
 // in the form expected by Security.framework and Keychain Services, or
 // NULL on failure.
-CFMutableArrayRef CreateSecCertificateArray(absl::Span<const absl::string_view> certs) {
+CFMutableArrayRef CreateSecCertificateArray(const std::vector<std::string>& certs) {
   CFMutableArrayRef cert_array =
       CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
 
@@ -70,7 +70,7 @@ envoy_cert_validation_result make_result(envoy_status_t status, uint8_t tls_aler
   return result;
 }
 
-envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs,
+envoy_cert_validation_result verify_cert(const std::vector<std::string>& certs,
                                          absl::string_view /*hostname*/) {
   CFArrayRef trust_policies = CreateTrustPolicies();
   if (!trust_policies) {

--- a/mobile/library/common/network/apple_platform_cert_verifier.cc
+++ b/mobile/library/common/network/apple_platform_cert_verifier.cc
@@ -43,7 +43,8 @@ CFMutableArrayRef CreateSecCertificateArray(absl::Span<const absl::string_view> 
   }
 
   for (absl::string_view cert : certs) {
-    CFDataRef cert_data = CFDataCreate(kCFAllocatorDefault, reinterpret_cast<const uint8_t*>(cert.data()), cert.length());
+    CFDataRef cert_data = CFDataCreate(
+        kCFAllocatorDefault, reinterpret_cast<const uint8_t*>(cert.data()), cert.length());
     if (!cert_data) {
       CFRelease(cert_array);
       return NULL;
@@ -69,7 +70,8 @@ envoy_cert_validation_result make_result(envoy_status_t status, uint8_t tls_aler
   return result;
 }
 
-envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs, absl::string_view /*hostname*/) {
+envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs,
+                                         absl::string_view /*hostname*/) {
   CFArrayRef trust_policies = CreateTrustPolicies();
   if (!trust_policies) {
     return make_result(ENVOY_FAILURE, SSL_AD_CERTIFICATE_UNKNOWN,

--- a/mobile/library/common/network/apple_platform_cert_verifier.cc
+++ b/mobile/library/common/network/apple_platform_cert_verifier.cc
@@ -70,7 +70,7 @@ envoy_cert_validation_result make_result(envoy_status_t status, uint8_t tls_aler
 }
 
 envoy_cert_validation_result verify_cert(const envoy_data* certs, uint8_t num_certs,
-                                                const char* /*hostname*/) {
+                                         const char* /*hostname*/) {
   CFArrayRef trust_policies = CreateTrustPolicies();
   if (!trust_policies) {
     return make_result(ENVOY_FAILURE, SSL_AD_CERTIFICATE_UNKNOWN,

--- a/mobile/library/common/network/apple_platform_cert_verifier.h
+++ b/mobile/library/common/network/apple_platform_cert_verifier.h
@@ -1,16 +1,7 @@
 #pragma once
 
+#include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
+
 // NOLINT(namespace-envoy)
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * Registers the Apple platform cert verifier API.
- */
-void register_apple_platform_cert_verifier();
-
-#ifdef __cplusplus
-}
-#endif
+envoy_cert_validation_result verify_cert(const envoy_data* certs, uint8_t num_certs,
+                                         const char* hostname);

--- a/mobile/library/common/network/apple_platform_cert_verifier.h
+++ b/mobile/library/common/network/apple_platform_cert_verifier.h
@@ -2,8 +2,8 @@
 
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 // NOLINT(namespace-envoy)
-envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs, absl::string_view hostname);
+envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs,
+                                         absl::string_view hostname);

--- a/mobile/library/common/network/apple_platform_cert_verifier.h
+++ b/mobile/library/common/network/apple_platform_cert_verifier.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 // NOLINT(namespace-envoy)
-envoy_cert_validation_result verify_cert(const envoy_data* certs, uint8_t num_certs,
-                                         const char* hostname);
+envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs, absl::string_view hostname);

--- a/mobile/library/common/network/apple_platform_cert_verifier.h
+++ b/mobile/library/common/network/apple_platform_cert_verifier.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <vector>
+
 #include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 
 // NOLINT(namespace-envoy)
-envoy_cert_validation_result verify_cert(absl::Span<const absl::string_view> certs,
+envoy_cert_validation_result verify_cert(const std::vector<std::string>& certs,
                                          absl::string_view hostname);

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -6,7 +6,6 @@
 #include "library/common/api/c_types.h"
 
 #import "library/common/main_interface.h"
-#import "library/common/network/apple_platform_cert_verifier.h"
 #import "library/common/types/c_types.h"
 #import "library/common/extensions/key_value/platform/c_types.h"
 #import "library/cc/engine_builder.h"
@@ -509,10 +508,6 @@ static void ios_track_event(envoy_map map, const void *context) {
 
   for (NSString *name in config.keyValueStores) {
     [self registerKeyValueStore:name keyValueStore:config.keyValueStores[name]];
-  }
-
-  if (config.enablePlatformCertificateValidation) {
-    register_apple_platform_cert_verifier();
   }
 }
 

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
@@ -4,7 +4,6 @@
 #include "library/common/data/utility.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
 #include "library/common/main_interface.h"
-#include "library/common/network/apple_platform_cert_verifier.h"
 #include "library/common/stats/utility.h"
 
 // This file exists in order to expose headers for Envoy's C++ libraries

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/BUILD
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     repository = "@envoy",
     deps = [
         "//library/common/extensions/cert_validator/platform_bridge:config",
+        "//test/common/mocks/common:common_mocks",
         "@envoy//source/extensions/transport_sockets/tls/cert_validator:cert_validator_lib",
         "@envoy//test/extensions/transport_sockets/tls:ssl_test_utils",
         "@envoy//test/extensions/transport_sockets/tls/cert_validator:test_common",

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -55,7 +55,8 @@ public:
 class MockValidator {
 public:
   MOCK_METHOD(void, cleanup, ());
-  MOCK_METHOD(envoy_cert_validation_result, validate, (absl::Span<const absl::string_view> certs, absl::string_view hostname));
+  MOCK_METHOD(envoy_cert_validation_result, validate,
+              (absl::Span<const absl::string_view> certs, absl::string_view hostname));
 };
 
 class PlatformBridgeCertValidatorTest
@@ -100,7 +101,8 @@ protected:
     return GetParam() == CertificateValidationContext::ACCEPT_UNTRUSTED;
   }
 
-  envoy_cert_validation_result validate(absl::Span<const absl::string_view> certs, absl::string_view hostname) {
+  envoy_cert_validation_result validate(absl::Span<const absl::string_view> certs,
+                                        absl::string_view hostname) {
     // Validate must be called on the worker thread, not the main thread.
     EXPECT_NE(main_thread_id_, std::this_thread::get_id());
 

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -56,7 +56,7 @@ class MockValidator {
 public:
   MOCK_METHOD(void, cleanup, ());
   MOCK_METHOD(envoy_cert_validation_result, validate,
-              (absl::Span<const absl::string_view> certs, absl::string_view hostname));
+              (const std::vector<std::string>& certs, absl::string_view hostname));
 };
 
 class PlatformBridgeCertValidatorTest
@@ -101,7 +101,7 @@ protected:
     return GetParam() == CertificateValidationContext::ACCEPT_UNTRUSTED;
   }
 
-  envoy_cert_validation_result validate(absl::Span<const absl::string_view> certs,
+  envoy_cert_validation_result validate(const std::vector<std::string>& certs,
                                         absl::string_view hostname) {
     // Validate must be called on the worker thread, not the main thread.
     EXPECT_NE(main_thread_id_, std::this_thread::get_id());

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -111,8 +111,8 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
 
 TEST_P(ClientIntegrationTest, BasicHttps) {
   EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).Times(0);
-  EXPECT_CALL(helper_handle_->mock_helper(), validateCertificateChain(_, _, _)).Times(1);
-  EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation()).Times(1);
+  EXPECT_CALL(helper_handle_->mock_helper(), validateCertificateChain(_, _, _));
+  EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation());
 
   builder_.enablePlatformCertificatesValidation(true);
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -109,6 +109,52 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
   ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
+TEST_P(ClientIntegrationTest, BasicHttps) {
+  EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).Times(0);
+  EXPECT_CALL(helper_handle_->mock_helper(), validateCertificateChain(_, _, _)).Times(1);
+  EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation()).Times(1);
+
+  builder_.enablePlatformCertificatesValidation(true);
+
+  upstream_tls_ = true;
+
+  initialize();
+  default_request_headers_.setScheme("https");
+
+  Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
+  default_request_headers_.addCopy(AutonomousStream::EXPECT_REQUEST_SIZE_BYTES,
+                                   std::to_string(request_data.length()));
+
+  stream_prototype_->setOnData([this](envoy_data c_data, bool end_stream) {
+    if (end_stream) {
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "");
+    } else {
+      EXPECT_EQ(c_data.length, 10);
+    }
+    cc_.on_data_calls++;
+    release_envoy_data(c_data);
+  });
+
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
+  stream_->sendData(c_data);
+
+  Platform::RequestTrailersBuilder builder;
+  std::shared_ptr<Platform::RequestTrailers> trailers =
+      std::make_shared<Platform::RequestTrailers>(builder.build());
+  stream_->close(trailers);
+
+  terminal_callback_.waitReady();
+
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  ASSERT_EQ(cc_.status, "200");
+  ASSERT_EQ(cc_.on_data_calls, 2);
+  ASSERT_EQ(cc_.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_header_consumed_bytes_from_response, 27);
+  ASSERT_EQ(cc_.on_complete_received_byte_count, 67);
+}
+
 TEST_P(ClientIntegrationTest, BasicNon2xx) {
   initialize();
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -111,7 +111,7 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
 
 TEST_P(ClientIntegrationTest, BasicHttps) {
   EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).Times(0);
-  EXPECT_CALL(helper_handle_->mock_helper(), validateCertificateChain(_, _, _));
+  EXPECT_CALL(helper_handle_->mock_helper(), validateCertificateChain(_, _));
   EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation());
 
   builder_.enablePlatformCertificatesValidation(true);

--- a/mobile/test/common/mocks/common/mocks.cc
+++ b/mobile/test/common/mocks/common/mocks.cc
@@ -4,9 +4,15 @@ namespace Envoy {
 namespace test {
 
 using testing::_;
+using testing::Return;
 
 MockSystemHelper::MockSystemHelper() {
-  ON_CALL(*this, isCleartextPermitted(_)).WillByDefault(testing::Return(true));
+  ON_CALL(*this, isCleartextPermitted(_)).WillByDefault(Return(true));
+  envoy_cert_validation_result success;
+  success.result = ENVOY_SUCCESS;
+  success.tls_alert = 0;
+  success.error_details = "";
+  ON_CALL(*this, validateCertificateChain(_, _, _)).WillByDefault(Return(success));
 }
 
 } // namespace test

--- a/mobile/test/common/mocks/common/mocks.cc
+++ b/mobile/test/common/mocks/common/mocks.cc
@@ -12,7 +12,7 @@ MockSystemHelper::MockSystemHelper() {
   success.result = ENVOY_SUCCESS;
   success.tls_alert = 0;
   success.error_details = "";
-  ON_CALL(*this, validateCertificateChain(_, _, _)).WillByDefault(Return(success));
+  ON_CALL(*this, validateCertificateChain(_, _)).WillByDefault(Return(success));
 }
 
 } // namespace test

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -11,8 +11,8 @@ public:
 
   // SystemHelper:
   MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view hostname));
-  MOCK_METHOD(envoy_cert_validation_result, validateCertificateChain, (const envoy_data* certs, uint8_t size,
-                                                                       const char* host_name));
+  MOCK_METHOD(envoy_cert_validation_result, validateCertificateChain,
+              (const envoy_data* certs, uint8_t size, const char* host_name));
   MOCK_METHOD(void, cleanupAfterCertificateValidation, ());
 };
 

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -12,7 +12,7 @@ public:
   // SystemHelper:
   MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view hostname));
   MOCK_METHOD(envoy_cert_validation_result, validateCertificateChain,
-              (const envoy_data* certs, uint8_t size, const char* host_name));
+              (absl::Span<const absl::string_view> certs, absl::string_view hostname));
   MOCK_METHOD(void, cleanupAfterCertificateValidation, ());
 };
 

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -11,6 +11,9 @@ public:
 
   // SystemHelper:
   MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view hostname));
+  MOCK_METHOD(envoy_cert_validation_result, validateCertificateChain, (const envoy_data* certs, uint8_t size,
+                                                                       const char* host_name));
+  MOCK_METHOD(void, cleanupAfterCertificateValidation, ());
 };
 
 // SystemHelperPeer allows the replacement of the SystemHelper singleton

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -12,7 +12,7 @@ public:
   // SystemHelper:
   MOCK_METHOD(bool, isCleartextPermitted, (absl::string_view hostname));
   MOCK_METHOD(envoy_cert_validation_result, validateCertificateChain,
-              (absl::Span<const absl::string_view> certs, absl::string_view hostname));
+              (const std::vector<std::string>& certs, absl::string_view hostname));
   MOCK_METHOD(void, cleanupAfterCertificateValidation, ());
 };
 


### PR DESCRIPTION
Add cert verification support to the mobile SystemHelper

Change the PlatformBridgeCertValidator to get the underlying platform verifier from the SystemHelper instead of the Envoy Mobile register API mechanism. This allows the Envoy Mobile certificate verification API to be C++-ified by using string_view instead of envoy_data. This change fixed a memory leak in the Apple platform cert verified.

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A