### PR TITLE
Fix typo - adjustNewConnectionIdForRouting

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,9 +18,6 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
-- area: quic
-  change: |
-    Corrected function name ``adjustNewConnectionIdForRoutine`` to ``adjustNewConnectionIdForRouting``.
 - area: connection pool
   change: |
     Increase granularity mapping connection pool failures to specific stream failure reasons to make it more transparent why

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,6 +18,9 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: quic
+  change: |
+    Corrected function name ``adjustNewConnectionIdForRoutine`` to ``adjustNewConnectionIdForRouting``.
 - area: connection pool
   change: |
     Increase granularity mapping connection pool failures to specific stream failure reasons to make it more transparent why

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -278,7 +278,7 @@ void configQuicInitialFlowControlWindow(const envoy::config::core::v3::QuicProto
                static_cast<quic::QuicByteCount>(session_flow_control_window_to_send)));
 }
 
-void adjustNewConnectionIdForRoutine(quic::QuicConnectionId& new_connection_id,
+void adjustNewConnectionIdForRouting(quic::QuicConnectionId& new_connection_id,
                                      const quic::QuicConnectionId& old_connection_id) {
   char* new_connection_id_data = new_connection_id.mutable_data();
   const char* old_connection_id_ptr = old_connection_id.data();

--- a/source/common/quic/envoy_quic_utils.h
+++ b/source/common/quic/envoy_quic_utils.h
@@ -190,7 +190,7 @@ void configQuicInitialFlowControlWindow(const envoy::config::core::v3::QuicProto
 
 // Modify new_connection_id according to given old_connection_id to make sure packets with the new
 // one can be routed to the same listener.
-void adjustNewConnectionIdForRoutine(quic::QuicConnectionId& new_connection_id,
+void adjustNewConnectionIdForRouting(quic::QuicConnectionId& new_connection_id,
                                      const quic::QuicConnectionId& old_connection_id);
 
 } // namespace Quic

--- a/source/extensions/quic/connection_id_generator/envoy_deterministic_connection_id_generator.cc
+++ b/source/extensions/quic/connection_id_generator/envoy_deterministic_connection_id_generator.cc
@@ -13,7 +13,7 @@ EnvoyDeterministicConnectionIdGenerator::GenerateNextConnectionId(
     const quic::QuicConnectionId& original) {
   auto new_cid = DeterministicConnectionIdGenerator::GenerateNextConnectionId(original);
   if (new_cid.has_value()) {
-    adjustNewConnectionIdForRoutine(new_cid.value(), original);
+    adjustNewConnectionIdForRouting(new_cid.value(), original);
   }
   return (new_cid.has_value() && new_cid.value() == original) ? absl::nullopt : new_cid;
 }
@@ -23,7 +23,7 @@ EnvoyDeterministicConnectionIdGenerator::MaybeReplaceConnectionId(
     const quic::QuicConnectionId& original, const quic::ParsedQuicVersion& version) {
   auto new_cid = DeterministicConnectionIdGenerator::MaybeReplaceConnectionId(original, version);
   if (new_cid.has_value()) {
-    adjustNewConnectionIdForRoutine(new_cid.value(), original);
+    adjustNewConnectionIdForRouting(new_cid.value(), original);
   }
   return (new_cid.has_value() && new_cid.value() == original) ? absl::nullopt : new_cid;
 }


### PR DESCRIPTION
Commit Message: Fix typo - adjustNewConnectionIdForRouting
Additional Description: `adjustNewConnectionIdForRoutine` should be `adjustNewConnectionIdForRouting`. When corrected the function is self-explanatory, before correction it's actively misleading.
Risk Level: Negligible; no practical change.
Testing: Existing coverage.
Docs Changes: n/a
Release Notes: Yes.
Platform Specific Features: n/a
