### PR TITLE
mobile: compile time options fix

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -37,6 +37,7 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --config=ci \
             --define=envoy_yaml=disabled \
+            --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
             //test/common/integration:client_integration_test --test_output=all
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     container:
-      image: envoyproxy/envoy-build-ubuntu:b0ff77ae3f25b0bf595f9b8bba46b489723ab446
+      image: envoyproxy/envoy-build-ubuntu:41c5a05d708972d703661b702a63ef5060125c33
     steps:
     - uses: actions/checkout@v3
     - name: Add safe directory
@@ -31,34 +31,13 @@ jobs:
     - name: 'Build C++ library'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Envoy Mobile build which verifies that the build configuration where YAML is disabled.
       run: |
-      # Envoy Mobile build which verifies that the build configuration where HTTP/3 is enabled and
-      # HTTP Datagrams are disabled works.
-        cd mobile
-        ./bazelw test \
+        cd mobile && ./bazelw test \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
-            --define=signal_trace=disabled \
-            --define=admin_html=enabled \
-            --define=envoy_mobile_request_compression=disabled \
-            --define=envoy_enable_http_datagrams=disabled \
-            --define=google_grpc=disabled \
-            --@envoy//bazel:http3=False \
-            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/cc/...
-        # Envoy Mobile build which verifies that the build configuration where YAML is disabled.
-        ./bazelw test \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --config=ci \
-            --fat_apk_cpu=x86_64 \
-            --define=signal_trace=disabled \
-            --define=envoy_mobile_request_compression=disabled \
-            --define=envoy_enable_http_datagrams=disabled \
-            --define=google_grpc=disabled \
             --define=envoy_yaml=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/java/integration:android_engine_socket_tag_test \
-            //test/java/integration:android_engine_start_test \
-            //test/java/io/envoyproxy/envoymobile/utilities:certificate_verification_tests \
             //test/common/integration:client_integration_test
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -37,8 +37,7 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --config=ci \
             --define=envoy_yaml=disabled \
-            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/common/integration:client_integration_test --test_output=all
+            //test/common/integration:client_integration_test
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - name: 'Build C++ library'
+    - name: 'Building C++ library'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Envoy Mobile build which verifies that the build configuration where YAML is disabled.

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -38,7 +38,7 @@ jobs:
             --config=ci \
             --define=envoy_yaml=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/common/integration:client_integration_test
+            //test/common/integration:client_integration_test --test_output=all
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -37,7 +37,7 @@ jobs:
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --config=ci \
             --define=envoy_yaml=disabled \
-            //test/common/integration:client_integration_test
+            //test/common/integration:client_integration_test --test_output=all
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env


### PR DESCRIPTION
reinstating compile time options build (broken by bad yaml)
removing linux !h3 tests as we have swift e2e.  I could add it to the kotlin build if we have concerns
otherwise moving linux compile time options build to mimic common test options, and simplifying down to client integration test (avoid a bunch of flakey android deps and macos constraints) now that the client integration test works.