### PR TITLE
[Ext_proc]: only allow clear_route_cache on the INBOUND responses.

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -288,6 +288,7 @@ message CommonResponse {
   // Clear the route cache for the current request.
   // This is necessary if the remote server
   // modified headers that are used to calculate the route.
+  // No-op if returned on response path.
   bool clear_route_cache = 5;
 }
 

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -366,11 +366,13 @@ absl::Status ProcessorState::handleTrailersResponse(const TrailersResponse& resp
 }
 
 void ProcessorState::clearRouteCache(const CommonResponse& common_response) {
-  // Only clear the route cache if there is a mutation to the header and clearing is allowed.
+  // Only clear the route cache if on INBOUND path, there is a mutation to the header and clearing
+  // is allowed.
   if (filter_.config().disableClearRouteCache()) {
     filter_.stats().clear_route_cache_disabled_.inc();
     ENVOY_LOG(debug, "NOT clearing route cache, it is disabled in the config");
-  } else if (common_response.has_header_mutation()) {
+  } else if (common_response.has_header_mutation() &&
+             traffic_direction_ == envoy::config::core::v3::TrafficDirection::INBOUND) {
     ENVOY_LOG(debug, "clearing route cache");
     filter_callbacks_->downstreamCallbacks()->clearRouteCache();
   } else {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -2076,7 +2076,7 @@ TEST_F(HttpFilterTest, ClearRouteCacheHeaderMutation) {
 
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, true));
 
-  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
   processRequestHeaders(false, [](const HttpHeaders&, ProcessingResponse&, HeadersResponse& resp) {
     auto* resp_headers_mut = resp.mutable_response()->mutable_header_mutation();
     auto* resp_add = resp_headers_mut->add_set_headers();


### PR DESCRIPTION
Commit Message: Only allow clear_route_cache be performed on the request path, make it an NO-OP on the response path. 
Additional Description:
Risk Level: LOW, filter in alpha 
Testing: unit test
Docs Changes:
Release Notes:
Platform Specific Features: