### PR TITLE
TLS Inspector: Enable tls_inspector buffer to dynamically size.

### DIFF
--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -24,10 +24,10 @@ message TlsInspector {
   // Populate ``JA3`` fingerprint hash using data from the TLS Client Hello packet. Default is false.
   google.protobuf.BoolValue enable_ja3_fingerprinting = 1;
 
-  // The size of the initial buffer requested by the tls_inspector.
+  // The size in bytes of the initial buffer requested by the tls_inspector.
   // If the filter needs to read additional bytes from the socket, the
   // filter will double the buffer up to it's default maximum of 64KiB.
   // If this size is not defined, defaults to maximum 64KiB that the
   // tls inspector will consume.
-  google.protobuf.UInt32Value initial_read_buffer_size = 2;
+  google.protobuf.UInt32Value initial_read_buffer_size = 2 {lt: 65537 gt: 0}];
 }

--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -6,6 +6,7 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.listener.tls_inspector.v3";
 option java_outer_classname = "TlsInspectorProto";
@@ -29,5 +30,6 @@ message TlsInspector {
   // filter will double the buffer up to it's default maximum of 64KiB.
   // If this size is not defined, defaults to maximum 64KiB that the
   // tls inspector will consume.
-  google.protobuf.UInt32Value initial_read_buffer_size = 2 {lt: 65537 gt: 0}];
+  google.protobuf.UInt32Value initial_read_buffer_size = 2
+      [(validate.rules).uint32 = {gt: 0, lt: 65537}];
 }

--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -23,4 +23,11 @@ message TlsInspector {
 
   // Populate ``JA3`` fingerprint hash using data from the TLS Client Hello packet. Default is false.
   google.protobuf.BoolValue enable_ja3_fingerprinting = 1;
+
+  // The size of the initial buffer requested by the tls_inspector.
+  // If the filter needs to read additional bytes from the socket, the
+  // filter will double the buffer up to it's default maximum of 64KiB.
+  // If this size is not defined, defaults to maximum 64KiB that the
+  // tls inspector will consume.
+  google.protobuf.UInt32Value initial_read_buffer_size = 2;
 }

--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -31,5 +31,5 @@ message TlsInspector {
   // If this size is not defined, defaults to maximum 64KiB that the
   // tls inspector will consume.
   google.protobuf.UInt32Value initial_read_buffer_size = 2
-      [(validate.rules).uint32 = {gt: 0, lt: 65537}];
+      [(validate.rules).uint32 = {lt: 65537 gt: 0}];
 }

