### PR TITLE
stats: Skip slowRejects if we have a definitive answer from fastRejects.

### DIFF
--- a/source/common/stats/stats_matcher_impl.cc
+++ b/source/common/stats/stats_matcher_impl.cc
@@ -89,6 +89,14 @@ bool StatsMatcherImpl::fastRejectMatch(StatName stat_name) const {
 }
 
 bool StatsMatcherImpl::slowRejects(FastResult fast_result, StatName stat_name) const {
+  // Skip slowRejectMatch if we already have a definitive answer from fastRejects.
+  if (fast_result == FastResult::Rejects) {
+    return true;
+  }
+  if (fast_result == FastResult::Matches) {
+    return false;
+  }
+
   bool match = slowRejectMatch(stat_name);
 
   if (is_inclusive_ || match || fast_result != FastResult::Matches) {

--- a/source/common/stats/stats_matcher_impl.cc
+++ b/source/common/stats/stats_matcher_impl.cc
@@ -99,7 +99,7 @@ bool StatsMatcherImpl::slowRejects(FastResult fast_result, StatName stat_name) c
 
   bool match = slowRejectMatch(stat_name);
 
-  if (is_inclusive_ || match || fast_result != FastResult::Matches) {
+  if (is_inclusive_ || match) {
     //  is_inclusive_ | match | return
     // ---------------+-------+--------
     //        T       |   T   |   T   Default-inclusive and matching an (exclusion) matcher, deny.

--- a/source/common/stats/stats_matcher_impl.cc
+++ b/source/common/stats/stats_matcher_impl.cc
@@ -99,7 +99,7 @@ bool StatsMatcherImpl::slowRejects(FastResult fast_result, StatName stat_name) c
 
   bool match = slowRejectMatch(stat_name);
 
-  if (is_inclusive_ || match) {
+  if (is_inclusive_ || match || fast_result == FastResult::NoMatch) {
     //  is_inclusive_ | match | return
     // ---------------+-------+--------
     //        T       |   T   |   T   Default-inclusive and matching an (exclusion) matcher, deny.

--- a/source/common/stats/stats_matcher_impl.cc
+++ b/source/common/stats/stats_matcher_impl.cc
@@ -94,7 +94,7 @@ bool StatsMatcherImpl::slowRejects(FastResult fast_result, StatName stat_name) c
     return fast_result == FastResult::Rejects;
   }
 
-  bool match = slowRejectMatch(stat_name);
+  const bool match = slowRejectMatch(stat_name);
 
   //  is_inclusive_ | match | return
   // ---------------+-------+--------

--- a/source/common/stats/stats_matcher_impl.cc
+++ b/source/common/stats/stats_matcher_impl.cc
@@ -90,11 +90,8 @@ bool StatsMatcherImpl::fastRejectMatch(StatName stat_name) const {
 
 bool StatsMatcherImpl::slowRejects(FastResult fast_result, StatName stat_name) const {
   // Skip slowRejectMatch if we already have a definitive answer from fastRejects.
-  if (fast_result == FastResult::Rejects) {
-    return true;
-  }
-  if (fast_result == FastResult::Matches) {
-    return false;
+  if (fast_result != FastResult::NoMatch) {
+    return fast_result == FastResult::Rejects;
   }
 
   bool match = slowRejectMatch(stat_name);

--- a/source/common/stats/stats_matcher_impl.cc
+++ b/source/common/stats/stats_matcher_impl.cc
@@ -99,19 +99,15 @@ bool StatsMatcherImpl::slowRejects(FastResult fast_result, StatName stat_name) c
 
   bool match = slowRejectMatch(stat_name);
 
-  if (is_inclusive_ || match || fast_result == FastResult::NoMatch) {
-    //  is_inclusive_ | match | return
-    // ---------------+-------+--------
-    //        T       |   T   |   T   Default-inclusive and matching an (exclusion) matcher, deny.
-    //        T       |   F   |   F   Otherwise, allow.
-    //        F       |   T   |   F   Default-exclusive and matching an (inclusion) matcher, allow.
-    //        F       |   F   |   T   Otherwise, deny.
-    //
-    // This is an XNOR, which can be evaluated by checking for equality.
-    return match == is_inclusive_;
-  }
-
-  return false;
+  //  is_inclusive_ | match | return
+  // ---------------+-------+--------
+  //        T       |   T   |   T   Default-inclusive and matching an (exclusion) matcher, deny.
+  //        T       |   F   |   F   Otherwise, allow.
+  //        F       |   T   |   F   Default-exclusive and matching an (inclusion) matcher, allow.
+  //        F       |   F   |   T   Otherwise, deny.
+  //
+  // This is an XNOR, which can be evaluated by checking for equality.
+  return match == is_inclusive_;
 }
 
 bool StatsMatcherImpl::slowRejectMatch(StatName stat_name) const {

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -231,6 +231,30 @@ envoy_benchmark_test(
     benchmark_binary = "symbol_table_benchmark",
 )
 
+envoy_cc_benchmark_binary(
+    name = "stats_matcher_impl_benchmark",
+    srcs = [
+        "stats_matcher_impl_speed_test.cc",
+    ],
+    external_deps = [
+        "abseil_strings",
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/memory:stats_lib",
+        "//source/common/stats:stats_matcher_lib",
+        "//test/test_common:logging_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+        "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_benchmark_test(
+    name = "stats_matcher_impl_benchmark_test",
+    benchmark_binary = "stats_matcher_impl_benchmark",
+)
+
 envoy_cc_test(
     name = "tag_extractor_impl_test",
     srcs = ["tag_extractor_impl_test.cc"],

--- a/test/common/stats/stats_matcher_impl_speed_test.cc
+++ b/test/common/stats/stats_matcher_impl_speed_test.cc
@@ -39,7 +39,8 @@ private:
 } // namespace Stats
 } // namespace Envoy
 
-static void bmInclusion(benchmark::State& state) {
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_Inclusion(benchmark::State& state) {
   // Create matcher.
   Envoy::Stats::StatsMatcherPerf context;
   context.inclusionList()->set_suffix("1");
@@ -60,9 +61,10 @@ static void bmInclusion(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(bmInclusion);
+BENCHMARK(BM_Inclusion);
 
-static void bmExclusion(benchmark::State& state) {
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_Exclusion(benchmark::State& state) {
   // Create matcher.
   Envoy::Stats::StatsMatcherPerf context;
   context.exclusionList()->set_suffix("1");
@@ -83,4 +85,4 @@ static void bmExclusion(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(bmExclusion);
+BENCHMARK(BM_Exclusion);

--- a/test/common/stats/stats_matcher_impl_speed_test.cc
+++ b/test/common/stats/stats_matcher_impl_speed_test.cc
@@ -52,7 +52,7 @@ static void BM_Inclusion(benchmark::State& state) {
     stat_names.push_back(context.pool_.add(absl::StrCat("2.", idx)));
   }
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     for (auto idx = 0; idx < 1000; ++idx) {
       const Envoy::Stats::StatName stat_name = stat_names[idx % 10];
       const Envoy::Stats::StatsMatcher::FastResult fast_result =
@@ -76,7 +76,7 @@ static void BM_Exclusion(benchmark::State& state) {
     stat_names.push_back(context.pool_.add(absl::StrCat("2.", idx)));
   }
 
-  for (auto _ : state) {
+  for (auto _ : state) { // NOLINT
     for (auto idx = 0; idx < 1000; ++idx) {
       const Envoy::Stats::StatName stat_name = stat_names[idx % 10];
       const Envoy::Stats::StatsMatcher::FastResult fast_result =

--- a/test/common/stats/stats_matcher_impl_speed_test.cc
+++ b/test/common/stats/stats_matcher_impl_speed_test.cc
@@ -1,0 +1,73 @@
+// Note: this should be run with --compilation_mode=opt, and would benefit from a
+// quiescent system with disabled cstate power management.
+
+#include "envoy/config/metrics/v3/stats.pb.h"
+#include "envoy/type/matcher/v3/string.pb.h"
+
+#include "source/common/stats/stats_matcher_impl.h"
+#include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Stats {
+
+class StatsMatcherPerf {
+public:
+  StatsMatcherPerf() : pool_(symbol_table_) {}
+
+  void initMatcher() {
+    stats_matcher_impl_ = std::make_unique<StatsMatcherImpl>(stats_config_, symbol_table_);
+  }
+
+  envoy::type::matcher::v3::StringMatcher* inclusionList() {
+    return stats_config_.mutable_stats_matcher()->mutable_inclusion_list()->add_patterns();
+  }
+  envoy::type::matcher::v3::StringMatcher* exclusionList() {
+    return stats_config_.mutable_stats_matcher()->mutable_exclusion_list()->add_patterns();
+  }
+
+  SymbolTableImpl symbol_table_;
+  StatNamePool pool_;
+  std::unique_ptr<StatsMatcherImpl> stats_matcher_impl_;
+
+private:
+  envoy::config::metrics::v3::StatsConfig stats_config_;
+};
+
+} // namespace Stats
+} // namespace Envoy
+
+static void BM_Inclusion(benchmark::State& state) {
+  // Create matcher.
+  Envoy::Stats::StatsMatcherPerf context;
+  context.inclusionList()->set_suffix("1");
+  context.inclusionList()->set_prefix("2.");
+  context.initMatcher();
+
+  for (auto _ : state) {
+    for (auto idx = 0; idx < 1000; ++idx) {
+      Envoy::Stats::StatName stat_name = context.pool_.add(absl::StrCat("2.", idx % 10));
+      const auto fast_result = context.stats_matcher_impl_->fastRejects(stat_name);
+      (void)context.stats_matcher_impl_->slowRejects(fast_result, stat_name);
+    }
+  }
+}
+BENCHMARK(BM_Inclusion);
+
+static void BM_Exclusion(benchmark::State& state) {
+  // Create matcher.
+  Envoy::Stats::StatsMatcherPerf context;
+  context.exclusionList()->set_suffix("1");
+  context.exclusionList()->set_prefix("2.");
+  context.initMatcher();
+
+  for (auto _ : state) {
+    for (auto idx = 0; idx < 1000; ++idx) {
+      Envoy::Stats::StatName stat_name = context.pool_.add(absl::StrCat("2.", idx % 10));
+      const auto fast_result = context.stats_matcher_impl_->fastRejects(stat_name);
+      (void)context.stats_matcher_impl_->slowRejects(fast_result, stat_name);
+    }
+  }
+}
+BENCHMARK(BM_Exclusion);

--- a/test/common/stats/stats_matcher_impl_speed_test.cc
+++ b/test/common/stats/stats_matcher_impl_speed_test.cc
@@ -39,7 +39,7 @@ private:
 } // namespace Stats
 } // namespace Envoy
 
-static void BM_Inclusion(benchmark::State& state) {
+static void bmInclusion(benchmark::State& state) {
   // Create matcher.
   Envoy::Stats::StatsMatcherPerf context;
   context.inclusionList()->set_suffix("1");
@@ -60,9 +60,9 @@ static void BM_Inclusion(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(BM_Inclusion);
+BENCHMARK(bmInclusion);
 
-static void BM_Exclusion(benchmark::State& state) {
+static void bmExclusion(benchmark::State& state) {
   // Create matcher.
   Envoy::Stats::StatsMatcherPerf context;
   context.exclusionList()->set_suffix("1");
@@ -83,4 +83,4 @@ static void BM_Exclusion(benchmark::State& state) {
     }
   }
 }
-BENCHMARK(BM_Exclusion);
+BENCHMARK(bmExclusion);

--- a/test/common/stats/stats_matcher_impl_speed_test.cc
+++ b/test/common/stats/stats_matcher_impl_speed_test.cc
@@ -5,6 +5,7 @@
 #include "envoy/type/matcher/v3/string.pb.h"
 
 #include "source/common/stats/stats_matcher_impl.h"
+
 #include "test/test_common/utility.h"
 
 #include "benchmark/benchmark.h"
@@ -44,12 +45,18 @@ static void BM_Inclusion(benchmark::State& state) {
   context.inclusionList()->set_suffix("1");
   context.inclusionList()->set_prefix("2.");
   context.initMatcher();
+  std::vector<Envoy::Stats::StatName> stat_names;
+  stat_names.reserve(10);
+  for (auto idx = 0; idx < 10; ++idx) {
+    stat_names.push_back(context.pool_.add(absl::StrCat("2.", idx)));
+  }
 
   for (auto _ : state) {
     for (auto idx = 0; idx < 1000; ++idx) {
-      Envoy::Stats::StatName stat_name = context.pool_.add(absl::StrCat("2.", idx % 10));
-      const auto fast_result = context.stats_matcher_impl_->fastRejects(stat_name);
-      (void)context.stats_matcher_impl_->slowRejects(fast_result, stat_name);
+      const Envoy::Stats::StatName stat_name = stat_names[idx % 10];
+      const Envoy::Stats::StatsMatcher::FastResult fast_result =
+          context.stats_matcher_impl_->fastRejects(stat_name);
+      context.stats_matcher_impl_->slowRejects(fast_result, stat_name);
     }
   }
 }
@@ -61,12 +68,18 @@ static void BM_Exclusion(benchmark::State& state) {
   context.exclusionList()->set_suffix("1");
   context.exclusionList()->set_prefix("2.");
   context.initMatcher();
+  std::vector<Envoy::Stats::StatName> stat_names;
+  stat_names.reserve(10);
+  for (auto idx = 0; idx < 10; ++idx) {
+    stat_names.push_back(context.pool_.add(absl::StrCat("2.", idx)));
+  }
 
   for (auto _ : state) {
     for (auto idx = 0; idx < 1000; ++idx) {
-      Envoy::Stats::StatName stat_name = context.pool_.add(absl::StrCat("2.", idx % 10));
-      const auto fast_result = context.stats_matcher_impl_->fastRejects(stat_name);
-      (void)context.stats_matcher_impl_->slowRejects(fast_result, stat_name);
+      const Envoy::Stats::StatName stat_name = stat_names[idx % 10];
+      const Envoy::Stats::StatsMatcher::FastResult fast_result =
+          context.stats_matcher_impl_->fastRejects(stat_name);
+      context.stats_matcher_impl_->slowRejects(fast_result, stat_name);
     }
   }
 }

--- a/test/common/stats/stats_matcher_impl_test.cc
+++ b/test/common/stats/stats_matcher_impl_test.cc
@@ -330,5 +330,29 @@ TEST_F(StatsMatcherTest, CheckMultipleAssortedExclusionMatchersWithPrefix) {
   EXPECT_FALSE(stats_matcher_impl_->rejectsAll());
 }
 
+TEST_F(StatsMatcherTest, SkipSlowRejectsOnFastReject) {
+  inclusionList()->set_suffix("xyz");
+  initMatcher();
+  StatName stat_name = pool_.add("wxyz");
+  // Verify that we skip the slow check if fast_result is not NoMatch.
+  EXPECT_TRUE(stats_matcher_impl_->slowRejects(StatsMatcher::FastResult::Rejects, stat_name));
+
+  // Verify we don't skip the slow check if fast_result is NoMatch.
+  EXPECT_FALSE(
+      stats_matcher_impl_->slowRejects(stats_matcher_impl_->fastRejects(stat_name), stat_name));
+}
+
+TEST_F(StatsMatcherTest, SkipSlowRejectsOnFastMatches) {
+  exclusionList()->set_suffix("xyz");
+  initMatcher();
+  StatName stat_name = pool_.add("wxyz");
+  // Verify that we skip the slow check if fast_result is not NoMatch.
+  EXPECT_FALSE(stats_matcher_impl_->slowRejects(StatsMatcher::FastResult::Matches, stat_name));
+
+  // Verify we don't skip the slow check if fast_result is NoMatch.
+  EXPECT_TRUE(
+      stats_matcher_impl_->slowRejects(stats_matcher_impl_->fastRejects(stat_name), stat_name));
+}
+
 } // namespace Stats
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Checking stat rejection using the stats matcher is ALWAYS a two step process. We first do a fast check using fastRejects, and then call slowRejects with the output of fastRejects. The slow check needs to happen only if the answer from fastRejects is not definitive, i.e. if it is `FastResult::NoMatch` and not one of `FastResult::Matches` or `FastResult::Rejects`. 

We were previously doing the slow check on a few occasions even when we had a definitive answer from fastRejects (for eg. for `FastResult::Matches`). This PR fixes that.

Result of `stats_matcher_impl_speed_test` benchmark with and without changes:
```
Without changes:
-------------------------------------------------------
Benchmark             Time             CPU   Iterations
-------------------------------------------------------
BM_Inclusion     119343 ns       119334 ns         5884
BM_Exclusion     121073 ns       121073 ns         5767

With changes:
-------------------------------------------------------
Benchmark             Time             CPU   Iterations
-------------------------------------------------------
BM_Inclusion      29523 ns        29523 ns        23658
BM_Exclusion      28243 ns        28242 ns        24387
```
Additional Description:
Risk Level: Low
Testing: Added tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
