### PR TITLE
Fix flake in ListenerMaxConnectionPerSocketEventTest.AcceptsConnectionsUpToTheMaximumPerSocketEvent

### DIFF
--- a/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_integration_test.cc
+++ b/test/extensions/resource_monitors/injected_resource/injected_resource_monitor_integration_test.cc
@@ -184,8 +184,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ListenerMaxConnectionPerSocketEventTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-TEST_P(ListenerMaxConnectionPerSocketEventTest,
-       DISABLED_AcceptsConnectionsUpToTheMaximumPerSocketEvent) {
+TEST_P(ListenerMaxConnectionPerSocketEventTest, AcceptsConnectionsUpToTheMaximumPerSocketEvent) {
   auto set_max_connections_per_socket_event_to_two =
       [](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
         for (auto& listener_config : *bootstrap.mutable_static_resources()->mutable_listeners()) {
@@ -219,23 +218,26 @@ TEST_P(ListenerMaxConnectionPerSocketEventTest,
 
     // As we are using level trigger for listeners, all new connections get recognized.
     test_server_->waitForGaugeEq(downstream_cx_active, 10);
+
+    // Wait for the histogram to be updated as that occurs after the logs we are
+    // expecting.
+    const std::string connections_accepted_per_socket_event =
+        (version_ == Network::Address::IpVersion::v4)
+            ? "listener.127.0.0.1_0.connections_accepted_per_socket_event"
+            : "listener.[__1]_0.connections_accepted_per_socket_event";
+    test_server_->waitUntilHistogramHasSamples(connections_accepted_per_socket_event);
+    auto connections_accepted_histogram =
+        test_server_->histogram(connections_accepted_per_socket_event);
+    EXPECT_EQ(TestUtility::readSampleCount(test_server_->server().dispatcher(),
+                                           *connections_accepted_histogram),
+              5);
+    EXPECT_EQ(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
+                                                          *connections_accepted_histogram)),
+              10);
   });
 
   std::for_each(client_codecs.begin(), client_codecs.end(),
                 [](IntegrationCodecClientPtr& client_codec) { client_codec->close(); });
-  const std::string connections_accepted_per_socket_event =
-      (version_ == Network::Address::IpVersion::v4)
-          ? "listener.127.0.0.1_0.connections_accepted_per_socket_event"
-          : "listener.[__1]_0.connections_accepted_per_socket_event";
-  test_server_->waitUntilHistogramHasSamples(connections_accepted_per_socket_event);
-  auto connections_accepted_histogram =
-      test_server_->histogram(connections_accepted_per_socket_event);
-  EXPECT_EQ(TestUtility::readSampleCount(test_server_->server().dispatcher(),
-                                         *connections_accepted_histogram),
-            5);
-  EXPECT_EQ(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
-                                                        *connections_accepted_histogram)),
-            10);
 }
 
 } // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix flake in ListenerMaxConnectionPerSocketEventTest.AcceptsConnectionsUpToTheMaximumPerSocketEvent.
Additional Description:
Risk Level: low
Testing: ran 1000x under conditions where flaked prior to fix
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #28175

