### PR TITLE
mobile: Improve the xDS APIs on EngineBuilder

### DIFF
--- a/mobile/docs/root/api/starting_envoy.rst
+++ b/mobile/docs/root/api/starting_envoy.rst
@@ -495,67 +495,44 @@ Note that Envoy will fail to start up in debug mode if an unknown guard is speci
   // Swift
   builder.setRuntimeGuard("feature", true)
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-``addRtdsLayer``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Adds an RTDS layer to the bootstrap configuration.
-Requires that ADS be configured via `setAggregatedDiscoveryService()`.
-See the following link for details:
-https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto
-
-**Example**::
-
-  // Kotlin
-  builder.addRtdsLayer(layerName = "rtds_layer_name", timeoutSeconds = 10)
-
-  // Swift
-  builder.addRTDSLayer(layerName: "rtds_layer_name", timeoutSeconds: 10)
-
-  // C++
-  builder.addRtdsLayer("rtds_layer_name", 10)
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-``addCdsLayer``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Adds a CDS layer to the bootstrap configuration.
-Requires that ADS be configured via `setAggregatedDiscoveryService()`.
-See the following link for details:
-https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cds
-
-**Example**::
-
-  // Kotlin
-  builder.addCdsLayer(resourcesLocator = "xdstp://td-location.com/cluster_location", timeoutSeconds = 10)
-
-  // Swift
-  builder.addCDSLayer(resourcesLocator: "xdstp://td-location.com/cluster_location", timeoutSeconds: 10)
-
-  // C++
-  builder.addCdsLayer("xdstp://td-location.com/cluster_location", 10)
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``setAggregatedDiscoveryService``
+``setXds``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Adds ADS to bootstrap configuration, for instance to be used with RTDS and CDS layers.
-Optional params allow configuring a JWT token and SSL. See the following link for details:
-https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/xds_api#config-overview-ads
+Sets the Bootstrap configuration up with `xDS <https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/xds_api#config-overview-ads>`_
+to fetch dynamic configuration from an xDS management server. The xDS management server must
+support the ADS protocol. At this moment, only the State-of-the-World (SotW) xDS protocol is
+supported, not the Delta protocol. The Envoy Mobile client will communicate with the configured
+xDS management server over gRPC.
+
+Use the XdsBuilder class to configure the xDS for the Envoy Mobile engine.  For example, the
+`addRuntimeDiscoveryService()` method can be used to configure the
+`Runtime Discovery Service (RTDS) <https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto>`_
+and the `addClusterDiscoveryService()` method to configure the
+`Cluster Discovery Service (CDS) <https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cds>`_.
 
 Parameters:
-address, port, (optional) jwt_token, (optional) jwt_token_lifetime_seconds, (optional) ssl_root_certs
+xds_builder
 
 **Example**::
 
   // Kotlin
-  builder.setAggregatedDiscoveryService(address = "192.168.1.1", port = 0)
+  val xdsBuilder = new XdsBuilder(address = "my_xds_server.com", port = 443)
+                       .addRuntimeDiscoveryService("my_rtds_resource")
+                       .addClusterDiscoveryService()
+  builder.setXds(xdsBuilder)
 
   // Swift
-  builder.setAggregatedDiscoveryService(address: "192.168.1.1", port: 0)
+  var xdsBuilder = XdsBuilder(address: "my_xds_server.com", port: 443)
+                       .addRuntimeDiscoveryService("my_rtds_resource")
+                       .addClusterDiscoveryService()
+  builder.setXds(xdsBuilder)
 
   // C++
