### PR TITLE
Runtime: reinstate yaml behavior when using strings instead of structs

### DIFF
--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -26,6 +26,7 @@
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
+#include "re2/re2.h"
 
 #ifdef ENVOY_ENABLE_QUIC
 #include "quiche_platform_impl/quiche_flags_impl.h"
@@ -271,22 +272,24 @@ void parseEntryDoubleValue(Envoy::Runtime::Snapshot::Entry& entry) {
   }
 }
 
-// Handle an absolutely awful corner case where we explicitly shove a yaml percent in a proto string
-// value.
+// Handle an awful corner case where we explicitly shove a yaml percent in a proto string
+// value. Basically due to prior paring logic we have to handle any combination
+// of numerator: #### [denominator Y] with quotes braces etc that could possibly be valid json.
+// E.g. "final_value": "{\"numerator\": 10000, \"denominator\": \"TEN_THOUSAND\"}",
 void parseEntryFractionalPercentValue(Envoy::Runtime::Snapshot::Entry& entry) {
   if (!absl::StrContains(entry.raw_string_value_, "numerator")) {
     return;
   }
 
-  const std::regex numerator_re(".*numerator[^\\d]+(\\d+)[^\\d]*");
+  const re2::RE2 numerator_re(".*numerator[^\\d]+(\\d+)[^\\d]*");
 
-  std::cmatch match;
-  if (!std::regex_match(entry.raw_string_value_.c_str(), match, numerator_re)) {
+  std::string match_string;
+  if (!re2::RE2::FullMatch(entry.raw_string_value_.c_str(), numerator_re, &match_string)) {
     return;
   }
 
   uint32_t numerator;
-  if (!absl::SimpleAtoi(match.str(1), &numerator)) {
+  if (!absl::SimpleAtoi(match_string, &numerator)) {
     return;
   }
   envoy::type::v3::FractionalPercent converted_fractional_percent;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -273,7 +273,7 @@ void parseEntryDoubleValue(Envoy::Runtime::Snapshot::Entry& entry) {
 }
 
 // Handle an awful corner case where we explicitly shove a yaml percent in a proto string
-// value. Basically due to prior paring logic we have to handle any combination
+// value. Basically due to prior parsing logic we have to handle any combination
 // of numerator: #### [denominator Y] with quotes braces etc that could possibly be valid json.
 // E.g. "final_value": "{\"numerator\": 10000, \"denominator\": \"TEN_THOUSAND\"}",
 void parseEntryFractionalPercentValue(Envoy::Runtime::Snapshot::Entry& entry) {

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -741,7 +741,7 @@ TEST_F(StaticLoaderImplTest, ProtoParsing) {
   const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
       .createEntry(empty_value);
 
-  // make sure the hacky fractional percent function works.
+  // Make sure the hacky fractional percent function works.
   ProtobufWkt::Value fractional_value;
   fractional_value.set_string_value(" numerator:  11 ");
   auto entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
@@ -769,7 +769,7 @@ TEST_F(StaticLoaderImplTest, ProtoParsing) {
             envoy::type::v3::FractionalPercent::MILLION);
   EXPECT_EQ(entry.fractional_percent_value_->numerator(), 10000);
 
-  // test atoi failure for the hacky fractional percent value function.
+  // Test atoi failure for the hacky fractional percent value function.
   fractional_value.set_string_value(" numerator:  1.1 ");
   entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
               .createEntry(fractional_value);

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -740,6 +740,40 @@ TEST_F(StaticLoaderImplTest, ProtoParsing) {
   ProtobufWkt::Value empty_value;
   const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
       .createEntry(empty_value);
+
+  // make sure the hacky fractional percent function works.
+  ProtobufWkt::Value fractional_value;
+  fractional_value.set_string_value(" numerator:  11 ");
+  auto entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
+                   .createEntry(fractional_value);
+  ASSERT_TRUE(entry.fractional_percent_value_.has_value());
+  EXPECT_EQ(entry.fractional_percent_value_->denominator(),
+            envoy::type::v3::FractionalPercent::HUNDRED);
+  EXPECT_EQ(entry.fractional_percent_value_->numerator(), 11);
+
+  // Make sure the hacky percent function works with numerator and denominator
+  fractional_value.set_string_value("{\"numerator\": 10000, \"denominator\": \"TEN_THOUSAND\"}");
+  entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
+              .createEntry(fractional_value);
+  ASSERT_TRUE(entry.fractional_percent_value_.has_value());
+  EXPECT_EQ(entry.fractional_percent_value_->denominator(),
+            envoy::type::v3::FractionalPercent::TEN_THOUSAND);
+  EXPECT_EQ(entry.fractional_percent_value_->numerator(), 10000);
+
+  // Make sure the hacky fractional percent function works with nullion
+  fractional_value.set_string_value("{\"numerator\": 10000, \"denominator\": \"MILLION\"}");
+  entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
+              .createEntry(fractional_value);
+  ASSERT_TRUE(entry.fractional_percent_value_.has_value());
+  EXPECT_EQ(entry.fractional_percent_value_->denominator(),
+            envoy::type::v3::FractionalPercent::MILLION);
+  EXPECT_EQ(entry.fractional_percent_value_->numerator(), 10000);
+
+  // test atoi failure for the hacky fractional precent value function.
+  fractional_value.set_string_value(" numerator:  1.1 ");
+  entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
+              .createEntry(fractional_value);
+  ASSERT_FALSE(entry.fractional_percent_value_.has_value());
 }
 
 TEST_F(StaticLoaderImplTest, InvalidNumerator) {

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -760,7 +760,7 @@ TEST_F(StaticLoaderImplTest, ProtoParsing) {
             envoy::type::v3::FractionalPercent::TEN_THOUSAND);
   EXPECT_EQ(entry.fractional_percent_value_->numerator(), 10000);
 
-  // Make sure the hacky fractional percent function works with nullion
+  // Make sure the hacky fractional percent function works with million
   fractional_value.set_string_value("{\"numerator\": 10000, \"denominator\": \"MILLION\"}");
   entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
               .createEntry(fractional_value);
@@ -769,7 +769,7 @@ TEST_F(StaticLoaderImplTest, ProtoParsing) {
             envoy::type::v3::FractionalPercent::MILLION);
   EXPECT_EQ(entry.fractional_percent_value_->numerator(), 10000);
 
-  // test atoi failure for the hacky fractional precent value function.
+  // test atoi failure for the hacky fractional percent value function.
   fractional_value.set_string_value(" numerator:  1.1 ");
   entry = const_cast<SnapshotImpl&>(dynamic_cast<const SnapshotImpl&>(loader_->snapshot()))
               .createEntry(fractional_value);

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -199,6 +199,7 @@ paths:
     - source/server/admin/stats_request.cc
     - source/server/admin/utils.h
     - source/server/admin/utils.cc
+    - source/common/runtime/runtime_impl.cc
     - tools/clang_tools/api_booster/main.cc
     - tools/clang_tools/api_booster/proto_cxx_utils.cc
 

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -87,6 +87,9 @@ paths:
   exception:
     include:
     - source/common/config/utility.h
+    - source/common/matcher/map_matcher.h
+    - source/common/matcher/field_matcher.h
+    - source/extensions/common/matcher/trie_matcher.h
     # These files should not throw exceptions. Add HTTP/1 when exceptions removed.
     exclude:
     - source/common/http/http2/codec_impl.h
@@ -153,6 +156,7 @@ paths:
     - test/test_common/test_time.h
     - test/test_common/utility.cc
     - test/tools/wee8_compile/wee8_compile.cc
+    - test/extensions/filters/http/stateful_session/stateful_session_integration_test.cc
 
   # Tests in these paths may make use of the Registry::RegisterFactory constructor or the
   # REGISTER_FACTORY macro. Other locations should use the InjectFactory helper class to
@@ -199,7 +203,6 @@ paths:
     - source/server/admin/stats_request.cc
     - source/server/admin/utils.h
     - source/server/admin/utils.cc
-    - source/common/runtime/runtime_impl.cc
     - tools/clang_tools/api_booster/main.cc
     - tools/clang_tools/api_booster/proto_cxx_utils.cc
 


### PR DESCRIPTION
reinstates prior behavior when parsing "buggy" yaml, where fractional structs are encoded as strings.  Previously when doing a round trip from json -> proto -> json this formatting would be parsed, so doing some string checks to support it going forward

Risk Level: low
Testing: new unit tests
Docs Changes: n/a
Release Notes: n/a
Fixes commit #PR: https://github.com/envoyproxy/envoy/pull/26451
