### PR TITLE
socket: user space io handle invokes drain trackers immediately upon write

### DIFF
--- a/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
@@ -691,6 +691,7 @@ public:
   MOCK_METHOD(void*, linearize, (uint32_t), (override));
   MOCK_METHOD(void, move, (Instance&), (override));
   MOCK_METHOD(void, move, (Instance&, uint64_t), (override));
+  MOCK_METHOD(void, move, (Instance&, uint64_t, bool), (override));
   MOCK_METHOD(Buffer::Reservation, reserveForRead, (), (override));
   MOCK_METHOD(Buffer::ReservationSingleSlice, reserveSingleSlice, (uint64_t, bool), (override));
   MOCK_METHOD(void, commit,

--- a/envoy/buffer/buffer.h
+++ b/envoy/buffer/buffer.h
@@ -277,6 +277,18 @@ public:
   virtual void move(Instance& rhs, uint64_t length) PURE;
 
   /**
+   * Move a portion of a buffer into this buffer. If reset_drain_trackers_and_accounting is true,
+   * then any drain trackers on the source buffer are also called and cleared so that the
+   * connection originating the source buffer (e.g. an internal listener connection) may be deleted
+   * without causing a use-after-free.
+   * @param rhs supplies the buffer to move.
+   * @param length supplies the amount of data to move.
+   * @param reset_drain_trackers_and_accounting whether the drain trackers on the source buffers
+   * should be cleared, so that the source buffer is deletable.
+   */
+  virtual void move(Instance& rhs, uint64_t length, bool reset_drain_trackers_and_accounting) PURE;
+
+  /**
    * Reserve space in the buffer for reading into. The amount of space reserved is determined
    * based on buffer settings and performance considerations.
    * @return a `Reservation`, on which `commit()` can be called, or which can

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -669,6 +669,7 @@ public:
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
+  void move(Instance& rhs, uint64_t length, bool reset_drain_trackers_and_accounting) override;
   Reservation reserveForRead() override;
   ReservationSingleSlice reserveSingleSlice(uint64_t length, bool separate_slice = false) override;
   ssize_t search(const void* data, uint64_t size, size_t start, size_t length) const override;

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -67,6 +67,12 @@ void WatermarkBuffer::move(Instance& rhs, uint64_t length) {
   checkHighAndOverflowWatermarks();
 }
 
+void WatermarkBuffer::move(Instance& rhs, uint64_t length,
+                           bool reset_drain_trackers_and_accounting) {
+  OwnedImpl::move(rhs, length, reset_drain_trackers_and_accounting);
+  checkHighAndOverflowWatermarks();
+}
+
 SliceDataPtr WatermarkBuffer::extractMutableFrontSlice() {
   auto result = OwnedImpl::extractMutableFrontSlice();
   checkLowWatermark();

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -38,6 +38,7 @@ public:
   void drain(uint64_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
+  void move(Instance& rhs, uint64_t length, bool reset_drain_trackers_and_accounting) override;
   SliceDataPtr extractMutableFrontSlice() override;
   Reservation reserveForRead() override;
   void postProcess() override { checkLowWatermark(); }

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -43,7 +43,7 @@ uint64_t moveUpTo(Buffer::Instance& dst, Buffer::Instance& src, uint64_t max_len
     }
   }
   uint64_t res = std::min(max_length, src.length());
-  dst.move(src, res);
+  dst.move(src, res, /*reset_drain_trackers_and_accounting=*/true);
   return res;
 }
 } // namespace

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -156,7 +156,10 @@ public:
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }
 
-  void move(Buffer::Instance& rhs, uint64_t length) override {
+  void move(Buffer::Instance& rhs, uint64_t length) override { move(rhs, length, false); }
+
+  void move(Buffer::Instance& rhs, uint64_t length,
+            bool reset_drain_trackers_and_accounting) override {
     StringBuffer& src = dynamic_cast<StringBuffer&>(rhs);
     add(src.start(), length);
     src.start_ += length;

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -158,8 +158,7 @@ public:
 
   void move(Buffer::Instance& rhs, uint64_t length) override { move(rhs, length, false); }
 
-  void move(Buffer::Instance& rhs, uint64_t length,
-            bool reset_drain_trackers_and_accounting) override {
+  void move(Buffer::Instance& rhs, uint64_t length, bool) override {
     StringBuffer& src = dynamic_cast<StringBuffer&>(rhs);
     add(src.start(), length);
     src.start_ += length;

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -24,6 +24,8 @@ public:
 
   MOCK_METHOD(void, move, (Buffer::Instance & rhs));
   MOCK_METHOD(void, move, (Buffer::Instance & rhs, uint64_t length));
+  MOCK_METHOD(void, move,
+              (Buffer::Instance & rhs, uint64_t length, bool reset_drain_trackers_and_accounting));
   MOCK_METHOD(void, drain, (uint64_t size));
 
   void baseMove(Buffer::Instance& rhs) { BaseClass::move(rhs); }


### PR DESCRIPTION
Fix use-after-free in user space IO handle where a drain callback may refer to a freed object (i.e. the connection on the other side of the internal listener, which may already have died). The solution employed herein is to call and clear the drain trackers on write(), since - as far as the handle being written to is concerned - we don't care about the write buffer as soon as it has been written to the peer's IO handle.

Signed off by: Eugene Chan <eugenechan@google.com>

Commit Message: socket: user space io handle invokes drain trackers immediately upon write
Risk Level: low (affects alpha feature only)
Testing: CI