### PR TITLE
original_dst: fix timer lifetime

### DIFF
--- a/source/extensions/clusters/original_dst/original_dst_cluster.h
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.h
@@ -49,7 +49,7 @@ public:
   OriginalDstCluster(const envoy::config::cluster::v3::Cluster& config,
                      ClusterFactoryContext& context);
 
-  ~OriginalDstCluster() { cleanup_timer_->disableTimer(); }
+  ~OriginalDstCluster() override { cleanup_timer_->disableTimer(); }
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }

--- a/source/extensions/clusters/original_dst/original_dst_cluster.h
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.h
@@ -49,6 +49,8 @@ public:
   OriginalDstCluster(const envoy::config::cluster::v3::Cluster& config,
                      ClusterFactoryContext& context);
 
+  ~OriginalDstCluster() { cleanup_timer_->disableTimer(); }
+
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
 

--- a/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
+++ b/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
@@ -82,6 +82,8 @@ public:
     cluster_->initialize([&]() -> void { initialized_.ready(); });
   }
 
+  void TearDown() override { EXPECT_CALL(*cleanup_timer_, disableTimer()); }
+
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
   Stats::TestUtil::TestStore& stats_store_ = server_context_.store_;
   Ssl::MockContextManager ssl_context_manager_;


### PR DESCRIPTION
Commit Message: Ensure timer is not invoked past parent cluster deletion.
Additional Description:
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none