### PR TITLE
ci: Remove fetch-depth in Traffic Director workflow YAML

### DIFF
--- a/.github/workflows/mobile-traffic_director.yml
+++ b/.github/workflows/mobile-traffic_director.yml
@@ -31,8 +31,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
         fetch-depth: 0
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy

--- a/.github/workflows/mobile-traffic_director.yml
+++ b/.github/workflows/mobile-traffic_director.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
     - name: 'Run GcpTrafficDirectorIntegrationTest'


### PR DESCRIPTION
Switching to use the default value of `1`, as the workflow doesn't operate on pull requests.