### PR TITLE
ci: Fix cache mount

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -24,6 +24,9 @@ parameters:
 - name: cacheKeyDockerTmpDir
   type: string
   default: /mnt/docker_cache
+- name: cacheKeyDockerNoTmpfs
+  type: string
+  default: ''
 - name: cacheKey
   type: string
   default: $(cacheKeyBazelFiles)
@@ -151,6 +154,7 @@ steps:
     name: "${{ parameters.cacheKeyDockerName }}"
     path: "${{ parameters.cacheKeyDockerPath }}"
     tmpDirectory: "${{ parameters.cacheKeyDockerTmpDir }}"
+    tmpNoTmpfs: "${{ parameters.cacheKeyDockerNoTmpfs }}"
     arch: "${{ parameters.artifactSuffix }}"
 
 - ${{ each step in parameters.stepsPre }}:

--- a/.azure-pipelines/cached.yml
+++ b/.azure-pipelines/cached.yml
@@ -15,6 +15,9 @@ parameters:
 - name: tmpDirectory
   type: string
   default: /mnt/docker_cache
+- name: tmpNoTmpfs
+  type: string
+  default:
 - name: path
   type: string
   default: /mnt/docker
@@ -27,7 +30,7 @@ parameters:
 
 
 steps:
-- script: sudo .azure-pipelines/docker/prepare_cache.sh "${{ parameters.tmpDirectory }}"
+- script: sudo .azure-pipelines/docker/prepare_cache.sh "${{ parameters.tmpDirectory }}" "${{ parameters.tmpNoTmpfs }}"
   displayName: "Cache/prepare (${{ parameters.name }})"
 - task: Cache@2
   env:

--- a/.azure-pipelines/docker/load_cache.sh
+++ b/.azure-pipelines/docker/load_cache.sh
@@ -43,9 +43,13 @@ fi
 echo "Starting Docker daemon ..."
 systemctl start docker
 
-echo "Unmount cache tmp ${DOCKER_CACHE_PATH} ..."
-umount "${DOCKER_CACHE_PATH}"
-
+if mountpoint -q "${DOCKER_CACHE_PATH}"; then
+    echo "Unmount cache tmp ${DOCKER_CACHE_PATH} ..."
+    umount "${DOCKER_CACHE_PATH}"
+else
+    echo "Remove cache tmp ${DOCKER_CACHE_PATH} ..."
+    rm -rf "${DOCKER_CACHE_PATH}"
+fi
 docker images
 df -h
 

--- a/.azure-pipelines/docker/prepare_cache.sh
+++ b/.azure-pipelines/docker/prepare_cache.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 DOCKER_CACHE_PATH="$1"
+NO_MOUNT_TMPFS="${2:-}"
 DOCKER_CACHE_OWNERSHIP="vsts:vsts"
 
 
@@ -13,7 +14,10 @@ if ! id -u vsts &> /dev/null; then
     DOCKER_CACHE_OWNERSHIP=azure-pipelines
 fi
 
-echo "Mounting tmpfs cache directory (${DOCKER_CACHE_PATH}) ..."
+echo "Creating cache directory (${DOCKER_CACHE_PATH}) ..."
 mkdir -p "${DOCKER_CACHE_PATH}"
-mount -t tmpfs none "${DOCKER_CACHE_PATH}"
+if [[ -z "$NO_MOUNT_TMPFS" ]]; then
+    echo "Mount tmpfs directory: ${DOCKER_CACHE_PATH}"
+    mount -t tmpfs none "$DOCKER_CACHE_PATH"
+fi
 chown -R "$DOCKER_CACHE_OWNERSHIP" "${DOCKER_CACHE_PATH}"

--- a/.azure-pipelines/docker/save_cache.sh
+++ b/.azure-pipelines/docker/save_cache.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 DOCKER_CACHE_PATH="$1"
+NO_MOUNT_TMPFS="${2:-}"
 
 if [[ -z "$DOCKER_CACHE_PATH" ]]; then
     echo "prime_docker_cache called without path arg" >&2
@@ -19,9 +20,13 @@ docker images
 echo "Stopping Docker ..."
 systemctl stop docker
 
-echo "Creating tmpfs directory to save tarball: ${DOCKER_CACHE_PATH}"
+echo "Creating directory to save tarball: ${DOCKER_CACHE_PATH}"
 mkdir -p "$DOCKER_CACHE_PATH"
-mount -t tmpfs none "$DOCKER_CACHE_PATH"
+
+if [[ -z "$NO_MOUNT_TMPFS" ]]; then
+    echo "Mount tmpfs directory: ${DOCKER_CACHE_PATH}"
+    mount -t tmpfs none "$DOCKER_CACHE_PATH"
+fi
 
 echo "Creating tarball: /var/lib/docker -> ${DOCKER_CACHE_TARBALL}"
 tar cf - -C /var/lib/docker . | zstd - -T0 -o "$DOCKER_CACHE_TARBALL"

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -118,6 +118,7 @@ jobs:
       cacheKeyDocker: "ci/Dockerfile-envoy | VERSION.txt| $(cacheKeyBazelFiles)"
       cacheKeyDockerName: publish_docker
       cacheKeyDockerTmpDir: /var/azpcache
+      cacheKeyDockerNoTmpfs: true
       cacheKeyDockerPath: ""
       cacheKeyDockerVersion: "$(cacheKeyDockerBuild)"
       env:
@@ -185,7 +186,7 @@ jobs:
           GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_RBE: "1"
-      - script: sudo .azure-pipelines/docker/save_cache.sh /var/azpcache
+      - script: sudo .azure-pipelines/docker/save_cache.sh /var/azpcache true
         displayName: "Cache/save (publish_docker)"
 
 - job: package_x64


### PR DESCRIPTION
The Docker publishing job now caches the docker build image, and the docker cache for building images (and the bazel cache)

For other jobs, the Docker cache is loaded to/from tmpfs to speed up caching, for the Docker job there is insufficient room for this, so this switches it to using fs

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
