### PR TITLE
cel_matcher: match on xds attributes. 

### DIFF
--- a/source/extensions/matching/http/cel_input/cel_input.h
+++ b/source/extensions/matching/http/cel_input/cel_input.h
@@ -39,13 +39,8 @@ public:
     ResponseHeaderMapOptConstRef maybe_response_headers = data.responseHeaders();
     ResponseTrailerMapOptConstRef maybe_response_trailers = data.responseTrailers();
 
-    // Returns NotAvailable state when all of three below are empty.
-    if (!maybe_request_headers && !maybe_response_headers && !maybe_response_trailers) {
-      return {Matcher::DataInputGetResult::DataAvailability::NotAvailable, absl::monostate()};
-    }
-
-    // CEL library supports mixed matching condition of request headers, response headers and
-    // response trailers.
+    // CEL library supports mixed matching of request/response attributes(e.g., headers, trailers)
+    // and attributes from stream info.
     std::unique_ptr<google::api::expr::runtime::BaseActivation> activation =
         Extensions::Filters::Common::Expr::createActivation(
             data.streamInfo(), maybe_request_headers.ptr(), maybe_response_headers.ptr(),

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
@@ -117,9 +117,9 @@ public:
     return match_tree();
   }
 
-  void setUpstreamClusterMetadata(const std::string& name_space, const std::string& metadata_key,
+  void setUpstreamClusterMetadata(const std::string& namespace, const std::string& metadata_key,
                                   const std::string& metadata_value) {
-    Envoy::Config::Metadata::mutableMetadataValue(metadata_, name_space, metadata_key)
+    Envoy::Config::Metadata::mutableMetadataValue(metadata_, namespace, metadata_key)
         .set_string_value(metadata_value);
     EXPECT_CALL(*cluster_info_, metadata()).WillRepeatedly(testing::ReturnPointee(&metadata_));
     stream_info_.setUpstreamClusterInfo(cluster_info_);

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
@@ -40,10 +40,15 @@ enum class ExpressionType {
   NoExpression = 2,
 };
 
+constexpr absl::string_view kFilterNamespace = "cel_matcher";
+constexpr absl::string_view kMetadataKey = "service_name";
+constexpr absl::string_view kMetadataValue = "test_service";
+
 class CelMatcherTest : public ::testing::Test {
 public:
   CelMatcherTest()
       : inject_action_(action_factory_),
+        cluster_info_(std::make_shared<testing::NiceMock<Upstream::MockClusterInfo>>()),
         data_(Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_)) {}
 
   void buildCustomHeader(const absl::flat_hash_map<std::string, std::string>& custom_value_pairs,
@@ -112,11 +117,21 @@ public:
     return match_tree();
   }
 
+  void setUpstreamClusterMetadata(const std::string& name_space, const std::string& metadata_key,
+                                  const std::string& metadata_value) {
+    Envoy::Config::Metadata::mutableMetadataValue(metadata_, name_space, metadata_key)
+        .set_string_value(metadata_value);
+    EXPECT_CALL(*cluster_info_, metadata()).WillRepeatedly(testing::ReturnPointee(&metadata_));
+    stream_info_.setUpstreamClusterInfo(cluster_info_);
+  }
+
   Matcher::StringActionFactory action_factory_;
   Registry::InjectFactory<Matcher::ActionFactory<absl::string_view>> inject_action_;
+  std::shared_ptr<testing::NiceMock<Upstream::MockClusterInfo>> cluster_info_;
   testing::NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   absl::string_view context_ = "";
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
+  envoy::config::core::v3::Metadata metadata_;
 
   TestRequestHeaderMapImpl default_headers_{
       {":method", "GET"}, {":scheme", "http"}, {":authority", "host"}};
@@ -130,7 +145,6 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderMatched) {
   TestRequestHeaderMapImpl request_headers = default_headers_;
   buildCustomHeader({{"authenticated_user", "staging"}}, request_headers);
   data_.onRequestHeaders(request_headers);
-  // data.onRequestHeaders(request_headers);
 
   const auto result = matcher_tree->match(data_);
   // The match was complete, match found.
@@ -164,13 +178,31 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderNotMatched) {
   EXPECT_EQ(result_2.on_match_, absl::nullopt);
 }
 
-TEST_F(CelMatcherTest, CelMatcherNoRequestAttributes) {
-  auto matcher_tree = buildMatcherTree(RequestHeaderCelExprString);
+TEST_F(CelMatcherTest, CelMatcherClusterMetadtaMatched) {
+  setUpstreamClusterMetadata(std::string(kFilterNamespace), std::string(kMetadataKey),
+                             std::string(kMetadataValue));
+  Envoy::Http::Matching::HttpMatchingDataImpl data =
+      Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
+  auto matcher_tree = buildMatcherTree(absl::StrFormat(
+      UpstreamClusterMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
+  const auto result = matcher_tree->match(data_);
+  // The match was complete, match found.
+  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
+  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+}
 
-  // No request attributes added to matching data.
+TEST_F(CelMatcherTest, CelMatcherClusterMetadtaNotMatched) {
+  setUpstreamClusterMetadata(std::string(kFilterNamespace), std::string(kMetadataKey),
+                             "wrong_service");
+  Envoy::Http::Matching::HttpMatchingDataImpl data =
+      Envoy::Http::Matching::HttpMatchingDataImpl(stream_info_);
+  auto matcher_tree = buildMatcherTree(absl::StrFormat(
+      UpstreamClusterMetadataCelString, kFilterNamespace, kMetadataKey, kMetadataValue));
+
   const auto result = matcher_tree->match(data_);
   // The match was completed, no match found.
-  EXPECT_EQ(result.match_state_, Matcher::MatchState::UnableToMatch);
+  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
   EXPECT_EQ(result.on_match_, absl::nullopt);
 }
 

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
@@ -178,7 +178,7 @@ TEST_F(CelMatcherTest, CelMatcherRequestHeaderNotMatched) {
   EXPECT_EQ(result_2.on_match_, absl::nullopt);
 }
 
-TEST_F(CelMatcherTest, CelMatcherClusterMetadtaMatched) {
+TEST_F(CelMatcherTest, CelMatcherClusterMetadataMatched) {
   setUpstreamClusterMetadata(std::string(kFilterNamespace), std::string(kMetadataKey),
                              std::string(kMetadataValue));
   Envoy::Http::Matching::HttpMatchingDataImpl data =
@@ -192,7 +192,7 @@ TEST_F(CelMatcherTest, CelMatcherClusterMetadtaMatched) {
   EXPECT_NE(result.on_match_->action_cb_, nullptr);
 }
 
-TEST_F(CelMatcherTest, CelMatcherClusterMetadtaNotMatched) {
+TEST_F(CelMatcherTest, CelMatcherClusterMetadataNotMatched) {
   setUpstreamClusterMetadata(std::string(kFilterNamespace), std::string(kMetadataKey),
                              "wrong_service");
   Envoy::Http::Matching::HttpMatchingDataImpl data =

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
@@ -117,9 +117,9 @@ public:
     return match_tree();
   }
 
-  void setUpstreamClusterMetadata(const std::string& namespace, const std::string& metadata_key,
+  void setUpstreamClusterMetadata(const std::string& namespace_str, const std::string& metadata_key,
                                   const std::string& metadata_value) {
-    Envoy::Config::Metadata::mutableMetadataValue(metadata_, namespace, metadata_key)
+    Envoy::Config::Metadata::mutableMetadataValue(metadata_, namespace_str, metadata_key)
         .set_string_value(metadata_value);
     EXPECT_CALL(*cluster_info_, metadata()).WillRepeatedly(testing::ReturnPointee(&metadata_));
     stream_info_.setUpstreamClusterInfo(cluster_info_);

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.h
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Matching {
@@ -543,6 +545,64 @@ inline constexpr char RequestAndResponseCelString[] = R"pb(
     positions {
       key: 20
       value: 82
+    }
+  }
+)pb";
+
+// xds.cluster_metadata.filter_metadata['cel_matcher']['service_name'] == 'test_service'
+inline constexpr absl::string_view UpstreamClusterMetadataCelString = R"pb(
+  expr {
+    id: 8
+    call_expr {
+      function: "_==_"
+      args {
+        id: 6
+        call_expr {
+          function: "_[_]"
+          args {
+            id: 4
+            call_expr {
+              function: "_[_]"
+              args {
+                id: 3
+                select_expr {
+                  operand {
+                    id: 2
+                    select_expr {
+                      operand {
+                        id: 1
+                        ident_expr {
+                          name: "xds"
+                        }
+                      }
+                      field: "cluster_metadata"
+                    }
+                  }
+                  field: "filter_metadata"
+                }
+              }
+              args {
+                id: 5
+                const_expr {
+                  string_value: "%s"
+                }
+              }
+            }
+          }
+          args {
+            id: 7
+            const_expr {
+              string_value: "%s"
+            }
+          }
+        }
+      }
+      args {
+        id: 9
+        const_expr {
+          string_value: "%s"
+        }
+      }
     }
   }
 )pb";

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -190,6 +190,11 @@ MockStreamInfo::MockStreamInfo()
       }));
   ON_CALL(*this, downstreamTransportFailureReason())
       .WillByDefault(ReturnPointee(&downstream_transport_failure_reason_));
+  ON_CALL(*this, setUpstreamClusterInfo(_))
+      .WillByDefault(Invoke([this](const Upstream::ClusterInfoConstSharedPtr& cluster_info) {
+        upstream_cluster_info_ = std::move(cluster_info);
+      }));
+  ON_CALL(*this, upstreamClusterInfo()).WillByDefault(ReturnPointee(&upstream_cluster_info_));
 }
 
 MockStreamInfo::~MockStreamInfo() = default;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -146,6 +146,7 @@ public:
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   absl::optional<std::string> connection_termination_details_;
+  absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_;
   std::shared_ptr<UpstreamInfo> upstream_info_;
   uint64_t response_flags_{};
   envoy::config::core::v3::Metadata metadata_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

With PR #25818, xds attributes (like upstream cluster metadata) are provided via streamInfo and are available to CEL library. This PR enables them and tests upstream cluster metadata specifically. 

