### PR TITLE
RLQS: Improve the test coverage

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -63,10 +63,10 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
   if (matcher_ == nullptr) {
     return absl::InternalError("Matcher tree has not been initialized yet.");
   } else {
-    data_ptr_->onRequestHeaders(headers);
-    // TODO(tyxia) This function should trigger the CEL expression matching. Here, we need to
-    // implement the custom_matcher and factory, also statically register it so that CEL matching
-    // will be triggered with its own match() method.
+    // TODO(tyxia) Update the logic with the CEL matcher and other attributes besides header.
+    if (!headers.empty()) {
+      data_ptr_->onRequestHeaders(headers);
+    }
     auto match_result = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, *data_ptr_);
 
     if (match_result.match_state_ == Matcher::MatchState::MatchComplete) {
@@ -78,7 +78,7 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
       }
     } else {
       // The returned state from `evaluateMatch` function is `MatchState::UnableToMatch` here.
-      return absl::InternalError("Unable to match the request.");
+      return absl::InternalError("Unable to match due to the required data not being available.");
     }
   }
 }

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -83,8 +83,6 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
   }
 }
 
-void RateLimitQuotaFilter::onComplete(const RateLimitQuotaBucketSettings&, RateLimitStatus) {}
-
 } // namespace RateLimitQuota
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -72,7 +72,6 @@ public:
     return *data_ptr_;
   }
 
-  void onComplete(const RateLimitQuotaBucketSettings&, RateLimitStatus);
   ~RateLimitQuotaFilter() override = default;
 
 private:

--- a/source/extensions/filters/http/rate_limit_quota/matcher.cc
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.cc
@@ -46,9 +46,6 @@ RateLimitOnMatchAction::generateBucketId(const Http::Matching::HttpMatchingDataI
       if (!str.empty()) {
         // Build the bucket id from the matched result.
         bucket_id.mutable_bucket()->insert({bucket_id_key, str});
-      } else {
-        // TODO(tyxia) Nothing hits this line at this moment.
-        return absl::InternalError("Empty resulting data from custom value config.");
       }
       break;
     }

--- a/source/extensions/filters/http/rate_limit_quota/matcher.h
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.h
@@ -40,6 +40,7 @@ public:
   absl::StatusOr<BucketId> generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
                                             Server::Configuration::FactoryContext& factory_context,
                                             RateLimitQuotaValidationVisitor& visitor) const;
+
 private:
   RateLimitQuotaBucketSettings setting_;
 };

--- a/source/extensions/filters/http/rate_limit_quota/matcher.h
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.h
@@ -40,8 +40,6 @@ public:
   absl::StatusOr<BucketId> generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
                                             Server::Configuration::FactoryContext& factory_context,
                                             RateLimitQuotaValidationVisitor& visitor) const;
-  RateLimitQuotaBucketSettings bucketSettings() const { return setting_; }
-
 private:
   RateLimitQuotaBucketSettings setting_;
 };

--- a/test/extensions/filters/http/rate_limit_quota/filter_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/filter_test.cc
@@ -405,6 +405,18 @@ TEST_F(FilterTest, RequestMatchingFailed) {
   EXPECT_EQ(match.status().message(), "Matching completed but no match result was found.");
 }
 
+TEST_F(FilterTest, RequestMatchingFailedWithEmptyHeader) {
+  addMatcherConfig(MatcherConfigType::Valid);
+  createFilter();
+  Http::TestRequestHeaderMapImpl empty_header = {};
+  // Perform request matching.
+  auto match = filter_->requestMatching(empty_header);
+  // Not_OK status is expected to be returned because the matching failed due to empty headers.
+  EXPECT_FALSE(match.ok());
+  EXPECT_EQ(match.status().message(),
+            "Unable to match due to the required data not being available.");
+}
+
 TEST_F(FilterTest, RequestMatchingFailedWithNoCallback) {
   addMatcherConfig(MatcherConfigType::Valid);
   createFilter(/*set_callback*/ false);

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -39,7 +39,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/http/ip_tagging:88.0"
 "source/extensions/filters/http/kill_request:91.7" # Death tests don't report LCOV
 "source/extensions/filters/http/wasm:1.9"
-"source/extensions/filters/http/rate_limit_quota:94.8" # TODO(tyxia) WIP. Improve coverage as development continues
 "source/extensions/filters/listener/original_dst:82.9"
 "source/extensions/filters/listener/original_src:92.1"
 "source/extensions/filters/network/common:96.2"


### PR DESCRIPTION
Improve test coverage by : add a test case for data_unavailable/MatchState::UnableToMatch and remove untested code.

Fix: #24353