### PR TITLE
backport PR 27296 to v1.26: enable build with boringssl_fips in contrib

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -198,7 +198,8 @@ envoy_cmake(
     lib_source = "@com_github_google_libsxg//:all",
     out_static_libs = ["libsxg.a"],
     tags = ["skip_on_windows"],
-    deps = ["@boringssl//:ssl"],
+    # Use boringssl alias to select fips vs non-fips version.
+    deps = ["//bazel:boringssl"],
 )
 
 envoy_cmake(

--- a/bazel/foreign_cc/ipp-crypto-skip-dynamic-lib.patch
+++ b/bazel/foreign_cc/ipp-crypto-skip-dynamic-lib.patch
@@ -1,0 +1,46 @@
+diff --git a/sources/ippcp/crypto_mb/src/CMakeLists.txt b/sources/ippcp/crypto_mb/src/CMakeLists.txt
+index f75f448..043a0a2 100644
+--- a/sources/ippcp/crypto_mb/src/CMakeLists.txt
++++ b/sources/ippcp/crypto_mb/src/CMakeLists.txt
+@@ -90,41 +90,6 @@ if(CMAKE_C_COMPILER_VERSION VERSION_LESS 20.2.3)
+                                                                 COMPILE_FLAGS        "${AVX512_CFLAGS} ${CMAKE_C_FLAGS_SECURITY}")
+ endif()
+ 
+-# Create shared library
+-if(DYNAMIC_LIB OR MB_STANDALONE)
+-    if(WIN32)
+-        add_library(${MB_DYN_LIB_TARGET} SHARED ${CRYPTO_MB_HEADERS} ${CRYPTO_MB_SOURCES} ${CPU_FEATURES_FILE} ${WIN_RESOURCE_FILE})
+-    else()
+-        add_library(${MB_DYN_LIB_TARGET} SHARED ${CRYPTO_MB_HEADERS} ${CRYPTO_MB_SOURCES} ${CPU_FEATURES_FILE})
+-    endif()
+-
+-    set_target_properties(${MB_DYN_LIB_TARGET} PROPERTIES C_VISIBILITY_PRESET hidden
+-                                                          VISIBILITY_INLINES_HIDDEN ON
+-                                                          LINK_FLAGS "${LINK_FLAGS_DYNAMIC} ${LINK_FLAG_SECURITY}"
+-                                                          PUBLIC_HEADER "${PUBLIC_HEADERS}"
+-                                                          )
+-
+-    if(UNIX)
+-        set_target_properties(${MB_DYN_LIB_TARGET} PROPERTIES  VERSION   ${MBX_INTERFACE_VERSION}
+-                                                               SOVERSION ${MBX_INTERFACE_VERSION_MAJOR})
+-    endif()
+-
+-    target_link_libraries(${MB_DYN_LIB_TARGET} OpenSSL::Crypto)
+-endif(DYNAMIC_LIB OR MB_STANDALONE)
+-
+-# Installation of the shared library
+-if (MB_STANDALONE) # standalone crypto_mb's cmake run
+-    install(TARGETS ${MB_DYN_LIB_TARGET}
+-            LIBRARY DESTINATION "lib"
+-            RUNTIME DESTINATION "lib"
+-            PUBLIC_HEADER DESTINATION "include/crypto_mb")
+-elseif (DYNAMIC_LIB) # build from ippcp's cmake
+-    install(TARGETS ${MB_DYN_LIB_TARGET}
+-            LIBRARY DESTINATION "lib/intel64"
+-            RUNTIME DESTINATION "lib/intel64"
+-            PUBLIC_HEADER DESTINATION "include/crypto_mb")
+-endif()
+-
+ # Static library
+ if(WIN32)
+     add_library(${MB_STATIC_LIB_TARGET} STATIC ${CRYPTO_MB_HEADERS} ${CRYPTO_MB_SOURCES} ${CPU_FEATURES_FILE} ${WIN_RESOURCE_FILE})

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -475,6 +475,12 @@ def _com_github_unicode_org_icu():
 def _com_github_intel_ipp_crypto_crypto_mb():
     external_http_archive(
         name = "com_github_intel_ipp_crypto_crypto_mb",
+        # Patch removes from CMakeLists.txt instructions to
+        # to create dynamic *.so library target. Linker fails when linking
+        # with boringssl_fips library. Envoy uses only static library
+        # anyways, so created dynamic library would not be used anyways.
+        patches = ["@envoy//bazel/foreign_cc:ipp-crypto-skip-dynamic-lib.patch"],
+        patch_args = ["-p1"],
         build_file_content = BUILD_ALL_CONTENT,
     )
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: boringssl
+  change: |
+    Fixed the crash that occurs when contrib is compiled with ``boringssl=fips`` defined.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/contrib/cryptomb/private_key_providers/source/BUILD
+++ b/contrib/cryptomb/private_key_providers/source/BUILD
@@ -28,7 +28,8 @@ envoy_cmake(
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:private"],
     working_directory = "sources/ippcp/crypto_mb",
-    deps = ["@boringssl//:ssl"],
+    # Use boringssl alias to select fips vs non-fips version.
+    deps = ["//bazel:boringssl"],
 )
 
 envoy_cc_library(

--- a/contrib/qat/BUILD
+++ b/contrib/qat/BUILD
@@ -32,6 +32,7 @@ configure_make(
     ],
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),
     visibility = ["//visibility:public"],
-    deps = ["@boringssl//:ssl"],
+    # Use boringssl alias to select fips vs non-fips version.
+    deps = ["//bazel:boringssl"],
     alwayslink = True,
 )

--- a/contrib/sxg/filters/http/source/BUILD
+++ b/contrib/sxg/filters/http/source/BUILD
@@ -29,8 +29,9 @@ envoy_cc_library(
         "//source/common/stats:symbol_table_lib",
         "//source/common/stats:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
-        "@boringssl//:ssl",
         "@envoy_api//contrib/envoy/extensions/filters/http/sxg/v3alpha:pkg_cc_proto",
+        # use boringssl alias to select fips vs non-fips version.
+        "//bazel:boringssl",
     ],
 )
 


### PR DESCRIPTION
Commit Message:
backport PR 27296: enable build with boringssl_fips in contrib
Additional Description:
Risk Level: Low
Testing: compiled locally and run the image
Docs Changes: no
Release Notes: no
Platform Specific Features: no