### PR TITLE
dns_cares: Add debug log entry when resolution response holds no records

### DIFF
--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -146,11 +146,14 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
 
   if (status != ARES_SUCCESS) {
     parent_.chargeGetAddrInfoErrorStats(status, timeouts);
-  }
 
-  if (status != ARES_SUCCESS && !isResponseWithNoRecords(status)) {
-    ENVOY_LOG_EVENT(debug, "cares_resolution_failure",
-                    "dns resolution for {} failed with c-ares status {}", dns_name_, status);
+    if (!isResponseWithNoRecords(status)) {
+      ENVOY_LOG_EVENT(debug, "cares_resolution_failure",
+                      "dns resolution for {} failed with c-ares status {}", dns_name_, status);
+    } else {
+      ENVOY_LOG_EVENT(debug, "cares_resolution_no_records", "dns resolution without records for {}",
+                      dns_name_);
+    }
   }
 
   // We receive ARES_EDESTRUCTION when destructing with pending queries.


### PR DESCRIPTION
Commit Message: dns_cares: Add debug log entry when resolution response holds no records
Additional Description: Better tracking of empty DNS resolution responses (all details on the linked ticket)
Risk Level: Low
Testing: Existing coverage.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #27214
