### PR TITLE
[file_system_http_cache] fix broken design doc link

### DIFF
--- a/api/envoy/extensions/http/cache/file_system_http_cache/v3/file_system_http_cache.proto
+++ b/api/envoy/extensions/http/cache/file_system_http_cache/v3/file_system_http_cache.proto
@@ -26,7 +26,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 //
 // By default this cache uses a least-recently-used eviction strategy.
 //
-// For implementation details, see `DESIGN.md <https://github.com/envoyproxy/envoy/blob/main/test/extensions/http/cache/file_system_http_cache/DESIGN.md>`_.
+// For implementation details, see `DESIGN.md <https://github.com/envoyproxy/envoy/blob/main/source/extensions/http/cache/file_system_http_cache/DESIGN.md>`_.
 // [#next-free-field: 11]
 message FileSystemHttpCacheConfig {
   // Configuration of a manager for how the file system is used asynchronously.


### PR DESCRIPTION
Commit Message: [file_system_http_cache] fix broken design doc link
Additional Description: Link before goes to 404. Link after works.
Risk Level: n/a
Testing: n/a
Docs Changes: Yes it is.
Release Notes: n/a
Platform Specific Features: n/a
