### PR TITLE
Flake: Fix flake OverloadIntegrationTest.NoNewStreamsWhenOverloaded

### DIFF
--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_integration_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_integration_test.cc
@@ -86,6 +86,7 @@ public:
                       injected_resource_filename_1_, injected_resource_filename_2_);
       *bootstrap.mutable_overload_manager() =
           TestUtility::parseYaml<envoy::config::overload::v3::OverloadManager>(overload_config);
+      bootstrap.set_enable_dispatcher_stats(true);
     });
 
     updateResource(file_updater_1_, 0);
@@ -137,9 +138,6 @@ TEST_P(OverloadIntegrationTest, StopAcceptingConnectionsWhenOverloaded) {
 }
 
 TEST_P(OverloadIntegrationTest, NoNewStreamsWhenOverloaded) {
-  // For https://github.com/envoyproxy/envoy/issues/26264
-  // Set to trace since unable to reproduce issue locally.
-  LogLevelSetter save_levels(spdlog::level::trace);
   initialize();
   updateResource(file_updater_1_, 0.7);
 
@@ -158,6 +156,18 @@ TEST_P(OverloadIntegrationTest, NoNewStreamsWhenOverloaded) {
   // encoding the headers.
   updateResource(file_updater_2_, 0.9);
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.disable_http_keepalive.active", 1);
+
+  // The call to disable keep alive could take some time to be executed on the worker
+  // even if the stat on the main thread is shows the action is enabled.
+  // Waiting for additional dispatch loops on the worker so that the overload
+  // state will have propagated.
+  auto worker_dispatch_duration_histogram =
+      test_server_->histogram("listener_manager.worker_0.dispatcher.loop_duration_us");
+  const uint64_t num_samples = TestUtility::readSampleCount(test_server_->server().dispatcher(),
+                                                            *worker_dispatch_duration_histogram);
+  const uint64_t required_num_samples = num_samples + 2;
+  test_server_->waitForNumHistogramSamplesGe(
+      "listener_manager.worker_0.dispatcher.loop_duration_us", required_num_samples);
 
   upstream_request_->encodeHeaders(default_response_headers_, /*end_stream=*/false);
   upstream_request_->encodeData(10, true);

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -475,8 +475,14 @@ public:
   void waitUntilHistogramHasSamples(
       const std::string& name,
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) override {
-    ASSERT_TRUE(TestUtility::waitUntilHistogramHasSamples(statStore(), name, time_system_,
-                                                          server().dispatcher(), timeout));
+    waitForNumHistogramSamplesGe(name, 1, timeout);
+  }
+
+  void waitForNumHistogramSamplesGe(
+      const std::string& name, uint64_t sample_count,
+      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) override {
+    ASSERT_TRUE(TestUtility::waitForNumHistogramSamplesGe(
+        statStore(), name, sample_count, time_system_, server().dispatcher(), timeout));
   }
 
   Stats::CounterSharedPtr counter(const std::string& name) override {

--- a/test/integration/server_stats.h
+++ b/test/integration/server_stats.h
@@ -47,6 +47,16 @@ public:
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) PURE;
 
   /**
+   * Wait until a histogram has at least sample_count samples.
+   * @param name histogram name.
+   * @param sample_count the number of samples the histogram should at least
+   * have.
+   */
+  virtual void waitForNumHistogramSamplesGe(
+      const std::string& name, uint64_t sample_count,
+      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) PURE;
+
+  /**
    * Wait for a gauge to >= a given value.
    * @param name gauge name.
    * @param value target value.

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -236,8 +236,9 @@ AssertionResult TestUtility::waitForGaugeDestroyed(Stats::Store& store, const st
   return AssertionSuccess();
 }
 
-AssertionResult TestUtility::waitUntilHistogramHasSamples(Stats::Store& store,
+AssertionResult TestUtility::waitForNumHistogramSamplesGe(Stats::Store& store,
                                                           const std::string& name,
+                                                          uint64_t min_sample_count_required,
                                                           Event::TestTimeSystem& time_system,
                                                           Event::Dispatcher& main_dispatcher,
                                                           std::chrono::milliseconds timeout) {
@@ -246,7 +247,7 @@ AssertionResult TestUtility::waitUntilHistogramHasSamples(Stats::Store& store,
     auto histo = findByName<Stats::ParentHistogramSharedPtr>(store.histograms(), name);
     if (histo) {
       uint64_t sample_count = readSampleCount(main_dispatcher, *histo);
-      if (sample_count) {
+      if (sample_count >= min_sample_count_required) {
         break;
       }
     }
@@ -254,10 +255,19 @@ AssertionResult TestUtility::waitUntilHistogramHasSamples(Stats::Store& store,
     time_system.advanceTimeWait(std::chrono::milliseconds(10));
 
     if (timeout != std::chrono::milliseconds::zero() && !bound.withinBound()) {
-      return AssertionFailure() << fmt::format("timed out waiting for {} to have samples", name);
+      return AssertionFailure() << fmt::format("timed out waiting for {} to have {} samples", name,
+                                               min_sample_count_required);
     }
   }
   return AssertionSuccess();
+}
+
+AssertionResult TestUtility::waitUntilHistogramHasSamples(Stats::Store& store,
+                                                          const std::string& name,
+                                                          Event::TestTimeSystem& time_system,
+                                                          Event::Dispatcher& main_dispatcher,
+                                                          std::chrono::milliseconds timeout) {
+  return waitForNumHistogramSamplesGe(store, name, 1, time_system, main_dispatcher, timeout);
 }
 
 uint64_t TestUtility::readSampleCount(Event::Dispatcher& main_dispatcher,

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -307,6 +307,20 @@ public:
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
 
   /**
+   * Wait for a histogram to have samples.
+   * @param store supplies the stats store.
+   * @param name histogram name.
+   * @param time_system the time system to use for waiting.
+   * @param timeout the maximum time to wait before timing out, or 0 for no timeout.
+   * @return AssertionSuccess() if the histogram was populated within the timeout, else
+   * AssertionFailure().
+   */
+  static AssertionResult waitForNumHistogramSamplesGe(
+      Stats::Store& store, const std::string& name, uint64_t min_sample_count_required,
+      Event::TestTimeSystem& time_system, Event::Dispatcher& main_dispatcher,
+      std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
+
+  /**
    * Read a histogram's sample count from the main thread.
    * @param store supplies the stats store.
    * @param name histogram name.


### PR DESCRIPTION
state is propagated to the worker.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Flake: Fix flake OverloadIntegrationTest.NoNewStreamsWhenOverloaded
Additional Description: Flake: Fix rare flake that can occur if the response is encoded before overload state is propagated to the worker. See https://source.cloud.google.com/results/invocations/aebfdb13-c078-4bdf-922c-dbd8838d72b6/targets/@envoy%2F%2Ftest%2Fextensions%2Fresource_monitors%2Finjected_resource:injected_resource_monitor_integration_test/log for example of failed run with trace to understand the flake failure mode.
Risk Level: low
Testing: fixed test
Docs Changes: na
Release Notes: na
Platform Specific Features: na
[Optional Runtime guard:] na
Fixes #26264

