### PR TITLE
mobile: c++ explicit flow control tests and fixes

### DIFF
--- a/mobile/library/cc/stream.cc
+++ b/mobile/library/cc/stream.cc
@@ -21,6 +21,11 @@ Stream& Stream::sendData(envoy_data data) {
   return *this;
 }
 
+Stream& Stream::readData(size_t bytes_to_read) {
+  ::read_data(engine_handle_, handle_, bytes_to_read);
+  return *this;
+}
+
 void Stream::close(RequestTrailersSharedPtr trailers) {
   envoy_headers raw_headers = rawHeaderMapAsEnvoyHeaders(trailers->allHeaders());
   ::send_trailers(engine_handle_, handle_, raw_headers);

--- a/mobile/library/cc/stream.h
+++ b/mobile/library/cc/stream.h
@@ -19,6 +19,7 @@ public:
 
   Stream& sendHeaders(RequestHeadersSharedPtr headers, bool end_stream);
   Stream& sendData(envoy_data data);
+  Stream& readData(size_t bytes_to_read);
   void close(RequestTrailersSharedPtr trailers);
   void close(envoy_data data);
   void cancel();

--- a/mobile/library/cc/stream_callbacks.cc
+++ b/mobile/library/cc/stream_callbacks.cc
@@ -103,7 +103,6 @@ void* c_on_send_window_available(envoy_stream_intel intel, void* context) {
     auto on_send_window_available = stream_callbacks->on_send_window_available.value();
     on_send_window_available(intel);
   }
-  delete stream_callbacks_ptr;
   return nullptr;
 }
 


### PR DESCRIPTION
Handling reentrant callbacks for data, and slow uploads for explicit flow control mode properly.

Testing: e2e tests
Docs Changes: n/a
Release Notes:n/a
[Optional Runtime guard:] n/a