### PR TITLE
docs: fix xDS RPC variant list

### DIFF
--- a/docs/root/api-docs/xds_protocol.rst
+++ b/docs/root/api-docs/xds_protocol.rst
@@ -162,27 +162,42 @@ Each of these RPC services can provide a method for each of the SotW and Increme
 variants. Here are the RPC services and methods for each resource type:
 
 -  Listener: Listener Discovery Service (LDS)
+
    -  SotW: ListenerDiscoveryService.StreamListeners
    -  Incremental: ListenerDiscoveryService.DeltaListeners
+
 -  RouteConfiguration: Route Discovery Service (RDS)
+
    -  SotW: RouteDiscoveryService.StreamRoutes
    -  Incremental: RouteDiscoveryService.DeltaRoutes
+
 -  ScopedRouteConfiguration: Scoped Route Discovery Service (SRDS)
+
    -  SotW: ScopedRouteDiscoveryService.StreamScopedRoutes
    -  Incremental: ScopedRouteDiscoveryService.DeltaScopedRoutes
+
 -  VirtualHost: Virtual Host Discovery Service (VHDS)
+
    -  SotW: N/A
    -  Incremental: VirtualHostDiscoveryService.DeltaVirtualHosts
+
 -  Cluster: Cluster Discovery Service (CDS)
+
    -  SotW: ClusterDiscoveryService.StreamClusters
    -  Incremental: ClusterDiscoveryService.DeltaClusters
+
 -  ClusterLoadAssignment: Endpoint Discovery Service (EDS)
+
    -  SotW: EndpointDiscoveryService.StreamEndpoints
    -  Incremental: EndpointDiscoveryService.DeltaEndpoints
+
 -  Secret: Secret Discovery Service (SDS)
+
    -  SotW: SecretDiscoveryService.StreamSecrets
    -  Incremental: SecretDiscoveryService.DeltaSecrets
+
 -  Runtime: Runtime Discovery Service (RTDS)
+
    -  SotW: RuntimeDiscoveryService.StreamRuntime
    -  Incremental: RuntimeDiscoveryService.DeltaRuntime
 


### PR DESCRIPTION
*Commit Message:*

In restructured text, nested lists need a blank line separator to make them render as lists rather than as paragraph content.

*Additional Description:* N/A
*Risk Level:* Low.
*Testing:* Local docs build.
*Docs Changes:* Yes.
*Release Notes:* N/A
*Platform Specific Features:* N/A

Before:
<img width="821" alt="Screen Shot 2023-05-31 at 12 03 35 pm" src="https://github.com/envoyproxy/envoy/assets/9917/52cd2aa3-ca16-4eda-94aa-d3612c9e3326">

After:

<img width="782" alt="Screen Shot 2023-05-31 at 12 03 56 pm" src="https://github.com/envoyproxy/envoy/assets/9917/ae31263a-9f66-41ee-a33c-3dbd0d9e379b">


