### PR TITLE
ci: Improve `/retest`

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,7 +1,11 @@
 name: commands
+
 on:
   issue_comment:
     types: [created]
+
+permissions:
+  contents: read
 
 jobs:
   retest:
@@ -13,8 +17,10 @@ jobs:
          && github.actor != 'dependabot[bot]'
       }}
     name: Retest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
-    - uses: jpsim/retest@c158dec0a7f67cb85f8367468dc8a9a75308bb7f
+    - uses: envoyproxy/toolshed/gh-actions/retest@56d5781416445ed530e075b71546dedee94cf054
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- `/retest envoy` is ignored by mobile retest
- mobile retest works with the command at the start of any line
- `/retest mobile` is ignored by repokitteh
- repokitteh is a load quieter
- mobile creds have been restricted

this uses a forked version of the `/retest` module in the toolshed repo

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
