### PR TITLE
[ZK filter] Add 'addWatch' opcode support

### DIFF
--- a/api/envoy/extensions/filters/network/zookeeper_proxy/v3/zookeeper_proxy.proto
+++ b/api/envoy/extensions/filters/network/zookeeper_proxy/v3/zookeeper_proxy.proto
@@ -89,6 +89,7 @@ message LatencyThresholdOverride {
     GetEphemerals = 23;
     GetAllChildrenNumber = 24;
     SetWatches2 = 25;
+    AddWatch = 26;
   }
 
   // The ZooKeeper opcodes. Can be found as part of the ZooKeeper source code:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -336,6 +336,9 @@ new_features:
     added host related information :ref:`metadata <envoy_v3_api_field_data.core.v3.HealthCheckEvent.metadata>` and
     :ref:`locality <envoy_v3_api_field_data.core.v3.HealthCheckEvent.locality>` to
     the :ref:`health check event <envoy_v3_api_msg_data.core.v3.HealthCheckEvent>` definition.
+- area: zookeeper
+  change: |
+    Add "addWatch" opcode support to the ZooKeeper proxy filter.
 
 deprecated:
 - area: access_log

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -338,7 +338,7 @@ new_features:
     the :ref:`health check event <envoy_v3_api_msg_data.core.v3.HealthCheckEvent>` definition.
 - area: zookeeper
   change: |
-    Add "addWatch" opcode support to the ZooKeeper proxy filter.
+    Added the "addWatch" opcode support to the ZooKeeper proxy filter.
 
 deprecated:
 - area: access_log

--- a/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
@@ -63,6 +63,7 @@ The following counters are available:
   reconfig_rq, Counter, Number of reconfig requests
   setwatches_rq, Counter, Number of setwatches requests
   setwatches2_rq, Counter, Number of setwatches2 requests
+  addwatch_rq, Counter, Number of addwatch requests
   checkwatches_rq, Counter, Number of checkwatches requests
   removewatches_rq, Counter, Number of removewatches requests
   getephemerals_rq, Counter, Number of getephemerals requests
@@ -91,6 +92,7 @@ The following counters are available:
   setauth_resp, Counter, Number of setauth responses
   setwatches_resp, Counter, Number of setwatches responses
   setwatches2_resp, Counter, Number of setwatches2 responses
+  addwatch_resp, Counter, Number of addwatch responses
   checkwatches_resp, Counter, Number of checkwatches responses
   removewatches_resp, Counter, Number of removewatches responses
   getephemerals_resp, Counter, Number of getephemerals responses
@@ -119,6 +121,7 @@ The following counters are available:
   setauth_resp_fast, Counter, Number of setauth responses faster than or equal to the threshold
   setwatches_resp_fast, Counter, Number of setwatches responses faster than or equal to the threshold
   setwatches2_resp_fast, Counter, Number of setwatches2 responses faster than or equal to the threshold
+  addwatch_resp_fast, Counter, Number of addwatch responses faster than or equal to the threshold
   checkwatches_resp_fast, Counter, Number of checkwatches responses faster than or equal to the threshold
   removewatches_resp_fast, Counter, Number of removewatches responses faster than or equal to the threshold
   getephemerals_resp_fast, Counter, Number of getephemerals responses faster than or equal to the threshold
@@ -146,6 +149,7 @@ The following counters are available:
   setauth_resp_slow, Counter, Number of setauth responses slower than the threshold
   setwatches_resp_slow, Counter, Number of setwatches responses slower than the threshold
   setwatches2_resp_slow, Counter, Number of setwatches2 responses slower than the threshold
+  addwatch_resp_slow, Counter, Number of addwatch responses slower than the threshold
   checkwatches_resp_slow, Counter, Number of checkwatches responses slower than the threshold
   removewatches_resp_slow, Counter, Number of removewatches responses slower than the threshold
   getephemerals_resp_slow, Counter, Number of getephemerals responses slower than the threshold
@@ -190,6 +194,7 @@ Latency stats are in milliseconds:
   setauth_resp_latency, Histogram, Opcode execution time in milliseconds
   setwatches_resp_latency, Histogram, Opcode execution time in milliseconds
   setwatches2_resp_latency, Histogram, Opcode execution time in milliseconds
