### PR TITLE
router: corrent host_selection_retry_max_attempts comments

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -1098,8 +1098,7 @@ message RetryPolicy {
   repeated RetryHostPredicate retry_host_predicate = 5;
 
   // The maximum number of times host selection will be reattempted before giving up, at which
-  // point the host that was last selected will be routed to. If unspecified, this will default to
-  // retrying once.
+  // point the host that was last selected will be routed to. The default value is 1.
   int64 host_selection_retry_max_attempts = 6;
 
   // HTTP status codes that should trigger a retry in addition to those specified by retry_on.

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1556,8 +1556,7 @@ message RetryPolicy {
   repeated core.v3.TypedExtensionConfig retry_options_predicates = 12;
 
   // The maximum number of times host selection will be reattempted before giving up, at which
-  // point the host that was last selected will be routed to. If unspecified, this will default to
-  // retrying once.
+  // point the host that was last selected will be routed to. The default value is 1.
   int64 host_selection_retry_max_attempts = 6;
 
   // HTTP status codes that should trigger a retry in addition to those specified by retry_on.


### PR DESCRIPTION
The `host_selection_attempts_` is set to 1 as default:

https://github.com/envoyproxy/envoy/blob/bf96fc81a475f1b0fc7187b0ed91e7f562812faf/source/common/router/config_impl.h#L439

And if not specified, no change it to retrying:

https://github.com/envoyproxy/envoy/blob/bf96fc81a475f1b0fc7187b0ed91e7f562812faf/source/common/router/config_impl.cc#L294-L297

Risk Level: Low