### PR TITLE
build: include "cstdint" for the types uint8_t and uint16_t

### DIFF
--- a/source/common/common/hex.h
+++ b/source/common/common/hex.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/source/extensions/clusters/redis/crc16.h
+++ b/source/extensions/clusters/redis/crc16.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include <cstdint>
 
 #include "absl/strings/ascii.h"
 


### PR DESCRIPTION
This fixes a build problem on Fedora 38 with clang 16. (there are other build problems in external libraries)

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: