### PR TITLE
Log uncaught exception

### DIFF
--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -21,8 +21,7 @@ std::terminate_handler TerminateHandler::logOnTerminate() const {
         ENVOY_LOG(critical, "std::terminate called! Uncaught EnvoyException '{}', see trace.",
                   e.what());
       } catch (const std::exception& e) {
-        ENVOY_LOG(critical, "std::terminate called! Uncaught exception '{}', see trace.",
-                  e.what());
+        ENVOY_LOG(critical, "std::terminate called! Uncaught exception '{}', see trace.", e.what());
       } catch (...) {
         ENVOY_LOG(critical,
                   "std::terminate called! See trace. Uncaught unknown exception, see trace.");

--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -13,7 +13,6 @@ namespace Envoy {
 
 std::terminate_handler TerminateHandler::logOnTerminate() const {
   return std::set_terminate([]() {
-    std::exception_ptr current_exception = std::current_exception();
     logException(std::current_exception());
     BACKTRACE_LOG();
     std::abort();

--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -30,8 +30,7 @@ void TerminateHandler::logException(const std::exception_ptr current_exception) 
     } catch (const std::exception& e) {
       ENVOY_LOG(critical, "std::terminate called! Uncaught exception '{}', see trace.", e.what());
     } catch (...) {
-      ENVOY_LOG(critical,
-                "std::terminate called! Uncaught unknown exception, see trace.");
+      ENVOY_LOG(critical, "std::terminate called! Uncaught unknown exception, see trace.");
     }
   } else {
     ENVOY_LOG(critical, "std::terminate called! See trace.");

--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -18,14 +18,14 @@ std::terminate_handler TerminateHandler::logOnTerminate() const {
       try {
         std::rethrow_exception(current_exception);
       } catch (const EnvoyException& e) {
-        ENVOY_LOG(critical,
-                  "std::terminate called! Uncaught EnvoyException '{}', see trace.", e.what());
+        ENVOY_LOG(critical, "std::terminate called! Uncaught EnvoyException '{}', see trace.",
+                  e.what());
       } catch (const std::exception& e) {
-        ENVOY_LOG(critical,
-                  "std::terminate called! Uncaught exception '{}', see trace.", e.what());
+        ENVOY_LOG(critical, "std::terminate called! Uncaught exception '{}', see trace.",
+                  e.what());
       } catch (...) {
         ENVOY_LOG(critical,
-                 "std::terminate called! See trace. Uncaught unknown exception, see trace.");
+                  "std::terminate called! See trace. Uncaught unknown exception, see trace.");
       }
     } else {
       ENVOY_LOG(critical, "std::terminate called! See trace.");

--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -2,14 +2,28 @@
 
 #include <cstdlib>
 
+#include "envoy/common/exception.h"
 #include "source/common/common/logger.h"
 #include "source/server/backtrace.h"
+
+#include "absl/strings/str_format.h"
 
 namespace Envoy {
 
 std::terminate_handler TerminateHandler::logOnTerminate() const {
   return std::set_terminate([]() {
-    ENVOY_LOG(critical, "std::terminate called! (possible uncaught exception, see trace)");
+    auto currentException = std::current_exception();
+    if (currentException) {
+      try {
+        std::rethrow_exception(currentException);
+      } catch (const EnvoyException& e) {
+        ENVOY_LOG(critical, absl::StrFormat("std::terminate called! Uncaught EnvoyException '%s', see trace.", e.what()));
+      } catch (...) {
+        ENVOY_LOG(critical, "std::terminate called! See trace. Uncaught unknown exception, see trace.");
+      }
+    } else {
+      ENVOY_LOG(critical, "std::terminate called! See trace.");
+    }
     BACKTRACE_LOG();
     std::abort();
   });

--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -14,24 +14,28 @@ namespace Envoy {
 std::terminate_handler TerminateHandler::logOnTerminate() const {
   return std::set_terminate([]() {
     std::exception_ptr current_exception = std::current_exception();
-    if (current_exception != nullptr) {
-      try {
-        std::rethrow_exception(current_exception);
-      } catch (const EnvoyException& e) {
-        ENVOY_LOG(critical, "std::terminate called! Uncaught EnvoyException '{}', see trace.",
-                  e.what());
-      } catch (const std::exception& e) {
-        ENVOY_LOG(critical, "std::terminate called! Uncaught exception '{}', see trace.", e.what());
-      } catch (...) {
-        ENVOY_LOG(critical,
-                  "std::terminate called! See trace. Uncaught unknown exception, see trace.");
-      }
-    } else {
-      ENVOY_LOG(critical, "std::terminate called! See trace.");
-    }
+    logException(std::current_exception());
     BACKTRACE_LOG();
     std::abort();
   });
+}
+
+void TerminateHandler::logException(const std::exception_ptr current_exception) {
+  if (current_exception != nullptr) {
+    try {
+      std::rethrow_exception(current_exception);
+    } catch (const EnvoyException& e) {
+      ENVOY_LOG(critical, "std::terminate called! Uncaught EnvoyException '{}', see trace.",
+                e.what());
+    } catch (const std::exception& e) {
+      ENVOY_LOG(critical, "std::terminate called! Uncaught exception '{}', see trace.", e.what());
+    } catch (...) {
+      ENVOY_LOG(critical,
+                "std::terminate called! Uncaught unknown exception, see trace.");
+    }
+  } else {
+    ENVOY_LOG(critical, "std::terminate called! See trace.");
+  }
 }
 
 } // namespace Envoy

--- a/source/exe/terminate_handler.h
+++ b/source/exe/terminate_handler.h
@@ -13,11 +13,18 @@ public:
   ~TerminateHandler() { std::set_terminate(previous_terminate_); }
 
 private:
+  friend class TerminateHandlerTest;
+
   /**
    * Sets the std::terminate to a function which will log as much of a backtrace as
    * possible, then call abort. Returns the previous handler.
    */
   std::terminate_handler logOnTerminate() const;
+
+  /**
+   * Logs exception details when possible
+   */
+  static void logException(const std::exception_ptr);
 
   const std::terminate_handler previous_terminate_;
 };

--- a/test/exe/terminate_handler_test.cc
+++ b/test/exe/terminate_handler_test.cc
@@ -6,9 +6,37 @@
 
 namespace Envoy {
 
+class TerminateHandlerTest : public testing::Test {
+public:
+void logException(const std::exception_ptr e) {
+  handler.logException(e);  
+};
+
+TerminateHandler handler;
+};
+
 TEST(TerminateHandlerDeathTest, HandlerInstalledTest) {
   TerminateHandler handler;
   EXPECT_DEATH([]() -> void { std::terminate(); }(), ".*std::terminate called!.*");
+}
+
+TEST_F(TerminateHandlerTest, LogsEnvoyException) {
+  EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught EnvoyException 'boom', see trace.",
+		     logException(std::make_exception_ptr(EnvoyException("boom"))));  
+}
+
+TEST_F(TerminateHandlerTest, LogsStdException) {
+  EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught exception 'std::exception', see trace.",
+                     logException(std::make_exception_ptr(std::exception())));
+}
+
+TEST_F(TerminateHandlerTest, LogsUnknownException) {
+  EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught unknown exception, see trace.",
+                     logException(std::make_exception_ptr("Boom")));
+}
+
+TEST_F(TerminateHandlerTest, HandlesNullptrCurrentException) {
+  EXPECT_LOG_CONTAINS("critical", "std::terminate called! See trace.", logException(nullptr));
 }
 
 } // namespace Envoy

--- a/test/exe/terminate_handler_test.cc
+++ b/test/exe/terminate_handler_test.cc
@@ -8,7 +8,7 @@ namespace Envoy {
 
 class TerminateHandlerTest : public testing::Test {
 public:
-void logException(const std::exception_ptr e) { handler.logException(e); };
+  void logException(const std::exception_ptr e) { handler.logException(e); };
 
   TerminateHandler handler;
 };
@@ -21,7 +21,7 @@ TEST(TerminateHandlerDeathTest, HandlerInstalledTest) {
 TEST_F(TerminateHandlerTest, LogsEnvoyException) {
   EXPECT_LOG_CONTAINS("critical",
                       "std::terminate called! Uncaught EnvoyException 'boom', see trace.",
-                      logException(std::make_exception_ptr(EnvoyException("boom"))));  
+                      logException(std::make_exception_ptr(EnvoyException("boom"))));
 }
 
 TEST_F(TerminateHandlerTest, LogsStdException) {

--- a/test/exe/terminate_handler_test.cc
+++ b/test/exe/terminate_handler_test.cc
@@ -24,11 +24,19 @@ TEST_F(TerminateHandlerTest, LogsEnvoyException) {
                       logException(std::make_exception_ptr(EnvoyException("boom"))));
 }
 
+#ifdef WIN32
+TEST_F(TerminateHandlerTest, LogsStdException) {
+  EXPECT_LOG_CONTAINS("critical",
+                      "std::terminate called! Uncaught exception 'Unknown exception', see trace.",
+                      logException(std::make_exception_ptr(std::exception())));
+}
+#else
 TEST_F(TerminateHandlerTest, LogsStdException) {
   EXPECT_LOG_CONTAINS("critical",
                       "std::terminate called! Uncaught exception 'std::exception', see trace.",
                       logException(std::make_exception_ptr(std::exception())));
 }
+#endif
 
 TEST_F(TerminateHandlerTest, LogsUnknownException) {
   EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught unknown exception, see trace.",

--- a/test/exe/terminate_handler_test.cc
+++ b/test/exe/terminate_handler_test.cc
@@ -8,11 +8,9 @@ namespace Envoy {
 
 class TerminateHandlerTest : public testing::Test {
 public:
-void logException(const std::exception_ptr e) {
-  handler.logException(e);  
-};
+void logException(const std::exception_ptr e) { handler.logException(e); };
 
-TerminateHandler handler;
+  TerminateHandler handler;
 };
 
 TEST(TerminateHandlerDeathTest, HandlerInstalledTest) {
@@ -21,18 +19,20 @@ TEST(TerminateHandlerDeathTest, HandlerInstalledTest) {
 }
 
 TEST_F(TerminateHandlerTest, LogsEnvoyException) {
-  EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught EnvoyException 'boom', see trace.",
-		     logException(std::make_exception_ptr(EnvoyException("boom"))));  
+  EXPECT_LOG_CONTAINS("critical",
+                      "std::terminate called! Uncaught EnvoyException 'boom', see trace.",
+                      logException(std::make_exception_ptr(EnvoyException("boom"))));  
 }
 
 TEST_F(TerminateHandlerTest, LogsStdException) {
-  EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught exception 'std::exception', see trace.",
-                     logException(std::make_exception_ptr(std::exception())));
+  EXPECT_LOG_CONTAINS("critical",
+                      "std::terminate called! Uncaught exception 'std::exception', see trace.",
+                      logException(std::make_exception_ptr(std::exception())));
 }
 
 TEST_F(TerminateHandlerTest, LogsUnknownException) {
   EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught unknown exception, see trace.",
-                     logException(std::make_exception_ptr("Boom")));
+                      logException(std::make_exception_ptr("Boom")));
 }
 
 TEST_F(TerminateHandlerTest, HandlesNullptrCurrentException) {

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -246,6 +246,7 @@ paths:
   raw_try:
     include:
     - source/common/common/thread.h
+    - source/exe/terminate_handler.cc
 
   # Files matching these exact names can reference real-world time. These include the class
   # definitions for real-world time, the construction of them in main(), and perf annotation.


### PR DESCRIPTION
Currently when the terminate handler handles an uncaught exception, it provides limited information about what happened and what exception was thrown. This change attempts to log additional details about the exception. 

Commit Message: Log uncaught exceptions when possible
Additional Description: Provide more details when possible when an uncaught exception is handled in terminate handler.
Risk Level: low