### PR TITLE
Opentracing dynamic: Commit generated files to avoid cmake.

### DIFF
--- a/bazel/io_opentracing_cpp.patch
+++ b/bazel/io_opentracing_cpp.patch
@@ -57,3 +57,76 @@ index 1721fb3..3873b3a 100644
  endif()
  
  # ==============================================================================
+diff --git a/include/opentracing/config.h b/include/opentracing/config.h
+new file mode 100755
+index 0000000..cae3e61
+--- /dev/null
++++ b/include/opentracing/config.h
+@@ -0,0 +1,3 @@
++#pragma once
++
++#define OPENTRACING_BUILD_DYNAMIC_LOADING
+diff --git a/include/opentracing/version.h b/include/opentracing/version.h
+new file mode 100755
+index 0000000..25b9945
+--- /dev/null
++++ b/include/opentracing/version.h
+@@ -0,0 +1,14 @@
++#ifndef OPENTRACING_VERSION_H
++#define OPENTRACING_VERSION_H
++
++#define OPENTRACING_VERSION "1.5.1"
++#define OPENTRACING_ABI_VERSION "2"
++
++// clang-format off
++#define BEGIN_OPENTRACING_ABI_NAMESPACE \
++  inline namespace v2 {
++#define END_OPENTRACING_ABI_NAMESPACE \
++  }  // namespace v2
++// clang-format on
++
++#endif // OPENTRACING_VERSION_H
+diff --git a/BUILD.bazel b/BUILD.bazel
+index c57dc9f..587bf0e 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,10 +1,7 @@
+ cc_library(
+     name = "opentracing",
+     srcs = glob(["src/**/*.cpp"], exclude=["src/dynamic_load_unsupported.cpp", "src/dynamic_load_windows.cpp"]),
+-    hdrs = glob(["include/opentracing/**/*.h"]) + [
+-        ":include/opentracing/config.h",
+-        ":include/opentracing/version.h",
+-    ],
++    hdrs = glob(["include/opentracing/**/*.h"]),
+     strip_include_prefix = "include",
+     visibility = ["//visibility:public"],
+     deps = [
+@@ -15,27 +12,3 @@ cc_library(
+       "-ldl",
+     ],
+ )
+-
+-genrule(
+-    name = "generate_version_h",
+-    srcs = glob([
+-        "*",
+-        "cmake/*",
+-        "src/**/*.cpp",
+-    ]),
+-    outs = [
+-      "include/opentracing/config.h",
+-      "include/opentracing/version.h"
+-    ],
+-    cmd = """
+-    TEMP_DIR=$$(mktemp -d)
+-    CONFIG_H_OUT=$${PWD}/$(location :include/opentracing/config.h)
+-    VERSION_H_OUT=$${PWD}/$(location :include/opentracing/version.h)
+-    OPENTRACING_ROOT=$$(dirname $${PWD}/$(location :CMakeLists.txt))
+-    cd $$TEMP_DIR
+-    cmake -DBUILD_TESTING=OFF -DBUILD_MOCKTRACER=OFF -L $$OPENTRACING_ROOT
+-    mv include/opentracing/config.h $$CONFIG_H_OUT
+-    mv include/opentracing/version.h $$VERSION_H_OUT
+-    rm -rf $$TEMP_DIR
+-    """,
+-)


### PR DESCRIPTION
Commit Message: Opentracing dynamic: Commit generated files to avoid cmake.
Additional Description: See related PRs, issues
Risk Level: Low
Testing: Covered by CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] No
[Optional Fixes #Issue]: Related to #9958
[Optional Fixes commit #PR or SHA]: Potentially replaces #27244, #27246
[Optional Deprecated:] Needs to be considered in future for this OpenTracing dynamic component
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
