### PR TITLE
tap: Fix the failure of protobuf to PCAP generation

### DIFF
--- a/api/tools/tap2pcap.py
+++ b/api/tools/tap2pcap.py
@@ -49,7 +49,7 @@ def tap2pcap(tap_path, pcap_path):
         with open(tap_path, 'r') as f:
             text_format.Merge(f.read(), wrapper)
     else:
-        with open(tap_path, 'r') as f:
+        with open(tap_path, 'rb') as f:
             wrapper.ParseFromString(f.read())
 
     trace = wrapper.socket_buffered_trace


### PR DESCRIPTION
When run 'bazel run @envoy_api//tools:tap2pcap path_0.pb path_0.pcap':
  ...
  Traceback (most recent call last):
  File "..../tools/tap2pcap.runfiles/envoy_api/tools/tap2pcap.py", line 88, in <module>
    tap2pcap(sys.argv[1], sys.argv[2])
  File "..../tools/tap2pcap.runfiles/envoy_api/tools/tap2pcap.py", line 53, in tap2pcap
    wrapper.ParseFromString(f.read())
                            ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb8 in position 1: invalid start byte
  ...

Since protobuf file is binary format, open this file in binary mode will help to generate the PCAP successfully.