--- a/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
+++ b/api/envoy/extensions/filters/listener/tls_inspector/v3/tls_inspector.proto
@@ -31,5 +31,5 @@ message TlsInspector {
   // If this size is not defined, defaults to maximum 64KiB that the
   // tls inspector will consume.
   google.protobuf.UInt32Value initial_read_buffer_size = 2
-      [(validate.rules).uint32 = {lt: 65537 gt: 0}];
+      [(validate.rules).uint32 = {lt: 65537 gt: 255}];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -248,6 +248,13 @@ new_features:
     the connection uses tls this records the tls client hello size. In cases
     where the connection doesn't use tls this records the amount of bytes the
     tls_inspector processed until it realized the connection was not using tls.
+- area: tls_inspector
+  change: |
+    added new configuration field :ref:`initial_read_buffer_size
+    <envoy_v3_api_field_extensions.filters.listener.tls_inspector.v3.TlsInspector.initial_read_buffer_size>`
+    to allow users to tune the buffer size requested by the filter. If
+    configured, and the filter needs additional bytes, the filter will double
+    the number of bytes requested up to the default 64KiB maximum.
 - area: access_log
   change: |
     added access log filter :ref:`log_type_filter <envoy_v3_api_field_config.accesslog.v3.AccessLogFilter.log_type_filter>`

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -152,22 +152,16 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
     const size_t len = raw_slice.len_ - read_;
     const uint64_t bytes_already_processed = read_;
     read_ = raw_slice.len_;
-    ENVOY_LOG(trace, "TLS onData: len {} bytes_already_processed {} read_ {}", len,
-              bytes_already_processed, read_);
-    ENVOY_LOG(trace, "Data: {}", absl::string_view(reinterpret_cast<const char*>(data), len));
     ParseState parse_state = parseClientHello(data, len, bytes_already_processed);
     switch (parse_state) {
     case ParseState::Error:
       cb_->socket().ioHandle().close();
-      ENVOY_LOG(trace, "Parse state error, closed connection");
       return Network::FilterStatus::StopIteration;
     case ParseState::Done:
       // Finish the inspect.
-      ENVOY_LOG(trace, "Parse state done, continue iteration");
       return Network::FilterStatus::Continue;
     case ParseState::Continue:
       // Do nothing but wait for the next event.
-      ENVOY_LOG(trace, "Parse state continue, stopping iteration");
       return Network::FilterStatus::StopIteration;
     }
     IS_ENVOY_BUG("unexpected tcp filter parse_state");
@@ -195,7 +189,6 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
     switch (SSL_get_error(ssl_.get(), ret)) {
     case SSL_ERROR_WANT_READ:
       if (read_ == maxConfigReadBytes()) {
-        ENVOY_LOG(trace, "maxConfigReadBytes {} read_ {}", maxConfigReadBytes(), read_);
         // We've hit the specified size limit. This is an unreasonably large ClientHello;
         // indicate failure.
         config_->stats().client_hello_too_large_.inc();
@@ -203,13 +196,11 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
       }
       if (read_ == requested_read_bytes_) {
         // Double requested bytes up to the maximum configured.
-        ENVOY_LOG(trace, "doubling requested read bytes to {}", 2 * requested_read_bytes_);
         requested_read_bytes_ = std::min<uint32_t>(2 * requested_read_bytes_, maxConfigReadBytes());
       }
       return ParseState::Continue;
     case SSL_ERROR_SSL:
       if (clienthello_success_) {
-        ENVOY_LOG(trace, "clienthello success");
         config_->stats().tls_found_.inc();
         if (alpn_found_) {
           config_->stats().alpn_found_.inc();
@@ -218,12 +209,10 @@ ParseState Filter::parseClientHello(const void* data, size_t len,
         }
         cb_->socket().setDetectedTransportProtocol("tls");
       } else {
-        ENVOY_LOG(trace, "tls not found");
         config_->stats().tls_not_found_.inc();
       }
       return ParseState::Done;
     default:
-      ENVOY_LOG(trace, "default clause");
       return ParseState::Error;
     }
   }();

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -152,6 +152,9 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
     const size_t len = raw_slice.len_ - read_;
     const uint64_t bytes_already_processed = read_;
     read_ = raw_slice.len_;
+    ENVOY_LOG(trace, "TLS onData: len {} bytes_already_processed {} read_ {}", len,
+              bytes_already_processed, read_);
+    ENVOY_LOG(trace, "Data: {}", absl::string_view(reinterpret_cast<const char*>(data), len));
     ParseState parse_state = parseClientHello(data, len, bytes_already_processed);
     switch (parse_state) {
     case ParseState::Error:

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -103,7 +103,7 @@ private:
   bool clienthello_success_{false};
   // We dynamically adjust the number of bytes requested by the filter up to the
   // maxConfigReadBytes.
-  uint32_t requested_read_bytes_{0};
+  uint32_t requested_read_bytes_;
 
   // Allows callbacks on the SSL_CTX to set fields in this class.
   friend class Config;

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -55,11 +55,16 @@ filter_disabled:
   void initializeWithTlsInspector(bool ssl_client, const std::string& log_format,
                                   absl::optional<bool> listener_filter_disabled = absl::nullopt,
                                   bool enable_ja3_fingerprinting = false) {
-    config_helper_.renameListener("echo");
     std::string tls_inspector_config = ConfigHelper::tlsInspectorFilter(enable_ja3_fingerprinting);
     if (listener_filter_disabled.has_value()) {
       tls_inspector_config = appendMatcher(tls_inspector_config, listener_filter_disabled.value());
     }
+    initializeWithTlsInspector(ssl_client, log_format, tls_inspector_config);
+  }
+
+  void initializeWithTlsInspector(bool ssl_client, const std::string& log_format,
+                                  const std::string& tls_inspector_config) {
+    config_helper_.renameListener("echo");
     config_helper_.addListenerFilter(tls_inspector_config);
 
     config_helper_.addConfigModifier([ssl_client](
@@ -202,6 +207,52 @@ TEST_P(TlsInspectorIntegrationTest, JA3FingerprintIsSet) {
   EXPECT_EQ(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
                                                         *bytes_processed_histogram)),
             115);
+}
+
+TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanGrow) {
+  const std::string small_initial_buffer_tls_inspector_config = R"EOF(
+    name: "envoy.filters.listener.tls_inspector"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      initial_read_buffer_size: 256
+  )EOF";
+  initializeWithTlsInspector(true, "%RESPONSE_CODE_DETAILS%",
+                             small_initial_buffer_tls_inspector_config);
+
+  Network::Address::InstanceConstSharedPtr address =
+      Ssl::getSslAddress(version_, lookupPort("echo"));
+
+  Ssl::ClientSslTransportOptions ssl_options;
+  ssl_options.setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
+  ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
+  const std::string really_long_sni(absl::StrCat(std::string(240, 'a'), ".foo.com"));
+  ssl_options.setSni(really_long_sni);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  Network::TransportSocketPtr transport_socket = context_->createTransportSocket(
+      std::make_shared<Network::TransportSocketOptionsImpl>(
+          absl::string_view(""), std::vector<std::string>(), std::vector<std::string>{"envoyalpn"}),
+      nullptr);
+
+  client_ = dispatcher_->createClientConnection(address, Network::Address::InstanceConstSharedPtr(),
+                                                std::move(transport_socket), nullptr, nullptr);
+  client_->addConnectionCallbacks(connect_callbacks_);
+  client_->connect();
+
+  while (!connect_callbacks_.connected() && !connect_callbacks_.closed()) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  }
+
+  ASSERT(connect_callbacks_.connected());
+  client_->close(Network::ConnectionCloseType::NoFlush);
+
+  test_server_->waitUntilHistogramHasSamples("tls_inspector.bytes_processed");
+  auto bytes_processed_histogram = test_server_->histogram("tls_inspector.bytes_processed");
+  EXPECT_EQ(
+      TestUtility::readSampleCount(test_server_->server().dispatcher(), *bytes_processed_histogram),
+      1);
+  EXPECT_EQ(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
+                                                        *bytes_processed_histogram)),
+            515);
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, TlsInspectorIntegrationTest,

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -66,8 +66,7 @@ public:
               const size_t amount_to_copy = std::min(iov->iov_len, client_hello.size());
               memcpy(iov->iov_base, client_hello.data(), amount_to_copy);
               return Api::SysCallSizeResult{ssize_t(amount_to_copy), 0};
