### PR TITLE
test: making E-M e2e test work sans yaml

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -31,9 +31,9 @@ jobs:
     - name: 'Build C++ library'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Envoy Mobile build verifies that the build configuration where HTTP/3 is enabled and
-      # HTTP Datagrams are disabled works.
       run: |
+      # Envoy Mobile build which verifies that the build configuration where HTTP/3 is enabled and
+      # HTTP Datagrams are disabled works.
         cd mobile && ./bazelw test \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --define=signal_trace=disabled \
@@ -43,7 +43,22 @@ jobs:
             --define=google_grpc=disabled \
             --@envoy//bazel:http3=False \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/cc/...
+            //test/cc/... \
+      # Envoy Mobile build which verifies that the build configuration where YAML is disabled.
+        && ./bazelw test \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=ci \
+            --fat_apk_cpu=x86_64 \
+            --define=signal_trace=disabled \
+            --define=envoy_mobile_request_compression=disabled \
+            --define=envoy_enable_http_datagrams=disabled \
+            --define=google_grpc=disabled \
+            --define=envoy_yaml=disabled \
+            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
+            //test/java/integration:android_engine_socket_tag_test \
+            //test/java/integration:android_engine_start_test \
+            //test/java/io/envoyproxy/envoymobile/utilities:certificate_verification_tests
+            //test/common/integration:client_integration_test
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env
@@ -103,18 +118,4 @@ jobs:
             --define=google_grpc=disabled \
             --define=envoy_yaml=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //:android_dist \
-        && ./bazelw test \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
-            --config=ci \
-            --fat_apk_cpu=x86_64 \
-            --define=signal_trace=disabled \
-            --define=admin_html=enabled \
-            --define=envoy_mobile_request_compression=disabled \
-            --define=envoy_enable_http_datagrams=disabled \
-            --define=google_grpc=disabled \
-            --define=envoy_yaml=disabled \
-            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/java/integration:android_engine_socket_tag_test \
-            //test/java/integration:android_engine_start_test \
-            //test/java/io/envoyproxy/envoymobile/utilities:certificate_verification_tests
+            //:android_dist

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -57,10 +57,11 @@ inline std::string defaultStaticClusterJson(const std::string& name) {
 inline envoy::config::bootstrap::v3::Bootstrap
 parseBootstrapFromV3Json(const std::string& json_string) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  // TODO(alyssawilk) rename to JSON
 #ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromJson(json_string, bootstrap);
 #else
-  PANIC("Cannot parse " + json_string);
+  PANIC("JSON compiled out: cannot parse " + json_string);
 #endif
   return bootstrap;
 }
@@ -70,7 +71,7 @@ inline envoy::config::cluster::v3::Cluster parseClusterFromV3Json(const std::str
 #ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromJson(json_string, cluster);
 #else
-  PANIC("Cannot parse " + json_string);
+  PANIC("JSON compiled out: cannot parse " + json_string);
 #endif
   return cluster;
 }
@@ -80,7 +81,7 @@ inline envoy::config::cluster::v3::Cluster parseClusterFromV3Yaml(const std::str
 #ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(yaml, cluster);
 #else
-  PANIC("Cannot parse " + yaml);
+  PANIC("JSON compiled out: cannot parse " + yaml);
 #endif
   return cluster;
 }
@@ -89,7 +90,7 @@ inline envoy::config::cluster::v3::Cluster defaultStaticCluster(const std::strin
 #ifdef ENVOY_ENABLE_YAML
   return parseClusterFromV3Json(defaultStaticClusterJson(name));
 #else
-  PANIC("Cannot parse " + name);
+  PANIC("JSON compiled out: cannot parse " + name);
 #endif
 }
 
