### PR TITLE
logging: Add ENVOY_TAGGED_LOG macro to enable tagged logging

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -307,18 +307,18 @@ void setLogFormatForLogger(spdlog::logger& logger, const std::string& log_format
   logger.set_formatter(std::move(formatter));
 }
 
-std::string serializeLogTags(std::map<std::string, std::string> tags) {
+std::string serializeLogTags(const std::map<std::string, std::string>& tags) {
   if (tags.empty()) {
     return "";
   }
 
-  std::stringstream string_stream;
-  string_stream << "[Tags: ";
+  std::stringstream tags_stream;
+  tags_stream << "[Tags: ";
   for (const auto& tag : tags) {
-    string_stream << "\"" << tag.first << "\":\"" << tag.second << "\",";
+    tags_stream << "\"" << tag.first << "\":\"" << tag.second << "\",";
   }
 
-  std::string serialized = string_stream.str();
+  std::string serialized = tags_stream.str();
   serialized.pop_back();
   serialized += "] ";
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -315,7 +315,7 @@ std::string serializeLogTags(std::map<std::string, std::string> tags) {
   std::stringstream string_stream;
   string_stream << "[Tags: ";
   for (const auto& tag : tags) {
-      string_stream << "\"" << tag.first << "\":\"" << tag.second << "\",";
+    string_stream << "\"" << tag.first << "\":\"" << tag.second << "\",";
   }
 
   std::string serialized = string_stream.str();

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -3,6 +3,7 @@
 #include <cassert> // use direct system-assert to avoid cyclic dependency.
 #include <cstdint>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -304,6 +305,24 @@ void setLogFormatForLogger(spdlog::logger& logger, const std::string& log_format
           CustomFlagFormatter::EscapeMessageJsonString::Placeholder)
       .set_pattern(log_format);
   logger.set_formatter(std::move(formatter));
+}
+
+std::string serializeLogTags(std::map<std::string, std::string> tags) {
+  if (tags.empty()) {
+    return "";
+  }
+
+  std::stringstream string_stream;
+  string_stream << "[Tags: ";
+  for (const auto& tag : tags) {
+      string_stream << "\"" << tag.first << "\":\"" << tag.second << "\",";
+  }
+
+  std::string serialized = string_stream.str();
+  serialized.pop_back();
+  serialized += "] ";
+
+  return serialized;
 }
 
 } // namespace Utility

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -401,6 +401,11 @@ namespace Utility {
  */
 void setLogFormatForLogger(spdlog::logger& logger, const std::string& log_format);
 
+/**
+ * Serializes custom log tags to a string that will be prepended to the log message.
+ */
+std::string serializeLogTags(std::map<std::string, std::string> tags);
+
 } // namespace Utility
 
 // Contains custom flags to introduce user defined flags in log pattern. Reference:
@@ -516,6 +521,24 @@ public:
  * Command line options for log macros: use Fine-Grain Logger or not.
  */
 #define ENVOY_LOG(LEVEL, ...) ENVOY_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, ##__VA_ARGS__)
+
+#define ENVOY_TAGGED_LOG_TO_LOGGER(LOGGER, LEVEL, TAGS, FORMAT, ...)                               \
+  do {                                                                                             \
+    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
+      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,\
+                          ##__VA_ARGS__);                                                          \
+    }                                                                                              \
+  } while (0)
+
+/**
+ * Log with tags which are a map of key and value strings. When ENVOY_TAGGED_LOG is used, the tags
+ * are serialized and prepended to the log message.
+ * For example, the map {{"key1","val1","key2","val2"}} would be serialized to:
+ * [Tags: "key1":"val1","key2":"val2"]. The serialization pattern is defined by
+ * Envoy::Logger::Utility::serializeLogTags function.
+ */
+#define ENVOY_TAGGED_LOG(LEVEL, TAGS, FORMAT, ...)                                                 \
+  ENVOY_TAGGED_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, FORMAT, ##__VA_ARGS__)
 
 /**
  * Log with a stable event name. This allows emitting a log line with a stable name in addition to

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -404,7 +404,7 @@ void setLogFormatForLogger(spdlog::logger& logger, const std::string& log_format
 /**
  * Serializes custom log tags to a string that will be prepended to the log message.
  */
