### PR TITLE
Make ENVOY_MAKE_SOCKET_OPTION_NAME macro more explicit

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -40,7 +40,7 @@ private:
 // ENVOY_MAKE_SOCKET_OPTION_NAME is a helper macro to generate a
 // SocketOptionName with a descriptive string name.
 #define ENVOY_MAKE_SOCKET_OPTION_NAME(level, option)                                               \
-  Network::SocketOptionName(level, option, #level "/" #option)
+  ::Envoy::Network::SocketOptionName(level, option, #level "/" #option)
 
 // Moved from source/common/network/socket_option_impl.h to avoid dependency loops.
 #ifdef IP_TRANSPARENT


### PR DESCRIPTION
Commit Message: Make ENVOY_MAKE_SOCKET_OPTION_NAME macro more explicit
Additional Description: This macro (and the macros that depend on it) are currently unusable from a namespace with `Network` at a different level, or outside of `::Envoy` namespace. This change makes the macro more explicit so it will work anywhere.
Risk Level: Negligible, it's a no-op.
Testing: Covered by existing tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
