### PR TITLE
sub-formatter: fixing access to UPSTREAM_HEADER_BYTES_RECEIVED, UPSTREAM_WIRE_BYTES_SENT

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -983,8 +983,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getUpstreamBytesMeter()
-                                        ->headerBytesReceived();
+                                    auto bytes_meter = stream_info.getUpstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->headerBytesReceived() : 0;
                                   });
                             }}},
                           {"DOWNSTREAM_WIRE_BYTES_RECEIVED",
@@ -1062,7 +1062,8 @@ const StreamInfoFormatter::FieldExtractorLookupTbl& StreamInfoFormatter::getKnow
                             [](const std::string&, const absl::optional<size_t>&) {
                               return std::make_unique<StreamInfoUInt64FieldExtractor>(
                                   [](const StreamInfo::StreamInfo& stream_info) {
-                                    return stream_info.getUpstreamBytesMeter()->wireBytesSent();
+                                    auto bytes_meter = stream_info.getUpstreamBytesMeter();
+                                    return bytes_meter ? bytes_meter->wireBytesSent() : 0;
                                   });
                             }}},
                           {"UPSTREAM_HEADER_BYTES_SENT",

--- a/test/common/router/route_corpus/wrong_UPSTREAM_HEADER_BYTES_RECEIVED
+++ b/test/common/router/route_corpus/wrong_UPSTREAM_HEADER_BYTES_RECEIVED
@@ -1,0 +1,30 @@
+config {
+  name: "\000\0004**-6264\000 "
+  virtual_hosts {
+    name: "0"
+    domains: "*"
+    routes {
+      match {
+        path: ""
+      }
+      route {
+        cluster_header: "A"
+      }
+      request_headers_to_add {
+        header {
+          key: "["
+          value: "`%START_TIME()%%REQ(T_||?|STARTO2s)%%UPSTREAM_HEADER_BYTES_RECEIVED%%PER_REQUEST_STATE(%f(%f%sRESPONSE_259462C_Swwwwww`TART_TIME()%%REQ(T_||?|STARTOC_Swwwwww`%START_TIME()%%REQ(T_||?|STARTOC_SwwwwwwUB(UB(OD)%T%START_TIME()%%REQ(T_<|?|STARTOC_SwwwwwwUB(UB(OD)%TA"
+        }
+      }
+    }
+  }
+}
+headers {
+  headers {
+    key: "x-forwarded-proto"
+    value: "2"
+  }
+  headers {
+    key: ":path"
+  }
+}


### PR DESCRIPTION
Commit Message: sub-formatter: fixing access to UPSTREAM_HEADER_BYTES_RECEIVED, UPSTREAM_WIRE_BYTES_SENT
Additional Description:
Similar to #27281, a possible null-pointer access when formatting `UPSTREAM_HEADER_BYTES_RECEIVED` or `UPSTREAM_WIRE_BYTES_SENT`.
This cannot happen in non-test code, as the getter `stream_info.getUpstreamBytesMeter()` always returns an initialized value.

Risk Level: low
Testing: Fuzz test case
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Fixes fuzz issue [59116](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59116)