### PR TITLE
Increase cluster_manager_impl_test test timeout to avoid TSAN flakes

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -60,6 +60,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "cluster_manager_impl_test",
+    size = "large",
     srcs = ["cluster_manager_impl_test.cc"],
     args = [
         # Force creation of c-ares DnsResolverImpl when running test on macOS.


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
