### PR TITLE
formatter: add two tests NaN and Infinity

### DIFF
--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2249,7 +2249,7 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFormatter) {
                 ProtoEq(ValueUtil::stringValue("test_value")));
   }
 
-  // Add the NaN test for number value. This behavior will be changed in the future proto
+  // Add the NaN test for number value. This behavior will be changed in the future Protobuf
   // dependency upgrade, and the Json serialization will fail if the number value is NaN or
   // Infinity. We need to change the `getJsonStringFromMessage` description, re-evaluate the use
   // of ENVOY_BUG in the MetaDataFormatter::format method, and modify the following two tests.

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2248,6 +2248,36 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFormatter) {
                                       stream_info, body, AccessLog::AccessLogType::NotSet),
                 ProtoEq(ValueUtil::stringValue("test_value")));
   }
+
+  // Add the NaN test for number value. This behavior will be changed in the future proto
+  // dependency upgrade, and the Json serialization will fail if the number value is NaN or
+  // Infinity. We need to change the `getJsonStringFromMessage` description, re-evaluate the use
+  // of ENVOY_BUG in the MetaDataFormatter::format method, and modify the following two tests.
+  {
+    ProtobufWkt::Value val;
+    val.set_number_value(std::numeric_limits<double>::quiet_NaN());
+    ProtobufWkt::Struct struct_obj;
+    (*struct_obj.mutable_fields())["nan_val"] = val;
+    (*metadata.mutable_filter_metadata())["com.test"] = struct_obj;
+
+    DynamicMetadataFormatter formatter("com.test", {"nan_val"}, absl::optional<size_t>());
+    EXPECT_EQ("\"NaN\"", formatter.format(request_headers, response_headers, response_trailers,
+                                          stream_info, body, AccessLog::AccessLogType::NotSet));
+  }
+
+  // Add the Infinity test for number value.
+  {
+    ProtobufWkt::Value val;
+    val.set_number_value(std::numeric_limits<double>::infinity());
+    ProtobufWkt::Struct struct_obj;
+    (*struct_obj.mutable_fields())["inf_val"] = val;
+    (*metadata.mutable_filter_metadata())["com.test"] = struct_obj;
+
+    DynamicMetadataFormatter formatter("com.test", {"inf_val"}, absl::optional<size_t>());
+    EXPECT_EQ("\"Infinity\"",
+              formatter.format(request_headers, response_headers, response_trailers, stream_info,
+                               body, AccessLog::AccessLogType::NotSet));
+  }
 }
 
 TEST(SubstitutionFormatterTest, FilterStateFormatter) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
https://github.com/envoyproxy/envoy/pull/26464 removed JsonOrDie function but added ENVOY_BUG in the format call path.

The pre-release version of Protobuf includes this change:
`Expect fail when serialize inf and nan for Value.number_value in json format. fixes #11259` 
https://github.com/protocolbuffers/protobuf/commit/ca1cb1ba80ef18f5dccfb5b6ee7fa623ba6caab5

If we bump the Protobuf version, there will be an exception & crash using `NaN/inf/-inf` in `protobuf.struct` `number_value` when performing the serialization, while there is no check for this behavior right now.

Added 2 tests to catch this behavior change in the future.

Commit Message:
Additional Description:
Risk Level: Low
Testing: unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
