### PR TITLE
Refactoring ext_proc clear_route_cache API.

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -285,10 +285,21 @@ message CommonResponse {
   // along with the CONTINUE_AND_REPLACE status.
   config.core.v3.HeaderMap trailers = 4;
 
-  // Clear the route cache for the current request.
-  // This is necessary if the remote server
-  // modified headers that are used to calculate the route.
-  bool clear_route_cache = 5;
+  // Specify the response data specially for downstream client request.
+  // If the external processing server set this field when responding
+  // to the upstream response request, it will be ignored by Envoy.
+  DownstreamRequestResponse downstream_response = 5;
+}
+
+// This message specifies the response data from the external processing
+// server for downstream client request.
+message DownstreamRequestResponse {
+  // When the external processing server sends the response corresponding to either
+  // downstream header request or downstream body request, it may contain
+  // :ref:`header_mutation <envoy_v3_api_field_service.ext_proc.v3.CommonResponse.header_mutation>`.
+  // At same time, it may set this ``clear_route_cache`` to true to clear the route cache,
+  // and recalculate the route.
+  bool clear_route_cache = 1;
 }
 
 // This message causes the filter to attempt to create a locally

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -129,7 +129,7 @@ message ProcessingResponse {
 
     // The server must send back this message in response to a message with the
     // ``request_headers`` field set.
-    DownstreamHeadersResponse request_headers = 1;
+    RequestHeadersResponse request_headers = 1;
 
     // The server must send back this message in response to a message with the
     // ``response_headers`` field set.
@@ -137,7 +137,7 @@ message ProcessingResponse {
 
     // The server must send back this message in response to a message with
     // the ``request_body`` field set.
-    DownstreamBodyResponse request_body = 3;
+    RequestBodyResponse request_body = 3;
 
     // The server must send back this message in response to a message with
     // the ``response_body`` field set.
@@ -229,8 +229,8 @@ message HeadersResponse {
   CommonResponse response = 1;
 }
 
-// This message must be sent in response to a downstream HttpHeaders message.
-message DownstreamHeadersResponse {
+// This message must be sent in response to a HttpHeaders request message.
+message RequestHeadersResponse {
   CommonResponse response = 1;
   // Clear the route cache for the current request.
   // This is necessary if the remote server
@@ -244,13 +244,13 @@ message TrailersResponse {
   HeaderMutation header_mutation = 1;
 }
 
-// This message must be sent in response to an upstream HttpBody message.
+// This message must be sent in response to a HttpBody response message.
 message BodyResponse {
   CommonResponse response = 1;
 }
 
-// This message must be sent in response to a downstream HttpBody message.
-message DownstreamBodyResponse {
+// This message must be sent in response to a HttpBody request message.
+message RequestBodyResponse {
   CommonResponse response = 1;
   // Clear the route cache for the current request.
   // This is necessary if the remote server

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -129,7 +129,7 @@ message ProcessingResponse {
 
     // The server must send back this message in response to a message with the
     // ``request_headers`` field set.
-    HeadersResponse request_headers = 1;
+    DownstreamHeadersResponse request_headers = 1;
 
     // The server must send back this message in response to a message with the
     // ``response_headers`` field set.
@@ -137,7 +137,7 @@ message ProcessingResponse {
 
     // The server must send back this message in response to a message with
     // the ``request_body`` field set.
-    BodyResponse request_body = 3;
+    DownstreamBodyResponse request_body = 3;
 
     // The server must send back this message in response to a message with
     // the ``response_body`` field set.
@@ -224,9 +224,18 @@ message HttpTrailers {
 
 // The following are messages that may be sent back by the server.
 
-// This message must be sent in response to an HttpHeaders message.
+// This message must be sent in response to an upstream HttpHeaders message.
 message HeadersResponse {
   CommonResponse response = 1;
+}
+
+// This message must be sent in response to a downstream HttpHeaders message.
+message DownstreamHeadersResponse {
+  CommonResponse response = 1;
+  // Clear the route cache for the current request.
+  // This is necessary if the remote server
+  // modified headers that are used to calculate the route.
+  bool clear_route_cache = 2;
 }
 
 // This message must be sent in response to an HttpTrailers message.
@@ -235,13 +244,22 @@ message TrailersResponse {
   HeaderMutation header_mutation = 1;
 }
 
-// This message must be sent in response to an HttpBody message.
+// This message must be sent in response to an upstream HttpBody message.
 message BodyResponse {
   CommonResponse response = 1;
 }
 
+// This message must be sent in response to a downstream HttpBody message.
+message DownstreamBodyResponse {
+  CommonResponse response = 1;
+  // Clear the route cache for the current request.
+  // This is necessary if the remote server
+  // modified headers that are used to calculate the route.
+  bool clear_route_cache = 2;
+}
+
 // This message contains common fields between header and body responses.
-// [#next-free-field: 6]
+// [#next-free-field: 5]
 message CommonResponse {
   enum ResponseStatus {
     // Apply the mutation instructions in this message to the
@@ -284,22 +302,6 @@ message CommonResponse {
   // HttpHeaders or HttpBody message, but only if this message is returned
   // along with the CONTINUE_AND_REPLACE status.
   config.core.v3.HeaderMap trailers = 4;
-
-  // Specify the response data specially for downstream client request.
-  // If the external processing server set this field when responding
-  // to the upstream response request, it will be ignored by Envoy.
-  DownstreamRequestResponse downstream_response = 5;
-}
-
-// This message specifies the response data from the external processing
-// server for downstream client request.
-message DownstreamRequestResponse {
-  // When the external processing server sends the response corresponding to either
-  // downstream header request or downstream body request, it may contain
-  // :ref:`header_mutation <envoy_v3_api_field_service.ext_proc.v3.CommonResponse.header_mutation>`.
-  // At same time, it may set this ``clear_route_cache`` to true to clear the route cache,
-  // and recalculate the route.
-  bool clear_route_cache = 1;
 }
 
 // This message causes the filter to attempt to create a locally


### PR DESCRIPTION
This is a follow up PR for https://github.com/envoyproxy/envoy/pull/27657.

In that PR, there is a comment to refactor the clear_route_cache API to make it cleaner.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
