### PR TITLE
Reserve more CPU cores for integration tests with high rate of flakes

### DIFF
--- a/test/extensions/filters/http/local_ratelimit/BUILD
+++ b/test/extensions/filters/http/local_ratelimit/BUILD
@@ -40,6 +40,9 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["local_ratelimit_integration_test.cc"],
     extension_names = ["envoy.filters.http.local_ratelimit"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         "//source/extensions/filters/http/local_ratelimit:config",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/network/local_ratelimit/BUILD
+++ b/test/extensions/filters/network/local_ratelimit/BUILD
@@ -32,6 +32,9 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["local_ratelimit_integration_test.cc"],
     extension_names = ["envoy.filters.network.local_ratelimit"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         "//source/extensions/filters/network/local_ratelimit:config",
         "//source/extensions/filters/network/tcp_proxy:config",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -57,6 +57,9 @@ envoy_cc_test(
     srcs = envoy_select_admin_functionality(
         ["ads_integration_test.cc"],
     ),
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":ads_integration_lib",
         ":http_integration_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -415,6 +415,9 @@ envoy_cc_test(
         "http2_flood_integration_test.cc",
     ],
     shard_count = 8,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":autonomous_upstream_lib",
         ":http_integration_lib",
@@ -441,6 +444,9 @@ envoy_cc_test(
         "multiplexed_integration_test.cc",
     ],
     shard_count = 16,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_protocol_integration_lib",
         ":socket_interface_swap_lib",
@@ -510,6 +516,9 @@ envoy_cc_test(
         "buffer_accounting_integration_test.cc",
     ],
     shard_count = 4,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":base_overload_integration_test_lib",
         ":http_integration_lib",
@@ -622,6 +631,9 @@ envoy_cc_test(
         "filter_integration_test.cc",
     ]),
     shard_count = 16,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_protocol_integration_lib",
         ":socket_interface_swap_lib",
@@ -696,6 +708,9 @@ envoy_cc_test(
     # As this test has many H1/H2/v4/v6 tests it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 48,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":protocol_integration_test_lib",
     ],
@@ -719,6 +734,9 @@ envoy_cc_test(
         "multiplexed_upstream_integration_test.cc",
     ],
     shard_count = 4,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
@@ -836,6 +854,9 @@ envoy_cc_test(
     # As this test has many pauses for idle timeouts, it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 8,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_protocol_integration_lib",
         "//test/integration/filters:backpressure_filter_config_lib",
@@ -1160,6 +1181,9 @@ envoy_cc_test(
         "integration_test.h",
     ],
     shard_count = 2,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         "//envoy/registry",
@@ -1222,6 +1246,9 @@ envoy_cc_test(
         "websocket_integration_test.h",
     ],
     shard_count = 4,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
@@ -1362,6 +1389,9 @@ envoy_cc_test(
     size = "large",
     srcs = ["overload_integration_test.cc"],
     shard_count = 8,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":base_overload_integration_test_lib",
         ":http_protocol_integration_lib",
@@ -1536,6 +1566,9 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     shard_count = 2,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":integration_lib",
         ":tcp_proxy_integration_proto_cc_proto",
@@ -1571,7 +1604,7 @@ envoy_cc_test(
     ],
     shard_count = 1,
     tags = [
-        "cpu:4",
+        "cpu:3",
     ],
     deps = [
         ":integration_lib",
@@ -1603,6 +1636,9 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     shard_count = 16,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         ":http_protocol_integration_lib",
@@ -2068,6 +2104,7 @@ envoy_cc_test(
     data = ["//test/config/integration/certs"],
     shard_count = 12,
     tags = [
+        "cpu:4",
         "nofips",
     ],
     deps = select({
@@ -2105,6 +2142,7 @@ envoy_cc_test(
     # Each of these tests exceeds 20s;
     # QuicHttpIntegrationTests/QuicHttpIntegrationTest.MultipleQuicConnections[With|No]BPF*
     tags = [
+        "cpu:3",
         "fails_on_clang_cl",
         "fails_on_windows",
         "nofips",
@@ -2191,6 +2229,9 @@ envoy_cc_test(
     srcs = ["tcp_proxy_odcds_integration_test.cc"],
     data = [
         "//test/config/integration/certs",
+    ],
+    tags = [
+        "cpu:3",
     ],
     deps = [
         ":ads_integration_lib",


### PR DESCRIPTION
Additional Description: 
This should reduce the rate of timing related flakes (which it does in local runs). However to take full advantage of CPU reservation all integration tests need to be configured with more CPU cores.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
