### PR TITLE
Temporary fix for ext_proc coverage issue.

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -35,6 +35,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/common/fault:94.5"
 "source/extensions/filters/common/rbac:90.5"
 "source/extensions/filters/http/cache:93.4"
+"source/extensions/filters/http/ext_proc:96.0" # TODO(tyxia) Improve coverage for ext_proc/config.cc
 "source/extensions/filters/http/grpc_json_transcoder:95.6"
 "source/extensions/filters/http/ip_tagging:88.0"
 "source/extensions/filters/http/kill_request:91.7" # Death tests don't report LCOV


### PR DESCRIPTION

Commit Message:
Additional Description:
#27621 introduced a change which is leading to CI for subsequent (unrelated) PRs to fail with low coverage errors for the `ext_proc` extension: https://dev.azure.com/cncf/envoy/_build/results?buildId=140094&view=logs&j=5035ce29-be3c-5fcf-dc50-abb6a265f8b1&t=fa1604b8-8cc1-5fec-21c7-5a4fad8d70ea

Temporarily reduce the coverage for `source/extensions/filters/http/ext_proc` to unblock unrelated PRs as @tyxia works on adding a test to fix it.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A