### PR TITLE
sub-formatter: fix wrong handling of UPSTREAM_WIRE_BYTES_RECEIVED

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -974,7 +974,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getUpstreamBytesMeter()->wireBytesReceived();
+                                    auto bytes_meter = stream_info.getUpstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->wireBytesReceived() : 0;
                                   });
                             }}},
                           {"UPSTREAM_HEADER_BYTES_RECEIVED",

--- a/test/common/router/route_corpus/wrong_UPSTREAM_WIRE_BYTES_RECEIVED
+++ b/test/common/router/route_corpus/wrong_UPSTREAM_WIRE_BYTES_RECEIVED
@@ -1,0 +1,27 @@
+config {
+  virtual_hosts {
+    name: "eMn"
+    domains: "*"
+    matcher {
+      on_no_match {
+        action {
+          name: "%"
+          typed_config {
+            type_url: "/envoy.config.route.v3.Route"
+            value: "\n\002\n\000\022\003\n\001~J\217\007\n\214\007\n\001~\022\206\007`%START_TIME()%\00184\177\177\177%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%UPSTREAM_WIRE_BYTES_RECEIVED%%%%UPSTREAM_TLS_SESSION_ID%%%%%%%%%%%%%%%%%%%%%%%%REQUEST_TX_DURATION%%%%%%UPSTREAM_WIRE_BYTES_RECEIVED%%%%UPSTREAM_TLS_SESSION_ID%%%%%%UPSTREAM_TLS_SESSION_ID%%%%%%%%%%%%%%%%%%%%%%%%%%%%%VTSTNAME%START_TIME(/TIME%_%%%%%%%%%%%%%%%%%%%%%%%%%%_)%TA\177\177?\017%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%REQUEST_TX_DURATION%%%%%%UPSTREAM_WIRE_BYTES_RECEIVED%%%%UPSTREAM_TLS_SESSION_ID%%%%%%UPSTREAM_TLS_SESSION_ID%%%%%%%%%%%%%%%%%%%%%%%%%%%%%VTSTNAM%%%%%%%%%%%%%%%%%%%%%%%%%UPSTREAM_WIRE_BYTES_RECEIVED%%%%UPSTREAM_TLS_SESSION_ID%%%%%%%%%%%%%%%%%%%%%%%%REQUEST_TX_DURATION%%%%%%UPSTREAM_WIRE_BYTES_RECEIVED%%%%UPSTREAM_TLS_SESSION_ID%%%%%%UPSTREAM_TLS_SESSION_ID%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%E%START_TIME(/TIME%_%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%SSION_ID(%%%%%%%%%SSION_ID(%%%%_)%TA"
+          }
+        }
+      }
+    }
+  }
+  ignore_port_in_host_matching: true
+}
+headers {
+  headers {
+    key: ":path"
+  }
+  headers {
+    key: "x-forwarded-proto"
+    value: "2"
+  }
+}


### PR DESCRIPTION
Commit Message: substitution formatter fix wrong handling of UPSTREAM_WIRE_BYTES_RECEIVED
Additional Description:
Fixing a possible null-pointer access when formatting `UPSTREAM_WIRE_BYTES_RECEIVED`. This requires a wrong config.

Risk Level: low
Testing: added fuzz test.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes fuzz bug [58747](https://oss-fuzz.com/testcase-detail/6553814881927168)
