### PR TITLE
previous_hosts: remove useless assign

### DIFF
--- a/source/extensions/retry/host/previous_hosts/config.h
+++ b/source/extensions/retry/host/previous_hosts/config.h
@@ -13,8 +13,8 @@ namespace Host {
 class PreviousHostsRetryPredicateFactory : public Upstream::RetryHostPredicateFactory {
 public:
   Upstream::RetryHostPredicateSharedPtr createHostPredicate(const Protobuf::Message&,
-                                                            uint32_t retry_count) override {
-    return std::make_shared<PreviousHostsRetryPredicate>(retry_count);
+                                                            uint32_t) override {
+    return std::make_shared<PreviousHostsRetryPredicate>();
   }
 
   std::string name() const override { return "envoy.retry_host_predicates.previous_hosts"; }

--- a/source/extensions/retry/host/previous_hosts/previous_hosts.h
+++ b/source/extensions/retry/host/previous_hosts/previous_hosts.h
@@ -6,8 +6,6 @@
 namespace Envoy {
 class PreviousHostsRetryPredicate : public Upstream::RetryHostPredicate {
 public:
-  PreviousHostsRetryPredicate(uint32_t retry_count) : attempted_hosts_(retry_count) {}
-
   bool shouldSelectAnotherHost(const Upstream::Host& candidate_host) override {
     return std::find(attempted_hosts_.begin(), attempted_hosts_.end(), &candidate_host) !=
            attempted_hosts_.end();


### PR DESCRIPTION
Now we use `emplace_back` to add elements, the initial size will be always set to empty value which means extra useless cost.

The example:

```
#include <iostream>
#include <vector>

using namespace std;

int main()
{
	vector<int> g1(2);
    	cout << "\nVector elements are: ";
    	for (auto it = g1.begin(); it != g1.end(); it++)
		cout << *it << " ";
    	cout << "\nSize : " << g1.size();

	for (int i = 1; i <= 5; i++)
		g1.emplace_back(i);

    	cout << "\nVector elements are: ";
	for (auto it = g1.begin(); it != g1.end(); it++)
		cout << *it << " ";

	cout << "\nSize : " << g1.size();
}
```

Output:
```
Vector elements are: 0 0 
Size : 2
Vector elements are: 0 0 1 2 3 4 5 
Size : 7
```

Commit Message:
Additional Description:
Risk Level: Low