### PR TITLE
server: support using the ApiListener from a worker thread

### DIFF
--- a/envoy/server/api_listener.h
+++ b/envoy/server/api_listener.h
@@ -22,21 +22,17 @@ public:
   virtual absl::string_view name() const PURE;
 
   /**
-   * Shutdown the ApiListener. This is an interrupt, not a drain. In other words, calling this
-   * function results in termination of all active streams vs. draining where no new streams are
-   * allowed, but already existing streams are allowed to finish.
-   */
-  virtual void shutdown() PURE;
-
-  /**
    * @return the Type of the ApiListener.
    */
   virtual Type type() const PURE;
 
   /**
-   * @return valid ref IFF type() == Type::HttpApiListener, otherwise nullopt.
+   * Create an Http::ApiListener capable of starting synthetic HTTP streams. The returned listener
+   * must only be deleted in the dispatcher's thread.
+   *
+   * @return valid pointer IFF type() == Type::HttpApiListener, otherwise nullptr.
    */
-  virtual Http::ApiListenerOptRef http() PURE;
+  virtual Http::ApiListenerPtr createHttpApiListener(Event::Dispatcher& dispatcher) PURE;
 };
 
 using ApiListenerPtr = std::unique_ptr<ApiListener>;

--- a/envoy/server/api_listener.h
+++ b/envoy/server/api_listener.h
@@ -30,6 +30,9 @@ public:
    * Create an Http::ApiListener capable of starting synthetic HTTP streams. The returned listener
    * must only be deleted in the dispatcher's thread.
    *
+   * While Envoy Mobile only uses this from the main thread, taking a dispatcher as a parameter
+   * allows other users to use this from worker threads as well.
+   *
    * @return valid pointer IFF type() == Type::HttpApiListener, otherwise nullptr.
    */
   virtual Http::ApiListenerPtr createHttpApiListener(Event::Dispatcher& dispatcher) PURE;

