### PR TITLE
[mobile]Fix CronvoyUrlRequest state transition and callback logic

### DIFF
--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.chromium.net.CallbackException;
 import org.chromium.net.CronetException;
 import org.chromium.net.InlineExecutionProhibitedException;
-import org.chromium.net.NetworkException;
 import org.chromium.net.RequestFinishedInfo;
 import org.chromium.net.RequestFinishedInfo.Metrics;
 import org.chromium.net.UploadDataProvider;
@@ -541,7 +540,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
                                  mCurrentUrl, mRequestContext.getBuilder().quicEnabled());
     mCronvoyCallbacks = new CronvoyHttpCallbacks();
     mStream.set(mRequestContext.getEnvoyEngine().startStream(mCronvoyCallbacks,
-                                                             /* explicitFlowCrontrol= */ true,
+                                                             /* explicitFlowCrontrol */ true,
                                                              /* minDeliverySize */ 0));
     mStream.get().sendHeaders(envoyRequestHeaders, mUploadDataStream == null);
     if (mUploadDataStream != null && mUrlChain.size() == 1) {
@@ -864,10 +863,20 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
       mEndStream = endStream;
       @State int originalState;
       @State int updatedState;
-      do {
-        originalState = mState.get();
-        updatedState = determineNextState(endStream, originalState, State.AWAITING_READ);
-      } while (!mState.compareAndSet(originalState, updatedState));
+      if (endStream && !data.hasRemaining()) {
+        // This read is the final read.
+        do {
+          originalState = mState.get();
+          updatedState = determineNextState(endStream, originalState, State.COMPLETE);
+        } while (!mState.compareAndSet(originalState, updatedState));
+        // onComplete still needs to be called - this always returns false.
+        mSucceededState.hasReachedFinalState(SucceededState.FINAL_READ_DONE);
+      } else {
+        do {
+          originalState = mState.get();
+          updatedState = determineNextState(endStream, originalState, State.AWAITING_READ);
+        } while (!mState.compareAndSet(originalState, updatedState));
+      }
       if (completeAbandonIfAny(originalState, updatedState)) {
         return;
       }
@@ -882,9 +891,12 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
           try {
             ByteBuffer userBuffer = mUserCurrentReadBuffer;
             mUserCurrentReadBuffer = null; // Avoid the reference to a potentially large buffer.
+            int dataRead = data.remaining();
             userBuffer.put(data); // NPE ==> BUG, BufferOverflowException ==> User not behaving.
-            mWaitingOnRead.set(true);
-            mCallback.onReadCompleted(CronvoyUrlRequest.this, mUrlResponseInfo, userBuffer);
+            if (dataRead > 0 || !endStream) {
+              mWaitingOnRead.set(true);
+              mCallback.onReadCompleted(CronvoyUrlRequest.this, mUrlResponseInfo, userBuffer);
+            }
           } catch (Throwable t) {
             onCallbackException(t);
           }

--- a/mobile/test/java/org/chromium/net/impl/CronvoyEngineTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CronvoyEngineTest.java
@@ -133,8 +133,19 @@ public class CronvoyEngineTest {
     mockWebServer.start();
     RequestScenario requestScenario = new RequestScenario().addResponseBuffers(13);
 
-    Response response = sendRequest(requestScenario);
+    UrlRequestCallbackTester<Response> urlRequestCallbackTester = new UrlRequestCallbackTester<>();
+    UrlRequestCallback testCallback = new UrlRequestCallback(
+        requestScenario.responseBody, urlRequestCallbackTester, requestScenario);
+    ExperimentalUrlRequest.Builder builder = cronvoyEngine.newUrlRequestBuilder(
+        mockWebServer.url(requestScenario.urlPath).toString(),
+        urlRequestCallbackTester.getWrappedUrlRequestCallback(testCallback),
+        Executors.newSingleThreadExecutor());
 
+    Response response = urlRequestCallbackTester.waitForResponse(builder.build());
+
+    // The response will come in 3 chunks. The 4th read is the final read and shouldn't trigger
+    // OnReadComplete() as no data is read.
+    assertThat(testCallback.getNumOnReadCompleteCalled()).isEqualTo(3);
     assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
     assertThat(response.getBodyAsString()).isEqualTo("hello, world");
     assertThat(response.getNbResponseChunks()).isEqualTo(3); // 5 bytes, 5 bytes, and 2 bytes
@@ -346,6 +357,7 @@ public class CronvoyEngineTest {
     private final AtomicInteger nbChunks = new AtomicInteger(0);
     private final AtomicInteger bufferLastRemaining = new AtomicInteger();
     private final RequestScenario requestScenario;
+    private int numOnReadCompleteCalled = 0;
 
     private UrlRequestCallback(List<ByteBuffer> responseBodyBuffers,
                                UrlRequestCallbackTester<Response> urlRequestCallbackTester,
@@ -355,6 +367,8 @@ public class CronvoyEngineTest {
       this.requestScenario = requestScenario;
       buffers = new ConcurrentLinkedQueue<>(responseBodyBuffers);
     }
+
+    public int getNumOnReadCompleteCalled() { return numOnReadCompleteCalled; }
 
     @Override
     public void onRedirectReceived(UrlRequest urlRequest, UrlResponseInfo info,
@@ -379,6 +393,7 @@ public class CronvoyEngineTest {
     @Override
     public void onReadCompleted(UrlRequest urlRequest, UrlResponseInfo info,
                                 ByteBuffer byteBuffer) {
+      numOnReadCompleteCalled++;
       ByteBuffer buffer = buffers.peek();
       if (byteBuffer != buffer) {
         throw new AssertionError("Can't happen...");

--- a/mobile/test/java/org/chromium/net/testing/TestUrlRequestCallback.java
+++ b/mobile/test/java/org/chromium/net/testing/TestUrlRequestCallback.java
@@ -339,12 +339,7 @@ public class TestUrlRequestCallback extends UrlRequest.Callback {
     request.read(buffer);
   }
 
-  public boolean isDone() {
-    // It's not mentioned by the Android docs, but block(0) seems to block
-    // indefinitely, so have to block for one millisecond to get state
-    // without blocking.
-    return !mDone.isBlocked();
-  }
+  public boolean isDone() { return !mDone.isBlocked(); }
 
   protected void openDone() { mDone.open(); }
 


### PR DESCRIPTION
Commit Message:Fix CronvoyUrlRequest state transition and callback logic
Additional Description:
Suppose the application sends a Cronvoy request and keeps calling request.read() until the end is reached, and the response is structured in a way such that the endStream signal comes by itself without any data.

Before this change, the behavior at the end of the stream is: 
EnvoyMobile calls OnData() and OnComplete() callbacks to Cronvoy. As a result, the application gets an OnReadCompleted() callback with no data read, but no OnSucceeded() because the [stream](https://source.corp.google.com/piper///depot/google3/third_party/envoy/src/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java;l=1000) hasn't reached its final state.
The application tries to read again, and [OnSucceeded()](https://source.corp.google.com/piper///depot/google3/third_party/envoy/src/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java;l=313) will be triggered.

After this change, the behavior at the end of the stream is:
EnvoyMobile calls OnData() and OnComplete() callbacks to Cronvoy. In the OnData() callback, the stream state will be updated to reflect that the final read is done. It will not invoke OnReadComplete() because it shouldn't be called when no data is read.
When OnComplete() is called, the stream can successfully move to its final state and invokes OnSucceeded() callback.


Risk Level: Low
Testing: Unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Android only
