### PR TITLE
application logs: add ENVOY_TAGGED_CONN_LOG and ENVOY_TAGGED_STREAM_LOG

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -605,9 +605,19 @@ public:
 #define ENVOY_TAGGED_LOG(LEVEL, TAGS, FORMAT, ...)                                                 \
   ENVOY_TAGGED_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, FORMAT, ##__VA_ARGS__)
 
+/**
+ * Log with tags which are a map of key and value strings. Has the same operation as
+ * ENVOY_TAGGED_LOG, only this macro will also add the connection ID to the tags, if the provided
+ * tags do not already have a ConnectionId key existing.
+ */
 #define ENVOY_TAGGED_CONN_LOG(LEVEL, TAGS, CONNECTION, FORMAT, ...)                                \
   ENVOY_TAGGED_CONN_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, CONNECTION, FORMAT, ##__VA_ARGS__)
 
+/**
+ * Log with tags which are a map of key and value strings. Has the same operation as
+ * ENVOY_TAGGED_LOG, only this macro will also add the connection and stream ID to the tags,
+ * if the provided tags do not already have a ConnectionId or StreamId keys existing.
+ */
 #define ENVOY_TAGGED_STREAM_LOG(LEVEL, TAGS, STREAM, FORMAT, ...)                                  \
   ENVOY_TAGGED_STREAM_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, STREAM, FORMAT, ##__VA_ARGS__)
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -573,6 +573,28 @@ public:
     }                                                                                              \
   } while (0)
 
+#define ENVOY_TAGGED_CONN_LOG_TO_LOGGER(LOGGER, LEVEL, TAGS, CONNECTION, FORMAT, ...)              \
+  do {                                                                                             \
+    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
+      TAGS.emplace("ConnectionId", std::to_string((CONNECTION).id()));                             \
+      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
+                          ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,               \
+                          ##__VA_ARGS__);                                                          \
+    }                                                                                              \
+  } while (0)
+
+#define ENVOY_TAGGED_STREAM_LOG_TO_LOGGER(LOGGER, LEVEL, TAGS, STREAM, FORMAT, ...)                \
+  do {                                                                                             \
+    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
+      TAGS.emplace("ConnectionId",                                                                 \
+                   (STREAM).connection() ? std::to_string((STREAM).connection()->id()) : "0");     \
+      TAGS.emplace("StreamId", std::to_string((STREAM).streamId()));                               \
+      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
+                          ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,               \
+                          ##__VA_ARGS__);                                                          \
+    }                                                                                              \
+  } while (0)
+
 /**
  * Log with tags which are a map of key and value strings. When ENVOY_TAGGED_LOG is used, the tags
  * are serialized and prepended to the log message.
@@ -582,6 +604,12 @@ public:
  */
 #define ENVOY_TAGGED_LOG(LEVEL, TAGS, FORMAT, ...)                                                 \
   ENVOY_TAGGED_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, FORMAT, ##__VA_ARGS__)
