### PR TITLE
http: Ensure that multiple referer header entries are added

### DIFF
--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -264,7 +264,7 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMultipleEntriesAreFound) {
   // If the referer header is registered with `CustomInlineHeaderRegistry` somewhere else already,
   // multiple headers will be placed into same slot. (i.e., single entry). Thus, assert here
   // to ensure that two entries are created before proceeding to test multiple entries removal.
-  ASSERT_TRUE(headers.size(), 2);
+  ASSERT_EQ(headers.size(), 2);
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true, Tracing::Reason::NotTraceable}),
             callMutateRequestHeaders(headers, Protocol::Http2));
   EXPECT_TRUE(headers.get(Http::CustomHeaders::get().Referer).empty());

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -263,7 +263,7 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMultipleEntriesAreFound) {
 
   // If the referer header is registered with `CustomInlineHeaderRegistry` somewhere else already,
   // multiple headers will be placed into same slot. (i.e., single entry). Thus, assert here
-  // to ensure that two entries are created before proceeding to test mutilple entries removal.
+  // to ensure that two entries are created before proceeding to test multiple entries removal.
   ASSERT_TRUE(headers.size(), 2);
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true, Tracing::Reason::NotTraceable}),
             callMutateRequestHeaders(headers, Protocol::Http2));

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -260,6 +260,11 @@ TEST_F(ConnectionManagerUtilityTest, RemoveRefererIfMultipleEntriesAreFound) {
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   TestRequestHeaderMapImpl headers{{"referer", "https://example.com/"},
                                    {"referer", "https://google.com/"}};
+
+  // If the referer header is registered with `CustomInlineHeaderRegistry` somewhere else already,
+  // multiple headers will be placed into same slot. (i.e., single entry). Thus, assert here
+  // to ensure that two entries are created before proceeding to test mutilple entries removal.
+  ASSERT_TRUE(headers.size(), 2);
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true, Tracing::Reason::NotTraceable}),
             callMutateRequestHeaders(headers, Protocol::Http2));
   EXPECT_TRUE(headers.get(Http::CustomHeaders::get().Referer).empty());


### PR DESCRIPTION
If custom header is already registered by `RegisterCustomInlineHeader` (for example, due to linking described in #27540), there will be only single entry added in the test here. 

Thus, check and fail earlier to manifest the failure reason. Otherwise, people will waste time debugging `callMutateRequestHeaders`