-  builder.setAggregatedDiscoveryService("192.168.1.1", 0)
+  auto xds_builder = std::make_unique<XdsBuilder>(/*address=*/"my_xds_server.com", /*port=*/443);
+  xds_builder->addRuntimeDiscoveryService("my_rtds_resource")
+      ->addClusterDiscoveryService();
+  builder.setXds(std::move(xds_builder));
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``setNodeId``

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -60,13 +60,13 @@ public class EnvoyConfiguration {
   public final List<String> statSinks;
   public final Map<String, String> runtimeGuards;
   public final Boolean enablePlatformCertificatesValidation;
-  public final String rtdsLayerName;
+  public final String rtdsResourceName;
   public final Integer rtdsTimeoutSeconds;
-  public final String adsAddress;
-  public final Integer adsPort;
-  public final String adsToken;
-  public final Integer adsTokenLifetime;
-  public final String adsRootCerts;
+  public final String xdsAddress;
+  public final Integer xdsPort;
+  public final String xdsJwtToken;
+  public final Integer xdsJwtTokenLifetime;
+  public final String xdsRootCerts;
   public final String nodeId;
   public final String nodeRegion;
   public final String nodeZone;
@@ -129,20 +129,20 @@ public class EnvoyConfiguration {
    * @param stringAccessors                               platform string accessors to register.
    * @param keyValueStores                                platform key-value store implementations.
    * @param enablePlatformCertificatesValidation          whether to use the platform verifier.
-   * @param rtdsLayerName                                 the RTDS layer name for this client.
+   * @param rtdsResourceName                                 the RTDS layer name for this client.
    * @param rtdsTimeoutSeconds                            the timeout for RTDS fetches.
-   * @param adsAddress                                    the address for the ADS server.
-   * @param adsPort                                       the port for the ADS server.
-   * @param adsToken                                      the token to use for authenticating with
-   *                                                      the ADS server.
-   * @param adsTokenLifetime                              the lifetime of the ADS token.
-   * @param adsRootCerts                                  the root certificates to use for
-   *     validating the ADS server.
-   * @param nodeId                                        the node ID to use for the ADS server.
-   * @param nodeRegion                                    the node region to use for the ADS server.
-   * @param nodeZone                                      the node zone to use for the ADS server.
-   * @param nodeSubZone                                   the node sub-zone to use for the ADS
-   *     server.
+   * @param xdsAddress                                    the address for the xDS management server.
+   * @param xdsPort                                       the port for the xDS server.
+   * @param xdsJwtToken                                   the JWT token to use for authenticating
+   *                                                      with the xDS server.
+   * @param xdsTokenLifetime                              the lifetime of the JWT token.
+   * @param xdsRootCerts                                  the root certificates to use for the TLS
+   *                                                      handshake during connection establishment
+   *                                                      with the xDS management server.
+   * @param nodeId                                        the node ID in the Node metadata.
+   * @param nodeRegion                                    the node region in the Node metadata.
+   * @param nodeZone                                      the node zone in the Node metadata.
+   * @param nodeSubZone                                   the node sub-zone in the Node metadata.
    * @param cdsResourcesLocator                           the resources locator for CDS.
    * @param cdsTimeoutSeconds                             the timeout for CDS fetches.
    * @param enableCds                                     enables CDS, used because all CDS params
@@ -164,8 +164,8 @@ public class EnvoyConfiguration {
       Map<String, EnvoyStringAccessor> stringAccessors,
       Map<String, EnvoyKeyValueStore> keyValueStores, List<String> statSinks,
       Map<String, Boolean> runtimeGuards, boolean enablePlatformCertificatesValidation,
-      String rtdsLayerName, Integer rtdsTimeoutSeconds, String adsAddress, Integer adsPort,
-      String adsToken, Integer adsTokenLifetime, String adsRootCerts, String nodeId,
+      String rtdsResourceName, Integer rtdsTimeoutSeconds, String xdsAddress, Integer xdsPort,
+      String xdsJwtToken, Integer xdsJwtTokenLifetime, String xdsRootCerts, String nodeId,
       String nodeRegion, String nodeZone, String nodeSubZone, String cdsResourcesLocator,
       Integer cdsTimeoutSeconds, boolean enableCds) {
     JniLibrary.load();
@@ -217,13 +217,13 @@ public class EnvoyConfiguration {
       this.runtimeGuards.put(guardAndValue.getKey(), String.valueOf(guardAndValue.getValue()));
     }
     this.enablePlatformCertificatesValidation = enablePlatformCertificatesValidation;
-    this.rtdsLayerName = rtdsLayerName;
+    this.rtdsResourceName = rtdsResourceName;
     this.rtdsTimeoutSeconds = rtdsTimeoutSeconds;
-    this.adsAddress = adsAddress;
-    this.adsPort = adsPort;
-    this.adsToken = adsToken;
-    this.adsTokenLifetime = adsTokenLifetime;
-    this.adsRootCerts = adsRootCerts;
+    this.xdsAddress = xdsAddress;
+    this.xdsPort = xdsPort;
+    this.xdsJwtToken = xdsJwtToken;
+    this.xdsJwtTokenLifetime = xdsJwtTokenLifetime;
+    this.xdsRootCerts = xdsRootCerts;
     this.nodeId = nodeId;
     this.nodeRegion = nodeRegion;
     this.nodeZone = nodeZone;
@@ -253,9 +253,9 @@ public class EnvoyConfiguration {
         h2ConnectionKeepaliveTimeoutSeconds, maxConnectionsPerHost, statsFlushSeconds,
         streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion, appId,
         enforceTrustChainVerification, filter_chain, stats_sinks,
-        enablePlatformCertificatesValidation, runtime_guards, rtdsLayerName, rtdsTimeoutSeconds,
-        adsAddress, adsPort, adsToken, adsTokenLifetime, adsRootCerts, nodeId, nodeRegion, nodeZone,
-        nodeSubZone, cdsResourcesLocator, cdsTimeoutSeconds, enableCds);
+        enablePlatformCertificatesValidation, runtime_guards, rtdsResourceName, rtdsTimeoutSeconds,
+        xdsAddress, xdsPort, xdsJwtToken, xdsJwtTokenLifetime, xdsRootCerts, nodeId, nodeRegion,
+        nodeZone, nodeSubZone, cdsResourcesLocator, cdsTimeoutSeconds, enableCds);
   }
 
   static class ConfigurationException extends RuntimeException {

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -309,8 +309,9 @@ public class JniLibrary {
       long maxConnectionsPerHost, long statsFlushSeconds, long streamIdleTimeoutSeconds,
       long perTryIdleTimeoutSeconds, String appVersion, String appId,
       boolean trustChainVerification, byte[][] filterChain, byte[][] statSinks,
-      boolean enablePlatformCertificatesValidation, byte[][] runtimeGuards, String rtdsLayerName,
-      long rtdsTimeoutSeconds, String adsAddress, long adsPort, String adsToken,
-      long adsTokenLifetime, String adsRootCerts, String nodeId, String nodeRegion, String nodeZone,
-      String nodeSubZone, String cdsResourcesLocator, long cdsTimeoutSeconds, boolean enableCds);
+      boolean enablePlatformCertificatesValidation, byte[][] runtimeGuards, String rtdsResourceName,
+      long rtdsTimeoutSeconds, String xdsAddress, long xdsPort, String xdsJwtToken,
+      long xdsJwtTokenLifetime, String xdsRootCerts, String nodeId, String nodeRegion,
+      String nodeZone, String nodeSubZone, String cdsResourcesLocator, long cdsTimeoutSeconds,
+      boolean enableCds);
 }

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -61,20 +61,10 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
   private String mAppId = "unspecified";
   private TrustChainVerification mTrustChainVerification = VERIFY_TRUST_CHAIN;
   private boolean mEnablePlatformCertificatesValidation = true;
-  private String mRtdsLayerName = "";
-  private int mRtdsTimeoutSeconds = 0;
-  private String mAdsAddress = "";
-  private int mAdsPort = 0;
-  private String mAdsToken = "";
-  private int mAdsTokenLifetime = 0;
-  private String mAdsRootCerts = "";
   private String mNodeId = "";
   private String mNodeRegion = "";
   private String mNodeZone = "";
   private String mNodeSubZone = "";
-  private String mCdsResourcesLocator = "";
-  private int mCdsTimeoutSeconds = 0;
-  private boolean mEnableCds = false;
 
   /**
    * Builder for Native Cronet Engine. Default config enables SPDY, disables QUIC and HTTP cache.
@@ -141,8 +131,9 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
         mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion, mAppId,
         mTrustChainVerification, nativeFilterChain, platformFilterChain, stringAccessors,
         keyValueStores, statSinks, runtimeGuards, mEnablePlatformCertificatesValidation,
-        mRtdsLayerName, mRtdsTimeoutSeconds, mAdsAddress, mAdsPort, mAdsToken, mAdsTokenLifetime,
-        mAdsRootCerts, mNodeId, mNodeRegion, mNodeZone, mNodeSubZone, mCdsResourcesLocator,
-        mCdsTimeoutSeconds, mEnableCds);
+        /*rtdsResourceName=*/"", /*rtdsTimeoutSeconds=*/0, /*xdsAddress=*/"",
+        /*xdsPort=*/0, /*xdsJwtToken=*/"", /*xdsJwtTokenLifetime=*/0, /*xdsSslRootCerts=*/"",
+        mNodeId, mNodeRegion, mNodeZone, mNodeSubZone, /*cdsResourcesLocator=*/"",
+        /*cdsTimeoutSeconds=*/0, /*enableCds=*/false);
   }
 }

