### PR TITLE
tcp_stats: adding additional tcp stats

### DIFF
--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -30,7 +30,7 @@
    cx_tx_percent_retransmitted_segments, Histogram, Percent of segments on a connection which were retransmistted
    cx_rtt_us, Histogram, Smoothed round trip time estimate in microseconds
    cx_rtt_variance_us, Histogram, Estimated variance in microseconds of the round trip time. Higher values indicated more variability.
-   cx_rcv_rtt_us, Histogram, Receiver side round trip time estimate in microseconds
+   cx_rcv_rtt, Histogram, Receiver side round trip time estimate in microseconds
    cx_tx_window_scale, Histogram, Shift value to scale send window
    cx_rx_window_scale, Histogram, Shift value to scale receive window
    cx_congestion_window, Histogram, urrent congestion window in bytes for sending data

--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -15,24 +15,21 @@
    cx_rx_bytes_received, Counter, Total payload bytes received for which TCP acknowledgments have been sent.
    cx_tx_bytes_sent, Counter, Total payload bytes transmitted (including retransmitted bytes).
    cx_data_segments_delivered, Counter, Data segments delivered to the receiver including retransmits
-   cx_reordering, Counter, Maximum observed reordering distance
+   cx_lost, Counter, Lost TCP segments
    cx_tx_unsent_bytes, Gauge, Bytes which Envoy has sent to the operating system which have not yet been sent
    cx_tx_unacked_segments, Gauge, Segments which have been transmitted that have not yet been acknowledged
-   cx_rto_us, Gauge, Retransmission timeout
-   cx_ato_us, Gauge, Ack timeout
-   cx_lost, Gauge, Lost segments
-   cx_tx_ssthreshold, Gauge, Sender's slow start threshold expressed in packets
-   cx_rx_ssthreshold, Gauge, Maximum number of bytes currently advertised as the TCP receive window
-   cx_tx_mss_bytes, Gauge, Maximum segment size in bytes for sending
-   cx_rx_mss_bytes, Gauge, Maximum segment size in bytes for receiving
-   cx_advmss_bytes, Gauge, Advertised in the maximum segment size in bytes
-   cx_pmtu_bytes, Gauge, Bytes the TCP stack believes can be transmitted in one IP packet without fragmentation
    cx_tx_percent_retransmitted_segments, Histogram, Percent of segments on a connection which were retransmistted
    cx_rtt_us, Histogram, Smoothed round trip time estimate in microseconds
    cx_rtt_variance_us, Histogram, Estimated variance in microseconds of the round trip time. Higher values indicated more variability.
    cx_rcv_rtt, Histogram, Receiver side round trip time estimate in microseconds
    cx_tx_window_scale, Histogram, Shift value to scale send window
    cx_rx_window_scale, Histogram, Shift value to scale receive window
+   cx_reordering, Histogram, Maximum observed reordering distance
+   cx_rto, Histogram, Retransmission timeout in microseconds
+   cx_ato, Histogram, Ack timeout in microseconds
+   cx_tx_mss_bytes, Histogram, Maximum segment size in bytes for sending
+   cx_rx_mss_bytes, Histogram, Maximum segment size in bytes for receiving
+   cx_advmss_bytes, Histogram, Advertised in the maximum segment size in bytes
    cx_congestion_window, Histogram, Congestion window in bytes for sending data
-   cx_pacing_rate, Histogram, Pacing rate in MB per second
-   cx_delivery_rate, Histogram, Observed maximum delivery rate in MB per second
+   cx_pacing_rate, Histogram, Pacing rate in bytes per second
+   cx_delivery_rate, Histogram, Observed maximum delivery rate in bytes per second

--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -14,8 +14,25 @@
    cx_tx_retransmitted_segments, Counter, Total TCP segments retransmitted
    cx_rx_bytes_received, Counter, Total payload bytes received for which TCP acknowledgments have been sent.
    cx_tx_bytes_sent, Counter, Total payload bytes transmitted (including retransmitted bytes).
+   cx_data_segments_delivered, Counter, Data segments delivered to the receiver including retransmits
+   cx_reordering, Counter, Maximum observed reordering distance
    cx_tx_unsent_bytes, Gauge, Bytes which Envoy has sent to the operating system which have not yet been sent
    cx_tx_unacked_segments, Gauge, Segments which have been transmitted that have not yet been acknowledged
