### PR TITLE
tests: Eliminate retry backoffs in the SDS integration tests

### DIFF
--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -111,6 +111,9 @@ public:
 
   Network::Address::IpVersion ipVersion() const override { return GetParam().ip_version; }
   Grpc::ClientType clientType() const override { return GetParam().sds_grpc_type; }
+  virtual std::unique_ptr<FakeUpstream>& sdsUpstream() { return fake_upstreams_[0]; }
+  // Index in fake_upstreams_ vector of the data plane upstream.
+  int upstreamIndex() { return 1; }
 
 protected:
   void createSdsStream(FakeUpstream&) {
@@ -130,7 +133,7 @@ protected:
     api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
     api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
     auto* grpc_service = api_config_source->add_grpc_services();
-    setGrpcService(*grpc_service, "sds_cluster.lyft.com", fake_upstreams_.back()->localAddress());
+    setGrpcService(*grpc_service, "sds_cluster.lyft.com", sdsUpstream()->localAddress());
   }
 
   envoy::extensions::transport_sockets::tls::v3::Secret getServerSecretRsa() {
@@ -230,10 +233,14 @@ public:
     });
 
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // Add a static sds cluster
-      auto* sds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      // Add a static SDS cluster as the first cluster in the list.
+      // The SDS cluster needs to appear before the cluster that uses it for secrets, so that it
+      // gets initialized first.
+      bootstrap.mutable_static_resources()->add_clusters()->MergeFrom(
+          bootstrap.static_resources().clusters(0));
+      auto* sds_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
       sds_cluster->set_name("sds_cluster.lyft.com");
+      sds_cluster->mutable_load_assignment()->set_cluster_name("sds_cluster.lyft.com");
       ConfigHelper::setHttp2(*sds_cluster);
     });
 
@@ -321,8 +328,10 @@ resources:
   }
 
   void createUpstreams() override {
-    create_xds_upstream_ = true;
-    HttpIntegrationTest::createUpstreams();
+    // SDS cluster is H2, while the data cluster is H1.
+    addFakeUpstream(Http::CodecType::HTTP2);
+    addFakeUpstream(Http::CodecType::HTTP1);
+    xds_upstream_ = fake_upstreams_.front().get();
   }
 
   void waitForSdsUpdateStats(size_t times) {
@@ -386,7 +395,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, BasicRotation) {
       {TestEnvironment::runfilesPath("test/integration/sds_dynamic_key_rotation_setup.sh")});
 
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCurrentServerSecret());
   };
   initialize();
@@ -398,7 +407,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, BasicRotation) {
     return makeSslClientConnection();
   };
   // First request with server{cert,key}.pem.
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
   cleanupUpstreamAndDownstream();
   // Rotate.
   TestEnvironment::renameFile(TestEnvironment::temporaryPath("root/new"),
@@ -409,7 +418,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, BasicRotation) {
   EXPECT_EQ(0, test_server_->counter("sds.server_cert_rsa.update_rejected")->value());
 
   // First request with server_ecdsa{cert,key}.pem.
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 }
 
 // Validate that rotating to a directory with missing certs is handled.
@@ -419,7 +428,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, EmptyRotation) {
       {TestEnvironment::runfilesPath("test/integration/sds_dynamic_key_rotation_setup.sh")});
 
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCurrentServerSecret());
   };
   initialize();
@@ -431,7 +440,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, EmptyRotation) {
     return makeSslClientConnection();
   };
   // First request with server{cert,key}.pem.
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
   cleanupUpstreamAndDownstream();
 
   // Rotate to an empty directory, this should fail.
@@ -444,14 +453,14 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, EmptyRotation) {
   EXPECT_EQ(0, test_server_->counter("sds.server_cert_rsa.update_rejected")->value());
 
   // Requests continue to work with key/cert pair.
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 }
 
 // A test that SDS server send a good server secret for a static listener.
 // The first ssl request should be OK.
 TEST_P(SdsDynamicDownstreamIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getServerSecretRsa());
   };
   initialize();
