### PR TITLE
access log: attempt to fix test flake

### DIFF
--- a/source/common/access_log/access_log_manager_impl.h
+++ b/source/common/access_log/access_log_manager_impl.h
@@ -114,8 +114,8 @@ private:
                    // high performance. It is always local to the process.
   Thread::ThreadPtr flush_thread_;
   Thread::CondVar flush_event_;
-  std::atomic<bool> flush_thread_exit_{};
-  std::atomic<bool> reopen_file_{};
+  bool flush_thread_exit_ ABSL_GUARDED_BY(write_lock_){false};
+  bool reopen_file_ ABSL_GUARDED_BY(write_lock_){false};
   Buffer::OwnedImpl
       flush_buffer_ ABSL_GUARDED_BY(write_lock_); // This buffer is used by multiple threads. It
                                                   // gets filled and then flushed either when max

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -428,6 +428,8 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
   log_file->write("drop data during reopen fail");
   log_file->reopen();
 
+  ENVOY_LOG_MISC(critical, "after reopen before wait");
+
   {
     Thread::LockGuard lock(file_->open_mutex_);
     while (file_->num_opens_ != 2) {
@@ -436,6 +438,7 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
     timer->invokeCallback();
   }
 
+  ENVOY_LOG_MISC(critical, "after num_opens_ == 2");
   {
     Thread::LockGuard lock(file_->open_mutex_);
     while (file_->num_opens_ != 3) {
@@ -443,6 +446,7 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
     }
   }
 
+  ENVOY_LOG_MISC(critical, "after num_opens_ == 3");
   log_file->write("after reopen");
   timer->invokeCallback();
 
@@ -452,6 +456,7 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
       file_->write_event_.wait(file_->write_mutex_);
     }
   }
+  ENVOY_LOG_MISC(critical, "after num_writes_ == 2");
   waitForCounterEq("filesystem.reopen_failed", 1);
   waitForGaugeEq("filesystem.write_total_buffered", 0);
 }

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -115,12 +115,7 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFilePeriodically) {
 
   log_file->write("test");
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 1) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 1));
 
   waitForCounterEq("filesystem.write_completed", 1);
   EXPECT_EQ(1UL, store_.counter("filesystem.write_buffered").value());
@@ -144,12 +139,7 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFilePeriodically) {
   EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
   timer->invokeCallback();
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 2) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 2));
 
   waitForCounterEq("filesystem.write_completed", 2);
   EXPECT_EQ(0UL, store_.counter("filesystem.write_failed").value());
@@ -179,12 +169,7 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFileOnDemand) {
       }));
   log_file->write("prime-it");
   uint32_t expected_writes = 1;
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != expected_writes) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, expected_writes));
 
   EXPECT_CALL(*file_, write_(_))
       .WillOnce(Invoke([](absl::string_view data) -> Api::IoCallSizeResult {
@@ -195,18 +180,13 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFileOnDemand) {
   log_file->write("test");
 
   {
-    Thread::LockGuard lock(file_->write_mutex_);
+    absl::MutexLock lock(&file_->mutex_);
     EXPECT_EQ(expected_writes, file_->num_writes_);
   }
 
   log_file->flush();
   expected_writes++;
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != expected_writes) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, expected_writes));
 
   waitForCounterEq("filesystem.write_completed", 2);
   EXPECT_EQ(0UL, store_.counter("filesystem.flushed_by_timer").value());
@@ -223,12 +203,7 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFileOnDemand) {
   timer->invokeCallback();
   expected_writes++;
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != expected_writes) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, expected_writes));
   EXPECT_CALL(*file_, close_()).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 }
 
@@ -250,13 +225,7 @@ TEST_F(AccessLogManagerImplTest, FlushCountsIOErrors) {
 
   log_file->write("test");
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 1) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
-
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 1));
   waitForCounterEq("filesystem.write_failed", 1);
   EXPECT_EQ(0UL, store_.counter("filesystem.write_completed").value());
 
@@ -282,13 +251,7 @@ TEST_F(AccessLogManagerImplTest, ReopenFile) {
 
   log_file->write("before");
   timer->invokeCallback();
-
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 1) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 1));
 
   EXPECT_CALL(*file_, close_())
       .InSequence(sq)
@@ -312,18 +275,8 @@ TEST_F(AccessLogManagerImplTest, ReopenFile) {
   log_file->write("reopened");
   timer->invokeCallback();
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 2) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
-  {
-    Thread::LockGuard lock(file_->open_mutex_);
-    while (file_->num_opens_ != 2) {
-      file_->open_event_.wait(file_->open_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 2));
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_opens_, 2));
 }
 
 // Test that the `reopen()` will trigger file reopen even if no data is waiting.
