### PR TITLE
tls: fix tag extraction of tls cipher, version, sigalgs, curves

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -33,6 +33,13 @@ behavior_changes:
     Preserve the active-health check status of a host after a cluster/assignment update. This is now preserved in cases
     where the assignment updates a host's locality. This behavioral change can be temporarily reverted by setting the
     runtime flag ``envoy.reloadable_features.keep_endpoint_active_hc_status_on_locality_update`` to false.
+- area: stats tls
+  change: |
+    fixed metric tag extraction so that TLS parameters are properly extracted from the stats, both for listeners and clusters.
+    This changes the Prometheus names from ``envoy_listener_ssl_ciphers_ECDHE_RSA_AES128_GCM_SHA256{envoy_listener_address="0.0.0.0_10000"}`` to
+    ``envoy_listener_ssl_ciphers_ECDHE_RSA_AES128_GCM_SHA256{envoy_listener_address="0.0.0.0_10000", envoy_listener_ssl_cipher="ECDHE_RSA_AES128_GCM_SHA256"}``, and
+    similar for ``envoy_listener_ssl_versions_TLSv1_2``, ``envoy_cluster_ssl_versions_TLSv1_2``, ``envoy_listener_ssl_curves_P_256``, ``envoy_cluster_ssl_curves_P_256``,
+    ``envoy_listener_ssl_sigalgs.rsa_pss_rsae_sha256``.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -19,11 +19,15 @@ std::string expandRegex(const std::string& regex) {
               // Cipher names can contain alphanumerics with dashes and
               // underscores.
               {"<CIPHER>", R"([\w-]+)"},
+              // TLS version strings are always of the form "TLSv1.3".
+              {"<TLS_VERSION>", R"(TLSv\d\.\d)"},
               // A generic name can contain any character except dots.
               {"<TAG_VALUE>", TAG_VALUE_REGEX},
               // Route names may contain dots in addition to alphanumerics and
               // dashes with underscores.
-              {"<ROUTE_CONFIG_NAME>", R"([\w-\.]+)"}});
+              {"<ROUTE_CONFIG_NAME>", R"([\w-\.]+)"},
+              // Match a prefix that is either a listener plus name or cluster plus name
+              {"<LISTENER_OR_CLUSTER_WITH_NAME>", R"((?:listener|cluster)\..*?)"}});
 }
 
 const Regex::CompiledGoogleReMatcher& validTagValueRegex() {
@@ -102,8 +106,19 @@ TagNameValues::TagNameValues() {
   // http.[<stat_prefix>.]fault.(<downstream_cluster>.)*
   addTokenized(FAULT_DOWNSTREAM_CLUSTER, "http.*.fault.$.**");
 
-  // listener.[<address>.]ssl.cipher.(<cipher>)
-  addRe2(SSL_CIPHER, R"(^listener\..*?\.ssl\.cipher(\.(<CIPHER>))$)");
+  // listener.[<address>.]ssl.ciphers.(<cipher>)
+  addRe2(SSL_CIPHER, R"(^listener\..*?\.ssl\.ciphers(\.(<CIPHER>))$)");
+
+  // Curves and ciphers have the same pattern so they use the same regex.
+  // listener.[<address>.]ssl.curves.(<curve>)
+  addRe2(SSL_CURVE, R"(^<LISTENER_OR_CLUSTER_WITH_NAME>\.ssl\.curves(\.(<CIPHER>))$)");
+
+  // Signing algorithms and ciphers have the same pattern so they use the same regex.
+  // listener.[<address>.]ssl.sigalgs.(<algorithm>)
+  addRe2(SSL_SIGALG, R"(^<LISTENER_OR_CLUSTER_WITH_NAME>\.ssl\.sigalgs(\.(<CIPHER>))$)");
+
+  // listener.[<address>.]ssl.versions.(<version>)
+  addRe2(SSL_VERSION, R"(^<LISTENER_OR_CLUSTER_WITH_NAME>\.ssl\.versions(\.(<TLS_VERSION>))$)");
 
   // cluster.[<cluster_name>.]ssl.ciphers.(<cipher>)
   addRe2(SSL_CIPHER_SUITE, R"(^cluster\.<TAG_VALUE>\.ssl\.ciphers(\.(<CIPHER>))$)",

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -91,6 +91,12 @@ public:
   const std::string HTTP_USER_AGENT = "envoy.http_user_agent";
   // SSL cipher for a connection
   const std::string SSL_CIPHER = "envoy.ssl_cipher";
+  // SSL curve for a connection
+  const std::string SSL_CURVE = "envoy.ssl_curve";
+  // SSL sigalg for a connection
+  const std::string SSL_SIGALG = "envoy.ssl_sigalg";
+  // SSL version for a connection
+  const std::string SSL_VERSION = "envoy.ssl_version";
   // SSL cipher suite
   const std::string SSL_CIPHER_SUITE = "cipher_suite";
   // Stats prefix for the Client SSL Auth network filter

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -70,6 +70,11 @@ public:
       return *this;
     }
 
+    ServerSslOptions& setCurves(const std::vector<std::string>& curves) {
+      curves_ = curves;
+      return *this;
+    }
+
     ServerSslOptions& setExpectClientEcdsaCert(bool expect_client_ecdsa_cert) {
       expect_client_ecdsa_cert_ = expect_client_ecdsa_cert;
       return *this;
@@ -124,6 +129,7 @@ public:
     bool ecdsa_cert_ocsp_staple_{false};
     bool ocsp_staple_required_{false};
     bool tlsv1_3_{false};
+    std::vector<std::string> curves_;
     bool expect_client_ecdsa_cert_{false};
     bool keylog_local_filter_{false};
     bool keylog_remote_filter_{false};
@@ -381,9 +387,12 @@ public:
   void applyConfigModifiers();
 
   // Configure Envoy to do TLS to upstream.
-  void configureUpstreamTls(bool use_alpn = false, bool http3 = false,
-                            absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>
-                                alternate_protocol_cache_config = {});
+  void configureUpstreamTls(
+      bool use_alpn = false, bool http3 = false,
+      absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>
+          alternate_protocol_cache_config = {},
+      std::function<void(envoy::extensions::transport_sockets::tls::v3::CommonTlsContext&)>
+          configure_tls_context = nullptr);
 
   // Skip validation that ensures that all upstream ports are referenced by the
   // configuration generated in ConfigHelper::finalize.

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.h
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.h
@@ -30,6 +30,7 @@ public:
 
 protected:
   bool server_tlsv1_3_{false};
+  std::vector<std::string> server_curves_;
   bool server_rsa_cert_{true};
   bool server_rsa_cert_ocsp_staple_{false};
   bool server_ecdsa_cert_{false};


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fixed metric tag extraction so that TLS parameters are properly extracted from the stats, both for listeners and clusters. This changes the Prometheus names from `envoy_listener_ssl_ciphers_ECDHE_RSA_AES128_GCM_SHA256{envoy_listener_address="0.0.0.0_10000"}` to `envoy_listener_ssl_ciphers_ECDHE_RSA_AES128_GCM_SHA256{envoy_listener_address="0.0.0.0_10000", envoy_listener_ssl_cipher="ECDHE_RSA_AES128_GCM_SHA256"}`, and similar for `envoy_listener_ssl_versions_TLSv1_2`, `envoy_cluster_ssl_versions_TLSv1_2`, `envoy_listener_ssl_curves_P_256`, `envoy_cluster_ssl_curves_P_256`,
`envoy_listener_ssl_sigalgs.rsa_pss_rsae_sha256`.

Additional Description:
Risk Level: Medium - this does change existing stats
Testing: new tests added
Docs Changes:
Release Notes: added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