-std::string serializeLogTags(std::map<std::string, std::string> tags);
+std::string serializeLogTags(const std::map<std::string, std::string>& tags);
 
 } // namespace Utility
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -525,7 +525,8 @@ public:
 #define ENVOY_TAGGED_LOG_TO_LOGGER(LOGGER, LEVEL, TAGS, FORMAT, ...)                               \
   do {                                                                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
-      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,\
+      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
+                          ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,               \
                           ##__VA_ARGS__);                                                          \
     }                                                                                              \
   } while (0)

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -32,11 +32,15 @@ public:
     ENVOY_STREAM_LOG(info, "fake message", stream_);
     ENVOY_CONN_LOG(error, "fake error", connection_);
     ENVOY_STREAM_LOG(error, "fake error", stream_);
+    ENVOY_TAGGED_LOG(info, tags_, "fake message {}", "val");
+    ENVOY_TAGGED_LOG(info, (std::map<std::string, std::string>{{"key", "val"}}), "fake message {}",
+                     "val");
   }
 
   void logMessageEscapeSequences() { ENVOY_LOG_MISC(info, "line 1 \n line 2 \t tab \\r test"); }
 
 private:
+  std::map<std::string, std::string> tags_{{"key", "val"}};
   NiceMock<Network::MockConnection> connection_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> stream_;
 };

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -384,6 +384,25 @@ TEST(LoggerTest, TestJsonFormatWithNestedJsonMessage) {
   ENVOY_LOG_MISC(info, "{\"nested_message\":\"hello\"}");
 }
 
+TEST(LoggerUtilityTest, TestSerializeLogTags) {
+  // No entries
+  EXPECT_EQ("", Envoy::Logger::Utility::serializeLogTags({}));
+
+  // Empty key or value
+  EXPECT_EQ("[Tags: \"\":\"\"] ", Envoy::Logger::Utility::serializeLogTags({{"", ""}}));
+  EXPECT_EQ("[Tags: \"\":\"value\"] ", Envoy::Logger::Utility::serializeLogTags({{"", "value"}}));
+  EXPECT_EQ("[Tags: \"key\":\"\"] ", Envoy::Logger::Utility::serializeLogTags({{"key", ""}}));
+
+  // Single entry
+  EXPECT_EQ("[Tags: \"key\":\"value\"] ",
+            Envoy::Logger::Utility::serializeLogTags({{"key", "value"}}));
+
+  // Multiple enties
+  EXPECT_EQ("[Tags: \"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"] ",
+            Envoy::Logger::Utility::serializeLogTags(
+                {{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));
+}
+
 } // namespace
 } // namespace Logger
 } // namespace Envoy

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -397,7 +397,7 @@ TEST(LoggerUtilityTest, TestSerializeLogTags) {
   EXPECT_EQ("[Tags: \"key\":\"value\"] ",
             Envoy::Logger::Utility::serializeLogTags({{"key", "value"}}));
 
-  // Multiple enties
+  // Multiple entries
   EXPECT_EQ("[Tags: \"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"] ",
             Envoy::Logger::Utility::serializeLogTags(
                 {{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));


### PR DESCRIPTION
Commit Message: logging: Add ENVOY_TAGGED_LOG macro to enable tagged logging
Additional Description: Further description below
Risk Level: low (new macro)
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None

Example usage:
```
std::map<std::string, std::string> tags{{"key", "val"}, {"key2", "val2"}};
ENVOY_TAGGED_LOG(info, tags, "some_message {}", "val");
```

Expected output message: ``[Tags: "key":"val","key2":"val2"] some message val``

The idea here is that after #27278 was introduced to enable flushing application logs in JSON format, if ``json_format`` is set, then the ``%j`` flag would extract the tags from the message flushed to the sink, so the ``[Tags: "key":"val","key2":"val2"]`` part will be removed from the message. Additionally, a new flag will be introduced that will append the tags to the JSON string, so eventually we will get the following JSON string (for example): ``{"Timestamp":"%t","Message":"%j","key":"val","key2":"val2"}``