### PR TITLE
Add TcpProxy::CombinedUpstream for using Router::UpstreamRequest in tcp tunneling path

### DIFF
--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1495,6 +1495,18 @@ public:
    * @param trailers supplies the trailers to encode.
    */
   virtual void encodeTrailers(const Http::RequestTrailerMap& trailers) PURE;
+
+  // TODO(vikaschoudhary16): Remove this api.
+  // This api is only used to enable half-close semantics on the upstream connection.
+  // This ideally should be done via calling connection.enableHalfClose() but since TcpProxy
+  // does not have access to the upstream connection, it is done via this api for now.
+  /**
+   * Enable half-close semantics on the upstream connection. Receiving close from the upstream
+   * will not fully close the downstream connection. Downstream can still send traffic.
+   * This is off by default.
+   * @param enabled Whether to set half-close semantics as enabled or disabled.
+   */
+  virtual void enableHalfClose() PURE;
   /**
    * Enable/disable further data from this stream.
    */

--- a/envoy/tcp/BUILD
+++ b/envoy/tcp/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "//envoy/http:header_evaluator",
         "//envoy/tcp:conn_pool_interface",
         "//envoy/upstream:upstream_interface",
+        "//source/common/router:router_lib",
         "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/envoy/tcp/upstream.h
+++ b/envoy/tcp/upstream.h
@@ -2,10 +2,13 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.h"
+#include "envoy/http/filter.h"
 #include "envoy/http/header_evaluator.h"
 #include "envoy/stream_info/stream_info.h"
 #include "envoy/tcp/conn_pool.h"
 #include "envoy/upstream/upstream.h"
+
+#include "source/common/router/router.h"
 
 namespace Envoy {
 
@@ -48,6 +51,10 @@ public:
   virtual void
   propagateResponseTrailers(Http::ResponseTrailerMapPtr&& trailers,
                             const StreamInfo::FilterStateSharedPtr& filter_state) const PURE;
+  // Returns the router filter config.
+  virtual const Envoy::Router::FilterConfig& routerFilterConfig() const PURE;
+  // Returns the stream Id.
+  virtual uint64_t streamId() const PURE;
 };
 
 using TunnelingConfigHelperOptConstRef = OptRef<const TunnelingConfigHelper>;
@@ -175,6 +182,7 @@ public:
                         TunnelingConfigHelperOptConstRef config,
                         Upstream::LoadBalancerContext* context,
                         Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks,
+                        Http::StreamDecoderFilterCallbacks& stream_decoder_callbacks,
                         StreamInfo::StreamInfo& downstream_info) const PURE;
 };
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -289,6 +289,7 @@ private:
     OptRef<const Tracing::Config> tracingConfig() const override;
     const ScopeTrackedObject& scope() override;
     OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return *this; }
