### PR TITLE
[fuzz] Keep config part of input for network_readfilter.

### DIFF
--- a/test/extensions/filters/network/common/fuzz/BUILD
+++ b/test/extensions/filters/network/common/fuzz/BUILD
@@ -107,6 +107,7 @@ envoy_cc_fuzz_test(
         "//source/common/config:utility_lib",
         "//test/config:utility_lib",
         "//test/test_common:test_runtime_lib",
+        "@com_github_google_libprotobuf_mutator//:libprotobuf_mutator",
     ] + envoy_filters_from_selected(READFILTER_FUZZ_FILTERS),
 )
 

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
@@ -27,8 +27,12 @@ message Action {
   }
 }
 
+message Actions {
+  repeated Action actions = 1;
+}
+
 message FilterFuzzTestCase {
   // This is actually a protobuf type for the config of network filters.
   envoy.config.listener.v3.Filter config = 1;
-  repeated Action actions = 2;
+  Actions actions = 2;
 }

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
@@ -27,6 +27,7 @@ message Action {
   }
 }
 
+// Helper to mutate actions in FilterFuzzTestCase, because mutate() does not apply to repreated members.
 message FuzzHelperForActions {
   repeated Action actions = 1;
 }

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
@@ -27,7 +27,7 @@ message Action {
   }
 }
 
-// Helper to mutate actions in FilterFuzzTestCase, because mutate() does not apply to repreated members.
+// Helper to mutate actions in FilterFuzzTestCase, because mutate() does not apply to repeated members.
 message FuzzHelperForActions {
   repeated Action actions = 1;
 }

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz.proto
@@ -27,12 +27,12 @@ message Action {
   }
 }
 
-message Actions {
+message FuzzHelperForActions {
   repeated Action actions = 1;
 }
 
 message FilterFuzzTestCase {
   // This is actually a protobuf type for the config of network filters.
   envoy.config.listener.v3.Filter config = 1;
-  Actions actions = 2;
+  repeated Action actions = 2;
 }

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz_test.cc
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz_test.cc
@@ -10,6 +10,9 @@
 #include "test/test_common/test_runtime.h"
 
 #include "libprotobuf_mutator/src/libfuzzer/libfuzzer_macro.h"
+
+// TODO: Needed for protobuf_mutator::ParseTextMessage() and ::SaveMessageAsText(). Replace by
+// envoy-style input parsing methods.
 #include "src/text_format.h" // from libprotobuf_mutator/
 
 namespace Envoy {


### PR DESCRIPTION
Commit Message: [fuzz] Keep config part of input for network_readfilter.
Additional Description:
In network_readfilter_fuzz_test keep the config part of the input and mutate the actions only for some time. Only every 1000 fuzz runs allow to mutate the config.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a