### PR TITLE
chore(dlb): remove unused isOpen call

### DIFF
--- a/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
+++ b/contrib/network/connection_balance/dlb/source/connection_balancer_impl.cc
@@ -236,9 +236,9 @@ void DlbBalancedConnectionHandlerImpl::setDlbEvent() {
   dlb_event_->setEnabled(Event::FileReadyType::Read);
 }
 
-void DlbBalancedConnectionHandlerImpl::post(Network::ConnectionSocketPtr&& socket) {
+void DlbBalancedConnectionHandlerImpl::post(
+    [[maybe_unused]] Network::ConnectionSocketPtr&& socket) {
 #ifdef DLB_DISABLED
-  socket->isOpen();
   throw EnvoyException("X86_64 architecture is required for Dlb.");
 #else
   // The pointer will be casted to unique_ptr in onDlbEvents(), no need to consider free.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: remove unused isOpen call
Additional Description: The call `socket->isOpen()` is unnecessary as we throw an exception after it
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
