### PR TITLE
Fix file_system_buffer flake

### DIFF
--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -228,6 +228,7 @@ void FileSystemBufferFilter::setEncoderFilterCallbacks(
 }
 
 void FileSystemBufferFilter::onDestroy() {
+  *is_destroyed_ = true;
   if (cancel_in_flight_async_action_) {
     cancel_in_flight_async_action_();
   }
@@ -400,11 +401,10 @@ bool FileSystemBufferFilter::maybeStorage(BufferedStreamState& state,
       // was deleted before the callback, not just do nothing.
       cancel_in_flight_async_action_ = config_->asyncFileManager().createAnonymousFile(
           config_->storageBufferPath(),
-          [this, me = std::weak_ptr<FileSystemBufferFilter>(shared_from_this()),
-           dispatcher = &request_callbacks_->dispatcher(),
+          [this, is_destroyed = is_destroyed_, dispatcher = &request_callbacks_->dispatcher(),
            &state](absl::StatusOr<AsyncFileHandle> file_handle) {
-            dispatcher->post([this, me = std::move(me), &state, file_handle]() {
-              if (!me.lock()) {
+            dispatcher->post([this, is_destroyed, &state, file_handle]() {
+              if (*is_destroyed) {
                 // If we opened a file but the filter went away in the meantime, close the file
                 // to avoid leaving a dangling file handle.
                 if (file_handle.ok()) {
@@ -456,10 +456,10 @@ std::function<void(absl::Status)> FileSystemBufferFilter::getOnFileActionComplet
 }
 
 std::function<void(std::function<void()>)> FileSystemBufferFilter::getSafeDispatch() {
-  return [me = std::weak_ptr<FileSystemBufferFilter>(shared_from_this()),
+  return [is_destroyed = is_destroyed_,
           dispatcher = &request_callbacks_->dispatcher()](std::function<void()> callback) {
-    dispatcher->post([me = std::move(me), callback = std::move(callback)]() {
-      if (me.lock()) {
+    dispatcher->post([is_destroyed, callback = std::move(callback)]() {
+      if (!*is_destroyed) {
         callback();
       }
     });

--- a/source/extensions/filters/http/file_system_buffer/filter.h
+++ b/source/extensions/filters/http/file_system_buffer/filter.h
@@ -41,8 +41,7 @@ struct BufferedStreamState {
 
 class FileSystemBufferFilter : public Http::StreamFilter,
                                public Http::DownstreamWatermarkCallbacks,
-                               public Logger::Loggable<Logger::Id::http2>,
-                               public std::enable_shared_from_this<FileSystemBufferFilter> {
+                               public Logger::Loggable<Logger::Id::http2> {
 public:
   explicit FileSystemBufferFilter(std::shared_ptr<FileSystemBufferFilterConfig> base_config);
 
@@ -67,6 +66,12 @@ public:
   void onDestroy() override;
 
 private:
+  // This is captured so that callbacks can alter their behavior (and avoid nullptr)
+  // if the filter has been destroyed since the callback was queued.
+  // We use this rather than shared_from_this because onDestroy happens potentially
+  // significantly earlier than the destructor, and we want to abort callbacks after
+  // onDestroy.
+  std::shared_ptr<bool> is_destroyed_ = std::make_shared<bool>(false);
   // Merges any per-route config with the default config. Returns false if the config lacked
   // a file manager.
   bool initPerRouteConfig();


### PR DESCRIPTION
Commit Message: Fix file_system_buffer flake
Additional Description: #27515 is, I think, caused by a race in which the filter's onDestroy is called, then on the same thread a dispatched callback for the filter, then the filter's destructor. This change makes it so the dispatched callback after onDestroy is discarded the same as the dispatched callback after the destructor would be. (The production consequences of this mistake would be that very rarely a file-descriptor could be left unclosed.)
Risk Level: Low.
Testing: Existing tests pass; flake did not repro but I can't guarantee it's fixed.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
