### PR TITLE
Harmonize transfer-encoding and content-length checks for UHV

### DIFF
--- a/envoy/http/header_validator_errors.h
+++ b/envoy/http/header_validator_errors.h
@@ -24,5 +24,14 @@ struct UhvResponseCodeDetailValues {
 
 using UhvResponseCodeDetail = ConstSingleton<UhvResponseCodeDetailValues>;
 
+struct Http1ResponseCodeDetailValues {
+  const std::string InvalidTransferEncoding = "http1.invalid_transfer_encoding";
+  const std::string TransferEncodingNotAllowed = "uhv.http1.transfer_encoding_not_allowed";
+  const std::string ContentLengthNotAllowed = "uhv.http1.content_length_not_allowed";
+  const std::string ChunkedContentLength = "http1.content_length_and_chunked_not_allowed";
+};
+
+using Http1ResponseCodeDetail = ConstSingleton<Http1ResponseCodeDetailValues>;
+
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -970,7 +970,9 @@ bool ConnectionManagerImpl::ActiveStream::validateHeaders() {
     }
     if (failure) {
       std::function<void(ResponseHeaderMap & headers)> modify_headers;
-      Code response_code = Code::BadRequest;
+      Code response_code = failure_details == Http1ResponseCodeDetail::get().InvalidTransferEncoding
+                               ? Code::NotImplemented
+                               : Code::BadRequest;
       absl::optional<Grpc::Status::GrpcStatus> grpc_status;
       bool is_grpc = Grpc::Common::hasGrpcContentType(*request_headers_);
       if (redirect && !is_grpc) {

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -150,6 +150,10 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   http_validation_policy.require_header_colon = true;
   http_validation_policy.disallow_multiple_content_length = false;
   http_validation_policy.disallow_transfer_encoding_with_content_length = false;
+#ifdef ENVOY_ENABLE_UHV
+  // UHV - disable transfer-encoding validations in Balsa
+  http_validation_policy.validate_transfer_encoding = false;
+#endif
   framer_.set_http_validation_policy(http_validation_policy);
 
   framer_.set_balsa_headers(&headers_);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -910,7 +910,6 @@ StatusOr<CallbackResult> ConnectionImpl::onHeadersCompleteImpl() {
           "http/1.1 protocol error: both 'Content-Length' and 'Transfer-Encoding' are set.");
     }
   }
-#endif
 
   // Per https://tools.ietf.org/html/rfc7230#section-3.3.1 Envoy should reject
   // transfer-codings it does not understand.
@@ -925,6 +924,7 @@ StatusOr<CallbackResult> ConnectionImpl::onHeadersCompleteImpl() {
       return codecProtocolError("http/1.1 protocol error: unsupported transfer encoding");
     }
   }
+#endif
 
   auto statusor = onHeadersCompleteBase();
   if (!statusor.ok()) {

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -23,15 +23,7 @@ using ::Envoy::Http::Protocol;
 using ::Envoy::Http::RequestHeaderMap;
 using ::Envoy::Http::UhvResponseCodeDetail;
 using ValidationResult = ::Envoy::Http::HeaderValidator::ValidationResult;
-
-struct Http1ResponseCodeDetailValues {
-  const std::string InvalidTransferEncoding = "uhv.http1.invalid_transfer_encoding";
-  const std::string TransferEncodingNotAllowed = "uhv.http1.transfer_encoding_not_allowed";
-  const std::string ContentLengthNotAllowed = "uhv.http1.content_length_not_allowed";
-  const std::string ChunkedContentLength = "http1.content_length_and_chunked_not_allowed";
-};
-
-using Http1ResponseCodeDetail = ConstSingleton<Http1ResponseCodeDetailValues>;
+using Http1ResponseCodeDetail = ::Envoy::Http::Http1ResponseCodeDetail;
 
 /*
  * Header validation implementation for the Http/1 codec. This class follows guidance from
@@ -97,6 +89,20 @@ Http1HeaderValidator::validateResponseHeaderEntry(const HeaderString& key,
 
   // Validate the header value
   return validateGenericHeaderValue(value);
+}
+
+ValidationResult Http1HeaderValidator::validateContentLengthAndTransferEncoding(
+    const ::Envoy::Http::RequestOrResponseHeaderMap& header_map) {
+  if (header_map.TransferEncoding()) {
+    if (header_map.ContentLength() &&
+        hasChunkedTransferEncoding(header_map.TransferEncoding()->value()) &&
+        !config_.http1_protocol_options().allow_chunked_length()) {
+      // Configuration does not allow chunked length, reject the request
+      return {ValidationResult::Action::Reject,
+              Http1ResponseCodeDetail::get().ChunkedContentLength};
+    }
+  }
+  return ValidationResult::success();
 }
 
 ValidationResult Http1HeaderValidator::validateRequestHeaders(const RequestHeaderMap& header_map) {
@@ -166,16 +172,6 @@ ValidationResult Http1HeaderValidator::validateRequestHeaders(const RequestHeade
   }
 
   // Step 2: Validate Transfer-Encoding and Content-Length headers.
-  // HTTP/1.1 disallows a Transfer-Encoding and Content-Length headers,
-  // https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2:
-  //
-  // A sender MUST NOT send a Content-Length header field in any message that
-  // contains a Transfer-Encoding header field.
-  //
-  // The http1_protocol_options.allow_chunked_length config setting can
-  // override the RFC compliance to allow a Transfer-Encoding of "chunked" with
-  // a Content-Length set. In this exception case, we remove the Content-Length
-  // header.
   if (header_map.TransferEncoding()) {
     // CONNECT methods must not contain any content so reject the request if Transfer-Encoding or
     // Content-Length is provided, per RFC 9110,
@@ -188,12 +184,9 @@ ValidationResult Http1HeaderValidator::validateRequestHeaders(const RequestHeade
               Http1ResponseCodeDetail::get().TransferEncodingNotAllowed};
     }
 
-    if (header_map.ContentLength() &&
-        hasChunkedTransferEncoding(header_map.TransferEncoding()->value()) &&
-        !config_.http1_protocol_options().allow_chunked_length()) {
-      // Configuration does not allow chunked length, reject the request
-      return {ValidationResult::Action::Reject,
-              Http1ResponseCodeDetail::get().ChunkedContentLength};
+    ValidationResult result = validateContentLengthAndTransferEncoding(header_map);
+    if (!result.ok()) {
+      return result;
     }
   }
 
@@ -275,7 +268,8 @@ ValidationResult Http1HeaderValidator::validateRequestHeaders(const RequestHeade
   return ValidationResult::success();
 }
 
-void Http1HeaderValidator::sanitizeContentLength(::Envoy::Http::RequestHeaderMap& header_map) {
+void Http1HeaderValidator::sanitizeContentLength(
+    ::Envoy::Http::RequestOrResponseHeaderMap& header_map) {
   // The http1_protocol_options.allow_chunked_length config setting can
   // override the RFC compliance to allow a Transfer-Encoding of "chunked" with
   // a Content-Length set. In this exception case, we remove the Content-Length
@@ -288,10 +282,17 @@ void Http1HeaderValidator::sanitizeContentLength(::Envoy::Http::RequestHeaderMap
         header_map.removeContentLength();
       }
     }
-  } else if (header_map.ContentLength() && header_map.getContentLengthValue() == "0" &&
-             ::Envoy::Http::HeaderUtility::isConnect(header_map)) {
+  }
+}
+
+void ServerHttp1HeaderValidator::sanitizeContentLength(
+    ::Envoy::Http::RequestHeaderMap& header_map) {
+  if (header_map.ContentLength() && header_map.getContentLengthValue() == "0" &&
+      ::Envoy::Http::HeaderUtility::isConnect(header_map)) {
     // Remove a 0 content length from a CONNECT request
     header_map.removeContentLength();
+  } else {
+    Http1HeaderValidator::sanitizeContentLength(header_map);
   }
 }
 
@@ -306,6 +307,12 @@ ServerHttp1HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeader
     }
   }
   return ::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult::success();
+}
+
+::Envoy::Http::HeaderValidator::TransformationResult
+ClientHttp1HeaderValidator::transformResponseHeaders(::Envoy::Http::ResponseHeaderMap& header_map) {
+  sanitizeContentLength(header_map);
+  return TransformationResult::success();
 }
 
 ValidationResult
@@ -331,6 +338,11 @@ Http1HeaderValidator::validateResponseHeaders(const ::Envoy::Http::ResponseHeade
     // of 1xx (Informational) or 204 (No Content).
     return {ValidationResult::Action::Reject,
             Http1ResponseCodeDetail::get().TransferEncodingNotAllowed};
+  }
+
+  ValidationResult result = validateContentLengthAndTransferEncoding(header_map);
+  if (!result.ok()) {
+    return result;
   }
 
   // Step 3: Verify each response header

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -7,6 +7,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/extensions/http/header_validators/envoy_default/v3/header_validator.pb.h"
 #include "envoy/http/codec.h"
+#include "envoy/http/header_validator_errors.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/utility.h"
@@ -120,9 +121,14 @@ public:
         }
         failure_details = transformation_result.details();
       }
-      sendLocalReply(Http::Code::BadRequest, Http::CodeUtility::toString(Http::Code::BadRequest),
-                     nullptr, absl::nullopt, failure_details);
-      response_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+      Code response_code = failure_details == Http1ResponseCodeDetail::get().InvalidTransferEncoding
+                               ? Code::NotImplemented
+                               : Code::BadRequest;
+      sendLocalReply(response_code, Http::CodeUtility::toString(response_code), nullptr,
+                     absl::nullopt, failure_details);
+      if (response_encoder_) {
+        response_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+      }
       connection_.state_ = Network::Connection::State::Closing;
     } else {
       MockRequestDecoder::decodeHeaders(std::move(headers), end_stream);
@@ -500,33 +506,67 @@ TEST_P(Http1ServerConnectionImplTest, EmptyHeader) {
 // We support the identity encoding, but because it does not end in chunked encoding we reject it
 // per RFC 7230 Section 3.3.3
 TEST_P(Http1ServerConnectionImplTest, IdentityEncodingNoChunked) {
+#ifdef ENVOY_ENABLE_UHV
+  // TODO(#27377): http-parser will not be used together with UHV and triggers an internal
+  // transfer-encoding check preventing UHV to be called.
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    return;
+  }
+#endif
   initialize();
 
   InSequence sequence;
 
-  MockRequestDecoder decoder;
+  MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\ntransfer-encoding: identity\r\n\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\nHost: host\r\ntransfer-encoding: identity\r\n\r\n");
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, _, _, _,
+                                      "http1.invalid_transfer_encoding"));
   auto status = codec_->dispatch(buffer);
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_TRUE(status.ok());
+#else
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
+#endif
 }
 
 TEST_P(Http1ServerConnectionImplTest, UnsupportedEncoding) {
+#ifdef ENVOY_ENABLE_UHV
+  // TODO(#27377): http-parser will not be used together with UHV and triggers an internal
+  // transfer-encoding check preventing UHV to be called.
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    return;
+  }
+#endif
   initialize();
 
   InSequence sequence;
 
-  MockRequestDecoder decoder;
+  MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\ntransfer-encoding: gzip\r\n\r\n");
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\nHost: host\r\ntransfer-encoding: gzip\r\n\r\n");
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, _, _, _,
+                                      "http1.invalid_transfer_encoding"));
+#else
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, _, _, _,
+                                        "http1.invalid_transfer_encoding"));
+  } else {
+    // TODO(#27375): Balsa codec produces invalid response in non UHV mode
+    EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, _, _, _, "http1.codec_error"));
+  }
+#endif
   auto status = codec_->dispatch(buffer);
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_TRUE(status.ok());
+#else
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
+#endif
 }
 
 // Verify that the optimization which moves large slices of body instead of copying them is working.
@@ -738,6 +778,13 @@ TEST_P(Http1ServerConnectionImplTest, InvalidChunkHeader) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, IdentityAndChunkedBody) {
+#ifdef ENVOY_ENABLE_UHV
+  // TODO(#27377): http-parser will not be used together with UHV and triggers an internal
+  // transfer-encoding check preventing UHV to be called.
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    return;
+  }
+#endif
   initialize();
 
   InSequence sequence;
@@ -745,13 +792,23 @@ TEST_P(Http1ServerConnectionImplTest, IdentityAndChunkedBody) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  Buffer::OwnedImpl buffer("POST / HTTP/1.1\r\ntransfer-encoding: "
+  Buffer::OwnedImpl buffer("POST / HTTP/1.1\r\nHost: host\r\ntransfer-encoding: "
                            "identity,chunked\r\n\r\nb\r\nHello World\r\n0\r\n\r\n");
 
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, _, _, _,
+                                        "http1.invalid_transfer_encoding"));
+  } else {
+    // TODO(#27375): Balsa codec produces invalid response in non UHV mode
+    EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, _, _, _, "http1.codec_error"));
+  }
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
-  EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
+  } else {
+    EXPECT_EQ(status.message(), "http/1.1 protocol error: REQUIRED_BODY_BUT_NO_CONTENT_LENGTH");
+  }
 }
 
 TEST_P(Http1ServerConnectionImplTest, HostWithLWS) {
@@ -2232,17 +2289,30 @@ TEST_P(Http1ServerConnectionImplTest, ConnectRequestWithTEChunked) {
   initialize();
 
   InSequence sequence;
-  NiceMock<MockRequestDecoder> decoder;
-  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
+  MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
+  EXPECT_CALL(callbacks_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+        decoder.setResponseEncoder(&encoder);
+        return decoder;
+      }));
 
   // Per https://tools.ietf.org/html/rfc7231#section-4.3.6 CONNECT with body has no defined
   // semantics: Envoy will reject chunked CONNECT requests.
-  EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, _, _, _, _));
+#else
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, _, _, _,
+                                      "http1.invalid_transfer_encoding"));
+#endif
   Buffer::OwnedImpl buffer(
       "CONNECT host:80 HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n12345abcd");
   auto status = codec_->dispatch(buffer);
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_TRUE(status.ok());
+#else
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
+#endif
 }
 
 TEST_P(Http1ServerConnectionImplTest, ConnectRequestWithNonZeroContentLength) {
@@ -4435,13 +4505,18 @@ TEST_P(Http1ServerConnectionImplTest, MultipleTransferEncoding) {
   initialize();
   InSequence s;
 
-  StrictMock<MockRequestDecoder> decoder;
+  MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         response_encoder = &encoder;
+        decoder.setResponseEncoder(&encoder);
         return decoder;
       }));
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, "Not Implemented", _, _,
+                                      "http1.invalid_transfer_encoding"));
+#else
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
     EXPECT_CALL(decoder,
                 sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
@@ -4449,14 +4524,17 @@ TEST_P(Http1ServerConnectionImplTest, MultipleTransferEncoding) {
     EXPECT_CALL(decoder, sendLocalReply(Http::Code::NotImplemented, "Not Implemented", _, _,
                                         "http1.invalid_transfer_encoding"));
   }
-
-  Buffer::OwnedImpl buffer("POST / HTTP/1.1\r\n"
+#endif
+  Buffer::OwnedImpl buffer("POST / HTTP/1.1\r\nHost: foo.bar\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "\r\n");
 
   auto status = codec_->dispatch(buffer);
 
+#ifdef ENVOY_ENABLE_UHV
+  EXPECT_TRUE(status.ok());
+#else
   EXPECT_TRUE(isCodecProtocolError(status));
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
@@ -4466,6 +4544,7 @@ TEST_P(Http1ServerConnectionImplTest, MultipleTransferEncoding) {
     EXPECT_EQ("http1.invalid_transfer_encoding", response_encoder->getStream().responseDetails());
     EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
   }
+#endif
 }
 
 } // namespace Http


### PR DESCRIPTION
Commit Message:
This PR moves transfer-encoding and content-length check into UHV in UNV mode and re-enables integration tests that were disabled pending this change.

Some codec_impl_tests validating transfer-encoding are disabled for UHV+http-parser, as they produce an invalid response code and will be re-enabled when #27377 is addressed.

Risk Level: Low, build flag protected
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
