### PR TITLE
Avoid copying garbage if pthread_getname_np fails

### DIFF
--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -99,7 +99,7 @@ private:
   // may fail, if the thread exits prior to the system call.
   bool getNameFromOS(std::string& name) {
     // Verify that the name got written into the thread as expected.
-    char buf[PTHREAD_MAX_THREADNAME_LEN_INCLUDING_NULL_BYTE];
+    char buf[PTHREAD_MAX_THREADNAME_LEN_INCLUDING_NULL_BYTE] = {0};
     const int get_name_rc = pthread_getname_np(thread_handle_, buf, sizeof(buf));
     name = buf;
     return get_name_rc == 0;


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
