### PR TITLE
upstream: only recreate worker local lb for thread aware lb

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -171,6 +171,11 @@ public:
    * @return LoadBalancerPtr a new worker local load balancer.
    */
   virtual LoadBalancerPtr create(LoadBalancerParams params) PURE;
+
+  /**
+   * @return bool whether the load balancer should be recreated when the host set changes.
+   */
+  virtual bool recreateOnHostChange() const { return true; }
 };
 
 using LoadBalancerFactorySharedPtr = std::shared_ptr<LoadBalancerFactory>;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1225,7 +1225,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::updateHost
                             hosts_added, hosts_removed, weighted_priority_health,
                             overprovisioning_factor, std::move(cross_priority_host_map));
   // If an LB is thread aware, create a new worker local LB on membership changes.
-  if (lb_factory_ != nullptr) {
+  if (lb_factory_ != nullptr && lb_factory_->recreateOnHostChange()) {
     ENVOY_LOG(debug, "re-creating local LB for TLS cluster {}", name);
     lb_ = lb_factory_->create({priority_set_, parent_.local_priority_set_});
   }

--- a/source/extensions/load_balancing_policies/common/factory_base.h
+++ b/source/extensions/load_balancing_policies/common/factory_base.h
@@ -47,6 +47,8 @@ private:
                     time_source_);
     }
 
+    bool recreateOnHostChange() const override { return false; }
+
   public:
     OptRef<const ProtoType> proto_config_;
     const Upstream::ClusterInfo& cluster_info_;

--- a/source/extensions/load_balancing_policies/subset/config.cc
+++ b/source/extensions/load_balancing_policies/subset/config.cc
@@ -116,6 +116,7 @@ public:
         params.local_priority_set, cluster_info_.lbStats(), cluster_info_.statsScope(), runtime_,
         random_, time_source_);
   }
+  bool recreateOnHostChange() const override { return false; }
 
 private:
   const SubsetLoadBalancerConfig& subset_config_;

--- a/source/extensions/load_balancing_policies/subset/subset_lb.cc
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.cc
@@ -903,7 +903,7 @@ void SubsetLoadBalancer::PrioritySubsetImpl::update(uint32_t priority,
   // Create a new worker local LB if needed.
   // TODO(mattklein123): See the PrioritySubsetImpl constructor for additional comments on how
   // we can do better here.
-  if (thread_aware_lb_ != nullptr) {
+  if (thread_aware_lb_ != nullptr && thread_aware_lb_->factory()->recreateOnHostChange()) {
     lb_ = thread_aware_lb_->factory()->create({*this, original_local_priority_set_});
   }
 }


### PR DESCRIPTION


Commit Message: upstream: only recreate worker local lb for thread aware lb
Additional Description: 

If the new `load_balancing_policy` is configured, the `least request`, `random`, etc. non-thread-aware Lbs will also be created by the `LoadBalancerFactory`. This means these LBs will be recreated when the host is changed even it's unnecessary.

This PR add a new flag to tell envoy don't recreate these LBs when the host is changed.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.