### PR TITLE
ci/dockerhub: Improve publishing and add test

### DIFF
--- a/.azure-pipelines/stage/prechecks.yml
+++ b/.azure-pipelines/stage/prechecks.yml
@@ -115,6 +115,20 @@ jobs:
         timeoutInMinutes: 10
         condition: and(failed(), eq(variables['CI_TARGET'], 'docs'))
 
+      # Dockerhub readme publishing
+      - script: |
+          ci/run_envoy_docker.sh 'ci/do_ci.sh dockerhub-readme'
+        displayName: "Dockerhub publishing test"
+        env:
+          ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+          ENVOY_RBE: "1"
+          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
+          BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+          BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+          GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
+          GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
+        condition: eq(variables['CI_TARGET'], 'docs')
+
       stepsPost:
 
       # Format fixes

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -260,9 +260,16 @@ jobs:
     displayName: "Generate docs"
 
   - script: |
-      bazel run //tools/distribution:update_dockerhub_repository
+      ci/run_envoy_docker.sh 'ci/do_ci.sh dockerhub-publish'
     displayName: "Publish Dockerhub description and README"
     env:
+      ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+      ENVOY_RBE: "1"
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
+      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+      GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
+      GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
       DOCKERHUB_USERNAME: ${{ parameters.authDockerUser }}
       DOCKERHUB_PASSWORD: ${{ parameters.authDockerPassword }}
     condition: and(eq(variables['isMain'], 'true'), eq(variables['PostSubmit'], true))

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -513,6 +513,19 @@ case $CI_TARGET in
         "${ENVOY_SRCDIR}/ci/upload_gcs_artifact.sh" "${BUILD_DIR}/build_images" docker
         ;;
 
+    dockerhub-publish)
+        setup_clang_toolchain
+        bazel run "${BAZEL_BUILD_OPTIONS[@]}" \
+              //tools/distribution:update_dockerhub_repository
+        ;;
+
+    dockerhub-readme)
+        setup_clang_toolchain
+        bazel build "${BAZEL_BUILD_OPTIONS[@]}" \
+              //distribution/dockerhub:readme
+        cat bazel-bin/distribution/dockerhub/readme.md
+        ;;
+
     fix_proto_format)
         # proto_format.sh needs to build protobuf.
         setup_clang_toolchain


### PR DESCRIPTION
When we updated python in #25359 it broke the dockerhub publishing 

As this is only currently used on `main` it wasnt detected. This Pr adds a precheck test and improves the existing publishing target

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
