### PR TITLE
stats: reproduce redundant TYPE tags problem in Prometheus.

### DIFF
--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -168,6 +168,8 @@ envoy_cc_test(
     name = "prometheus_stats_test",
     srcs = envoy_select_admin_functionality(["prometheus_stats_test.cc"]),
     deps = [
+        "//source/common/stats:tag_producer_lib",
+        "//source/common/stats:thread_local_store_lib",
         "//source/server/admin:prometheus_stats_lib",
         "//test/test_common:utility_lib",
     ],

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -289,6 +289,18 @@ envoy_cluster_default_total_match_count{envoy_cluster_name="a"} 0
 envoy_cluster_default_total_match_count{envoy_cluster_name="x"} 0
 )EOF";
 
+  // Note: in the version of prometheus_stats_test.cc that works with the
+  // streaming GroupedStatsRequest, the test code is slightly different;
+  // it's based on the local 'store' object rather than being based on
+  // the counters_ member variable.
+  //    StatsParams params;
+  //    params.type_ = StatsType::Counters;
+  //    params.format_ = StatsFormat::Prometheus;
+  //    auto request = std::make_unique<GroupedStatsRequest>(store, params, custom_namespaces_);
+  //    EXPECT_EQ(expected_output, response(*request));
+  // This code is left here so that we can verify the bug is fixed if we decide to
+  // re-try the streaming Prometheus implementation.
+
   Buffer::OwnedImpl response;
   const uint64_t size = PrometheusStatsFormatter::statsAsPrometheus(
       counters_, gauges_, histograms_, textReadouts_, response, StatsParams(), custom_namespaces);


### PR DESCRIPTION
Commit Message: Reproduces a scenario where it's difficult to use a streaming optimization for Prometheus stats based on scopes without introducing a bug. Context:

  * Issue that /stats/prometheus endpoint takes too much much memory: https://github.com/envoyproxy/envoy/issues/16139
  * Solution for non-Prometheus endpoints to use less memory for /stats and run faster: https://github.com/envoyproxy/envoy/pull/19693 which I believe is working well.
  * This solution mapped to Prometheus: https://github.com/envoyproxy/envoy/pull/24998 
  * A case where this solution has a duplicate`# TYPE` line due to two stats with the same tag-extracted-stat name from two different scopes: https://github.com/envoyproxy/envoy/issues/27173

Note that the existing unit tests did not exercise that scenario so this PR adds a testcase.

@rulex123 FYI
@zirain FYI

Additional Description:
Risk Level: low
Testing: just the new test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
