### PR TITLE
ci: Update Ubuntu host agents

### DIFF
--- a/.azure-pipelines/env.yml
+++ b/.azure-pipelines/env.yml
@@ -38,7 +38,7 @@ jobs:
 - job: cache
   displayName: Cache
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - template: cached.yml
     parameters:
@@ -48,7 +48,7 @@ jobs:
   dependsOn: []
   displayName: Cache (arm64)
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - template: cached.yml
     parameters:
@@ -60,7 +60,7 @@ jobs:
   dependsOn: []
   displayName: Repository
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - checkout: self
     fetchDepth: 0
@@ -259,7 +259,7 @@ jobs:
   displayName: Test artifacts
   condition: ne(variables['Build.DefinitionName'], 'envoy-postsubmit')
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - script: $(Build.SourcesDirectory)/.azure-pipelines/gpg/generate-test-key.sh
     displayName: "Generate snakeoil GPG key for testing"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -13,6 +13,9 @@ pr: none
 
 
 variables:
+- name: agentUbuntu
+  value: ubuntu-20.04
+
 - name: isDev
   # This must be checked/set in a `step` from the VERSION.txt file, in order to be useful
   value: true

--- a/.azure-pipelines/stage/checks.yml
+++ b/.azure-pipelines/stage/checks.yml
@@ -68,7 +68,7 @@ jobs:
         CI_TARGET: "bazel.api"
   timeoutInMinutes: 180
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - template: ../bazel.yml
     parameters:
@@ -132,7 +132,7 @@ jobs:
   displayName: "Checks complete"
   dependsOn: ["bazel", "coverage"]
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) check passes if all of
   # the preceding checks either pass or are skipped
   # adapted from:

--- a/.azure-pipelines/stage/linux.yml
+++ b/.azure-pipelines/stage/linux.yml
@@ -48,7 +48,7 @@ jobs:
   displayName: Complete
   dependsOn: ["release"]
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) job passes if all of
   # the preceeding jobs either pass or are skipped
   # adapted from:

--- a/.azure-pipelines/stage/macos.yml
+++ b/.azure-pipelines/stage/macos.yml
@@ -43,7 +43,7 @@ jobs:
   displayName: Complete
   dependsOn: ["test"]
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) job passes if all of
   # the preceeding jobs either pass or are skipped
   # adapted from:

--- a/.azure-pipelines/stage/prechecks.yml
+++ b/.azure-pipelines/stage/prechecks.yml
@@ -39,7 +39,7 @@ jobs:
   displayName: Precheck
   timeoutInMinutes: 30
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   variables:
     CI_TARGET: ""
   strategy:
@@ -165,7 +165,7 @@ jobs:
   displayName: Precheck dependencies
   timeoutInMinutes: 20
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   condition: |
     and(not(canceled()),
         eq(${{ parameters.checkDeps }}, 'true'))
@@ -183,7 +183,7 @@ jobs:
   displayName: Prechecked
   dependsOn: ["prechecks", "dependencies"]
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) job passes if all of
   # the preceeding jobs either pass or are skipped
   # adapted from:

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -104,7 +104,7 @@ jobs:
         eq(${{ parameters.runDocker }}, 'true'))
   timeoutInMinutes: 120
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -201,7 +201,7 @@ jobs:
         eq(${{ parameters.runPackaging }}, 'true'))
   timeoutInMinutes: 120
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -268,7 +268,7 @@ jobs:
     and(not(canceled()),
         eq(${{ parameters.publishDocs }}, 'true'))
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - template: ../bazel.yml
     parameters:
@@ -348,7 +348,7 @@ jobs:
         eq(${{ parameters.runPackaging }}, 'true'))
   timeoutInMinutes: 120
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -377,7 +377,7 @@ jobs:
   dependsOn: ["docker", "docs", "signed_release"]
   displayName: Success (linux artefacts)
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) check passes if all of
   # the preceding checks either pass or are skipped
   # adapted from:
@@ -400,7 +400,7 @@ jobs:
         in(dependencies.success.result, 'Succeeded', 'SucceededWithIssues'),
         eq(${{ parameters.publishGithubRelease }}, 'true'))
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:

--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -13,7 +13,7 @@ jobs:
   condition: and(not(canceled()), succeeded(), ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.docsOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.examplesOnly'], 'true'))
   timeoutInMinutes: 120
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -61,7 +61,7 @@ jobs:
   displayName: Verification complete
   dependsOn: ["packages_x64", "packages_arm64"]
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) check passes if all of
   # the preceding checks either pass or are skipped
   # adapted from:

--- a/.azure-pipelines/stage/windows.yml
+++ b/.azure-pipelines/stage/windows.yml
@@ -107,7 +107,7 @@ jobs:
   displayName: Complete
   dependsOn: ["release", "docker"]
   pool:
-    vmImage: "ubuntu-20.04"
+    vmImage: $(agentUbuntu)
   # This condition ensures that this (required) job passes if all of
   # the preceeding jobs either pass or are skipped
   # adapted from:

--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       ${{
           github.repository == 'envoyproxy/envoy'

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
     - name: 'Checkout Repository'

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -3,6 +3,8 @@ name: Environment
 on:
   workflow_call:
     outputs:
+      agent_ubuntu:
+        value: ubuntu-22.04
       build_image_ubuntu:
         value: ${{ jobs.repo.outputs.build_image_ubuntu }}
       build_image_ubuntu_mobile:
@@ -41,7 +43,7 @@ concurrency:
 jobs:
   repo:
     if: github.repository == 'envoyproxy/envoy'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       build_image_ubuntu: ${{ steps.build_image.outputs.build_image_ubuntu }}
       build_image_ubuntu_mobile: ${{ steps.build_image.outputs.build_image_ubuntu_mobile }}

--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'envoyproxy/envoy'
     strategy:
       fail-fast: false

--- a/.github/workflows/envoy-verify.yml
+++ b/.github/workflows/envoy-verify.yml
@@ -35,7 +35,7 @@ jobs:
 
   # Runs untrusted code
   verify-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check
     steps:
     - run: |

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_android_build == 'true' }}
     needs: env
     name: android_build
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 90
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}

--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -80,7 +80,7 @@ jobs:
     # Only kotlin tests are executed since with linux:
     # https://github.com/envoyproxy/envoy-mobile/issues/1418.
     name: kotlin_tests_linux
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 90
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}

--- a/.github/workflows/mobile-asan.yml
+++ b/.github/workflows/mobile-asan.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_asan == 'true' }}
     needs: env
     name: asan
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 180
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}

--- a/.github/workflows/mobile-cc_tests.yml
+++ b/.github/workflows/mobile-cc_tests.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_cc_tests == 'true' }}
     needs: env
     name: cc_tests
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -19,7 +19,7 @@ jobs:
   cc_test:
     needs: env
     name: cc_test
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
     container:
       image: envoyproxy/envoy-build-ubuntu:41c5a05d708972d703661b702a63ef5060125c33

--- a/.github/workflows/mobile-core.yml
+++ b/.github/workflows/mobile-core.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     needs: env
     name: unit_tests
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_coverage == 'true' }}
     needs: env
     name: coverage
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/mobile-docs.yml
+++ b/.github/workflows/mobile-docs.yml
@@ -19,7 +19,7 @@ jobs:
   docs:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     needs: env
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 20
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}

--- a/.github/workflows/mobile-format.yml
+++ b/.github/workflows/mobile-format.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
     name: format_all
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 45
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}
@@ -51,7 +51,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
     name: swift_lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 5
     container:
       image: ghcr.io/realm/swiftlint:0.50.3

--- a/.github/workflows/mobile-perf.yml
+++ b/.github/workflows/mobile-perf.yml
@@ -14,7 +14,7 @@ jobs:
   sizecurrent:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     name: size_current
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}
@@ -41,7 +41,7 @@ jobs:
   sizemain:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     name: size_main
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}
@@ -73,7 +73,7 @@ jobs:
     - sizecurrent
     - sizemain
     name: size_compare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}

--- a/.github/workflows/mobile-tsan.yml
+++ b/.github/workflows/mobile-tsan.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ needs.env.outputs.mobile_tsan == 'true' }}
     needs: env
     name: tsan
-    runs-on: ubuntu-20.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 90
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}

--- a/.github/workflows/mobile_release.yml
+++ b/.github/workflows/mobile_release.yml
@@ -15,7 +15,7 @@ jobs:
               || !contains(github.actor, '[bot]'))
       }}
     name: android_release_artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -13,7 +13,7 @@ jobs:
       statuses: read  # for pr_notifier.py
       pull-requests: read  # for pr_notifier.py
     name: PR Notifier
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       ${{
           github.repository == 'envoyproxy/envoy'

--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   fork_release_branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'envoyproxy/envoy'
     permissions:
       contents: write
@@ -27,7 +27,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   reopen_branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'envoyproxy/envoy'
     permissions:
       contents: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
     name: Prune Stale
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: |
       ${{
           github.repository == 'envoyproxy/envoy'

--- a/.github/workflows/workflow-complete.yml
+++ b/.github/workflows/workflow-complete.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   complete:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/workflow-start.yml
+++ b/.github/workflows/workflow-start.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   start:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       statuses: write
     steps:


### PR DESCRIPTION
The build container needs to be a specific version to ensure that Envoy is compiled with the correct/compatible glibc version

That is not the case for the host tho, with the caveat that the host kernel will be in effect (for local, non-RBE jobs)

This update sets the host agent/s use in authoritative places (for azp and gh) where possible, and updates ~everything to use ubuntu 22.04 for the host/kernel

There are a couple of exceptions - codeql/mobile-traffic-director - which do a host compile

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
