### PR TITLE
stats: change extractAndAppendTags() implementation of IsolatedStatsStore to no-op

### DIFF
--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -234,8 +234,8 @@ public:
     return constRootScope()->iterate(fn);
   }
 
-  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override{}
-  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override{}
+  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {}
+  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {}
 
 protected:
   /**

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -234,13 +234,8 @@ public:
     return constRootScope()->iterate(fn);
   }
 
-  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
-  }
-
-  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
-  }
+  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override{}
+  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override{}
 
 protected:
   /**

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -357,8 +357,8 @@ public:
   bool iterate(const IterateFn<Histogram>& fn) const override { return store_.iterate(fn); }
   bool iterate(const IterateFn<TextReadout>& fn) const override { return store_.iterate(fn); }
 
-  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {};
-  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {};
+  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override{};
+  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override{};
 
   // Stats::StoreRoot
   void addSink(Sink&) override {}

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -357,13 +357,8 @@ public:
   bool iterate(const IterateFn<Histogram>& fn) const override { return store_.iterate(fn); }
   bool iterate(const IterateFn<TextReadout>& fn) const override { return store_.iterate(fn); }
 
-  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
-  };
-
-  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {
-    IS_ENVOY_BUG("Unexpected call to a function that is not yet implemented");
-  };
+  void extractAndAppendTags(StatName, StatNamePool&, StatNameTagVector&) override {};
+  void extractAndAppendTags(absl::string_view, StatNamePool&, StatNameTagVector&) override {};
 
   // Stats::StoreRoot
   void addSink(Sink&) override {}


### PR DESCRIPTION
Commit Message: stats: change extractAndAppendTags() implementation of IsolatedStatsStore to no-op
Additional Description: PR #27215 added ``extractAndAppendTags()`` methods for ``Stats::Store``, which is not implemented in the IsolatedStore, as it is meant for testing and does not have configured tags. The problem is that unit tests that use ``MockIsolatedStatsStore`` will always fail if the underlying production code calls ``extractAndAppendTags()``. Since IsolatedStoreImpl does not use the configured or well-known tags, a no-op is the practical implementation here.
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None

cc @jmarantz 