@@ -346,13 +299,7 @@ TEST_F(AccessLogManagerImplTest, ReopenFileNoWrite) {
 
   log_file->write("before");
   timer->invokeCallback();
-
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 1) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 1));
 
   EXPECT_CALL(*file_, close_())
       .InSequence(sq)
@@ -367,12 +314,7 @@ TEST_F(AccessLogManagerImplTest, ReopenFileNoWrite) {
 
   log_file->reopen();
 
-  {
-    Thread::LockGuard lock(file_->open_mutex_);
-    while (file_->num_opens_ != 2) {
-      file_->open_event_.wait(file_->open_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_opens_, 2));
 }
 
 TEST_F(AccessLogManagerImplTest, ReopenRetry) {
@@ -395,29 +337,28 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
 
   log_file->write("before reopen");
   timer->invokeCallback();
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 1) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 1));
 
   EXPECT_CALL(*file_, close_())
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 
   EXPECT_CALL(*file_, open_(_))
+      .Times(3)
       .InSequence(sq)
-      .WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))));
-
-  EXPECT_CALL(*file_, open_(_))
-      .InSequence(sq)
+      .WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))))
+      .WillOnce(Return(ByMove(Filesystem::resultFailure<bool>(false, 0))))
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 
   EXPECT_CALL(*file_, write_(_))
+      .Times(2)
       .InSequence(sq)
       .WillOnce(Invoke([](absl::string_view data) -> Api::IoCallSizeResult {
-        EXPECT_EQ(0, data.compare("after reopen"));
+        EXPECT_EQ(data, "retry reopen");
+        return Filesystem::resultSuccess<ssize_t>(static_cast<ssize_t>(data.length()));
+      }))
+      .WillOnce(Invoke([](absl::string_view data) -> Api::IoCallSizeResult {
+        EXPECT_EQ(data, "after reopen");
         return Filesystem::resultSuccess<ssize_t>(static_cast<ssize_t>(data.length()));
       }));
 
@@ -425,39 +366,26 @@ TEST_F(AccessLogManagerImplTest, ReopenRetry) {
       .InSequence(sq)
       .WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 
-  log_file->write("drop data during reopen fail");
   log_file->reopen();
 
-  ENVOY_LOG_MISC(critical, "after reopen before wait");
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_opens_, 2));
 
-  {
-    Thread::LockGuard lock(file_->open_mutex_);
-    while (file_->num_opens_ != 2) {
-      file_->open_event_.wait(file_->open_mutex_);
-    }
-    timer->invokeCallback();
-  }
+  // Retry the reopen by calling `reopen()` another time.
+  // This time is also set to fail.
+  log_file->reopen();
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_opens_, 3));
 
-  ENVOY_LOG_MISC(critical, "after num_opens_ == 2");
-  {
-    Thread::LockGuard lock(file_->open_mutex_);
-    while (file_->num_opens_ != 3) {
-      file_->open_event_.wait(file_->open_mutex_);
-    }
-  }
+  // Retry the reopen by writing more data and running the timer.
+  log_file->write("retry reopen");
+  timer->invokeCallback();
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_opens_, 4));
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 2));
 
-  ENVOY_LOG_MISC(critical, "after num_opens_ == 3");
   log_file->write("after reopen");
   timer->invokeCallback();
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 2) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
-  ENVOY_LOG_MISC(critical, "after num_writes_ == 2");
-  waitForCounterEq("filesystem.reopen_failed", 1);
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 3));
+  waitForCounterEq("filesystem.reopen_failed", 2);
   waitForGaugeEq("filesystem.write_total_buffered", 0);
 }
 
@@ -473,13 +401,7 @@ TEST_F(AccessLogManagerImplTest, BigDataChunkShouldBeFlushedWithoutTimer) {
       }));
 
   log_file->write("a");
-
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 1) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 1));
 
   // First write happens without waiting on thread_flush_. Now make a big string and it should be
   // flushed even when timer is not enabled
@@ -492,13 +414,8 @@ TEST_F(AccessLogManagerImplTest, BigDataChunkShouldBeFlushedWithoutTimer) {
 
   std::string big_string(1024 * 64 + 1, 'b');
   log_file->write(big_string);
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_writes_, 2));
 
-  {
-    Thread::LockGuard lock(file_->write_mutex_);
-    while (file_->num_writes_ != 2) {
-      file_->write_event_.wait(file_->write_mutex_);
-    }
-  }
   EXPECT_CALL(*file_, close_()).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
 }
 
