### PR TITLE
composite: Implements onStreamComplete

### DIFF
--- a/source/extensions/filters/http/composite/filter.cc
+++ b/source/extensions/filters/http/composite/filter.cc
@@ -200,6 +200,16 @@ void Filter::StreamFilterWrapper::onDestroy() {
   }
 }
 
+void Filter::StreamFilterWrapper::onStreamComplete() {
+  if (decoder_filter_) {
+    decoder_filter_->onStreamComplete();
+  }
+
+  if (encoder_filter_) {
+    encoder_filter_->onStreamComplete();
+  }
+}
+
 } // namespace Composite
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -64,6 +64,14 @@ public:
     }
   }
 
+  void onStreamComplete() override {
+    if (delegated_filter_) {
+      // We need to explicitly specify which base class to the conversion via due
+      // to the diamond inheritance between StreamFilter and StreamFilterBase.
+      static_cast<Http::StreamDecoderFilter&>(*delegated_filter_).onStreamComplete();
+    }
+  }
+
   void onMatchCallback(const Matcher::Action& action) override;
 
   // AccessLog::Instance
@@ -118,6 +126,7 @@ private:
 
     // Http::StreamFilterBase
     void onDestroy() override;
+    void onStreamComplete() override;
 
   private:
     Http::StreamEncoderFilterSharedPtr encoder_filter_;

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -101,7 +101,9 @@ TEST_F(FilterTest, StreamEncoderFilterDelegation) {
   doAllDecodingCallbacks();
   expectDelegatedEncoding(*stream_filter);
   doAllEncodingCallbacks();
+  EXPECT_CALL(*stream_filter, onStreamComplete());
   EXPECT_CALL(*stream_filter, onDestroy());
+  filter_.onStreamComplete();
   filter_.onDestroy();
 }
 
@@ -120,7 +122,9 @@ TEST_F(FilterTest, StreamDecoderFilterDelegation) {
   expectDelegatedDecoding(*stream_filter);
   doAllDecodingCallbacks();
   doAllEncodingCallbacks();
+  EXPECT_CALL(*stream_filter, onStreamComplete());
   EXPECT_CALL(*stream_filter, onDestroy());
+  filter_.onStreamComplete();
   filter_.onDestroy();
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

`onStreamComplete` is missing in composite filter. Without the fix, `onStreamComplete` will not be invoked in composite's delegated filter even if the delegated filter implements this function. 

Test: unit test with mock. Also, confirmed this function will be invoked in `filter_A + composite_filter(delegated to filter_B)` as expected.
