### PR TITLE
[fuzz] Prevent using too deeply nested configurations by cut-off.

### DIFF
--- a/test/fuzz/mutable_visitor.cc
+++ b/test/fuzz/mutable_visitor.cc
@@ -16,7 +16,7 @@ namespace {
 void traverseMessageWorkerExt(ProtoVisitor& visitor, Protobuf::Message& message,
                               std::vector<const Protobuf::Message*>& parents,
                               bool was_any_or_top_level, bool recurse_into_any,
-                              absl::string_view const& field_name) {
+                              const absl::string_view& field_name) {
   visitor.onEnterMessage(message, parents, was_any_or_top_level, field_name);
   absl::Cleanup message_leaver = [&visitor, &parents, &message, was_any_or_top_level, field_name] {
     visitor.onLeaveMessage(message, parents, was_any_or_top_level, field_name);

--- a/test/fuzz/mutable_visitor.h
+++ b/test/fuzz/mutable_visitor.h
@@ -22,9 +22,9 @@ public:
   //                             Any before being unpacked for further recursion. The latter can
   //                             only be achieved by using recurse_into_any.
   virtual void onEnterMessage(Protobuf::Message&, absl::Span<const Protobuf::Message* const>,
-                              bool was_any_or_top_level, absl::string_view const& field_name) PURE;
+                              bool was_any_or_top_level, const absl::string_view& field_name) PURE;
   virtual void onLeaveMessage(Protobuf::Message&, absl::Span<const Protobuf::Message* const>,
-                              bool was_any_or_top_level, absl::string_view const& field_name) PURE;
+                              bool was_any_or_top_level, const absl::string_view& field_name) PURE;
 };
 
 void traverseMessage(ProtoVisitor& visitor, Protobuf::Message& message, bool recurse_into_any);

