### PR TITLE
[fuzz] Reduce valid input gen depth to 20.

### DIFF
--- a/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz_test.cc
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz_test.cc
@@ -46,7 +46,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::network::FilterFuzzTestCase
                          factory->createEmptyConfigProto()->GetDescriptor()->full_name()));
 
         ProtobufMessage::ValidatedInputGenerator generator(
-            seed, ProtobufMessage::composeFiltersAnyMap(), 40);
+            seed, ProtobufMessage::composeFiltersAnyMap(), 20);
         ProtobufMessage::traverseMessage(generator, *input, true);
       }};
 

--- a/test/extensions/filters/network/common/fuzz/network_writefilter_fuzz_test.cc
+++ b/test/extensions/filters/network/common/fuzz/network_writefilter_fuzz_test.cc
@@ -39,8 +39,8 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::network::FilterFuzzTestCase
         input->mutable_config()->mutable_typed_config()->set_type_url(
             absl::StrCat("type.googleapis.com/",
                          factory->createEmptyConfigProto()->GetDescriptor()->full_name()));
-        ProtobufMessage::ValidatedInputGenerator generator(seed,
-                                                           ProtobufMessage::composeFiltersAnyMap());
+        ProtobufMessage::ValidatedInputGenerator generator(
+            seed, ProtobufMessage::composeFiltersAnyMap(), 20);
         ProtobufMessage::traverseMessage(generator, *input, true);
       }};
   try {


### PR DESCRIPTION
Commit Message: [fuzz] Reduce valid input gen depth to 20.
Additional Description:
Reducing the maximum allowed depth during Protobuf message traversal in the valid input generation visitor to 20 to further reduce the possibility of stack overflows.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a