### PR TITLE
filter: clear route cache in language filter

### DIFF
--- a/api/contrib/envoy/extensions/filters/http/language/v3alpha/language.proto
+++ b/api/contrib/envoy/extensions/filters/http/language/v3alpha/language.proto
@@ -33,4 +33,9 @@ message Language {
     unique: true
     items {string {min_len: 2}}
   }];
+
+  // If the x-language header is altered, clear the route cache for the current request.
+  // This should be set if the route configuration may depend on the x-language header.
+  // Otherwise it should be unset to avoid the performance cost of route recalculation.
+  bool clear_route_cache = 3;
 }

--- a/contrib/language/filters/http/source/config.cc
+++ b/contrib/language/filters/http/source/config.cc
@@ -55,7 +55,8 @@ Http::FilterFactoryCb LanguageFilterFactory::createFilterFactoryFromProtoTyped(
   }
 
   auto config = std::make_shared<LanguageFilterConfigImpl>(
-      std::make_shared<icu::Locale>(default_locale), locale_matcher, stats_prefix, context.scope());
+      std::make_shared<icu::Locale>(default_locale), locale_matcher,
+      proto_config.clear_route_cache(), stats_prefix, context.scope());
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter = std::make_shared<LanguageFilter>(config);

--- a/contrib/language/filters/http/source/language_filter.h
+++ b/contrib/language/filters/http/source/language_filter.h
@@ -41,6 +41,8 @@ public:
 
   virtual const std::shared_ptr<icu::LocaleMatcher>& localeMatcher() const PURE;
 
+  virtual bool clearRouteCache() const PURE;
+
   virtual LanguageStats& stats() PURE;
 };
 
@@ -51,11 +53,14 @@ class LanguageFilterConfigImpl : public LanguageFilterConfig {
 public:
   LanguageFilterConfigImpl(const std::shared_ptr<icu::Locale> default_locale,
                            const std::shared_ptr<icu::LocaleMatcher> locale_matcher,
-                           const std::string& stats_prefix, Stats::Scope& scope);
+                           const bool clear_route_cache, const std::string& stats_prefix,
+                           Stats::Scope& scope);
 
   const std::shared_ptr<icu::Locale>& defaultLocale() const override;
 
   const std::shared_ptr<icu::LocaleMatcher>& localeMatcher() const override;
+
+  bool clearRouteCache() const override;
 
   LanguageStats& stats() override;
 
@@ -63,6 +68,8 @@ private:
   const std::shared_ptr<icu::Locale> default_locale_;
 
   const std::shared_ptr<icu::LocaleMatcher> locale_matcher_;
+
+  const bool clear_route_cache_;
 
   LanguageStats stats_;
 };


### PR DESCRIPTION
Adds a new option to the contrib http language filter to allow users to clear the route cache when the x-language header was added.

Related

- https://github.com/envoyproxy/envoy/issues/27840