@@ -459,7 +468,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, BasicSuccess) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.server_cert_rsa.update_success")->value());
@@ -468,7 +477,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, BasicSuccess) {
 
 TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getServerSecretRsa());
   };
 
@@ -484,7 +493,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-ECDSA-AES128-GCM-SHA256"}),
       context_manager_, *api_);
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   cleanupUpstreamAndDownstream();
   client_ssl_ctx_ = createClientSslTransportSocketFactory(
@@ -492,7 +501,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"}),
       context_manager_, *api_);
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.server_cert_rsa.update_success")->value());
@@ -520,7 +529,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
 // via sds and give a simple case of selecting cert based on SNI.
 TEST_P(SdsDynamicDownstreamIntegrationTest, MultipleCerts) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getServerSecretRsa());
   };
 
@@ -576,7 +585,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, MultipleCerts) {
 // then SDS send a good server secret,  the second request should be OK.
 TEST_P(SdsDynamicDownstreamIntegrationTest, WrongSecretFirst) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getWrongSecret(server_cert_rsa_));
   };
   initialize();
@@ -598,7 +607,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, WrongSecretFirst) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.server_cert_rsa.update_success")->value());
@@ -621,10 +630,14 @@ public:
             configureInlinedCerts(&common_tls_context);
           });
 
-      // Add a static sds cluster
-      auto* sds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      // Add a static SDS cluster as the first cluster in the list.
+      // The SDS cluster needs to appear before the cluster that uses it for secrets, so that it
+      // gets initialized first.
+      bootstrap.mutable_static_resources()->add_clusters()->MergeFrom(
+          bootstrap.static_resources().clusters(0));
+      auto* sds_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
       sds_cluster->set_name("sds_cluster.lyft.com");
+      sds_cluster->mutable_load_assignment()->set_cluster_name("sds_cluster.lyft.com");
       ConfigHelper::setHttp2(*sds_cluster);
 
       envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext upstream_tls_context;
@@ -641,8 +654,9 @@ public:
           TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
       upstream_tls_certificate->mutable_private_key()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
-      auto* upstream_transport_socket =
-          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+      auto* upstream_transport_socket = bootstrap.mutable_static_resources()
+                                            ->mutable_clusters(upstreamIndex())
+                                            ->mutable_transport_socket();
       upstream_transport_socket->set_name("envoy.transport_sockets.tls");
       upstream_transport_socket->mutable_typed_config()->PackFrom(upstream_tls_context);
     });
@@ -681,9 +695,11 @@ public:
   }
 
   void createUpstreams() override {
-    // Fake upstream with SSL/TLS for the first cluster.
+    // SDS cluster for the first cluster.
+    addFakeUpstream(Http::CodecType::HTTP2);
+    // Fake upstream with SSL/TLS for the second cluster.
     addFakeUpstream(createUpstreamSslContext(), upstreamProtocol(), /*autonomous_upstream=*/false);
-    create_xds_upstream_ = true;
+    xds_upstream_ = fake_upstreams_.front().get();
   }
 
   Network::DownstreamTransportSocketFactoryPtr createUpstreamSslContext() {
@@ -726,7 +742,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, SdsDynamicDownstreamCertValidatio
 // The first ssl request should be OK.
 TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicSuccess) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCvcSecret());
   };
   initialize();
@@ -734,7 +750,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicSuccess) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -747,7 +763,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicSuccess) {
 TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedCertValidationContextSuccess) {
   enableCombinedValidationContext(true);
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCvcSecretWithOnlyTrustedCa());
   };
   initialize();
@@ -755,7 +771,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedCertValidationCont
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -767,7 +783,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedCertValidationCont
 TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicWithSharedSecret) {
   shareValidationSecret(true);
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCvcSecret());
   };
   initialize();
@@ -781,7 +797,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicWithSharedSecret) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -794,7 +810,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedValidationContextW
   enableCombinedValidationContext(true);
   shareValidationSecret(true);
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCvcSecretWithOnlyTrustedCa());
   };
   initialize();
