### PR TITLE
ci: Upload Docker images to GCS

### DIFF
--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -84,7 +84,7 @@ jobs:
     parameters:
       name: publish_docker
       # VERSION.txt is included to refresh Docker images for release
-      key: "ci/Dockerfile-envoy | VERSION.txt"
+      key: "ci/Dockerfile-envoy | VERSION.txt| $(cacheKeyBazelFiles)"
       version: "$(cacheKeyDockerBuild)"
       path: ""
   - bash: |
@@ -122,17 +122,26 @@ jobs:
       DOCKERHUB_USERNAME: ${{ parameters.authDockerUser }}
       DOCKERHUB_PASSWORD: ${{ parameters.authDockerPassword }}
       DOCKER_BUILD_TIMEOUT: ${{ parameters.timeoutDockerBuild }}
+
   - bash: |
       echo "disk space at end of build:"
       df -h
     displayName: "Check disk space at end"
     condition: not(canceled())
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: "$(Build.StagingDirectory)/build_images"
-      artifactName: docker
-    timeoutInMinutes: 10
-    condition: not(canceled())
+
+  # Publish docker
+  - script: |
+      ci/run_envoy_docker.sh 'ci/do_ci.sh docker-upload'
+    displayName: "Upload Docker to GCS"
+    env:
+      ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+      ENVOY_RBE: "1"
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
+      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+      GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
+      GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
+
   - script: sudo .azure-pipelines/docker/save_cache.sh /mnt/docker_cache
     displayName: "Cache/save (publish_docker)"
 

--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -1,6 +1,10 @@
 
 parameters:
 
+- name: bucketGCP
+  type: string
+  default: ""
+
 # Auth
 - name: authGCP
   type: string
@@ -35,8 +39,8 @@ jobs:
               variant=dev
               filename="envoy.tar"
           fi
-          echo "Download docker image (https://storage.googleapis.com/envoy-pr/${DOWNLOAD_PATH}/docker/${filename}) ..."
-          curl -sLO "https://storage.googleapis.com/envoy-pr/${DOWNLOAD_PATH}/docker/${filename}"
+          echo "Download docker image (https://storage.googleapis.com/${{ parameters.bucketGCP }}/${DOWNLOAD_PATH}/docker/${filename}) ..."
+          curl -sLO "https://storage.googleapis.com/${{ parameters.bucketGCP }}/${DOWNLOAD_PATH}/docker/${filename}"
           echo "Copy oci image: oci-archive:${filename} docker-daemon:envoyproxy/envoy:${variant}"
           skopeo copy -q "oci-archive:${filename}" "docker-daemon:envoyproxy/envoy:${variant}"
           rm "$filename"

--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -15,12 +15,40 @@ jobs:
   steps:
   - bash: .azure-pipelines/cleanup.sh
     displayName: "Removing tools from agent"
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      buildType: current
-      artifactName: "docker"
-      itemPattern: "docker/envoy*.tar"
-      targetPath: $(Build.StagingDirectory)
+  - bash: |
+      set -e
+
+      if [[ "$BUILD_REASON" == "PullRequest" ]]; then
+          DOWNLOAD_PATH="$(git rev-parse HEAD | head -c7)"
+      else
+          DOWNLOAD_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
+      fi
+
+      tmpdir=$(mktemp -d)
+      cd "$tmpdir"
+      images=("" "contrib" "google-vrp")
+      for image in "${images[@]}"; do
+          if [[ -n "$image" ]]; then
+              variant="${image}-dev"
+              filename="envoy-${image}.tar"
+          else
+              variant=dev
+              filename="envoy.tar"
+          fi
+          echo "Download docker image (https://storage.googleapis.com/envoy-pr/${DOWNLOAD_PATH}/docker/${filename}) ..."
+          curl -sLO "https://storage.googleapis.com/envoy-pr/${DOWNLOAD_PATH}/docker/${filename}"
+          echo "Copy oci image: oci-archive:${filename} docker-daemon:envoyproxy/envoy:${variant}"
+          skopeo copy -q "oci-archive:${filename}" "docker-daemon:envoyproxy/envoy:${variant}"
+          rm "$filename"
+      done
+      docker images | grep envoy
+
+  - bash: |
+      set -e
+      export DEBIAN_FRONTEND=noninteractive
+      sudo apt-get -qq update -y
+      sudo apt-get -qq install -y --no-install-recommends expect
+
   - bash: ./ci/do_ci.sh verify_examples
     env:
       ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -167,6 +167,7 @@ stages:
   - template: stage/verify.yml
     parameters:
       authGCP: $(GcpServiceAccountKey)
+      bucketGCP: $(GcsArtifactBucket)
 
 - stage: macos
   displayName: macOS

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -157,31 +157,6 @@ function bazel_contrib_binary_build() {
 }
 
 function run_ci_verify () {
-    local images image oci_archive
-    echo "verify examples..."
-
-    images=("" "contrib" "google-vrp")
-
-    for image in "${images[@]}"; do
-        if [[ -n "$image" ]]; then
-            variant="${image}-dev"
-            filename="envoy-${image}.tar"
-        else
-            variant=dev
-            filename="envoy.tar"
-        fi
-        oci_archive="${ENVOY_DOCKER_BUILD_DIR}/docker/${filename}"
-
-        echo "Copy oci image: oci-archive:${oci_archive} docker-daemon:envoyproxy/envoy:${variant}"
-        skopeo copy -q "oci-archive:${oci_archive}" "docker-daemon:envoyproxy/envoy:${variant}"
-        rm "$oci_archive"
-    done
-
-    docker images | grep envoy
-
-    export DEBIAN_FRONTEND=noninteractive
-    sudo apt-get -qq update -y
-    sudo apt-get -qq install -y --no-install-recommends expect
     export DOCKER_NO_PULL=1
     export DOCKER_RMI_CLEANUP=1
     # This is set to simulate an environment where users have shared home drives protected
@@ -531,6 +506,11 @@ case $CI_TARGET in
     docs-upload)
         setup_clang_toolchain
         "${ENVOY_SRCDIR}/ci/upload_gcs_artifact.sh" /source/generated/docs docs
+        ;;
+
+    docker-upload)
+        setup_clang_toolchain
+        "${ENVOY_SRCDIR}/ci/upload_gcs_artifact.sh" "${BUILD_DIR}/build_images" docker
         ;;
 
     fix_proto_format)


### PR DESCRIPTION
This uses GCS rather than azp's artefact storage to host the images created in CI that are tested in example verification

The benefit of doing this is that we can far more easily move the verify job out of azp by adding a trigger azp -> github, and github can then pick up the built artefacts from a public URL

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
