### PR TITLE
generic proxy: add support to the original dst cluster and subset lb

### DIFF
--- a/contrib/generic_proxy/filters/network/source/interface/filter.h
+++ b/contrib/generic_proxy/filters/network/source/interface/filter.h
@@ -75,6 +75,11 @@ public:
    * @return absl::optional<ExtendedOptions> the extended options from upstream response.
    */
   virtual absl::optional<ExtendedOptions> responseOptions() const PURE;
+
+  /**
+   * @return const Network::Connection* downstream connection.
+   */
+  virtual const Network::Connection* connection() const PURE;
 };
 
 class UpstreamBindingCallback {

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -137,6 +137,10 @@ OptRef<UpstreamManager> ActiveStream::ActiveDecoderFilter::boundUpstreamConn() {
   return parent_.parent_.boundUpstreamConn();
 }
 
+const Network::Connection* ActiveStream::ActiveFilterBase::connection() const {
+  return &parent_.parent_.connection();
+}
+
 void ActiveStream::continueEncoding() {
   if (active_stream_reset_ || local_or_upstream_response_stream_ == nullptr) {
     return;

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -130,6 +130,7 @@ public:
     absl::optional<ExtendedOptions> responseOptions() const override {
       return parent_.local_or_upstream_response_options_;
     }
+    const Network::Connection* connection() const override;
 
     bool isDualFilter() const { return is_dual_; }
 

--- a/contrib/generic_proxy/filters/network/source/router/BUILD
+++ b/contrib/generic_proxy/filters/network/source/router/BUILD
@@ -25,6 +25,8 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:linked_object",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/config:well_known_names",
+        "//source/common/router:metadatamatchcriteria_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tracing:tracer_lib",
         "//source/common/upstream:load_balancer_lib",

--- a/contrib/generic_proxy/filters/network/source/router/router.h
+++ b/contrib/generic_proxy/filters/network/source/router/router.h
@@ -142,6 +142,10 @@ public:
 
   std::list<UpstreamRequestPtr>& upstreamRequestsForTest() { return upstream_requests_; }
 
+  // Upstream::LoadBalancerContextBase
+  const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() override;
+  const Network::Connection* downstreamConnection() const override;
+
 private:
   friend class UpstreamRequest;
   friend class UpstreamManagerImpl;
@@ -158,6 +162,8 @@ private:
   const RouteEntry* route_entry_{};
   Upstream::ClusterInfoConstSharedPtr cluster_;
   Request* request_{};
+
+  Envoy::Router::MetadataMatchCriteriaConstPtr metadata_match_;
 
   RequestEncoderPtr request_encoder_;
 

--- a/contrib/generic_proxy/filters/network/test/mocks/filter.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/filter.h
@@ -115,6 +115,7 @@ public:
   MOCK_METHOD(OptRef<const Tracing::Config>, tracingConfig, (), (const));
   MOCK_METHOD(absl::optional<ExtendedOptions>, requestOptions, (), (const));
   MOCK_METHOD(absl::optional<ExtendedOptions>, responseOptions, (), (const));
+  MOCK_METHOD(const Network::Connection*, connection, (), (const));
 };
 
 class MockUpstreamManager : public UpstreamManager {

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -427,6 +427,27 @@ TEST_F(FilterTest, ActiveStreamPerFilterConfigNoRouteEntry) {
   EXPECT_EQ(nullptr, active_stream->decoderFiltersForTest()[0]->perFilterConfig());
 }
 
+TEST_F(FilterTest, ActiveStreamConnection) {
+  mock_stream_filters_.push_back(
+      {"fake_test_filter_name_0", std::make_shared<NiceMock<MockStreamFilter>>()});
+
+  initializeFilter();
+
+  auto request = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
+  filter_->newDownstreamRequest(std::move(request), ExtendedOptions());
+  EXPECT_EQ(1, filter_->activeStreamsForTest().size());
+
+  auto active_stream = filter_->activeStreamsForTest().begin()->get();
+
+  EXPECT_EQ(1, active_stream->decoderFiltersForTest().size());
+  EXPECT_EQ(1, active_stream->encoderFiltersForTest().size());
+  EXPECT_EQ(1, active_stream->nextDecoderFilterIndexForTest());
+  EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
+
+  EXPECT_EQ(&filter_callbacks_.connection_,
+            active_stream->decoderFiltersForTest()[0]->connection());
+}
+
 TEST_F(FilterTest, ActiveStreamAddFilters) {
   initializeFilter();
 

--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -276,6 +276,42 @@ public:
     EXPECT_EQ(1, filter_->upstreamRequestsForTest().size());
   }
 
+  void verifyMetadataMatchCriteria() {
+    ProtobufWkt::Struct request_struct;
+    ProtobufWkt::Value val;
+
+    // Populate metadata like StreamInfo.setDynamicMetadata() would.
+    auto& fields_map = *request_struct.mutable_fields();
+    val.set_string_value("v3.1");
+    fields_map["version"] = val;
+    val.set_string_value("devel");
+    fields_map["stage"] = val;
+    val.set_string_value("1");
+    fields_map["xkey_in_request"] = val;
+    (*mock_stream_info_.metadata_
+          .mutable_filter_metadata())[Envoy::Config::MetadataFilters::get().ENVOY_LB] =
+        request_struct;
+
+    auto match = filter_->metadataMatchCriteria()->metadataMatchCriteria();
+
+    EXPECT_EQ(match.size(), 3);
+    auto it = match.begin();
+
+    // Note: metadataMatchCriteria() keeps its entries sorted, so the order for checks
+    // below matters.
+
+    EXPECT_EQ((*it)->name(), "stage");
+    EXPECT_EQ((*it)->value().value().string_value(), "devel");
+    it++;
+
+    EXPECT_EQ((*it)->name(), "version");
+    EXPECT_EQ((*it)->value().value().string_value(), "v3.1");
+    it++;
+
+    EXPECT_EQ((*it)->name(), "xkey_in_request");
+    EXPECT_EQ((*it)->value().value().string_value(), "1");
+  }
+
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   NiceMock<Envoy::Event::MockDispatcher> dispatcher_;
 
@@ -705,6 +741,24 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseDecodingFailure) {
 
   expectConnectionClose();
   notifyDecodingFailure();
+}
+
+TEST_P(RouterFilterTest, LoadBalancerContextDownstreamConnection) {
+  setup();
+  EXPECT_CALL(mock_filter_callback_, connection());
+  filter_->downstreamConnection();
+}
+
+TEST_P(RouterFilterTest, LoadBalancerContextNoMetadataMatchCriteria) {
+  setup();
+
+  // No metadata match criteria by default.
+  EXPECT_EQ(nullptr, filter_->metadataMatchCriteria());
+}
+
+TEST_P(RouterFilterTest, LoadBalancerContextMetadataMatchCriteria) {
+  setup();
+  verifyMetadataMatchCriteria();
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: generic proxy: add support to the original dst cluster and subset lb
Additional Description:

Minor extending to the generic router filter make it support the `donstreamConnection` and `metadataMatchCriteria`. Then the subset lb and original dst cluster could be used for generic proxy.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
