### PR TITLE
buffer: Disable flaky test on windows.

### DIFF
--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -1386,18 +1386,8 @@ TYPED_TEST(OwnedImplTypedTest, ReadReserveAndCommit) {
   const ssize_t rc = os_sys_calls.write(fds[1], data.data(), data.size()).return_value_;
   ASSERT_GT(rc, 0);
 
-  // The remainder Windows flakes under Windows. E.g.
-  //     [ RUN      ] OwnedImplTypedTest/0.ReadReserveAndCommit
-  //     test/common/buffer/owned_impl_test.cc(1389): error: Expected equality of these values:
-  //       result.return_value_
-  //         Which is: 0
-  //       static_cast<uint64_t>(rc)
-  //         Which is: 1
-  //     Stack trace: (elided)
-  //     ... Google Test internal frames ...
-  //
-  //     [  FAILED  ] OwnedImplTypedTest/0.ReadReserveAndCommit, where
-  //                  TypeParam = class Envoy::Network::IoSocketHandleImpl (1 ms)
+  // The remainder of this test flakes under Windows.
+  // See https://github.com/envoyproxy/envoy/issues/28177.
   DISABLE_UNDER_WINDOWS;
   Api::IoCallUint64Result result = io_handle.read(buf, read_length);
   ASSERT_EQ(result.return_value_, static_cast<uint64_t>(rc));

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -1385,6 +1385,20 @@ TYPED_TEST(OwnedImplTypedTest, ReadReserveAndCommit) {
   std::string data = "e";
   const ssize_t rc = os_sys_calls.write(fds[1], data.data(), data.size()).return_value_;
   ASSERT_GT(rc, 0);
+
+  // The remainder Windows flakes under Windows. E.g.
+  //     [ RUN      ] OwnedImplTypedTest/0.ReadReserveAndCommit
+  //     test/common/buffer/owned_impl_test.cc(1389): error: Expected equality of these values:
+  //       result.return_value_
+  //         Which is: 0
+  //       static_cast<uint64_t>(rc)
+  //         Which is: 1
+  //     Stack trace: (elided)
+  //     ... Google Test internal frames ...
+  //
+  //     [  FAILED  ] OwnedImplTypedTest/0.ReadReserveAndCommit, where
+  //                  TypeParam = class Envoy::Network::IoSocketHandleImpl (1 ms)
+  DISABLE_UNDER_WINDOWS;
   Api::IoCallUint64Result result = io_handle.read(buf, read_length);
   ASSERT_EQ(result.return_value_, static_cast<uint64_t>(rc));
   ASSERT_EQ(os_sys_calls.close(fds[1]).return_value_, 0);

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -22,6 +22,7 @@
 #include "test/mocks/server/transport_socket_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
 
 #include "absl/strings/str_format.h"
 #include "absl/types/optional.h"
@@ -30,14 +31,6 @@
 #define DISABLE_UNDER_COVERAGE return
 #else
 #define DISABLE_UNDER_COVERAGE                                                                     \
-  do {                                                                                             \
-  } while (0)
-#endif
-
-#ifdef WIN32
-#define DISABLE_UNDER_WINDOWS return
-#else
-#define DISABLE_UNDER_WINDOWS                                                                      \
   do {                                                                                             \
   } while (0)
 #endif

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1321,4 +1321,12 @@ MATCHER_P(JsonStringEq, expected, "") {
 }
 #endif
 
+#ifdef WIN32
+#define DISABLE_UNDER_WINDOWS return
+#else
+#define DISABLE_UNDER_WINDOWS                                                                      \
+  do {                                                                                             \
+  } while (0)
+#endif
+
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Avoids a recent test-flake on Windows by returning early from that test. This works around (but does not fix) https://github.com/envoyproxy/envoy/issues/28177
Risk Level: low
Testing: Just the failed test.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