--- a/test/fuzz/validated_input_generator.cc
+++ b/test/fuzz/validated_input_generator.cc
@@ -206,7 +206,8 @@ void ValidatedInputGenerator::handleAnyRules(
 void ValidatedInputGenerator::handleMessageTypedField(
     Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
     const Protobuf::Reflection* reflection, const validate::FieldRules& rules,
-    const absl::Span<const Protobuf::Message* const>& parents, const bool force_create) {
+    const absl::Span<const Protobuf::Message* const>& parents, const bool force_create,
+    const bool cut_off) {
 
   if (field.is_repeated()) {
     const validate::RepeatedRules& repeated_rules = rules.repeated();
@@ -250,6 +251,9 @@ void ValidatedInputGenerator::handleMessageTypedField(
         break;
       }
       default:
+        if (cut_off) {
+          value->Clear();
+        }
         break;
       }
     }
@@ -314,13 +318,13 @@ void ValidatedInputGenerator::handleIntrinsicTypedField(Protobuf::Message& msg,
 void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                       const Protobuf::FieldDescriptor& field,
                                       const absl::Span<const Protobuf::Message* const> parents) {
-  onField(msg, field, parents, false);
+  onField(msg, field, parents, false, false);
 }
 
 void ValidatedInputGenerator::onField(Protobuf::Message& msg,
                                       const Protobuf::FieldDescriptor& field,
                                       const absl::Span<const Protobuf::Message* const> parents,
-                                      const bool force_create) {
+                                      const bool force_create, const bool cut_off) {
   const Protobuf::Reflection* reflection = msg.GetReflection();
 
   if (!field.options().HasExtension(validate::rules) && !force_create) {
@@ -393,7 +397,7 @@ void ValidatedInputGenerator::onField(Protobuf::Message& msg,
     break;
   }
   case Protobuf::FieldDescriptor::CPPTYPE_MESSAGE: {
-    handleMessageTypedField(msg, field, reflection, rules, parents, force_create);
+    handleMessageTypedField(msg, field, reflection, rules, parents, force_create, cut_off);
     break;
   }
   default:
@@ -416,28 +420,28 @@ void ValidatedInputGenerator::onEnterMessage(Protobuf::Message& msg,
       any_message->Clear();
     }
   }
+  const bool max_depth_exceeded = max_depth_ > 0 && current_depth_ > max_depth_;
   for (int oneof_index = 0; oneof_index < descriptor->oneof_decl_count(); ++oneof_index) {
     const Protobuf::OneofDescriptor* oneof_desc = descriptor->oneof_decl(oneof_index);
-    if (oneof_desc->options().HasExtension(validate::required) &&
-        oneof_desc->options().GetExtension(validate::required) &&
-        !reflection->HasOneof(msg, descriptor->oneof_decl(oneof_index))) {
+    if (max_depth_exceeded || (oneof_desc->options().HasExtension(validate::required) &&
+                               oneof_desc->options().GetExtension(validate::required) &&
+                               !reflection->HasOneof(msg, descriptor->oneof_decl(oneof_index)))) {
       // No required member in one of set, so create one.
       for (int index = 0; index < oneof_desc->field_count(); ++index) {
         const std::string parents_class_name = parents.back()->GetDescriptor()->full_name();
         // Treat matchers special, because in their oneof they reference themselves, which may
         // create long chains. Prefer the first alternative, which does not reference itself.
         // Nevertheless do it randomly to allow for some nesting.
-        if ((max_depth_ > 0 && current_depth_ > max_depth_) ||
-            ((parents_class_name == "xds.type.matcher.v3.Matcher.MatcherList.Predicate" ||
-              parents_class_name ==
-                  "xds.type.matcher.v3.Matcher.MatcherList.Predicate.SinglePredicate") &&
-             (random_() % 200) > 0)) {
-          onField(msg, *oneof_desc->field(0), parents, true);
+        if ((parents_class_name == "xds.type.matcher.v3.Matcher.MatcherList.Predicate" ||
+             parents_class_name ==
+                 "xds.type.matcher.v3.Matcher.MatcherList.Predicate.SinglePredicate") &&
+            (random_() % 200) > 0) {
+          onField(msg, *oneof_desc->field(0), parents, true, max_depth_exceeded);
         } else {
           // Do not use the first available alternative all the time, because of cyclic
           // dependencies.
           const int rnd_index = random_() % oneof_desc->field_count();
-          onField(msg, *oneof_desc->field(rnd_index), parents, true);
+          onField(msg, *oneof_desc->field(rnd_index), parents, true, max_depth_exceeded);
         }
         // Check if for the above field an entry could be created and quit the inner loop if so.
         // It might not be possible, when the datatype is not supported (yet).

--- a/test/fuzz/validated_input_generator.h
+++ b/test/fuzz/validated_input_generator.h
@@ -42,7 +42,7 @@ public:
                                const Protobuf::Reflection* reflection,
                                const validate::FieldRules& rules,
                                const absl::Span<const Protobuf::Message* const>& parents,
-                               const bool force_create);
+                               const bool force_create, const bool cut_off);
 
   // Handle all validation rules for intrinsic types like int, uint and string.
   // Messages are more complicated to handle and can not be handled here.
@@ -58,7 +58,8 @@ public:
                const absl::Span<const Protobuf::Message* const> parents) override;
 
   void onField(Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
-               const absl::Span<const Protobuf::Message* const> parents, const bool force_create);
+               const absl::Span<const Protobuf::Message* const> parents, const bool force_create,
+               const bool cut_off);
 
   void onEnterMessage(Protobuf::Message& msg, absl::Span<const Protobuf::Message* const> parents,
                       bool, absl::string_view const& field_name) override;


### PR DESCRIPTION
Commit Message: [fuzz] Prevent using too deeply nested configurations by cut-off.
Additional Description:
Fix a stack overflow by cutting of configurations in fuzzing when a certain depth has been reached.

Signed-off-by: Andre Vehreschild <vehre@x41-dsec.de>
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a