### PR TITLE
application_logs: add bootstrap option to set log format

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -110,6 +110,11 @@ message Bootstrap {
         // support all the format flags specified in the :option:`--log-format`
         // command line options section, except for the ``%v`` and ``%_`` flags.
         google.protobuf.Struct json_format = 1;
+
+        // Flush application log in a format defined by a string. The text format
+        // can support all the format flags specified in the :option:`--log-format`
+        // command line option section.
+        string text_format = 2;
       }
     }
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -292,6 +292,11 @@ new_features:
     Added bootstrap option
     :ref:`application_log_format <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.ApplicationLogConfig.LogFormat.json_format>`
     to enable setting application log format as JSON structure.
+- area: application_logs
+  change: |
+    Added bootstrap option
+    :ref:`application_log_format <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.ApplicationLogConfig.LogFormat.text_format>`
+    to enable setting application log text format from config.
 - area: ext_proc
   change: |
     added new field ``filter_metadata <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExtProc.filter_metadata`` to aid in logging.

--- a/source/server/utils.cc
+++ b/source/server/utils.cc
@@ -34,8 +34,13 @@ void assertExclusiveLogFormatMethod(
 
 void maybeSetApplicationLogFormat(
     const envoy::config::bootstrap::v3::Bootstrap::ApplicationLogConfig& application_log_config) {
-  if (application_log_config.has_log_format() &&
-      application_log_config.log_format().has_json_format()) {
+  if (!application_log_config.has_log_format()) {
+    return;
+  }
+
+  if (application_log_config.log_format().has_text_format()) {
+    Logger::Registry::setLogFormat(application_log_config.log_format().text_format());
+  } else if (application_log_config.log_format().has_json_format()) {
     const auto status =
         Logger::Registry::setJsonLogFormat(application_log_config.log_format().json_format());
 

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -128,6 +128,23 @@ public:
   }
 };
 
+class TextApplicationLogsValidationServerTest : public ValidationServerTest {
+public:
+  static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
+    setupTestDirectory();
+  }
+
+  static void setupTestDirectory() {
+    directory_ =
+        TestEnvironment::runfilesDirectory("envoy/test/server/config_validation/test_data/");
+  }
+
+  static const std::vector<std::string> getAllConfigFiles() {
+    setupTestDirectory();
+    return {"text_application_logs.yaml"};
+  }
+};
+
 TEST_P(ValidationServerTest, Validate) {
   EXPECT_TRUE(validateConfig(options_, Network::Address::InstanceConstSharedPtr(),
                              component_factory_, Thread::threadFactoryForTest(),
@@ -323,6 +340,30 @@ INSTANTIATE_TEST_SUITE_P(
     AllConfigs, JsonApplicationLogsValidationServerForbiddenFlag_Test,
     ::testing::ValuesIn(
         JsonApplicationLogsValidationServerForbiddenFlag_Test::getAllConfigFiles()));
+
+TEST_P(TextApplicationLogsValidationServerTest, TextApplicationLogs) {
+  Thread::MutexBasicLockable access_log_lock;
+  Stats::IsolatedStoreImpl stats_store;
+  DangerousDeprecatedTestTime time_system;
+  ValidationInstance server(options_, time_system.timeSystem(),
+                            Network::Address::InstanceConstSharedPtr(), stats_store,
+                            access_log_lock, component_factory_, Thread::threadFactoryForTest(),
+                            Filesystem::fileSystemForTest());
+
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto& log) {
+    EXPECT_THAT(msg, HasSubstr("[lvl: info][msg: hello]"));
+    EXPECT_EQ(log.logger_name, "misc");
+  }));
+
+  ENVOY_LOG_MISC(info, "hello");
+  server.shutdown();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllConfigs, TextApplicationLogsValidationServerTest,
+    ::testing::ValuesIn(TextApplicationLogsValidationServerTest::getAllConfigFiles()));
 
 } // namespace
 } // namespace Server

--- a/test/server/config_validation/test_data/text_application_logs.yaml
+++ b/test/server/config_validation/test_data/text_application_logs.yaml
@@ -1,0 +1,10 @@
+---
+application_log_config:
+  log_format:
+    text_format: "[lvl: %l][msg: %v]"
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9000

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1660,6 +1660,19 @@ TEST_P(ServerInstanceImplTest, JsonApplicationLogFailWithForbiddenFlag_) {
       "setJsonLogFormat error: INVALID_ARGUMENT: Usage of %_ is unavailable for JSON log formats");
 }
 
+TEST_P(ServerInstanceImplTest, TextApplicationLog) {
+  EXPECT_NO_THROW(initialize("test/server/test_data/server/text_application_log.yaml"));
+
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto& log) {
+    EXPECT_THAT(msg, HasSubstr("[lvl: info][msg: hello]"));
+    EXPECT_EQ(log.logger_name, "misc");
+  }));
+
+  ENVOY_LOG_MISC(info, "hello");
+}
+
 } // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/test_data/server/text_application_log.yaml
+++ b/test/server/test_data/server/text_application_log.yaml
@@ -1,0 +1,10 @@
+---
+application_log_config:
+  log_format:
+    text_format: "[lvl: %l][msg: %v]"
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9000

--- a/test/server/utils_test.cc
+++ b/test/server/utils_test.cc
@@ -71,6 +71,12 @@ TEST(UtilsTest, MaybeSetApplicationLogFormat) {
 
   {
     envoy::config::bootstrap::v3::Bootstrap::ApplicationLogConfig log_config;
+    log_config.mutable_log_format()->mutable_text_format();
+    EXPECT_NO_THROW(Utility::maybeSetApplicationLogFormat(log_config));
+  }
+
+  {
+    envoy::config::bootstrap::v3::Bootstrap::ApplicationLogConfig log_config;
     auto* format = log_config.mutable_log_format()->mutable_json_format();
     format->mutable_fields()->operator[]("Message").set_string_value("%v");
     EXPECT_THROW_WITH_MESSAGE(Utility::maybeSetApplicationLogFormat(log_config), EnvoyException,


### PR DESCRIPTION
Commit Message: application_logs: add bootstrap option to set log format
Additional Description: Related to  https://github.com/envoyproxy/envoy/pull/27278 which adds a bootstrap option to set JSON log format. Resolves #27761
Risk Level: Low
Testing: Unit tests
Docs Changes: Changelog
Release Notes: None
Platform Specific Features: None