### PR TITLE
Ext_proc filter response header size limit API definition

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -96,7 +96,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // messages, and the server must reply with
 // :ref:`ProcessingResponse <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>`.
 
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message ExternalProcessor {
   // Configuration for the gRPC service that the filter will communicate with.
   // The filter supports both the "Envoy" and "Google" gRPC clients.
@@ -186,6 +186,28 @@ message ExternalProcessor {
   // Allow headers matching the ``forward_rules`` to be forwarded to the external processing server.
   // If not set, all headers are forwarded to the external processing server.
   HeaderForwardingRules forward_rules = 12;
+
+  // [#not-implemented-hide:]
+  // Set the response header size and number limit for the responses sent back by
+  // the external processing server.
+  ResponseHeaderLimit header_limit = 13;
+}
+
+// The ResponseHeaderLimit structure specifies the header size and number limit
+// for the response sent back by the external processing server.
+message ResponseHeaderLimit {
+  // The maximum response headers size from external processing server.
+  // If unconfigured, the default max response headers allowed is 60 KiB.
+  // Response that exceed this limit will be dropped, and the response will
+  // be considered as spurious.
+  google.protobuf.UInt32Value max_response_headers_kb = 1
+      [(validate.rules).uint32 = {lte: 8192 gt: 0}];
+
+  // The maximum response headers number from the external processing server.
+  // If unconfigured, the default maximum number of response headers allowed is 100.
+  // Response that exceed this limit will be dropped, and the response will
+  // be considered as spurious.
+  google.protobuf.UInt32Value max_headers_count = 2 [(validate.rules).uint32 = {gte: 1}];
 }
 
 // The HeaderForwardingRules structure specifies what headers are


### PR DESCRIPTION
When ext_proc filter receives response from external processing server, it needs to check the maximum number of response headers, and maximum size of the response headers.

This PR is to define those two APIs in the ext_proc filter config.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
