### PR TITLE
Add debug logs to dynamic forward proxy failure paths

### DIFF
--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -357,6 +357,7 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   std::string host = Common::DynamicForwardProxy::DnsHostInfo::normalizeHostForDfp(raw_host, port);
 
   if (host.empty()) {
+    ENVOY_LOG(debug, "host empty");
     return nullptr;
   }
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -368,9 +368,11 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     absl::ReaderMutexLock lock{&cluster_.host_map_lock_};
     const auto host_it = cluster_.host_map_.find(host);
     if (host_it == cluster_.host_map_.end()) {
+      ENVOY_LOG(debug, "host {} not found", host);
       return nullptr;
     } else {
       if (host_it->second.logical_host_->coarseHealth() == Upstream::Host::Health::Unhealthy) {
+        ENVOY_LOG(debug, "host {} is unhealthy", host);
         return nullptr;
       }
       host_it->second.shared_host_info_->touch();


### PR DESCRIPTION
Additional Description: None
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None

For context about why I'm adding this - I'm experiencing weird behavior where some host is resolved in the sni_dfp filter, then sometimes flows work as expected, but sometimes they fail (to the same dest host) due to ``no healthy host for HTTP connection pool`` (I'm using TCP tunneling therefore the upstream is HTTP).

Since I'm using DFP cluster that has its own load balancer logic, it seems as runtime is going through either one of the flows I added debug logs to. These debug logs could help further understand what's going on.