### PR TITLE
golang filter: always use GC finalizer to delete the req object in C++

### DIFF
--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -215,10 +215,4 @@ func envoyGoFilterOnHttpDestroy(r *C.httpRequest, reason uint64) {
 	f.OnDestroy(v)
 
 	Requests.DeleteReq(r)
-
-	// no one is using req now, we can remove it manually, for better performance.
-	if v == api.Normal {
-		runtime.SetFinalizer(req, nil)
-		req.Finalize(api.GCFinalize)
-	}
 }


### PR DESCRIPTION
It could be safer since people may still use the request object in Go even after it told C++ it had already finished processing.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