+  addwatch_resp_latency, Histogram, Opcode execution time in milliseconds
   checkwatches_resp_latency, Histogram, Opcode execution time in milliseconds
   removewatches_resp_latency, Histogram, Opcode execution time in milliseconds
   check_resp_latency, Histogram, Opcode execution time in milliseconds

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -149,6 +149,9 @@ void DecoderImpl::decodeOnData(Buffer::Instance& data, uint64_t& offset) {
   case OpCodes::SetWatches2:
     parseSetWatches2Request(data, offset, len);
     break;
+  case OpCodes::AddWatch:
+    parseAddWatchRequest(data, offset, len);
+    break;
   case OpCodes::CheckWatches:
     parseXWatchesRequest(data, offset, len, OpCodes::CheckWatches);
     break;
@@ -465,6 +468,15 @@ void DecoderImpl::parseSetWatches2Request(Buffer::Instance& data, uint64_t& offs
   skipStrings(data, offset);
 
   callbacks_.onSetWatches2Request();
+}
+
+void DecoderImpl::parseAddWatchRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len) {
+  ensureMinLength(len, XID_LENGTH + OPCODE_LENGTH + (2 * INT_LENGTH));
+
+  const std::string path = helper_.peekString(data, offset);
+  const int32_t mode = helper_.peekInt32(data, offset);
+
+  callbacks_.onAddWatchRequest(path, mode);
 }
 
 void DecoderImpl::parseXWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len,

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -51,10 +51,13 @@ enum class OpCodes {
   SetWatches = 101,
   GetEphemerals = 103,
   GetAllChildrenNumber = 104,
-  SetWatches2 = 105
+  SetWatches2 = 105,
+  AddWatch = 106,
 };
 
 enum class WatcherType { Children = 1, Data = 2, Any = 3 };
+
+enum class AddWatchMode { Persistent, PersistentRecursive };
 
 enum class CreateFlags {
   Persistent,
@@ -96,6 +99,7 @@ public:
   virtual void onReconfigRequest() PURE;
   virtual void onSetWatchesRequest() PURE;
   virtual void onSetWatches2Request() PURE;
+  virtual void onAddWatchRequest(const std::string& path, const int32_t mode) PURE;
   virtual void onCheckWatchesRequest(const std::string& path, int32_t type) PURE;
   virtual void onRemoveWatchesRequest(const std::string& path, int32_t type) PURE;
   virtual void onCloseRequest() PURE;
@@ -167,6 +171,7 @@ private:
   void parseReconfigRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseSetWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseSetWatches2Request(Buffer::Instance& data, uint64_t& offset, uint32_t len);
+  void parseAddWatchRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len);
   void parseXWatchesRequest(Buffer::Instance& data, uint64_t& offset, uint32_t len, OpCodes opcode);
   void skipString(Buffer::Instance& data, uint64_t& offset);
   void skipStrings(Buffer::Instance& data, uint64_t& offset);

--- a/source/extensions/filters/network/zookeeper_proxy/filter.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.cc
@@ -81,6 +81,8 @@ ZooKeeperFilterConfig::ZooKeeperFilterConfig(
              stats_.setwatches_resp_slow_, "setwatches_resp");
   initOpCode(OpCodes::SetWatches2, stats_.setwatches2_resp_, stats_.setwatches2_resp_fast_,
              stats_.setwatches2_resp_slow_, "setwatches2_resp");