@@ -567,19 +484,8 @@ TEST_F(AccessLogManagerImplTest, ReopenAllFiles) {
   log->write("this is to force reopen");
   log2->write("this is to force reopen");
 
-  {
-    Thread::LockGuard lock(file_->open_mutex_);
-    while (file_->num_opens_ != 2) {
-      file_->open_event_.wait(file_->open_mutex_);
-    }
-  }
-
-  {
-    Thread::LockGuard lock(file2->open_mutex_);
-    while (file2->num_opens_ != 2) {
-      file2->open_event_.wait(file2->open_mutex_);
-    }
-  }
+  EXPECT_TRUE(file_->waitForEventCount(file_->num_opens_, 2));
+  EXPECT_TRUE(file2->waitForEventCount(file2->num_opens_, 2));
 
   EXPECT_CALL(*file_, close_())
       .InSequence(sq)

--- a/test/mocks/filesystem/mocks.cc
+++ b/test/mocks/filesystem/mocks.cc
@@ -6,55 +6,51 @@
 namespace Envoy {
 namespace Filesystem {
 
-MockFile::MockFile() : num_opens_(0), num_writes_(0), is_open_(false) {}
+MockFile::MockFile() = default;
 MockFile::~MockFile() = default;
 
 Api::IoCallBoolResult MockFile::open(FlagSet flag) {
-  Thread::LockGuard lock(open_mutex_);
+  absl::MutexLock lock(&mutex_);
 
   Api::IoCallBoolResult result = open_(flag);
   is_open_ = result.return_value_;
   num_opens_++;
-  open_event_.notifyOne();
 
   return result;
 }
 
 Api::IoCallSizeResult MockFile::write(absl::string_view buffer) {
-  Thread::LockGuard lock(write_mutex_);
+  absl::MutexLock lock(&mutex_);
   if (!is_open_) {
     return {-1, Api::IoErrorPtr(nullptr, [](Api::IoError*) { PANIC("reached unexpected code"); })};
   }
 
   Api::IoCallSizeResult result = write_(buffer);
   num_writes_++;
-  write_event_.notifyOne();
 
   return result;
 }
 
 Api::IoCallSizeResult MockFile::pread(void* buf, uint64_t count, uint64_t offset) {
-  Thread::LockGuard lock(pread_mutex_);
+  absl::MutexLock lock(&mutex_);
   if (!is_open_) {
     return {-1, Api::IoErrorPtr(nullptr, [](Api::IoError*) { PANIC("reached unexpected code"); })};
   }
 
   Api::IoCallSizeResult result = pread_(buf, count, offset);
   num_preads_++;
-  pread_event_.notifyOne();
 
   return result;
 }
 
 Api::IoCallSizeResult MockFile::pwrite(const void* buf, uint64_t count, uint64_t offset) {
-  Thread::LockGuard lock(pwrite_mutex_);
+  absl::MutexLock lock(&mutex_);
   if (!is_open_) {
     return {-1, Api::IoErrorPtr(nullptr, [](Api::IoError*) { PANIC("reached unexpected code"); })};
   }
 
   Api::IoCallSizeResult result = pwrite_(buf, count, offset);
   num_pwrites_++;
-  pwrite_event_.notifyOne();
 
   return result;
 }

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -36,21 +36,21 @@ public:
   MOCK_METHOD(Api::IoCallSizeResult, pread_, (void* buf, uint64_t count, uint64_t offset));
   MOCK_METHOD(Api::IoCallSizeResult, pwrite_, (const void* buf, uint64_t count, uint64_t offset));
 
-  size_t num_opens_;
-  size_t num_writes_;
-  size_t num_preads_;
-  size_t num_pwrites_;
-  Thread::MutexBasicLockable open_mutex_;
-  Thread::MutexBasicLockable write_mutex_;
-  Thread::MutexBasicLockable pread_mutex_;
-  Thread::MutexBasicLockable pwrite_mutex_;
-  Thread::CondVar open_event_;
-  Thread::CondVar write_event_;
-  Thread::CondVar pread_event_;
-  Thread::CondVar pwrite_event_;
+  absl::Mutex mutex_;
+  uint64_t num_opens_{0};
+  uint64_t num_writes_{0};
+  uint64_t num_preads_{0};
+  uint64_t num_pwrites_{0};
+
+  bool waitForEventCount(uint64_t& event_counter, uint64_t expected) {
+    auto func = [&]() { return event_counter == expected; };
+    bool result = mutex_.LockWhenWithTimeout(absl::Condition(&func), absl::Seconds(15));
+    mutex_.Unlock();
+    return result;
+  }
 
 private:
-  bool is_open_;
+  bool is_open_{false};
 };
 
 class MockInstance : public Instance {


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: CI showed a failure in TEST_F(AccessLogManagerImplTest, ReopenFileOnTimerOnly). Attempting to use more rigid thread-syncronization primitives instead of atomics to avoid races and/or undefined/misunderstood behavior.

Additional Description:
Risk Level: Low
Testing: Modified tests to fit new expectations
Docs Changes: noen
Release Notes: none
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