-            }))
-        .WillOnce(Return(Api::SysCallSizeResult{ssize_t(-1), SOCKET_ERROR_AGAIN}));
+            }));
 #else
     EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
         .WillOnce(Invoke(

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -444,9 +444,6 @@ TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoublesIfNeedAdditonalData) {
   const uint32_t initial_buffer_size = 64;
   proto_config.mutable_initial_read_buffer_size()->set_value(initial_buffer_size);
   cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
-  buffer_ = std::make_unique<Network::ListenerFilterBufferImpl>(
-      *io_handle_, dispatcher_, [](bool) {}, [](Network::ListenerFilterBuffer&) {},
-      cfg_->initialReadBufferSize());
   const uint16_t tls_min_version = std::get<0>(GetParam());
   const uint16_t tls_max_version = std::get<1>(GetParam());
   std::vector<uint8_t> client_hello =
@@ -486,9 +483,6 @@ TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoesNotGoBeyondMaxSize) {
   const size_t max_size = 50;
   proto_config.mutable_initial_read_buffer_size()->set_value(initial_buffer_size);
   cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config, max_size);
-  buffer_ = std::make_unique<Network::ListenerFilterBufferImpl>(
-      *io_handle_, dispatcher_, [](bool) {}, [](Network::ListenerFilterBuffer&) {},
-      cfg_->initialReadBufferSize());
   std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
       std::get<0>(GetParam()), std::get<1>(GetParam()), "example.com", "\x02h2");
 

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -66,6 +66,8 @@ public:
           .WillOnce(Invoke([=, &client_hello](os_fd_t, void* buffer, size_t length,
                                               int) -> Api::SysCallSizeResult {
             const size_t amount_to_copy = std::min(length, client_hello.size());
+            ENVOY_LOG_MISC(debug, "mock recv length: {} client_hello {}", length,
+                           client_hello.size());
             memcpy(buffer, client_hello.data(), amount_to_copy);
             return Api::SysCallSizeResult{ssize_t(amount_to_copy), 0};
           }));
