### PR TITLE
golang filter: remove config on the Go side while deconstructing filter config.

### DIFF
--- a/contrib/golang/common/dso/dso.cc
+++ b/contrib/golang/common/dso/dso.cc
@@ -50,6 +50,9 @@ HttpFilterDsoImpl::HttpFilterDsoImpl(const std::string dso_name) : HttpFilterDso
   loaded_ &= dlsymInternal<decltype(envoy_go_filter_merge_http_plugin_config_)>(
       envoy_go_filter_merge_http_plugin_config_, handler_, dso_name,
       "envoyGoFilterMergeHttpPluginConfig");
+  loaded_ &= dlsymInternal<decltype(envoy_go_filter_destroy_http_plugin_config_)>(
+      envoy_go_filter_destroy_http_plugin_config_, handler_, dso_name,
+      "envoyGoFilterDestroyHttpPluginConfig");
   loaded_ &= dlsymInternal<decltype(envoy_go_filter_on_http_header_)>(
       envoy_go_filter_on_http_header_, handler_, dso_name, "envoyGoFilterOnHttpHeader");
   loaded_ &= dlsymInternal<decltype(envoy_go_filter_on_http_data_)>(
@@ -68,6 +71,11 @@ GoUint64 HttpFilterDsoImpl::envoyGoFilterMergeHttpPluginConfig(GoUint64 p0, GoUi
                                                                GoUint64 p2, GoUint64 p3) {
   ASSERT(envoy_go_filter_merge_http_plugin_config_ != nullptr);
   return envoy_go_filter_merge_http_plugin_config_(p0, p1, p2, p3);
+}
+
+void HttpFilterDsoImpl::envoyGoFilterDestroyHttpPluginConfig(GoUint64 p0) {
+  ASSERT(envoy_go_filter_destroy_http_plugin_config_ != nullptr);
+  return envoy_go_filter_destroy_http_plugin_config_(p0);
 }
 
 GoUint64 HttpFilterDsoImpl::envoyGoFilterOnHttpHeader(httpRequest* p0, GoUint64 p1, GoUint64 p2,

--- a/contrib/golang/common/dso/dso.h
+++ b/contrib/golang/common/dso/dso.h
@@ -34,6 +34,7 @@ public:
                                                     GoUint64 p3) PURE;
   virtual GoUint64 envoyGoFilterMergeHttpPluginConfig(GoUint64 p0, GoUint64 p1, GoUint64 p2,
                                                       GoUint64 p3) PURE;
+  virtual void envoyGoFilterDestroyHttpPluginConfig(GoUint64 p0) PURE;
   virtual GoUint64 envoyGoFilterOnHttpHeader(httpRequest* p0, GoUint64 p1, GoUint64 p2,
                                              GoUint64 p3) PURE;
   virtual GoUint64 envoyGoFilterOnHttpData(httpRequest* p0, GoUint64 p1, GoUint64 p2,
@@ -50,6 +51,7 @@ public:
                                             GoUint64 p3) override;
   GoUint64 envoyGoFilterMergeHttpPluginConfig(GoUint64 p0, GoUint64 p1, GoUint64 p2,
                                               GoUint64 p3) override;
+  void envoyGoFilterDestroyHttpPluginConfig(GoUint64 p0) override;
   GoUint64 envoyGoFilterOnHttpHeader(httpRequest* p0, GoUint64 p1, GoUint64 p2,
                                      GoUint64 p3) override;
   GoUint64 envoyGoFilterOnHttpData(httpRequest* p0, GoUint64 p1, GoUint64 p2, GoUint64 p3) override;
@@ -60,6 +62,7 @@ private:
                                                       GoUint64 p3) = {nullptr};
   GoUint64 (*envoy_go_filter_merge_http_plugin_config_)(GoUint64 p0, GoUint64 p1, GoUint64 p2,
                                                         GoUint64 p3) = {nullptr};
