### PR TITLE
[ZK filter] pass std::chrono::milliseconds by value

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -617,7 +617,7 @@ void DecoderImpl::decode(Buffer::Instance& data, DecodeType dtype, uint64_t full
 }
 
 void DecoderImpl::parseConnectResponse(Buffer::Instance& data, uint64_t& offset, uint32_t len,
-                                       const std::chrono::milliseconds& latency) {
+                                       const std::chrono::milliseconds latency) {
   ensureMinLength(len, PROTOCOL_VERSION_LENGTH + TIMEOUT_LENGTH + SESSION_LENGTH + INT_LENGTH);
 
   const auto timeout = helper_.peekInt32(data, offset);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -101,9 +101,9 @@ public:
   virtual void onCloseRequest() PURE;
   virtual void onResponseBytes(uint64_t bytes) PURE;
   virtual void onConnectResponse(int32_t proto_version, int32_t timeout, bool readonly,
-                                 const std::chrono::milliseconds& latency) PURE;
+                                 const std::chrono::milliseconds latency) PURE;
   virtual void onResponse(OpCodes opcode, int32_t xid, int64_t zxid, int32_t error,
-                          const std::chrono::milliseconds& latency) PURE;
+                          const std::chrono::milliseconds latency) PURE;
   virtual void onWatchEvent(int32_t event_type, int32_t client_state, const std::string& path,
                             int64_t zxid, int32_t error) PURE;
 };
@@ -174,7 +174,7 @@ private:
   void ensureMaxLength(int32_t len) const;
   std::string pathOnlyRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseConnectResponse(Buffer::Instance& data, uint64_t& offset, uint32_t len,
-                            const std::chrono::milliseconds& latency);
+                            const std::chrono::milliseconds latency);
   void parseWatchEvent(Buffer::Instance& data, uint64_t& offset, uint32_t len, int64_t zxid,
                        int32_t error);
   bool maybeReadBool(Buffer::Instance& data, uint64_t& offset);

--- a/source/extensions/filters/network/zookeeper_proxy/filter.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.cc
@@ -368,7 +368,7 @@ void ZooKeeperFilter::onCloseRequest() {
 
 void ZooKeeperFilter::onConnectResponse(const int32_t proto_version, const int32_t timeout,
                                         const bool readonly,
-                                        const std::chrono::milliseconds& latency) {
+                                        const std::chrono::milliseconds latency) {
   config_->stats_.connect_resp_.inc();
 
   switch (config_->errorBudgetDecision(OpCodes::Connect, latency)) {
@@ -394,7 +394,7 @@ void ZooKeeperFilter::onConnectResponse(const int32_t proto_version, const int32
 }
 
 void ZooKeeperFilter::onResponse(const OpCodes opcode, const int32_t xid, const int64_t zxid,
-                                 const int32_t error, const std::chrono::milliseconds& latency) {
+                                 const int32_t error, const std::chrono::milliseconds latency) {
   Stats::StatName opcode_latency = config_->unknown_opcode_latency_;
   std::string opname = "";
   auto iter = config_->op_code_map_.find(opcode);

--- a/source/extensions/filters/network/zookeeper_proxy/filter.h
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.h
@@ -291,9 +291,9 @@ public:
   void onCloseRequest() override;
   void onResponseBytes(uint64_t bytes) override;
   void onConnectResponse(int32_t proto_version, int32_t timeout, bool readonly,
-                         const std::chrono::milliseconds& latency) override;
+                         const std::chrono::milliseconds latency) override;
   void onResponse(OpCodes opcode, int32_t xid, int64_t zxid, int32_t error,
-                  const std::chrono::milliseconds& latency) override;
+                  const std::chrono::milliseconds latency) override;
   void onWatchEvent(int32_t event_type, int32_t client_state, const std::string& path, int64_t zxid,
                     int32_t error) override;
 


### PR DESCRIPTION
Commit Message: [ZK filter] pass std::chrono::milliseconds by value
Additional Description: We prefer to pass `std::chrono::milliseconds` by value since the overhead of copying is minimal and it aligns with the rest of the repo.
Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A