@@ -808,7 +824,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedValidationContextW
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -826,20 +842,25 @@ public:
       setUpstreamProtocol(Http::CodecType::HTTP3);
     }
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // add sds cluster first.
-      auto* sds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      // Add a static SDS cluster as the first cluster in the list.
+      // The SDS cluster needs to appear before the cluster that uses it for secrets, so that it
+      // gets initialized first.
+      bootstrap.mutable_static_resources()->add_clusters()->MergeFrom(
+          bootstrap.static_resources().clusters(0));
+      auto* sds_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
       sds_cluster->set_name("sds_cluster.lyft.com");
+      sds_cluster->mutable_load_assignment()->set_cluster_name("sds_cluster.lyft.com");
       ConfigHelper::setHttp2(*sds_cluster);
 
-      // Unwind Quic for sds cluster.
+      // Unwind Quic for SDS cluster.
       if (test_quic_) {
         sds_cluster->clear_transport_socket();
       }
 
       // change the first cluster with ssl and sds.
-      auto* transport_socket =
-          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+      auto* transport_socket = bootstrap.mutable_static_resources()
+                                   ->mutable_clusters(upstreamIndex())
+                                   ->mutable_transport_socket();
       envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
       tls_context.set_sni("lyft.com");
       auto* secret_config =
@@ -872,10 +893,12 @@ public:
   }
 
   void createUpstreams() override {
-    // This is for backend with ssl
+    // SDS cluster for the first cluster.
+    addFakeUpstream(Http::CodecType::HTTP2);
+    // FakeUpstream with SSL/TLS for the second cluster.
     addFakeUpstream(createUpstreamSslContext(context_manager_, *api_, test_quic_),
                     upstreamProtocol(), /*autonomous_upstream=*/false);
-    create_xds_upstream_ = true;
+    xds_upstream_ = fake_upstreams_.front().get();
   }
 };
 
@@ -886,7 +909,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, SdsDynamicUpstreamIntegrationTest,
 // The first request should work.
 TEST_P(SdsDynamicUpstreamIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getClientSecret());
   };
 
@@ -902,19 +925,19 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, BasicSuccess) {
   test_server_->waitForCounterGe(
       "cluster.cluster_0.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
 
-  testRouterHeaderOnlyRequestAndResponse();
+  testRouterHeaderOnlyRequestAndResponse(/*create_connection=*/nullptr, upstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.client_cert.update_success")->value());
   EXPECT_EQ(0, test_server_->counter("sds.client_cert.update_rejected")->value());
 }
 
-// To test a static cluster with sds. SDS send a bad client secret first.
-// The first request should fail with 503,  then SDS sends a good client secret,
-// the second request should work.
+// Tests a static cluster with SDS.
+// SDS sends a bad client secret first, so the request fails with a 503.
+// Then, SDS sends a good client secret, so the second request is successful.
 TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getWrongSecret(client_cert_));
   };
   initialize();
@@ -928,7 +951,7 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
   // Wait for the raw TCP connection with bad credentials and close it.
   if (upstreamProtocol() != Http::CodecType::HTTP3) {
     FakeRawConnectionPtr fake_upstream_connection;
-    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+    ASSERT_TRUE(fake_upstreams_[upstreamIndex()]->waitForRawConnection(fake_upstream_connection));
     ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
   }
 
@@ -943,7 +966,7 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
   EXPECT_EQ(1, test_server_->counter("sds.client_cert.update_rejected")->value());
 
   // Verify the update succeeded.
-  testRouterHeaderOnlyRequestAndResponse();
+  testRouterHeaderOnlyRequestAndResponse(/*create_connection=*/nullptr, upstreamIndex());
 }
 
 // Test CDS with SDS. A cluster provided by CDS raises new SDS request for upstream cert.
