### PR TITLE
Envoy ext_proc filter throw exception when received response timeout Duration is too large

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -139,12 +139,12 @@ message ExternalProcessor {
   repeated string response_attributes = 6;
 
   // Specifies the timeout for each individual message sent on the stream and
-  // when the filter is running in synchronous mode. Whenever
-  // the proxy sends a message on the stream that requires a response, it will
-  // reset this timer, and will stop processing and return an error (subject
-  // to the processing mode) if the timer expires before a matching response
-  // is received. There is no timeout when the filter is running in asynchronous
-  // mode. Default is 200 milliseconds.
+  // when the filter is running in synchronous mode. Whenever the proxy sends
+  // a message on the stream that requires a response, it will reset this timer,
+  // and will stop processing and return an error (subject to the processing mode)
+  // if the timer expires before a matching response is received. There is no
+  // timeout when the filter is running in asynchronous mode. The
+  // ``message_timeout`` range is >= 0s and <= 3600s. Default is 200 milliseconds.
   google.protobuf.Duration message_timeout = 7 [(validate.rules).duration = {
     lte {seconds: 3600}
     gte {}
@@ -169,6 +169,7 @@ message ExternalProcessor {
 
   // Specify the upper bound of
   // :ref:`override_message_timeout <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.override_message_timeout>`
+  // The ``max_message_timeout`` range is >= 0s and <= 3600s.
   // If not specified, by default it is 0, which will effectively disable the ``override_message_timeout`` API.
   google.protobuf.Duration max_message_timeout = 10 [(validate.rules).duration = {
     lte {seconds: 3600}

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -145,7 +145,10 @@ message ExternalProcessor {
   // to the processing mode) if the timer expires before a matching response
   // is received. There is no timeout when the filter is running in asynchronous
   // mode. Default is 200 milliseconds.
-  google.protobuf.Duration message_timeout = 7;
+  google.protobuf.Duration message_timeout = 7 [(validate.rules).duration = {
+    lte {seconds: 3600}
+    gte {}
+  }];
 
   // Optional additional prefix to use when emitting statistics. This allows to distinguish
   // emitted statistics between configured *ext_proc* filters in an HTTP filter chain.
@@ -167,7 +170,10 @@ message ExternalProcessor {
   // Specify the upper bound of
   // :ref:`override_message_timeout <envoy_v3_api_field_service.ext_proc.v3.ProcessingResponse.override_message_timeout>`
   // If not specified, by default it is 0, which will effectively disable the ``override_message_timeout`` API.
-  google.protobuf.Duration max_message_timeout = 10;
+  google.protobuf.Duration max_message_timeout = 10 [(validate.rules).duration = {
+    lte {seconds: 3600}
+    gte {}
+  }];
 
   // Prevents clearing the route-cache when the
   // :ref:`clear_route_cache <envoy_v3_api_field_service.ext_proc.v3.CommonResponse.clear_route_cache>`

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -185,7 +185,10 @@ message ProcessingResponse {
   // :ref:`max_message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>`
   // Such message can be sent at most once in a particular Envoy ext_proc filter processing state.
   // To enable this API, one has to set ``max_message_timeout`` to a number >= 1ms.
-  google.protobuf.Duration override_message_timeout = 10;
+  google.protobuf.Duration override_message_timeout = 10 [(validate.rules).duration = {
+    lte {seconds: 3600}
+    gte {nanos: 1000000}
+  }];
 }
 
 // The following are messages that are sent to the server.

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -185,10 +185,7 @@ message ProcessingResponse {
   // :ref:`max_message_timeout <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.max_message_timeout>`
   // Such message can be sent at most once in a particular Envoy ext_proc filter processing state.
   // To enable this API, one has to set ``max_message_timeout`` to a number >= 1ms.
-  google.protobuf.Duration override_message_timeout = 10 [(validate.rules).duration = {
-    lte {seconds: 3600}
-    gte {nanos: 1000000}
-  }];
+  google.protobuf.Duration override_message_timeout = 10;
 }
 
 // The following are messages that are sent to the server.

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -645,34 +645,57 @@ ProtobufWkt::Value ValueUtil::listValue(const std::vector<ProtobufWkt::Value>& v
 
 namespace {
 
-void validateDuration(const ProtobufWkt::Duration& duration, int64_t max_seconds_value) {
+void validateDuration(const ProtobufWkt::Duration& duration, int64_t max_seconds_value,
+                      bool throw_exception, bool& error) {
+  error = false;
   if (duration.seconds() < 0 || duration.nanos() < 0) {
-    throw DurationUtil::OutOfRangeException(
-        fmt::format("Expected positive duration: {}", duration.DebugString()));
+    if (throw_exception) {
+      throw DurationUtil::OutOfRangeException(
+          fmt::format("Expected positive duration: {}", duration.DebugString()));
+    } else {
+      error = true;
+      return;
+    }
   }
   if (duration.nanos() > 999999999 || duration.seconds() > max_seconds_value) {
-    throw DurationUtil::OutOfRangeException(
-        fmt::format("Duration out-of-range: {}", duration.DebugString()));
+    if (throw_exception) {
+      throw DurationUtil::OutOfRangeException(
+          fmt::format("Duration out-of-range: {}", duration.DebugString()));
+    } else {
+      error = true;
+    }
   }
 }
 
 void validateDuration(const ProtobufWkt::Duration& duration) {
-  validateDuration(duration, Protobuf::util::TimeUtil::kDurationMaxSeconds);
+  bool error = false;
+  validateDuration(duration, Protobuf::util::TimeUtil::kDurationMaxSeconds, true, error);
 }
 
-void validateDurationAsMilliseconds(const ProtobufWkt::Duration& duration) {
+void validateDurationAsMilliseconds(const ProtobufWkt::Duration& duration, bool throw_exception,
+                                    bool& error) {
   // Apply stricter max boundary to the `seconds` value to avoid overflow.
   // Note that protobuf internally converts to nanoseconds.
   // The kMaxInt64Nanoseconds = 9223372036, which is about 300 years.
   constexpr int64_t kMaxInt64Nanoseconds =
       std::numeric_limits<int64_t>::max() / (1000 * 1000 * 1000);
-  validateDuration(duration, kMaxInt64Nanoseconds);
+  validateDuration(duration, kMaxInt64Nanoseconds, throw_exception, error);
 }
 
 } // namespace
 
 uint64_t DurationUtil::durationToMilliseconds(const ProtobufWkt::Duration& duration) {
-  validateDurationAsMilliseconds(duration);
+  bool error = false;
+  validateDurationAsMilliseconds(duration, true, error);
+  return Protobuf::util::TimeUtil::DurationToMilliseconds(duration);
+}
+
+uint64_t DurationUtil::durationToMillisecondsNoThrow(const ProtobufWkt::Duration& duration,
+                                                     bool& error) {
+  validateDurationAsMilliseconds(duration, false, error);
+  if (error) {
+    return 0;
+  }
   return Protobuf::util::TimeUtil::DurationToMilliseconds(duration);
 }
 

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -645,25 +645,21 @@ ProtobufWkt::Value ValueUtil::listValue(const std::vector<ProtobufWkt::Value>& v
 
 namespace {
 
-void validateDuration(const ProtobufWkt::Duration& duration, int64_t max_seconds_value) {
-  if (duration.seconds() < 0 || duration.nanos() < 0) {
-    throw DurationUtil::OutOfRangeException(
-        fmt::format("Expected positive duration: {}", duration.DebugString()));
-  }
-  if (duration.nanos() > 999999999 || duration.seconds() > max_seconds_value) {
-    throw DurationUtil::OutOfRangeException(
-        fmt::format("Duration out-of-range: {}", duration.DebugString()));
-  }
-}
-
-bool validateDurationErrorNoThrow(const ProtobufWkt::Duration& duration,
-                                  int64_t max_seconds_value) {
+absl::Status validateDurationNoThrow(const ProtobufWkt::Duration& duration,
+                                     int64_t max_seconds_value) {
   if (duration.seconds() < 0 || duration.nanos() < 0 || duration.nanos() > 999999999 ||
       duration.seconds() > max_seconds_value) {
     ENVOY_LOG_MISC(warn, "Duration out-of-range: {}", duration.DebugString());
-    return true;
+    return absl::OutOfRangeError("Duration out-of-range");
   }
-  return false;
+  return absl::OkStatus();
+}
+
+void validateDuration(const ProtobufWkt::Duration& duration, int64_t max_seconds_value) {
+  if (!validateDurationNoThrow(duration, max_seconds_value).ok()) {
+    throw DurationUtil::OutOfRangeException(
+        fmt::format("Duration out-of-range: {}", duration.DebugString()));
+  }
 }
 
 void validateDuration(const ProtobufWkt::Duration& duration) {
@@ -679,13 +675,10 @@ void validateDurationAsMilliseconds(const ProtobufWkt::Duration& duration) {
   validateDuration(duration, kMaxInt64Nanoseconds);
 }
 
-bool validateDurationAsMillisecondsErrorNoThrow(const ProtobufWkt::Duration& duration) {
-  // Apply stricter max boundary to the `seconds` value to avoid overflow.
-  // Note that protobuf internally converts to nanoseconds.
-  // The kMaxInt64Nanoseconds = 9223372036, which is about 300 years.
+absl::Status validateDurationAsMillisecondsNoThrow(const ProtobufWkt::Duration& duration) {
   constexpr int64_t kMaxInt64Nanoseconds =
       std::numeric_limits<int64_t>::max() / (1000 * 1000 * 1000);
-  return validateDurationErrorNoThrow(duration, kMaxInt64Nanoseconds);
+  return validateDurationNoThrow(duration, kMaxInt64Nanoseconds);
 }
 
 } // namespace
@@ -697,7 +690,7 @@ uint64_t DurationUtil::durationToMilliseconds(const ProtobufWkt::Duration& durat
 
 uint64_t DurationUtil::durationToMillisecondsNoThrow(const ProtobufWkt::Duration& duration,
                                                      bool& error) {
-  if ((error = validateDurationAsMillisecondsErrorNoThrow(duration))) {
+  if ((error = !validateDurationAsMillisecondsNoThrow(duration).ok())) {
     return 0;
   }
   return Protobuf::util::TimeUtil::DurationToMilliseconds(duration);

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -15,6 +15,7 @@
 #include "source/common/singleton/const_singleton.h"
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/str_join.h"
 
 // Obtain the value of a wrapped field (e.g. google.protobuf.UInt32Value) if set. Otherwise, return
@@ -685,12 +686,11 @@ public:
 
   /**
    * Same as DurationUtil::durationToMilliseconds but does not throw an exception.
-   * Instead, it returns error if duration is out-of-range.
    * @param duration protobuf.
-   * @param error bool, set into true in case of duration out-of-range; otherwise false.
-   * @return duration in milliseconds.
+   * @return duration in milliseconds or an error status.
    */
-  static uint64_t durationToMillisecondsNoThrow(const ProtobufWkt::Duration& duration, bool& error);
+  static absl::StatusOr<uint64_t>
+  durationToMillisecondsNoThrow(const ProtobufWkt::Duration& duration);
 
   /**
    * Same as Protobuf::util::TimeUtil::DurationToSeconds but with extra validation logic.

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -684,6 +684,15 @@ public:
   static uint64_t durationToMilliseconds(const ProtobufWkt::Duration& duration);
 
   /**
+   * Same as DurationUtil::durationToMilliseconds but does not throw an exception.
+   * Instead, it returns error if duration is out-of-range.
+   * @param duration protobuf.
+   * @param error bool, set into true in case of duration out-of-range; otherwise false.
+   * @return duration in milliseconds.
+   */
+  static uint64_t durationToMillisecondsNoThrow(const ProtobufWkt::Duration& duration, bool& error);
+
+  /**
    * Same as Protobuf::util::TimeUtil::DurationToSeconds but with extra validation logic.
    * Specifically, we ensure that the duration is positive.
    * @param duration protobuf.

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -191,7 +191,7 @@ public:
   void onGrpcClose() override;
 
   void onMessageTimeout();
-  void onNewTimeout(const uint32_t message_timeout_ms);
+  void onNewTimeout(const ProtobufWkt::Duration& override_message_timeout);
 
   void sendBufferedData(ProcessorState& state, ProcessorState::CallbackState new_state,
                         bool end_stream) {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1711,54 +1711,43 @@ TEST(DurationUtilTest, NoThrow) {
     ProtobufWkt::Duration duration;
     duration.set_seconds(5);
     duration.set_nanos(10000000);
-    bool error = false;
-    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
-    EXPECT_FALSE(error);
-    EXPECT_TRUE(ms == 5010);
+    const auto result = DurationUtil::durationToMillisecondsNoThrow(duration);
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(result.value() == 5010);
   }
 
   // Below are out-of-range tests
   {
     ProtobufWkt::Duration duration;
     duration.set_seconds(-1);
-    bool error = false;
-    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
-    EXPECT_TRUE(error);
-    EXPECT_TRUE(ms == 0);
+    const auto result = DurationUtil::durationToMillisecondsNoThrow(duration);
+    EXPECT_FALSE(result.ok());
   }
   {
     ProtobufWkt::Duration duration;
     duration.set_nanos(-1);
-    bool error = false;
-    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
-    EXPECT_TRUE(error);
-    EXPECT_TRUE(ms == 0);
+    const auto result = DurationUtil::durationToMillisecondsNoThrow(duration);
+    EXPECT_FALSE(result.ok());
   }
   {
     ProtobufWkt::Duration duration;
     duration.set_nanos(1000000000);
-    bool error = false;
-    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
-    EXPECT_TRUE(error);
-    EXPECT_TRUE(ms == 0);
+    const auto result = DurationUtil::durationToMillisecondsNoThrow(duration);
+    EXPECT_FALSE(result.ok());
   }
   {
     ProtobufWkt::Duration duration;
     duration.set_seconds(Protobuf::util::TimeUtil::kDurationMaxSeconds + 1);
-    bool error = false;
-    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
-    EXPECT_TRUE(error);
-    EXPECT_TRUE(ms == 0);
+    const auto result = DurationUtil::durationToMillisecondsNoThrow(duration);
+    EXPECT_FALSE(result.ok());
   }
   {
     ProtobufWkt::Duration duration;
     constexpr int64_t kMaxInt64Nanoseconds =
         std::numeric_limits<int64_t>::max() / (1000 * 1000 * 1000);
     duration.set_seconds(kMaxInt64Nanoseconds + 1);
-    bool error = false;
-    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
-    EXPECT_TRUE(error);
-    EXPECT_TRUE(ms == 0);
+    const auto result = DurationUtil::durationToMillisecondsNoThrow(duration);
+    EXPECT_FALSE(result.ok());
   }
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1705,6 +1705,63 @@ TEST(DurationUtilTest, OutOfRange) {
   }
 }
 
+TEST(DurationUtilTest, NoThrow) {
+  {
+    // In range test
+    ProtobufWkt::Duration duration;
+    duration.set_seconds(5);
+    duration.set_nanos(10000000);
+    bool error = false;
+    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
+    EXPECT_FALSE(error);
+    EXPECT_TRUE(ms == 5010);
+  }
+
+  // Below are out-of-range tests
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_seconds(-1);
+    bool error = false;
+    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
+    EXPECT_TRUE(error);
+    EXPECT_TRUE(ms == 0);
+  }
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_nanos(-1);
+    bool error = false;
+    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
+    EXPECT_TRUE(error);
+    EXPECT_TRUE(ms == 0);
+  }
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_nanos(1000000000);
+    bool error = false;
+    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
+    EXPECT_TRUE(error);
+    EXPECT_TRUE(ms == 0);
+  }
+  {
+    ProtobufWkt::Duration duration;
+    duration.set_seconds(Protobuf::util::TimeUtil::kDurationMaxSeconds + 1);
+    bool error = false;
+    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
+    EXPECT_TRUE(error);
+    EXPECT_TRUE(ms == 0);
+  }
+  {
+    ProtobufWkt::Duration duration;
+    constexpr int64_t kMaxInt64Nanoseconds =
+        std::numeric_limits<int64_t>::max() / (1000 * 1000 * 1000);
+    duration.set_seconds(kMaxInt64Nanoseconds + 1);
+    bool error = false;
+    auto ms = DurationUtil::durationToMillisecondsNoThrow(duration, error);
+    EXPECT_TRUE(error);
+    EXPECT_TRUE(ms == 0);
+  }
+}
+
 // Verify WIP accounting of the file based annotations. This test uses the strict validator to test
 // that code path.
 TEST_F(ProtobufUtilityTest, MessageInWipFile) {

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1960,7 +1960,7 @@ TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutNegativeTestTimeoutNotAcc
   newTimeoutWrongConfigTest(500);
 }
 
-// Send the new timeout to be an extremely large number, which will trigger exception being thrown.
+// Send the new timeout to be an extremely large number, which is out-of-range of duration.
 // Verify the code appropriately handled it.
 TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutOutOfBounds) {
   // Config max_message_timeout proto to 100ms to enable the new timeout API.

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -315,7 +315,7 @@ protected:
 
   // ext_proc server sends back a response to tell Envoy to stop the
   // original timer and start a new timer.
-  void serverSendNewTimeout(const uint32_t timeout_ms) {
+  void serverSendNewTimeout(const uint64_t timeout_ms) {
     ProcessingResponse response;
     if (timeout_ms < 1000) {
       response.mutable_override_message_timeout()->set_nanos(timeout_ms * 1000000);
@@ -327,7 +327,7 @@ protected:
 
   // The new timeout message is ignored by Envoy due to different reasons, like
   // new_timeout setting is out-of-range, or max_message_timeout is not configured.
-  void newTimeoutWrongConfigTest(const uint32_t timeout_ms) {
+  void newTimeoutWrongConfigTest(const uint64_t timeout_ms) {
     // Set envoy filter timeout to be 200ms.
     proto_config_.mutable_message_timeout()->set_nanos(200000000);
     // Config max_message_timeout proto to enable the new timeout API.
@@ -1958,6 +1958,15 @@ TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutNegativeTestTimeoutTooBig
 // Not setting the max_message_timeout effectively disabled the new timeout API.
 TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutNegativeTestTimeoutNotAcceptedDefaultMax) {
   newTimeoutWrongConfigTest(500);
+}
+
+// Send the new timeout to be an extremely large number, which will trigger exception being thrown.
+// Verify the code appropriately handled it.
+TEST_P(ExtProcIntegrationTest, RequestMessageNewTimeoutOutOfBounds) {
+  // Config max_message_timeout proto to 100ms to enable the new timeout API.
+  max_message_timeout_ms_ = 100;
+  const uint64_t override_message_timeout = 1000000000000000;
+  newTimeoutWrongConfigTest(override_message_timeout);
 }
 
 } // namespace Envoy

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/crash-caae576f1c5a5c4bd6f831dd7d159b2504f476b0
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/crash-caae576f1c5a5c4bd6f831dd7d159b2504f476b0
@@ -1,0 +1,36 @@
+config {
+  grpc_service {
+    envoy_grpc {
+      cluster_name: "#"
+      retry_policy {
+        retry_back_off {
+          base_interval {
+            seconds: 137438953472
+          }
+        }
+      }
+    }
+    timeout {
+      seconds: 137438953472
+      nanos: 655360
+    }
+  }
+  request_attributes: "#"
+  message_timeout {
+    seconds: 137438953472
+  }
+  max_message_timeout {
+    seconds: 137438953472
+  }
+  disable_clear_route_cache: true
+}
+request {
+}
+response {
+  request_headers {
+  }
+  override_message_timeout {
+    seconds: 137438953472
+    nanos: 655360
+  }
+}


### PR DESCRIPTION
Properly handle dataplane exception when received response timeout Duration is too large.

Also adding PGVs for ext_proc filter config.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
