### PR TITLE
contrib: enable build with boringssl_fips

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -1,4 +1,9 @@
-load("//bazel:envoy_build_system.bzl", "envoy_cmake", "envoy_package")
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cmake",
+    "envoy_package",
+    "envoy_select_boringssl",
+)
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 licenses(["notice"])  # Apache 2
@@ -198,7 +203,10 @@ envoy_cmake(
     lib_source = "@com_github_google_libsxg//:all",
     out_static_libs = ["libsxg.a"],
     tags = ["skip_on_windows"],
-    deps = ["@boringssl//:ssl"],
+    deps = envoy_select_boringssl(
+        ["@boringssl_fips//:ssl"],
+        ["@boringssl//:ssl"],
+    ),
 )
 
 envoy_cmake(

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -1,8 +1,4 @@
-load(
-    "//bazel:envoy_build_system.bzl",
-    "envoy_cmake",
-    "envoy_package",
-)
+load("//bazel:envoy_build_system.bzl", "envoy_cmake", "envoy_package")
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 licenses(["notice"])  # Apache 2

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -2,7 +2,6 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cmake",
     "envoy_package",
-    "envoy_select_boringssl",
 )
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
@@ -203,10 +202,8 @@ envoy_cmake(
     lib_source = "@com_github_google_libsxg//:all",
     out_static_libs = ["libsxg.a"],
     tags = ["skip_on_windows"],
-    deps = envoy_select_boringssl(
-        ["@boringssl_fips//:ssl"],
-        ["@boringssl//:ssl"],
-    ),
+    # Use boringssl alias to select fips vs non-fips version.
+    deps = ["//bazel:boringssl"],
 )
 
 envoy_cmake(

--- a/bazel/foreign_cc/ipp-crypto-skip-dynamic-lib.patch
+++ b/bazel/foreign_cc/ipp-crypto-skip-dynamic-lib.patch
@@ -1,0 +1,46 @@
+diff --git a/sources/ippcp/crypto_mb/src/CMakeLists.txt b/sources/ippcp/crypto_mb/src/CMakeLists.txt
+index f75f448..043a0a2 100644
+--- a/sources/ippcp/crypto_mb/src/CMakeLists.txt
++++ b/sources/ippcp/crypto_mb/src/CMakeLists.txt
+@@ -90,41 +90,6 @@ if(CMAKE_C_COMPILER_VERSION VERSION_LESS 20.2.3)
+                                                                 COMPILE_FLAGS        "${AVX512_CFLAGS} ${CMAKE_C_FLAGS_SECURITY}")
+ endif()
+ 
+-# Create shared library
+-if(DYNAMIC_LIB OR MB_STANDALONE)
+-    if(WIN32)
+-        add_library(${MB_DYN_LIB_TARGET} SHARED ${CRYPTO_MB_HEADERS} ${CRYPTO_MB_SOURCES} ${CPU_FEATURES_FILE} ${WIN_RESOURCE_FILE})
+-    else()
+-        add_library(${MB_DYN_LIB_TARGET} SHARED ${CRYPTO_MB_HEADERS} ${CRYPTO_MB_SOURCES} ${CPU_FEATURES_FILE})
+-    endif()
+-
+-    set_target_properties(${MB_DYN_LIB_TARGET} PROPERTIES C_VISIBILITY_PRESET hidden
+-                                                          VISIBILITY_INLINES_HIDDEN ON
+-                                                          LINK_FLAGS "${LINK_FLAGS_DYNAMIC} ${LINK_FLAG_SECURITY}"
+-                                                          PUBLIC_HEADER "${PUBLIC_HEADERS}"
+-                                                          )
+-
+-    if(UNIX)
+-        set_target_properties(${MB_DYN_LIB_TARGET} PROPERTIES  VERSION   ${MBX_INTERFACE_VERSION}
+-                                                               SOVERSION ${MBX_INTERFACE_VERSION_MAJOR})
+-    endif()
+-
+-    target_link_libraries(${MB_DYN_LIB_TARGET} OpenSSL::Crypto)
+-endif(DYNAMIC_LIB OR MB_STANDALONE)
+-
+-# Installation of the shared library
+-if (MB_STANDALONE) # standalone crypto_mb's cmake run
+-    install(TARGETS ${MB_DYN_LIB_TARGET}
+-            LIBRARY DESTINATION "lib"
+-            RUNTIME DESTINATION "lib"
+-            PUBLIC_HEADER DESTINATION "include/crypto_mb")
+-elseif (DYNAMIC_LIB) # build from ippcp's cmake
+-    install(TARGETS ${MB_DYN_LIB_TARGET}
+-            LIBRARY DESTINATION "lib/intel64"
+-            RUNTIME DESTINATION "lib/intel64"
+-            PUBLIC_HEADER DESTINATION "include/crypto_mb")
+-endif()
+-
+ # Static library
+ if(WIN32)
+     add_library(${MB_STATIC_LIB_TARGET} STATIC ${CRYPTO_MB_HEADERS} ${CRYPTO_MB_SOURCES} ${CPU_FEATURES_FILE} ${WIN_RESOURCE_FILE})

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -473,6 +473,12 @@ def _com_github_unicode_org_icu():
 def _com_github_intel_ipp_crypto_crypto_mb():
     external_http_archive(
         name = "com_github_intel_ipp_crypto_crypto_mb",
+        # Patch removes from CMakeLists.txt instructions to
+        # to create dynamic *.so library target. Linker fails when linking
+        # with boringssl_fips library. Envoy uses only static library
+        # anyways, so created dynamic library would not be used anyways.
+        patches = ["@envoy//bazel/foreign_cc:ipp-crypto-skip-dynamic-lib.patch"],
+        patch_args = ["-p1"],
         build_file_content = BUILD_ALL_CONTENT,
     )
 