@@ -84,6 +86,8 @@ public:
     EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
         .WillOnce(Invoke(
             [&client_hello](os_fd_t, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
+              ENVOY_LOG_MISC(debug, "mock recv length: {} client_hello {}", length,
+                             client_hello.size());
               const size_t amount_to_copy = std::min(length, client_hello.size());
               memcpy(buffer, client_hello.data(), amount_to_copy);
               return Api::SysCallSizeResult{ssize_t(amount_to_copy), 0};
@@ -448,6 +452,7 @@ TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoublesIfNeedAdditonalData) {
   const uint16_t tls_max_version = std::get<1>(GetParam());
   std::vector<uint8_t> client_hello =
       Tls::Test::generateClientHello(tls_min_version, tls_max_version, "example.com", "\x02h2");
+  std::cerr << "kbaichoo: client hello size:" << client_hello.size() << std::endl;
 
   init();
   EXPECT_CALL(socket_, setRequestedServerName(_));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -66,9 +66,6 @@ public:
           .WillOnce(Invoke([=, &client_hello](os_fd_t, void* buffer, size_t length,
                                               int) -> Api::SysCallSizeResult {
             const size_t amount_to_copy = std::min(length, client_hello.size());
-            // TODO(kbaichoo): remove
-            ENVOY_LOG_MISC(debug, "mock recv length: {} client_hello {} amount_to_copy {}", length,
-                           client_hello.size(), amount_to_copy);
             memcpy(buffer, client_hello.data(), amount_to_copy);
             return Api::SysCallSizeResult{ssize_t(amount_to_copy), 0};
           }));
@@ -279,7 +276,7 @@ TEST_P(TlsInspectorTest, ClientHelloTooBig) {
       cfg_->maxClientHelloSize());
 
   filter_->onAccept(cb_);
-  mockSysCallForPeek(client_hello);
+  mockSysCallForPeek(client_hello, true);
   EXPECT_CALL(socket_, detectedTransportProtocol()).Times(::testing::AnyNumber());
   file_event_callback_(Event::FileReadyType::Read);
   auto state = filter_->onData(*buffer_);
@@ -442,8 +439,6 @@ TEST_P(TlsInspectorTest, EarlyTerminationShouldNotRecordBytesProcessed) {
 }
 
 TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoesNotGoBeyondMaxSize) {
-  // TODO(kbaichoo): remove
-  LogLevelSetter save_levels{spdlog::level::trace};
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
   const uint32_t initial_buffer_size = 15;
   const size_t max_size = 50;

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -87,7 +87,7 @@ public:
     EXPECT_CALL(os_sys_calls_, readv(_, _, _))
         .WillOnce(Invoke(
             [&client_hello](os_fd_t fd, const iovec* iov, int iovcnt) -> Api::SysCallSizeResult {
-              memcpy(iov->iov_base, client_hello.data(), iov->iov_len));
+              memcpy(iov->iov_base, client_hello.data(), iov->iov_len);
               return Api::SysCallSizeResult{ssize_t(iov->iov_len), 0};
             }))
         .WillOnce(Return(Api::SysCallSizeResult{ssize_t(-1), SOCKET_ERROR_AGAIN}));

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -439,6 +439,7 @@ TEST_P(TlsInspectorTest, EarlyTerminationShouldNotRecordBytesProcessed) {
 }
 
 TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoublesIfNeedAdditonalData) {
+  LogLevelSetter save_levels{spdlog::level::trace};
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
   const uint32_t initial_buffer_size = 1;
   proto_config.mutable_initial_read_buffer_size()->set_value(initial_buffer_size);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: TLS Inspector: Enable tls_inspector buffer to dynamically size.
Additional Description: Users can set initial buffer size based on data from the histogram added in #27742. The filter will request more data (growing the listener filter buffer) as needed.
Risk Level: low / med
Testing: uint test
Docs Changes: n/a
Release Notes: included
Platform Specific Features:
Runtime guard: Config guarded