+   cx_rto_us, Gauge, Retransmission timeout
+   cx_ato_us, Gauge, Ack timeout
+   cx_lost, Gauge, Lost segments
+   cx_tx_ssthreshold, Gauge, Sender's slow start threshold expressed in packets
+   cx_rx_ssthreshold, Gauge, Maximum number of bytes currently advertised as the TCP receive window
+   cx_tx_mss_bytes, Gauge, Maximum segment size in bytes for sending
+   cx_rx_mss_bytes, Gauge, Maximum segment size in bytes for receiving
+   cx_advmss_bytes, Gauge, Advertised in the maximum segment size in bytes
+   cx_pmtu_bytes, Gauge, Bytes the TCP stack believes can be transmitted in one IP packet without fragmentation
    cx_tx_percent_retransmitted_segments, Histogram, Percent of segments on a connection which were retransmistted
    cx_rtt_us, Histogram, Smoothed round trip time estimate in microseconds
    cx_rtt_variance_us, Histogram, Estimated variance in microseconds of the round trip time. Higher values indicated more variability.
+   cx_rcv_rtt_us, Histogram, Receiver side round trip time estimate in microseconds
+   cx_tx_window_scale, Histogram, Shift value to scale send window
+   cx_rx_window_scale, Histogram, Shift value to scale receive window
+   cx_congestion_window, Histogram, urrent congestion window in bytes for sending data
+   cx_pacing_rate, Histogram, Pacing rate in MB per second
+   cx_delivery_rate, Histogram, Observed maximum delivery rate in MB per second

--- a/docs/root/_include/tcp_stats.rst
+++ b/docs/root/_include/tcp_stats.rst
@@ -33,6 +33,6 @@
    cx_rcv_rtt, Histogram, Receiver side round trip time estimate in microseconds
    cx_tx_window_scale, Histogram, Shift value to scale send window
    cx_rx_window_scale, Histogram, Shift value to scale receive window
-   cx_congestion_window, Histogram, urrent congestion window in bytes for sending data
+   cx_congestion_window, Histogram, Congestion window in bytes for sending data
    cx_pacing_rate, Histogram, Pacing rate in MB per second
    cx_delivery_rate, Histogram, Observed maximum delivery rate in MB per second

--- a/docs/root/configuration/listeners/stats.rst
+++ b/docs/root/configuration/listeners/stats.rst
@@ -49,6 +49,11 @@ are rooted at *listener.<address>.tcp_stats.*:
 
 .. include:: ../../_include/tcp_stats.rst
 
+.. note::
+  Above metrics can be included in the access logs of listener and command operators (DYNAMIC_METADATA) are used to extract values
+  that will be inserted into the access logs. These metrics can be found in ``envoy.tcp_stats`` namespace of DYNAMIC_METADATA.
+  For example, to log ``cx_tx_segments`` one can use ``%DYNAMIC_METADATA(envoy.tcp_stats:cx_tx_segments)%``.
+
 .. _config_listener_stats_udp:
 
 UDP statistics

--- a/docs/root/configuration/listeners/stats.rst
+++ b/docs/root/configuration/listeners/stats.rst
@@ -49,11 +49,6 @@ are rooted at *listener.<address>.tcp_stats.*:
 
 .. include:: ../../_include/tcp_stats.rst
 
-.. note::
-  Above metrics can be included in the access logs of listener and command operators (DYNAMIC_METADATA) are used to extract values
-  that will be inserted into the access logs. These metrics can be found in ``envoy.tcp_stats`` namespace of DYNAMIC_METADATA.
-  For example, to log ``cx_tx_segments`` one can use ``%DYNAMIC_METADATA(envoy.tcp_stats:cx_tx_segments)%``.
-
 .. _config_listener_stats_udp:
 
 UDP statistics

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -133,13 +133,6 @@ void TcpStatsSocket::recordStats() {
     config_->stats_.cx_tx_percent_retransmitted_segments_.recordValue(percent_retransmissions);
   }
 
