### PR TITLE
hcm router fuzzer: call correct fromHeaders implementation

### DIFF
--- a/test/common/http/hcm_router_fuzz_test.cc
+++ b/test/common/http/hcm_router_fuzz_test.cc
@@ -259,7 +259,7 @@ public:
     FuzzUpstream* s = select(stream);
     if (s) {
       auto trailers = std::make_unique<Http::TestResponseTrailerMapImpl>(
-          Fuzz::fromHeaders<Http::TestResponseTrailerMapImpl>(response_trailers));
+          fromHeaders<Http::TestResponseTrailerMapImpl>(response_trailers));
       s->sendTrailers(std::move(trailers));
     }
   }


### PR DESCRIPTION
I forgot to switch one call to the correct `fromHeaders` implementation that will not debug assert when faced with invalid headers. This PR fixes the call otherwise leading to noise in oss-fuzz.