+  initOpCode(OpCodes::AddWatch, stats_.addwatch_resp_, stats_.addwatch_resp_fast_,
+             stats_.addwatch_resp_slow_, "addwatch_resp");
   initOpCode(OpCodes::CheckWatches, stats_.checkwatches_resp_, stats_.checkwatches_resp_fast_,
              stats_.checkwatches_resp_slow_, "checkwatches_resp");
   initOpCode(OpCodes::RemoveWatches, stats_.removewatches_resp_, stats_.removewatches_resp_fast_,
@@ -349,6 +351,11 @@ void ZooKeeperFilter::onSetWatchesRequest() {
 void ZooKeeperFilter::onSetWatches2Request() {
   config_->stats_.setwatches2_rq_.inc();
   setDynamicMetadata("opname", "setwatches2");
+}
+
+void ZooKeeperFilter::onAddWatchRequest(const std::string& path, const int32_t mode) {
+  config_->stats_.addwatch_rq_.inc();
+  setDynamicMetadata({{"opname", "addwatch"}, {"path", path}, {"mode", std::to_string(mode)}});
 }
 
 void ZooKeeperFilter::onGetEphemeralsRequest(const std::string& path) {

--- a/source/extensions/filters/network/zookeeper_proxy/filter.h
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.h
@@ -52,6 +52,7 @@ namespace ZooKeeperProxy {
   COUNTER(setauth_rq)                                                                              \
   COUNTER(setwatches_rq)                                                                           \
   COUNTER(setwatches2_rq)                                                                          \
+  COUNTER(addwatch_rq)                                                                             \
   COUNTER(checkwatches_rq)                                                                         \
   COUNTER(removewatches_rq)                                                                        \
   COUNTER(check_rq)                                                                                \
@@ -80,6 +81,7 @@ namespace ZooKeeperProxy {
   COUNTER(setauth_resp)                                                                            \
   COUNTER(setwatches_resp)                                                                         \
   COUNTER(setwatches2_resp)                                                                        \
+  COUNTER(addwatch_resp)                                                                           \
   COUNTER(checkwatches_resp)                                                                       \
   COUNTER(removewatches_resp)                                                                      \
   COUNTER(check_resp)                                                                              \
@@ -108,6 +110,7 @@ namespace ZooKeeperProxy {
   COUNTER(setauth_resp_fast)                                                                       \
   COUNTER(setwatches_resp_fast)                                                                    \
   COUNTER(setwatches2_resp_fast)                                                                   \
+  COUNTER(addwatch_resp_fast)                                                                      \
   COUNTER(checkwatches_resp_fast)                                                                  \
   COUNTER(removewatches_resp_fast)                                                                 \
   COUNTER(check_resp_fast)                                                                         \
@@ -135,6 +138,7 @@ namespace ZooKeeperProxy {
   COUNTER(setauth_resp_slow)                                                                       \
   COUNTER(setwatches_resp_slow)                                                                    \
   COUNTER(setwatches2_resp_slow)                                                                   \
+  COUNTER(addwatch_resp_slow)                                                                      \
   COUNTER(checkwatches_resp_slow)                                                                  \
   COUNTER(removewatches_resp_slow)                                                                 \
   COUNTER(check_resp_slow)
@@ -232,7 +236,8 @@ private:
                                        {LatencyThresholdOverride::SetWatches, 101},
                                        {LatencyThresholdOverride::GetEphemerals, 103},
                                        {LatencyThresholdOverride::GetAllChildrenNumber, 104},
-                                       {LatencyThresholdOverride::SetWatches2, 105}});
+                                       {LatencyThresholdOverride::SetWatches2, 105},
+                                       {LatencyThresholdOverride::AddWatch, 106}});
   }
 
   int32_t getOpCodeIndex(LatencyThresholdOverride_Opcode opcode);
@@ -284,6 +289,7 @@ public:
   void onReconfigRequest() override;
   void onSetWatchesRequest() override;
   void onSetWatches2Request() override;
+  void onAddWatchRequest(const std::string& path, const int32_t mode) override;
   void onCheckWatchesRequest(const std::string& path, int32_t type) override;
   void onRemoveWatchesRequest(const std::string& path, int32_t type) override;
   void onGetEphemeralsRequest(const std::string& path) override;

--- a/test/extensions/filters/network/zookeeper_proxy/config_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/config_test.cc
@@ -253,7 +253,7 @@ TEST_F(ZookeeperFilterConfigTest, FullConfig) {
   EXPECT_EQ(proto_config_.enable_latency_threshold_metrics(), true);
   EXPECT_EQ(proto_config_.default_latency_threshold(),
             ProtobufWkt::util::TimeUtil::MillisecondsToDuration(100));
-  EXPECT_EQ(proto_config_.latency_threshold_overrides_size(), 26);
+  EXPECT_EQ(proto_config_.latency_threshold_overrides_size(), 27);
 
   for (int i = 0; i < opcode_descriptor->value_count(); i++) {
     LatencyThresholdOverride threshold_override = proto_config_.latency_threshold_overrides().at(i);

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -1240,6 +1240,20 @@ TEST_F(ZooKeeperFilterTest, SetWatches2Request) {
       config_->stats().setwatches2_resp_slow_);
 }
 
+TEST_F(ZooKeeperFilterTest, AddWatchRequest) {
+  initialize();
+
+  Buffer::OwnedImpl data =
+      encodePathVersion("/foo", enumToSignedInt(AddWatchMode::PersistentRecursive),
+                        enumToSignedInt(OpCodes::AddWatch));
+
+  testRequest(data, {{{"opname", "addwatch"}, {"path", "/foo"}, {"mode", "1"}}, {{"bytes", "24"}}},
+              config_->stats().addwatch_rq_, 24);
+  testResponse({{{"opname", "addwatch_resp"}, {"zxid", "2000"}, {"error", "0"}}, {{"bytes", "20"}}},
+               config_->stats().addwatch_resp_, config_->stats().addwatch_resp_fast_,
+               config_->stats().addwatch_resp_slow_);
+}
+
 TEST_F(ZooKeeperFilterTest, CheckWatchesRequest) {
   initialize();
 


### PR DESCRIPTION
Commit Message: [ZK filter] Add 'addWatch' opcode support
Additional Description: Add the 'addWatch' opcode support to Envoy ZK filter, based on the [ZK opcode list](https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/ZooDefs.java#L94).
Risk Level: Low
Testing: Unit tests
Docs Changes: Update the addWatch-opcode-related metrics in the [ZK proxy filter doc](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/zookeeper_proxy_filter#statistics).
Release Notes: Added the "addWatch" opcode support to the ZooKeeper proxy filter.
Platform Specific Features: N/A
[[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] Update the ZK proxy proto opcode enum list by adding the 'addWatch' opcode.