-  const uint64_t mss = (tcp_info->tcpi_snd_mss > 0) ? tcp_info->tcpi_snd_mss : 1460;
-  // Convert packets to bytes.
-  auto snd_cwnd = tcp_info->tcpi_snd_cwnd * mss;
-  // Convert delivery & pacing rate to MB.
-  auto delivery_rate_mb = std::round(static_cast<float>(tcp_info->tcpi_delivery_rate) / 1000000);
-  auto pacing_rate_mb = std::round(static_cast<float>(tcp_info->tcpi_pacing_rate) / 1000000);
-
   update_counter(config_->stats_.cx_tx_segments_, last_cx_tx_segments_, tcp_info->tcpi_segs_out);
   update_counter(config_->stats_.cx_rx_segments_, last_cx_rx_segments_, tcp_info->tcpi_segs_in);
   update_counter(config_->stats_.cx_tx_data_segments_, last_cx_tx_data_segments_,
@@ -154,70 +147,31 @@ void TcpStatsSocket::recordStats() {
                  tcp_info->tcpi_bytes_sent);
   update_counter(config_->stats_.cx_data_segments_delivered_, last_cx_data_segments_delivered_,
                  tcp_info->tcpi_delivered);
-  update_counter(config_->stats_.cx_reordering_, last_cx_reordering_, tcp_info->tcpi_reordering);
-
+  update_counter(config_->stats_.cx_lost_, last_cx_lost_, tcp_info->tcpi_lost);
   update_gauge(config_->stats_.cx_tx_unsent_bytes_, last_cx_tx_unsent_bytes_,
                tcp_info->tcpi_notsent_bytes);
   update_gauge(config_->stats_.cx_tx_unacked_segments_, last_cx_tx_unacked_segments_,
                tcp_info->tcpi_unacked);
-  update_gauge(config_->stats_.cx_rto_us_, last_cx_rto_us_, tcp_info->tcpi_rto);
-  update_gauge(config_->stats_.cx_ato_us_, last_cx_ato_us_, tcp_info->tcpi_ato);
-  update_gauge(config_->stats_.cx_lost_, last_cx_lost_, tcp_info->tcpi_lost);
-  update_gauge(config_->stats_.cx_tx_ssthreshold_, last_cx_tx_ssthreshold_,
-               tcp_info->tcpi_snd_ssthresh);
-  update_gauge(config_->stats_.cx_rx_ssthreshold_, last_cx_rx_ssthreshold_,
-               tcp_info->tcpi_rcv_ssthresh);
-  update_gauge(config_->stats_.cx_tx_mss_bytes_, last_cx_tx_mss_bytes_, tcp_info->tcpi_snd_mss);
-  update_gauge(config_->stats_.cx_rx_mss_bytes_, last_cx_rx_mss_bytes_, tcp_info->tcpi_rcv_mss);
-  update_gauge(config_->stats_.cx_advmss_bytes_, last_cx_advmss_bytes_, tcp_info->tcpi_advmss);
-  update_gauge(config_->stats_.cx_pmtu_bytes_, last_cx_pmtu_bytes_, tcp_info->tcpi_pmtu);
 
   config_->stats_.cx_rtt_us_.recordValue(tcp_info->tcpi_rtt);
   config_->stats_.cx_rtt_variance_us_.recordValue(tcp_info->tcpi_rttvar);
-  config_->stats_.cx_congestion_window_.recordValue(snd_cwnd);
-  config_->stats_.cx_pacing_rate_.recordValue(pacing_rate_mb);
-  config_->stats_.cx_delivery_rate_.recordValue(delivery_rate_mb);
+  config_->stats_.cx_pacing_rate_.recordValue(tcp_info->tcpi_pacing_rate);
+  config_->stats_.cx_delivery_rate_.recordValue(tcp_info->tcpi_delivery_rate);
   config_->stats_.cx_rcv_rtt_.recordValue(tcp_info->tcpi_rcv_rtt);
   config_->stats_.cx_tx_window_scale_.recordValue(tcp_info->tcpi_snd_wscale);
   config_->stats_.cx_rx_window_scale_.recordValue(tcp_info->tcpi_rcv_wscale);
-
-  Envoy::ProtobufWkt::Struct meta_struct;
-  auto& fields = *meta_struct.mutable_fields();
-  *fields["cx_tx_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_segs_out);
-  *fields["cx_rx_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_segs_in);
-  *fields["cx_tx_data_segments"].mutable_string_value() =
-      absl::StrCat(tcp_info->tcpi_data_segs_out);
-  *fields["cx_rx_data_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_data_segs_in);
-  *fields["cx_tx_retransmitted_segments"].mutable_string_value() =
-      absl::StrCat(tcp_info->tcpi_total_retrans);
-  *fields["cx_rx_bytes_received"].mutable_string_value() =
-      absl::StrCat(tcp_info->tcpi_bytes_received);
-  *fields["cx_tx_bytes_sent"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_bytes_sent);
-  *fields["cx_tx_unsent_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_notsent_bytes);
-  *fields["cx_tx_unacked_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_unacked);
-  *fields["cx_data_segments_delivered"].mutable_string_value() =
-      absl::StrCat(tcp_info->tcpi_delivered);
-  *fields["cx_reordering"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_reordering);
-  *fields["cx_rto_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rto);
-  *fields["cx_ato_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_ato);
-  *fields["cx_lost"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_lost);
-  *fields["cx_tx_ssthreshold"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_snd_ssthresh);
-  *fields["cx_rx_ssthreshold"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_ssthresh);
-  *fields["cx_tx_mss_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_snd_mss);
-  *fields["cx_rx_mss_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_mss);
-  *fields["cx_advmss_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_advmss);
-  *fields["cx_pmtu_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_pmtu);
-  *fields["cx_rtt_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rtt);
-  *fields["cx_rtt_variance_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rttvar);
-  *fields["cx_rcv_rtt"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_rtt);
-  *fields["cx_tx_window_scale"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_snd_wscale);
-  *fields["cx_rx_window_scale"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_wscale);
-  *fields["cx_congestion_window"].mutable_string_value() = absl::StrCat(snd_cwnd);
-  *fields["cx_pacing_rate"].mutable_string_value() = absl::StrCat(pacing_rate_mb);
-  *fields["cx_delivery_rate"].mutable_string_value() = absl::StrCat(delivery_rate_mb);
-
-  // Update dynamic metadata with tcp stats.
-  callbacks_->connection().streamInfo().setDynamicMetadata("envoy.tcp_stats", meta_struct);
+  config_->stats_.cx_reordering_.recordValue(tcp_info->tcpi_reordering);
+  config_->stats_.cx_rto_.recordValue(tcp_info->tcpi_rto);
+  config_->stats_.cx_ato_.recordValue(tcp_info->tcpi_ato);
+  config_->stats_.cx_tx_mss_bytes_.recordValue(tcp_info->tcpi_snd_mss);
+  config_->stats_.cx_rx_mss_bytes_.recordValue(tcp_info->tcpi_rcv_mss);
+  config_->stats_.cx_advmss_bytes_.recordValue(tcp_info->tcpi_advmss);
+  // Don't record congestion window if send mss is 0.
+  if (tcp_info->tcpi_snd_mss > 0) {
+    // Convert packets to bytes.
+    config_->stats_.cx_congestion_window_.recordValue(tcp_info->tcpi_snd_cwnd *
+                                                      tcp_info->tcpi_snd_mss);
+  }
 }
 
 } // namespace TcpStats

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -133,6 +133,13 @@ void TcpStatsSocket::recordStats() {
     config_->stats_.cx_tx_percent_retransmitted_segments_.recordValue(percent_retransmissions);
   }
 
+  const uint64_t mss = (tcp_info->tcpi_snd_mss > 0) ? tcp_info->tcpi_snd_mss : 1460;
+  // Convert packets to bytes.
+  auto snd_cwnd = tcp_info->tcpi_snd_cwnd * mss;
+  // Convert delivery & pacing rate to MB.
+  auto delivery_rate_mb = std::round(static_cast<float>(tcp_info->tcpi_delivery_rate) / 1000000);
+  auto pacing_rate_mb = std::round(static_cast<float>(tcp_info->tcpi_pacing_rate) / 1000000);
+
   update_counter(config_->stats_.cx_tx_segments_, last_cx_tx_segments_, tcp_info->tcpi_segs_out);
   update_counter(config_->stats_.cx_rx_segments_, last_cx_rx_segments_, tcp_info->tcpi_segs_in);
   update_counter(config_->stats_.cx_tx_data_segments_, last_cx_tx_data_segments_,
@@ -145,14 +152,72 @@ void TcpStatsSocket::recordStats() {
                  tcp_info->tcpi_bytes_received);
   update_counter(config_->stats_.cx_tx_bytes_sent_, last_cx_tx_bytes_sent_,
                  tcp_info->tcpi_bytes_sent);
+  update_counter(config_->stats_.cx_data_segments_delivered_, last_cx_data_segments_delivered_,
+                 tcp_info->tcpi_delivered);
+  update_counter(config_->stats_.cx_reordering_, last_cx_reordering_, tcp_info->tcpi_reordering);
 
   update_gauge(config_->stats_.cx_tx_unsent_bytes_, last_cx_tx_unsent_bytes_,
                tcp_info->tcpi_notsent_bytes);
   update_gauge(config_->stats_.cx_tx_unacked_segments_, last_cx_tx_unacked_segments_,
                tcp_info->tcpi_unacked);
+  update_gauge(config_->stats_.cx_rto_us_, last_cx_rto_us_, tcp_info->tcpi_rto);
+  update_gauge(config_->stats_.cx_ato_us_, last_cx_ato_us_, tcp_info->tcpi_ato);
+  update_gauge(config_->stats_.cx_lost_, last_cx_lost_, tcp_info->tcpi_lost);
+  update_gauge(config_->stats_.cx_tx_ssthreshold_, last_cx_tx_ssthreshold_,
+               tcp_info->tcpi_snd_ssthresh);
+  update_gauge(config_->stats_.cx_rx_ssthreshold_, last_cx_rx_ssthreshold_,
+               tcp_info->tcpi_rcv_ssthresh);
+  update_gauge(config_->stats_.cx_tx_mss_bytes_, last_cx_tx_mss_bytes_, tcp_info->tcpi_snd_mss);
+  update_gauge(config_->stats_.cx_rx_mss_bytes_, last_cx_rx_mss_bytes_, tcp_info->tcpi_rcv_mss);
+  update_gauge(config_->stats_.cx_advmss_bytes_, last_cx_advmss_bytes_, tcp_info->tcpi_advmss);
+  update_gauge(config_->stats_.cx_pmtu_bytes_, last_cx_pmtu_bytes_, tcp_info->tcpi_pmtu);
 
   config_->stats_.cx_rtt_us_.recordValue(tcp_info->tcpi_rtt);
   config_->stats_.cx_rtt_variance_us_.recordValue(tcp_info->tcpi_rttvar);
+  config_->stats_.cx_congestion_window_.recordValue(snd_cwnd);
+  config_->stats_.cx_pacing_rate_.recordValue(pacing_rate_mb);
+  config_->stats_.cx_delivery_rate_.recordValue(delivery_rate_mb);
+  config_->stats_.cx_rcv_rtt_.recordValue(tcp_info->tcpi_rcv_rtt);
+  config_->stats_.cx_tx_window_scale_.recordValue(tcp_info->tcpi_snd_wscale);
+  config_->stats_.cx_rx_window_scale_.recordValue(tcp_info->tcpi_rcv_wscale);
+
+  Envoy::ProtobufWkt::Struct meta_struct;
+  auto& fields = *meta_struct.mutable_fields();
+  *fields["cx_tx_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_segs_out);
+  *fields["cx_rx_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_segs_in);
+  *fields["cx_tx_data_segments"].mutable_string_value() =
+      absl::StrCat(tcp_info->tcpi_data_segs_out);
+  *fields["cx_rx_data_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_data_segs_in);
+  *fields["cx_tx_retransmitted_segments"].mutable_string_value() =
+      absl::StrCat(tcp_info->tcpi_total_retrans);
+  *fields["cx_rx_bytes_received"].mutable_string_value() =
+      absl::StrCat(tcp_info->tcpi_bytes_received);
+  *fields["cx_tx_bytes_sent"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_bytes_sent);
+  *fields["cx_tx_unsent_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_notsent_bytes);
+  *fields["cx_tx_unacked_segments"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_unacked);
+  *fields["cx_data_segments_delivered"].mutable_string_value() =
+      absl::StrCat(tcp_info->tcpi_delivered);
+  *fields["cx_reordering"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_reordering);
+  *fields["cx_rto_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rto);
+  *fields["cx_ato_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_ato);
+  *fields["cx_lost"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_lost);
+  *fields["cx_tx_ssthreshold"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_snd_ssthresh);
+  *fields["cx_rx_ssthreshold"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_ssthresh);
+  *fields["cx_tx_mss_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_snd_mss);
+  *fields["cx_rx_mss_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_mss);
+  *fields["cx_advmss_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_advmss);
+  *fields["cx_pmtu_bytes"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_pmtu);
+  *fields["cx_rtt_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rtt);
+  *fields["cx_rtt_variance_us"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rttvar);
+  *fields["cx_rcv_rtt"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_rtt);
+  *fields["cx_tx_window_scale"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_snd_wscale);
+  *fields["cx_rx_window_scale"].mutable_string_value() = absl::StrCat(tcp_info->tcpi_rcv_wscale);
+  *fields["cx_congestion_window"].mutable_string_value() = absl::StrCat(snd_cwnd);
+  *fields["cx_pacing_rate"].mutable_string_value() = absl::StrCat(pacing_rate_mb);
+  *fields["cx_delivery_rate"].mutable_string_value() = absl::StrCat(delivery_rate_mb);
+
+  // Update dynamic metadata with tcp stats.
+  callbacks_->connection().streamInfo().setDynamicMetadata("envoy.tcp_stats", meta_struct);
 }
 
 } // namespace TcpStats

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.cc
@@ -166,7 +166,7 @@ void TcpStatsSocket::recordStats() {
   config_->stats_.cx_tx_mss_bytes_.recordValue(tcp_info->tcpi_snd_mss);
   config_->stats_.cx_rx_mss_bytes_.recordValue(tcp_info->tcpi_rcv_mss);
   config_->stats_.cx_advmss_bytes_.recordValue(tcp_info->tcpi_advmss);
-  // Don't record congestion window if send mss is 0.
+  // Record congestion window only when `snd_mss` is greater than 0.
   if (tcp_info->tcpi_snd_mss > 0) {
     // Convert packets to bytes.
     config_->stats_.cx_congestion_window_.recordValue(tcp_info->tcpi_snd_cwnd *

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -28,11 +28,28 @@ namespace TcpStats {
   COUNTER(cx_tx_retransmitted_segments)                                                            \
   COUNTER(cx_rx_bytes_received)                                                                    \
   COUNTER(cx_tx_bytes_sent)                                                                        \
+  COUNTER(cx_data_segments_delivered)                                                              \
+  COUNTER(cx_reordering)                                                                           \
   GAUGE(cx_tx_unsent_bytes, Accumulate)                                                            \
   GAUGE(cx_tx_unacked_segments, Accumulate)                                                        \
+  GAUGE(cx_rto_us, Accumulate)                                                                     \
+  GAUGE(cx_ato_us, Accumulate)                                                                     \
+  GAUGE(cx_lost, Accumulate)                                                                       \
+  GAUGE(cx_tx_ssthreshold, Accumulate)                                                             \
+  GAUGE(cx_rx_ssthreshold, Accumulate)                                                             \
+  GAUGE(cx_tx_mss_bytes, Accumulate)                                                               \
+  GAUGE(cx_rx_mss_bytes, Accumulate)                                                               \
+  GAUGE(cx_advmss_bytes, Accumulate)                                                               \
+  GAUGE(cx_pmtu_bytes, Accumulate)                                                                 \
   HISTOGRAM(cx_tx_percent_retransmitted_segments, Percent)                                         \
   HISTOGRAM(cx_rtt_us, Microseconds)                                                               \
-  HISTOGRAM(cx_rtt_variance_us, Microseconds)
+  HISTOGRAM(cx_rtt_variance_us, Microseconds)                                                      \
+  HISTOGRAM(cx_rcv_rtt, Microseconds)                                                              \
+  HISTOGRAM(cx_tx_window_scale, Unspecified)                                                       \
+  HISTOGRAM(cx_rx_window_scale, Unspecified)                                                       \
+  HISTOGRAM(cx_congestion_window, Unspecified)                                                     \
+  HISTOGRAM(cx_pacing_rate, Unspecified)                                                           \
+  HISTOGRAM(cx_delivery_rate, Unspecified)
 
 struct TcpStats {
   ALL_TCP_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
@@ -79,6 +96,17 @@ private:
   uint32_t last_cx_tx_bytes_sent_{};
   uint32_t last_cx_tx_unsent_bytes_{};
   uint32_t last_cx_tx_unacked_segments_{};
+  uint32_t last_cx_data_segments_delivered_{};
+  uint32_t last_cx_reordering_{};
+  uint32_t last_cx_rto_us_{};
+  uint32_t last_cx_ato_us_{};
+  uint32_t last_cx_lost_{};
+  uint32_t last_cx_tx_ssthreshold_{};
+  uint32_t last_cx_rx_ssthreshold_{};
+  uint32_t last_cx_tx_mss_bytes_{};
+  uint32_t last_cx_rx_mss_bytes_{};
+  uint32_t last_cx_advmss_bytes_{};
+  uint32_t last_cx_pmtu_bytes_{};
 };
 
 } // namespace TcpStats

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -29,27 +29,24 @@ namespace TcpStats {
   COUNTER(cx_rx_bytes_received)                                                                    \
   COUNTER(cx_tx_bytes_sent)                                                                        \
   COUNTER(cx_data_segments_delivered)                                                              \
-  COUNTER(cx_reordering)                                                                           \
+  COUNTER(cx_lost)                                                                                 \
   GAUGE(cx_tx_unsent_bytes, Accumulate)                                                            \
   GAUGE(cx_tx_unacked_segments, Accumulate)                                                        \
-  GAUGE(cx_rto_us, Accumulate)                                                                     \
-  GAUGE(cx_ato_us, Accumulate)                                                                     \
-  GAUGE(cx_lost, Accumulate)                                                                       \
-  GAUGE(cx_tx_ssthreshold, Accumulate)                                                             \
-  GAUGE(cx_rx_ssthreshold, Accumulate)                                                             \
-  GAUGE(cx_tx_mss_bytes, Accumulate)                                                               \
-  GAUGE(cx_rx_mss_bytes, Accumulate)                                                               \
-  GAUGE(cx_advmss_bytes, Accumulate)                                                               \
-  GAUGE(cx_pmtu_bytes, Accumulate)                                                                 \
   HISTOGRAM(cx_tx_percent_retransmitted_segments, Percent)                                         \
   HISTOGRAM(cx_rtt_us, Microseconds)                                                               \
   HISTOGRAM(cx_rtt_variance_us, Microseconds)                                                      \
   HISTOGRAM(cx_rcv_rtt, Microseconds)                                                              \
   HISTOGRAM(cx_tx_window_scale, Unspecified)                                                       \
   HISTOGRAM(cx_rx_window_scale, Unspecified)                                                       \
+  HISTOGRAM(cx_reordering, Unspecified)                                                            \
   HISTOGRAM(cx_congestion_window, Unspecified)                                                     \
-  HISTOGRAM(cx_pacing_rate, Unspecified)                                                           \
-  HISTOGRAM(cx_delivery_rate, Unspecified)
+  HISTOGRAM(cx_rto, Microseconds)                                                                  \
+  HISTOGRAM(cx_ato, Microseconds)                                                                  \
+  HISTOGRAM(cx_tx_mss_bytes, Bytes)                                                                \
+  HISTOGRAM(cx_rx_mss_bytes, Bytes)                                                                \
+  HISTOGRAM(cx_advmss_bytes, Bytes)                                                                \
+  HISTOGRAM(cx_pacing_rate, Bytes)                                                                 \
+  HISTOGRAM(cx_delivery_rate, Bytes)
 
 struct TcpStats {
   ALL_TCP_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
@@ -97,16 +94,7 @@ private:
   uint32_t last_cx_tx_unsent_bytes_{};
   uint32_t last_cx_tx_unacked_segments_{};
   uint32_t last_cx_data_segments_delivered_{};
-  uint32_t last_cx_reordering_{};
-  uint32_t last_cx_rto_us_{};
-  uint32_t last_cx_ato_us_{};
   uint32_t last_cx_lost_{};
-  uint32_t last_cx_tx_ssthreshold_{};
-  uint32_t last_cx_rx_ssthreshold_{};
-  uint32_t last_cx_tx_mss_bytes_{};
-  uint32_t last_cx_rx_mss_bytes_{};
-  uint32_t last_cx_advmss_bytes_{};
-  uint32_t last_cx_pmtu_bytes_{};
 };
 
 } // namespace TcpStats


### PR DESCRIPTION
Commit Message: adding additional TCP stats and access them in access logger of listener.
Additional Description: Adding most of the remaining tcp stats for improving visibility to issues and making these stats available in listener's access logger via dynamic_metadata.
Risk Level: low
Testing: Manual testing
Docs Changes: Updated tcp stats page with additional stats.
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