--- a/mobile/library/common/engine.cc
+++ b/mobile/library/common/engine.cc
@@ -109,8 +109,8 @@ envoy_status_t Engine::main(std::unique_ptr<Envoy::OptionsImpl>&& options) {
           // on-the-fly without risking contention on system with lots of threads.
           // It also comes with ease of programming.
           stat_name_set_ = client_scope_->symbolTable().makeSet("pulse");
-          auto api_listener = server_->listenerManager().apiListener()->get()
-              .createHttpApiListener(server_->dispatcher());
+          auto api_listener = server_->listenerManager().apiListener()->get().createHttpApiListener(
+              server_->dispatcher());
           ASSERT(api_listener != nullptr);
           http_client_ = std::make_unique<Http::Client>(std::move(api_listener), *dispatcher_,
                                                         server_->serverFactoryContext().scope(),
@@ -158,9 +158,7 @@ envoy_status_t Engine::terminate() {
     ASSERT(dispatcher_);
 
     // We must destroy the Http::ApiListener in the main thread.
-    dispatcher_->post([this]() {
-      http_client_->shutdownApiListener();
-    });
+    dispatcher_->post([this]() { http_client_->shutdownApiListener(); });
 
     // Exit the event loop and finish up in Engine::run(...)
     if (std::this_thread::get_id() == main_thread_.get_id()) {

--- a/mobile/library/common/engine.cc
+++ b/mobile/library/common/engine.cc
@@ -109,9 +109,10 @@ envoy_status_t Engine::main(std::unique_ptr<Envoy::OptionsImpl>&& options) {
           // on-the-fly without risking contention on system with lots of threads.
           // It also comes with ease of programming.
           stat_name_set_ = client_scope_->symbolTable().makeSet("pulse");
-          auto api_listener = server_->listenerManager().apiListener()->get().http();
-          ASSERT(api_listener.has_value());
-          http_client_ = std::make_unique<Http::Client>(api_listener.value(), *dispatcher_,
+          auto api_listener = server_->listenerManager().apiListener()->get()
+              .createHttpApiListener(server_->dispatcher());
+          ASSERT(api_listener != nullptr);
+          http_client_ = std::make_unique<Http::Client>(std::move(api_listener), *dispatcher_,
                                                         server_->serverFactoryContext().scope(),
                                                         server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
@@ -155,6 +156,11 @@ envoy_status_t Engine::terminate() {
 
     ASSERT(event_dispatcher_);
     ASSERT(dispatcher_);
+
+    // We must destroy the Http::ApiListener in the main thread.
+    dispatcher_->post([this]() {
+      http_client_->shutdownApiListener();
+    });
 
     // Exit the event loop and finish up in Engine::run(...)
     if (std::this_thread::get_id() == main_thread_.get_id()) {

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -463,7 +463,7 @@ void Client::startStream(envoy_stream_t new_stream_handle, envoy_http_callbacks 
   // Note: streams created by Envoy Mobile are tagged as is_internally_created. This means that
   // the Http::ConnectionManager _will not_ sanitize headers when creating a stream.
   direct_stream->request_decoder_ =
-      &api_listener_.newStream(*direct_stream->callbacks_, true /* is_internally_created */);
+      &api_listener_->newStream(*direct_stream->callbacks_, true /* is_internally_created */);
 
   streams_.emplace(new_stream_handle, std::move(direct_stream));
   ENVOY_LOG(debug, "[S{}] start stream", new_stream_handle);

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -52,7 +52,7 @@ struct HttpClientStats {
 class Client : public Logger::Loggable<Logger::Id::http> {
 public:
   Client(ApiListenerPtr&& api_listener, Event::ProvisionalDispatcher& dispatcher,
-	 Stats::Scope& scope, Random::RandomGenerator& random)
+         Stats::Scope& scope, Random::RandomGenerator& random)
       : api_listener_(std::move(api_listener)), dispatcher_(dispatcher),
         stats_(
             HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."),

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -127,9 +127,7 @@ public:
     CONSTRUCT_ON_FIRST_USE(std::string, "client_cancelled_stream");
   }
 
-  void shutdownApiListener() {
-    api_listener_.reset();
-  }
+  void shutdownApiListener() { api_listener_.reset(); }
 
 private:
   class DirectStream;

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -51,8 +51,8 @@ struct HttpClientStats {
  */
 class Client : public Logger::Loggable<Logger::Id::http> {
 public:
-  Client(ApiListenerPtr api_listener, Event::ProvisionalDispatcher& dispatcher, Stats::Scope& scope,
-         Random::RandomGenerator& random)
+  Client(ApiListenerPtr&& api_listener, Event::ProvisionalDispatcher& dispatcher,
+	 Stats::Scope& scope, Random::RandomGenerator& random)
       : api_listener_(std::move(api_listener)), dispatcher_(dispatcher),
         stats_(
             HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."),

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -154,7 +154,8 @@ public:
   NiceMock<Random::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   bool explicit_flow_control_{GetParam()};
-  Client http_client_{std::move(owned_api_listener_), dispatcher_, *stats_store_.rootScope(), random_};
+  Client http_client_{std::move(owned_api_listener_), dispatcher_, *stats_store_.rootScope(),
+                      random_};
   envoy_stream_t stream_ = 1;
 };
 

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -362,11 +362,11 @@ private:
  */
 class HttpConnectionManagerFactory {
 public:
-  static std::function<Http::ApiListenerPtr()> createHttpConnectionManagerFactoryFromProto(
+  static std::function<Http::ApiListenerPtr(Network::ReadFilterCallbacks&)>
+  createHttpConnectionManagerFactoryFromProto(
       const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
           proto_config,
-      Server::Configuration::FactoryContext& context, Network::ReadFilterCallbacks& read_callbacks,
-      bool clear_hop_by_hop_headers);
+      Server::Configuration::FactoryContext& context, bool clear_hop_by_hop_headers);
 };
 
 /**

--- a/source/server/api_listener_impl.cc
+++ b/source/server/api_listener_impl.cc
@@ -21,8 +21,7 @@ ApiListenerImplBase::ApiListenerImplBase(const envoy::config::listener::v3::List
       address_(Network::Address::resolveProtoAddress(config.address())),
       global_scope_(server.stats().createScope("")),
       listener_scope_(server.stats().createScope(fmt::format("listener.api.{}.", name_))),
-      factory_context_(server, config_, *this, *global_scope_, *listener_scope_, isQuic(config)),
-      read_callbacks_(SyntheticReadCallbacks(*this)) {}
+      factory_context_(server, config_, *this, *global_scope_, *listener_scope_, isQuic(config)) {}
 
 void ApiListenerImplBase::SyntheticReadCallbacks::SyntheticConnection::raiseConnectionEvent(
     Network::ConnectionEvent event) {
@@ -31,9 +30,53 @@ void ApiListenerImplBase::SyntheticReadCallbacks::SyntheticConnection::raiseConn
   }
 }
 
+class HttpApiListener::HttpConnectionManagerState : public ThreadLocal::ThreadLocalObject {
+public:
+  explicit HttpConnectionManagerState(
+      std::unique_ptr<SyntheticReadCallbacks> read_callbacks,
+      std::function<Http::ApiListenerPtr(Network::ReadFilterCallbacks&)>
+          http_connection_manager_factory)
+      : read_callbacks_(std::move(read_callbacks)),
+        http_connection_manager_factory_(http_connection_manager_factory) {}
+
+  ~HttpConnectionManagerState() override {
+    // The Http::ConnectionManagerImpl is a callback target for the
+    // read_callback_.connection_. By raising connection closure,
+    // Http::ConnectionManagerImpl::onEvent is fired. In that case the
+    // Http::ConnectionManagerImpl will reset any ActiveStreams it has.
+    read_callbacks_->connection_.raiseConnectionEvent(Network::ConnectionEvent::RemoteClose);
+  }
+
+  Http::ApiListener& httpApiListener() {
+    if (http_api_listener_ == nullptr) {
+      // We need it initialize this lazily as this function depends on other
+      // thread-local state already being set up.
+      http_api_listener_ = http_connection_manager_factory_(*read_callbacks_);
+    }
+    return *http_api_listener_;
+  }
+
+  SyntheticReadCallbacks& readCallbacks() { return *read_callbacks_; }
+
+private:
+  std::unique_ptr<SyntheticReadCallbacks> read_callbacks_;
+
+  // Need to store the factory due to the shared_ptrs that need to be kept
+  // alive: date provider, route config manager, scoped route config manager.
+  std::function<Http::ApiListenerPtr(Network::ReadFilterCallbacks&)>
+      http_connection_manager_factory_;
+
+  // Http::ServerConnectionCallbacks is the API surface that this class provides
+  // via its handle().
+  std::unique_ptr<Http::ApiListener> http_api_listener_;
+};
+
 HttpApiListener::HttpApiListener(const envoy::config::listener::v3::Listener& config,
                                  Server::Instance& server, const std::string& name)
     : ApiListenerImplBase(config, server, name) {
+  std::function<Http::ApiListenerPtr(Network::ReadFilterCallbacks&)>
+      http_connection_manager_factory;
+
   if (config.api_listener().api_listener().type_url() ==
       absl::StrCat("type.googleapis.com/",
                    envoy::extensions::filters::network::http_connection_manager::v3::
@@ -44,32 +87,38 @@ HttpApiListener::HttpApiListener(const envoy::config::listener::v3::Listener& co
             EnvoyMobileHttpConnectionManager>(config.api_listener().api_listener(),
                                               factory_context_.messageValidationVisitor());
 
-    http_connection_manager_factory_ = Envoy::Extensions::NetworkFilters::HttpConnectionManager::
+    http_connection_manager_factory = Envoy::Extensions::NetworkFilters::HttpConnectionManager::
         HttpConnectionManagerFactory::createHttpConnectionManagerFactoryFromProto(
-            typed_config.config(), factory_context_, read_callbacks_, false);
+            typed_config.config(), factory_context_, false);
   } else {
     auto typed_config = MessageUtil::anyConvertAndValidate<
         envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager>(
         config.api_listener().api_listener(), factory_context_.messageValidationVisitor());
 
-    http_connection_manager_factory_ = Envoy::Extensions::NetworkFilters::HttpConnectionManager::
-        HttpConnectionManagerFactory::createHttpConnectionManagerFactoryFromProto(
-            typed_config, factory_context_, read_callbacks_, true);
+    http_connection_manager_factory =
+        Envoy::Extensions::NetworkFilters::HttpConnectionManager::HttpConnectionManagerFactory::
+            createHttpConnectionManagerFactoryFromProto(typed_config, factory_context_, true);
   }
+
+  tls_ = ThreadLocal::TypedSlot<HttpConnectionManagerState>::makeUnique(server.threadLocal());
+  tls_->set([this, http_connection_manager_factory](
+                Event::Dispatcher& dispatcher) -> std::shared_ptr<HttpConnectionManagerState> {
+    auto read_callbacks = std::make_unique<SyntheticReadCallbacks>(*this, dispatcher);
+    return std::make_shared<HttpConnectionManagerState>(std::move(read_callbacks),
+                                                        http_connection_manager_factory);
+  });
 }
 
 Http::ApiListenerOptRef HttpApiListener::http() {
-  if (!http_connection_manager_) {
-    http_connection_manager_ = http_connection_manager_factory_();
-  }
-  return Http::ApiListenerOptRef(std::ref(*http_connection_manager_));
+  OptRef<HttpConnectionManagerState> http_connection_manager_state = tls_->get();
+  return Http::ApiListenerOptRef(std::ref(http_connection_manager_state->httpApiListener()));
 }
 
-void HttpApiListener::shutdown() {
-  // The Http::ConnectionManagerImpl is a callback target for the read_callback_.connection_. By
-  // raising connection closure, Http::ConnectionManagerImpl::onEvent is fired. In that case the
-  // Http::ConnectionManagerImpl will reset any ActiveStreams it has.
-  read_callbacks_.connection_.raiseConnectionEvent(Network::ConnectionEvent::RemoteClose);
+void HttpApiListener::shutdown() { tls_.reset(); }
+
+Network::ReadFilterCallbacks& HttpApiListener::readCallbacksForTest() {
+  OptRef<HttpConnectionManagerState> http_connection_manager_state = tls_->get();
+  return http_connection_manager_state->readCallbacks();
 }
 
 } // namespace Server

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -968,13 +968,6 @@ void InstanceImpl::terminate() {
 
   // Shutdown all the workers now that the main dispatch loop is done.
   if (listener_manager_ != nullptr) {
-    // Also shutdown the listener manager's ApiListener, if there is one, which runs on the main
-    // thread. This needs to happen ahead of calling thread_local_.shutdown() below to prevent any
-    // objects in the ApiListener destructor to reference any objects in thread local storage.
-    if (listener_manager_->apiListener().has_value()) {
-      listener_manager_->apiListener()->get().shutdown();
-    }
-
     listener_manager_->stopWorkers();
   }
 

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -169,16 +169,12 @@ api_listener:
   Network::MockConnectionCallbacks network_connection_callbacks;
   // TODO(junr03): potentially figure out a way of unit testing this behavior without exposing a
   // ForTest function.
-  http_api_listener.readCallbacksForTest(*api_listener)
-      .connection()
-      .addConnectionCallbacks(network_connection_callbacks);
-  EXPECT_FALSE(http_api_listener.readCallbacksForTest(*api_listener)
-                   .connection()
-                   .lastRoundTripTime()
-                   .has_value());
-  http_api_listener.readCallbacksForTest(*api_listener)
-      .connection()
-      .configureInitialCongestionWindow(100, std::chrono::microseconds(123));
+  auto& connection = dynamic_cast<HttpApiListener::ApiListenerWrapper*>(api_listener.get())
+                         ->readCallbacks()
+                         .connection();
+  connection.addConnectionCallbacks(network_connection_callbacks);
+  EXPECT_FALSE(connection.lastRoundTripTime().has_value());
+  connection.configureInitialCongestionWindow(100, std::chrono::microseconds(123));
 
   EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
   // Shutting down the ApiListener should raise an event on all connection callback targets.

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -57,7 +57,7 @@ api_listener:
 
   ASSERT_EQ("test_api_listener", http_api_listener.name());
   ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener.type());
-  ASSERT_TRUE(http_api_listener.http().has_value());
+  ASSERT_NE(http_api_listener.createHttpApiListener(server_.dispatcher()), nullptr);
 }
 
 TEST_F(ApiListenerTest, MobileApiListener) {
@@ -92,7 +92,7 @@ api_listener:
 
   ASSERT_EQ("test_api_listener", http_api_listener.name());
   ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener.type());
-  ASSERT_TRUE(http_api_listener.http().has_value());
+  ASSERT_NE(http_api_listener.createHttpApiListener(server_.dispatcher()), nullptr);
 }
 
 TEST_F(ApiListenerTest, HttpApiListenerThrowsWithBadConfig) {
@@ -163,21 +163,26 @@ api_listener:
 
   ASSERT_EQ("test_api_listener", http_api_listener.name());
   ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener.type());
-  ASSERT_TRUE(http_api_listener.http().has_value());
+  auto api_listener = http_api_listener.createHttpApiListener(server_.dispatcher());
+  ASSERT_NE(api_listener, nullptr);
 
   Network::MockConnectionCallbacks network_connection_callbacks;
   // TODO(junr03): potentially figure out a way of unit testing this behavior without exposing a
   // ForTest function.
-  http_api_listener.readCallbacksForTest().connection().addConnectionCallbacks(
-      network_connection_callbacks);
-  EXPECT_FALSE(
-      http_api_listener.readCallbacksForTest().connection().lastRoundTripTime().has_value());
-  http_api_listener.readCallbacksForTest().connection().configureInitialCongestionWindow(
-      100, std::chrono::microseconds(123));
+  http_api_listener.readCallbacksForTest(*api_listener)
+      .connection()
+      .addConnectionCallbacks(network_connection_callbacks);
+  EXPECT_FALSE(http_api_listener.readCallbacksForTest(*api_listener)
+                   .connection()
+                   .lastRoundTripTime()
+                   .has_value());
+  http_api_listener.readCallbacksForTest(*api_listener)
+      .connection()
+      .configureInitialCongestionWindow(100, std::chrono::microseconds(123));
 
   EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::RemoteClose));
   // Shutting down the ApiListener should raise an event on all connection callback targets.
-  http_api_listener.shutdown();
+  api_listener.reset();
 }
 
 } // namespace Server


### PR DESCRIPTION
Commit Message: server: support using the ApiListener from a worker thread
Additional Description:

Before this change, the SyntheticReadCallbacks used by the ApiListener hard-coded the main thread dispatcher, resulting in dispatcher assertion failures if the ApiListener was used from a worker thread. This change allows it to use the appropriate dispatcher whether used from the main thread or a worker thread.

This change is motivated by a project at Google that needs to run synthetic requests through the Envoy filter chain at a relatively high QPS; doing so via the ApiListener seems much cleaner and more efficient than doing so via a loopback interface. Thus, to sustain a higher level of QPS efficiently, we seek to use the ApiListener from multiple worker threads in parallel.

Risk Level: Low.
Testing: test/server:api_listener_test test/integration:api_listener_integration_test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A