### PR TITLE
docs: we can only choose bazelisk via Homebrew

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -122,7 +122,7 @@ for how to update or override dependencies.
     ### macOS
     On macOS, you'll need to install several dependencies. This can be accomplished via [Homebrew](https://brew.sh/):
     ```console
-    brew install coreutils wget libtool go bazel clang-format autoconf aspell
+    brew install coreutils wget libtool go bazelisk clang-format autoconf aspell
     ```
     _notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`
 


### PR DESCRIPTION
If we try to install bazelisk & bazel, there will be an error:

Error: Cannot install bazel because conflicting formulae are installed.
  bazelisk: because Bazelisk replaces the bazel binary

Please `brew unlink bazelisk` before continuing.

The rest of this doc recommends using bazelisk, so we replace bazel here to bazelisk.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: we can only choose bazelisk via Homebrew
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: bazel/README.md
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
