### PR TITLE
Assert(valid) when ext_proc filter apply header mutations

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -766,7 +766,7 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
           response.headers(), headers, false, immediateResponseChecker().checker(),
           stats_.rejected_header_mutations_);
       if (!mut_status.ok()) {
-        ENVOY_LOG(error, "Immediate response mutations failed");
+        ENVOY_LOG(debug, "Immediate response mutations failed");
       }
     }
   };

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -766,7 +766,8 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
           response.headers(), headers, false, immediateResponseChecker().checker(),
           stats_.rejected_header_mutations_);
       if (!mut_status.ok()) {
-        ENVOY_LOG_EVERY_POW_2(error, "Immediate response mutations failed");
+        ENVOY_LOG_EVERY_POW_2(error, "Immediate response mutations failed with {}",
+                              mut_status.message());
       }
     }
   };

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -765,7 +765,9 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
       const auto mut_status = MutationUtils::applyHeaderMutations(
           response.headers(), headers, false, immediateResponseChecker().checker(),
           stats_.rejected_header_mutations_);
-      ENVOY_BUG(mut_status.ok(), "Immediate response mutations should not fail");
+      if (!mut_status.ok()) {
+        ENVOY_LOG(error, "Immediate response mutations failed");
+      }
     }
   };
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -766,7 +766,7 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
           response.headers(), headers, false, immediateResponseChecker().checker(),
           stats_.rejected_header_mutations_);
       if (!mut_status.ok()) {
-        ENVOY_LOG(debug, "Immediate response mutations failed");
+        ENVOY_LOG_EVERY_POW_2(error, "Immediate response mutations failed");
       }
     }
   };

