### PR TITLE
bazel: remove tags from repository definition

### DIFF
--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -47,7 +47,6 @@ def api_dependencies():
     external_http_archive(
         name = "com_github_bufbuild_buf",
         build_file_content = BUF_BUILD_CONTENT,
-        tags = ["manual"],
     )
 
 PROMETHEUSMETRICS_BUILD_CONTENT = """

--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -137,7 +137,6 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bufbuild/buf/releases/download/v{version}/buf-Linux-x86_64.tar.gz"],
         release_date = "2023-02-09",
         use_category = ["api"],
-        tags = ["manual"],
         license = "Apache-2.0",
         license_url = "https://github.com/bufbuild/buf/blob/v{version}/LICENSE",
     ),


### PR DESCRIPTION
I don't think these do anything here except for produce this warning:

```
DEBUG: Rule 'com_github_bufbuild_buf' indicated that a canonical reproducible form can be obtained by dropping arguments ["tags"]
DEBUG: Repository com_github_bufbuild_buf instantiated at:
  /Users/ksmiley/dev/envoy4/WORKSPACE:9:23: in <toplevel>
  /Users/ksmiley/dev/envoy4/bazel/api_repositories.bzl:4:21: in envoy_api_dependencies
  /private/var/tmp/_bazel_ksmiley/81424bb29de8eeef22a825a179047d5f/external/envoy_api/bazel/repositories.bzl:47:26: in api_dependencies
  /private/var/tmp/_bazel_ksmiley/81424bb29de8eeef22a825a179047d5f/external/envoy_api/bazel/repositories.bzl:9:23: in external_http_archive
  /private/var/tmp/_bazel_ksmiley/81424bb29de8eeef22a825a179047d5f/external/envoy_api/bazel/envoy_http_archive.bzl:16:17: in envoy_http_archive
```