### PR TITLE
build: adding an disable_exceptions (which does not yet work)

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -375,6 +375,13 @@ config_setting(
     values = {"define": "envoy_yaml=disabled"},
 )
 
+# The goal here is to allow Envoy to build with this option but it is not yet
+# complete.  See https://github.com/envoyproxy/envoy/issues/27412
+config_setting(
+    name = "disable_exceptions",
+    values = {"define": "envoy_exceptions=disabled"},
+)
+
 config_setting(
     name = "disable_envoy_mobile_listener",
     values = {"define": "envoy_mobile_listener=disabled"},

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -22,6 +22,7 @@ load(
     _envoy_select_admin_html = "envoy_select_admin_html",
     _envoy_select_admin_no_html = "envoy_select_admin_no_html",
     _envoy_select_boringssl = "envoy_select_boringssl",
+    _envoy_select_disable_exceptions = "envoy_select_disable_exceptions",
     _envoy_select_disable_logging = "envoy_select_disable_logging",
     _envoy_select_enable_http3 = "envoy_select_enable_http3",
     _envoy_select_enable_http_datagrams = "envoy_select_enable_http_datagrams",
@@ -242,6 +243,7 @@ envoy_select_disable_logging = _envoy_select_disable_logging
 envoy_select_google_grpc = _envoy_select_google_grpc
 envoy_select_enable_http3 = _envoy_select_enable_http3
 envoy_select_enable_yaml = _envoy_select_enable_yaml
+envoy_select_disable_exceptions = _envoy_select_disable_exceptions
 envoy_select_hot_restart = _envoy_select_hot_restart
 envoy_select_enable_http_datagrams = _envoy_select_enable_http_datagrams
 envoy_select_signal_trace = _envoy_select_signal_trace

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -1,6 +1,6 @@
 # DO NOT LOAD THIS FILE. Targets from this file should be considered private
 # and not used outside of the @envoy//bazel package.
-load(":envoy_select.bzl", "envoy_select_admin_html", "envoy_select_disable_logging", "envoy_select_google_grpc", "envoy_select_hot_restart", "envoy_select_signal_trace", "envoy_select_static_extension_registration")
+load(":envoy_select.bzl", "envoy_select_admin_html", "envoy_select_disable_exceptions", "envoy_select_disable_logging", "envoy_select_google_grpc", "envoy_select_hot_restart", "envoy_select_signal_trace", "envoy_select_static_extension_registration")
 
 # Compute the final copts based on various options.
 def envoy_copts(repository, test = False):
@@ -119,6 +119,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:uhv_enabled": ["-DENVOY_ENABLE_UHV"],
                "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
+           envoy_select_disable_exceptions(["-fno-unwind-tables", "-fno-exceptions"], repository) + \
            envoy_select_admin_html(["-DENVOY_ADMIN_HTML"], repository) + \
            envoy_select_static_extension_registration(["-DENVOY_STATIC_EXTENSION_REGISTRATION"], repository) + \
            envoy_select_disable_logging(["-DENVOY_DISABLE_LOGGING"], repository) + \

--- a/bazel/envoy_mobile_defines.bzl
+++ b/bazel/envoy_mobile_defines.bzl
@@ -1,11 +1,12 @@
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
-load(":envoy_select.bzl", "envoy_select_admin_functionality", "envoy_select_enable_http3", "envoy_select_enable_http_datagrams", "envoy_select_enable_yaml", "envoy_select_envoy_mobile_listener", "envoy_select_envoy_mobile_request_compression", "envoy_select_envoy_mobile_stats_reporting", "envoy_select_google_grpc")
+load(":envoy_select.bzl", "envoy_select_admin_functionality", "envoy_select_disable_exceptions", "envoy_select_enable_http3", "envoy_select_enable_http_datagrams", "envoy_select_enable_yaml", "envoy_select_envoy_mobile_listener", "envoy_select_envoy_mobile_request_compression", "envoy_select_envoy_mobile_stats_reporting", "envoy_select_google_grpc")
 
 # Compute the defines needed for Envoy Mobile libraries that don't use Envoy's main library wrappers.
 def envoy_mobile_defines(repository):
     return envoy_select_admin_functionality(["ENVOY_ADMIN_FUNCTIONALITY"], repository) + \
            envoy_select_enable_http3(["ENVOY_ENABLE_QUIC"], repository) + \
            envoy_select_enable_yaml(["ENVOY_ENABLE_YAML"], repository) + \
+           envoy_select_disable_exceptions(["ENVOY_DISABLE_EXCEPTIONS"], repository) + \
            envoy_select_enable_http_datagrams(["ENVOY_ENABLE_HTTP_DATAGRAMS"], repository) + \
            envoy_select_envoy_mobile_listener(["ENVOY_MOBILE_ENABLE_LISTENER"], repository) + \
            envoy_select_envoy_mobile_stats_reporting(["ENVOY_MOBILE_STATS_REPORTING"], repository) + \

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -94,6 +94,13 @@ def envoy_select_enable_yaml(xs, repository = ""):
         "//conditions:default": xs,
     })
 
