### PR TITLE
Move HTTP/1.0 check into HTTP1 codec

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1084,31 +1084,10 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
   // them as early as possible.
   const Protocol protocol = connection_manager_.codec_->protocol();
   state_.saw_connection_close_ = HeaderUtility::shouldCloseConnection(protocol, *request_headers_);
+  filter_manager_.streamInfo().protocol(protocol);
 
   // We end the decode here to mark that the downstream stream is complete.
   maybeEndDecode(end_stream);
-
-  // Make sure we are getting a codec version we support.
-  if (protocol == Protocol::Http10) {
-    // Assume this is HTTP/1.0. This is fine for HTTP/0.9 but this code will also affect any
-    // requests with non-standard version numbers (0.9, 1.3), basically anything which is not
-    // HTTP/1.1.
-    //
-    // The protocol may have shifted in the HTTP/1.0 case so reset it.
-    filter_manager_.streamInfo().protocol(protocol);
-    if (!connection_manager_.config_.http1Settings().accept_http_10_) {
-      // Send "Upgrade Required" if HTTP/1.0 support is not explicitly configured on.
-      sendLocalReply(Code::UpgradeRequired, "", nullptr, absl::nullopt,
-                     StreamInfo::ResponseCodeDetails::get().LowVersion);
-      return;
-    }
-    if (!request_headers_->Host() &&
-        !connection_manager_.config_.http1Settings().default_host_for_http_10_.empty()) {
-      // Add a default host if configured to do so.
-      request_headers_->setHost(
-          connection_manager_.config_.http1Settings().default_host_for_http_10_);
-    }
-  }
 
   if (!validateHeaders()) {
     ENVOY_STREAM_LOG(debug, "request headers validation failed\n{}", *this, *request_headers_);

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -835,7 +835,7 @@ Status ConnectionImpl::onHeaderValueImpl(const char* data, size_t length) {
 StatusOr<CallbackResult> ConnectionImpl::onHeadersCompleteImpl() {
   ASSERT(!processing_trailers_);
   ASSERT(dispatching_);
-  ENVOY_CONN_LOG(trace, "onHeadersCompleteBase", connection_);
+  ENVOY_CONN_LOG(trace, "onHeadersCompleteImpl", connection_);
   RETURN_IF_ERROR(completeCurrentHeader());
 
   if (!parser_->isHttp11()) {
@@ -1149,6 +1149,27 @@ Status ServerConnectionImpl::handlePath(RequestHeaderMap& headers, absl::string_
   return okStatus();
 }
 
+Status ServerConnectionImpl::checkProtocolVersion(RequestHeaderMap& headers) {
+  if (protocol() == Protocol::Http10) {
+    // Assume this is HTTP/1.0. This is fine for HTTP/0.9 but this code will also affect any
+    // requests with non-standard version numbers (0.9, 1.3), basically anything which is not
+    // HTTP/1.1.
+    //
+    // The protocol may have shifted in the HTTP/1.0 case so reset it.
+    if (!codec_settings_.accept_http_10_) {
+      // Send "Upgrade Required" if HTTP/1.0 support is not explicitly configured on.
+      error_code_ = Http::Code::UpgradeRequired;
+      RETURN_IF_ERROR(sendProtocolError(StreamInfo::ResponseCodeDetails::get().LowVersion));
+      return codecProtocolError("Upgrade required for HTTP/1.0 or HTTP/0.9");
+    }
+    if (!headers.Host() && !codec_settings_.default_host_for_http_10_.empty()) {
+      // Add a default host if configured to do so.
+      headers.setHost(codec_settings_.default_host_for_http_10_);
+    }
+  }
+  return okStatus();
+}
+
 Envoy::StatusOr<CallbackResult> ServerConnectionImpl::onHeadersCompleteBase() {
   // Handle the case where response happens prior to request complete. It's up to upper layer code
   // to disconnect the connection but we shouldn't fire any more events since it doesn't make
@@ -1182,6 +1203,7 @@ Envoy::StatusOr<CallbackResult> ServerConnectionImpl::onHeadersCompleteBase() {
     ASSERT(active_request_->request_url_.empty());
 
     headers->setMethod(parser_->methodName());
+    RETURN_IF_ERROR(checkProtocolVersion(*headers));
 
     // Make sure the host is valid.
     auto details = HeaderUtility::requestHeadersValid(*headers);

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -557,6 +557,7 @@ private:
 
   Status doFloodProtectionChecks() const;
   Status checkHeaderNameForUnderscores() override;
+  Status checkProtocolVersion(RequestHeaderMap& headers);
 
   ServerConnectionCallbacks& callbacks_;
   std::unique_ptr<ActiveRequest> active_request_;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -919,6 +919,7 @@ TEST_P(Http1ServerConnectionImplTest, CodecHasDefaultStreamErrorIfNotSet) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http10) {
+  codec_settings_.accept_http_10_ = true;
   initialize();
 
   InSequence sequence;
@@ -936,7 +937,29 @@ TEST_P(Http1ServerConnectionImplTest, Http10) {
   EXPECT_EQ(Protocol::Http10, codec_->protocol());
 }
 
+TEST_P(Http1ServerConnectionImplTest, Http10HostAdded) {
+  codec_settings_.accept_http_10_ = true;
+  codec_settings_.default_host_for_http_10_ = "example.com";
+  initialize();
+
+  InSequence sequence;
+
+  MockRequestDecoder decoder;
+  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
+
+  TestRequestHeaderMapImpl expected_headers{
+      {":path", "/"}, {":method", "GET"}, {":authority", "example.com"}};
+  EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
+
+  Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
+  auto status = codec_->dispatch(buffer);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(0U, buffer.length());
+  EXPECT_EQ(Protocol::Http10, codec_->protocol());
+}
+
 TEST_P(Http1ServerConnectionImplTest, Http10AbsoluteNoOp) {
+  codec_settings_.accept_http_10_ = true;
   initialize();
 
   TestRequestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
@@ -945,6 +968,7 @@ TEST_P(Http1ServerConnectionImplTest, Http10AbsoluteNoOp) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http10Absolute) {
+  codec_settings_.accept_http_10_ = true;
   initialize();
 
   TestRequestHeaderMapImpl expected_headers{{":authority", "www.somewhere.com"},
@@ -956,6 +980,7 @@ TEST_P(Http1ServerConnectionImplTest, Http10Absolute) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http10MultipleResponses) {
+  codec_settings_.accept_http_10_ = true;
   initialize();
 
   MockRequestDecoder decoder;
@@ -978,7 +1003,7 @@ TEST_P(Http1ServerConnectionImplTest, Http10MultipleResponses) {
     ON_CALL(connection_, write(_, _)).WillByDefault(AddBufferToString(&output));
     TestResponseHeaderMapImpl headers{{":status", "200"}};
     response_encoder->encodeHeaders(headers, true);
-    EXPECT_EQ("HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", output);
+    EXPECT_EQ("HTTP/1.0 200 OK\r\ncontent-length: 0\r\n\r\n", output);
     EXPECT_EQ(Protocol::Http10, codec_->protocol());
   }
 
@@ -995,6 +1020,7 @@ TEST_P(Http1ServerConnectionImplTest, Http10MultipleResponses) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, HttpVersion) {
+  codec_settings_.accept_http_10_ = true;
   // SPELLCHECKER(off)
   HTTPStringTestCase kRequestHTTPStringTestCases[] = {
       {"", {}, {}}, // HTTP/0.9 has no HTTP-version.
@@ -4542,6 +4568,29 @@ TEST_P(Http1ServerConnectionImplTest, MultipleTransferEncoding) {
     EXPECT_EQ(status.message(), "http/1.1 protocol error: unsupported transfer encoding");
   }
 #endif
+}
+
+TEST_P(Http1ServerConnectionImplTest, Http10Rejected) {
+  initialize();
+  InSequence s;
+
+  StrictMock<MockRequestDecoder> decoder;
+  Http::ResponseEncoder* response_encoder = nullptr;
+  EXPECT_CALL(callbacks_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+        response_encoder = &encoder;
+        return decoder;
+      }));
+  EXPECT_CALL(decoder, sendLocalReply(Http::Code::UpgradeRequired, _, _, _, "low_version"));
+
+  Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
+
+  auto status = codec_->dispatch(buffer);
+
+  EXPECT_TRUE(isCodecProtocolError(status));
+  EXPECT_EQ("low_version", response_encoder->getStream().responseDetails());
+
+  EXPECT_THAT(status.message(), StartsWith("Upgrade required"));
 }
 
 } // namespace Http


### PR DESCRIPTION
Commit Message:
Move HTTP/1.0 check into HTTP1 codec to better encapsulate it since it is HTTP/1 specific logic.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
