### PR TITLE
Make json value getter no throw for data plane usage

### DIFF
--- a/envoy/json/json_object.h
+++ b/envoy/json/json_object.h
@@ -8,6 +8,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
+#include "source/common/common/statusor.h"
 
 #include "absl/types/variant.h"
 
@@ -49,7 +50,7 @@ public:
    * @param name supplies the key name.
    * @return bool the value.
    */
-  virtual ValueType getValue(const std::string& name) const PURE;
+  virtual absl::StatusOr<ValueType> getValue(const std::string& name) const PURE;
 
   /**
    * Get a boolean value by name.

--- a/envoy/json/json_object.h
+++ b/envoy/json/json_object.h
@@ -8,6 +8,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
+
 #include "source/common/common/statusor.h"
 
 #include "absl/types/variant.h"

--- a/source/common/json/json_internal.cc
+++ b/source/common/json/json_internal.cc
@@ -60,7 +60,7 @@ public:
 
   uint64_t hash() const override;
 
-  ValueType getValue(const std::string& name) const override;
+  absl::StatusOr<ValueType> getValue(const std::string& name) const override;
   bool getBoolean(const std::string& name) const override;
   bool getBoolean(const std::string& name, bool default_value) const override;
   double getDouble(const std::string& name) const override;
@@ -384,11 +384,11 @@ nlohmann::json Field::asJsonDocument() const {
 
 uint64_t Field::hash() const { return HashUtil::xxHash64(asJsonString()); }
 
-ValueType Field::getValue(const std::string& name) const {
+absl::StatusOr<ValueType> Field::getValue(const std::string& name) const {
   auto value_itr = value_.object_value_.find(name);
   if (value_itr == value_.object_value_.end()) {
-    throw Exception(fmt::format("key '{}' missing from lines {}-{}", name, line_number_start_,
-                                line_number_end_));
+    return absl::NotFoundError(fmt::format("key '{}' missing from lines {}-{}", name,
+                                           line_number_start_, line_number_end_));
   }
   switch (value_itr->second->type_) {
   case Type::Boolean:
@@ -400,8 +400,8 @@ ValueType Field::getValue(const std::string& name) const {
   case Type::String:
     return value_itr->second->stringValue();
   default:
-    throw Exception(fmt::format("key '{}' not a value type from lines {}-{}", name,
-                                line_number_start_, line_number_end_));
+    return absl::InternalError(fmt::format("key '{}' not a value type from lines {}-{}", name,
+                                           line_number_start_, line_number_end_));
   }
 }
 

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test(
     deps = [
         "//source/common/json:json_loader_lib",
         "//source/common/stats:isolated_store_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )


### PR DESCRIPTION
Commit Message:
Address https://github.com/envoyproxy/envoy/pull/27926#discussion_r1245729093 so we don't need to catch exception
in data plane, specifically in http json to metadata filter which is WIP.
Additional Description:
Risk Level: low
Testing: unit