@@ -952,8 +975,34 @@ class SdsCdsIntegrationTest : public SdsDynamicIntegrationBaseTest {
 public:
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // Create the dynamic cluster. This cluster will be using sds.
-      dynamic_cluster_ = bootstrap.mutable_static_resources()->clusters(0);
+      // The 1st cluster, which already exists in the Bootstrap config, will be the CDS cluster.
+      // The 2nd cluster, which will be added, will be the SDS cluster.
+      // The 3rd cluster, which will be added after that, will be the dynamic cluster, which will
+      // use SDS.
+      // The xDS clusters need to appear before the cluster that uses it, so that they get
+      // initialized first.
+
+      // The SDS cluster.
+      auto* sds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      sds_cluster->MergeFrom(bootstrap.static_resources().clusters(0));
+      // The static cluster.
+      auto* static_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      static_cluster->MergeFrom(bootstrap.static_resources().clusters(0));
+      // Make a copy of the static cluster to create and set up the dynamic cluster.
+      dynamic_cluster_ = *static_cluster;
+
+      // Set up the first cluster, the CDS cluster.
+      auto* cds_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+      cds_cluster->set_name("cds_cluster");
+      cds_cluster->mutable_load_assignment()->set_cluster_name("cds_cluster");
+      ConfigHelper::setHttp2(*cds_cluster);
+
+      // Set up the second cluster, the SDS cluster.
+      sds_cluster->set_name("sds_cluster.lyft.com");
+      sds_cluster->mutable_load_assignment()->set_cluster_name("sds_cluster.lyft.com");
+      ConfigHelper::setHttp2(*sds_cluster);
+
+      // Set up the dynamic cluster to use SDS.
       dynamic_cluster_.set_name("dynamic");
       dynamic_cluster_.mutable_connect_timeout()->MergeFrom(
           ProtobufUtil::TimeUtil::MillisecondsToDuration(500000));
@@ -966,17 +1015,7 @@ public:
       transport_socket->set_name("envoy.transport_sockets.tls");
       transport_socket->mutable_typed_config()->PackFrom(tls_context);
 
-      // Add cds cluster first.
-      auto* cds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      cds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-      cds_cluster->set_name("cds_cluster");
-      ConfigHelper::setHttp2(*cds_cluster);
-      // Then add sds cluster.
-      auto* sds_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-      sds_cluster->set_name("sds_cluster.lyft.com");
-      ConfigHelper::setHttp2(*sds_cluster);
-
+      // Set up the Bootstrap's CDS config to fetch from the CDS cluster.
       const std::string cds_yaml = R"EOF(
     resource_api_version: V3
     api_config_source:
@@ -1010,13 +1049,17 @@ public:
   }
 
   void createUpstreams() override {
+    // CDS Cluster.
+    addFakeUpstream(Http::CodecType::HTTP2);
+    // SDS Cluster.
+    addFakeUpstream(Http::CodecType::HTTP2);
     // Static cluster.
     addFakeUpstream(Http::CodecType::HTTP1);
-    // Cds Cluster.
-    addFakeUpstream(Http::CodecType::HTTP2);
-    // Sds Cluster.
-    addFakeUpstream(Http::CodecType::HTTP2);
+    xds_upstream_ = fake_upstreams_.front().get();
   }
+
+  std::unique_ptr<FakeUpstream>& cdsUpstream() { return fake_upstreams_[0]; }
+  std::unique_ptr<FakeUpstream>& sdsUpstream() override { return fake_upstreams_[1]; }
 
   void sendCdsResponse() {
     EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", {}, {}, {}, true));
@@ -1032,6 +1075,7 @@ public:
     discovery_response.add_resources()->PackFrom(secret);
     sds_stream.sendGrpcMessage(discovery_response);
   }
+
   envoy::config::cluster::v3::Cluster dynamic_cluster_;
   FakeHttpConnectionPtr sds_connection_;
   FakeStreamPtr sds_stream_;
