### PR TITLE
ci: Increase timeout in Swift integration tests

### DIFF
--- a/mobile/test/swift/integration/ResetConnectivityStateTest.swift
+++ b/mobile/test/swift/integration/ResetConnectivityStateTest.swift
@@ -84,7 +84,7 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation1], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation1], timeout: 10), .completed)
 
     engine.resetConnectivityState()
 

--- a/mobile/test/swift/integration/SetLoggerTest.swift
+++ b/mobile/test/swift/integration/SetLoggerTest.swift
@@ -86,8 +86,8 @@ static_resources:
       }
       .build()
 
-    XCTAssertEqual(XCTWaiter.wait(for: [engineExpectation], timeout: 1), .completed)
-    XCTAssertEqual(XCTWaiter.wait(for: [loggingExpectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [engineExpectation], timeout: 10), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [loggingExpectation], timeout: 10), .completed)
 
     // Send a request to trigger the test filter which should log an event.
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",


### PR DESCRIPTION
Some work was done previously in
https://github.com/envoyproxy/envoy/pull/24892 to increase the Swift integration test timeout to 10 seconds to match the Kotlin test counterparts and reduce test flakiness.

However, there are still some places where the timeout was low and it caused flakey tests, see
https://github.com/envoyproxy/envoy/issues/28115.

This change increases the timeout to 10 seconds in the other Swift tests as well.

Fixes #28115
