### PR TITLE
[fuzz] Only add filters that are whitelisted.

### DIFF
--- a/test/extensions/filters/network/common/fuzz/BUILD
+++ b/test/extensions/filters/network/common/fuzz/BUILD
@@ -6,8 +6,9 @@ load(
     "envoy_proto_library",
 )
 load(
-    "//source/extensions:all_extensions.bzl",
-    "envoy_all_network_filters",
+    "filter_fuzz_support.bzl",
+    "fuzz_filters_targets",
+    "generate_from_template",
 )
 
 licenses(["notice"])  # Apache 2
@@ -35,6 +36,19 @@ envoy_proto_library(
         "@envoy_api//envoy/config/listener/v3:pkg",
     ],
 )
+
+_readfilter_fuzz_filters = [
+    "envoy.filters.network.client_ssl_auth",
+    "envoy.filters.network.ext_authz",
+    "envoy.filters.network.envoy_mobile_http_connection_manager",
+    # A dedicated http_connection_manager fuzzer can be found in
+    # test/common/http/conn_manager_impl_fuzz_test.cc
+    "envoy.filters.network.http_connection_manager",
+    "envoy.filters.network.local_ratelimit",
+    "envoy.filters.network.rbac",
+    # TODO(asraa): Remove when fuzzer sets up connections for TcpProxy properly.
+    # "envoy.filters.network.tcp_proxy",
+]
 
 envoy_cc_test_library(
     name = "vig_anymap_ext_lib",
@@ -85,15 +99,28 @@ envoy_cc_fuzz_test(
     srcs = ["network_readfilter_fuzz_test.cc"],
     corpus = "network_readfilter_corpus",
     dictionaries = ["network_readfilter_fuzz_test.dict"],
-    # All Envoy network filters must be linked to the test in order for the fuzzer to pick
-    # these up via the NamedNetworkFilterConfigFactory.
     deps = [
         ":uber_readfilter_lib",
         ":vig_anymap_ext_lib",
         "//source/common/config:utility_lib",
         "//test/config:utility_lib",
         "//test/test_common:test_runtime_lib",
-    ] + envoy_all_network_filters(),
+    ] + fuzz_filters_targets(_readfilter_fuzz_filters),
+)
+
+_writefilter_fuzz_filters = [
+    "envoy.filters.network.zookeeper_proxy",
+    "envoy.filters.network.kafka_broker",
+    "envoy.filters.network.mongo_proxy",
+    "envoy.filters.network.mysql_proxy",
+    # TODO(jianwendong) Add "NetworkFilterNames::get().Postgres" after it
+    # supports untrusted data.
+]
+
+generate_from_template(
+    name = "uber_per_writefilter",
+    filters = _writefilter_fuzz_filters,
+    template_file = "uber_per_writefilter.tmpl.cc",
 )
 
 envoy_cc_test_library(
@@ -123,8 +150,6 @@ envoy_cc_fuzz_test(
         ":uber_writefilter_lib",
         ":vig_anymap_ext_lib",
         "//source/common/config:utility_lib",
-        "//source/extensions/filters/network/mongo_proxy:config",
-        "//source/extensions/filters/network/zookeeper_proxy:config",
         "//test/config:utility_lib",
-    ],
+    ] + fuzz_filters_targets(_writefilter_fuzz_filters),
 )

--- a/test/extensions/filters/network/common/fuzz/filter_fuzz_support.bzl
+++ b/test/extensions/filters/network/common/fuzz/filter_fuzz_support.bzl
@@ -1,0 +1,36 @@
+load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
+
+def _selected_extension_target(target):
+    return target + "_envoy_extension"
+
+def fuzz_filters_targets(filters):
+    all_extensions = EXTENSIONS
+
+    return [v for k, v in all_extensions.items() if (k in filters)]
+
+def generate_from_template(**kwargs):
+    _generate_from_template(
+        source_file = "{name}.cc".format(**kwargs),
+        **kwargs
+    )
+
+def _generate_from_template_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template_file,
+        output = ctx.outputs.source_file,
+        substitutions = {
+            "{{FILTERS}}": "\"" + ("\", \"".join(ctx.attr.filters)) + "\"",
+        },
+    )
+
+_generate_from_template = rule(
+    implementation = _generate_from_template_impl,
+    attrs = {
+        "filters": attr.string_list(mandatory = True),
+        "template_file": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "source_file": attr.output(mandatory = True),
+    },
+)

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -21,28 +21,10 @@ std::vector<absl::string_view> UberFilterFuzzer::filterNames() {
   // traffic.
   static std::vector<absl::string_view> filter_names;
   if (filter_names.empty()) {
-    const auto factories = Registry::FactoryRegistry<
-        Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
-    const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ClientSslAuth, NetworkFilterNames::get().ExtAuthorization,
-        NetworkFilterNames::get().EnvoyMobileHttpConnectionManager,
-        // A dedicated http_connection_manager fuzzer can be found in
-        // test/common/http/conn_manager_impl_fuzz_test.cc
-        NetworkFilterNames::get().HttpConnectionManager, NetworkFilterNames::get().LocalRateLimit,
-        NetworkFilterNames::get().RateLimit, NetworkFilterNames::get().Rbac,
-        // TODO(asraa): Remove when fuzzer sets up connections for TcpProxy properly.
-        // NetworkFilterNames::get().TcpProxy,
-    };
-    // Check whether each filter is loaded into Envoy.
-    // Some customers build Envoy without some filters. When they run fuzzing, the use of a filter
-    // that does not exist will cause fatal errors.
-    for (auto& filter_name : supported_filter_names) {
-      if (factories.contains(filter_name)) {
-        filter_names.push_back(filter_name);
-      } else {
-        ENVOY_LOG_MISC(debug, "Filter name not found in the factory: {}", filter_name);
-      }
-    }
+    // Only use the names of the filters that are compiled into envoy. The build system takes care
+    // about reducing these to the allowed set.
+    filter_names = Registry::FactoryRegistry<
+        Server::Configuration::NamedNetworkFilterConfigFactory>::registeredNames();
   }
   return filter_names;
 }

--- a/test/extensions/filters/network/common/fuzz/uber_per_writefilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_writefilter.cc
@@ -10,21 +10,8 @@ std::vector<absl::string_view> UberWriteFilterFuzzer::filterNames() {
   // Will extend to cover other network filters one by one.
   static std::vector<absl::string_view> filter_names;
   if (filter_names.empty()) {
-    const auto factories = Registry::FactoryRegistry<
-        Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
-    const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ZooKeeperProxy, NetworkFilterNames::get().KafkaBroker,
-        NetworkFilterNames::get().MongoProxy, NetworkFilterNames::get().MySQLProxy
-        // TODO(jianwendong) Add "NetworkFilterNames::get().Postgres" after it supports untrusted
-        // data.
-    };
-    for (auto& filter_name : supported_filter_names) {
-      if (factories.contains(filter_name)) {
-        filter_names.push_back(filter_name);
-      } else {
-        ENVOY_LOG_MISC(debug, "Filter name not found in the factory: {}", filter_name);
-      }
-    }
+    filter_names = Registry::FactoryRegistry<
+        Server::Configuration::NamedNetworkFilterConfigFactory>::registeredNames();
   }
   return filter_names;
 }


### PR DESCRIPTION
- Add only filters that are whitelisted to the build of:
	- network_readfilter_fuzz_test
	- network_writefilter_fuzz_test
- Retrieve the list of filters available from the factory.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