--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -35,28 +35,28 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
-@property (nonatomic, strong) NSString *appVersion;
-@property (nonatomic, strong) NSString *appId;
+@property (nonatomic, strong, nullable) NSString *appVersion;
+@property (nonatomic, strong, nullable) NSString *appId;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *runtimeGuards;
 @property (nonatomic, strong) NSArray<EnvoyNativeFilterConfig *> *nativeFilterChain;
 @property (nonatomic, strong) NSArray<EnvoyHTTPFilterFactory *> *httpPlatformFilterFactories;
 @property (nonatomic, strong) NSDictionary<NSString *, EnvoyStringAccessor *> *stringAccessors;
 @property (nonatomic, strong) NSDictionary<NSString *, id<EnvoyKeyValueStore>> *keyValueStores;
 @property (nonatomic, strong) NSArray<NSString *> *statsSinks;
-@property (nonatomic, strong, nullable) NSString *rtdsLayerName;
-@property (nonatomic, assign) UInt32 rtdsTimeoutSeconds;
-@property (nonatomic, strong, nullable) NSString *adsAddress;
-@property (nonatomic, assign) UInt32 adsPort;
-@property (nonatomic, strong, nullable) NSString *adsJwtToken;
-@property (nonatomic, assign) UInt32 adsJwtTokenLifetimeSeconds;
-@property (nonatomic, strong, nullable) NSString *adsSslRootCerts;
 @property (nonatomic, strong, nullable) NSString *nodeId;
 @property (nonatomic, strong, nullable) NSString *nodeRegion;
 @property (nonatomic, strong, nullable) NSString *nodeZone;
 @property (nonatomic, strong, nullable) NSString *nodeSubZone;
-@property (nonatomic, strong) NSString *cdsResourcesLocator;
-@property (nonatomic, assign) UInt32 cdsTimeoutSeconds;
+@property (nonatomic, strong, nullable) NSString *xdsServerAddress;
+@property (nonatomic, assign) UInt32 xdsServerPort;
+@property (nonatomic, strong, nullable) NSString *xdsJwtToken;
+@property (nonatomic, assign) UInt32 xdsJwtTokenLifetimeSeconds;
+@property (nonatomic, strong, nullable) NSString *xdsSslRootCerts;
+@property (nonatomic, strong, nullable) NSString *rtdsResourceName;
+@property (nonatomic, assign) UInt32 rtdsTimeoutSeconds;
 @property (nonatomic, assign) BOOL enableCds;
