### PR TITLE
add StarryVae to go extension code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -347,7 +347,7 @@ extensions/filters/http/oauth2 @derekargueta @mattklein123
 /contrib/client_ssl_auth/ @UNOWNED @UNOWNED
 /contrib/common/sqlutils/ @cpakulski @cpakulski
 /contrib/dynamo/ @UNOWNED @UNOWNED
-/contrib/golang/ @doujiang24 @wangfakang
+/contrib/golang/ @doujiang24 @wangfakang @StarryVae
 /contrib/squash/ @yuval-k @alyssawilk
 /contrib/kafka/ @mattklein123 @adamkotwasinski
 /contrib/rocketmq_proxy/ @aaron-ai @lizhanhui @lizan


### PR DESCRIPTION
Commit Message: add StarryVae to go extension code owner
Additional Description: N/A
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
