### PR TITLE
[fuzz] Use absl::Cleanup to ensure leaveMessage is called.

### DIFF
--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -89,6 +89,7 @@ envoy_cc_test_library(
         "//source/common/protobuf:visitor_lib",
         "@com_github_cncf_udpa//udpa/type/v1:pkg_cc_proto",
         "@com_github_cncf_udpa//xds/type/v3:pkg_cc_proto",
+        "@com_google_absl//absl/cleanup",
     ],
 )
 

--- a/test/fuzz/mutable_visitor.cc
+++ b/test/fuzz/mutable_visitor.cc
@@ -5,6 +5,7 @@
 #include "source/common/protobuf/utility.h"
 #include "source/common/protobuf/visitor_helper.h"
 
+#include "absl/cleanup/cleanup.h"
 #include "udpa/type/v1/typed_struct.pb.h"
 #include "xds/type/v3/typed_struct.pb.h"
 
@@ -17,6 +18,9 @@ void traverseMessageWorkerExt(ProtoVisitor& visitor, Protobuf::Message& message,
                               bool was_any_or_top_level, bool recurse_into_any,
                               absl::string_view const& field_name) {
   visitor.onEnterMessage(message, parents, was_any_or_top_level, field_name);
+  absl::Cleanup message_leaver = [&visitor, &parents, &message, was_any_or_top_level, field_name] {
+    visitor.onLeaveMessage(message, parents, was_any_or_top_level, field_name);
+  };
 
   // If told to recurse into Any messages, do that here and skip the rest of the function.
   if (recurse_into_any) {
@@ -71,7 +75,6 @@ void traverseMessageWorkerExt(ProtoVisitor& visitor, Protobuf::Message& message,
       }
     }
   }
-  visitor.onLeaveMessage(message, parents, was_any_or_top_level, field_name);
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: [fuzz] Use absl::Cleanup to ensure leaveMessage is called.
Additional Description:
In the traverseMessageWorkerExt for the mutable_visitor make sure the leaveMessage() method is called on every exit of the routine.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a