### PR TITLE
redis_proxy: add formatter support for catch_all_route

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -160,7 +160,7 @@ bug_fixes:
   change: |
     Fixes a bug where route properties such as key_formatter, prefix and remove_prefix do
     not take effect when configured for :ref:`catch_all_route
-    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.Route>`
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.Route>`.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -156,6 +156,10 @@ bug_fixes:
     - `CVE-2023-31147 <https://nvd.nist.gov/vuln/detail/CVE-2023-31147>`_.
     - `CVE-2023-31124 <https://nvd.nist.gov/vuln/detail/CVE-2023-31124>`_.
     - `CVE-2023-32067 <https://nvd.nist.gov/vuln/detail/CVE-2023-32067>`_.
+- area: redis_proxy
+  change: |
+    Fixes a bug where route properties such as key_formatter, prefix and remove_prefix do not take effect when configured for :ref:`catch_all_route
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.Route>`
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -158,7 +158,8 @@ bug_fixes:
     - `CVE-2023-32067 <https://nvd.nist.gov/vuln/detail/CVE-2023-32067>`_.
 - area: redis_proxy
   change: |
-    Fixes a bug where route properties such as key_formatter, prefix and remove_prefix do not take effect when configured for :ref:`catch_all_route
+    Fixes a bug where route properties such as key_formatter, prefix and remove_prefix do
+    not take effect when configured for :ref:`catch_all_route
     <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.Route>`
 
 removed_config_or_runtime:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -159,7 +159,7 @@ bug_fixes:
 - area: redis_proxy
   change: |
     Fixes a bug where route properties such as key_formatter,
-    prefix and remove_prefix do not take effect when configured for :ref:`catch_all_route 
+    prefix and remove_prefix do not take effect when configured for :ref:`catch_all_route
     <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.catch_all_route>`.
 
 removed_config_or_runtime:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -158,8 +158,9 @@ bug_fixes:
     - `CVE-2023-32067 <https://nvd.nist.gov/vuln/detail/CVE-2023-32067>`_.
 - area: redis_proxy
   change: |
-    Fixes a bug where route properties such as key_formatter, prefix and remove_prefix do
-    not take effect when configured for :ref:`catch_all_route <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.catch_all_route>`.
+    Fixes a bug where route properties such as key_formatter,
+    prefix and remove_prefix do not take effect when configured for :ref:`catch_all_route 
+    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.catch_all_route>`.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -159,8 +159,7 @@ bug_fixes:
 - area: redis_proxy
   change: |
     Fixes a bug where route properties such as key_formatter, prefix and remove_prefix do
-    not take effect when configured for :ref:`catch_all_route
-    <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.Route>`.
+    not take effect when configured for :ref:`catch_all_route <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.catch_all_route>`.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -87,6 +87,10 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
     value = prefix_lookup_table_.findLongestPrefix(key.c_str());
   }
 
+  if (value == nullptr) {
+    // prefix route not found, default to catch all route.
+    value = catch_all_route_;
+  }
   if (value != nullptr) {
     if (value->removePrefix()) {
       key.erase(0, value->prefix().length());
@@ -94,10 +98,8 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
     if (!value->keyFormatter().empty()) {
       formatKey(key, value->keyFormatter());
     }
-    return value;
   }
-
-  return catch_all_route_;
+  return value;
 }
 
 void PrefixRoutes::formatKey(std::string& key, std::string redis_key_formatter) {

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -91,13 +91,12 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key) {
     // prefix route not found, default to catch all route.
     value = catch_all_route_;
   }
-  if (value != nullptr) {
-    if (value->removePrefix()) {
-      key.erase(0, value->prefix().length());
-    }
-    if (!value->keyFormatter().empty()) {
-      formatKey(key, value->keyFormatter());
-    }
+
+  if (value->removePrefix()) {
+    key.erase(0, value->prefix().length());
+  }
+  if (!value->keyFormatter().empty()) {
+    formatKey(key, value->keyFormatter());
   }
   return value;
 }

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -87,7 +87,7 @@ private:
   TrieLookupTable<PrefixSharedPtr> prefix_lookup_table_;
   const bool case_insensitive_;
   Upstreams upstreams_;
-  RouteSharedPtr catch_all_route_;
+  PrefixSharedPtr catch_all_route_;
   Network::ReadFilterCallbacks* callbacks_{};
   const std::string redis_key_formatter_command_ = "%KEY%";
 };

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -49,19 +49,6 @@ createPrefixRoutes() {
   return prefix_routes;
 }
 
-TEST(PrefixRoutesTest, MissingCatchAll) {
-  Upstreams upstreams;
-  upstreams.emplace("fake_clusterA", std::make_shared<ConnPool::MockInstance>());
-  upstreams.emplace("fake_clusterB", std::make_shared<ConnPool::MockInstance>());
-
-  Runtime::MockLoader runtime_;
-
-  PrefixRoutes router(createPrefixRoutes(), std::move(upstreams), runtime_);
-
-  std::string key("c:bar");
-  EXPECT_EQ(nullptr, router.upstreamPool(key));
-}
-
 TEST(PrefixRoutesTest, RoutedToCatchAll) {
   auto upstream_c = std::make_shared<ConnPool::MockInstance>();
 


### PR DESCRIPTION
Commit Message: `catch_all_route` is of type `extensions.filters.network.redis_proxy.v3.RedisProxy.PrefixRoutes.Route`. However `remove_prefix`, `prefix` and `key_formatter` does not work when set against `catch_all_route`. This PR fixes the same and adds a unit test exercising these properties against `catch_all_route`
Additional Description: Related to https://github.com/envoyproxy/envoy/pull/26560
Risk Level: Low
Testing: Unit test
Docs Changes: Yes
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