@@ -1044,8 +1088,7 @@ TEST_P(SdsCdsIntegrationTest, BasicSuccess) {
   on_server_init_function_ = [this]() {
     {
       // CDS.
-      AssertionResult result =
-          fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, xds_connection_);
+      AssertionResult result = cdsUpstream()->waitForHttpConnection(*dispatcher_, xds_connection_);
       RELEASE_ASSERT(result, result.message());
       result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
       RELEASE_ASSERT(result, result.message());
@@ -1054,8 +1097,7 @@ TEST_P(SdsCdsIntegrationTest, BasicSuccess) {
     }
     {
       // SDS.
-      AssertionResult result =
-          fake_upstreams_[2]->waitForHttpConnection(*dispatcher_, sds_connection_);
+      AssertionResult result = sdsUpstream()->waitForHttpConnection(*dispatcher_, sds_connection_);
       RELEASE_ASSERT(result, result.message());
 
       result = sds_connection_->waitForNewStream(*dispatcher_, sds_stream_);
@@ -1122,7 +1164,7 @@ TEST_P(SdsDynamicDownstreamPrivateKeyIntegrationTest, BasicPrivateKeyProvider) {
       test_private_key_method_factory(test_factory);
 
   on_server_init_function_ = [this]() {
-    createSdsStream(*(fake_upstreams_[1]));
+    createSdsStream(*sdsUpstream());
     sendSdsResponse(getCurrentServerPrivateKeyProviderSecret());
   };
   initialize();
@@ -1133,7 +1175,7 @@ TEST_P(SdsDynamicDownstreamPrivateKeyIntegrationTest, BasicPrivateKeyProvider) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator);
+  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
 
   cleanupUpstreamAndDownstream();
 }
@@ -1184,8 +1226,7 @@ TEST_P(SdsCdsPrivateKeyIntegrationTest, BasicSdsCdsPrivateKeyProvider) {
   on_server_init_function_ = [this]() {
     {
       // CDS.
-      AssertionResult result =
-          fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, xds_connection_);
+      AssertionResult result = cdsUpstream()->waitForHttpConnection(*dispatcher_, xds_connection_);
       EXPECT_TRUE(result);
       result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
       EXPECT_TRUE(result);
@@ -1194,8 +1235,7 @@ TEST_P(SdsCdsPrivateKeyIntegrationTest, BasicSdsCdsPrivateKeyProvider) {
     }
     {
       // SDS.
-      AssertionResult result =
-          fake_upstreams_[2]->waitForHttpConnection(*dispatcher_, sds_connection_);
+      AssertionResult result = sdsUpstream()->waitForHttpConnection(*dispatcher_, sds_connection_);
       EXPECT_TRUE(result);
 
       result = sds_connection_->waitForNewStream(*dispatcher_, sds_stream_);
@@ -1216,5 +1256,6 @@ TEST_P(SdsCdsPrivateKeyIntegrationTest, BasicSdsCdsPrivateKeyProvider) {
   // Successfully removed the dynamic cluster.
   test_server_->waitForGaugeEq("cluster_manager.active_clusters", 3);
 }
+
 } // namespace Ssl
 } // namespace Envoy

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -113,7 +113,7 @@ public:
   Grpc::ClientType clientType() const override { return GetParam().sds_grpc_type; }
   virtual std::unique_ptr<FakeUpstream>& sdsUpstream() { return fake_upstreams_[0]; }
   // Index in fake_upstreams_ vector of the data plane upstream.
-  int upstreamIndex() { return 1; }
+  int dataPlaneUpstreamIndex() { return 1; }
 
 protected:
   void createSdsStream(FakeUpstream&) {
@@ -407,7 +407,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, BasicRotation) {
     return makeSslClientConnection();
   };
   // First request with server{cert,key}.pem.
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
   cleanupUpstreamAndDownstream();
   // Rotate.
   TestEnvironment::renameFile(TestEnvironment::temporaryPath("root/new"),
@@ -418,7 +418,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, BasicRotation) {
   EXPECT_EQ(0, test_server_->counter("sds.server_cert_rsa.update_rejected")->value());
 
   // First request with server_ecdsa{cert,key}.pem.
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 }
 
 // Validate that rotating to a directory with missing certs is handled.
@@ -440,7 +440,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, EmptyRotation) {
     return makeSslClientConnection();
   };
   // First request with server{cert,key}.pem.
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
   cleanupUpstreamAndDownstream();
 
   // Rotate to an empty directory, this should fail.
@@ -453,7 +453,7 @@ TEST_P(SdsDynamicKeyRotationIntegrationTest, EmptyRotation) {
   EXPECT_EQ(0, test_server_->counter("sds.server_cert_rsa.update_rejected")->value());
 
   // Requests continue to work with key/cert pair.
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 }
 
 // A test that SDS server send a good server secret for a static listener.
@@ -468,7 +468,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, BasicSuccess) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.server_cert_rsa.update_success")->value());
@@ -493,7 +493,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-ECDSA-AES128-GCM-SHA256"}),
       context_manager_, *api_);
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   cleanupUpstreamAndDownstream();
   client_ssl_ctx_ = createClientSslTransportSocketFactory(
@@ -501,7 +501,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"}),
       context_manager_, *api_);
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.server_cert_rsa.update_success")->value());
@@ -607,7 +607,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, WrongSecretFirst) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.server_cert_rsa.update_success")->value());
@@ -655,7 +655,7 @@ public:
       upstream_tls_certificate->mutable_private_key()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
       auto* upstream_transport_socket = bootstrap.mutable_static_resources()