+# Selects the given values if exceptions are disabled in the current build.
+def envoy_select_disable_exceptions(xs, repository = ""):
+    return select({
+        repository + "//bazel:disable_exceptions": xs,
+        "//conditions:default": [],
+    })
+
 # Selects the given values if HTTP datagram support is enabled in the current build.
 def envoy_select_enable_http_datagrams(xs, repository = ""):
     return select({

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -254,6 +254,18 @@ public:
   }
 #endif
 
+#ifdef ENVOY_DISABLE_EXCEPTIONS
+#define MULTI_CATCH(ExceptionType, Handler)
+#else
+#define MULTI_CATCH(Exception, Handler, Handler2)                                                  \
+  catch (Exception) {                                                                              \
+    Handler                                                                                        \
+  }                                                                                                \
+  catch (...) {                                                                                    \
+    Handler2                                                                                       \
+  }
+#endif
+
 // These convenience macros assert properties of the threading system, when
 // feasible. There is a platform-specific mechanism for determining whether the
 // current thread is from main(), which we call the "test thread", and if that

--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -237,9 +237,22 @@ public:
 
 #define END_TRY }
 
+#ifdef ENVOY_DISABLE_EXCEPTIONS
+#define TRY_NEEDS_AUDIT {
+#else
 // TODO(chaoqinli-1123): Remove this macros after we have removed all the exceptions from data
 // plane.
-#define TRY_NEEDS_AUDIT try
+#define TRY_NEEDS_AUDIT try {
+#endif
+
+#ifdef ENVOY_DISABLE_EXCEPTIONS
+#define CATCH(ExceptionType, Handler)
+#else
+#define CATCH(Exception, Handler)                                                                  \
+  catch (Exception) {                                                                              \
+    Handler                                                                                        \
+  }
+#endif
 
 // These convenience macros assert properties of the threading system, when
 // feasible. There is a platform-specific mechanism for determining whether the
@@ -277,6 +290,9 @@ public:
 
 #endif
 
+#ifdef ENVOY_DISABLE_EXCEPTIONS
+#define TRY_ASSERT_MAIN_THREAD {
+#else
 /**
  * To improve exception safety in data plane, we plan to forbid the use of raw
  * try in the core code base. This macros uses main thread assertion to make
@@ -285,6 +301,7 @@ public:
 #define TRY_ASSERT_MAIN_THREAD                                                                     \
   try {                                                                                            \
     ASSERT_IS_MAIN_OR_TEST_THREAD();
+#endif
 
 /**
  * RAII class to override thread assertions checks in the macros:

--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -21,7 +21,7 @@ void validateTypeUrlHelper(const std::string& type_url,
                            const absl::flat_hash_set<std::string> require_type_urls) {
   if (!require_type_urls.contains(type_url)) {
     throw EnvoyException(fmt::format("Error: filter config has type URL {} but expect {}.",
-                                     type_url, absl::StrJoin(require_type_urls, ", ")));
+                                           type_url, absl::StrJoin(require_type_urls, ", ")));
   }
 }
 
@@ -98,8 +98,8 @@ void FilterConfigSubscription::onConfigUpdate(
   const auto& filter_config = dynamic_cast<const envoy::config::core::v3::TypedExtensionConfig&>(
       resources[0].get().resource());
   if (filter_config.name() != filter_config_name_) {
-    throw EnvoyException(fmt::format("Unexpected resource name in ExtensionConfigDS response: {}",
-                                     filter_config.name()));
+    throw EnvoyException(fmt::format(
+        "Unexpected resource name in ExtensionConfigDS response: {}", filter_config.name()));
   }
   // Skip update if hash matches
   next->config_hash_ = MessageUtil::hash(filter_config.typed_config());
@@ -220,11 +220,12 @@ void FilterConfigProviderManagerImplBase::applyLastOrDefaultConfig(
                                subscription->lastFactoryName());
       last_config_valid = true;
     }
-    END_TRY catch (const EnvoyException& e) {
+    END_TRY CATCH(const EnvoyException& e, {
       ENVOY_LOG(debug, "ECDS subscription {} is invalid in a listener context: {}.",
                 filter_config_name, e.what());
       subscription->incrementConflictCounter();
-    }
+    });
+
     if (last_config_valid) {
       provider.onConfigUpdate(*subscription->lastConfig(), subscription->lastVersionInfo(),
                               nullptr);
@@ -241,9 +242,10 @@ void FilterConfigProviderManagerImplBase::validateProtoConfigDefaultFactory(
     const bool null_default_factory, const std::string& filter_config_name,
     absl::string_view type_url) const {
   if (null_default_factory) {
-    throw EnvoyException(fmt::format("Error: cannot find filter factory {} for default filter "
-                                     "configuration with type URL {}.",
-                                     filter_config_name, type_url));
+    throw EnvoyException(
+        fmt::format("Error: cannot find filter factory {} for default filter "
+                    "configuration with type URL {}.",
+                    filter_config_name, type_url));
   }
 }
 

--- a/source/common/filter/config_discovery_impl.cc
+++ b/source/common/filter/config_discovery_impl.cc
@@ -21,7 +21,7 @@ void validateTypeUrlHelper(const std::string& type_url,
                            const absl::flat_hash_set<std::string> require_type_urls) {
   if (!require_type_urls.contains(type_url)) {
     throw EnvoyException(fmt::format("Error: filter config has type URL {} but expect {}.",
-                                           type_url, absl::StrJoin(require_type_urls, ", ")));
+                                     type_url, absl::StrJoin(require_type_urls, ", ")));
   }
 }
 
@@ -98,8 +98,8 @@ void FilterConfigSubscription::onConfigUpdate(
   const auto& filter_config = dynamic_cast<const envoy::config::core::v3::TypedExtensionConfig&>(
       resources[0].get().resource());
   if (filter_config.name() != filter_config_name_) {
-    throw EnvoyException(fmt::format(
-        "Unexpected resource name in ExtensionConfigDS response: {}", filter_config.name()));
+    throw EnvoyException(fmt::format("Unexpected resource name in ExtensionConfigDS response: {}",
+                                     filter_config.name()));
   }
   // Skip update if hash matches
   next->config_hash_ = MessageUtil::hash(filter_config.typed_config());
@@ -242,10 +242,9 @@ void FilterConfigProviderManagerImplBase::validateProtoConfigDefaultFactory(
     const bool null_default_factory, const std::string& filter_config_name,
     absl::string_view type_url) const {
   if (null_default_factory) {
-    throw EnvoyException(
-        fmt::format("Error: cannot find filter factory {} for default filter "
-                    "configuration with type URL {}.",
-                    filter_config_name, type_url));
+    throw EnvoyException(fmt::format("Error: cannot find filter factory {} for default filter "
+                                     "configuration with type URL {}.",
+                                     filter_config_name, type_url));
   }
 }
 

--- a/source/common/router/header_parser_utils.cc
+++ b/source/common/router/header_parser_utils.cc
@@ -51,10 +51,7 @@ std::string HeaderParser::translateMetadataFormat(const std::string& header_valu
       int subs = absl::StrReplaceAll({{matches[0].as_string(), new_format}}, &new_header_value);
       ASSERT(subs > 0);
     }
-    END_TRY
-    catch (Json::Exception& e) {
-      return header_value;
-    }
+    END_TRY CATCH(Json::Exception & e, { return header_value; });
   }
 
   return new_header_value;

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -599,9 +599,10 @@ void RtdsSubscription::validateUpdateSize(uint32_t added_resources_num,
                                           uint32_t removed_resources_num) {
   if (added_resources_num + removed_resources_num != 1) {
     init_target_.ready();
-    throw EnvoyException(fmt::format("Unexpected RTDS resource length, number of added recources "
-                                     "{}, number of removed recources {}",
-                                     added_resources_num, removed_resources_num));
+    throw EnvoyException(
+        fmt::format("Unexpected RTDS resource length, number of added recources "
+                    "{}, number of removed recources {}",
+                    added_resources_num, removed_resources_num));
   }
 }
 
@@ -690,13 +691,13 @@ SnapshotImplPtr LoaderImpl::createNewSnapshot() {
           ++disk_layers;
         }
         END_TRY
-        catch (EnvoyException& e) {
+        CATCH(EnvoyException & e, {
           // TODO(htuch): Consider latching here, rather than ignoring the
           // layer. This would be consistent with filesystem RTDS.
           ++error_layers;
           ENVOY_LOG(debug, "error loading runtime values for layer {} from disk: {}",
                     layer.DebugString(), e.what());
-        }
+        });
       }
       break;
     }

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -599,10 +599,9 @@ void RtdsSubscription::validateUpdateSize(uint32_t added_resources_num,
                                           uint32_t removed_resources_num) {
   if (added_resources_num + removed_resources_num != 1) {
     init_target_.ready();
-    throw EnvoyException(
-        fmt::format("Unexpected RTDS resource length, number of added recources "
-                    "{}, number of removed recources {}",
-                    added_resources_num, removed_resources_num));
+    throw EnvoyException(fmt::format("Unexpected RTDS resource length, number of added recources "
+                                     "{}, number of removed recources {}",
+                                     added_resources_num, removed_resources_num));
   }
 }
 

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -47,8 +47,8 @@ void SdsApi::resolveDataSource(const FileContentMap& files,
 void SdsApi::onWatchUpdate() {
   // Filesystem reads and update callbacks can fail if the key material is missing or bad. We're not
   // under an onConfigUpdate() context, so we need to catch these cases explicitly here.
+  // Obtain a stable set of files. If a rotation happens while we're reading,
   TRY_ASSERT_MAIN_THREAD {
-    // Obtain a stable set of files. If a rotation happens while we're reading,
     // then we need to try again.
     uint64_t prev_hash = 0;
     FileContentMap files = loadFiles();
@@ -73,10 +73,10 @@ void SdsApi::onWatchUpdate() {
     }
   }
   END_TRY
-  catch (const EnvoyException& e) {
+  CATCH(const EnvoyException& e, {
     ENVOY_LOG_MISC(warn, fmt::format("Failed to reload certificates: {}", e.what()));
     sds_api_stats_.key_rotation_failed_.inc();
-  }
+  });
 }
 
 void SdsApi::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& resources,

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -47,8 +47,8 @@ void SdsApi::resolveDataSource(const FileContentMap& files,
 void SdsApi::onWatchUpdate() {
   // Filesystem reads and update callbacks can fail if the key material is missing or bad. We're not
   // under an onConfigUpdate() context, so we need to catch these cases explicitly here.
-  // Obtain a stable set of files. If a rotation happens while we're reading,
   TRY_ASSERT_MAIN_THREAD {
+    // Obtain a stable set of files. If a rotation happens while we're reading,
     // then we need to try again.
     uint64_t prev_hash = 0;
     FileContentMap files = loadFiles();

--- a/source/common/stats/tag_extractor_impl.cc
+++ b/source/common/stats/tag_extractor_impl.cc
@@ -21,9 +21,8 @@ namespace {
 std::regex parseStdRegex(const std::string& regex) {
   TRY_ASSERT_MAIN_THREAD { return std::regex(regex, std::regex::optimize); }
   END_TRY
-  catch (const std::regex_error& e) {
-    throw EnvoyException(fmt::format("Invalid regex '{}': {}", regex, e.what()));
-  }
+  CATCH(const std::regex_error& e,
+        { throw EnvoyException(fmt::format("Invalid regex '{}': {}", regex, e.what())); });
 }
 } // namespace
 

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -54,10 +54,10 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
       }
     }
     END_TRY
-    catch (const EnvoyException& e) {
-      exception_msgs.push_back(fmt::format("{}: {}", cluster.name(), e.what()));
-    }
+    CATCH(const EnvoyException& e,
+          { exception_msgs.push_back(fmt::format("{}: {}", cluster.name(), e.what())); });
   }
+
   for (const auto& resource_name : removed_resources) {
     if (cm_.removeCluster(resource_name)) {
       any_applied = true;

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -289,14 +289,14 @@ void HdsDelegate::onReceiveMessage(
                           server_context_.messageValidationContext().dynamicValidationVisitor());
   }
   END_TRY
-  catch (const ProtoValidationException& ex) {
+  CATCH(const ProtoValidationException& ex, {
     // Increment error count
     stats_.errors_.inc();
     ENVOY_LOG(warn, "Unable to validate health check specifier: {}", ex.what());
 
     // Do not continue processing message
     return;
-  }
+  });
 
   // Set response
   auto server_response_ms = PROTOBUF_GET_MS_OR_DEFAULT(*message, interval, 1000);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -94,9 +94,10 @@ createProtocolOptionsConfig(const std::string& name, const ProtobufWkt::Any& typ
   }
 
   if (factory == nullptr) {
-    throw EnvoyException(fmt::format("Didn't find a registered network or http filter or protocol "
-                                     "options implementation for name: '{}'",
-                                     name));
+    throw EnvoyException(
+        fmt::format("Didn't find a registered network or http filter or protocol "
+                    "options implementation for name: '{}'",
+                    name));
   }
 
   ProtobufTypes::MessagePtr proto_config = factory->createEmptyProtocolOptionsProto();
@@ -954,8 +955,9 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
   if (config.protocol_selection() == envoy::config::cluster::v3::Cluster::USE_CONFIGURED_PROTOCOL) {
     // Make sure multiple protocol configurations are not present
     if (config.has_http_protocol_options() && config.has_http2_protocol_options()) {
-      throw EnvoyException(fmt::format("cluster: Both HTTP1 and HTTP2 options may only be "
-                                       "configured with non-default 'protocol_selection' values"));
+      throw EnvoyException(
+          fmt::format("cluster: Both HTTP1 and HTTP2 options may only be "
+                      "configured with non-default 'protocol_selection' values"));
     }
   }
 
@@ -1093,15 +1095,16 @@ ClusterInfoImpl::ClusterInfoImpl(
       added_via_api_(added_via_api), has_configured_http_filters_(false) {
 #ifdef WIN32
   if (set_local_interface_name_on_upstream_connections_) {
-    throw EnvoyException("set_local_interface_name_on_upstream_connections_ cannot be set to true "
-                         "on Windows platforms");
+    throw EnvoyException(
+        "set_local_interface_name_on_upstream_connections_ cannot be set to true "
+        "on Windows platforms");
   }
 #endif
 
   if (config.has_max_requests_per_connection() &&
       http_protocol_options_->common_http_protocol_options_.has_max_requests_per_connection()) {
     throw EnvoyException("Only one of max_requests_per_connection from Cluster or "
-                         "HttpProtocolOptions can be specified");
+                               "HttpProtocolOptions can be specified");
   }
 
   // If load_balancing_policy is set we will use it directly, ignoring lb_policy.
@@ -1144,8 +1147,8 @@ ClusterInfoImpl::ClusterInfoImpl(
   if (config.lb_subset_config().locality_weight_aware() &&
       !config.common_lb_config().has_locality_weighted_lb_config()) {
     throw EnvoyException(fmt::format("Locality weight aware subset LB requires that a "
-                                     "locality_weighted_lb_config be set in {}",
-                                     name_));
+                                           "locality_weighted_lb_config be set in {}",
+                                           name_));
   }
 
   // Use default (1h) or configured `idle_timeout`, unless it's set to 0, indicating that no
@@ -1253,7 +1256,8 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
   }
 
   if (config.has_lb_subset_config()) {
-    throw EnvoyException("cluster: load_balancing_policy cannot be combined with lb_subset_config");
+    throw EnvoyException(
+        "cluster: load_balancing_policy cannot be combined with lb_subset_config");
   }
 
   if (config.has_common_lb_config()) {
@@ -1286,9 +1290,10 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
   }
 
   if (load_balancer_factory_ == nullptr) {
-    throw EnvoyException(fmt::format("cluster: didn't find a registered load balancer factory "
-                                     "implementation for cluster: '{}' with names from [{}]",
-                                     name_, absl::StrJoin(missing_policies, ", ")));
+    throw EnvoyException(
+        fmt::format("cluster: didn't find a registered load balancer factory "
+                    "implementation for cluster: '{}' with names from [{}]",
+                    name_, absl::StrJoin(missing_policies, ", ")));
   }
 
   lb_type_ = LoadBalancerType::LoadBalancingPolicyConfig;
@@ -1623,7 +1628,7 @@ const Network::Address::InstanceConstSharedPtr
 ClusterImplBase::resolveProtoAddress(const envoy::config::core::v3::Address& address) {
   TRY_ASSERT_MAIN_THREAD { return Network::Address::resolveProtoAddress(address); }
   END_TRY
-  catch (EnvoyException& e) {
+  CATCH(EnvoyException & e, {
     if (info_->type() == envoy::config::cluster::v3::Cluster::STATIC ||
         info_->type() == envoy::config::cluster::v3::Cluster::EDS) {
       throw EnvoyException(fmt::format("{}. Consider setting resolver_name or setting cluster type "
@@ -1631,7 +1636,7 @@ ClusterImplBase::resolveProtoAddress(const envoy::config::core::v3::Address& add
                                        e.what()));
     }
     throw e;
-  }
+  });
 }
 
 void ClusterImplBase::validateEndpointsForZoneAwareRouting(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -94,10 +94,9 @@ createProtocolOptionsConfig(const std::string& name, const ProtobufWkt::Any& typ
   }
 
   if (factory == nullptr) {
-    throw EnvoyException(
-        fmt::format("Didn't find a registered network or http filter or protocol "
-                    "options implementation for name: '{}'",
-                    name));
+    throw EnvoyException(fmt::format("Didn't find a registered network or http filter or protocol "
+                                     "options implementation for name: '{}'",
+                                     name));
   }
 
   ProtobufTypes::MessagePtr proto_config = factory->createEmptyProtocolOptionsProto();
@@ -955,9 +954,8 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
   if (config.protocol_selection() == envoy::config::cluster::v3::Cluster::USE_CONFIGURED_PROTOCOL) {
     // Make sure multiple protocol configurations are not present
     if (config.has_http_protocol_options() && config.has_http2_protocol_options()) {
-      throw EnvoyException(
-          fmt::format("cluster: Both HTTP1 and HTTP2 options may only be "
-                      "configured with non-default 'protocol_selection' values"));
+      throw EnvoyException(fmt::format("cluster: Both HTTP1 and HTTP2 options may only be "
+                                       "configured with non-default 'protocol_selection' values"));
     }
   }
 
@@ -1095,16 +1093,15 @@ ClusterInfoImpl::ClusterInfoImpl(
       added_via_api_(added_via_api), has_configured_http_filters_(false) {
 #ifdef WIN32
   if (set_local_interface_name_on_upstream_connections_) {
-    throw EnvoyException(
-        "set_local_interface_name_on_upstream_connections_ cannot be set to true "
-        "on Windows platforms");
+    throw EnvoyException("set_local_interface_name_on_upstream_connections_ cannot be set to true "
+                         "on Windows platforms");
   }
 #endif
 
   if (config.has_max_requests_per_connection() &&
       http_protocol_options_->common_http_protocol_options_.has_max_requests_per_connection()) {
     throw EnvoyException("Only one of max_requests_per_connection from Cluster or "
-                               "HttpProtocolOptions can be specified");
+                         "HttpProtocolOptions can be specified");
   }
 
   // If load_balancing_policy is set we will use it directly, ignoring lb_policy.
@@ -1147,8 +1144,8 @@ ClusterInfoImpl::ClusterInfoImpl(
   if (config.lb_subset_config().locality_weight_aware() &&
       !config.common_lb_config().has_locality_weighted_lb_config()) {
     throw EnvoyException(fmt::format("Locality weight aware subset LB requires that a "
-                                           "locality_weighted_lb_config be set in {}",
-                                           name_));
+                                     "locality_weighted_lb_config be set in {}",
+                                     name_));
   }
 
   // Use default (1h) or configured `idle_timeout`, unless it's set to 0, indicating that no
@@ -1256,8 +1253,7 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
   }
 
   if (config.has_lb_subset_config()) {
-    throw EnvoyException(
-        "cluster: load_balancing_policy cannot be combined with lb_subset_config");
+    throw EnvoyException("cluster: load_balancing_policy cannot be combined with lb_subset_config");
   }
 
   if (config.has_common_lb_config()) {
@@ -1290,10 +1286,9 @@ void ClusterInfoImpl::configureLbPolicies(const envoy::config::cluster::v3::Clus
   }
 
   if (load_balancer_factory_ == nullptr) {
-    throw EnvoyException(
-        fmt::format("cluster: didn't find a registered load balancer factory "
-                    "implementation for cluster: '{}' with names from [{}]",
-                    name_, absl::StrJoin(missing_policies, ", ")));
+    throw EnvoyException(fmt::format("cluster: didn't find a registered load balancer factory "
+                                     "implementation for cluster: '{}' with names from [{}]",
+                                     name_, absl::StrJoin(missing_policies, ", ")));
   }
 
   lb_type_ = LoadBalancerType::LoadBalancingPolicyConfig;

--- a/source/exe/stripped_main_base.cc
+++ b/source/exe/stripped_main_base.cc
@@ -129,10 +129,10 @@ void StrippedMainBase::configureHotRestarter(Random::RandomGenerator& random_gen
                                                                options_.socketMode());
         }
         END_TRY
-        catch (Server::HotRestartDomainSocketInUseException& ex) {
+        CATCH(Server::HotRestartDomainSocketInUseException & ex, {
           // No luck, try again.
           ENVOY_LOG_MISC(debug, "dynamic base id: {}", ex.what());
-        }
+        });
       }
 
       if (restarter == nullptr) {

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -74,7 +74,8 @@ FileBasedMetadataAuthenticator::GetMetadata(grpc::string_ref, grpc::string_ref,
   TRY_NEEDS_AUDIT {
     std::string header_value = Envoy::Config::DataSource::read(config_.secret_data(), true, api_);
     metadata->insert(std::make_pair(header_key, header_prefix + header_value));
-  } END_TRY
+  }
+  END_TRY
   catch (const EnvoyException& e) {
     return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
   }

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -77,7 +77,7 @@ FileBasedMetadataAuthenticator::GetMetadata(grpc::string_ref, grpc::string_ref,
   }
   END_TRY
   catch (const EnvoyException& e) {
-    return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
+    return {grpc::StatusCode::NOT_FOUND, e.what()};
   }
   return grpc::Status::OK;
 }

--- a/source/extensions/grpc_credentials/file_based_metadata/config.cc
+++ b/source/extensions/grpc_credentials/file_based_metadata/config.cc
@@ -74,7 +74,7 @@ FileBasedMetadataAuthenticator::GetMetadata(grpc::string_ref, grpc::string_ref,
   TRY_NEEDS_AUDIT {
     std::string header_value = Envoy::Config::DataSource::read(config_.secret_data(), true, api_);
     metadata->insert(std::make_pair(header_key, header_prefix + header_value));
-  }
+  } END_TRY
   catch (const EnvoyException& e) {
     return grpc::Status(grpc::StatusCode::NOT_FOUND, e.what());
   }

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -286,7 +286,8 @@ void DnsResolverImpl::PendingResolution::finishResolve() {
     // exception in fuzz tests.
     TRY_NEEDS_AUDIT {
       callback_(pending_response_.status_, std::move(pending_response_.address_list_));
-    } END_TRY
+    }
+    END_TRY
     catch (const EnvoyException& e) {
       ENVOY_LOG(critical, "EnvoyException in c-ares callback: {}", e.what());
       dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -286,7 +286,7 @@ void DnsResolverImpl::PendingResolution::finishResolve() {
     // exception in fuzz tests.
     TRY_NEEDS_AUDIT {
       callback_(pending_response_.status_, std::move(pending_response_.address_list_));
-    }
+    } END_TRY
     catch (const EnvoyException& e) {
       ENVOY_LOG(critical, "EnvoyException in c-ares callback: {}", e.what());
       dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -161,26 +161,24 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       false, "string", cmd);
 
   cmd.setExceptionHandling(false);
+
+  std::function failure_function = [&](TCLAP::ArgException& e) {
+    TRY_ASSERT_MAIN_THREAD { cmd.getOutput()->failure(cmd, e); }
+    END_TRY
+    CATCH(const TCLAP::ExitException&, {
+      // failure() has already written an informative message to stderr, so all that's left to do
+      // is throw our own exception with the original message.
+      throw MalformedArgvException(e.what());
+    });
+  };
+
   TRY_ASSERT_MAIN_THREAD {
     cmd.parse(args);
     count_ = cmd.getArgList().size();
   }
   END_TRY
-  CATCH(TCLAP::ArgException & e,
-        {
-          TRY_ASSERT_MAIN_THREAD { cmd.getOutput()->failure(cmd, e); }
-          END_TRY
-          CATCH(const TCLAP::ExitException&, {
-            // failure() has already written an informative message to stderr, so all that's left to
-            // do is throw our own exception with the original message.
-            throw MalformedArgvException(e.what());
-          });
-        })
-  CATCH(const TCLAP::ExitException& e, {
-    // parse() throws an ExitException with status 0 after printing the output for --help and
-    // --version.
-    throw NoServingException();
-  });
+  MULTI_CATCH(
+      TCLAP::ArgException & e, { failure_function(e); }, { throw NoServingException(); });
 
   hot_restart_disabled_ = disable_hot_restart.getValue();
   mutex_tracing_enabled_ = enable_mutex_tracing.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -166,20 +166,19 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
     count_ = cmd.getArgList().size();
   }
   END_TRY
-  catch (TCLAP::ArgException& e) {
+  CATCH (TCLAP::ArgException& e, {
     TRY_ASSERT_MAIN_THREAD { cmd.getOutput()->failure(cmd, e); }
     END_TRY
-    catch (const TCLAP::ExitException&) {
+    CATCH(const TCLAP::ExitException&, {
       // failure() has already written an informative message to stderr, so all that's left to do
       // is throw our own exception with the original message.
       throw MalformedArgvException(e.what());
-    }
-  }
-  catch (const TCLAP::ExitException& e) {
+    });
+  }) CATCH (const TCLAP::ExitException& e, {
     // parse() throws an ExitException with status 0 after printing the output for --help and
     // --version.
     throw NoServingException();
-  }
+  });
 
   hot_restart_disabled_ = disable_hot_restart.getValue();
   mutex_tracing_enabled_ = enable_mutex_tracing.getValue();

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -166,15 +166,17 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
     count_ = cmd.getArgList().size();
   }
   END_TRY
-  CATCH (TCLAP::ArgException& e, {
-    TRY_ASSERT_MAIN_THREAD { cmd.getOutput()->failure(cmd, e); }
-    END_TRY
-    CATCH(const TCLAP::ExitException&, {
-      // failure() has already written an informative message to stderr, so all that's left to do
-      // is throw our own exception with the original message.
-      throw MalformedArgvException(e.what());
-    });
-  }) CATCH (const TCLAP::ExitException& e, {
+  CATCH(TCLAP::ArgException & e,
+        {
+          TRY_ASSERT_MAIN_THREAD { cmd.getOutput()->failure(cmd, e); }
+          END_TRY
+          CATCH(const TCLAP::ExitException&, {
+            // failure() has already written an informative message to stderr, so all that's left to
+            // do is throw our own exception with the original message.
+            throw MalformedArgvException(e.what());
+          });
+        })
+  CATCH(const TCLAP::ExitException& e, {
     // parse() throws an ExitException with status 0 after printing the output for --help and
     // --version.
     throw NoServingException();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -104,38 +104,42 @@ InstanceImpl::InstanceImpl(
       grpc_context_(store.symbolTable()), http_context_(store.symbolTable()),
       router_context_(store.symbolTable()), process_context_(std::move(process_context)),
       hooks_(hooks), quic_stat_names_(store.symbolTable()), server_contexts_(*this),
-      enable_reuse_port_default_(true),
-      stats_flush_in_progress_(false){
-          TRY_ASSERT_MAIN_THREAD{if (!options.logPath().empty()){TRY_ASSERT_MAIN_THREAD{
-              file_logger_ = std::make_unique<Logger::FileSinkDelegate>(
-                  options.logPath(), access_log_manager_, Logger::Registry::getSink());
-} // namespace Server
-END_TRY
-CATCH(const EnvoyException& e, {
-  throw EnvoyException(
-      fmt::format("Failed to open log-file '{}'. e.what(): {}", options.logPath(), e.what()));
-});
+      enable_reuse_port_default_(true), stats_flush_in_progress_(false) {
+  std::function set_up_logger = [&] {
+    TRY_ASSERT_MAIN_THREAD {
+      file_logger_ = std::make_unique<Logger::FileSinkDelegate>(
+          options.logPath(), access_log_manager_, Logger::Registry::getSink());
+    }
+    END_TRY
+    CATCH(const EnvoyException& e, {
+      throw EnvoyException(
+          fmt::format("Failed to open log-file '{}'. e.what(): {}", options.logPath(), e.what()));
+    });
+  };
 
-restarter_.initialize(*dispatcher_, *this);
-drain_manager_ = component_factory.createDrainManager(*this);
-initialize(std::move(local_address), component_factory);
-} // namespace Envoy
-}
-END_TRY
-MULTI_CATCH(
-    const EnvoyException& e,
-    {
-      ENVOY_LOG(critical, "error initializing config '{} {} {}': {}",
-                options.configProto().DebugString(), options.configYaml(), options.configPath(),
-                e.what());
-      terminate();
-      throw;
-    },
-    {
-      ENVOY_LOG(critical, "error initializing due to unknown exception");
-      terminate();
-      throw;
-    })
+  TRY_ASSERT_MAIN_THREAD {
+    if (!options.logPath().empty()) {
+      set_up_logger();
+    }
+    restarter_.initialize(*dispatcher_, *this);
+    drain_manager_ = component_factory.createDrainManager(*this);
+    initialize(std::move(local_address), component_factory);
+  }
+  END_TRY
+  MULTI_CATCH(
+      const EnvoyException& e,
+      {
+        ENVOY_LOG(critical, "error initializing config '{} {} {}': {}",
+                  options.configProto().DebugString(), options.configYaml(), options.configPath(),
+                  e.what());
+        terminate();
+        throw;
+      },
+      {
+        ENVOY_LOG(critical, "error initializing due to unknown exception");
+        terminate();
+        throw;
+      });
 }
 
 InstanceImpl::~InstanceImpl() {


### PR DESCRIPTION
The new build option simply compiles out all try/catch code, while leaving in the exceptions.   This can not yet be successfully used as it turns up fno-exceptions which chokes on throw statements.  This is by design as if we compiled out throw as well, config failures would be fatal instead of gracefully handled.

Risk Level: low
Testing: manual testing 
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/27412