+  void (*envoy_go_filter_destroy_http_plugin_config_)(GoUint64 p0) = {nullptr};
   GoUint64 (*envoy_go_filter_on_http_header_)(httpRequest* p0, GoUint64 p1, GoUint64 p2,
                                               GoUint64 p3) = {nullptr};
   GoUint64 (*envoy_go_filter_on_http_data_)(httpRequest* p0, GoUint64 p1, GoUint64 p2,

--- a/contrib/golang/common/dso/test/mocks.h
+++ b/contrib/golang/common/dso/test/mocks.h
@@ -15,6 +15,7 @@ public:
               (GoUint64 p0, GoUint64 p1, GoUint64 p2, GoUint64 p3));
   MOCK_METHOD(GoUint64, envoyGoFilterMergeHttpPluginConfig,
               (GoUint64 p0, GoUint64 p1, GoUint64 p2, GoUint64 p3));
+  MOCK_METHOD(void, envoyGoFilterDestroyHttpPluginConfig, (GoUint64 p0));
   MOCK_METHOD(GoUint64, envoyGoFilterOnHttpHeader,
               (httpRequest * p0, GoUint64 p1, GoUint64 p2, GoUint64 p3));
   MOCK_METHOD(GoUint64, envoyGoFilterOnHttpData,

--- a/contrib/golang/common/dso/test/test_data/simple.go
+++ b/contrib/golang/common/dso/test/test_data/simple.go
@@ -7,13 +7,26 @@ typedef struct {
 */
 import "C"
 
+import (
+	"sync"
+)
+
+var configCache = &sync.Map{}
+
 //export envoyGoFilterNewHttpPluginConfig
 func envoyGoFilterNewHttpPluginConfig(namePtr, nameLen, configPtr, configLen uint64) uint64 {
-	return 100
+	// already existing return 0, just for testing the destroy api.
+	if _, ok := configCache.Load(configLen); ok {
+		return 0
+	}
+	// mark this configLen already existing
+	configCache.Store(configLen, configLen)
+	return configLen
 }
 
 //export envoyGoFilterDestroyHttpPluginConfig
 func envoyGoFilterDestroyHttpPluginConfig(id uint64) {
+	configCache.Delete(id)
 }
 
 //export envoyGoFilterMergeHttpPluginConfig

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -66,7 +66,11 @@ private:
 
   Dso::HttpFilterDsoPtr dso_lib_;
   uint64_t config_id_{0};
-  uint64_t merged_config_id_{0};
+  // since these two fields are updated in worker threads, we need to protect them with a mutex.
+  uint64_t merged_config_id_ ABSL_GUARDED_BY(mutex_){0};
+  uint64_t cached_parent_id_ ABSL_GUARDED_BY(mutex_){0};
+
+  absl::Mutex mutex_;
 };
 
 using RoutePluginConfigPtr = std::shared_ptr<RoutePluginConfig>;

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -30,8 +30,7 @@ public:
   FilterConfig(const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
                Dso::HttpFilterDsoPtr dso_lib, const std::string& stats_prefix,
                Server::Configuration::FactoryContext& context);
-  // TODO: delete config in Go
-  virtual ~FilterConfig() = default;
+  ~FilterConfig();
 
   const std::string& soId() const { return so_id_; }
   const std::string& soPath() const { return so_path_; }
@@ -57,8 +56,7 @@ class RoutePluginConfig : Logger::Loggable<Logger::Id::http> {
 public:
   RoutePluginConfig(const std::string plugin_name,
                     const envoy::extensions::filters::http::golang::v3alpha::RouterPlugin& config);
-  // TODO: delete plugin config in Go
-  ~RoutePluginConfig() = default;
+  ~RoutePluginConfig();
   uint64_t getConfigId();
   uint64_t getMergedConfigId(uint64_t parent_id);
 


### PR DESCRIPTION
to avoid memory leaking on the Go side.

fix #25370

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
