### PR TITLE
Deflake ManyRequestHeadersTimeout under TSAN

### DIFF
--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2332,7 +2332,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersAccepted) {
 // time-consuming byte size validations that will cause this test to timeout.
 TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersTimeout) {
   // Set timeout for 5 seconds, and ensure that a request with 10k+ headers can be sent.
-  testManyRequestHeaders(std::chrono::milliseconds(5000));
+  testManyRequestHeaders(TestUtility::DefaultTimeout * 5);
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersAccepted) {


### PR DESCRIPTION
Additional Description:
Test timeout did not take into account sanitizer slowdown factor.

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
