### PR TITLE
ci: Minor cleanup for build script

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -8,7 +8,7 @@
 set -e
 
 if [[ -n "$NO_BUILD_SETUP" ]]; then
-    exit
+    return
 fi
 
 export PPROF_PATH=/thirdparty_build/bin/pprof


### PR DESCRIPTION
The env var `NO_BUILD_SETUP` is used to skip running `./ci/build_setup.sh`

It was moved into the file itself to make the file idempotent, but i inadvertently made it `exit` rather than `return` - this fixes that

This fix is necessary for the go-control-plane repo to sync correctly

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