@@ -186,7 +187,7 @@ parseHealthCheckFromV3Yaml(const std::string& yaml_string) {
 #ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYamlAndValidate(yaml_string, health_check);
 #else
-  PANIC("Cannot parse " + yaml_string);
+  PANIC("JSON compiled out: cannot parse " + yaml_string);
 #endif
   return health_check;
 }

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -57,24 +57,40 @@ inline std::string defaultStaticClusterJson(const std::string& name) {
 inline envoy::config::bootstrap::v3::Bootstrap
 parseBootstrapFromV3Json(const std::string& json_string) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromJson(json_string, bootstrap);
+#else
+  PANIC("Cannot parse " + json_string);
+#endif
   return bootstrap;
 }
 
 inline envoy::config::cluster::v3::Cluster parseClusterFromV3Json(const std::string& json_string) {
   envoy::config::cluster::v3::Cluster cluster;
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromJson(json_string, cluster);
+#else
+  PANIC("Cannot parse " + json_string);
+#endif
   return cluster;
 }
 
 inline envoy::config::cluster::v3::Cluster parseClusterFromV3Yaml(const std::string& yaml) {
   envoy::config::cluster::v3::Cluster cluster;
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(yaml, cluster);
+#else
+  PANIC("Cannot parse " + yaml);
+#endif
   return cluster;
 }
 
 inline envoy::config::cluster::v3::Cluster defaultStaticCluster(const std::string& name) {
+#ifdef ENVOY_ENABLE_YAML
   return parseClusterFromV3Json(defaultStaticClusterJson(name));
+#else
+  PANIC("Cannot parse " + name);
+#endif
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
@@ -167,15 +183,11 @@ makeLocalityWeights(std::initializer_list<uint32_t> locality_weights) {
 inline envoy::config::core::v3::HealthCheck
 parseHealthCheckFromV3Yaml(const std::string& yaml_string) {
   envoy::config::core::v3::HealthCheck health_check;
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYamlAndValidate(yaml_string, health_check);
-  return health_check;
-}
-
-// For DEPRECATED TEST CASES
-inline envoy::config::core::v3::HealthCheck
-parseHealthCheckFromV2Yaml(const std::string& yaml_string) {
-  envoy::config::core::v3::HealthCheck health_check;
-  TestUtility::loadFromYamlAndValidate(yaml_string, health_check);
+#else
+  PANIC("Cannot parse " + yaml_string);
+#endif
   return health_check;
 }
 

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -38,7 +38,7 @@ basicBootstrap(envoy::config::bootstrap::v3::Bootstrap& bootstrap, const std::st
 #else
   UNREFERENCED_PARAMETER(config);
   UNREFERENCED_PARAMETER(bootstrap);
-  PANIC("can't load config");
+  PANIC("JSON compiled out: can't load config");
 #endif
   return bootstrap;
 }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -33,7 +33,13 @@ namespace Envoy {
 namespace {
 envoy::config::bootstrap::v3::Bootstrap&
 basicBootstrap(envoy::config::bootstrap::v3::Bootstrap& bootstrap, const std::string& config) {
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(config, bootstrap);
+#else
+  UNREFERENCED_PARAMETER(config);
+  UNREFERENCED_PARAMETER(bootstrap);
+  PANIC("can't load config");
+#endif
   return bootstrap;
 }
 } // namespace
@@ -513,7 +519,6 @@ ConfigHelper::buildStaticCluster(const std::string& name, int port, const std::s
   (*cluster.mutable_typed_extension_protocol_options())
       ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
           .PackFrom(protocol_options);
-
   return cluster;
 }
 
@@ -576,7 +581,6 @@ ConfigHelper::buildTlsCluster(const std::string& name,
           TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
   socket->set_name("envoy.transport_sockets.tls");
   socket->mutable_typed_config()->PackFrom(tls_socket);
-
   return cluster;
 }
 
@@ -623,6 +627,7 @@ envoy::config::listener::v3::Listener
 ConfigHelper::buildBaseListener(const std::string& name, const std::string& address,
                                 const std::string& filter_chains) {
   API_NO_BOOST(envoy::config::listener::v3::Listener) listener;
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(fmt::format(
                                 R"EOF(
       name: {}
@@ -636,6 +641,12 @@ ConfigHelper::buildBaseListener(const std::string& name, const std::string& addr
                                 name, address, filter_chains),
                             listener);
   return listener;
+#else
+  UNREFERENCED_PARAMETER(name);
+  UNREFERENCED_PARAMETER(address);
+  UNREFERENCED_PARAMETER(filter_chains);
+  PANIC("YAML support compiled out");
+#endif
 }
 
 envoy::config::listener::v3::Listener ConfigHelper::buildListener(const std::string& name,
@@ -667,6 +678,7 @@ envoy::config::listener::v3::Listener ConfigHelper::buildListener(const std::str
 envoy::config::route::v3::RouteConfiguration
 ConfigHelper::buildRouteConfig(const std::string& name, const std::string& cluster) {
   API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(fmt::format(R"EOF(
       name: "{}"
       virtual_hosts:
@@ -679,6 +691,11 @@ ConfigHelper::buildRouteConfig(const std::string& name, const std::string& clust
                                         name, cluster),
                             route);
   return route;
+#else
+  UNREFERENCED_PARAMETER(name);
+  UNREFERENCED_PARAMETER(cluster);
+  PANIC("YAML support compiled out");
+#endif
 }
 
 envoy::config::endpoint::v3::Endpoint ConfigHelper::buildEndpoint(const std::string& address) {
@@ -770,6 +787,7 @@ void ConfigHelper::addListenerTypedMetadata(absl::string_view key, ProtobufWkt::
 
 void ConfigHelper::addClusterFilterMetadata(absl::string_view metadata_yaml,
                                             absl::string_view cluster_name) {
+#ifdef ENVOY_ENABLE_YAML
   RELEASE_ASSERT(!finalized_, "");
   ProtobufWkt::Struct cluster_metadata;
   TestUtility::loadFromYaml(std::string(metadata_yaml), cluster_metadata);
@@ -787,6 +805,11 @@ void ConfigHelper::addClusterFilterMetadata(absl::string_view metadata_yaml,
     }
     break;
   }
+#else
+  UNREFERENCED_PARAMETER(metadata_yaml);
+  UNREFERENCED_PARAMETER(cluster_name);
+  PANIC("YAML support compiled out");
+#endif
 }
 
 void ConfigHelper::setConnectConfig(
@@ -1163,7 +1186,13 @@ void ConfigHelper::prependFilter(const std::string& config, bool downstream) {
     loadHttpConnectionManager(hcm_config);
 
     auto* filter_list_back = hcm_config.add_http_filters();
+#ifdef ENVOY_ENABLE_YAML
     TestUtility::loadFromYaml(config, *filter_list_back);
+#else
+    UNREFERENCED_PARAMETER(config);
+    UNREFERENCED_PARAMETER(filter_list_back);
+    PANIC("YAML support compiled out");
+#endif
 
     // Now move it to the front.
     for (int i = hcm_config.http_filters_size() - 1; i > 0; --i) {
@@ -1188,7 +1217,12 @@ void ConfigHelper::prependFilter(const std::string& config, bool downstream) {
       old_protocol_options.add_http_filters()->set_name("envoy.filters.http.upstream_codec");
     }
     auto* filter_list_back = old_protocol_options.add_http_filters();
+#ifdef ENVOY_ENABLE_YAML
     TestUtility::loadFromYaml(config, *filter_list_back);
+#else
+    UNREFERENCED_PARAMETER(filter_list_back);
+    PANIC("YAML support compiled out");
+#endif
     for (int i = old_protocol_options.http_filters_size() - 1; i > 0; --i) {
       old_protocol_options.mutable_http_filters()->SwapElements(i, i - 1);
     }
@@ -1400,7 +1434,12 @@ void ConfigHelper::initializeTls(
           filename: "{{ test_rundir }}/test/config/integration/certs/intermediate_partial_ca_cert_chain.pem"
       )EOF";
       }
+#ifdef ENVOY_ENABLE_YAML
       TestUtility::loadFromYaml(TestEnvironment::substitute(cert_yaml), *validation_context);
+#else
+      UNREFERENCED_PARAMETER(cert_yaml);
+      PANIC("YAML support compiled out");
+#endif
       if (options.max_verify_depth_.has_value()) {
         validation_context->mutable_max_verify_depth()->set_value(
             options.max_verify_depth_.value());
@@ -1478,7 +1517,13 @@ void ConfigHelper::addNetworkFilter(const std::string& filter_yaml) {
   auto* filter_chain =
       bootstrap_.mutable_static_resources()->mutable_listeners(0)->mutable_filter_chains(0);
   auto* filter_list_back = filter_chain->add_filters();
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(filter_yaml, *filter_list_back);
+#else
+  UNREFERENCED_PARAMETER(filter_list_back);
+  UNREFERENCED_PARAMETER(filter_yaml);
+  PANIC("YAML support compiled out");
+#endif
 
   // Now move it to the front.
   for (int i = filter_chain->filters_size() - 1; i > 0; --i) {
@@ -1490,7 +1535,13 @@ void ConfigHelper::addListenerFilter(const std::string& filter_yaml) {
   RELEASE_ASSERT(!finalized_, "");
   auto* listener = bootstrap_.mutable_static_resources()->mutable_listeners(0);
   auto* filter_list_back = listener->add_listener_filters();
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(filter_yaml, *filter_list_back);
+#else
+  UNREFERENCED_PARAMETER(filter_list_back);
+  UNREFERENCED_PARAMETER(filter_yaml);
+  PANIC("YAML support compiled out");
+#endif
 
   // Now move it to the front.
   for (int i = listener->listener_filters_size() - 1; i > 0; --i) {
@@ -1501,7 +1552,13 @@ void ConfigHelper::addListenerFilter(const std::string& filter_yaml) {
 void ConfigHelper::addBootstrapExtension(const std::string& config) {
   RELEASE_ASSERT(!finalized_, "");
   auto* extension = bootstrap_.add_bootstrap_extensions();
+#ifdef ENVOY_ENABLE_YAML
   TestUtility::loadFromYaml(config, *extension);
+#else
+  UNREFERENCED_PARAMETER(extension);
+  UNREFERENCED_PARAMETER(config);
+  PANIC("YAML support compiled out");
+#endif
 }
 
 bool ConfigHelper::loadHttpConnectionManager(
@@ -1548,9 +1605,14 @@ void ConfigHelper::setLds(absl::string_view version_info) {
 
   const std::string lds_filename =
       bootstrap().dynamic_resources().lds_config().path_config_source().path();
+#ifdef ENVOY_ENABLE_YAML
   std::string file = TestEnvironment::writeStringToFileForTest(
       "new_lds_file", MessageUtil::getJsonStringFromMessageOrError(lds));
   TestEnvironment::renameFile(file, lds_filename);
+#else
+  UNREFERENCED_PARAMETER(lds_filename);
+  PANIC("YAML support compiled out");
+#endif
 }
 
 void ConfigHelper::setDownstreamOutboundFramesLimits(uint32_t max_all_frames,

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -79,7 +79,7 @@ public:
         "@type": type.googleapis.com/envoy.extensions.health_checkers.redis.v3.Redis
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
@@ -164,7 +164,7 @@ public:
         key: foo
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1053,7 +1053,6 @@ envoy_cc_test_library(
         "//source/common/config:api_version_lib",
         "//source/extensions/clusters/eds:eds_lib",
         "//source/extensions/clusters/static:static_cluster_lib",
-        "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
         "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
         "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
         "//source/extensions/load_balancing_policies/maglev:config",
@@ -1081,7 +1080,9 @@ envoy_cc_test_library(
     ] + select({
         "//bazel:apple": ["//source/extensions/network/dns_resolver/apple:config"],
         "//conditions:default": [],
-    }),
+    }) + envoy_select_enable_yaml([
+        "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
+    ]),
 )
 
 envoy_cc_test_library(
@@ -1101,12 +1102,14 @@ envoy_cc_test_library(
     name = "utility_lib",
     srcs = [
         "server.cc",
+        "ssl_utility.cc",
         "utility.cc",
-    ] + envoy_select_enable_yaml(["ssl_utility.cc"]),
+    ],
     hdrs = [
         "server.h",
+        "ssl_utility.h",
         "utility.h",
-    ] + envoy_select_enable_yaml(["ssl_utility.h"]),
+    ],
     data = ["//test/common/runtime:filesystem_test_data"],
     deps = [
         ":server_stats_interface",
@@ -1140,6 +1143,8 @@ envoy_cc_test_library(
         "//source/server:options_lib",
         "//source/server:process_context_lib",
         "//source/server:server_lib",
+        "//test/common/upstream:utility_lib",
+        "//test/config:utility_lib",
         "//test/mocks:common_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/runtime:runtime_mocks",
@@ -1157,10 +1162,7 @@ envoy_cc_test_library(
         "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
-    ] + envoy_select_enable_yaml([
-        "//test/common/upstream:utility_lib",
-        "//test/config:utility_lib",
-    ]),
+    ],
 )
 
 envoy_cc_test_library(

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -36,7 +36,7 @@ envoy::config::bootstrap::v3::Bootstrap configToBootstrap(const std::string& con
   return bootstrap;
 #else
   UNREFERENCED_PARAMETER(config);
-  PANIC("Can't parse YAML");
+  PANIC("YAML support compiled out: can't parse YAML");
 #endif
 }
 
@@ -136,7 +136,7 @@ void BaseIntegrationTest::initialize() {
 Network::DownstreamTransportSocketFactoryPtr
 BaseIntegrationTest::createUpstreamTlsContext(const FakeUpstreamConfig& upstream_config) {
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
-  std::string rundir = TestEnvironment::runfilesDirectory();
+  const std::string rundir = TestEnvironment::runfilesDirectory();
   tls_context.mutable_common_tls_context()
       ->mutable_validation_context()
       ->mutable_trusted_ca()
@@ -228,7 +228,7 @@ std::string BaseIntegrationTest::finalizeConfigWithPorts(ConfigHelper& config_he
     TestEnvironment::writeStringToFileForTest(
         lds_path, MessageUtil::getJsonStringFromMessageOrError(lds), true);
 #else
-    PANIC("Can't parse YAML");
+    PANIC("YAML support compiled out: can't parse YAML");
 #endif
     // Now that the listeners have been written to the lds file, remove them from static resources
     // or they will not be reloadable.

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -30,9 +30,14 @@
 
 namespace Envoy {
 envoy::config::bootstrap::v3::Bootstrap configToBootstrap(const std::string& config) {
+#ifdef ENVOY_ENABLE_YAML
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   TestUtility::loadFromYaml(config, bootstrap);
   return bootstrap;
+#else
+  UNREFERENCED_PARAMETER(config);
+  PANIC("Can't parse YAML");
+#endif
 }
 
 using ::testing::_;
@@ -131,19 +136,17 @@ void BaseIntegrationTest::initialize() {
 Network::DownstreamTransportSocketFactoryPtr
 BaseIntegrationTest::createUpstreamTlsContext(const FakeUpstreamConfig& upstream_config) {
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
-  const std::string yaml = absl::StrFormat(
-      R"EOF(
-common_tls_context:
-  tls_certificates:
-  - certificate_chain: { filename: "%s" }
-    private_key: { filename: "%s" }
-  validation_context:
-    trusted_ca: { filename: "%s" }
-)EOF",
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"),
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"),
-      TestEnvironment::runfilesPath("test/config/integration/certs/cacert.pem"));
-  TestUtility::loadFromYaml(yaml, tls_context);
+  std::string rundir = TestEnvironment::runfilesDirectory();
+  tls_context.mutable_common_tls_context()
+      ->mutable_validation_context()
+      ->mutable_trusted_ca()
+      ->set_filename(rundir + "/test/config/integration/certs/cacert.pem");
+  auto* certs = tls_context.mutable_common_tls_context()->add_tls_certificates();
+  certs->mutable_certificate_chain()->set_filename(
+      rundir + "/test/config/integration/certs/upstreamcert.pem");
+  certs->mutable_private_key()->set_filename(rundir +
+                                             "/test/config/integration/certs/upstreamkey.pem");
+
   if (upstream_config.upstream_protocol_ == Http::CodecType::HTTP2) {
     tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
   } else if (upstream_config.upstream_protocol_ == Http::CodecType::HTTP1) {
@@ -221,15 +224,22 @@ std::string BaseIntegrationTest::finalizeConfigWithPorts(ConfigHelper& config_he
       ProtobufWkt::Any* resource = lds.add_resources();
       resource->PackFrom(listener);
     }
+#ifdef ENVOY_ENABLE_YAML
     TestEnvironment::writeStringToFileForTest(
         lds_path, MessageUtil::getJsonStringFromMessageOrError(lds), true);
-
+#else
+    PANIC("Can't parse YAML");
+#endif
     // Now that the listeners have been written to the lds file, remove them from static resources
     // or they will not be reloadable.
     bootstrap.mutable_static_resources()->mutable_listeners()->Clear();
   }
+#ifdef ENVOY_ENABLE_YAML
   ENVOY_LOG_MISC(debug, "Running Envoy with configuration:\n{}",
                  MessageUtil::getYamlStringFromMessage(bootstrap));
+#else
+  ENVOY_LOG_MISC(debug, "Running Envoy with configuration:\n{}", bootstrap.DebugString());
+#endif
 
   const std::string bootstrap_path = TestEnvironment::writeStringToFileForTest(
       "bootstrap.pb", TestUtility::getProtobufBinaryStringFromMessage(bootstrap));
@@ -426,7 +436,11 @@ std::string getListenerDetails(Envoy::Server::Instance& server) {
   const auto& cbs_maps = server.admin()->getConfigTracker().getCallbacksMap();
   ProtobufTypes::MessagePtr details = cbs_maps.at("listeners")(Matchers::UniversalStringMatcher());
   auto listener_info = Protobuf::down_cast<envoy::admin::v3::ListenersConfigDump>(*details);
+#ifdef ENVOY_ENABLE_YAML
   return MessageUtil::getYamlStringFromMessage(listener_info.dynamic_listeners(0).error_state());
+#else
+  return listener_info.dynamic_listeners(0).error_state().DebugString();
+#endif
 }
 
 void BaseIntegrationTest::createGeneratedApiTestServer(
@@ -766,16 +780,16 @@ AssertionResult BaseIntegrationTest::compareDeltaDiscoveryRequest(
 // Attempt to heuristically discover missing tag-extraction rules when new stats are added.
 // This is done by looking through the entire config for fields named `stat_prefix`, and then
 // validating that those values do not appear in the tag-extracted name of any stat. The alternate
-// approach of looking for the prefix in the extracted tags was more difficult because in the tests
-// some prefix values are reused (leading to false negatives) and some tests have base configuration
-// that sets a stat_prefix but don't produce any stats at all with that configuration (leading to
-// false positives).
+// approach of looking for the prefix in the extracted tags was more difficult because in the
+// tests some prefix values are reused (leading to false negatives) and some tests have base
+// configuration that sets a stat_prefix but don't produce any stats at all with that
+// configuration (leading to false positives).
 //
 // To add a rule, see `source/common/config/well_known_names.cc`.
 //
-// This is done in all integration tests because it is testing new stats and scopes that are created
-// for which the author isn't aware that tag extraction rules need to be written, and thus the
-// author wouldn't think to write tests for that themselves.
+// This is done in all integration tests because it is testing new stats and scopes that are
+// created for which the author isn't aware that tag extraction rules need to be written, and thus
+// the author wouldn't think to write tests for that themselves.
 void BaseIntegrationTest::checkForMissingTagExtractionRules() {
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
       test_server_->adminAddress(), "GET", "/config_dump", "", Http::CodecType::HTTP1);
@@ -791,9 +805,9 @@ void BaseIntegrationTest::checkForMissingTagExtractionRules() {
   std::vector<std::string> stat_prefixes;
   Json::ObjectCallback find_stat_prefix = [&](const std::string& name,
                                               const Json::Object& root) -> bool {
-    // Looking for `stat_prefix` is based on precedent for how this is usually named in the config.
-    // If there are other names used for a similar purpose, this check could be expanded to add them
-    // also.
+    // Looking for `stat_prefix` is based on precedent for how this is usually named in the
+    // config. If there are other names used for a similar purpose, this check could be expanded
+    // to add them also.
     if (name == "stat_prefix") {
       auto prefix = root.asString();
       if (!prefix.empty()) {

--- a/test/integration/ssl_utility.cc
+++ b/test/integration/ssl_utility.cc
@@ -25,47 +25,30 @@ namespace Ssl {
 void initializeUpstreamTlsContextConfig(
     const ClientSslTransportOptions& options,
     envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext& tls_context) {
-  std::string yaml_plain = R"EOF(
-  common_tls_context:
-    validation_context:
-      trusted_ca:
-        filename: "{{ test_rundir }}/test/config/integration/certs/cacert.pem"
-)EOF";
+  std::string rundir = TestEnvironment::runfilesDirectory();
+  tls_context.mutable_common_tls_context()
+      ->mutable_validation_context()
+      ->mutable_trusted_ca()
+      ->set_filename(rundir + "/test/config/integration/certs/cacert.pem");
+  auto* certs = tls_context.mutable_common_tls_context()->add_tls_certificates();
+  std::string chain;
+  std::string key;
   if (options.client_ecdsa_cert_) {
-    yaml_plain += R"EOF(
-    tls_certificates:
-      certificate_chain:
-        filename: "{{ test_rundir }}/test/config/integration/certs/client_ecdsacert.pem"
-      private_key:
-        filename: "{{ test_rundir }}/test/config/integration/certs/client_ecdsakey.pem"
-)EOF";
+    chain = rundir + "/test/config/integration/certs/client_ecdsacert.pem";
+    key = rundir + "/test/config/integration/certs/client_ecdsakey.pem";
   } else if (options.use_expired_spiffe_cert_) {
-    yaml_plain += R"EOF(
-    tls_certificates:
-      certificate_chain:
-        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/expired_spiffe_san_cert.pem"
-      private_key:
-        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/expired_spiffe_san_key.pem"
-)EOF";
+    chain = rundir + "/test/extensions/transport_sockets/tls/test_data/expired_spiffe_san_cert.pem";
+    key = rundir + "/test/extensions/transport_sockets/tls/test_data/expired_spiffe_san_key.pem";
   } else if (options.client_with_intermediate_cert_) {
-    yaml_plain += R"EOF(
-    tls_certificates:
-      certificate_chain:
-        filename: "{{ test_rundir }}/test/config/integration/certs/client2_chain.pem"
-      private_key:
-        filename: "{{ test_rundir }}/test/config/integration/certs/client2key.pem"
-)EOF";
+    chain = rundir + "/test/config/integration/certs/client2_chain.pem";
+    key = rundir + "/test/config/integration/certs/client2key.pem";
   } else {
-    yaml_plain += R"EOF(
-    tls_certificates:
-      certificate_chain:
-        filename: "{{ test_rundir }}/test/config/integration/certs/clientcert.pem"
-      private_key:
-        filename: "{{ test_rundir }}/test/config/integration/certs/clientkey.pem"
-)EOF";
+    chain = rundir + "/test/config/integration/certs/clientcert.pem";
+    key = rundir + "/test/config/integration/certs/clientkey.pem";
   }
+  certs->mutable_certificate_chain()->set_filename(chain);
+  certs->mutable_private_key()->set_filename(key);
 
-  TestUtility::loadFromYaml(TestEnvironment::substitute(yaml_plain), tls_context);
   auto* common_context = tls_context.mutable_common_tls_context();
 
   if (options.alpn_) {

--- a/test/integration/ssl_utility.cc
+++ b/test/integration/ssl_utility.cc
@@ -25,7 +25,7 @@ namespace Ssl {
 void initializeUpstreamTlsContextConfig(
     const ClientSslTransportOptions& options,
     envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext& tls_context) {
-  std::string rundir = TestEnvironment::runfilesDirectory();
+  const std::string rundir = TestEnvironment::runfilesDirectory();
   tls_context.mutable_common_tls_context()
       ->mutable_validation_context()
       ->mutable_trusted_ca()


### PR DESCRIPTION
bazel test --config=remote --define=envoy_yaml=disabled  //test/common/integration:client_integration_test

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