+
+#define ENVOY_TAGGED_CONN_LOG(LEVEL, TAGS, CONNECTION, FORMAT, ...)                                \
+  ENVOY_TAGGED_CONN_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, CONNECTION, FORMAT, ##__VA_ARGS__)
+
+#define ENVOY_TAGGED_STREAM_LOG(LEVEL, TAGS, STREAM, FORMAT, ...)                                  \
+  ENVOY_TAGGED_STREAM_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, TAGS, STREAM, FORMAT, ##__VA_ARGS__)
 
 /**
  * Log with a stable event name. This allows emitting a log line with a stable name in addition to

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -212,6 +212,8 @@ envoy_cc_test(
     srcs = ["logger_test.cc"],
     deps = [
         "//source/common/common:minimal_logger_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/network:network_mocks",
     ],
 )
 

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -38,7 +38,6 @@ public:
     ENVOY_TAGGED_CONN_LOG(info, tags_, connection_, "fake message {}", "val");
     ENVOY_TAGGED_CONN_LOG(info, (std::map<std::string, std::string>{{"key", "val"}}), connection_,
                           "fake message {}", "val");
-
     ENVOY_TAGGED_STREAM_LOG(info, tags_, stream_, "fake message {}", "val");
     ENVOY_TAGGED_STREAM_LOG(info, (std::map<std::string, std::string>{{"key", "val"}}), stream_,
                             "fake message {}", "val");

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -35,6 +35,13 @@ public:
     ENVOY_TAGGED_LOG(info, tags_, "fake message {}", "val");
     ENVOY_TAGGED_LOG(info, (std::map<std::string, std::string>{{"key", "val"}}), "fake message {}",
                      "val");
+    ENVOY_TAGGED_CONN_LOG(info, tags_, connection_, "fake message {}", "val");
+    ENVOY_TAGGED_CONN_LOG(info, (std::map<std::string, std::string>{{"key", "val"}}), connection_,
+                          "fake message {}", "val");
+
+    ENVOY_TAGGED_STREAM_LOG(info, tags_, stream_, "fake message {}", "val");
+    ENVOY_TAGGED_STREAM_LOG(info, (std::map<std::string, std::string>{{"key", "val"}}), stream_,
+                            "fake message {}", "val");
   }
 
   void logMessageEscapeSequences() { ENVOY_LOG_MISC(info, "line 1 \n line 2 \t tab \\r test"); }

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -525,8 +525,7 @@ TEST(TaggedLogTest, TestTaggedConnLog) {
                     HasSubstr("[Tags: \"ConnectionId\":\"200\",\"key\":\"val\"] fake message"));
       }))
       .WillOnce(Invoke([](auto msg, auto&) {
-        EXPECT_THAT(msg,
-                    HasSubstr("[Tags: \"ConnectionId\":\"105\"] fake message"));
+        EXPECT_THAT(msg, HasSubstr("[Tags: \"ConnectionId\":\"105\"] fake message"));
       }));
 
   std::map<std::string, std::string> empty_tags;

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -523,14 +523,20 @@ TEST(TaggedLogTest, TestTaggedConnLog) {
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_THAT(msg,
                     HasSubstr("[Tags: \"ConnectionId\":\"200\",\"key\":\"val\"] fake message"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(msg,
+                    HasSubstr("[Tags: \"ConnectionId\":\"105\"] fake message"));
       }));
 
   std::map<std::string, std::string> empty_tags;
   std::map<std::string, std::string> tags{{"key", "val"}};
+  std::map<std::string, std::string> tags_with_conn_id{{"ConnectionId", "105"}};
 
   ClassForTaggedLog object;
   object.logMessageWithConnection(empty_tags);
   object.logMessageWithConnection(tags);
+  object.logMessageWithConnection(tags_with_conn_id);
 }
 
 TEST(TaggedLogTest, TestTaggedStreamLog) {
@@ -549,14 +555,20 @@ TEST(TaggedLogTest, TestTaggedStreamLog) {
         EXPECT_THAT(
             msg, HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"300\",\"key\":\"val\"] "
                            "fake message"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(
+            msg, HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"405\"] fake message"));
       }));
 
   std::map<std::string, std::string> empty_tags;
   std::map<std::string, std::string> tags{{"key", "val"}};
+  std::map<std::string, std::string> tags_with_stream_id{{"StreamId", "405"}};
 
   ClassForTaggedLog object;
   object.logMessageWithStream(empty_tags);
   object.logMessageWithStream(tags);
+  object.logMessageWithStream(tags_with_stream_id);
 }
 
 TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -454,6 +454,8 @@ public:
   ClassForTaggedLog() {
     EXPECT_CALL(connection_, id()).WillRepeatedly(Return(200));
     EXPECT_CALL(stream_, streamId()).WillRepeatedly(Return(300));
+    EXPECT_CALL(stream_, connection())
+        .WillRepeatedly(Return(makeOptRef(dynamic_cast<const Network::Connection&>(connection_))));
   }
 
   void logMessageWithPreCreatedTags() { ENVOY_TAGGED_LOG(info, tags_, "fake message {}", "val"); }
@@ -540,13 +542,13 @@ TEST(TaggedLogTest, TestTaggedStreamLog) {
         EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
       }))
       .WillOnce(Invoke([](auto msg, auto&) {
-        EXPECT_THAT(msg,
-                    HasSubstr("[Tags: \"ConnectionId\":\"0\",\"StreamId\":\"300\"] fake message"));
+        EXPECT_THAT(
+            msg, HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"300\"] fake message"));
       }))
       .WillOnce(Invoke([](auto msg, auto&) {
-        EXPECT_THAT(msg,
-                    HasSubstr("[Tags: \"ConnectionId\":\"0\",\"StreamId\":\"300\",\"key\":\"val\"] "
-                              "fake message"));
+        EXPECT_THAT(
+            msg, HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"300\",\"key\":\"val\"] "
+                           "fake message"));
       }));
 
   std::map<std::string, std::string> empty_tags;
@@ -645,7 +647,7 @@ TEST(TaggedLogTest, TestTaggedStreamLogWithJsonFormat) {
         EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
         EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
         EXPECT_THAT(msg, HasSubstr("\"StreamId\":\"300\""));
-        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"0\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
       }))
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
@@ -653,7 +655,7 @@ TEST(TaggedLogTest, TestTaggedStreamLogWithJsonFormat) {
         EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
         EXPECT_THAT(msg, HasSubstr("\"key\":\"val\""));
         EXPECT_THAT(msg, HasSubstr("\"StreamId\":\"300\""));
-        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"0\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
       }));
 
   std::map<std::string, std::string> empty_tags;

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -5,6 +5,8 @@
 #include "source/common/common/logger.h"
 
 #include "test/mocks/common.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/network/mocks.h"
 #include "test/test_common/environment.h"
 
 #include "gmock/gmock.h"
@@ -13,6 +15,7 @@
 using testing::_;
 using testing::HasSubstr;
 using testing::Invoke;
+using testing::Return;
 
 namespace Envoy {
 namespace Logger {
@@ -448,6 +451,11 @@ TEST(LoggerUtilityTest, TestSerializeLogTags) {
 
 class ClassForTaggedLog : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 public:
+  ClassForTaggedLog() {
+    EXPECT_CALL(connection_, id()).WillRepeatedly(Return(200));
+    EXPECT_CALL(stream_, streamId()).WillRepeatedly(Return(300));
+  }
+
   void logMessageWithPreCreatedTags() { ENVOY_TAGGED_LOG(info, tags_, "fake message {}", "val"); }
 
   void logMessageWithInlineTags() {
@@ -459,15 +467,29 @@ public:
     ENVOY_TAGGED_LOG(info, tags_with_escaping_, "fake me\"ssage {}", "val");
   }
 
+  void logMessageWithConnection(std::map<std::string, std::string>& tags) {
+    ENVOY_TAGGED_CONN_LOG(info, tags, connection_, "fake message");
+  }
+
+  void logMessageWithStream(std::map<std::string, std::string>& tags) {
+    ENVOY_TAGGED_STREAM_LOG(info, tags, stream_, "fake message");
+  }
+
 private:
   std::map<std::string, std::string> tags_{{"key", "val"}};
   std::map<std::string, std::string> tags_with_escaping_{{"key", "val"}, {"ke\"y", "v\"al"}};
+  NiceMock<Network::MockConnection> connection_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> stream_;
 };
 
 TEST(TaggedLogTest, TestTaggedLog) {
   Envoy::Logger::Registry::setLogFormat("%v");
   MockLogSink sink(Envoy::Logger::Registry::getSink());
   EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_THAT(msg, HasSubstr("[Tags: \"key\":\"val\"] fake message val"));
       }))
@@ -485,6 +507,56 @@ TEST(TaggedLogTest, TestTaggedLog) {
   object.logMessageWithEscaping();
 }
 
+TEST(TaggedLogTest, TestTaggedConnLog) {
+  Envoy::Logger::Registry::setLogFormat("%v");
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(msg, HasSubstr("[Tags: \"ConnectionId\":\"200\"] fake message"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(msg,
+                    HasSubstr("[Tags: \"ConnectionId\":\"200\",\"key\":\"val\"] fake message"));
+      }));
+
+  std::map<std::string, std::string> empty_tags;
+  std::map<std::string, std::string> tags{{"key", "val"}};
+
+  ClassForTaggedLog object;
+  object.logMessageWithConnection(empty_tags);
+  object.logMessageWithConnection(tags);
+}
+
+TEST(TaggedLogTest, TestTaggedStreamLog) {
+  Envoy::Logger::Registry::setLogFormat("%v");
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(msg,
+                    HasSubstr("[Tags: \"ConnectionId\":\"0\",\"StreamId\":\"300\"] fake message"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(msg,
+                    HasSubstr("[Tags: \"ConnectionId\":\"0\",\"StreamId\":\"300\",\"key\":\"val\"] "
+                              "fake message"));
+      }));
+
+  std::map<std::string, std::string> empty_tags;
+  std::map<std::string, std::string> tags{{"key", "val"}};
+
+  ClassForTaggedLog object;
+  object.logMessageWithStream(empty_tags);
+  object.logMessageWithStream(tags);
+}
+
 TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {
   ProtobufWkt::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
@@ -495,6 +567,10 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {
 
   MockLogSink sink(Envoy::Logger::Registry::getSink());
   EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
         EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
@@ -514,6 +590,80 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {
   object.logMessageWithEscaping();
 }
 
+TEST(TaggedLogTest, TestTaggedConnLogWithJsonFormat) {
+  ProtobufWkt::Struct log_struct;
+  (*log_struct.mutable_fields())["Level"].set_string_value("%l");
+  (*log_struct.mutable_fields())["Message"].set_string_value("%j");
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  EXPECT_TRUE(Envoy::Logger::Registry::setJsonLogFormat(log_struct).ok());
+  EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
+
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"key\":\"val\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
+      }));
+
+  std::map<std::string, std::string> empty_tags;
+  std::map<std::string, std::string> tags{{"key", "val"}};
+
+  ClassForTaggedLog object;
+  object.logMessageWithConnection(empty_tags);
+  object.logMessageWithConnection(tags);
+}
+
+TEST(TaggedLogTest, TestTaggedStreamLogWithJsonFormat) {
+  ProtobufWkt::Struct log_struct;
+  (*log_struct.mutable_fields())["Level"].set_string_value("%l");
+  (*log_struct.mutable_fields())["Message"].set_string_value("%j");
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  EXPECT_TRUE(Envoy::Logger::Registry::setJsonLogFormat(log_struct).ok());
+  EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
+
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"StreamId\":\"300\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"0\""));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"key\":\"val\""));
+        EXPECT_THAT(msg, HasSubstr("\"StreamId\":\"300\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"0\""));
+      }));
+
+  std::map<std::string, std::string> empty_tags;
+  std::map<std::string, std::string> tags{{"key", "val"}};
+
+  ClassForTaggedLog object;
+  object.logMessageWithStream(empty_tags);
+  object.logMessageWithStream(tags);
+}
+
 TEST(TaggedLogTest, TestTaggedLogWithJsonFormatMultipleJFlags) {
   ProtobufWkt::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
@@ -524,13 +674,18 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormatMultipleJFlags) {
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
   MockLogSink sink(Envoy::Logger::Registry::getSink());
-  EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto&) {
-    EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
-    EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
-    EXPECT_THAT(msg, HasSubstr("\"Message1\":\"fake message val\""));
-    EXPECT_THAT(msg, HasSubstr("\"Message2\":\"fake message val\""));
-    EXPECT_THAT(msg, HasSubstr("\"key\":\"val\""));
-  }));
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message1\":\"fake message val\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message2\":\"fake message val\""));
+        EXPECT_THAT(msg, HasSubstr("\"key\":\"val\""));
+      }));
 
   ClassForTaggedLog object;
   object.logMessageWithPreCreatedTags();


### PR DESCRIPTION
Additional Description: These macros extend ``ENVOY_TAGGED_LOG`` (added in https://github.com/envoyproxy/envoy/pull/27882) with a connection/stream and add the connection/stream ID to the tags, similar to ``ENVOY_CONN_LOG`` and ``ENVOY_STREAM_LOG``
Risk Level: Low
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None