### PR TITLE
Fix flaky test QuicHttpIntegrationTest::DeferredLoggingWithRetransmission

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1399,7 +1399,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithRetransmission) {
   socket_swap.write_matcher_->setDestinationPort(lookupPort("http"));
   socket_swap.write_matcher_->setWriteOverride(ebadf);
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-  absl::SleepFor(absl::Milliseconds(500 * TSAN_TIMEOUT_FACTOR));
+  absl::SleepFor(absl::Milliseconds(1000 * TSAN_TIMEOUT_FACTOR));
   // Allow the response to be sent downstream again.
   socket_swap.write_matcher_->setWriteOverride(nullptr);
 

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1400,7 +1400,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithRetransmission) {
     socket_swap.write_matcher_->setDestinationPort(lookupPort("http"));
     socket_swap.write_matcher_->setWriteOverride(ebadf);
     upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-    absl::SleepFor(absl::Milliseconds(1000 * TSAN_TIMEOUT_FACTOR));
+    absl::SleepFor(absl::Seconds(TSAN_TIMEOUT_FACTOR));
   }
 
   ASSERT_TRUE(response->waitForEndStream());

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1400,7 +1400,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithRetransmission) {
     socket_swap.write_matcher_->setDestinationPort(lookupPort("http"));
     socket_swap.write_matcher_->setWriteOverride(ebadf);
     upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-    absl::SleepFor(absl::Seconds(TSAN_TIMEOUT_FACTOR));
+    timeSystem().advanceTimeWait(std::chrono::seconds(TSAN_TIMEOUT_FACTOR));
   }
 
   ASSERT_TRUE(response->waitForEndStream());


### PR DESCRIPTION
Fixes #27841:

- Increase the sleep from 500->1000 ms.
- Properly clean up the SocketInterfaceSwap.

Commit Message: Fix flaky test DeferredLoggingWithRetransmission
Risk Level: N/A, just testing
