### PR TITLE
Revert "test: moving ssl utility to use parsed protos (#27585)"

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1101,14 +1101,12 @@ envoy_cc_test_library(
     name = "utility_lib",
     srcs = [
         "server.cc",
-        "ssl_utility.cc",
         "utility.cc",
-    ],
+    ] + envoy_select_enable_yaml(["ssl_utility.cc"]),
     hdrs = [
         "server.h",
-        "ssl_utility.h",
         "utility.h",
-    ],
+    ] + envoy_select_enable_yaml(["ssl_utility.h"]),
     data = ["//test/common/runtime:filesystem_test_data"],
     deps = [
         ":server_stats_interface",


### PR DESCRIPTION
This reverts commit 9f1aa4330060331bd074be2ee20516252f909d1a.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