+@property (nonatomic, strong, nullable) NSString *cdsResourcesLocator;
+@property (nonatomic, assign) UInt32 cdsTimeoutSeconds;
 @property (nonatomic, assign) intptr_t bootstrapPointer;
 
 /**
@@ -102,20 +102,20 @@ NS_ASSUME_NONNULL_BEGIN
                                        (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
                                            keyValueStores
                                        statsSinks:(NSArray<NSString *> *)statsSinks
-                                    rtdsLayerName:(nullable NSString *)rtdsLayerName
-                               rtdsTimeoutSeconds:(UInt32)rtdsTimeoutSeconds
-                                       adsAddress:(nullable NSString *)adsAddress
-                                          adsPort:(UInt32)adsPort
-                                      adsJwtToken:(nullable NSString *)adsJwtToken
-                       adsJwtTokenLifetimeSeconds:(UInt32)adsJwtTokenLifetimeSeconds
-                                  adsSslRootCerts:(nullable NSString *)adsSslRootCerts
                                            nodeId:(nullable NSString *)nodeId
                                        nodeRegion:(nullable NSString *)nodeRegion
                                          nodeZone:(nullable NSString *)nodeZone
                                       nodeSubZone:(nullable NSString *)nodeSubZone
-                              cdsResourcesLocator:(NSString *)cdsResourcesLocator
-                                cdsTimeoutSeconds:(UInt32)cdsTimeoutSeconds
-                                        enableCds:(BOOL)enableCds;
+                                 xdsServerAddress:(nullable NSString *)xdsServerAddress
+                                    xdsServerPort:(UInt32)xdsServerPort
+                                      xdsJwtToken:(nullable NSString *)xdsJwtToken
+                       xdsJwtTokenLifetimeSeconds:(UInt32)xdsJwtTokenLifetimeSeconds
+                                  xdsSslRootCerts:(nullable NSString *)xdsSslRootCerts
+                                 rtdsResourceName:(nullable NSString *)rtdsResourceName
+                               rtdsTimeoutSeconds:(UInt32)rtdsTimeoutSeconds
+                                        enableCds:(BOOL)enableCds
+                              cdsResourcesLocator:(nullable NSString *)cdsResourcesLocator
+                                cdsTimeoutSeconds:(UInt32)cdsTimeoutSeconds;
 
 /**
  Generate a string description of the C++ Envoy bootstrap from this configuration.

--- a/mobile/test/common/integration/cds_integration_test.cc
+++ b/mobile/test/common/integration/cds_integration_test.cc
@@ -19,15 +19,15 @@ public:
   void createEnvoy() override {
     sotw_or_delta_ = sotwOrDelta();
     const std::string target_uri = Network::Test::getLoopbackAddressUrlString(ipVersion());
-    builder_.setAggregatedDiscoveryService(target_uri,
-                                           fake_upstreams_[1]->localAddress()->ip()->port());
-
+    auto xds_builder = std::make_unique<Platform::XdsBuilder>(
+        target_uri, fake_upstreams_[1]->localAddress()->ip()->port());
     std::string cds_resources_locator;
     if (use_xdstp_) {
       cds_namespace_ = "xdstp://" + target_uri + "/envoy.config.cluster.v3.Cluster";
       cds_resources_locator = cds_namespace_ + "/*";
     }
-    builder_.addCdsLayer(cds_resources_locator, /*timeout_seconds=*/1);
+    xds_builder->addClusterDiscoveryService(cds_resources_locator, /*timeout_in_seconds=*/1);
+    builder_.setXds(std::move(xds_builder));
 
     XdsIntegrationTest::createEnvoy();
   }

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -18,10 +18,12 @@ public:
     initializeXdsStream();
   }
   void createEnvoy() override {
-    builder_.setAggregatedDiscoveryService(Network::Test::getLoopbackAddressUrlString(ipVersion()),
-                                           fake_upstreams_[1]->localAddress()->ip()->port());
+    auto xds_builder = std::make_unique<Platform::XdsBuilder>(
+        /*xds_server_address=*/Network::Test::getLoopbackAddressUrlString(ipVersion()),
+        /*xds_server_port=*/fake_upstreams_[1]->localAddress()->ip()->port());
     // Add the layered runtime config, which includes the RTDS layer.
-    builder_.addRtdsLayer("some_rtds_layer", 1);
+    xds_builder->addRuntimeDiscoveryService("some_rtds_resource", /*timeout_in_seconds=*/1);
+    builder_.setXds(std::move(xds_builder));
     XdsIntegrationTest::createEnvoy();
   }
 
@@ -57,15 +59,15 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
   const std::string load_success_counter = "runtime.load_success";
   uint64_t load_success_value = getCounterValue(load_success_counter);
   // Send a RTDS request and get back the RTDS response.
