### PR TITLE
UHV: allow validation of HTTP/1.0 requests

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1086,6 +1086,28 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
   // We end the decode here to mark that the downstream stream is complete.
   maybeEndDecode(end_stream);
 
+  // Make sure we are getting a codec version we support.
+  if (protocol == Protocol::Http10) {
+    // Assume this is HTTP/1.0. This is fine for HTTP/0.9 but this code will also affect any
+    // requests with non-standard version numbers (0.9, 1.3), basically anything which is not
+    // HTTP/1.1.
+    //
+    // The protocol may have shifted in the HTTP/1.0 case so reset it.
+    filter_manager_.streamInfo().protocol(protocol);
+    if (!connection_manager_.config_.http1Settings().accept_http_10_) {
+      // Send "Upgrade Required" if HTTP/1.0 support is not explicitly configured on.
+      sendLocalReply(Code::UpgradeRequired, "", nullptr, absl::nullopt,
+                     StreamInfo::ResponseCodeDetails::get().LowVersion);
+      return;
+    }
+    if (!request_headers_->Host() &&
+        !connection_manager_.config_.http1Settings().default_host_for_http_10_.empty()) {
+      // Add a default host if configured to do so.
+      request_headers_->setHost(
+          connection_manager_.config_.http1Settings().default_host_for_http_10_);
+    }
+  }
+
   if (!validateHeaders()) {
     ENVOY_STREAM_LOG(debug, "request headers validation failed\n{}", *this, *request_headers_);
     return;
@@ -1138,28 +1160,6 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
   connection_manager_.user_agent_.initializeFromHeaders(*request_headers_,
                                                         connection_manager_.stats_.prefixStatName(),
                                                         connection_manager_.stats_.scope_);
-
-  // Make sure we are getting a codec version we support.
-  if (protocol == Protocol::Http10) {
-    // Assume this is HTTP/1.0. This is fine for HTTP/0.9 but this code will also affect any
-    // requests with non-standard version numbers (0.9, 1.3), basically anything which is not
-    // HTTP/1.1.
-    //
-    // The protocol may have shifted in the HTTP/1.0 case so reset it.
-    filter_manager_.streamInfo().protocol(protocol);
-    if (!connection_manager_.config_.http1Settings().accept_http_10_) {
-      // Send "Upgrade Required" if HTTP/1.0 support is not explicitly configured on.
-      sendLocalReply(Code::UpgradeRequired, "", nullptr, absl::nullopt,
-                     StreamInfo::ResponseCodeDetails::get().LowVersion);
-      return;
-    }
-    if (!request_headers_->Host() &&
-        !connection_manager_.config_.http1Settings().default_host_for_http_10_.empty()) {
-      // Add a default host if configured to do so.
-      request_headers_->setHost(
-          connection_manager_.config_.http1Settings().default_host_for_http_10_);
-    }
-  }
 
   if (!request_headers_->Host()) {
     // Require host header. For HTTP/1.1 Host has already been translated to :authority.

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
@@ -293,11 +293,6 @@ typed_config:
 // Verify the grpc cached logger is available after the initial logger filter is destroyed.
 // Regression test for https://github.com/envoyproxy/envoy/issues/18066
 TEST_P(AccessLogIntegrationTest, GrpcLoggerSurvivesAfterReloadConfig) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   config_helper_.disableDelayClose();
   autonomous_upstream_ = true;
   // The grpc access logger connection never closes. It's ok to see an incomplete logging stream.

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -252,11 +252,8 @@ typed_config:
   initializeFilter(FILTER_AND_CODE, "foo");
   std::string response;
 
-#ifndef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\n\r\n", &response, true);
   EXPECT_TRUE(response.find("HTTP/1.1 426 Upgrade Required\r\n") == 0);
-#endif
 
   response = "";
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.1\r\n\r\n", &response, true);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1109,11 +1109,6 @@ TEST_P(IntegrationTest, BadHeader) {
 }
 
 TEST_P(IntegrationTest, Http10Disabled) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\n\r\n", &response, true);
@@ -1121,11 +1116,6 @@ TEST_P(IntegrationTest, Http10Disabled) {
 }
 
 TEST_P(IntegrationTest, Http10DisabledWithUpgrade) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\nUpgrade: h2c\r\n\r\n",
@@ -1135,11 +1125,6 @@ TEST_P(IntegrationTest, Http10DisabledWithUpgrade) {
 
 // Turn HTTP/1.0 support on and verify 09 style requests work.
 TEST_P(IntegrationTest, Http09Enabled) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   useAccessLog();
   autonomous_upstream_ = true;
   config_helper_.addConfigModifier(&setAllowHttp10WithDefaultHost);
@@ -1165,11 +1150,6 @@ TEST_P(IntegrationTest, Http09WithKeepalive) {
     return;
   }
 
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   useAccessLog();
   autonomous_upstream_ = true;
   config_helper_.addConfigModifier(&setAllowHttp10WithDefaultHost);
@@ -1186,11 +1166,6 @@ TEST_P(IntegrationTest, Http09WithKeepalive) {
 
 // Turn HTTP/1.0 support on and verify the request is proxied and the default host is sent upstream.
 TEST_P(IntegrationTest, Http10Enabled) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   autonomous_upstream_ = true;
   config_helper_.addConfigModifier(&setAllowHttp10WithDefaultHost);
   initialize();
@@ -1392,11 +1367,6 @@ TEST_P(IntegrationTest, PipelineWithTrailers) {
 // an inline sendLocalReply to make sure the "kick" works under the call stack
 // of dispatch as well as when a response is proxied from upstream.
 TEST_P(IntegrationTest, PipelineInline) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.mutable_stream_error_on_invalid_http_message()->set_value(true); });

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -667,11 +667,6 @@ INSTANTIATE_TEST_SUITE_P(Protocols, LdsIntegrationTest,
 
 // Sample test making sure our config framework correctly reloads listeners.
 TEST_P(LdsIntegrationTest, ReloadConfig) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#23287) - Determine HTTP/0.9 and HTTP/1.0 support within UHV
-  return;
-#endif
-
   config_helper_.disableDelayClose();
   autonomous_upstream_ = true;
   initialize();


### PR DESCRIPTION
Commit Message:
This change allows UHV to validate HTTP/1.0 and HTTP/0.9 requests. Envoy does not treat pre HTTP/1.1 requests differently other than allowing the Host header to be optional and adding it using the `default_host_for_http_10` configuration value if it is not present in the request.

This change moves check for pre HTTP/1.1 protocol and addition of the Host header to before the UHV is invoked (instead of doing it after). This allows UHV to check it as 1.1 protocol as the Host header should be present at this point.

Moving this check into UHV is problematic, because validation is immutable and the Host header can not be added during validation (and transformation is done after validation). Given that this is an edge case, it should be ok to leave this check in HCM. Alternatively it can even be moved into H/1 codec, to improve encapsulation.

Risk Level: Low, build flag protected
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #23287
