### PR TITLE
[ZK filter] Fix The definition of CreateMode does not comply with the…

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.h
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.h
@@ -62,8 +62,8 @@ enum class AddWatchMode { Persistent, PersistentRecursive };
 
 enum class CreateFlags {
   Persistent,
-  PersistentSequential,
   Ephemeral,
+  PersistentSequential,
   EphemeralSequential,
   Container,
   PersistentWithTtl,


### PR DESCRIPTION
Commit Message: [ZK filter] Fix The definition of CreateMode does not comply with the protocol
Additional Description: CreateMode definition in the zookeeper source code：
PERSISTENT(0, false, false, false, false)
PERSISTENT_SEQUENTIAL(2, false, true, false, false)
EPHEMERAL(1, true, false, false, false)
https://github.com/apache/zookeeper/blob/fe940cdd8fb23ba09684cefb73233d570f4a20fa/zookeeper-server/src/main/java/org/apache/zookeeper/CreateMode.java#L43

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
