### PR TITLE
docs: fix yaml syntax in scoped route example

### DIFF
--- a/api/envoy/api/v2/scoped_route.proto
+++ b/api/envoy/api/v2/scoped_route.proto
@@ -39,7 +39,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 //       fragments:
 //         - header_value_extractor:
 //             name: X-Route-Selector
-//             element_separator: ,
+//             element_separator: ","
 //             element:
 //               separator: =
 //               key: vip

--- a/api/envoy/config/route/v3/scoped_route.proto
+++ b/api/envoy/config/route/v3/scoped_route.proto
@@ -44,7 +44,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       fragments:
 //         - header_value_extractor:
 //             name: X-Route-Selector
-//             element_separator: ,
+//             element_separator: ","
 //             element:
 //               separator: =
 //               key: vip


### PR DESCRIPTION
Commit Message: docs: fix yaml syntax in scoped route example
Additional Description:

`element_separator: ,` is invalid in yaml

Risk Level: Low
Testing:
Docs Changes: 
Release Notes:
Platform Specific Features:
