### PR TITLE
cluster manager: add new feature connection pool per stream info

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -44,7 +44,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 57]
+// [#next-free-field: 58]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -1185,6 +1185,10 @@ message Cluster {
   // If ``connection_pool_per_downstream_connection`` is true, the cluster will use a separate
   // connection pool for every downstream connection
   bool connection_pool_per_downstream_connection = 51;
+
+  // If ``connection_pool_per_key_format`` is set, the cluster will use a separate connection
+  // pool for every unique string format
+  string connection_pool_per_key_format = 57 [(validate.rules).string = {min_len: 1}];
 }
 
 // Extensible load balancing policy configuration.

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -15,6 +15,11 @@ namespace ConnectionPool {
 class ConnectionLifetimeCallbacks;
 } // namespace ConnectionPool
 } // namespace Http
+
+namespace Formatter {
+class FormatterImpl;
+}
+
 namespace Upstream {
 
 /**
@@ -96,6 +101,11 @@ public:
    * and return the corresponding host directly.
    */
   virtual absl::optional<OverrideHost> overrideHostToSelect() const PURE;
+
+  /**
+   * Returns the string key computed by formatter input argument.
+   */
+  virtual std::string connectionPoolKeyFormat(const Formatter::FormatterImpl& formatter) const PURE;
 };
 
 /**

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -37,7 +37,9 @@ namespace Envoy {
 namespace Http {
 class FilterChainManager;
 }
-
+namespace Formatter {
+class FormatterImpl;
+}
 namespace Upstream {
 
 /**

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -32,6 +32,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/config/utility.h"
 #include "source/common/config/well_known_names.h"
+#include "source/common/formatter/substitution_formatter.h"
 #include "source/common/http/filter_chain_helper.h"
 #include "source/common/http/utility.h"
 #include "source/common/router/config_impl.h"
@@ -516,6 +517,11 @@ public:
     downstream_set_cookies_.emplace_back(
         Http::Utility::makeSetCookieValue(key, cookie_value, path, max_age, true));
     return cookie_value;
+  }
+
+  std::string connectionPoolKeyFormat(const Formatter::FormatterImpl& formatter) const override {
+    return formatter.format(*downstream_headers_, *Http::ResponseHeaderMapImpl::create(),
+                            *Http::ResponseTrailerMapImpl::create(), callbacks_->streamInfo(), "");
   }
 
   // RouterFilterInterface

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1703,6 +1703,15 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPoolImp
     context->downstreamConnection()->hashKey(hash_key);
   }
 
+  if (!cluster_info_->connectionPoolPerDownstreamConnection() &&
+      cluster_info_->connectionPoolPerKeyFormat() && context) {
+    auto key_format =
+        context->connectionPoolKeyFormat(cluster_info_->connectionPoolPerKeyFormatter());
+    if (!key_format.empty()) {
+      pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(key_format), hash_key);
+    }
+  }
+
   ConnPoolsContainer& container = *parent_.getHttpConnPoolsContainer(host, true);
 
   // Note: to simplify this, we assume that the factory is only called in the scope of this

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -240,6 +240,8 @@ public:
   }
 
   absl::optional<OverrideHost> overrideHostToSelect() const override { return {}; }
+
+  std::string connectionPoolKeyFormat(const Formatter::FormatterImpl&) const override { return {}; }
 };
 
 /**

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -49,6 +49,7 @@
 #include "source/common/common/thread.h"
 #include "source/common/config/metadata.h"
 #include "source/common/config/well_known_names.h"
+#include "source/common/formatter/substitution_formatter.h"
 #include "source/common/http/filter_chain_helper.h"
 #include "source/common/http/http1/codec_stats.h"
 #include "source/common/http/http2/codec_stats.h"
@@ -1083,6 +1084,8 @@ private:
   const bool added_via_api_ : 1;
   // true iff the cluster proto specified upstream http filters.
   bool has_configured_http_filters_ : 1;
+  const std::string connection_pool_per_key_format_;
+  const Formatter::FormatterImpl connection_pool_per_key_formatter_;
 };
 
 /**

--- a/test/mocks/upstream/BUILD
+++ b/test/mocks/upstream/BUILD
@@ -64,6 +64,7 @@ envoy_cc_mock(
     hdrs = ["load_balancer_context.h"],
     deps = [
         "//envoy/upstream:load_balancer_interface",
+        "//source/common/formatter:substitution_formatter_lib",
     ],
 )
 

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -1,9 +1,12 @@
 #pragma once
 #include "envoy/upstream/load_balancer.h"
 
+#include "source/common/formatter/substitution_formatter.h"
+
 #include "gmock/gmock.h"
 
 namespace Envoy {
+
 namespace Upstream {
 
 class MockLoadBalancerContext : public LoadBalancerContext {
@@ -24,6 +27,8 @@ public:
   MOCK_METHOD(Network::TransportSocketOptionsConstSharedPtr, upstreamTransportSocketOptions, (),
               (const));
   MOCK_METHOD(absl::optional<OverrideHost>, overrideHostToSelect, (), (const));
+  MOCK_METHOD(std::string, connectionPoolKeyFormat, (const Formatter::FormatterImpl&),
+              (const, override));
 
 private:
   HealthyAndDegradedLoad priority_load_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: new feature connection pool per unique stream info format. Cluster-manager creates connection pool per unique key derived for the format specified. 

Additional Description: This feature is not enforced if "connection_pool_per_downstream_connection" is set to true because the later is most granular i.e one upstream connection for each downstream connection. 

Risk Level: Medium
Testing: Add UT to validating connection pool per unique key in cluster manager
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #26817