### PR TITLE
[fuzz] Remove conn_manager from writefilter white list.

### DIFF
--- a/test/extensions/filters/network/common/fuzz/uber_per_writefilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_writefilter.cc
@@ -15,6 +15,10 @@ std::vector<absl::string_view> UberWriteFilterFuzzer::filterNames() {
     // See test/extensions/filters/network/common/fuzz/BUILD for more information.
     filter_names = Registry::FactoryRegistry<
         Server::Configuration::NamedNetworkFilterConfigFactory>::registeredNames();
+    // http_connection_manager gets into the build by dependencies, but shall not be
+    // fuzzed in the write filter.
+    filter_names.erase(std::remove(filter_names.begin(), filter_names.end(),
+                                   "envoy.filters.network.http_connection_manager"));
   }
   return filter_names;
 }


### PR DESCRIPTION
Commit Message: [fuzz] Remove conn_manager from writefilter white list.
Additional Description:
Due to build dependencies the network.http_connection_manager makes it into the list of filters, that are registered with the factories in the network_writefilter_fuzz_test. But that filter shall not be fuzzed there, because the environment is not set up correctly. Therefore remove it from the list of available filters.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
