### PR TITLE
accesslog: disable resource labels

### DIFF
--- a/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
@@ -22,9 +22,14 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // populate `opentelemetry.proto.collector.v1.logs.ExportLogsServiceRequest.resource_logs <https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto>`_.
 // In addition, the request start time is set in the dedicated field.
 // [#extension: envoy.access_loggers.open_telemetry]
+// [#next-free-field: 6]
 message OpenTelemetryAccessLogConfig {
   // [#comment:TODO(itamarkam): add 'filter_state_objects_to_log' to logs.]
   grpc.v3.CommonGrpcAccessLogConfig common_config = 1 [(validate.rules).message = {required: true}];
+
+  // If specified, Envoy will not generate built-in resource labels
+  // like ``log_name``, ``zone_name``, ``cluster_name``, ``node_name``.
+  bool disable_builtin_labels = 5;
 
   // OpenTelemetry `Resource <https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto#L51>`_
   // attributes are filled with Envoy node info.

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -52,10 +52,12 @@ void GrpcAccessLoggerImpl::initMessageRoot(
   auto* resource_logs = message_.add_resource_logs();
   root_ = resource_logs->add_scope_logs();
   auto* resource = resource_logs->mutable_resource();
-  *resource->add_attributes() = getStringKeyValue("log_name", config.common_config().log_name());
-  *resource->add_attributes() = getStringKeyValue("zone_name", local_info.zoneName());
-  *resource->add_attributes() = getStringKeyValue("cluster_name", local_info.clusterName());
-  *resource->add_attributes() = getStringKeyValue("node_name", local_info.nodeName());
+  if (!config.disable_builtin_labels()) {
+    *resource->add_attributes() = getStringKeyValue("log_name", config.common_config().log_name());
+    *resource->add_attributes() = getStringKeyValue("zone_name", local_info.zoneName());
+    *resource->add_attributes() = getStringKeyValue("cluster_name", local_info.clusterName());
+    *resource->add_attributes() = getStringKeyValue("node_name", local_info.nodeName());
+  }
 
   for (const auto& pair : config.resource_attributes().values()) {
     *resource->add_attributes() = pair;

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -39,11 +39,13 @@ const std::string NODE_NAME = "node_name";
 class GrpcAccessLoggerImplTestHelper {
 public:
   GrpcAccessLoggerImplTestHelper(LocalInfo::MockLocalInfo& local_info,
-                                 Grpc::MockAsyncClient* async_client)
+                                 Grpc::MockAsyncClient* async_client, bool expectCall = true)
       : async_client_(async_client) {
-    EXPECT_CALL(local_info, zoneName()).WillOnce(ReturnRef(ZONE_NAME));
-    EXPECT_CALL(local_info, clusterName()).WillOnce(ReturnRef(CLUSTER_NAME));
-    EXPECT_CALL(local_info, nodeName()).WillOnce(ReturnRef(NODE_NAME));
+    if (expectCall) {
+      EXPECT_CALL(local_info, zoneName()).WillOnce(ReturnRef(ZONE_NAME));
+      EXPECT_CALL(local_info, clusterName()).WillOnce(ReturnRef(CLUSTER_NAME));
+      EXPECT_CALL(local_info, nodeName()).WillOnce(ReturnRef(NODE_NAME));
+    }
   }
 
   void expectSentMessage(const std::string& expected_message_yaml) {
@@ -70,7 +72,7 @@ class GrpcAccessLoggerImplTest : public testing::Test {
 public:
   GrpcAccessLoggerImplTest()
       : async_client_(new Grpc::MockAsyncClient), timer_(new Event::MockTimer(&dispatcher_)),
-        grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
+        grpc_access_logger_impl_test_helper_(local_info_, async_client_, true) {
     EXPECT_CALL(*timer_, enableTimer(_, _));
     *config_.mutable_common_config()->mutable_log_name() = "test_log_name";
     config_.mutable_common_config()->mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
@@ -124,7 +126,7 @@ public:
   GrpcAccessLoggerCacheImplTest()
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
-        grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
+        grpc_access_logger_impl_test_helper_(local_info_, async_client_, true) {
     EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, createUncachedRawAsyncClient()).WillOnce(Invoke([this] {
@@ -223,6 +225,105 @@ values:
         - key: "node_name"
           value:
             string_value: "node_name"
+        - key: "host_name"
+          value:
+            string_value: "test_host_name"
+        - key: k8s.pod.uid
+          value:
+            string_value: xxxx-xxxx-xxxx-xxxx
+        - key: k8s.pod.createtimestamp
+          value:
+            int_value: 1655429509
+    scope_logs:
+      - log_records:
+          - severity_text: "test-severity-text"
+  )EOF");
+  opentelemetry::proto::logs::v1::LogRecord entry;
+  entry.set_severity_text("test-severity-text");
+  logger->log(opentelemetry::proto::logs::v1::LogRecord(entry));
+}
+
+class GrpcAccessLoggerDisableBuiltinImplTest : public testing::Test {
+public:
+  GrpcAccessLoggerDisableBuiltinImplTest()
+      : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
+        logger_cache_(async_client_manager_, scope_, tls_, local_info_),
+        grpc_access_logger_impl_test_helper_(local_info_, async_client_, false) {
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+          EXPECT_CALL(*factory_, createUncachedRawAsyncClient()).WillOnce(Invoke([this] {
+            return Grpc::RawAsyncClientPtr{async_client_};
+          }));
+          return Grpc::AsyncClientFactoryPtr{factory_};
+        }));
+  }
+
+  Grpc::MockAsyncClient* async_client_;
+  Grpc::MockAsyncClientFactory* factory_;
+  Grpc::MockAsyncClientManager async_client_manager_;
+  LocalInfo::MockLocalInfo local_info_;
+  NiceMock<Stats::MockIsolatedStatsStore> store_;
+  Stats::Scope& scope_{*store_.rootScope()};
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  GrpcAccessLoggerCacheImpl logger_cache_;
+  GrpcAccessLoggerImplTestHelper grpc_access_logger_impl_test_helper_;
+};
+
+TEST_F(GrpcAccessLoggerDisableBuiltinImplTest, WithoutResourceAttributes) {
+  envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig config;
+  config.mutable_common_config()->set_log_name("test_log");
+  config.mutable_common_config()->set_transport_api_version(
+      envoy::config::core::v3::ApiVersion::V3);
+  // Force a flush for every log entry.
+  config.mutable_common_config()->mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
+  config.set_disable_builtin_labels(true);
+
+  GrpcAccessLoggerSharedPtr logger =
+      logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);
+  grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
+  resource_logs:
+    resource:
+      attributes:
+    scope_logs:
+      - log_records:
+          - severity_text: "test-severity-text"
+  )EOF");
+  opentelemetry::proto::logs::v1::LogRecord entry;
+  entry.set_severity_text("test-severity-text");
+  logger->log(opentelemetry::proto::logs::v1::LogRecord(entry));
+}
+
+TEST_F(GrpcAccessLoggerDisableBuiltinImplTest, WithResourceAttributes) {
+  envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig config;
+  config.mutable_common_config()->set_log_name("test_log");
+  config.mutable_common_config()->set_transport_api_version(
+      envoy::config::core::v3::ApiVersion::V3);
+  // Force a flush for every log entry.
+  config.mutable_common_config()->mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
+  config.set_disable_builtin_labels(true);
+
+  opentelemetry::proto::common::v1::KeyValueList keyValueList;
+  const auto kv_yaml = R"EOF(
+values:
+- key: host_name
+  value:
+    string_value: test_host_name
+- key: k8s.pod.uid
+  value:
+    string_value: xxxx-xxxx-xxxx-xxxx
+- key: k8s.pod.createtimestamp
+  value:
+     int_value: 1655429509
+  )EOF";
+  TestUtility::loadFromYaml(kv_yaml, keyValueList);
+  *config.mutable_resource_attributes() = keyValueList;
+
+  GrpcAccessLoggerSharedPtr logger =
+      logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP);
+  grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
+  resource_logs:
+    resource:
+      attributes:
         - key: "host_name"
           value:
             string_value: "test_host_name"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add configuration for disable envoy builtin resource lables
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