+    bool allowDownstreamOpenOnUpstreamClosed() override { return false; }
 
     // DownstreamStreamFilterCallbacks
     void setRoute(Router::RouteConstSharedPtr route) override;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -836,9 +836,19 @@ FilterManager::commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_st
                                   FilterIterationStartState filter_iteration_start_state) {
   // Only do base state setting on the initial call. Subsequent calls for filtering do not touch
   // the base state.
+  ENVOY_STREAM_LOG(trace, "commonEncodePrefix end_stream: {}, isHalfCloseEnabled: {}", *this,
+                   end_stream, filter_manager_callbacks_.allowDownstreamOpenOnUpstreamClosed());
   if (filter == nullptr) {
-    ASSERT(!state_.local_complete_);
-    state_.local_complete_ = end_stream;
+    // half close is enabled in case tcp proxying is done with http1 encoder. In this case, we
+    // should not set the local_complete_ flag to true when end_stream is true.
+    // setting local_complete_ to true will cause any data sent in the upstream direction to be
+    // dropped.
+    if (end_stream && !filter_manager_callbacks_.allowDownstreamOpenOnUpstreamClosed()) {
+      ASSERT(!state_.local_complete_);
+      state_.local_complete_ = true;
+    } else {
+      state_.local_complete_ = false;
+    }
     return encoder_filters_.begin();
   }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -518,6 +518,11 @@ public:
    * Returns a handle to the downstream callbacks, if available.
    */
   virtual OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() { return {}; }
+  /**
+   * Returns if close from the upstream is to be handled with half-close semantics and
+   * will not reset the stream. This will allow the downstream to still send data.
+   */
+  virtual bool allowDownstreamOpenOnUpstreamClosed() PURE;
 };
 
 /**

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -80,7 +80,8 @@ public:
 
 UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
                                  std::unique_ptr<GenericConnPool>&& conn_pool,
-                                 bool can_send_early_data, bool can_use_http3)
+                                 bool can_send_early_data, bool can_use_http3,
+                                 bool enable_half_close)
     : parent_(parent), conn_pool_(std::move(conn_pool)),
       stream_info_(parent_.callbacks()->dispatcher().timeSource(), nullptr),
       start_time_(parent_.callbacks()->dispatcher().timeSource().monotonicTime()),
@@ -93,7 +94,8 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
       cleaned_up_(false), had_upstream_(false),
       stream_options_({can_send_early_data, can_use_http3}), grpc_rq_success_deferred_(false),
       upstream_wait_for_response_headers_before_disabling_read_(Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.upstream_wait_for_response_headers_before_disabling_read")) {
+          "envoy.reloadable_features.upstream_wait_for_response_headers_before_disabling_read")),
+      enable_half_close_(enable_half_close) {
   if (parent_.config().start_child_span_) {
     if (auto tracing_config = parent_.callbacks()->tracingConfig(); tracing_config.has_value()) {
       span_ = parent_.callbacks()->activeSpan().spawnChild(
@@ -252,7 +254,8 @@ void UpstreamRequest::decode1xxHeaders(Http::ResponseHeaderMapPtr&& headers) {
 // on to the router.
 void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(headers.get());
-  ENVOY_STREAM_LOG(trace, "upstream response headers:\n{}", *parent_.callbacks(), *headers);
+  ENVOY_STREAM_LOG(trace, "end_stream: {}, upstream response headers:\n{}", *parent_.callbacks(),
+                   end_stream, *headers);
   ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
 
   resetPerTryIdleTimer();
@@ -553,6 +556,9 @@ void UpstreamRequest::onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
   had_upstream_ = true;
   // Have the upstream use the account of the downstream.
   upstream_->setAccount(parent_.callbacks()->account());
+  if (enable_half_close_) {
+    upstream_->enableHalfClose();
+  }
 
   if (parent_.requestVcluster()) {
     // The cluster increases its upstream_rq_total_ counter right before firing this onPoolReady

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -69,19 +69,19 @@ class UpstreamRequest : public Logger::Loggable<Logger::Id::router>,
                         public Event::DeferredDeletable {
 public:
   UpstreamRequest(RouterFilterInterface& parent, std::unique_ptr<GenericConnPool>&& conn_pool,
-                  bool can_send_early_data, bool can_use_http3);
+                  bool can_send_early_data, bool can_use_http3, bool enable_tcp_tunneling = false);
   ~UpstreamRequest() override;
   void deleteIsPending() override { cleanUp(); }
 
   // To be called from the destructor, or prior to deferred delete.
   void cleanUp();
 
-  void acceptHeadersFromRouter(bool end_stream);
-  void acceptDataFromRouter(Buffer::Instance& data, bool end_stream);
+  virtual void acceptHeadersFromRouter(bool end_stream);
+  virtual void acceptDataFromRouter(Buffer::Instance& data, bool end_stream);
   void acceptTrailersFromRouter(Http::RequestTrailerMap& trailers);
   void acceptMetadataFromRouter(Http::MetadataMapPtr&& metadata_map_ptr);
 
-  void resetStream();
+  virtual void resetStream();
   void setupPerTryTimeout();
   void maybeEndDecode(bool end_stream);
   void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host);
@@ -255,6 +255,7 @@ private:
   Http::ConnectionPool::Instance::StreamOptions stream_options_;
   bool grpc_rq_success_deferred_ : 1;
   bool upstream_wait_for_response_headers_before_disabling_read_ : 1;
+  bool enable_half_close_ : 1;
 };
 
 class UpstreamRequestFilterManagerCallbacks : public Http::FilterManagerCallbacks,
@@ -368,7 +369,9 @@ public:
   void setUpstreamToDownstream(UpstreamToDownstream& upstream_to_downstream_interface) override {
     upstream_request_.upstream_interface_ = upstream_to_downstream_interface;
   }
-
+  bool allowDownstreamOpenOnUpstreamClosed() override {
+    return upstream_request_.enable_half_close_;
+  }
   Http::RequestTrailerMapPtr trailers_;
   Http::ResponseHeaderMapPtr informational_headers_;
   Http::ResponseHeaderMapPtr response_headers_;

--- a/source/common/tcp_proxy/BUILD
+++ b/source/common/tcp_proxy/BUILD
@@ -17,15 +17,21 @@ envoy_cc_library(
         "upstream.h",
     ],
     deps = [
+        "//envoy/http:header_map_interface",
+        "//envoy/router:router_ratelimit_interface",
         "//envoy/tcp:conn_pool_interface",
         "//envoy/tcp:upstream_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//envoy/upstream:load_balancer_interface",
         "//source/common/http:codec_client_lib",
+        "//source/common/http:hash_policy_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/network:utility_lib",
         "//source/common/router:header_parser_lib",
+        "//source/common/router:router_lib",
+        "//source/common/router:shadow_writer_lib",
     ],
 )
 

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -10,6 +10,7 @@
 #include "envoy/common/random_generator.h"
 #include "envoy/event/timer.h"
 #include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.h"
+#include "envoy/http/codec.h"
 #include "envoy/http/header_evaluator.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
@@ -22,6 +23,7 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "envoy/upstream/upstream.h"
 
+#include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
 #include "source/common/formatter/substitution_format_string.h"
 #include "source/common/http/header_map_impl.h"
@@ -149,24 +151,28 @@ public:
 private:
   const Http::ResponseTrailerMapPtr response_trailers_;
 };
-
+class Config;
 class TunnelingConfigHelperImpl : public TunnelingConfigHelper,
                                   protected Logger::Loggable<Logger::Id::filter> {
 public:
   TunnelingConfigHelperImpl(
-      const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_TunnelingConfig&
-          config_message,
+      Stats::Scope& scope,
+      const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy& config_message,
       Server::Configuration::FactoryContext& context);
   std::string host(const StreamInfo::StreamInfo& stream_info) const override;
   bool usePost() const override { return use_post_; }
   const std::string& postPath() const override { return post_path_; }
   Envoy::Http::HeaderEvaluator& headerEvaluator() const override { return *header_parser_; }
+
+  const Envoy::Router::FilterConfig& routerFilterConfig() const override { return router_config_; }
   void
   propagateResponseHeaders(Http::ResponseHeaderMapPtr&& headers,
                            const StreamInfo::FilterStateSharedPtr& filter_state) const override;
   void
   propagateResponseTrailers(Http::ResponseTrailerMapPtr&& trailers,
                             const StreamInfo::FilterStateSharedPtr& filter_state) const override;
+
+  uint64_t streamId() const override { return stream_id_; }
 
 private:
   const bool use_post_;
@@ -175,6 +181,9 @@ private:
   const bool propagate_response_headers_;
   const bool propagate_response_trailers_;
   std::string post_path_;
+  Stats::StatNameManagedStorage route_stat_name_storage_;
+  const Router::FilterConfig router_config_;
+  uint64_t stream_id_;
 };
 
 /**
@@ -462,6 +471,96 @@ public:
   };
 
   StreamInfo::StreamInfo& getStreamInfo();
+  class HttpStreamDecoderFilterCallbacks : public Http::StreamDecoderFilterCallbacks,
+                                           public ScopeTrackedObject {
+  public:
+    HttpStreamDecoderFilterCallbacks(Filter* parent);
+    // Http::StreamDecoderFilterCallbacks
+    OptRef<const Network::Connection> connection() override {
+      return parent_->read_callbacks_->connection();
+    }
+    StreamInfo::StreamInfo& streamInfo() override { return parent_->getStreamInfo(); }
+    const ScopeTrackedObject& scope() override { return *this; }
+    Event::Dispatcher& dispatcher() override {
+      return parent_->read_callbacks_->connection().dispatcher();
+    }
+    void resetStream(Http::StreamResetReason, absl::string_view) override {
+      IS_ENVOY_BUG("Not implemented. Unexpected call to resetStream()");
+    };
+    Router::RouteConstSharedPtr route() override { return nullptr; }
+    Upstream::ClusterInfoConstSharedPtr clusterInfo() override {
+      return parent_->cluster_manager_.getThreadLocalCluster(parent_->route_->clusterName())
+          ->info();
+    }
+    uint64_t streamId() const override {
+      return parent_->config_->tunnelingConfigHelper()->streamId();
+    }
+    Tracing::Span& activeSpan() override { return parent_->active_span_; }
+    OptRef<const Tracing::Config> tracingConfig() const override {
+      return makeOptRef<const Tracing::Config>(parent_->tracing_config_);
+    }
+    void continueDecoding() override {}
+    void addDecodedData(Buffer::Instance&, bool) override {}
+    void injectDecodedDataToFilterChain(Buffer::Instance&, bool) override {}
+    Http::RequestTrailerMap& addDecodedTrailers() override { return *request_trailer_map_; }
+    Http::MetadataMapVector& addDecodedMetadata() override {
+      static Http::MetadataMapVector metadata_map_vector;
+      return metadata_map_vector;
+    }
+    const Buffer::Instance* decodingBuffer() override { return nullptr; }
+    void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {}
+    void sendLocalReply(Http::Code, absl::string_view,
+                        std::function<void(Http::ResponseHeaderMap& headers)>,
+                        const absl::optional<Grpc::Status::GrpcStatus>,
+                        absl::string_view) override {}
+    void encode1xxHeaders(Http::ResponseHeaderMapPtr&&) override {}
+    Http::ResponseHeaderMapOptRef informationalHeaders() const override { return {}; }
+    void encodeHeaders(Http::ResponseHeaderMapPtr&&, bool, absl::string_view) override {}
+    Http::ResponseHeaderMapOptRef responseHeaders() const override { return {}; }
+    void encodeData(Buffer::Instance&, bool) override {}
+    void encodeTrailers(Http::ResponseTrailerMapPtr&&) override {}
+    Http::ResponseTrailerMapOptRef responseTrailers() const override { return {}; }
+    void encodeMetadata(Http::MetadataMapPtr&&) override {}
+    // TODO(vikaschoudhary16): Implement watermark callbacks and test through flow control e2es.
+    void onDecoderFilterAboveWriteBufferHighWatermark() override {}
+    void onDecoderFilterBelowWriteBufferLowWatermark() override {}
+    void addDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks&) override {}
+    void removeDownstreamWatermarkCallbacks(Http::DownstreamWatermarkCallbacks&) override {}
+    void setDecoderBufferLimit(uint32_t) override {}
+    uint32_t decoderBufferLimit() override { return 0; }
+    bool recreateStream(const Http::ResponseHeaderMap*) override { return false; }
+    void addUpstreamSocketOptions(const Network::Socket::OptionsSharedPtr&) override {}
+    Network::Socket::OptionsSharedPtr getUpstreamSocketOptions() const override { return nullptr; }
+    const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override {
+      return nullptr;
+    }
+    Buffer::BufferMemoryAccountSharedPtr account() const override { return nullptr; }
+    void setUpstreamOverrideHost(absl::string_view) override {}
+    void restoreContextOnContinue(ScopeTrackedObjectStack& tracked_object_stack) override {
+      tracked_object_stack.add(*this);
+    }
+    void traversePerFilterConfig(
+        std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+    Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return {}; }
+    OptRef<Http::DownstreamStreamFilterCallbacks> downstreamCallbacks() override { return {}; }
+    OptRef<Http::UpstreamStreamFilterCallbacks> upstreamCallbacks() override { return {}; }
+    void resetIdleTimer() override {}
+    absl::optional<absl::string_view> upstreamOverrideHost() const override {
+      return absl::nullopt;
+    }
+    absl::string_view filterConfigName() const override { return ""; }
+
+    // ScopeTrackedObject
+    void dumpState(std::ostream& os, int indent_level) const override {
+      const char* spaces = spacesForLevel(indent_level);
+      os << spaces << "TcpProxy " << this << DUMP_MEMBER(streamId()) << "\n";
+      DUMP_DETAILS(parent_->getStreamInfo().upstreamInfo());
+    }
+    Filter* parent_{};
+    Http::RequestTrailerMapPtr request_trailer_map_;
+  };
+  Tracing::NullSpan active_span_;
+  const Tracing::Config& tracing_config_;
 
 protected:
   struct DownstreamCallbacks : public Network::ConnectionCallbacks {
@@ -540,6 +639,7 @@ protected:
   uint32_t connect_attempts_{};
   bool connecting_{};
   bool downstream_closed_{};
+  HttpStreamDecoderFilterCallbacks upstream_decoder_filter_callbacks_;
 };
 
 // This class deals with an upstream connection that needs to finish flushing, when the downstream

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/http/conn_pool.h"
+#include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
+#include "envoy/router/router_ratelimit.h"
 #include "envoy/tcp/conn_pool.h"
 #include "envoy/tcp/upstream.h"
 #include "envoy/upstream/load_balancer.h"
@@ -10,7 +14,12 @@
 
 #include "source/common/common/dump_state_utils.h"
 #include "source/common/http/codec_client.h"
+#include "source/common/http/hash_policy.h"
+#include "source/common/network/utility.h"
+#include "source/common/router/config_impl.h"
 #include "source/common/router/header_parser.h"
+#include "source/common/router/router.h"
+#include "source/extensions/early_data/default_early_data_policy.h"
 
 namespace Envoy {
 namespace TcpProxy {
@@ -49,11 +58,19 @@ class HttpConnPool : public GenericConnPool, public Http::ConnectionPool::Callba
 public:
   HttpConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
                Upstream::LoadBalancerContext* context, const TunnelingConfigHelper& config,
-               Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks, Http::CodecType type,
+               Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks,
+               Http::StreamDecoderFilterCallbacks&, Http::CodecType type,
                StreamInfo::StreamInfo& downstream_info);
+
+  using RouterUpstreamRequest = Router::UpstreamRequest;
+  using RouterUpstreamRequestPtr = std::unique_ptr<RouterUpstreamRequest>;
   ~HttpConnPool() override;
 
-  bool valid() const { return conn_pool_data_.has_value(); }
+  bool valid() const { return conn_pool_data_.has_value() || generic_conn_pool_; }
+  Http::CodecType codecType() const { return type_; }
+  std::unique_ptr<Router::GenericConnPool> createConnPool(Upstream::ThreadLocalCluster&,
+                                                          Upstream::LoadBalancerContext* context,
+                                                          absl::optional<Http::Protocol> protocol);
 
   // GenericConnPool
   void newStream(GenericConnectionPoolCallbacks& callbacks) override;
@@ -66,16 +83,253 @@ public:
                    Upstream::HostDescriptionConstSharedPtr host, StreamInfo::StreamInfo& info,
                    absl::optional<Http::Protocol>) override;
 
+  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr);
+  void onHttpPoolReady(Upstream::HostDescriptionConstSharedPtr& host,
+                       Ssl::ConnectionInfoConstSharedPtr ssl_info);
+
+  struct NullHedgePolicy : public Router::HedgePolicy {
+    // Router::HedgePolicy
+    uint32_t initialRequests() const override { return 1; }
+    const envoy::type::v3::FractionalPercent& additionalRequestChance() const override {
+      return additional_request_chance_;
+    }
+    bool hedgeOnPerTryTimeout() const override { return false; }
+
+    const envoy::type::v3::FractionalPercent additional_request_chance_;
+  };
+
+  struct NullRateLimitPolicy : public Router::RateLimitPolicy {
+    // Router::RateLimitPolicy
+    const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>&
+    getApplicableRateLimit(uint64_t) const override {
+      return rate_limit_policy_entry_;
+    }
+    bool empty() const override { return true; }
+
+    static const std::vector<std::reference_wrapper<const Router::RateLimitPolicyEntry>>
+        rate_limit_policy_entry_;
+  };
+
+  struct NullConfig : public Router::Config {
+    Router::RouteConstSharedPtr route(const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
+                                      uint64_t) const override {
+      return nullptr;
+    }
+
+    Router::RouteConstSharedPtr route(const Router::RouteCallback&, const Http::RequestHeaderMap&,
+                                      const StreamInfo::StreamInfo&, uint64_t) const override {
+      return nullptr;
+    }
+
+    const std::list<Http::LowerCaseString>& internalOnlyHeaders() const override {
+      return internal_only_headers_;
+    }
+
+    const std::string& name() const override { return EMPTY_STRING; }
+    bool usesVhds() const override { return false; }
+    bool mostSpecificHeaderMutationsWins() const override { return false; }
+    uint32_t maxDirectResponseBodySizeBytes() const override { return 0; }
+
+    static const std::list<Http::LowerCaseString> internal_only_headers_;
+  };
+
+  struct NullVirtualHost : public Router::VirtualHost {
+    // Router::VirtualHost
+    Stats::StatName statName() const override { return {}; }
+    const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
+    const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
+    const Router::Config& routeConfig() const override { return route_configuration_; }
+    bool includeAttemptCountInRequest() const override { return false; }
+    bool includeAttemptCountInResponse() const override { return false; }
+    bool includeIsTimeoutRetryHeader() const override { return false; }
+    uint32_t retryShadowBufferLimit() const override {
+      return std::numeric_limits<uint32_t>::max();
+    }
+    const Router::RouteSpecificFilterConfig*
+    mostSpecificPerFilterConfig(const std::string&) const override {
+      return nullptr;
+    }
+    void traversePerFilterConfig(
+        const std::string&,
+        std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+    static const NullRateLimitPolicy rate_limit_policy_;
+    static const NullConfig route_configuration_;
+  };
+
+  struct NullPathMatchCriterion : public Router::PathMatchCriterion {
+    Router::PathMatchType matchType() const override { return Router::PathMatchType::None; }
+    const std::string& matcher() const override { return EMPTY_STRING; }
+  };
+
+  struct RouteEntryImpl : public Router::RouteEntry {
+    RouteEntryImpl(Upstream::ThreadLocalCluster& thread_local_cluster)
+        : cluster_name_(thread_local_cluster.info()->name()) {
+      retry_policy_ = std::make_unique<Router::RetryPolicyImpl>();
+    }
+
+    // Router::RouteEntry
+    const std::string& clusterName() const override { return cluster_name_; }
+    const Router::RouteStatsContextOptRef routeStatsContext() const override {
+      return Router::RouteStatsContextOptRef();
+    }
+    Http::Code clusterNotFoundResponseCode() const override {
+      return Http::Code::InternalServerError;
+    }
+    const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
+    absl::optional<std::string>
+    currentUrlPathAfterRewrite(const Http::RequestHeaderMap&) const override {
+      return {};
+    }
+    void finalizeRequestHeaders(Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
+                                bool) const override {}
+    Http::HeaderTransforms requestHeaderTransforms(const StreamInfo::StreamInfo&,
+                                                   bool) const override {
+      return {};
+    }
+    void finalizeResponseHeaders(Http::ResponseHeaderMap&,
+                                 const StreamInfo::StreamInfo&) const override {}
+    Http::HeaderTransforms responseHeaderTransforms(const StreamInfo::StreamInfo&,
+                                                    bool) const override {
+      return {};
+    }
+    const Http::HashPolicy* hashPolicy() const override { return hash_policy_.get(); }
+    const Router::HedgePolicy& hedgePolicy() const override { return hedge_policy_; }
+    const Router::MetadataMatchCriteria* metadataMatchCriteria() const override { return nullptr; }
+    Upstream::ResourcePriority priority() const override {
+      return Upstream::ResourcePriority::Default;
+    }
+    const Router::RateLimitPolicy& rateLimitPolicy() const override { return rate_limit_policy_; }
+    const Router::RetryPolicy& retryPolicy() const override { return *retry_policy_; }
+    const Router::InternalRedirectPolicy& internalRedirectPolicy() const override {
+      return internal_redirect_policy_;
+    }
+    const Router::PathMatcherSharedPtr& pathMatcher() const override { return path_matcher_; }
+    const Router::PathRewriterSharedPtr& pathRewriter() const override { return path_rewriter_; }
+    uint32_t retryShadowBufferLimit() const override {
+      return std::numeric_limits<uint32_t>::max();
+    }
+    const std::vector<Router::ShadowPolicyPtr>& shadowPolicies() const override {
+      return shadow_policies_;
+    }
+    std::chrono::milliseconds timeout() const override {
+      if (timeout_) {
+        return timeout_.value();
+      } else {
+        return std::chrono::milliseconds(0);
+      }
+    }
+    bool usingNewTimeouts() const override { return false; }
+    absl::optional<std::chrono::milliseconds> idleTimeout() const override { return absl::nullopt; }
+    absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
+      return absl::nullopt;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const override {
+      return absl::nullopt;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const override {
+      return absl::nullopt;
+    }
+    absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override {
+      return absl::nullopt;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutOffset() const override {
+      return absl::nullopt;
+    }
+    const Router::VirtualCluster* virtualCluster(const Http::HeaderMap&) const override {
+      return nullptr;
+    }
+    const Router::TlsContextMatchCriteria* tlsContextMatchCriteria() const override {
+      return nullptr;
+    }
+    const std::multimap<std::string, std::string>& opaqueConfig() const override {
+      return opaque_config_;
+    }
+    const Router::VirtualHost& virtualHost() const override { return virtual_host_; }
+    bool autoHostRewrite() const override { return false; }
+    bool appendXfh() const override { return false; }
+    bool includeVirtualHostRateLimits() const override { return true; }
+    const Router::PathMatchCriterion& pathMatchCriterion() const override {
+      return path_match_criterion_;
+    }
+
+    const ConnectConfigOptRef connectConfig() const override { return connect_config_nullopt_; }
+
+    bool includeAttemptCountInRequest() const override { return false; }
+    bool includeAttemptCountInResponse() const override { return false; }
+    const Router::RouteEntry::UpgradeMap& upgradeMap() const override { return upgrade_map_; }
+    const std::string& routeName() const override { return route_name_; }
+    const Router::EarlyDataPolicy& earlyDataPolicy() const override { return *early_data_policy_; }
+
+    std::unique_ptr<const Envoy::Http::HashPolicyImpl> hash_policy_;
+    std::unique_ptr<Router::RetryPolicy> retry_policy_;
+
+    static const NullHedgePolicy hedge_policy_;
+    static const NullRateLimitPolicy rate_limit_policy_;
+    static const Router::InternalRedirectPolicyImpl internal_redirect_policy_;
+    static const Router::PathMatcherSharedPtr path_matcher_;
+    static const Router::PathRewriterSharedPtr path_rewriter_;
+    static const std::vector<Router::ShadowPolicyPtr> shadow_policies_;
+    static const NullVirtualHost virtual_host_;
+    static const std::multimap<std::string, std::string> opaque_config_;
+    static const NullPathMatchCriterion path_match_criterion_;
+    static const ConnectConfigOptRef connect_config_nullopt_;
+
+    Router::RouteEntry::UpgradeMap upgrade_map_;
+    const std::string& cluster_name_;
+
+    absl::optional<std::chrono::milliseconds> timeout_;
+    const std::string route_name_;
+    // Pass early data option config through StreamOptions.
+    std::unique_ptr<Router::EarlyDataPolicy> early_data_policy_{
+        new Router::DefaultEarlyDataPolicy(true)};
+  };
+  struct RouteImpl : public Router::Route {
+    RouteImpl(Upstream::ThreadLocalCluster& thread_local_cluster, Upstream::LoadBalancerContext*)
+        : route_entry_(thread_local_cluster), typed_metadata_({}) {}
+
+    // Router::Route
+    const Router::DirectResponseEntry* directResponseEntry() const override { return nullptr; }
+    const Router::RouteEntry* routeEntry() const override { return &route_entry_; }
+    const Router::Decorator* decorator() const override { return nullptr; }
+    const Router::RouteTracing* tracingConfig() const override { return nullptr; }
+    const Router::RouteSpecificFilterConfig*
+    mostSpecificPerFilterConfig(const std::string&) const override {
+      return nullptr;
+    }
+    void traversePerFilterConfig(
+        const std::string&,
+        std::function<void(const Router::RouteSpecificFilterConfig&)>) const override {}
+    bool filterDisabled(absl::string_view) const override { return false; }
+    const envoy::config::core::v3::Metadata& metadata() const override { return metadata_; }
+    const Envoy::Config::TypedMetadata& typedMetadata() const override { return typed_metadata_; }
+
+    RouteEntryImpl route_entry_;
+    const envoy::config::core::v3::Metadata metadata_;
+    const Envoy::Config::TypedMetadataImpl<Envoy::Config::TypedMetadataFactory> typed_metadata_;
+  };
+
   class Callbacks {
   public:
     Callbacks(HttpConnPool& conn_pool, Upstream::HostDescriptionConstSharedPtr host,
               Ssl::ConnectionInfoConstSharedPtr ssl_info)
         : conn_pool_(&conn_pool), host_(host), ssl_info_(ssl_info) {}
     virtual ~Callbacks() = default;
-    virtual void onSuccess(Http::RequestEncoder& request_encoder) {
+    virtual void onSuccess(Http::RequestEncoder* request_encoder) {
       ASSERT(conn_pool_ != nullptr);
-      conn_pool_->onGenericPoolReady(host_, request_encoder.getStream().connectionInfoProvider(),
-                                     ssl_info_);
+      if (!Runtime::runtimeFeatureEnabled(
+              "envoy.reloadable_features.upstream_http_filters_with_tcp_proxy")) {
+        ASSERT(request_encoder != nullptr);
+        conn_pool_->onGenericPoolReady(host_, request_encoder->getStream().connectionInfoProvider(),
+                                       ssl_info_);
+        return;
+      }
+
+      Network::ConnectionInfoProviderSharedPtr local_connection_info_provider(
+          std::make_shared<Network::ConnectionInfoSetterImpl>(
+              Network::Utility::getCanonicalIpv4LoopbackAddress(),
+              Network::Utility::getCanonicalIpv4LoopbackAddress()));
+
+      conn_pool_->onGenericPoolReady(host_, *local_connection_info_provider.get(), ssl_info_);
     }
     virtual void onFailure() {
       ASSERT(conn_pool_ != nullptr);
@@ -101,9 +355,12 @@ private:
   absl::optional<Upstream::HttpPoolData> conn_pool_data_{};
   Http::ConnectionPool::Cancellable* upstream_handle_{};
   GenericConnectionPoolCallbacks* callbacks_{};
+  Http::StreamDecoderFilterCallbacks* decoder_filter_callbacks_;
   Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks_;
   std::unique_ptr<HttpUpstream> upstream_;
   StreamInfo::StreamInfo& downstream_info_;
+  std::unique_ptr<Router::GenericConnPool> generic_conn_pool_;
+  std::shared_ptr<RouteImpl> route_;
 };
 
 class TcpUpstream : public GenericUpstream {
@@ -123,16 +380,24 @@ private:
   Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;
 };
 
-class HttpUpstream : public GenericUpstream, protected Http::StreamCallbacks {
+class HttpUpstream : public GenericUpstream,
+                     public Envoy::Router::RouterFilterInterface,
+                     protected Http::StreamCallbacks {
 public:
   using TunnelingConfig =
       envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_TunnelingConfig;
 
+  using UpstreamRequest = Router::UpstreamRequest;
+  using UpstreamRequestPtr = std::unique_ptr<UpstreamRequest>;
+
   ~HttpUpstream() override;
+  virtual void setRouterUpstreamRequest(UpstreamRequestPtr) PURE;
+  virtual void newStream(GenericConnectionPoolCallbacks& callbacks) PURE;
   virtual bool isValidResponse(const Http::ResponseHeaderMap&) PURE;
 
   void doneReading();
   void doneWriting();
+  void cleanUp();
   Http::ResponseDecoder& responseDecoder() { return response_decoder_; }
 
   // GenericUpstream
@@ -157,9 +422,11 @@ public:
   Ssl::ConnectionInfoConstSharedPtr getUpstreamConnectionSslInfo() override { return nullptr; }
 
 protected:
-  HttpUpstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+  HttpUpstream(HttpConnPool& http_conn_pool, Http::StreamDecoderFilterCallbacks& decoder_callbacks,
+               Router::Route& route, Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
                const TunnelingConfigHelper& config, StreamInfo::StreamInfo& downstream_info);
-  void resetEncoder(Network::ConnectionEvent event, bool inform_downstream = true);
+  void virtual resetEncoder(Network::ConnectionEvent event, bool inform_downstream = true);
+  void onResetEncoder(Network::ConnectionEvent event, bool inform_downstream = true);
 
   // The encoder offered by the upstream http client.
   Http::RequestEncoder* request_encoder_{};
@@ -167,8 +434,58 @@ protected:
   const TunnelingConfigHelper& config_;
   // The downstream info that is owned by the downstream connection.
   StreamInfo::StreamInfo& downstream_info_;
+  std::list<UpstreamRequestPtr> upstream_requests_;
+  std::unique_ptr<Http::RequestHeaderMapImpl> downstream_headers_;
+  HttpConnPool& parent_;
 
 private:
+  // Router::RouterFilterInterface
+  void onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPtr&& headers,
+                         UpstreamRequest& upstream_request, bool end_stream) override;
+  void onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_request,
+                      bool end_stream) override;
+  void onUpstream1xxHeaders(Http::ResponseHeaderMapPtr&&, UpstreamRequest&) override {}
+  void onUpstreamTrailers(Http::ResponseTrailerMapPtr&&, UpstreamRequest&) override;
+  void onUpstreamMetadata(Http::MetadataMapPtr&&) override {}
+  void onUpstreamReset(Http::StreamResetReason stream_reset_reason,
+                       absl::string_view transport_failure_reason, UpstreamRequest&) override;
+  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host) override {
+    parent_.onUpstreamHostSelected(host);
+  }
+  void onPerTryTimeout(UpstreamRequest&) override {}
+  void onPerTryIdleTimeout(UpstreamRequest&) override {}
+  void onStreamMaxDurationReached(UpstreamRequest&) override {}
+  Http::StreamDecoderFilterCallbacks* callbacks() override { return &decoder_filter_callbacks_; }
+  Upstream::ClusterInfoConstSharedPtr cluster() override {
+    return decoder_filter_callbacks_.clusterInfo();
+  }
+  Router::FilterConfig& config() override {
+    return const_cast<Router::FilterConfig&>(config_.routerFilterConfig());
+  }
+  Router::FilterUtility::TimeoutData timeout() override { return {}; }
+  absl::optional<std::chrono::milliseconds> dynamicMaxStreamDuration() const override {
+    return absl::nullopt;
+  }
+  Http::RequestHeaderMap* downstreamHeaders() override;
+  Http::RequestTrailerMap* downstreamTrailers() override { return nullptr; }
+  bool downstreamResponseStarted() const override { return false; }
+  bool downstreamEndStream() const override { return false; }
+  uint32_t attemptCount() const override { return 0; }
+  const Router::VirtualCluster* requestVcluster() const override { return nullptr; }
+  const Router::RouteStatsContextOptRef routeStatsContext() const override {
+    return Router::RouteStatsContextOptRef();
+  }
+  const Router::Route* route() const override { return route_; }
+  const std::list<UpstreamRequestPtr>& upstreamRequests() const override {
+    // static const std::list<UpstreamRequestPtr> requests;
+    return upstream_requests_;
+  }
+  const UpstreamRequest* finalUpstreamRequest() const override { return nullptr; }
+  TimeSource& timeSource() override { return config().timeSource(); }
+
+  Upstream::ClusterInfoConstSharedPtr cluster_;
+  Http::StreamDecoderFilterCallbacks& decoder_filter_callbacks_;
+  Router::Route* route_;
   class DecoderShim : public Http::ResponseDecoder {
   public:
     DecoderShim(HttpUpstream& parent) : parent_(parent) {}
@@ -181,7 +498,7 @@ private:
       if (!is_valid_response || end_stream) {
         parent_.resetEncoder(Network::ConnectionEvent::LocalClose);
       } else if (parent_.conn_pool_callbacks_ != nullptr) {
-        parent_.conn_pool_callbacks_->onSuccess(*parent_.request_encoder_);
+        parent_.conn_pool_callbacks_->onSuccess(parent_.request_encoder_);
         parent_.conn_pool_callbacks_.reset();
       }
     }
@@ -219,21 +536,43 @@ private:
 
 class Http1Upstream : public HttpUpstream {
 public:
-  Http1Upstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+  Http1Upstream(HttpConnPool& http_conn_pool, Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+                Http::StreamDecoderFilterCallbacks& decoder_callbacks, Router::Route& route,
                 const TunnelingConfigHelper& config, StreamInfo::StreamInfo& downstream_info);
-
+  ~Http1Upstream() override;
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void setRequestEncoder(Http::RequestEncoder& request_encoder, bool is_ssl) override;
   bool isValidResponse(const Http::ResponseHeaderMap& headers) override;
+  void newStream(GenericConnectionPoolCallbacks&) override {}
+  void setRouterUpstreamRequest(UpstreamRequestPtr) override {}
 };
 
 class Http2Upstream : public HttpUpstream {
 public:
-  Http2Upstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+  Http2Upstream(HttpConnPool& http_conn_pool, Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+                Http::StreamDecoderFilterCallbacks& decoder_callbacks, Router::Route& route,
                 const TunnelingConfigHelper& config, StreamInfo::StreamInfo& downstream_info);
-
+  ~Http2Upstream() override;
   void setRequestEncoder(Http::RequestEncoder& request_encoder, bool is_ssl) override;
   bool isValidResponse(const Http::ResponseHeaderMap& headers) override;
+  void newStream(GenericConnectionPoolCallbacks&) override {}
+  void setRouterUpstreamRequest(UpstreamRequestPtr) override {}
+};
+
+class CombinedUpstream : public HttpUpstream {
+public:
+  CombinedUpstream(HttpConnPool& http_conn_pool, Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+                   Http::StreamDecoderFilterCallbacks& decoder_callbacks, Router::Route& route,
+                   const TunnelingConfigHelper& config, StreamInfo::StreamInfo& downstream_info);
+  ~CombinedUpstream() override;
+  void setRouterUpstreamRequest(UpstreamRequestPtr) override;
+  void newStream(GenericConnectionPoolCallbacks& callbacks) override;
+  void encodeData(Buffer::Instance& data, bool end_stream) override;
+  Tcp::ConnectionPool::ConnectionData* onDownstreamEvent(Network::ConnectionEvent event) override;
+  void setRequestEncoder(Http::RequestEncoder&, bool) override {}
+  bool isValidResponse(const Http::ResponseHeaderMap&) override;
+  void resetEncoder(Network::ConnectionEvent event, bool inform_downstream = true) override;
+  bool readDisable(bool disable) override;
 };
 
 } // namespace TcpProxy

--- a/source/extensions/upstreams/tcp/generic/BUILD
+++ b/source/extensions/upstreams/tcp/generic/BUILD
@@ -18,6 +18,7 @@ envoy_cc_extension(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//envoy/http:filter_interface",
         "//envoy/stream_info:bool_accessor_interface",
         "//source/common/http:codec_client_lib",
         "//source/common/tcp_proxy:upstream_lib",

--- a/source/extensions/upstreams/tcp/generic/config.cc
+++ b/source/extensions/upstreams/tcp/generic/config.cc
@@ -16,6 +16,7 @@ TcpProxy::GenericConnPoolPtr GenericConnPoolFactory::createGenericConnPool(
     Upstream::ThreadLocalCluster& thread_local_cluster,
     TcpProxy::TunnelingConfigHelperOptConstRef config, Upstream::LoadBalancerContext* context,
     Envoy::Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks,
+    Http::StreamDecoderFilterCallbacks& stream_decoder_callbacks,
     StreamInfo::StreamInfo& downstream_info) const {
   if (config.has_value() && !disableTunnelingByFilterState(downstream_info)) {
     Http::CodecType pool_type;
@@ -28,7 +29,8 @@ TcpProxy::GenericConnPoolPtr GenericConnPoolFactory::createGenericConnPool(
       pool_type = Http::CodecType::HTTP1;
     }
     auto ret = std::make_unique<TcpProxy::HttpConnPool>(
-        thread_local_cluster, context, *config, upstream_callbacks, pool_type, downstream_info);
+        thread_local_cluster, context, *config, upstream_callbacks, stream_decoder_callbacks,
+        pool_type, downstream_info);
     return (ret->valid() ? std::move(ret) : nullptr);
   }
   auto ret =

--- a/source/extensions/upstreams/tcp/generic/config.h
+++ b/source/extensions/upstreams/tcp/generic/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/extensions/upstreams/tcp/generic/v3/generic_connection_pool.pb.h"
+#include "envoy/http/filter.h"
 #include "envoy/registry/registry.h"
 #include "envoy/tcp/upstream.h"
 
@@ -22,6 +23,7 @@ public:
                         TcpProxy::TunnelingConfigHelperOptConstRef config,
                         Upstream::LoadBalancerContext* context,
                         Envoy::Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks,
+                        Http::StreamDecoderFilterCallbacks& stream_decoder_callbacks,
                         StreamInfo::StreamInfo& downstream_info) const override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/test/common/tcp_proxy/BUILD
+++ b/test/common/tcp_proxy/BUILD
@@ -79,9 +79,12 @@ envoy_cc_test(
     deps = [
         "//source/common/tcp_proxy",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/router:upstream_request",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/stats:stats_mocks",
         "//test/mocks/tcp:tcp_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/mocks/upstream:load_balancer_context_mock",
         "//test/test_common:test_runtime_lib",
     ],
 )

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -6,8 +6,11 @@
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/http/stream_encoder.h"
+#include "test/mocks/router/upstream_request.h"
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/stats/mocks.h"
 #include "test/mocks/tcp/mocks.h"
+#include "test/mocks/upstream/load_balancer_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/test_runtime.h"
@@ -23,58 +26,123 @@ using testing::Return;
 namespace Envoy {
 namespace TcpProxy {
 namespace {
-using envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_TunnelingConfig;
+using envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy;
 
 template <typename T> class HttpUpstreamTest : public testing::Test {
 public:
   HttpUpstreamTest() {
     EXPECT_CALL(encoder_, getStream()).Times(AnyNumber());
-    EXPECT_CALL(encoder_, encodeHeaders(_, false));
     EXPECT_CALL(encoder_, http1StreamEncoderOptions()).Times(AnyNumber());
     EXPECT_CALL(encoder_, enableTcpTunneling()).Times(AnyNumber());
+    if (typeid(T) != typeid(CombinedUpstream)) {
+      EXPECT_CALL(encoder_, encodeHeaders(_, false));
+    }
     if (typeid(T) == typeid(Http1Upstream)) {
       ON_CALL(encoder_, http1StreamEncoderOptions())
           .WillByDefault(Return(Http::Http1StreamEncoderOptionsOptRef(stream_encoder_options_)));
     }
     EXPECT_CALL(stream_encoder_options_, enableHalfClose()).Times(AnyNumber());
-    config_message_.set_hostname("default.host.com:443");
+    tcp_proxy_.mutable_tunneling_config()->set_hostname("default.host.com:443");
+  }
+
+  void expectCallOnEncodeData(std::string data_string, bool end_stream) {
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      EXPECT_CALL(*this->mock_router_upstream_request_,
+                  acceptDataFromRouter(BufferStringEqual(data_string), end_stream));
+    } else {
+      EXPECT_CALL(this->encoder_, encodeData(BufferStringEqual(data_string), end_stream));
+    }
+  }
+
+  void expectCallOnReadDisable(bool disable) {
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      disable ? EXPECT_CALL(*this->mock_router_upstream_request_, onAboveWriteBufferHighWatermark())
+                    .Times(1)
+              : EXPECT_CALL(*this->mock_router_upstream_request_, onAboveWriteBufferHighWatermark())
+                    .Times(0);
+    } else {
+      EXPECT_CALL(this->encoder_.stream_, readDisable(disable));
+    }
+  }
+
+  void expectCallOnResetStream() {
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      EXPECT_CALL(*this->mock_router_upstream_request_, resetStream());
+    } else {
+      EXPECT_CALL(this->encoder_.stream_, resetStream(Http::StreamResetReason::LocalReset));
+    }
   }
 
   void setupUpstream() {
-    config_ = std::make_unique<TunnelingConfigHelperImpl>(config_message_, context_);
-    upstream_ = std::make_unique<T>(callbacks_, *this->config_, downstream_stream_info_);
-    upstream_->setRequestEncoder(encoder_, true);
+    route_ = std::make_unique<HttpConnPool::RouteImpl>(cluster_, &lb_context_);
+    tunnel_config_ = std::make_unique<TunnelingConfigHelperImpl>(scope_, tcp_proxy_, context_);
+    conn_pool_ = std::make_unique<HttpConnPool>(cluster_, &lb_context_, *tunnel_config_, callbacks_,
+                                                decoder_callbacks_, Http::CodecType::HTTP2,
+                                                downstream_stream_info_);
+    upstream_ = std::make_unique<T>(*conn_pool_, callbacks_, decoder_callbacks_, *route_,
+                                    *tunnel_config_, downstream_stream_info_);
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      auto mock_conn_pool = std::make_unique<NiceMock<Router::MockGenericConnPool>>();
+      std::unique_ptr<Router::GenericConnPool> generic_conn_pool = std::move(mock_conn_pool);
+      config_ = std::make_shared<Config>(tcp_proxy_, factory_context_);
+      filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
+      filter_->initializeReadFilterCallbacks(filter_callbacks_);
+      auto mock_upst = std::make_unique<NiceMock<Router::MockUpstreamRequest>>(
+          *upstream_, std::move(generic_conn_pool));
+      mock_router_upstream_request_ = mock_upst.get();
+      upstream_->setRouterUpstreamRequest(std::move(mock_upst));
+      EXPECT_CALL(*mock_router_upstream_request_, acceptHeadersFromRouter(false));
+      upstream_->newStream(*filter_);
+    } else {
+      upstream_->setRequestEncoder(encoder_, true);
+    }
   }
+
+  Router::MockUpstreamRequest* mock_router_upstream_request_{};
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
+  ConfigSharedPtr config_;
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+  std::unique_ptr<Filter> filter_;
 
   NiceMock<StreamInfo::MockStreamInfo> downstream_stream_info_;
   Http::MockRequestEncoder encoder_;
   Http::MockHttp1StreamEncoderOptions stream_encoder_options_;
   NiceMock<Tcp::ConnectionPool::MockUpstreamCallbacks> callbacks_;
-  TcpProxy_TunnelingConfig config_message_;
-  std::unique_ptr<TunnelingConfigHelper> config_;
-  std::unique_ptr<HttpUpstream> upstream_;
+  TcpProxy tcp_proxy_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  Router::MockGenericConnPool* generic_conn_pool_{};
   NiceMock<Server::Configuration::MockFactoryContext> context_;
+  NiceMock<Upstream::MockThreadLocalCluster> cluster_;
+  NiceMock<Upstream::MockLoadBalancerContext> lb_context_;
+  std::unique_ptr<HttpConnPool> conn_pool_;
+  NiceMock<Stats::MockStore> store_;
+  Stats::MockScope& scope_{store_.mockScope()};
+  std::unique_ptr<TunnelingConfigHelper> tunnel_config_;
+  std::unique_ptr<HttpConnPool::RouteImpl> route_;
+  std::unique_ptr<HttpUpstream> upstream_;
 };
 
 using testing::Types;
 
-using Implementations = Types<Http1Upstream, Http2Upstream>;
+using Implementations = Types<Http1Upstream, Http2Upstream, CombinedUpstream>;
 
 TYPED_TEST_SUITE(HttpUpstreamTest, Implementations);
 
 TYPED_TEST(HttpUpstreamTest, WriteUpstream) {
   this->setupUpstream();
-  EXPECT_CALL(this->encoder_, encodeData(BufferStringEqual("foo"), false));
+  this->expectCallOnEncodeData("foo", false);
   Buffer::OwnedImpl buffer1("foo");
   this->upstream_->encodeData(buffer1, false);
-
-  EXPECT_CALL(this->encoder_, encodeData(BufferStringEqual("bar"), true));
+  this->expectCallOnEncodeData("bar", true);
   Buffer::OwnedImpl buffer2("bar");
   this->upstream_->encodeData(buffer2, true);
 
   // New upstream with no encoder.
-  this->upstream_ =
-      std::make_unique<TypeParam>(this->callbacks_, *this->config_, this->downstream_stream_info_);
+  auto mock_conn_pool = std::make_unique<NiceMock<Router::MockGenericConnPool>>();
+  std::unique_ptr<Router::GenericConnPool> generic_conn_pool = std::move(mock_conn_pool);
+  this->upstream_ = std::make_unique<TypeParam>(
+      *this->conn_pool_, this->callbacks_, this->decoder_callbacks_, *this->route_,
+      *this->tunnel_config_, this->downstream_stream_info_);
   this->upstream_->encodeData(buffer2, true);
 }
 
@@ -105,15 +173,18 @@ TYPED_TEST(HttpUpstreamTest, InvalidUpgradeWithNon200) {
 
 TYPED_TEST(HttpUpstreamTest, ReadDisable) {
   this->setupUpstream();
-  EXPECT_CALL(this->encoder_.stream_, readDisable(true));
+  this->expectCallOnReadDisable(true);
   EXPECT_TRUE(this->upstream_->readDisable(true));
 
-  EXPECT_CALL(this->encoder_.stream_, readDisable(false));
+  this->expectCallOnReadDisable(false);
   EXPECT_TRUE(this->upstream_->readDisable(false));
 
   // New upstream with no encoder.
-  this->upstream_ =
-      std::make_unique<TypeParam>(this->callbacks_, *this->config_, this->downstream_stream_info_);
+  auto mock_conn_pool = std::make_unique<NiceMock<Router::MockGenericConnPool>>();
+  std::unique_ptr<Router::GenericConnPool> generic_conn_pool = std::move(mock_conn_pool);
+  this->upstream_ = std::make_unique<TypeParam>(
+      *this->conn_pool_, this->callbacks_, this->decoder_callbacks_, *this->route_,
+      *this->tunnel_config_, this->downstream_stream_info_);
   EXPECT_FALSE(this->upstream_->readDisable(true));
 }
 
@@ -124,7 +195,7 @@ TYPED_TEST(HttpUpstreamTest, AddBytesSentCallbackForCoverage) {
 
 TYPED_TEST(HttpUpstreamTest, DownstreamDisconnect) {
   this->setupUpstream();
-  EXPECT_CALL(this->encoder_.stream_, resetStream(Http::StreamResetReason::LocalReset));
+  this->expectCallOnResetStream();
   EXPECT_CALL(this->callbacks_, onEvent(_)).Times(0);
   EXPECT_TRUE(this->upstream_->onDownstreamEvent(Network::ConnectionEvent::LocalClose) == nullptr);
 }
@@ -147,11 +218,16 @@ TYPED_TEST(HttpUpstreamTest, UpstreamWatermarks) {
 
 class MockHttpConnPoolCallbacks : public HttpConnPool::Callbacks {
 public:
-  MOCK_METHOD(void, onSuccess, (Http::RequestEncoder & request_encoder));
+  MOCK_METHOD(void, onSuccess, (Http::RequestEncoder * request_encoder));
   MOCK_METHOD(void, onFailure, ());
 };
 
 TYPED_TEST(HttpUpstreamTest, DownstreamDisconnectBeforeConnectResponse) {
+  if (std::is_same<TypeParam, CombinedUpstream>::value) {
+    // CombinedUpstream sets connPoolCallbacks_ when onUpstreamHostSelected is called
+    // by Router::UpstreamRequest. Hence this test is not applicable.
+    return;
+  }
   this->setupUpstream();
   auto conn_pool_callbacks = std::make_unique<MockHttpConnPoolCallbacks>();
   auto conn_pool_callbacks_raw = conn_pool_callbacks.get();
@@ -207,10 +283,11 @@ TYPED_TEST(HttpUpstreamTest, UpstreamTrailersNotMarksDoneReadingWhenFeatureDisab
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.finish_reading_on_decode_trailers", "false"}});
   this->setupUpstream();
-  EXPECT_CALL(this->encoder_.stream_, resetStream(_));
+  this->expectCallOnResetStream();
   this->upstream_->doneWriting();
   Http::ResponseTrailerMapPtr trailers{new Http::TestResponseTrailerMapImpl{{"key", "value"}}};
   this->upstream_->responseDecoder().decodeTrailers(std::move(trailers));
+  this->upstream_->cleanUp();
 }
 
 template <typename T> class HttpUpstreamRequestEncoderTest : public testing::Test {
@@ -225,14 +302,50 @@ public:
           .WillByDefault(Return(Http::Http1StreamEncoderOptionsOptRef(stream_encoder_options_)));
       is_http2_ = false;
     }
-    config_message_.set_hostname("default.host.com:443");
+    tcp_proxy_.mutable_tunneling_config()->set_hostname("default.host.com:443");
   }
 
   void setupUpstream() {
-    config_ = std::make_unique<TunnelingConfigHelperImpl>(config_message_, context_);
-    upstream_ = std::make_unique<T>(callbacks_, *this->config_, this->downstream_stream_info_);
+    route_ = std::make_unique<HttpConnPool::RouteImpl>(cluster_, &lb_context_);
+    config_ = std::make_unique<TunnelingConfigHelperImpl>(scope_, tcp_proxy_, context_);
+    conn_pool_ = std::make_unique<HttpConnPool>(cluster_, &lb_context_, *config_, callbacks_,
+                                                decoder_callbacks_, Http::CodecType::HTTP2,
+                                                downstream_stream_info_);
+    upstream_ = std::make_unique<T>(*conn_pool_, callbacks_, decoder_callbacks_, *route_, *config_,
+                                    downstream_stream_info_);
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      auto mock_conn_pool = std::make_unique<NiceMock<Router::MockGenericConnPool>>();
+      std::unique_ptr<Router::GenericConnPool> generic_conn_pool = std::move(mock_conn_pool);
+      filter_config_ = std::make_shared<Config>(tcp_proxy_, factory_context_);
+      filter_ = std::make_unique<Filter>(filter_config_, factory_context_.cluster_manager_);
+      filter_->initializeReadFilterCallbacks(filter_callbacks_);
+      auto mock_upst = std::make_unique<NiceMock<Router::MockUpstreamRequest>>(
+          *upstream_, std::move(generic_conn_pool));
+      mock_router_upstream_request_ = mock_upst.get();
+      upstream_->setRouterUpstreamRequest(std::move(mock_upst));
+    }
   }
 
+  void setRequestEncoderAndVerifyHeaders(Http::RequestHeaderMapImpl* expected_headers,
+                                         bool end_stream = false) {
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      upstream_->newStream(*filter_);
+      Router::RouterFilterInterface* router_filter =
+          dynamic_cast<Router::RouterFilterInterface*>(this->upstream_.get());
+      EXPECT_THAT(*router_filter->downstreamHeaders(), HeaderMapEqualRef(expected_headers));
+    } else {
+      upstream_->setRequestEncoder(encoder_, end_stream);
+    }
+  }
+
+  void expectCallOnSetRequestEncoder(Http::RequestHeaderMapImpl* expected_headers,
+                                     bool end_stream = false) {
+    if (typeid(T) == typeid(CombinedUpstream)) {
+      EXPECT_CALL(*mock_router_upstream_request_, acceptHeadersFromRouter(end_stream));
+    } else {
+      EXPECT_CALL(encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers), end_stream));
+    }
+  }
   void populateMetadata(envoy::config::core::v3::Metadata& metadata, const std::string& ns,
                         const std::string& key, const std::string& value) {
     ProtobufWkt::Struct struct_obj;
@@ -241,16 +354,30 @@ public:
     (*metadata.mutable_filter_metadata())[ns] = struct_obj;
   }
 
+  Router::MockUpstreamRequest* mock_router_upstream_request_{};
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
+  ConfigSharedPtr filter_config_;
+  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+  std::unique_ptr<Filter> filter_;
+
   NiceMock<StreamInfo::MockStreamInfo> downstream_stream_info_;
   Http::MockRequestEncoder encoder_;
   Http::MockHttp1StreamEncoderOptions stream_encoder_options_;
   NiceMock<Tcp::ConnectionPool::MockUpstreamCallbacks> callbacks_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
 
-  std::unique_ptr<HttpUpstream> upstream_;
-  TcpProxy_TunnelingConfig config_message_;
+  TcpProxy tcp_proxy_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   std::unique_ptr<TunnelingConfigHelper> config_;
   bool is_http2_ = true;
+  std::unique_ptr<HttpConnPool> conn_pool_;
+  std::unique_ptr<Router::GenericConnPool> generic_conn_pool_;
+  NiceMock<Upstream::MockThreadLocalCluster> cluster_;
+  NiceMock<Upstream::MockLoadBalancerContext> lb_context_;
+  NiceMock<Stats::MockStore> store_;
+  Stats::MockScope& scope_{store_.mockScope()};
+  std::unique_ptr<HttpConnPool::RouteImpl> route_;
+  std::unique_ptr<HttpUpstream> upstream_;
 };
 
 TYPED_TEST_SUITE(HttpUpstreamRequestEncoderTest, Implementations);
@@ -262,13 +389,12 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoder) {
       {Http::Headers::get().Method, "CONNECT"},
       {Http::Headers::get().Host, this->config_->host(this->downstream_stream_info_)},
   });
-
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderUsePost) {
-  this->config_message_.set_use_post(true);
+  this->tcp_proxy_.mutable_tunneling_config()->set_use_post(true);
   this->setupUpstream();
   std::unique_ptr<Http::RequestHeaderMapImpl> expected_headers;
   expected_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>({
@@ -281,14 +407,13 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderUsePost) {
     expected_headers->addReference(Http::Headers::get().Scheme,
                                    Http::Headers::get().SchemeValues.Http);
   }
-
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderUsePostWithCustomPath) {
-  this->config_message_.set_use_post(true);
-  this->config_message_.set_post_path("/test");
+  this->tcp_proxy_.mutable_tunneling_config()->set_use_post(true);
+  this->tcp_proxy_.mutable_tunneling_config()->set_post_path("/test");
   this->setupUpstream();
   std::unique_ptr<Http::RequestHeaderMapImpl> expected_headers;
   expected_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>({
@@ -302,30 +427,30 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderUsePostWithCustomPath) 
                                    Http::Headers::get().SchemeValues.Http);
   }
 
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderConnectWithCustomPath) {
-  this->config_message_.set_use_post(false);
-  this->config_message_.set_post_path("/test");
+  this->tcp_proxy_.mutable_tunneling_config()->set_use_post(false);
+  this->tcp_proxy_.mutable_tunneling_config()->set_post_path("/test");
   EXPECT_THROW_WITH_MESSAGE(this->setupUpstream(), EnvoyException,
                             "Can't set a post path when POST method isn't used");
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderHeaders) {
-  auto* header = this->config_message_.add_headers_to_add();
+  auto* header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   auto* hdr = header->mutable_header();
   hdr->set_key("header0");
   hdr->set_value("value0");
 
-  header = this->config_message_.add_headers_to_add();
+  header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   hdr = header->mutable_header();
   hdr->set_key("header1");
   hdr->set_value("value1");
   header->set_append_action(envoy::config::core::v3::HeaderValueOption::APPEND_IF_EXISTS_OR_ADD);
 
-  header = this->config_message_.add_headers_to_add();
+  header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   hdr = header->mutable_header();
   hdr->set_key("header1");
   hdr->set_value("value2");
@@ -342,18 +467,18 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderHeaders) {
   expected_headers->addCopy(Http::LowerCaseString("header1"), "value1");
   expected_headers->addCopy(Http::LowerCaseString("header1"), "value2");
 
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest, ConfigReuse) {
-  auto* header = this->config_message_.add_headers_to_add();
+  auto* header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   auto* hdr = header->mutable_header();
   hdr->set_key("key");
   hdr->set_value("value1");
   header->set_append_action(envoy::config::core::v3::HeaderValueOption::APPEND_IF_EXISTS_OR_ADD);
 
-  header = this->config_message_.add_headers_to_add();
+  header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   hdr = header->mutable_header();
   hdr->set_key("key");
   hdr->set_value("value2");
@@ -371,13 +496,14 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, ConfigReuse) {
 
   expected_headers->setCopy(Http::LowerCaseString("key"), "value1");
   expected_headers->addCopy(Http::LowerCaseString("key"), "value2");
-
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 
   Http::MockRequestEncoder another_encoder;
   auto another_upstream =
-      std::make_unique<TypeParam>(this->callbacks_, *this->config_, this->downstream_stream_info_);
+      std::make_unique<TypeParam>(*this->conn_pool_, this->callbacks_, this->decoder_callbacks_,
+                                  *this->route_, *this->config_, this->downstream_stream_info_);
+
   EXPECT_CALL(another_encoder, getStream()).Times(AnyNumber());
   EXPECT_CALL(another_encoder, http1StreamEncoderOptions()).Times(AnyNumber());
   EXPECT_CALL(another_encoder, enableTcpTunneling()).Times(AnyNumber());
@@ -386,17 +512,32 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, ConfigReuse) {
         .WillByDefault(
             Return(Http::Http1StreamEncoderOptionsOptRef(this->stream_encoder_options_)));
   }
-  EXPECT_CALL(another_encoder, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  another_upstream->setRequestEncoder(another_encoder, false);
+
+  if (typeid(TypeParam) == typeid(CombinedUpstream)) {
+    auto mock_conn_pool = std::make_unique<NiceMock<Router::MockGenericConnPool>>();
+    std::unique_ptr<Router::GenericConnPool> generic_conn_pool = std::move(mock_conn_pool);
+    auto mock_upst = std::make_unique<NiceMock<Router::MockUpstreamRequest>>(
+        *another_upstream, std::move(generic_conn_pool));
+    auto another_router_upstream_request = mock_upst.get();
+    another_upstream->setRouterUpstreamRequest(std::move(mock_upst));
+    EXPECT_CALL(*another_router_upstream_request, acceptHeadersFromRouter(false));
+    another_upstream->newStream(*this->filter_);
+    Router::RouterFilterInterface* router_filter =
+        dynamic_cast<Router::RouterFilterInterface*>(another_upstream.get());
+    EXPECT_THAT(*router_filter->downstreamHeaders(), HeaderMapEqualRef(expected_headers.get()));
+  } else {
+    EXPECT_CALL(another_encoder, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
+    another_upstream->setRequestEncoder(another_encoder, false);
+  }
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderHeadersWithDownstreamInfo) {
-  auto* header = this->config_message_.add_headers_to_add();
+  auto* header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   auto* hdr = header->mutable_header();
   hdr->set_key("header0");
   hdr->set_value("value0");
 
-  header = this->config_message_.add_headers_to_add();
+  header = this->tcp_proxy_.mutable_tunneling_config()->add_headers_to_add();
   hdr = header->mutable_header();
   hdr->set_key("downstream_local_port");
   hdr->set_value("%DOWNSTREAM_LOCAL_PORT%");
@@ -419,13 +560,13 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest, RequestEncoderHeadersWithDownstreamIn
   Network::ConnectionInfoSetterImpl connection_info(ip_port, ip_port);
   EXPECT_CALL(this->downstream_stream_info_, downstreamAddressProvider)
       .WillRepeatedly(testing::ReturnRef(connection_info));
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest,
            RequestEncoderHostnameWithDownstreamInfoRequestedServerName) {
-  this->config_message_.set_hostname("%REQUESTED_SERVER_NAME%:443");
+  this->tcp_proxy_.mutable_tunneling_config()->set_hostname("%REQUESTED_SERVER_NAME%:443");
   this->setupUpstream();
 
   std::unique_ptr<Http::RequestHeaderMapImpl> expected_headers;
@@ -442,15 +583,16 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest,
   Network::ConnectionInfoSetterImpl connection_info(ip_port, ip_port);
   connection_info.setRequestedServerName("www.google.com");
   EXPECT_CALL(this->downstream_stream_info_, downstreamAddressProvider)
-      .Times(2)
+      .Times(AnyNumber())
       .WillRepeatedly(testing::ReturnRef(connection_info));
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 
 TYPED_TEST(HttpUpstreamRequestEncoderTest,
            RequestEncoderHostnameWithDownstreamInfoDynamicMetadata) {
-  this->config_message_.set_hostname("%DYNAMIC_METADATA(tunnel:address)%:443");
+  this->tcp_proxy_.mutable_tunneling_config()->set_hostname(
+      "%DYNAMIC_METADATA(tunnel:address)%:443");
   this->setupUpstream();
 
   std::unique_ptr<Http::RequestHeaderMapImpl> expected_headers;
@@ -467,8 +609,8 @@ TYPED_TEST(HttpUpstreamRequestEncoderTest,
 
   EXPECT_CALL(testing::Const(this->downstream_stream_info_), dynamicMetadata())
       .WillRepeatedly(testing::ReturnRef(metadata));
-  EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
-  this->upstream_->setRequestEncoder(this->encoder_, false);
+  this->expectCallOnSetRequestEncoder(expected_headers.get(), false);
+  this->setRequestEncoderAndVerifyHeaders(expected_headers.get());
 }
 } // namespace
 } // namespace TcpProxy

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -72,6 +72,7 @@ template <class T> static void initializeMockStreamFilterCallbacks(T& callbacks)
 
 MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
   initializeMockStreamFilterCallbacks(*this);
+  ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, decodingBuffer()).WillByDefault(Invoke(&buffer_, &Buffer::InstancePtr::get));
 
   ON_CALL(*this, addDownstreamWatermarkCallbacks(_))

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -109,6 +109,7 @@ public:
   MOCK_METHOD(OptRef<const Tracing::Config>, tracingConfig, (), (const));
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, restoreContextOnContinue, (ScopeTrackedObjectStack&));
+  MOCK_METHOD(bool, isHalfCloseEnabled, ());
 
   ResponseHeaderMapPtr informational_headers_;
   ResponseHeaderMapPtr response_headers_;

--- a/test/mocks/router/BUILD
+++ b/test/mocks/router/BUILD
@@ -49,3 +49,12 @@ envoy_cc_mock(
         "//test/test_common:test_time_lib",
     ],
 )
+
+envoy_cc_mock(
+    name = "upstream_request",
+    srcs = ["upstream_request.cc"],
+    hdrs = ["upstream_request.h"],
+    deps = [
+        "//source/common/router:router_lib",
+    ],
+)

--- a/test/mocks/router/upstream_request.cc
+++ b/test/mocks/router/upstream_request.cc
@@ -1,0 +1,13 @@
+#include "test/mocks/router/upstream_request.h"
+
+namespace Envoy {
+namespace Router {
+
+MockUpstreamRequest::MockUpstreamRequest(RouterFilterInterface& router_interface,
+                                         std::unique_ptr<GenericConnPool>&& conn_pool)
+    : UpstreamRequest(router_interface, std::move(conn_pool), false, true, true) {}
+
+MockUpstreamRequest::~MockUpstreamRequest() = default;
+
+} // namespace Router
+} // namespace Envoy

--- a/test/mocks/router/upstream_request.h
+++ b/test/mocks/router/upstream_request.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "source/common/router/upstream_request.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Router {
+
+class MockUpstreamRequest : public UpstreamRequest {
+public:
+  MockUpstreamRequest(RouterFilterInterface& router_interface, std::unique_ptr<GenericConnPool>&&);
+  ~MockUpstreamRequest() override;
+  MOCK_METHOD(void, acceptHeadersFromRouter, (bool end_stream), (override));
+  MOCK_METHOD(void, acceptDataFromRouter, (Buffer::Instance & data, bool end_stream), (override));
+  MOCK_METHOD(void, onAboveWriteBufferHighWatermark, (), (override));
+  MOCK_METHOD(void, resetStream, (), (override));
+};
+
+} // namespace Router
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: This PR is carved out of https://github.com/envoyproxy/envoy/pull/27183#discussion_r1218113408
Additional Description: This PR adds a new upstream in tcpproxy, CombinedUpstream which own a Router::UpstreamRequest instance. There are only refactoring changes to add this new upstream but there are no functional changes as this new upstream is not initialized yet.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
