### PR TITLE
Add dynamic metadata support for ORIGINAL_DST cluster to pick a host

### DIFF
--- a/api/envoy/config/cluster/v3/BUILD
+++ b/api/envoy/config/cluster/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/endpoint/v3:pkg",
+        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
         "@com_github_cncf_udpa//xds/core/v3:pkg",

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -13,6 +13,7 @@ import "envoy/config/core/v3/health_check.proto";
 import "envoy/config/core/v3/protocol.proto";
 import "envoy/config/core/v3/resolver.proto";
 import "envoy/config/endpoint/v3/endpoint.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
@@ -551,6 +552,10 @@ message Cluster {
     // The port to override for the original dst address. This port
     // will take precedence over filter state and header override ports
     google.protobuf.UInt32Value upstream_port_override = 3 [(validate.rules).uint32 = {lte: 65535}];
+
+    // The dynamic metadata key to override destination address.
+    // First the request metadata is considered, then the connection one.
+    type.metadata.v3.MetadataKey metadata_key = 4;
   }
 
   // Common configuration for all load balancer implementations.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -440,7 +440,11 @@ new_features:
   change: |
     added :ref:`outbound_control_frames_active <statistics>` and :ref:`outbound_frames_active <statistics>`
     statistic.
-
+- area: original_dst
+  change: |
+    Filter state is pulled from request context first (if available), then falls back to connection context. Added ability to pick host
+    from dynamic metadata using :ref:`metadata_key <envoy_v3_api_field_config.cluster.v3.Cluster.OriginalDstLbConfig.metadata_key>`.
+    Same behavior - looks in request context first (if available), falls back to connection context.
 deprecated:
 - area: access_log
   change: |

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -6,6 +6,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/network/transport_socket.h"
 #include "envoy/router/router.h"
+#include "envoy/stream_info/stream_info.h"
 #include "envoy/upstream/types.h"
 #include "envoy/upstream/upstream.h"
 
@@ -44,6 +45,12 @@ public:
    * balancing.
    */
   virtual const Network::Connection* downstreamConnection() const PURE;
+
+  /**
+   * @return const StreamInfo* the incoming request stream info or nullptr to use during load
+   * balancing.
+   */
+  virtual const StreamInfo::StreamInfo* requestStreamInfo() const PURE;
 
   /**
    * @return const Http::HeaderMap* the incoming headers or nullptr to use during load

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -22,6 +22,7 @@
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
+#include "envoy/stream_info/stream_info.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "source/common/access_log/access_log_impl.h"
@@ -446,6 +447,9 @@ public:
   }
   const Network::Connection* downstreamConnection() const override {
     return callbacks_->connection().ptr();
+  }
+  const StreamInfo::StreamInfo* requestStreamInfo() const override {
+    return &callbacks_->streamInfo();
   }
   const Http::RequestHeaderMap* downstreamHeaders() const override { return downstream_headers_; }
 

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -19,6 +19,7 @@
 #include "envoy/extensions/load_balancing_policies/round_robin/v3/round_robin.pb.h"
 #include "envoy/extensions/load_balancing_policies/round_robin/v3/round_robin.pb.validate.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/stream_info/stream_info.h"
 #include "envoy/upstream/load_balancer.h"
 #include "envoy/upstream/upstream.h"
 
@@ -220,6 +221,8 @@ public:
   const Network::Connection* downstreamConnection() const override { return nullptr; }
 
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
+
+  const StreamInfo::StreamInfo* requestStreamInfo() const override { return nullptr; }
 
   const Http::RequestHeaderMap* downstreamHeaders() const override { return nullptr; }
 

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -13,6 +13,7 @@
 #include "envoy/extensions/load_balancing_policies/subset/v3/subset.pb.validate.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/stats/scope.h"
+#include "envoy/stream_info/stream_info.h"
 #include "envoy/upstream/load_balancer.h"
 
 #include "source/common/common/macros.h"
@@ -290,6 +291,9 @@ public:
     }
     const Network::Connection* downstreamConnection() const override {
       return wrapped_->downstreamConnection();
+    }
+    const StreamInfo::StreamInfo* requestStreamInfo() const override {
+      return wrapped_->requestStreamInfo();
     }
     const Http::RequestHeaderMap* downstreamHeaders() const override {
       return wrapped_->downstreamHeaders();

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "envoy/stream_info/stream_info.h"
 #include "envoy/upstream/load_balancer.h"
 
 #include "gmock/gmock.h"
@@ -14,6 +15,7 @@ public:
   MOCK_METHOD(absl::optional<uint64_t>, computeHashKey, ());
   MOCK_METHOD(Router::MetadataMatchCriteria*, metadataMatchCriteria, ());
   MOCK_METHOD(const Network::Connection*, downstreamConnection, (), (const));
+  MOCK_METHOD(const StreamInfo::StreamInfo*, requestStreamInfo, (), (const));
   MOCK_METHOD(const Http::RequestHeaderMap*, downstreamHeaders, (), (const));
   MOCK_METHOD(const HealthyAndDegradedLoad&, determinePriorityLoad,
               (const PrioritySet&, const HealthyAndDegradedLoad&,


### PR DESCRIPTION
Commit Message: Add dynamic metadata support for ORIGINAL_DST cluster to pick a host
Additional Description: One can specify a MetadataKey with a path selector to pick up a host from the dynamic metadata of the request. Selected value can either be a string or a list with at least a single element of string type.
Risk Level: Low
Testing: Unit Testing
Docs Changes: N/A
Release Notes: 
Platform Specific Features:
