### PR TITLE
Add more CPU for integration tests

### DIFF
--- a/contrib/generic_proxy/filters/network/test/BUILD
+++ b/contrib/generic_proxy/filters/network/test/BUILD
@@ -83,6 +83,9 @@ envoy_cc_test(
     srcs = [
         "integration_test.cc",
     ],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":fake_codec_lib",
         "//contrib/generic_proxy/filters/network/source:config",

--- a/test/extensions/filters/http/file_system_buffer/BUILD
+++ b/test/extensions/filters/http/file_system_buffer/BUILD
@@ -48,7 +48,10 @@ envoy_extension_cc_test(
     ],
     extension_names = ["envoy.filters.http.file_system_buffer"],
     shard_count = 2,
-    tags = ["skip_on_windows"],
+    tags = [
+        "cpu:3",
+        "skip_on_windows",
+    ],
     deps = [
         "//source/extensions/filters/http/file_system_buffer:config",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/http/on_demand/BUILD
+++ b/test/extensions/filters/http/on_demand/BUILD
@@ -32,6 +32,9 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["on_demand_integration_test.cc"],
     extension_names = ["envoy.filters.http.on_demand"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         "//source/extensions/filters/http/on_demand:config",
         "//source/extensions/filters/http/on_demand:on_demand_update_lib",

--- a/test/extensions/filters/network/echo/BUILD
+++ b/test/extensions/filters/network/echo/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test(
         # Uncomment this line to run this test repeatedly in exclusive mode if not using docker-sandbox,
         # or RBE, see comments in AddRemoveListener.
         # "exclusive",
+        "cpu:2",
     ],
     deps = [
         "//source/extensions/filters/network/echo:config",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -82,6 +82,9 @@ envoy_cc_test(
     name = "alpn_integration_test",
     size = "large",
     srcs = ["alpn_integration_test.cc"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [":http_integration_lib"],
 )
 
@@ -89,6 +92,9 @@ envoy_cc_test(
     name = "api_listener_integration_test",
     size = "large",
     srcs = ["api_listener_integration_test.cc"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         "//test/mocks/http:stream_encoder_mock",
@@ -125,6 +131,9 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     shard_count = 4,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         "//source/common/config:protobuf_link_hacks",
@@ -144,6 +153,9 @@ envoy_cc_test(
     name = "eds_integration_test",
     size = "large",
     srcs = ["eds_integration_test.cc"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         "//source/common/upstream:load_balancer_lib",
@@ -163,6 +175,9 @@ envoy_cc_test(
     name = "leds_integration_test",
     size = "large",
     srcs = ["leds_integration_test.cc"],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         "//test/config:utility_lib",
@@ -185,6 +200,9 @@ envoy_cc_test(
     size = "large",
     srcs = [
         "filter_manager_integration_test.cc",
+    ],
+    tags = [
+        "cpu:3",
     ],
     deps = [
         ":filter_manager_integration_proto_cc_proto",
@@ -270,6 +288,9 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":vhds_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
@@ -300,6 +321,9 @@ envoy_cc_test(
         "drain_close_integration_test.cc",
     ]),
     shard_count = 2,
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_protocol_integration_lib",
         "//test/test_common:utility_lib",
@@ -359,6 +383,9 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = [
+        "cpu:3",
+    ],
     deps = [
         ":http_integration_lib",
         "//test/test_common:utility_lib",
@@ -373,6 +400,9 @@ envoy_cc_test(
     size = "large",
     srcs = [
         "header_integration_test.cc",
+    ],
+    tags = [
+        "cpu:3",
     ],
     deps = [
         ":http_integration_lib",


### PR DESCRIPTION
Additional Description:
Add more CPU for recently flaked integration tests.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
