### PR TITLE
generic proxy: add new request matcher to simplify route table

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3/matcher.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3/matcher.proto
@@ -52,7 +52,6 @@ message PropertyMatchInput {
 message RequestMatchInput {
 }
 
-// [#not-implemented-hide:]
 // Used to match an arbitrary key-value pair for headers, trailers or properties.
 message KeyValueMatchEntry {
   // The key name to match on.
@@ -62,7 +61,6 @@ message KeyValueMatchEntry {
   type.matcher.v3.StringMatcher string_match = 2 [(validate.rules).message = {required: true}];
 }
 
-// [#not-implemented-hide:]
 // Custom matcher to match on the generic downstream request. This is used to match
 // multiple fields of the downstream request and avoid complex combinations of
 // HostMatchInput, PathMatchInput, MethodMatchInput and PropertyMatchInput.

--- a/contrib/generic_proxy/filters/network/source/match.cc
+++ b/contrib/generic_proxy/filters/network/source/match.cc
@@ -15,6 +15,94 @@ REGISTER_FACTORY(MethodMatchDataInputFactory, Matcher::DataInputFactory<Request>
 
 REGISTER_FACTORY(PropertyMatchDataInputFactory, Matcher::DataInputFactory<Request>);
 
+REGISTER_FACTORY(RequestMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+
+using StringMatcherImpl = Matchers::StringMatcherImpl<StringMatcherProto>;
+
+RequestMatchInputMatcher::RequestMatchInputMatcher(const RequestMatcherProto& proto_config) {
+
+  if (proto_config.has_host()) {
+    host_ = std::make_unique<StringMatcherImpl>(proto_config.host());
+  }
+  if (proto_config.has_path()) {
+    path_ = std::make_unique<StringMatcherImpl>(proto_config.path());
+  }
+  if (proto_config.has_method()) {
+    method_ = std::make_unique<StringMatcherImpl>(proto_config.method());
+  }
+
+  for (const auto& property : proto_config.properties()) {
+    properties_.push_back(
+        {property.name(), std::make_unique<StringMatcherImpl>(property.string_match())});
+  }
+}
+
+bool RequestMatchInputMatcher::match(const Matcher::MatchingDataType& input) {
+  if (!absl::holds_alternative<std::shared_ptr<Matcher::CustomMatchData>>(input)) {
+    return false;
+  }
+
+  const auto* typed_data = dynamic_cast<const RequestMatchData*>(
+      absl::get<std::shared_ptr<Matcher::CustomMatchData>>(input).get());
+
+  if (typed_data == nullptr) {
+    return false;
+  }
+
+  return match(typed_data->request());
+}
+
+bool RequestMatchInputMatcher::match(const Request& request) {
+  // TODO(wbpcode): may add more debug log for request match?
+  if (host_ != nullptr) {
+    if (!host_->match(request.host())) {
+      // Host does not match.
+      return false;
+    }
+  }
+
+  if (path_ != nullptr) {
+    if (!path_->match(request.path())) {
+      // Path does not match.
+      return false;
+    }
+  }
+
+  if (method_ != nullptr) {
+    if (!method_->match(request.method())) {
+      // Method does not match.
+      return false;
+    }
+  }
+
+  for (const auto& property : properties_) {
+    if (auto val = request.getByKey(property.first); val.has_value()) {
+      if (!property.second->match(val.value())) {
+        // Property does not match.
+        return false;
+      }
+    } else {
+      // Property does not exist.
+      return false;
+    }
+  }
+
+  // All matchers passed.
+  return true;
+}
+
+Matcher::InputMatcherFactoryCb RequestMatchDataInputMatcherFactory::createInputMatcherFactoryCb(
+    const Protobuf::Message& config, Server::Configuration::ServerFactoryContext& factory_context) {
+  const auto& proto_config = MessageUtil::downcastAndValidate<const RequestMatcherProto&>(
+      config, factory_context.messageValidationVisitor());
+
+  return [proto_config]() -> Matcher::InputMatcherPtr {
+    return std::make_unique<RequestMatchInputMatcher>(proto_config);
+  };
+}
+
+REGISTER_FACTORY(RequestMatchDataInputMatcherFactory, Matcher::InputMatcherFactory);
+
 } // namespace GenericProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/contrib/generic_proxy/filters/network/source/match.h
+++ b/contrib/generic_proxy/filters/network/source/match.h
@@ -24,6 +24,16 @@ using MethodDataInputProto =
     envoy::extensions::filters::network::generic_proxy::matcher::v3::MethodMatchInput;
 using PropertyDataInputProto =
     envoy::extensions::filters::network::generic_proxy::matcher::v3::PropertyMatchInput;
+using RequestInputProto =
+    envoy::extensions::filters::network::generic_proxy::matcher::v3::RequestMatchInput;
+using RequestMatcherProto =
+    envoy::extensions::filters::network::generic_proxy::matcher::v3::RequestMatcher;
+using StringMatcherProto = envoy::type::matcher::v3::StringMatcher;
+
+// Fully qualified name of the generic proxy request match data type to avoid any possible
+// collision with other match data types.
+inline constexpr absl::string_view GenericRequestMatcheInputType =
+    "Envoy::Extensions::NetworkFilters::GenericProxy::RequestMatchData";
 
 class ServiceMatchDataInput : public Matcher::DataInput<Request> {
 public:
@@ -156,6 +166,80 @@ public:
   }
 
   std::string name() const override { return "envoy.matching.generic_proxy.input.property"; }
+};
+
+// RequestMatchData is a wrapper of Request to be used as the matching data type.
+class RequestMatchData : public Matcher::CustomMatchData {
+public:
+  RequestMatchData(const Request& data) : data_(data) {}
+
+  const Request& request() const { return data_; }
+
+private:
+  const Request& data_;
+};
+
+class RequestMatchDataInput : public Matcher::DataInput<Request> {
+public:
+  RequestMatchDataInput() = default;
+
+  Matcher::DataInputGetResult get(const Request& data) const override {
+    auto request = std::make_shared<RequestMatchData>(data);
+    return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
+            Matcher::MatchingDataType{std::move(request)}};
+  }
+
+  absl::string_view dataInputType() const override { return GenericRequestMatcheInputType; }
+};
+
+class RequestMatchDataInputFactory : public Matcher::DataInputFactory<Request> {
+public:
+  RequestMatchDataInputFactory() = default;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<RequestInputProto>();
+  }
+
+  Matcher::DataInputFactoryCb<Request>
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+    return []() { return std::make_unique<RequestMatchDataInput>(); };
+  }
+
+  std::string name() const override { return "envoy.matching.generic_proxy.input.request"; }
+};
+
+class RequestMatchInputMatcher : public Matcher::InputMatcher {
+public:
+  RequestMatchInputMatcher(const RequestMatcherProto& config);
+
+  bool match(const Matcher::MatchingDataType& input) override;
+
+  bool match(const Request& request);
+
+  absl::flat_hash_set<std::string> supportedDataInputTypes() const override {
+    return absl::flat_hash_set<std::string>{std::string(GenericRequestMatcheInputType)};
+  }
+
+private:
+  Matchers::StringMatcherPtr host_;
+  Matchers::StringMatcherPtr path_;
+  Matchers::StringMatcherPtr method_;
+  std::vector<std::pair<std::string, Matchers::StringMatcherPtr>> properties_;
+};
+
+class RequestMatchDataInputMatcherFactory : public Matcher::InputMatcherFactory {
+public:
+  Matcher::InputMatcherFactoryCb createInputMatcherFactoryCb(
+      const Protobuf::Message& config,
+      Server::Configuration::ServerFactoryContext& factory_context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<RequestMatcherProto>();
+  }
+
+  std::string name() const override {
+    return "envoy.matching.input_matchers.generic_request_matcher";
+  }
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/test/match_test.cc
+++ b/contrib/generic_proxy/filters/network/test/match_test.cc
@@ -155,7 +155,7 @@ TEST(RequestMatchInputMatcherTest, SpecificRequestMatchInputMatcherTest) {
 
     const std::string config_yaml = R"EOF(
     host:
-      exact_match: fake_host
+      exact: fake_host
     )EOF";
 
     TestUtility::loadFromYaml(config_yaml, matcher_proto);
@@ -173,9 +173,9 @@ TEST(RequestMatchInputMatcherTest, SpecificRequestMatchInputMatcherTest) {
 
     const std::string config_yaml = R"EOF(
     host:
-      exact_match: fake_host
+      exact: fake_host
     path:
-      exact_match: fake_path
+      exact: fake_path
     )EOF";
 
     TestUtility::loadFromYaml(config_yaml, matcher_proto);
@@ -194,11 +194,11 @@ TEST(RequestMatchInputMatcherTest, SpecificRequestMatchInputMatcherTest) {
 
     const std::string config_yaml = R"EOF(
     host:
-      exact_match: fake_host
+      exact: fake_host
     path:
-      exact_match: fake_path
+      exact: fake_path
     method:
-      exact_match: fake_method
+      exact: fake_method
     )EOF";
 
     TestUtility::loadFromYaml(config_yaml, matcher_proto);
@@ -218,11 +218,11 @@ TEST(RequestMatchInputMatcherTest, SpecificRequestMatchInputMatcherTest) {
 
     const std::string config_yaml = R"EOF(
     host:
-      exact_match: fake_host
+      exact: fake_host
     path:
-      exact_match: fake_path
+      exact: fake_path
     method:
-      exact_match: fake_method
+      exact: fake_method
     properties:
       - name: key_0
         string_match:
@@ -247,11 +247,11 @@ TEST(RequestMatchInputMatcherTest, SpecificRequestMatchInputMatcherTest) {
 
     const std::string config_yaml = R"EOF(
     host:
-      exact_match: fake_host
+      exact: fake_host
     path:
-      exact_match: fake_path
+      exact: fake_path
     method:
-      exact_match: fake_method
+      exact: fake_method
     properties:
       - name: key_0
         string_match:

--- a/contrib/generic_proxy/filters/network/test/match_test.cc
+++ b/contrib/generic_proxy/filters/network/test/match_test.cc
@@ -3,6 +3,7 @@
 #include "contrib/generic_proxy/filters/network/source/match.h"
 #include "contrib/generic_proxy/filters/network/test/fake_codec.h"
 #include "gtest/gtest.h"
+#include <memory>
 
 using testing::NiceMock;
 
@@ -95,6 +96,178 @@ TEST(PropertyMatchDataInputTest, PropertyMatchDataInputTest) {
   request.data_["key_0"] = "value_0";
 
   EXPECT_EQ("value_0", absl::get<std::string>(input->get(request).data_));
+}
+
+TEST(RequestMatchDataInputTest, RequestMatchDataInputTest) {
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  RequestMatchDataInputFactory factory;
+  auto proto_config = factory.createEmptyConfigProto();
+  auto input =
+      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+
+  FakeStreamCodecFactory::FakeRequest request;
+
+  EXPECT_EQ(
+      &request,
+      &dynamic_cast<const RequestMatchData*>(
+           absl::get<std::shared_ptr<Matcher::CustomMatchData>>(input->get(request).data_).get())
+           ->request());
+}
+
+TEST(RequestMatchInputMatcherTest, RequestMatchInputMatcherTest) {
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  RequestMatchDataInputMatcherFactory factory;
+  auto proto_config = factory.createEmptyConfigProto();
+  auto matcher = factory.createInputMatcherFactoryCb(*proto_config,
+                                                     factory_context.getServerFactoryContext())();
+
+  {
+    Matcher::MatchingDataType input;
+    EXPECT_FALSE(matcher->match(input));
+  }
+
+  {
+    Matcher::MatchingDataType input = std::string("fake_data");
+    EXPECT_FALSE(matcher->match(input));
+  }
+
+  {
+    FakeStreamCodecFactory::FakeRequest request;
+    Matcher::MatchingDataType input = std::make_shared<RequestMatchData>(request);
+    EXPECT_TRUE(matcher->match(input));
+  }
+}
+
+TEST(RequestMatchInputMatcherTest, SpecificRequestMatchInputMatcherTest) {
+  // Empty matcher.
+  {
+    RequestMatcherProto matcher_proto;
+    RequestMatchInputMatcher matcher(matcher_proto);
+
+    FakeStreamCodecFactory::FakeRequest request;
+    EXPECT_TRUE(matcher.match(request));
+  }
+
+  // Host match failed.
+  {
+    RequestMatcherProto matcher_proto;
+
+    const std::string config_yaml = R"EOF(
+    host:
+      exact_match: fake_host
+    )EOF";
+
+    TestUtility::loadFromYaml(config_yaml, matcher_proto);
+
+    RequestMatchInputMatcher matcher(matcher_proto);
+
+    FakeStreamCodecFactory::FakeRequest request;
+    request.host_ = "another_fake_host";
+    EXPECT_FALSE(matcher.match(request));
+  }
+
+  // Path match failed.
+  {
+    RequestMatcherProto matcher_proto;
+
+    const std::string config_yaml = R"EOF(
+    host:
+      exact_match: fake_host
+    path:
+      exact_match: fake_path
+    )EOF";
+
+    TestUtility::loadFromYaml(config_yaml, matcher_proto);
+
+    RequestMatchInputMatcher matcher(matcher_proto);
+
+    FakeStreamCodecFactory::FakeRequest request;
+    request.host_ = "fake_host";
+    request.path_ = "another_fake_path";
+    EXPECT_FALSE(matcher.match(request));
+  }
+
+  // Method match failed.
+  {
+    RequestMatcherProto matcher_proto;
+
+    const std::string config_yaml = R"EOF(
+    host:
+      exact_match: fake_host
+    path:
+      exact_match: fake_path
+    method:
+      exact_match: fake_method
+    )EOF";
+
+    TestUtility::loadFromYaml(config_yaml, matcher_proto);
+
+    RequestMatchInputMatcher matcher(matcher_proto);
+
+    FakeStreamCodecFactory::FakeRequest request;
+    request.host_ = "fake_host";
+    request.path_ = "fake_path";
+    request.method_ = "another_fake_method";
+    EXPECT_FALSE(matcher.match(request));
+  }
+
+  // Property match failed.
+  {
+    RequestMatcherProto matcher_proto;
+
+    const std::string config_yaml = R"EOF(
+    host:
+      exact_match: fake_host
+    path:
+      exact_match: fake_path
+    method:
+      exact_match: fake_method
+    properties:
+      - name: key_0
+        string_match:
+          exact: value_0
+    )EOF";
+
+    TestUtility::loadFromYaml(config_yaml, matcher_proto);
+
+    RequestMatchInputMatcher matcher(matcher_proto);
+
+    FakeStreamCodecFactory::FakeRequest request;
+    request.host_ = "fake_host";
+    request.path_ = "fake_path";
+    request.method_ = "fake_method";
+    request.data_["key_0"] = "another_value_0";
+    EXPECT_FALSE(matcher.match(request));
+  }
+
+  // All match.
+  {
+    RequestMatcherProto matcher_proto;
+
+    const std::string config_yaml = R"EOF(
+    host:
+      exact_match: fake_host
+    path:
+      exact_match: fake_path
+    method:
+      exact_match: fake_method
+    properties:
+      - name: key_0
+        string_match:
+          exact: value_0
+    )EOF";
+
+    TestUtility::loadFromYaml(config_yaml, matcher_proto);
+
+    RequestMatchInputMatcher matcher(matcher_proto);
+
+    FakeStreamCodecFactory::FakeRequest request;
+    request.host_ = "fake_host";
+    request.path_ = "fake_path";
+    request.method_ = "fake_method";
+    request.data_["key_0"] = "value_0";
+    EXPECT_TRUE(matcher.match(request));
+  }
 }
 
 } // namespace

--- a/contrib/generic_proxy/filters/network/test/match_test.cc
+++ b/contrib/generic_proxy/filters/network/test/match_test.cc
@@ -1,9 +1,10 @@
+#include <memory>
+
 #include "test/mocks/server/factory_context.h"
 
 #include "contrib/generic_proxy/filters/network/source/match.h"
 #include "contrib/generic_proxy/filters/network/test/fake_codec.h"
 #include "gtest/gtest.h"
-#include <memory>
 
 using testing::NiceMock;
 


### PR DESCRIPTION


Commit Message: generic proxy: add new request matcher to simplify route table
Additional Description:

A new custom matcher for generic proxy is added to simplify the route table. When simple AND semantic is used, the users needn't write complex configuration to combine different input/match.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.