### PR TITLE
Fix redis transaction when traffic is mirrored (new PR instead of https://github.com/envoyproxy/envoy/pull/28149)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -189,6 +189,9 @@ bug_fixes:
 - area: maglev loadbalancer
   change: |
     Fixes maglev stability problem. Previously, maglev returns slightly different backend assignment from the same backends and keys.
+- area: redis
+  change: |
+    Fixes a bug where redis transactions do not work properly when redis traffic is mirrored.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -265,7 +265,11 @@ struct Transaction {
   // the mirroring policies.
   std::vector<ClientPtr> clients_;
   Network::ConnectionCallbacks* connection_cb_;
-  uint32_t current_client_idx{0};
+
+  // This index represents the current client on which traffic is being sent to.
+  // When sending to the main redis server it will be 0, and when sending to one of
+  // the mirror servers it will be 1..n.
+  uint32_t current_client_idx_{0};
 };
 
 class NoOpTransaction : public Transaction {

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -259,9 +259,11 @@ struct Transaction {
   bool connection_established_{false};
   bool should_close_{false};
 
-  std::string key_; /* The key which represents the transaction hash slot */
-  std::vector<ClientPtr>
-      clients_; /* One client for the main connection, and one for each mirror connection */
+  // The key which represents the transaction hash slot.
+  std::string key_;
+  // clients_[0] represents the main connection, clients_[1..n] are for
+  // the mirroring policies.
+  std::vector<ClientPtr> clients_;
   Network::ConnectionCallbacks* connection_cb_;
   uint32_t current_client_idx{0};
 };

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -84,14 +84,15 @@ struct SupportedCommands {
    * @return commands which alters the state of redis
    */
   static const absl::flat_hash_set<std::string>& writeCommands() {
-    CONSTRUCT_ON_FIRST_USE(
-        absl::flat_hash_set<std::string>, "append", "bitfield", "decr", "decrby", "del", "expire",
-        "expireat", "eval", "evalsha", "geoadd", "hdel", "hincrby", "hincrbyfloat", "hmset", "hset",
-        "hsetnx", "incr", "incrby", "incrbyfloat", "linsert", "lpop", "lpush", "lpushx", "lrem",
-        "lset", "ltrim", "mset", "persist", "pexpire", "pexpireat", "pfadd", "psetex", "restore",
-        "rpop", "rpush", "rpushx", "sadd", "set", "setbit", "setex", "setnx", "setrange", "spop",
-        "srem", "zadd", "zincrby", "touch", "zpopmin", "zpopmax", "zrem", "zremrangebylex",
-        "zremrangebyrank", "zremrangebyscore", "unlink");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "append", "bitfield", "decr", "decrby",
+                           "del", "discard", "exec", "expire", "expireat", "eval", "evalsha",
+                           "geoadd", "hdel", "hincrby", "hincrbyfloat", "hmset", "hset", "hsetnx",
+                           "incr", "incrby", "incrbyfloat", "linsert", "lpop", "lpush", "lpushx",
+                           "lrem", "lset", "ltrim", "mset", "multi", "persist", "pexpire",
+                           "pexpireat", "pfadd", "psetex", "restore", "rpop", "rpush", "rpushx",
+                           "sadd", "set", "setbit", "setex", "setnx", "setrange", "spop", "srem",
+                           "zadd", "zincrby", "touch", "zpopmin", "zpopmax", "zrem",
+                           "zremrangebylex", "zremrangebyrank", "zremrangebyscore", "unlink");
   }
 
   static bool isReadCommand(const std::string& command) {

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -31,12 +31,12 @@ Common::Redis::Client::PoolRequest* makeSingleServerRequest(
     Common::Redis::Client::Transaction& transaction) {
   // If a transaction is active, clients_[0] is the primary connection to the cluster.
   // The subsequent clients in the array are used for mirroring.
-  transaction.current_client_idx = 0;
+  transaction.current_client_idx_ = 0;
   auto handler = route->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
                                                 callbacks, transaction);
   if (handler) {
     for (auto& mirror_policy : route->mirrorPolicies()) {
-      transaction.current_client_idx++;
+      transaction.current_client_idx_++;
       if (mirror_policy->shouldMirror(command)) {
         mirror_policy->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
                                                null_pool_callbacks, transaction);

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -29,10 +29,14 @@ Common::Redis::Client::PoolRequest* makeSingleServerRequest(
     const RouteSharedPtr& route, const std::string& command, const std::string& key,
     Common::Redis::RespValueConstSharedPtr incoming_request, ConnPool::PoolCallbacks& callbacks,
     Common::Redis::Client::Transaction& transaction) {
+  // If a transaction is active, clients_[0] is the primary connection to the cluster.
+  // The subsequent clients in the array are used for mirroring.
+  transaction.current_client_idx = 0;
   auto handler = route->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
                                                 callbacks, transaction);
   if (handler) {
     for (auto& mirror_policy : route->mirrorPolicies()) {
+      transaction.current_client_idx++;
       if (mirror_policy->shouldMirror(command)) {
         mirror_policy->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
                                                null_pool_callbacks, transaction);
@@ -504,6 +508,7 @@ SplitRequestPtr TransactionRequest::create(Router& router,
   // key, and then send a MULTI command to the node that handles that key.
   // The response for the MULTI command will be discarded since we pass the null_pool_callbacks
   // to the handler.
+
   RouteSharedPtr route;
   if (transaction.key_.empty()) {
     transaction.key_ = incoming_request->asArray()[1].asString();
@@ -511,8 +516,11 @@ SplitRequestPtr TransactionRequest::create(Router& router,
     Common::Redis::RespValueSharedPtr multi_request =
         std::make_shared<Common::Redis::Client::MultiRequest>();
     if (route) {
+      // We reserve a client for the main connection and for each mirror connection.
+      transaction.clients_.resize(1 + route->mirrorPolicies().size());
       makeSingleServerRequest(route, "MULTI", transaction.key_, multi_request, null_pool_callbacks,
                               callbacks.transaction());
+      transaction.connection_established_ = true;
     }
   } else {
     route = router.upstreamPool(transaction.key_);
@@ -520,6 +528,7 @@ SplitRequestPtr TransactionRequest::create(Router& router,
 
   std::unique_ptr<TransactionRequest> request_ptr{
       new TransactionRequest(callbacks, command_stats, time_source, delay_command_latency)};
+
   if (route) {
     Common::Redis::RespValueSharedPtr base_request = std::move(incoming_request);
     request_ptr->handle_ =

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -283,7 +283,7 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key, RespVariant&&
     return nullptr;
   }
 
-  uint32_t client_idx = transaction.current_client_idx;
+  uint32_t client_idx = transaction.current_client_idx_;
   // If there is an active transaction, establish a new connection if necessary.
   if (transaction.active_ && !transaction.connection_established_) {
     transaction.clients_[client_idx] =

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -283,15 +283,15 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key, RespVariant&&
     return nullptr;
   }
 
+  uint32_t client_idx = transaction.current_client_idx;
   // If there is an active transaction, establish a new connection if necessary.
   if (transaction.active_ && !transaction.connection_established_) {
-    transaction.client_ =
+    transaction.clients_[client_idx] =
         client_factory_.create(host, dispatcher_, *config_, redis_command_stats_, *(stats_scope_),
                                auth_username_, auth_password_, true);
     if (transaction.connection_cb_) {
-      transaction.client_->addConnectionCallbacks(*transaction.connection_cb_);
+      transaction.clients_[client_idx]->addConnectionCallbacks(*transaction.connection_cb_);
     }
-    transaction.connection_established_ = true;
   }
 
   pending_requests_.emplace_back(*this, std::move(request), callbacks, host);
@@ -309,7 +309,7 @@ InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key, RespVariant&&
     pending_request.request_handler_ = client->redis_client_->makeRequest(
         getRequest(pending_request.incoming_request_), pending_request);
   } else {
-    pending_request.request_handler_ = transaction.client_->makeRequest(
+    pending_request.request_handler_ = transaction.clients_[client_idx]->makeRequest(
         getRequest(pending_request.incoming_request_), pending_request);
   }
 


### PR DESCRIPTION
Duplicate of: https://github.com/envoyproxy/envoy/pull/28149

I had to open this new PR since the commits in the previous PR were not signed properly.
Signing the commits retroactively was problematic because of a merge commit in the middle.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix redis transaction when traffic is mirrored

Additional Description:

When envoy is configured to mirror Redis traffic, using transactions (MULTI) would not work well, possibly leading to a crash. This PR fixes this issue by making the following changes:
1) I have defined MULTI, EXEC, and DISCARD as write commands, so they will be mirrored even when read commands are excluded from mirroring.
2) A dedicated connection for the transaction is opened for each redis server that receives mirrored commands, the same way a dedicated connection is opened to the main redis server.

This PR fixes the following issue: https://github.com/envoyproxy/envoy/issues/26342

Risk Level: Low
Testing: Integration tests and local tests. Reproduced the problem by using the same configuration used in the open issue.
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/26342
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
