### PR TITLE
docs: Fix type URI for custom_response example

### DIFF
--- a/api/envoy/extensions/filters/http/custom_response/v3/custom_response.proto
+++ b/api/envoy/extensions/filters/http/custom_response/v3/custom_response.proto
@@ -89,7 +89,7 @@ message CustomResponse {
   //         action:
   //           name: action
   //           typed_config:
-  //             "@type": type.googleapis.com/envoy.extensions.filters.http.custom_response.v3.RedirectPolicy
+  //             "@type": type.googleapis.com/envoy.extensions.http.custom_response.redirect_policy.v3.RedirectPolicy
   //             status_code: 299
   //             uri: "https://foo.example/gateway_error"
   //             response_headers_to_add:

--- a/api/envoy/extensions/filters/http/custom_response/v3/custom_response.proto
+++ b/api/envoy/extensions/filters/http/custom_response/v3/custom_response.proto
@@ -48,7 +48,7 @@ message CustomResponse {
   //         action:
   //           name: action
   //           typed_config:
-  //             "@type": type.googleapis.com/envoy.extensions.filters.http.custom_response.v3.LocalResponsePolicy
+  //             "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
   //             status_code: 499
   //             body:
   //               inline_string: "not allowed"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs: Fix type URI for custom_response example
Additional Description: The type URI `envoy.extensions.filters.http.custom_response.v3.LocalResponsePolicy` is not/no longer valid, the correct URI is `envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy` as evidenced by the fact that there are no longer any other references to the former for all of Envoy's codebase
Risk Level: Low
Testing:
Docs Changes: The use of `envoy.extensions.filters.http.custom_response.v3.LocalResponsePolicy` in the custom_response example is updated with `envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy`
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