-                                            ->mutable_clusters(upstreamIndex())
+                                            ->mutable_clusters(dataPlaneUpstreamIndex())
                                             ->mutable_transport_socket();
       upstream_transport_socket->set_name("envoy.transport_sockets.tls");
       upstream_transport_socket->mutable_typed_config()->PackFrom(upstream_tls_context);
@@ -750,7 +750,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicSuccess) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -771,7 +771,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedCertValidationCont
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -797,7 +797,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicWithSharedSecret) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -824,7 +824,7 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedValidationContextW
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.validation_secret.update_success")->value());
@@ -859,7 +859,7 @@ public:
 
       // change the first cluster with ssl and sds.
       auto* transport_socket = bootstrap.mutable_static_resources()
-                                   ->mutable_clusters(upstreamIndex())
+                                   ->mutable_clusters(dataPlaneUpstreamIndex())
                                    ->mutable_transport_socket();
       envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
       tls_context.set_sni("lyft.com");
@@ -925,7 +925,7 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, BasicSuccess) {
   test_server_->waitForCounterGe(
       "cluster.cluster_0.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
 
-  testRouterHeaderOnlyRequestAndResponse(/*create_connection=*/nullptr, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(/*create_connection=*/nullptr, dataPlaneUpstreamIndex());
 
   // Success
   EXPECT_EQ(1, test_server_->counter("sds.client_cert.update_success")->value());
@@ -951,7 +951,8 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
   // Wait for the raw TCP connection with bad credentials and close it.
   if (upstreamProtocol() != Http::CodecType::HTTP3) {
     FakeRawConnectionPtr fake_upstream_connection;
-    ASSERT_TRUE(fake_upstreams_[upstreamIndex()]->waitForRawConnection(fake_upstream_connection));
+    ASSERT_TRUE(
+        fake_upstreams_[dataPlaneUpstreamIndex()]->waitForRawConnection(fake_upstream_connection));
     ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
   }
 
@@ -966,7 +967,7 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
   EXPECT_EQ(1, test_server_->counter("sds.client_cert.update_rejected")->value());
 
   // Verify the update succeeded.
-  testRouterHeaderOnlyRequestAndResponse(/*create_connection=*/nullptr, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(/*create_connection=*/nullptr, dataPlaneUpstreamIndex());
 }
 
 // Test CDS with SDS. A cluster provided by CDS raises new SDS request for upstream cert.
@@ -1175,7 +1176,7 @@ TEST_P(SdsDynamicDownstreamPrivateKeyIntegrationTest, BasicPrivateKeyProvider) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();
   };
-  testRouterHeaderOnlyRequestAndResponse(&creator, upstreamIndex());
+  testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   cleanupUpstreamAndDownstream();
 }


### PR DESCRIPTION
When the xDS cluster is specified after the cluster that depends on it (e.g. for SDS) in the Bootstrap config, the cluster isn't available when making the xDS request, causing a backoff retry after [0,1s).  This adds an delays to the tests.

This commit fixes the issue by specifying the xDS cluster first in order, before the static cluster that depends on it, in the Bootstrap config.

There are about 120 tests in this file, so we save on average about 60 seconds of test runtime everytime the tests in this file are executed.