### PR TITLE
admin: Histogram html use summary-buckets mode by default

### DIFF
--- a/source/server/admin/html/active_stats.js
+++ b/source/server/admin/html/active_stats.js
@@ -97,11 +97,11 @@ async function loadStats() {
   const url = prefix + '/stats?format=json&usedonly&histogram_buckets=detailed&' +
         params.map(makeQueryParam).join('&');
 
-  TRY_NEEDS_AUDIT {
+  try {
     const response = await fetch(url);
     const data = await response.json();
     renderStats(data);
-  } END_TRY catch (e) {
+  } catch (e) {
     statusDiv.textContent = 'Error fetching ' + url + ': ' + e;
   }
 

--- a/source/server/admin/stats_html_render.cc
+++ b/source/server/admin/stats_html_render.cc
@@ -23,7 +23,7 @@ StatsHtmlRender::StatsHtmlRender(Http::ResponseHeaderMap& response_headers,
                                  Buffer::Instance& response, const StatsParams& params)
     : StatsTextRender(params), active_(params.format_ == StatsFormat::ActiveHtml) {
   AdminHtmlUtil::renderHead(response_headers, response);
-  if (!active_) {
+  if (!active_ && params.histogram_buckets_mode_ == Utility::HistogramBucketsMode::Detailed) {
     StatsParams json_params(params);
     json_params.histogram_buckets_mode_ = Utility::HistogramBucketsMode::Detailed;
     json_response_headers_ = Http::ResponseHeaderMapImpl::create();
@@ -35,7 +35,7 @@ StatsHtmlRender::StatsHtmlRender(Http::ResponseHeaderMap& response_headers,
 void StatsHtmlRender::finalize(Buffer::Instance& response) {
   // Render all the histograms here using the JSON data we've accumulated
   // for them.
-  if (!active_) {
+  if (histogram_json_render_ != nullptr) {
     histogram_json_render_->finalize(json_data_);
     response.add("</pre>\n<div id='histograms'></div>\n<script>\nconst json = \n");
     response.add(json_data_);
@@ -75,6 +75,21 @@ void StatsHtmlRender::noStats(Buffer::Instance& response, absl::string_view type
     response.addFragments({"</pre>\n<br/><i>No ", types, " found</i><br/>\n<pre>\n"});
   }
 }
+
+// We override the generate method for HTML to trigger some JS that will
+// render the histogram graphically. We will render that from JavaScript
+// and convey the histogram data to the JS via JSON, so we can delegate
+// to an instantiated JSON `sub-renderer` that will write into json_data_.
+void StatsHtmlRender::generate(Buffer::Instance& response, const std::string& name,
+                               const Stats::ParentHistogram& histogram) {
+  if (histogram_json_render_ != nullptr) {
+    histogram_json_render_->generate(json_data_, name, histogram);
+  } else {
+    StatsTextRender::generate(response, name, histogram);
+  }
+}
+
+
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/admin/stats_html_render.cc
+++ b/source/server/admin/stats_html_render.cc
@@ -76,10 +76,13 @@ void StatsHtmlRender::noStats(Buffer::Instance& response, absl::string_view type
   }
 }
 
-// We override the generate method for HTML to trigger some JS that will
-// render the histogram graphically. We will render that from JavaScript
-// and convey the histogram data to the JS via JSON, so we can delegate
-// to an instantiated JSON `sub-renderer` that will write into json_data_.
+// When using Detailed mode, We override the generate method for HTML to trigger
+// some JS that will render the histogram graphically. We will render that from
+// JavaScript and convey the histogram data to the JS via JSON, so we can
+// delegate to an instantiated JSON `sub-renderer` that will write into
+// json_data_. that `sub_renderer` will only be populated in Detailed mode.
+//
+// All other modes default to rendering the histogram textually.
 void StatsHtmlRender::generate(Buffer::Instance& response, const std::string& name,
                                const Stats::ParentHistogram& histogram) {
   if (histogram_json_render_ != nullptr) {

--- a/source/server/admin/stats_html_render.cc
+++ b/source/server/admin/stats_html_render.cc
@@ -89,7 +89,5 @@ void StatsHtmlRender::generate(Buffer::Instance& response, const std::string& na
   }
 }
 
-
-
 } // namespace Server
 } // namespace Envoy

--- a/source/server/admin/stats_html_render.cc
+++ b/source/server/admin/stats_html_render.cc
@@ -76,7 +76,7 @@ void StatsHtmlRender::noStats(Buffer::Instance& response, absl::string_view type
   }
 }
 
-// When using Detailed mode, We override the generate method for HTML to trigger
+// When using Detailed mode, we override the generate method for HTML to trigger
 // some JS that will render the histogram graphically. We will render that from
 // JavaScript and convey the histogram data to the JS via JSON, so we can
 // delegate to an instantiated JSON `sub-renderer` that will write into

--- a/source/server/admin/stats_html_render.h
+++ b/source/server/admin/stats_html_render.h
@@ -35,15 +35,8 @@ public:
     StatsTextRender::generate(response, name, value);
   }
 
-  // We override the generate method for HTML to trigger some JS that will
-  // render the histogram graphically. We will render that from JavaScript
-  // and convey the histogram data to the JS via JSON, so we can delegate
-  // to an instantiated JSON `sub-renderer` that will write into json_data_.
   void generate(Buffer::Instance&, const std::string& name,
-                const Stats::ParentHistogram& histogram) override {
-    histogram_json_render_->generate(json_data_, name, histogram);
-  }
-
+                const Stats::ParentHistogram& histogram) override;
   void finalize(Buffer::Instance&) override;
 
 private:

--- a/test/server/admin/stats_html_render_test.cc
+++ b/test/server/admin/stats_html_render_test.cc
@@ -27,33 +27,39 @@ const Admin::UrlHandler handler() {
 
 class StatsHtmlRenderTest : public StatsRenderTestBase {
 protected:
-  StatsHtmlRender renderer_{response_headers_, response_, params_};
   Http::Utility::QueryParams query_params_;
 };
 
 TEST_F(StatsHtmlRenderTest, String) {
-  EXPECT_THAT(render<std::string>(renderer_, "name", "abc 123 ~!@#$%^&*()-_=+;:'\",<.>/?"),
+  StatsHtmlRender renderer{response_headers_, response_, params_};
+  EXPECT_THAT(render<std::string>(renderer, "name", "abc 123 ~!@#$%^&*()-_=+;:'\",<.>/?"),
               HasSubstr("name: \"abc 123 ~!@#$%^&amp;*()-_=+;:&#39;&quot;,&lt;.&gt;/?\"\n"));
 }
 
 TEST_F(StatsHtmlRenderTest, HistogramNoBuckets) {
-  // The goal of this test is to show that we have embedded the histogram as a json fragment.
-  constexpr absl::string_view expected = "const json = \n{\"stats\":[{\"histograms\":";
-  EXPECT_THAT(render<>(renderer_, "h1", populateHistogram("h1", {200, 300, 300})),
+  constexpr absl::string_view expected =
+      "h1: P0(200,200) P25(207.5,207.5) P50(302.5,302.5) P75(306.25,306.25) "
+      "P90(308.5,308.5) P95(309.25,309.25) P99(309.85,309.85) P99.5(309.925,309.925) "
+      "P99.9(309.985,309.985) P100(310,310)\n";
+  params_.histogram_buckets_mode_ = Utility::HistogramBucketsMode::NoBuckets;
+  StatsHtmlRender renderer{response_headers_, response_, params_};
+  EXPECT_THAT(render<>(renderer, "h1", populateHistogram("h1", {200, 300, 300})),
               HasSubstr(expected));
 }
-class StatsActiveRenderTest : public StatsRenderTestBase {
-protected:
-  StatsActiveRenderTest() {
-    params_.format_ = StatsFormat::ActiveHtml;
-    renderer_ = std::make_unique<StatsHtmlRender>(response_headers_, response_, params_);
-  }
 
-  std::unique_ptr<StatsHtmlRender> renderer_;
-};
+TEST_F(StatsHtmlRenderTest, HistogramDetailed) {
+  // The goal of this test is to show that we have embedded the histogram as a json fragment.
+  params_.histogram_buckets_mode_ = Utility::HistogramBucketsMode::Detailed;
+  StatsHtmlRender renderer{response_headers_, response_, params_};
+  constexpr absl::string_view expected = "const json = \n{\"stats\":[{\"histograms\":";
+  EXPECT_THAT(render<>(renderer, "h1", populateHistogram("h1", {200, 300, 300})),
+              HasSubstr(expected));
+}
 
-TEST_F(StatsActiveRenderTest, RenderActive) {
-  renderer_->setupStatsPage(handler(), params_, response_);
+TEST_F(StatsHtmlRenderTest, RenderActive) {
+  params_.format_ = StatsFormat::ActiveHtml;
+  StatsHtmlRender renderer(response_headers_, response_, params_);
+  renderer.setupStatsPage(handler(), params_, response_);
   EXPECT_THAT(response_.toString(), HasSubstr("<script>"));
 }
 


### PR DESCRIPTION
Commit Message: The detailed histograms may be too detailed for the default HTML view. Instead, respect the buckets-mode, and only use detailed mode if this was requested by the user.

Also, fix an accidental script-driven change (#27987) to a JS file that made it invalid JS, breaking active_html mode.
Additional Description:
Risk Level: low
Testing: added new test for histogram modes in HTML, and manually rendered in a server.
Docs Changes: n/a -- this change makes the system behave as documented, rather than ignoring the buckets-mode for HTML.
Release Notes: n/a
Platform Specific Features: n/a

