### PR TITLE
ci: Add test targets to the mobile compile options workflow

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -63,7 +63,7 @@ jobs:
             --define=envoy_enable_http_datagrams=disabled \
             --define=google_grpc=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/cc/... //test/common/...
+            $(bazel query //test/cc/... + //test/common/... except //test/common/integration:client_integration_test)
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -56,6 +56,7 @@ jobs:
       run: |
         cd mobile
         ./bazelw test \
+            --test_output=all \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --config=ci \
             --define=signal_trace=disabled \

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -57,13 +57,13 @@ jobs:
         cd mobile
         ./bazelw test \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
-            --config=ci
+            --config=ci \
             --define=signal_trace=disabled \
             --define=envoy_mobile_request_compression=disabled \
             --define=envoy_enable_http_datagrams=disabled \
             --define=google_grpc=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/common/... --test_output=all
+            //test/cc/... //test/common/...
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -63,7 +63,7 @@ jobs:
             --define=envoy_enable_http_datagrams=disabled \
             --define=google_grpc=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            //test/cc/... //test/common/...
+            //test/common/... --test_output=all
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -16,6 +16,29 @@ jobs:
     uses: ./.github/workflows/env.yml
     secrets: inherit
 
+  cc_test_no_yaml:
+    needs: env
+    name: cc_test_no_yaml
+    runs-on: ubuntu-20.04
+    timeout-minutes: 120
+    container:
+      image: envoyproxy/envoy-build-ubuntu:41c5a05d708972d703661b702a63ef5060125c33
+    steps:
+    - uses: actions/checkout@v3
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy/envoy
+    - name: 'Running C++ test with YAML disabled'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Envoy Mobile build which verifies that the build configuration where YAML is disabled.
+      run: |
+        cd mobile
+        ./bazelw test \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
+            --config=ci \
+            --define=envoy_yaml=disabled \
+            --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
+            //test/common/integration:client_integration_test --test_output=all
   cc_test:
     needs: env
     name: cc_test
@@ -27,17 +50,20 @@ jobs:
     - uses: actions/checkout@v3
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
-    - name: 'Building C++ library'
+    - name: 'Running C++ tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Envoy Mobile build which verifies that the build configuration where YAML is disabled.
       run: |
-        cd mobile && ./bazelw test \
+        cd mobile
+        ./bazelw test \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
-            --config=ci \
-            --define=envoy_yaml=disabled \
-            --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-            //test/common/integration:client_integration_test --test_output=all
+            --config=ci
+            --define=signal_trace=disabled \
+            --define=envoy_mobile_request_compression=disabled \
+            --define=envoy_enable_http_datagrams=disabled \
+            --define=google_grpc=disabled \
+            --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
+            //test/cc/... //test/common/...
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env
@@ -52,8 +78,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw shutdown
-          ./bazelw build \
+        cd mobile
+        ./bazelw shutdown
+        ./bazelw build \
             --config=ios \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --define=signal_trace=disabled \
@@ -85,8 +112,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile \
-        && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --fat_apk_cpu=x86_64 \
             --define=signal_trace=disabled \

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -73,9 +73,11 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "sds_integration_test",
-    srcs = [
-        "sds_integration_test.cc",
-    ],
+    # The test relies on the Google gRPC library.
+    srcs = envoy_select_google_grpc(
+        ["sds_integration_test.cc"],
+        "@envoy",
+    ),
     data = [
         "@envoy//test/config/integration/certs",
     ],


### PR DESCRIPTION
All C++ test targets are added to the cc_test job in the workflow.

This can help us catch test build failures when the standard build
options are disabled as they would often be in a release build.

This update caught a bug in the sds_integration_test.cc, which
wasn't guarded with `envoy_select_google_grpc` in the BUILD
file, so that problem has been fixed in this commit as well.