### PR TITLE
test: fix flaky test DownstreamProtocolIntegrationTest.HandleDownstreamSocketFail

### DIFF
--- a/test/integration/buffer_accounting_integration_test.cc
+++ b/test/integration/buffer_accounting_integration_test.cc
@@ -120,7 +120,8 @@ public:
   }
 
   Http2BufferWatermarksTest()
-      : HttpIntegrationTest(
+      : SocketInterfaceSwap(Network::Socket::Type::Stream),
+        HttpIntegrationTest(
             std::get<0>(GetParam()).downstream_protocol, std::get<0>(GetParam()).version,
             ConfigHelper::httpProxyConfig(
                 /*downstream_is_quic=*/std::get<0>(GetParam()).downstream_protocol ==

--- a/test/integration/filters/test_socket_interface.h
+++ b/test/integration/filters/test_socket_interface.h
@@ -30,7 +30,12 @@ public:
   TestIoSocketHandle(WriteOverrideProc write_override_proc, os_fd_t fd = INVALID_SOCKET,
                      bool socket_v6only = false, absl::optional<int> domain = absl::nullopt)
       : Test::IoSocketHandlePlatformImpl(fd, socket_v6only, domain),
-        write_override_(write_override_proc) {}
+        write_override_(write_override_proc) {
+    int type;
+    socklen_t length = sizeof(int);
+    EXPECT_EQ(0, getOption(SOL_SOCKET, SO_TYPE, &type, &length).return_value_);
+    socket_type_ = type == SOCK_STREAM ? Socket::Type::Stream : Socket::Type::Datagram;
+  }
 
   void initializeFileEvent(Event::Dispatcher& dispatcher, Event::FileReadyCb cb,
                            Event::FileTriggerType trigger, uint32_t events) override {
@@ -59,6 +64,8 @@ public:
     return Test::IoSocketHandlePlatformImpl::peerAddress();
   }
 
+  Socket::Type getSocketType() const { return socket_type_; }
+
 private:
   IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen) override;
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
@@ -72,6 +79,7 @@ private:
   const WriteOverrideProc write_override_;
   absl::Mutex mutex_;
   Event::Dispatcher* dispatcher_ ABSL_GUARDED_BY(mutex_) = nullptr;
+  Socket::Type socket_type_;
 };
 
 /**

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -56,7 +56,9 @@ class Http2FloodMitigationTest
       public testing::TestWithParam<std::tuple<Network::Address::IpVersion, bool, bool>>,
       public Http2RawFrameIntegrationTest {
 public:
-  Http2FloodMitigationTest() : Http2RawFrameIntegrationTest(std::get<0>(GetParam())) {
+  Http2FloodMitigationTest()
+      : SocketInterfaceSwap(Network::Socket::Type::Stream),
+        Http2RawFrameIntegrationTest(std::get<0>(GetParam())) {
     // This test tracks the number of buffers created, and the tag extraction check uses some
     // buffers, so disable it in this test.
     skip_tag_extraction_rule_check_ = true;

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2406,7 +2406,13 @@ TEST_P(MultiplexedIntegrationTest, ConnectionPoolPerDownstream) {
 // Ordering of inheritance is important here, SocketInterfaceSwap must be
 // destroyed after HttpProtocolIntegrationTest.
 class SocketSwappableMultiplexedIntegrationTest : public SocketInterfaceSwap,
-                                                  public HttpProtocolIntegrationTest {};
+                                                  public HttpProtocolIntegrationTest {
+public:
+  SocketSwappableMultiplexedIntegrationTest()
+      : SocketInterfaceSwap(GetParam().downstream_protocol == Http::CodecType::HTTP3
+                                ? Network::Socket::Type::Datagram
+                                : Network::Socket::Type::Stream) {}
+};
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, SocketSwappableMultiplexedIntegrationTest,
                          testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -4295,7 +4295,8 @@ TEST_P(DownstreamProtocolIntegrationTest, HandleDownstreamSocketFail) {
 
   // Makes us have Envoy's writes to downstream return EBADF
   Network::IoSocketError* ebadf = Network::IoSocketError::getIoSocketEbadfInstance();
-  socket_swap.write_matcher_->setSourcePort(lookupPort("http"));
+  socket_swap.write_matcher_->setDestinationPort(
+      codec_client_->connection()->connectionInfoProvider().localAddress()->ip()->port());
   socket_swap.write_matcher_->setWriteOverride(ebadf);
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
 

--- a/test/integration/shadow_policy_integration_test.cc
+++ b/test/integration/shadow_policy_integration_test.cc
@@ -19,7 +19,8 @@ class ShadowPolicyIntegrationTest
       public SocketInterfaceSwap {
 public:
   ShadowPolicyIntegrationTest()
-      : HttpIntegrationTest(Http::CodecType::HTTP2, std::get<0>(GetParam())) {
+      : HttpIntegrationTest(Http::CodecType::HTTP2, std::get<0>(GetParam())),
+        SocketInterfaceSwap(Network::Socket::Type::Stream) {
     scoped_runtime_.mergeValues(
         {{"envoy.reloadable_features.streaming_shadow", streaming_shadow_ ? "true" : "false"}});
     setUpstreamProtocol(Http::CodecType::HTTP2);

--- a/test/integration/socket_interface_swap.cc
+++ b/test/integration/socket_interface_swap.cc
@@ -4,7 +4,8 @@ namespace Envoy {
 
 void preserveIoError(Api::IoError*) {}
 
-SocketInterfaceSwap::SocketInterfaceSwap() {
+SocketInterfaceSwap::SocketInterfaceSwap(Network::Socket::Type socket_type)
+    : write_matcher_(std::make_shared<IoHandleMatcher>(socket_type)) {
   Envoy::Network::SocketInterfaceSingleton::clear();
   test_socket_interface_loader_ = std::make_unique<Envoy::Network::SocketInterfaceLoader>(
       std::make_unique<Envoy::Network::TestSocketInterface>(


### PR DESCRIPTION
The test manually introduces EBADF error on the connection between Envoy and the test client. However, the IoHandleMatcher doesn't  distinguish UDP socket from TCP. If the upstream HTTP/3 connection gets the same port number as downstream TCP connection, the EBADF error will be applied to the wrong connection.

Enforce IoHandleMatcher to match socket type.

Risk Level: low, test only
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
Partially Fix #27490 
