### PR TITLE
ext_proc filter crash when sending trailers when request has no body

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -194,11 +194,8 @@ public:
   void onNewTimeout(const ProtobufWkt::Duration& override_message_timeout);
 
   void sendBufferedData(ProcessorState& state, ProcessorState::CallbackState new_state,
-                        bool end_stream) {
-    if (state.hasBufferedData()) {
-      sendBodyChunk(state, *state.bufferedData(), new_state, end_stream);
-    }
-  }
+                        bool end_stream);
+
   void sendBodyChunk(ProcessorState& state, const Buffer::Instance& data,
                      ProcessorState::CallbackState new_state, bool end_stream);
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -195,7 +195,9 @@ public:
 
   void sendBufferedData(ProcessorState& state, ProcessorState::CallbackState new_state,
                         bool end_stream) {
-    sendBodyChunk(state, *state.bufferedData(), new_state, end_stream);
+    if (state.hasBufferedData()) {
+      sendBodyChunk(state, *state.bufferedData(), new_state, end_stream);
+    }
   }
   void sendBodyChunk(ProcessorState& state, const Buffer::Instance& data,
                      ProcessorState::CallbackState new_state, bool end_stream);

--- a/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/clusterfuzz-testcase-minimized-ext_proc_unit_test_fuzz-5547889199546368.test
+++ b/test/extensions/filters/http/ext_proc/unit_test_fuzz/ext_proc_corpus/clusterfuzz-testcase-minimized-ext_proc_unit_test_fuzz-5547889199546368.test
@@ -1,0 +1,34 @@
+config {
+  grpc_service {
+    envoy_grpc {
+      cluster_name: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      retry_policy {
+      }
+    }
+    timeout {
+    }
+  }
+  processing_mode {
+    request_header_mode: SKIP
+    request_body_mode: BUFFERED
+  }
+  request_attributes: "\022."
+}
+request {
+  trailers {
+    headers {
+      key: "."
+    }
+  }
+}
+response {
+  response_body {
+    response {
+      header_mutation {
+      }
+    }
+  }
+  mode_override {
+    request_header_mode: SKIP
+  }
+}


### PR DESCRIPTION
ext_proc filter crash when sending trailers when request has no body.

The code is assuming the request always has body available and stored in the ext_proc buffer state when processing trailers, which leads into the crash.


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
