### PR TITLE
test: allowing bootstrap config in integration tests

### DIFF
--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -126,7 +126,7 @@ protected:
   //
   // Tests that need access to this method should go through the TestEngineBuilder class, which
   // provides access to this method.
-  EngineBuilder& setOverrideConfigForTests(std::string config);
+  EngineBuilder& setOverrideConfigForTests(std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> config);
 
 private:
   struct NativeFilterConfig {
@@ -153,7 +153,7 @@ private:
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";
   std::string device_os_ = "unspecified";
-  std::string config_override_for_tests_ = "";
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> config_override_for_tests_{};
   int stream_idle_timeout_seconds_ = 15;
   int per_try_idle_timeout_seconds_ = 15;
   bool gzip_decompression_filter_ = true;

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -204,7 +204,7 @@ void BaseClientIntegrationTest::createEnvoy() {
     finalizeConfigWithPorts(config_helper_, ports, use_lds_);
     ASSERT_FALSE(config_helper_.bootstrap().has_admin())
         << "Bootstrap config should not have `admin` configured in Envoy Mobile";
-    builder_.setOverrideConfig(MessageUtil::getYamlStringFromMessage(config_helper_.bootstrap()));
+    builder_.setOverrideConfig(std::make_unique<envoy::config::bootstrap::v3::Bootstrap>(config_helper_.bootstrap()));
   } else {
     ENVOY_LOG_MISC(warn, "Using builder config and ignoring config modifiers");
   }

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -79,15 +79,15 @@ Platform::LogLevel getPlatformLogLevelFromOptions() {
 // Use the Envoy mobile default config as much as possible in this test.
 // There are some config modifiers below which do result in deltas.
 // Note: This function is only used to build the Engine if `override_builder_config_` is true.
-std::string defaultConfig() {
+envoy::config::bootstrap::v3::Bootstrap defaultConfig() {
   Platform::EngineBuilder builder;
   std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap = builder.generateBootstrap();
-  return MessageUtil::getYamlStringFromMessage(*bootstrap);
+  envoy::config::bootstrap::v3::Bootstrap to_return = *bootstrap;
+  return to_return;
 }
 
-BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion ip_version,
-                                                     const std::string& bootstrap_config)
-    : BaseIntegrationTest(ip_version, bootstrap_config) {
+BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion ip_version)
+    : BaseIntegrationTest(BaseIntegrationTest::defaultAddressFunction(ip_version), ip_version, defaultConfig()) {
   skip_tag_extraction_rule_check_ = true;
   full_dispatcher_ = api_->allocateDispatcher("fake_envoy_mobile");
   use_lds_ = false;

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -29,7 +29,7 @@ Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers);
 
 // Creates a default bootstrap config from the EngineBuilder.
 // Only used to build the Engine if `override_builder_config_` is set to true.
-std::string defaultConfig();
+envoy::config::bootstrap::v3::Bootstrap defaultConfig();
 
 // A base class for Envoy Mobile client integration tests which interact with Envoy through the
 // Http::Client class.
@@ -38,8 +38,7 @@ std::string defaultConfig();
 // into a test lib.
 class BaseClientIntegrationTest : public BaseIntegrationTest {
 public:
-  BaseClientIntegrationTest(Network::Address::IpVersion ip_version,
-                            const std::string& bootstrap_config = defaultConfig());
+  BaseClientIntegrationTest(Network::Address::IpVersion ip_version);
   virtual ~BaseClientIntegrationTest() = default;
   // Note: This class does not inherit from testing::Test and so this TearDown() method
   // does not override testing::Test::TearDown(). As a result, it will not be called

--- a/mobile/test/common/integration/test_engine_builder.cc
+++ b/mobile/test/common/integration/test_engine_builder.cc
@@ -4,7 +4,7 @@
 
 namespace Envoy {
 
-Platform::EngineSharedPtr TestEngineBuilder::createEngine(std::string config) {
+Platform::EngineSharedPtr TestEngineBuilder::createEngine(std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> config) {
   absl::Notification engine_running;
   Platform::EngineSharedPtr engine = setOverrideConfigForTests(std::move(config))
                                          .addLogLevel(Platform::LogLevel::debug)
@@ -14,7 +14,7 @@ Platform::EngineSharedPtr TestEngineBuilder::createEngine(std::string config) {
   return engine;
 }
 
-void TestEngineBuilder::setOverrideConfig(std::string config) {
+void TestEngineBuilder::setOverrideConfig(std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> config) {
   setOverrideConfigForTests(std::move(config));
 }
 

--- a/mobile/test/common/integration/test_engine_builder.h
+++ b/mobile/test/common/integration/test_engine_builder.h
@@ -6,18 +6,18 @@ namespace Envoy {
 
 // A wrapper class around EngineBuilder, specifically for mobile tests.
 //
-// Mobile tests often supply their own YAML configuration for convenience, instead of using the
+// Mobile tests often supply their own configuration for convenience, instead of using the
 // EngineBuilder APIs. This wrapper class builds an Envoy Mobile Engine with the ability to
 // access setOverrideConfigForTests(), which is a protected method inside EngineBuilder.
 class TestEngineBuilder : public Platform::EngineBuilder {
 public:
   // Creates an Envoy Engine from the provided config and waits until the engine is running before
   // returning the Engine as a shared_ptr.
-  Platform::EngineSharedPtr createEngine(std::string config);
+  Platform::EngineSharedPtr createEngine(std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> config);
 
   // Overrides the EngineBuilder's config with the provided string. Calls to the EngineBuilder's
   // bootstrap modifying APIs do not take effect after this function is called.
-  void setOverrideConfig(std::string config);
+  void setOverrideConfig(std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> config);
 };
 
 } // namespace Envoy

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -139,13 +139,17 @@ public:
     absl::optional<uint32_t> max_verify_depth_{absl::nullopt};
   };
 
+  // Sets up config with the provided bootstrap.
+  ConfigHelper(const Network::Address::IpVersion version,
+               envoy::config::bootstrap::v3::Bootstrap& bootstrap);
+
   // Set up basic config, using the specified IpVersion for all connections: listeners, upstream,
   // and admin connections.
   //
   // By default, this runs with an L7 proxy config, but config can be set to TCP_PROXY_CONFIG
   // to test L4 proxying.
-  ConfigHelper(const Network::Address::IpVersion version, Api::Api& api,
-               const std::string& config = httpProxyConfig(false, false));
+  ConfigHelper(const Network::Address::IpVersion version, Api::Api&,
+               std::string config = httpProxyConfig(false, false));
 
   static void
   initializeTls(const ServerSslOptions& options,

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -29,6 +29,12 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
+envoy::config::bootstrap::v3::Bootstrap configToBootstrap(const std::string& config) {
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  TestUtility::loadFromYaml(config, bootstrap);
+  return bootstrap;
+}
+
 using ::testing::_;
 using ::testing::AssertionFailure;
 using ::testing::AssertionResult;
@@ -40,13 +46,13 @@ using ::testing::ReturnRef;
 
 BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstream_address_fn,
                                          Network::Address::IpVersion version,
-                                         const std::string& config)
+                                         envoy::config::bootstrap::v3::Bootstrap bootstrap)
     : api_(Api::createApiForTest(stats_store_, time_system_)),
       mock_buffer_factory_(new NiceMock<MockBufferFactory>),
       dispatcher_(api_->allocateDispatcher("test_thread",
                                            Buffer::WatermarkFactoryPtr{mock_buffer_factory_})),
       version_(version), upstream_address_fn_(upstream_address_fn),
-      config_helper_(version, *api_, config),
+      config_helper_(version, bootstrap),
       default_log_level_(TestEnvironment::getOptions().logLevel()) {
   Envoy::Server::validateProtoDescriptors();
   // This is a hack, but there are situations where we disconnect fake upstream connections and
@@ -73,14 +79,22 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
 #endif
 }
 
+BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstream_address_fn,
+                                         Network::Address::IpVersion version,
+                                         const std::string& config)
+    : BaseIntegrationTest(upstream_address_fn, version, configToBootstrap(config)) {}
+
+const BaseIntegrationTest::InstanceConstSharedPtrFn
+BaseIntegrationTest::defaultAddressFunction(Network::Address::IpVersion version) {
+  return [version](int) {
+    return Network::Utility::parseInternetAddress(Network::Test::getLoopbackAddressString(version),
+                                                  0);
+  };
+}
+
 BaseIntegrationTest::BaseIntegrationTest(Network::Address::IpVersion version,
                                          const std::string& config)
-    : BaseIntegrationTest(
-          [version](int) {
-            return Network::Utility::parseInternetAddress(
-                Network::Test::getLoopbackAddressString(version), 0);
-          },
-          version, config) {}
+    : BaseIntegrationTest(defaultAddressFunction(version), version, config) {}
 
 Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t port) {
   return makeClientConnectionWithOptions(port, nullptr);

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -66,7 +66,11 @@ struct ApiFilesystemConfig {
 class BaseIntegrationTest : protected Logger::Loggable<Logger::Id::testing> {
 public:
   using InstanceConstSharedPtrFn = std::function<Network::Address::InstanceConstSharedPtr(int)>;
+  static const InstanceConstSharedPtrFn defaultAddressFunction(Network::Address::IpVersion version);
 
+  BaseIntegrationTest(const InstanceConstSharedPtrFn& upstream_address_fn,
+                      Network::Address::IpVersion version,
+                      envoy::config::bootstrap::v3::Bootstrap bootstrap);
   // Creates a test fixture with an upstream bound to INADDR_ANY on an unspecified port using the
   // provided IP |version|.
   BaseIntegrationTest(Network::Address::IpVersion version,


### PR DESCRIPTION
Also removing use of yaml in E-M e2e tests.
base integration tests still use yaml so no CI regression testing yet.

Risk Level: n/a (test only)
Testing: yes
Docs Changes: no
Release Notes: no