-  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Runtime, "", {"some_rtds_layer"},
-                                      {"some_rtds_layer"}, {}, true));
-  auto some_rtds_layer = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
-    name: some_rtds_layer
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Runtime, "", {"some_rtds_resource"},
+                                      {"some_rtds_resource"}, {}, true));
+  auto some_rtds_resource = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
+    name: some_rtds_resource
     layer:
       envoy.reloadable_features.test_feature_false: True
   )EOF");
   sendDiscoveryResponse<envoy::service::runtime::v3::Runtime>(
-      Config::TypeUrl::get().Runtime, {some_rtds_layer}, {some_rtds_layer}, {}, "1");
+      Config::TypeUrl::get().Runtime, {some_rtds_resource}, {some_rtds_resource}, {}, "1");
   // Wait until the RTDS updates from the DiscoveryResponse have been applied.
   ASSERT_TRUE(waitForCounterGe(load_success_counter, load_success_value + 1));
 

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -98,13 +98,13 @@ class EnvoyConfigurationTest {
     runtimeGuards: Map<String,Boolean> = emptyMap(),
     statSinks: MutableList<String> = mutableListOf(),
     enablePlatformCertificatesValidation: Boolean = false,
-    rtdsLayerName: String = "",
+    rtdsResourceName: String = "",
     rtdsTimeoutSeconds: Int = 0,
-    adsAddress: String = "",
-    adsPort: Int = 0,
-    adsJwtToken: String = "",
-    adsJwtTokenLifetimeSeconds: Int = 0,
-    adsSslRootCerts: String = "",
+    xdsAddress: String = "",
+    xdsPort: Int = 0,
+    xdsJwtToken: String = "",
+    xdsJwtTokenLifetimeSeconds: Int = 0,
+    xdsSslRootCerts: String = "",
     nodeId: String = "",
     nodeRegion: String = "",
     nodeZone: String = "",
@@ -147,13 +147,13 @@ class EnvoyConfigurationTest {
       statSinks,
       runtimeGuards,
       enablePlatformCertificatesValidation,
-      rtdsLayerName,
+      rtdsResourceName,
       rtdsTimeoutSeconds,
-      adsAddress,
-      adsPort,
-      adsJwtToken,
-      adsJwtTokenLifetimeSeconds,
-      adsSslRootCerts,
+      xdsAddress,
+      xdsPort,
+      xdsJwtToken,
+      xdsJwtTokenLifetimeSeconds,
+      xdsSslRootCerts,
       nodeId,
       nodeRegion,
       nodeZone,
@@ -311,10 +311,10 @@ class EnvoyConfigurationTest {
   }
 
   @Test
-  fun `test adding RTDS and ADS`() {
+  fun `test adding RTDS`() {
     JniLibrary.loadTestLibrary()
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      rtdsLayerName = "fake_rtds_layer", rtdsTimeoutSeconds = 5432, adsAddress = "FAKE_ADDRESS", adsPort = 0
+      rtdsResourceName = "fake_rtds_layer", rtdsTimeoutSeconds = 5432, xdsAddress = "FAKE_ADDRESS", xdsPort = 0
     )
 
     val resolvedTemplate = TestJni.createYaml(envoyConfiguration)
@@ -328,7 +328,7 @@ class EnvoyConfigurationTest {
   fun `test adding RTDS and CDS`() {
     JniLibrary.loadTestLibrary()
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      cdsResourcesLocator = "FAKE_CDS_LOCATOR", cdsTimeoutSeconds = 356, adsAddress = "FAKE_ADDRESS", adsPort = 0, enableCds = true
+      cdsResourcesLocator = "FAKE_CDS_LOCATOR", cdsTimeoutSeconds = 356, xdsAddress = "FAKE_ADDRESS", xdsPort = 0, enableCds = true
     )
 
     val resolvedTemplate = TestJni.createYaml(envoyConfiguration)
@@ -342,7 +342,7 @@ class EnvoyConfigurationTest {
   fun `test not using enableCds`() {
     JniLibrary.loadTestLibrary()
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      cdsResourcesLocator = "FAKE_CDS_LOCATOR", cdsTimeoutSeconds = 356, adsAddress = "FAKE_ADDRESS", adsPort = 0
+      cdsResourcesLocator = "FAKE_CDS_LOCATOR", cdsTimeoutSeconds = 356, xdsAddress = "FAKE_ADDRESS", xdsPort = 0
     )
 
     val resolvedTemplate = TestJni.createYaml(envoyConfiguration)
@@ -355,7 +355,7 @@ class EnvoyConfigurationTest {
   fun `test enableCds with default string`() {
     JniLibrary.loadTestLibrary()
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      enableCds = true, adsAddress = "FAKE_ADDRESS", adsPort = 0
+      enableCds = true, xdsAddress = "FAKE_ADDRESS", xdsPort = 0
     )
 
     val resolvedTemplate = TestJni.createYaml(envoyConfiguration)
@@ -368,7 +368,7 @@ class EnvoyConfigurationTest {
   fun `test RTDS default timeout`() {
     JniLibrary.loadTestLibrary()
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      rtdsLayerName = "fake_rtds_layer", adsAddress = "FAKE_ADDRESS", adsPort = 0
+      rtdsResourceName = "fake_rtds_layer", xdsAddress = "FAKE_ADDRESS", xdsPort = 0
     )
 
     val resolvedTemplate = TestJni.createYaml(envoyConfiguration)

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -205,14 +205,22 @@ class EngineBuilderTest {
   }
 
   @Test
-  fun `specifying RTDS and ADS works`() {
+  fun `specifying xDS works`() {
+    var xdsBuilder = XdsBuilder("fake_test_address", 0)
+    xdsBuilder.setJwtAuthenticationToken("my_jwt_token")
+    xdsBuilder.setSslRootCerts("my_root_certs")
+    xdsBuilder.addRuntimeDiscoveryService("some_rtds_resource")
+    xdsBuilder.addClusterDiscoveryService("xdstp://fake_test_address/envoy.config.cluster.v3.Cluster/xyz")
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }
-    engineBuilder.addRtdsLayer("rtds_layer_name")
-    engineBuilder.setAggregatedDiscoveryService("fake_test_address", 0)
+    engineBuilder.setXds(xdsBuilder)
+
     val engine = engineBuilder.build() as EngineImpl
-    assertThat(engine.envoyConfiguration.rtdsLayerName).isEqualTo("rtds_layer_name")
-    assertThat(engine.envoyConfiguration.adsAddress).isEqualTo("fake_test_address")
+    assertThat(engine.envoyConfiguration.xdsAddress).isEqualTo("fake_test_address")
+    assertThat(engine.envoyConfiguration.xdsJwtToken).isEqualTo("my_jwt_token")
+    assertThat(engine.envoyConfiguration.xdsRootCerts).isEqualTo("my_root_certs")
+    assertThat(engine.envoyConfiguration.rtdsResourceName).isEqualTo("some_rtds_resource")
+    assertThat(engine.envoyConfiguration.cdsResourcesLocator).isEqualTo("xdstp://fake_test_address/envoy.config.cluster.v3.Cluster/xyz")
   }
 
   @Test

--- a/mobile/test/non_hermetic/gcp_traffic_director_integration_test.cc
+++ b/mobile/test/non_hermetic/gcp_traffic_director_integration_test.cc
@@ -98,12 +98,14 @@ public:
         TestEnvironment::runfilesPath("test/config/integration/certs/google_root_certs.pem")));
 
     // TODO(abeyad): switch to using API key authentication instead of a JWT token.
+    auto xds_builder = std::make_unique<Platform::XdsBuilder>(
+        /*xds_server_address=*/std::string(TD_API_ENDPOINT), /*xds_server_port=*/443);
+    xds_builder->setJwtAuthenticationToken(jwtToken(), Platform::DefaultJwtTokenLifetimeSeconds);
+    xds_builder->setSslRootCerts(std::move(root_certs));
+    xds_builder->addClusterDiscoveryService();
     builder_.addLogLevel(Platform::LogLevel::trace)
         .setNodeId(absl::Substitute("projects/$0/networks/default/nodes/111222333444", PROJECT_ID))
-        .addCdsLayer()
-        .setAggregatedDiscoveryService(std::string(TD_API_ENDPOINT), /*port=*/443, jwtToken(),
-                                       Platform::DefaultJwtTokenLifetimeSeconds,
-                                       std::move(root_certs));
+        .setXds(std::move(xds_builder));
 
     // Other test knobs.
     skip_tag_extraction_rule_check_ = true;

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -357,22 +357,24 @@ final class EngineBuilderTests: XCTestCase {
   }
 
 #if ENVOY_GOOGLE_GRPC
-  func testAddingRtdsAndAdsConfigurationWhenRunningEnvoy() {
+  func testAddingRtdsConfigurationWhenRunningEnvoy() {
+    let xdsBuilder = XdsBuilder(xdsServerAddress: "FAKE_SWIFT_ADDRESS", xdsServerPort: 0)
+      .addRuntimeDiscoveryService(resourceName: "some_rtds_resource", timeoutInSeconds: 14325)
     let bootstrapDebugDescription = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addRTDSLayer(name: "rtds_layer_name", timeoutSeconds: 14325)
-      .setAggregatedDiscoveryService(address: "FAKE_SWIFT_ADDRESS", port: 0)
+      .setXds(xdsBuilder)
       .bootstrapDebugDescription()
-    XCTAssertTrue(bootstrapDebugDescription.contains("rtds_layer_name"))
+    XCTAssertTrue(bootstrapDebugDescription.contains("some_rtds_resource"))
     XCTAssertTrue(bootstrapDebugDescription.contains("initial_fetch_timeout { seconds: 14325 }"))
     XCTAssertTrue(bootstrapDebugDescription.contains("FAKE_SWIFT_ADDRESS"))
   }
 
-  func testAddingCdsAndAdsConfigurationWhenRunningEnvoy() {
+  func testAddingCdsConfigurationWhenRunningEnvoy() {
+    let xdsBuilder = XdsBuilder(xdsServerAddress: "FAKE_SWIFT_ADDRESS", xdsServerPort: 0)
+      .addClusterDiscoveryService(cdsResourcesLocator: "FAKE_CDS_LOCATOR", timeoutInSeconds: 2543)
     let bootstrapDebugDescription = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addCDSLayer(resourcesLocator: "FAKE_CDS_LOCATOR", timeoutSeconds: 2543)
-      .setAggregatedDiscoveryService(address: "FAKE_SWIFT_ADDRESS", port: 0)
+      .setXds(xdsBuilder)
       .bootstrapDebugDescription()
     XCTAssertTrue(bootstrapDebugDescription.contains("FAKE_CDS_LOCATOR"))
     XCTAssertTrue(bootstrapDebugDescription.contains("initial_fetch_timeout { seconds: 2543 }"))
@@ -380,14 +382,16 @@ final class EngineBuilderTests: XCTestCase {
   }
 
   func testAddingDefaultCdsConfigurationWhenRunningEnvoy() {
+    let xdsBuilder = XdsBuilder(xdsServerAddress: "FAKE_SWIFT_ADDRESS", xdsServerPort: 0)
+      .addClusterDiscoveryService()
     let bootstrapDebugDescription = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addCDSLayer()
-      .setAggregatedDiscoveryService(address: "FAKE_SWIFT_ADDRESS", port: 0)
+      .setXds(xdsBuilder)
       .bootstrapDebugDescription()
     XCTAssertTrue(bootstrapDebugDescription.contains("cds_config {"))
     XCTAssertTrue(bootstrapDebugDescription.contains("initial_fetch_timeout { seconds: 5 }"))
   }
+#endif
 
   func testXDSDefaultValues() {
     // rtds, ads, node_id, node_locality
@@ -417,7 +421,6 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(bootstrapDebugDescription.contains(#"zone: "SWIFT_ZONE""#))
     XCTAssertTrue(bootstrapDebugDescription.contains(#"sub_zone: "SWIFT_SUB""#))
   }
-#endif
 
   func testAddingKeyValueStoreToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")


### PR DESCRIPTION
This change does a few things:
1. Makes the setNodeXXX APIs available even when GOOGLE_GRPC isn't. The node metadata APIs are useful in contexts other than for xDS.
2. Removes the setAggregatedDiscoveryServce, addCdsLayer, and addRtdsLayer methods in favor of a single setXds method, which takes in a newly introduced XdsBuilder to build up the xDS config.
3. A side benefit is the xDS server address/port are passed into the XdsBuilder's constructor, so we don't need to check in all of the xDS calls that "setAggregatedDiscoveryService" was called or not.
4. Fix up some variable naming.