### PR TITLE
Fix post-submit clang tidy

### DIFF
--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -113,7 +113,7 @@ public:
   }
 };
 
-class JsonApplicationLogsValidationServerForbiddenFlag_Test : public ValidationServerTest {
+class JsonApplicationLogsValidationServerForbiddenFlagUnderscoreTest : public ValidationServerTest {
 public:
   static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     setupTestDirectory();
@@ -306,7 +306,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(
         JsonApplicationLogsValidationServerForbiddenFlagvTest::getAllConfigFiles()));
 
-TEST_P(JsonApplicationLogsValidationServerForbiddenFlag_Test, TestForbiddenFlag) {
+TEST_P(JsonApplicationLogsValidationServerForbiddenFlagUnderscoreTest, TestForbiddenFlag) {
   Thread::MutexBasicLockable access_log_lock;
   Stats::IsolatedStoreImpl stats_store;
   DangerousDeprecatedTestTime time_system;
@@ -320,9 +320,9 @@ TEST_P(JsonApplicationLogsValidationServerForbiddenFlag_Test, TestForbiddenFlag)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    AllConfigs, JsonApplicationLogsValidationServerForbiddenFlag_Test,
+    AllConfigs, JsonApplicationLogsValidationServerForbiddenFlagUnderscoreTest,
     ::testing::ValuesIn(
-        JsonApplicationLogsValidationServerForbiddenFlag_Test::getAllConfigFiles()));
+        JsonApplicationLogsValidationServerForbiddenFlagUnderscoreTest::getAllConfigFiles()));
 
 } // namespace
 } // namespace Server

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1653,7 +1653,7 @@ TEST_P(ServerInstanceImplTest, JsonApplicationLogFailWithForbiddenFlagv) {
       "setJsonLogFormat error: INVALID_ARGUMENT: Usage of %v is unavailable for JSON log formats");
 }
 
-TEST_P(ServerInstanceImplTest, JsonApplicationLogFailWithForbiddenFlag_) {
+TEST_P(ServerInstanceImplTest, JsonApplicationLogFailWithForbiddenFlagUnderscore) {
   EXPECT_THROW_WITH_MESSAGE(
       initialize("test/server/test_data/server/json_application_log_forbidden_flag_.yaml"),
       EnvoyException,


### PR DESCRIPTION
Commit Message: Fixing clang-tidy caused by #27278.
Additional Description: https://dev.azure.com/cncf/envoy/_build/results?buildId=139360&view=logs&j=b7634614-24f3-5416-e791-4f3affaaed6c&t=d565ee52-b888-5d80-7fea-dfaed104c390
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
