### PR TITLE
thrift_proxy: remove a misleading macro

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/router/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/config.cc
@@ -16,8 +16,6 @@ namespace Router {
 ThriftFilters::FilterFactoryCb RouterFilterConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::network::thrift_proxy::router::v3::Router& proto_config,
     const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
-  UNREFERENCED_PARAMETER(proto_config);
-
   auto stats =
       std::make_shared<const RouterStats>(stat_prefix, context.scope(), context.localInfo());
   auto shadow_writer = std::make_shared<ShadowWriterImpl>(


### PR DESCRIPTION
Commit Message:
proto_config is actually referenced.
Additional Description:
Risk Level: low
