### PR TITLE
[Mobile] Use SystemHelper abstraction for remaining mobile C++ integration tests

### DIFF
--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -1,5 +1,3 @@
-#include "source/common/common/assert.h"
-
 #include "library/common/common/default_system_helper.h"
 #include "library/common/jni/android_jni_utility.h"
 #include "library/common/jni/android_network_utility.h"

--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -1,3 +1,5 @@
+#include "source/common/common/assert.h"
+
 #include "library/common/common/default_system_helper.h"
 #include "library/common/jni/android_jni_utility.h"
 #include "library/common/jni/android_network_utility.h"

--- a/mobile/test/common/BUILD
+++ b/mobile/test/common/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test(
         "//library/common/data:utility_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
+        "//test/common/mocks/common:common_mocks",
         "//test/common/mocks/event:event_mocks",
         "@envoy//test/common/http:common_lib",
         "@envoy_build_config//:test_extensions",

--- a/mobile/test/common/http/BUILD
+++ b/mobile/test/common/http/BUILD
@@ -12,6 +12,7 @@ envoy_cc_test(
         "//library/common/http:client_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
+        "//test/common/mocks/common:common_mocks",
         "//test/common/mocks/event:event_mocks",
         "@envoy//source/common/http:context_lib",
         "@envoy//source/common/stats:isolated_store_lib",

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -5,6 +5,7 @@
 #include "source/common/stats/isolated_store_impl.h"
 
 #include "test/common/http/common.h"
+#include "test/common/mocks/common/mocks.h"
 #include "test/common/mocks/event/mocks.h"
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/event/mocks.h"
@@ -111,6 +112,9 @@ public:
       cc->on_trailers_calls++;
       return nullptr;
     };
+    helper_handle_ = test::SystemHelperPeer::replaceSystemHelper();
+    EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_))
+        .WillRepeatedly(Return(true));
   }
 
   envoy_headers defaultRequestHeaders() {
@@ -155,6 +159,9 @@ public:
   bool explicit_flow_control_{GetParam()};
   Client http_client_{api_listener_, dispatcher_, *stats_store_.rootScope(), random_};
   envoy_stream_t stream_ = 1;
+
+protected:
+  std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
 };
 
 INSTANTIATE_TEST_SUITE_P(TestModes, ClientTest, ::testing::Bool());

--- a/mobile/test/common/main_interface_test.cc
+++ b/mobile/test/common/main_interface_test.cc
@@ -1,6 +1,7 @@
 #include "source/common/common/assert.h"
 
 #include "test/common/http/common.h"
+#include "test/common/mocks/common/mocks.h"
 
 #include "absl/synchronization/notification.h"
 #include "gmock/gmock.h"
@@ -12,7 +13,8 @@
 #include "library/common/main_interface.h"
 
 using testing::_;
-using testing::HasSubstr;
+using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 
@@ -131,7 +133,19 @@ Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   return transformed_headers;
 }
 
-TEST(MainInterfaceTest, BasicStream) {
+class MainInterfaceTest : public testing::Test {
+public:
+  void SetUp() override {
+    helper_handle_ = test::SystemHelperPeer::replaceSystemHelper();
+    EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_))
+        .WillRepeatedly(Return(true));
+  }
+
+protected:
+  std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
+};
+
+TEST_F(MainInterfaceTest, BasicStream) {
   const std::string level = "debug";
   engine_test_context engine_cbs_context{};
   envoy_engine_callbacks engine_cbs{[](void* context) -> void {
@@ -195,7 +209,7 @@ TEST(MainInterfaceTest, BasicStream) {
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
 
-TEST(MainInterfaceTest, SendMetadata) {
+TEST_F(MainInterfaceTest, SendMetadata) {
   engine_test_context engine_cbs_context{};
   envoy_engine_callbacks engine_cbs{[](void* context) -> void {
                                       auto* engine_running =
@@ -235,7 +249,7 @@ TEST(MainInterfaceTest, SendMetadata) {
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
 
-TEST(MainInterfaceTest, ResetStream) {
+TEST_F(MainInterfaceTest, ResetStream) {
   engine_test_context engine_cbs_context{};
   envoy_engine_callbacks engine_cbs{[](void* context) -> void {
                                       auto* engine_running =
@@ -285,7 +299,7 @@ TEST(MainInterfaceTest, ResetStream) {
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
 
-TEST(MainInterfaceTest, UsingMainInterfaceWithoutARunningEngine) {
+TEST_F(MainInterfaceTest, UsingMainInterfaceWithoutARunningEngine) {
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
@@ -307,7 +321,7 @@ TEST(MainInterfaceTest, UsingMainInterfaceWithoutARunningEngine) {
   release_envoy_headers(c_trailers);
 }
 
-TEST(MainInterfaceTest, RegisterPlatformApi) {
+TEST_F(MainInterfaceTest, RegisterPlatformApi) {
   engine_test_context engine_cbs_context{};
   envoy_engine_callbacks engine_cbs{[](void* context) -> void {
                                       auto* engine_running =
@@ -335,7 +349,7 @@ TEST(MainInterfaceTest, RegisterPlatformApi) {
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
 
-TEST(MainInterfaceTest, PreferredNetwork) {
+TEST_F(MainInterfaceTest, PreferredNetwork) {
   EXPECT_EQ(ENVOY_SUCCESS, set_preferred_network(0, ENVOY_NET_WLAN));
 }
 
@@ -557,7 +571,7 @@ TEST(EngineTest, EventTrackerRegistersEnvoyBugRecordAction) {
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
-TEST(MainInterfaceTest, ResetConnectivityState) {
+TEST_F(MainInterfaceTest, ResetConnectivityState) {
   engine_test_context test_context{};
   envoy_engine_callbacks engine_cbs{[](void* context) -> void {
                                       auto* engine_running =

--- a/mobile/test/common/main_interface_test.cc
+++ b/mobile/test/common/main_interface_test.cc
@@ -13,6 +13,7 @@
 #include "library/common/main_interface.h"
 
 using testing::_;
+using testing::HasSubstr;
 using testing::Return;
 using testing::ReturnRef;
 


### PR DESCRIPTION
This is a follow-up to https://github.com/envoyproxy/envoy/pull/27237 applying the same fix to the remaining 2 tests which needed it.  

Tested by forcing the system_helper to use android, verifying tests fail, and then fixing it via this change.