### PR TITLE
ci: fix the flaky of TcpProxyOdcdsIntegrationTest.ShutdownAllConnectionsOnClusterLookupTimeout

### DIFF
--- a/test/integration/tcp_proxy_odcds_integration_test.cc
+++ b/test/integration/tcp_proxy_odcds_integration_test.cc
@@ -303,8 +303,8 @@ TEST_P(TcpProxyOdcdsIntegrationTest, ShutdownAllConnectionsOnClusterLookupTimeou
   IntegrationTcpClientPtr tcp_client_2 = makeTcpConnection(lookupPort("tcp_proxy"));
   test_server_->waitForCounterEq("tcp.tcpproxy_stats.on_demand_cluster_attempt", 2);
 
-  tcp_client_1->waitForHalfClose();
-  tcp_client_2->waitForHalfClose();
+  tcp_client_1->waitForHalfClose(true);
+  tcp_client_2->waitForHalfClose(true);
   assertOnDemandCounters(0, 0, 2);
   tcp_client_1->close();
   tcp_client_2->close();


### PR DESCRIPTION
Commit Message: ci: fix the flaky of TcpProxyOdcdsIntegrationTest.ShutdownAllConnectionsOnClusterLookupTimeout
Additional Description:
This test is showing flaky when adding iouring support in https://github.com/envoyproxy/envoy/pull/24958, but it isn't related to the iouring, it is possible to happen in the current code.

The test created two clients.

https://github.com/envoyproxy/envoy/blob/fc5361a35bcfeeae8603e5d3957fefddf9d68a4d/test/integration/tcp_proxy_odcds_integration_test.cc#L306-L307

When invoking the TCP client's `waitForHalfClose`, both clients are blocking on the same dispatcher
https://github.com/envoyproxy/envoy/blob/fc5361a35bcfeeae8603e5d3957fefddf9d68a4d/test/integration/integration_tcp_client.cc#L129

The dispatcher will exit when it gets the end of the stream. 
https://github.com/envoyproxy/envoy/blob/fc5361a35bcfeeae8603e5d3957fefddf9d68a4d/test/integration/utility.cc#L383-L387

So there is a chance the second client gets the end of the stream first, which leads to the first client's `waitForHalfClose` returned (since they are the same dispatcher, and dispatcher.exit() invoked). Then the first client's `waitForHalfClose` begins to check the end of the stream flag
https://github.com/envoyproxy/envoy/blob/fc5361a35bcfeeae8603e5d3957fefddf9d68a4d/test/integration/integration_tcp_client.cc#L132

At that time, the first client didn't get the end of the stream yet. Then that expectation will fail

Risk Level: low
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #27577