### PR TITLE
[rbac] Correct deprecation comment

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -321,10 +321,10 @@ message Principal {
     // A CIDR block that describes the downstream IP.
     // This address will honor proxy protocol, but will not honor XFF.
     //
-    // This field is deprecated; either use :ref:`direct_remote_ip
-    // <envoy_v3_api_field_config.rbac.v3.Principal.direct_remote_ip>` for the same
+    // This field is deprecated; either use :ref:`remote_ip
+    // <envoy_v3_api_field_config.rbac.v3.Principal.remote_ip>` for the same
     // behavior, or use
-    // :ref:`remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.remote_ip>`.
+    // :ref:`direct_remote_ip <envoy_v3_api_field_config.rbac.v3.Principal.direct_remote_ip>`.
     core.v3.CidrRange source_ip = 5
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 


### PR DESCRIPTION
Commit Message: Correct deprecation comment
Additional Description: I added this comment (#26762), and it turns out I was wrong - direct_remote_ip is not behaviorally equivalent to source_ip, it turns out remote_ip is a better match. So reversing the recommendation in the doc-comment.
Risk Level: doc-only
Testing: tried replacing source_ip with direct_remote_ip and broke a live service; replacing it with remote_ip maintained existing behavior.
Docs Changes: Yes.
Release Notes: n/a
Platform Specific Features: n/a
