### PR TITLE
ext_proc filter fuzzer crashed when test cases contains regex config

### DIFF
--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/crash-2f5c31257230464b4b6015ecee3f6f090547fb0a
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/crash-2f5c31257230464b4b6015ecee3f6f090547fb0a
@@ -1,0 +1,43 @@
+config {
+  grpc_service {
+    envoy_grpc {
+      cluster_name: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    }
+  }
+  response_attributes: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  response_attributes: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  mutation_rules {
+    allow_expression {
+      regex: "!"
+    }
+  }
+  max_message_timeout {
+  }
+}
+request {
+}
+response {
+  request_body {
+  }
+  dynamic_metadata {
+    fields {
+      key: ""
+      value {
+        list_value {
+          values {
+            bool_value: false
+          }
+        }
+      }
+    }
+    fields {
+      key: ""
+      value {
+        string_value: ""
+      }
+    }
+  }
+  mode_override {
+    request_trailer_mode: SEND
+  }
+}

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_unit_test_fuzz.cc
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_unit_test_fuzz.cc
@@ -51,6 +51,11 @@ DEFINE_PROTO_FUZZER(
       input.config();
   ExternalProcessing::FilterConfigSharedPtr config;
 
+  // Create regex engine which is used by regex matcher code.
+  Regex::EnginePtr regex_engine = std::make_shared<Regex::GoogleReEngine>();
+  Regex::EngineSingleton::clear();
+  Regex::EngineSingleton::initialize(regex_engine.get());
+
   try {
     config = std::make_shared<ExternalProcessing::FilterConfig>(
         proto_config, std::chrono::milliseconds(200), 200, *stats_store.rootScope(),


### PR DESCRIPTION
ext_proc filter fuzzer crashed when test cases contains regex config.

This is due to the ext_proc filter fuzzer is lacking the regex engine creation in its initialization sequence.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
