### PR TITLE
grpc: optimize getGrpcStatus implementation

### DIFF
--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -123,25 +123,25 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::ResponseTra
   //   1. trailers gRPC status, if it exists.
   //   2. headers gRPC status, if it exists.
   //   3. Inferred from info HTTP status, if it exists.
-  const std::array<absl::optional<Grpc::Status::GrpcStatus>, 3> optional_statuses = {{
-      {Grpc::Common::getGrpcStatus(trailers, allow_user_defined)},
-      {Grpc::Common::getGrpcStatus(headers, allow_user_defined)},
-      {info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
-                                 Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
-                           : absl::nullopt},
-  }};
+  // const std::array<absl::optional<Grpc::Status::GrpcStatus>, 3> optional_statuses = {{
+  //     {Grpc::Common::getGrpcStatus(trailers, allow_user_defined)},
+  //     {Grpc::Common::getGrpcStatus(headers, allow_user_defined)},
+  //     {info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
+  //                                Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
+  //                          : absl::nullopt},
+  // }};
   absl::optional<Grpc::Status::GrpcStatus> optional_status;
-  optional_status = Grpc::Common::getGrpcStatus(trailers, allow_user_defined)
+  optional_status = Grpc::Common::getGrpcStatus(trailers, allow_user_defined);
     if (optional_status.has_value()) {
       return optional_status;
     }
-    optional_status = Grpc::Common::getGrpcStatus(headers, allow_user_defined)
+    optional_status = Grpc::Common::getGrpcStatus(headers, allow_user_defined);
     if (optional_status.has_value()) {
       return optional_status;
     }
     optional_status = info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
                                  Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
-                           : absl::nullopt
+                           : absl::nullopt;
                            if (optional_status.has_value()) {
                              return optional_status;
                            }

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -130,12 +130,21 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::ResponseTra
                                  Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
                            : absl::nullopt},
   }};
-
-  for (const auto& optional_status : optional_statuses) {
+  absl::optional<Grpc::Status::GrpcStatus> optional_status;
+  optional_status = Grpc::Common::getGrpcStatus(trailers, allow_user_defined)
     if (optional_status.has_value()) {
       return optional_status;
     }
-  }
+    optional_status = Grpc::Common::getGrpcStatus(headers, allow_user_defined)
+    if (optional_status.has_value()) {
+      return optional_status;
+    }
+    optional_status = info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
+                                 Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
+                           : absl::nullopt
+                           if (optional_status.has_value()) {
+                             return optional_status;
+                           }
 
   return absl::nullopt;
 }

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -123,30 +123,18 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::ResponseTra
   //   1. trailers gRPC status, if it exists.
   //   2. headers gRPC status, if it exists.
   //   3. Inferred from info HTTP status, if it exists.
-  // const std::array<absl::optional<Grpc::Status::GrpcStatus>, 3> optional_statuses = {{
-  //     {Grpc::Common::getGrpcStatus(trailers, allow_user_defined)},
-  //     {Grpc::Common::getGrpcStatus(headers, allow_user_defined)},
-  //     {info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
-  //                                Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
-  //                          : absl::nullopt},
-  // }};
   absl::optional<Grpc::Status::GrpcStatus> optional_status;
   optional_status = Grpc::Common::getGrpcStatus(trailers, allow_user_defined);
-    if (optional_status.has_value()) {
-      return optional_status;
-    }
-    optional_status = Grpc::Common::getGrpcStatus(headers, allow_user_defined);
-    if (optional_status.has_value()) {
-      return optional_status;
-    }
-    optional_status = info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
-                                 Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
-                           : absl::nullopt;
-                           if (optional_status.has_value()) {
-                             return optional_status;
-                           }
-
-  return absl::nullopt;
+  if (optional_status.has_value()) {
+    return optional_status;
+  }
+  optional_status = Grpc::Common::getGrpcStatus(headers, allow_user_defined);
+  if (optional_status.has_value()) {
+    return optional_status;
+  }
+  return info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
+                                   Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
+                             : absl::nullopt;
 }
 
 std::string Common::getGrpcMessage(const Http::ResponseHeaderOrTrailerMap& trailers) {


### PR DESCRIPTION
Commit Message: optimize getGrpcStatus implementation
Additional Description: optimize getGrpcStatus implementation by removing extra allocation and avoiding extra evaluations.
Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A