--- a/contrib/cryptomb/private_key_providers/source/BUILD
+++ b/contrib/cryptomb/private_key_providers/source/BUILD
@@ -4,7 +4,6 @@ load(
     "envoy_cc_library",
     "envoy_cmake",
     "envoy_contrib_package",
-    "envoy_select_boringssl",
 )
 load(
     "//contrib:all_contrib_extensions.bzl",
@@ -29,10 +28,8 @@ envoy_cmake(
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:private"],
     working_directory = "sources/ippcp/crypto_mb",
-    deps = envoy_select_boringssl(
-        ["@boringssl_fips//:ssl"],
-        ["@boringssl//:ssl"],
-    ),
+    # Use boringssl alias to select fips vs non-fips version.
+    deps = ["//bazel:boringssl"],
 )
 
 envoy_cc_library(

--- a/contrib/cryptomb/private_key_providers/source/BUILD
+++ b/contrib/cryptomb/private_key_providers/source/BUILD
@@ -4,6 +4,7 @@ load(
     "envoy_cc_library",
     "envoy_cmake",
     "envoy_contrib_package",
+    "envoy_select_boringssl",
 )
 load(
     "//contrib:all_contrib_extensions.bzl",
@@ -28,7 +29,10 @@ envoy_cmake(
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:private"],
     working_directory = "sources/ippcp/crypto_mb",
-    deps = ["@boringssl//:ssl"],
+    deps = envoy_select_boringssl(
+        ["@boringssl_fips//:ssl"],
+        ["@boringssl//:ssl"],
+    ),
 )
 
 envoy_cc_library(

--- a/contrib/qat/BUILD
+++ b/contrib/qat/BUILD
@@ -1,4 +1,8 @@
-load("//bazel:envoy_build_system.bzl", "envoy_contrib_package")
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_contrib_package",
+    "envoy_select_boringssl",
+)
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 load(
     "//contrib:all_contrib_extensions.bzl",
@@ -32,6 +36,9 @@ configure_make(
     ],
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:public"],
-    deps = ["@boringssl//:ssl"],
+    deps = envoy_select_boringssl(
+        ["@boringssl_fips//:ssl"],
+        ["@boringssl//:ssl"],
+    ),
     alwayslink = True,
 )

--- a/contrib/qat/BUILD
+++ b/contrib/qat/BUILD
@@ -1,7 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_contrib_package",
-    "envoy_select_boringssl",
 )
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 load(
@@ -36,9 +35,7 @@ configure_make(
     ],
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:public"],
-    deps = envoy_select_boringssl(
-        ["@boringssl_fips//:ssl"],
-        ["@boringssl//:ssl"],
-    ),
+    # Use boringssl alias to select fips vs non-fips version.
+    deps = ["//bazel:boringssl"],
     alwayslink = True,
 )

--- a/contrib/qat/BUILD
+++ b/contrib/qat/BUILD
@@ -1,7 +1,4 @@
-load(
-    "//bazel:envoy_build_system.bzl",
-    "envoy_contrib_package",
-)
+load("//bazel:envoy_build_system.bzl", "envoy_contrib_package")
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 load(
     "//contrib:all_contrib_extensions.bzl",

--- a/contrib/sxg/filters/http/source/BUILD
+++ b/contrib/sxg/filters/http/source/BUILD
@@ -3,7 +3,6 @@ load(
     "envoy_cc_contrib_extension",
     "envoy_cc_library",
     "envoy_contrib_package",
-    "envoy_select_boringssl",
 )
 
 licenses(["notice"])  # Apache 2
@@ -31,10 +30,9 @@ envoy_cc_library(
         "//source/common/stats:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy_api//contrib/envoy/extensions/filters/http/sxg/v3alpha:pkg_cc_proto",
-    ] + envoy_select_boringssl(
-        ["@boringssl_fips//:ssl"],
-        ["@boringssl//:ssl"],
-    ),
+        # use boringssl alias to select fips vs non-fips version.
+        "//bazel:boringssl",
+    ],
 )
 
 envoy_cc_contrib_extension(

--- a/contrib/sxg/filters/http/source/BUILD
+++ b/contrib/sxg/filters/http/source/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_contrib_extension",
     "envoy_cc_library",
     "envoy_contrib_package",
+    "envoy_select_boringssl",
 )
 
 licenses(["notice"])  # Apache 2
@@ -29,9 +30,11 @@ envoy_cc_library(
         "//source/common/stats:symbol_table_lib",
         "//source/common/stats:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
-        "@boringssl//:ssl",
         "@envoy_api//contrib/envoy/extensions/filters/http/sxg/v3alpha:pkg_cc_proto",
-    ],
+    ] + envoy_select_boringssl(
+        ["@boringssl_fips//:ssl"],
+        ["@boringssl//:ssl"],
+    ),
 )
 
 envoy_cc_contrib_extension(


### PR DESCRIPTION
Commit Message:
enable contrib build with boringssl_fips

Additional Description:
The problem was that `contrib` build was always successful with `boringssl=fips` flag, but executable asserted on `FIPS_mode` check. The root cause of that problem was that certain libraries in `contrib` linked non-fips version of `boringssl` and eclipsed fips version during the final linking state.
Risk Level: Low (no changes unless `boringssl=fips` flag is specified)
Testing: Manual
Docs Changes: No
Release Notes: No 
Platform Specific Features:No

