### PR TITLE
api: introduce the private key provider list field

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -180,7 +180,31 @@ message PrivateKeyProvider {
   }
 }
 
-// [#next-free-field: 9]
+// [#not-implemented-hide:]
+// BoringSSL private key method configuration. The private key methods are used for external
+// (potentially asynchronous) signing and decryption operations. Some use cases for private key
+// methods would be TPM support and TLS acceleration.
+message PrivateKeyProviderEntry {
+  // Private key method provider name. The name must match a
+  // supported private key method provider type.
+  string provider_name = 1 [(validate.rules).string = {min_len: 1}];
+}
+
+// [#not-implemented-hide:]
+// Provides a list of private key providers. Envoy will find out an available private
+// key provider from the list on order. If there is none of available private key provider,
+// it may fallback to BoringSSL default implementation based on the `fallback` fallback.
+message PrivateKeyProviderList {
+  // A list of private key providers, and at least one private key provider provided.
+  repeated PrivateKeyProviderEntry private_key_provider = 1 [(validate.rules).repeated = {min_items: 1}];
+
+  // If there is no available private key provider from the list, Envoy will fallback to
+  // the BoringSSL default implementation when the `fallback` is true. The default value
+  // is `false`.
+  bool fallback = 2;
+}
+
+// [#next-free-field: 10]
 message TlsCertificate {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.TlsCertificate";
 
@@ -234,6 +258,15 @@ message TlsCertificate {
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>` fields will result in an
   // error.
   PrivateKeyProvider private_key_provider = 6;
+
+  // [#not-implemented-hide:]
+  // This provides a list of BoringSSL private key method provider. Envoy will find out
+  // an available private key method provider. It may fallback to BoringSSL default implementation
+  // When there is no available one. All the private key provider will share the same private key
+  // in the `private_key` field. The old `private_key_provider` field will be deprecated. If both
+  // `private_key_provider` and `private_key_provider_list` are provided, the config will be
+  // rejected.
+  PrivateKeyProviderList private_key_provider_list = 9;
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
   // TLS private key is not password encrypted.

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -181,22 +181,12 @@ message PrivateKeyProvider {
 }
 
 // [#not-implemented-hide:]
-// BoringSSL private key method configuration. The private key methods are used for external
-// (potentially asynchronous) signing and decryption operations. Some use cases for private key
-// methods would be TPM support and TLS acceleration.
-message PrivateKeyProviderEntry {
-  // Private key method provider name. The name must match a
-  // supported private key method provider type.
-  string provider_name = 1 [(validate.rules).string = {min_len: 1}];
-}
-
-// [#not-implemented-hide:]
 // Provides a list of private key providers. Envoy will find out an available private
 // key provider from the list on order. If there is none of available private key provider,
 // it may fallback to BoringSSL default implementation based on the `fallback` fallback.
 message PrivateKeyProviderList {
   // A list of private key providers, and at least one private key provider provided.
-  repeated PrivateKeyProviderEntry private_key_provider = 1
+  repeated PrivateKeyProvider private_key_provider = 1
       [(validate.rules).repeated = {min_items: 1}];
 
   // If there is no available private key provider from the list, Envoy will fallback to

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -196,7 +196,8 @@ message PrivateKeyProviderEntry {
 // it may fallback to BoringSSL default implementation based on the `fallback` fallback.
 message PrivateKeyProviderList {
   // A list of private key providers, and at least one private key provider provided.
-  repeated PrivateKeyProviderEntry private_key_provider = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated PrivateKeyProviderEntry private_key_provider = 1
+      [(validate.rules).repeated = {min_items: 1}];
 
   // If there is no available private key provider from the list, Envoy will fallback to
   // the BoringSSL default implementation when the `fallback` is true. The default value

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -258,7 +258,8 @@ message TlsCertificate {
   // must be specified when the `proviate_key_provider_list` field is used. The old :ref:`private_key_provider
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>` field will be
   // deprecated. If both :ref:`private_key_provider <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>`
-  // and `private_key_provider_list` are provided, the config will be rejected.
+  // and `private_key_provider_list` are provided, the old
+  // :ref:`private_key_provider <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>` will be ignored.
   PrivateKeyProviderList private_key_provider_list = 9;
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -254,10 +254,12 @@ message TlsCertificate {
   // This provides a list of BoringSSL private key method provider. Envoy will find out
   // an available private key method provider. It may fallback to BoringSSL default implementation
   // when there is no available one. All the private key provider will share the same private key
-  // in the `private_key` field, so the `private_key` field must be specified when the
-  // `proviate_key_provider_list` field is used. The old `private_key_provider` field will be
-  // deprecated. If both `private_key_provider` and `private_key_provider_list` are provided, the
-  // config will be rejected.
+  // in the :ref:`private_key <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key>` field,
+  // so the :ref:`private_key <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key>` field
+  // must be specified when the `proviate_key_provider_list` field is used. The old :ref:`private_key_provider
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>` field will be
+  // deprecated. If both :ref:`private_key_provider <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>`
+  // and `private_key_provider_list` are provided, the config will be rejected.
   PrivateKeyProviderList private_key_provider_list = 9;
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -262,10 +262,11 @@ message TlsCertificate {
   // [#not-implemented-hide:]
   // This provides a list of BoringSSL private key method provider. Envoy will find out
   // an available private key method provider. It may fallback to BoringSSL default implementation
-  // When there is no available one. All the private key provider will share the same private key
-  // in the `private_key` field. The old `private_key_provider` field will be deprecated. If both
-  // `private_key_provider` and `private_key_provider_list` are provided, the config will be
-  // rejected.
+  // when there is no available one. All the private key provider will share the same private key
+  // in the `private_key` field, so the `private_key` field must be specified when the
+  // `proviate_key_provider_list` field is used. The old `private_key_provider` field will be
+  // deprecated. If both `private_key_provider` and `private_key_provider_list` are provided, the
+  // config will be rejected.
   PrivateKeyProviderList private_key_provider_list = 9;
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -186,8 +186,7 @@ message PrivateKeyProvider {
 // it may fallback to BoringSSL default implementation based on the `fallback` fallback.
 message PrivateKeyProviderList {
   // A list of private key providers, and at least one private key provider provided.
-  repeated PrivateKeyProvider private_key_provider = 1
-      [(validate.rules).repeated = {min_items: 1}];
+  repeated PrivateKeyProvider private_key_provider = 1 [(validate.rules).repeated = {min_items: 1}];
 
   // If there is no available private key provider from the list, Envoy will fallback to
   // the BoringSSL default implementation when the `fallback` is true. The default value


### PR DESCRIPTION
Commit Message: api: introduce the private key provider list field
Additional Description:
This PR introduces a new `private_key_provider_list` field. It allows the end user provide a list of private key providers which he want to use. Then Envoy will find out one of private key provider which available on the host. If there is none of available in the list. The Envoy will fallback to BoringSSL default implementation.


When the new field `private_key_provider_list` implemented,  there are list of fields are going to deprecate:

* `private_key_provider` will be replaced by `private_key_provider_list`
https://github.com/envoyproxy/envoy/blob/c49f392561ba8c246f845d61e555c9536d5edbea/api/envoy/extensions/transport_sockets/tls/v3/common.proto#L236

* qat provider's `private_key` field will be deprecated
https://github.com/envoyproxy/envoy/blob/c49f392561ba8c246f845d61e555c9536d5edbea/api/contrib/envoy/extensions/private_key_providers/qat/v3alpha/qat.proto#L29
  the QAT provider should use the private key at 
https://github.com/envoyproxy/envoy/blob/c49f392561ba8c246f845d61e555c9536d5edbea/api/envoy/extensions/transport_sockets/tls/v3/common.proto#L200

  If both the `TlsCertificate::private_key` and `QatPrivateKeyMethodConfig::private_key` are specified, the config will be rejected.

* same with qat, the cryptomb provider's private key will be deprecated
https://github.com/envoyproxy/envoy/blob/c49f392561ba8c246f845d61e555c9536d5edbea/api/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto#L32

Risk Level: low
Testing: n/a
Docs Changes: API doc
Release Notes: n/a
Platform Specific Features: n/a
Part of fixes #28214
