### PR TITLE
mobile: Optimize the Swift-C++ interop generateBootstrap bridge

### DIFF
--- a/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/cxx_swift_interop.h
@@ -37,7 +37,7 @@ inline void raw_header_map_set(Platform::RawHeaderMap& map, std::string key,
 
 // Smart pointers aren't currently supported by Swift / C++ interop, so we "erase"
 // it into a `BootstrapPtr` / `intptr_t`, which we can import from Swift.
-inline BootstrapPtr generateBootstrapPtr(Platform::EngineBuilder builder) {
+inline BootstrapPtr generateBootstrapPtr(Platform::EngineBuilder& builder) {
   return reinterpret_cast<BootstrapPtr>(builder.generateBootstrap().release());
 }
 

--- a/mobile/library/swift/cxx/Bootstrap.swift
+++ b/mobile/library/swift/cxx/Bootstrap.swift
@@ -20,8 +20,16 @@ final class Bootstrap {
 }
 
 extension Envoy.Platform.EngineBuilder {
+  /// Overrides the generateBootstrap() virtual function in the C++ EngineBuilder.
+  ///
+  /// NOTE: This function is `mutating` because we pass in the EngineBuilder by reference to
+  /// CxxSwift.generateBootstrapPtr(). The CxxSwift.generateBootstrapPtr() function cannot take
+  /// a const reference (const&) because passing by const reference is bridged as a value type
+  /// (see https://github.com/apple/swift/blob/main/docs/CppInteroperability/InteropOddities.md)
+  /// and EngineBuilder can't be a value type because it has virtual functions.
+  ///
   /// - returns: A generated bootstrap object.
-  func generateBootstrap() -> Bootstrap {
-    Bootstrap(pointer: Envoy.CxxSwift.generateBootstrapPtr(self))
+  mutating func generateBootstrap() -> Bootstrap {
+    Bootstrap(pointer: Envoy.CxxSwift.generateBootstrapPtr(&self))
   }
 }


### PR DESCRIPTION
This change passes a reference, instead of a copy, to the generateBootstrapPtr bridge function. Copying the EngineBuilder can be quite expensive, since it can hold lots of large strings (certs, filter configs, etc).

The Swift bridge's generateBootstrap method needs to be declared `mutating` because the EngineBuilder reference is not constant (const&). The method parameter cannot be const& because of an interop oddity described in
https://github.com/apple/swift/blob/main/docs/CppInteroperability/InteropOddities.md.