--- a/source/extensions/filters/http/ext_proc/mutation_utils.cc
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.cc
@@ -41,7 +41,7 @@ absl::Status MutationUtils::applyHeaderMutations(const HeaderMutation& mutation,
                                                  Counter& rejected_mutations) {
   for (const auto& hdr : mutation.remove_headers()) {
     if (!Envoy::Http::validHeaderString(hdr)) {
-      ENVOY_LOG(debug, "remove_headers mutation contain null character, may not be removed.");
+      ENVOY_LOG(debug, "remove_headers contain null character, may not be removed.");
       rejected_mutations.inc();
       return absl::InvalidArgumentError("Invalid null character in remove_headers mutation.");
     }
@@ -67,8 +67,9 @@ absl::Status MutationUtils::applyHeaderMutations(const HeaderMutation& mutation,
     if (!sh.has_header()) {
       continue;
     }
-    if (!Envoy::Http::validHeaderString(sh.header().key())) {
-      ENVOY_LOG(debug, "set_headers mutation contain null character, may not be appended.");
+    if (!Envoy::Http::validHeaderString(sh.header().key()) ||
+        !Envoy::Http::validHeaderString(sh.header().value())) {
+      ENVOY_LOG(debug, "set_headers contain null character in key or value, may not be appended.");
       rejected_mutations.inc();
       return absl::InvalidArgumentError("Invalid null character in set_headers mutation.");
     }

--- a/source/extensions/filters/http/ext_proc/mutation_utils.cc
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.cc
@@ -40,6 +40,11 @@ absl::Status MutationUtils::applyHeaderMutations(const HeaderMutation& mutation,
                                                  const Checker& checker,
                                                  Counter& rejected_mutations) {
   for (const auto& hdr : mutation.remove_headers()) {
+    if (!Envoy::Http::validHeaderString(hdr)) {
+      ENVOY_LOG(debug, "remove_headers mutation contain null character, may not be removed.");
+      rejected_mutations.inc();
+      return absl::InvalidArgumentError("Invalid null character in remove_headers mutation.");
+    }
     const LowerCaseString remove_header(hdr);
     switch (checker.check(CheckOperation::REMOVE, remove_header, "")) {
     case CheckResult::OK:
@@ -61,6 +66,11 @@ absl::Status MutationUtils::applyHeaderMutations(const HeaderMutation& mutation,
   for (const auto& sh : mutation.set_headers()) {
     if (!sh.has_header()) {
       continue;
+    }
+    if (!Envoy::Http::validHeaderString(sh.header().key())) {
+      ENVOY_LOG(debug, "set_headers mutation contain null character, may not be appended.");
+      rejected_mutations.inc();
+      return absl::InvalidArgumentError("Invalid null character in set_headers mutation.");
     }
     const LowerCaseString header_name(sh.header().key());
     const bool append = PROTOBUF_GET_WRAPPED_OR_DEFAULT(sh, append, false);
@@ -87,6 +97,7 @@ absl::Status MutationUtils::applyHeaderMutations(const HeaderMutation& mutation,
       break;
     case CheckResult::FAIL:
       ENVOY_LOG(debug, "Header {} may not be modified. Returning error", header_name);
+      rejected_mutations.inc();
       return absl::InvalidArgumentError(
           absl::StrCat("Invalid attempt to modify ", static_cast<absl::string_view>(header_name)));
     }

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1079,7 +1079,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
   EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
 }
 
-TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithNullCharacter) {
+TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithInvalidCharacter) {
   initializeConfig();
   HttpIntegrationTest::initialize();
   auto response = sendDownstreamRequest(absl::nullopt);

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1079,6 +1079,21 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
   EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
 }
 
+TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyWithNullCharacter) {
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  processAndRespondImmediately(*grpc_upstreams_[0], true, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    auto* hdr = immediate.mutable_headers()->add_set_headers();
+    hdr->mutable_header()->set_key("x-failure-reason\n");
+    hdr->mutable_header()->set_value("testing");
+  });
+
+  verifyDownstreamResponse(*response, 401);
+}
+
 // Test the filter using the default configuration by connecting to
 // an ext_proc server that responds to the request_headers message
 // by sending back an immediate_response message after the

--- a/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
+++ b/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
@@ -188,7 +188,7 @@ TEST(MutationUtils, TestNonAppendableHeaders) {
   EXPECT_THAT(&headers, HeaderMapEqualIgnoreOrder(&expected_headers));
 }
 
-TEST(MutationUtils, TestSetHeaderWithNullCharacter) {
+TEST(MutationUtils, TestSetHeaderWithInvalidCharacter) {
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"},
       {"host", "localhost:1000"},
@@ -197,7 +197,7 @@ TEST(MutationUtils, TestSetHeaderWithNullCharacter) {
   Envoy::Stats::MockCounter rejections;
   envoy::service::ext_proc::v3::HeaderMutation mutation;
   auto* s = mutation.add_set_headers();
-  // Test header key contains null character.
+  // Test header key contains invalid character.
   s->mutable_header()->set_key("x-append-this\n");
   s->mutable_header()->set_value("value");
   EXPECT_CALL(rejections, inc());
@@ -206,7 +206,7 @@ TEST(MutationUtils, TestSetHeaderWithNullCharacter) {
 
   mutation.Clear();
   s = mutation.add_set_headers();
-  // Test header value contains null character.
+  // Test header value contains invalid character.
   s->mutable_header()->set_key("x-append-this");
   s->mutable_header()->set_value("value\r");
   EXPECT_CALL(rejections, inc());
@@ -214,7 +214,7 @@ TEST(MutationUtils, TestSetHeaderWithNullCharacter) {
       MutationUtils::applyHeaderMutations(mutation, headers, false, checker, rejections).ok());
 }
 
-TEST(MutationUtils, TestRemoveHeaderWithNullCharacter) {
+TEST(MutationUtils, TestRemoveHeaderWithInvalidCharacter) {
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"},
       {"host", "localhost:1000"},

--- a/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
+++ b/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
@@ -198,7 +198,7 @@ TEST(MutationUtils, TestSetHeaderWithNullCharacter) {
   s->mutable_header()->set_key("x-append-this\n");
   Checker checker(HeaderMutationRules::default_instance());
   Envoy::Stats::MockCounter rejections;
-  EXPECT_CALL(rejections, inc()).Times(1);
+  EXPECT_CALL(rejections, inc());
   EXPECT_FALSE(
       MutationUtils::applyHeaderMutations(mutation, headers, false, checker, rejections).ok());
 }
@@ -212,7 +212,7 @@ TEST(MutationUtils, TestRemoveHeaderWithNullCharacter) {
   mutation.add_remove_headers("host\r");
   Checker checker(HeaderMutationRules::default_instance());
   Envoy::Stats::MockCounter rejections;
-  EXPECT_CALL(rejections, inc()).Times(1);
+  EXPECT_CALL(rejections, inc());
   EXPECT_FALSE(
       MutationUtils::applyHeaderMutations(mutation, headers, false, checker, rejections).ok());
 }


### PR DESCRIPTION
When ext_proc server sends back some header mutation settings which contain NULL characters, like /n, /r or /0, this will cause ext_proc filter ASSERT(valid) being fired up when Envoy is built in debug mode. 
In release mode, the ASSERT is no-op, however, we should add an explicit check to avoid such kind of headers get injected into Envoy.

Assert(valid) when ext_proc filter apply header mutations.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
