### PR TITLE
tls: pass the ssl object through ExtraValidationContext

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -48,7 +48,7 @@ public:
   // Wraps cert validation parameters added from time to time.
   struct ExtraValidationContext {
     // The pointer to SSL object.
-    // It is optional and the context doesn't take the owernship of this object.
+    // It is optional and the context doesn't take the ownership of ssl object.
     const SSL* ssl = nullptr;
   };
 

--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -46,7 +46,10 @@ struct ValidationResults {
 class CertValidator {
 public:
   // Wraps cert validation parameters added from time to time.
-  struct ExtraValidationContext {};
+  struct ExtraValidationContext {
+    // The pointer to SSL object. It is optional (nullptr by default).
+    const SSL* ssl = nullptr;
+  };
 
   virtual ~CertValidator() = default;
 

--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -47,7 +47,8 @@ class CertValidator {
 public:
   // Wraps cert validation parameters added from time to time.
   struct ExtraValidationContext {
-    // The pointer to SSL object. It is optional (nullptr by default).
+    // The pointer to SSL object.
+    // It is optional and the context doesn't take the owernship of this object.
     const SSL* ssl = nullptr;
   };
 

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -516,7 +516,7 @@ ValidationResults ContextImpl::customVerifyCertChain(
   const char* host_name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   ValidationResults result = cert_validator_->doVerifyCertChain(
       *cert_chain, extended_socket_info->createValidateResultCallback(), transport_socket_options,
-      *SSL_get_SSL_CTX(ssl), {}, SSL_is_server(ssl), absl::NullSafeStringView(host_name));
+      *SSL_get_SSL_CTX(ssl), {ssl}, SSL_is_server(ssl), absl::NullSafeStringView(host_name));
   if (result.status != ValidationResults::ValidationStatus::Pending) {
     extended_socket_info->setCertificateValidationStatus(result.detailed_status);
     extended_socket_info->onCertificateValidationCompleted(


### PR DESCRIPTION
`ExtraValidationContext` is placeholder struct designed for extra parameters that might be needed for certain cert validator.

Use this struct to pass the pointer of SSL object so that it can be used in custom validator.

