### PR TITLE
release/ci: Add dry-run var for non-postsubmit

### DIFF
--- a/.azure-pipelines/env.yml
+++ b/.azure-pipelines/env.yml
@@ -183,6 +183,8 @@ jobs:
       set -e
 
       PUBLISH_GITHUB_RELEASE=$(run.packaging)
+      # NB: leave this empty as it is checked `-n`
+      PUBLISH_GITHUB_RELEASE_DRY_RUN=
       PUBLISH_DOCKERHUB=false
       PUBLISH_DOCS=false
       PUBLISH_DOCS_LATEST=false
@@ -212,8 +214,12 @@ jobs:
               PUBLISH_DOCS=false
           fi
       fi
+      if [[ -z "$POSTSUBMIT" ]]; then
+          PUBLISH_GITHUB_RELEASE_DRY_RUN=true
+      fi
 
       echo "##vso[task.setvariable variable=githubRelease;isoutput=true]${PUBLISH_GITHUB_RELEASE}"
+      echo "##vso[task.setvariable variable=githubReleaseDryRun;isoutput=true]${PUBLISH_GITHUB_RELEASE_DRY_RUN}"
       echo "##vso[task.setvariable variable=dockerhub;isoutput=true]${PUBLISH_DOCKERHUB}"
       echo "##vso[task.setvariable variable=docs;isoutput=true]${PUBLISH_DOCS}"
       echo "##vso[task.setvariable variable=docsLatest;isoutput=true]${PUBLISH_DOCS_LATEST}"
@@ -240,6 +246,7 @@ jobs:
       echo "env.outputs['run.packaging']: $(run.packaging)"
       echo
       echo "env.outputs['publish.githubRelease']: $(publish.githubRelease)"
+      echo "env.outputs['publish.githubReleaseDryRun']: $(publish.githubReleaseDryRun)"
       echo "env.outputs['publish.dockerhub]: $(publish.dockerhub)"
       echo "env.outputs['publish.docs]: $(publish.docs)"
       echo "env.outputs['publish.docsLatest]: $(publish.docsLatest)"

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -90,6 +90,10 @@ parameters:
   displayName: "Publish Github release"
   type: string
   default: false
+- name: publishGithubReleaseDryRun
+  displayName: "Publish Github release (dry run)"
+  type: string
+  default: false
 
 
 jobs:
@@ -408,3 +412,5 @@ jobs:
       cacheVersion: $(cacheKeyBazel)
       publishEnvoy: false
       publishTestResults: false
+      env:
+        ENVOY_PUBLISH_DRY_RUN: ${{ parameters.publishGithubReleaseDryRun }}

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -122,6 +122,7 @@ stages:
     RUN_DOCKER: $[stageDependencies.env.repo.outputs['run.docker']]
     RUN_PACKAGING: $[stageDependencies.env.repo.outputs['run.packaging']]
     PUBLISH_GITHUB_RELEASE: $[stageDependencies.env.repo.outputs['publish.githubRelease']]
+    PUBLISH_GITHUB_RELEASE_DRY_RUN: $[stageDependencies.env.repo.outputs['publish.githubReleaseDryRun']]
     PUBLISH_DOCKERHUB: $[stageDependencies.env.repo.outputs['publish.dockerhub']]
     PUBLISH_DOCS: $[stageDependencies.env.repo.outputs['publish.docs']]
     PUBLISH_DOCS_LATEST: $[stageDependencies.env.repo.outputs['publish.docsLatest']]
@@ -153,6 +154,7 @@ stages:
       publishDocsRelease: variables['PUBLISH_DOCS_RELEASE']
       publishDockerhub: variables['PUBLISH_DOCKERHUB']
       publishGithubRelease: variables['PUBLISH_GITHUB_RELEASE']
+      publishGithubReleaseDryRun: variables['PUBLISH_GITHUB_RELEASE_DRY_RUN']
 
 - stage: verify
   displayName: Verify

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -624,7 +624,7 @@ case $CI_TARGET in
         PUBLISH_ARGS=(
             --publish-commitish="$BUILD_SHA"
             --publish-assets=/build/release.signed/release.signed.tar.zst)
-        if [[ "$VERSION_DEV" == "dev" ]]; then
+        if [[ "$VERSION_DEV" == "dev" ]] || [[ -n "$ENVOY_PUBLISH_DRY_RUN" ]]; then
             PUBLISH_ARGS+=(--dry-run)
         fi
         bazel run "${BAZEL_BUILD_OPTIONS[@]}" \

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -133,6 +133,7 @@ docker run --rm \
        -e ENVOY_BUILD_FILTER_EXAMPLE \
        -e ENVOY_COMMIT \
        -e ENVOY_HEAD_REF \
+       -e ENVOY_PUBLISH_DRY_RUN \
        -e ENVOY_REPO \
        -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
        -e GCS_ARTIFACT_BUCKET \


### PR DESCRIPTION
Currently the release publishing code is tested in all ci - but if the version is `-dev` then it run dry-run

This can create an issue for release prs that have the `-dev` removed but are not postsubmit/ready to publish

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
