### PR TITLE
test: more clean up test runtime

### DIFF
--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -43,7 +43,6 @@ envoy_cc_test(
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/test_common:logging_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -18,7 +18,6 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_format.h"

--- a/test/common/http/match_delegate/BUILD
+++ b/test/common/http/match_delegate/BUILD
@@ -15,7 +15,6 @@ envoy_cc_test(
         "//source/common/http/match_delegate:config",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
-        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/http/match_delegate/config_test.cc
+++ b/test/common/http/match_delegate/config_test.cc
@@ -7,7 +7,6 @@
 
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
-#include "test/test_common/test_runtime.h"
 
 #include "gtest/gtest.h"
 

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -554,7 +554,6 @@ envoy_cc_test(
         "//test/mocks/upstream:thread_aware_load_balancer_mocks",
         "//test/mocks/upstream:typed_load_balancer_factory_mocks",
         "//test/test_common:registry_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ] + envoy_select_enable_http3([
         "//source/common/quic:quic_transport_socket_factory_lib",

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -45,7 +45,6 @@
 #include "test/mocks/upstream/typed_load_balancer_factory.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/registry.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/access_loggers/common/BUILD
+++ b/test/extensions/access_loggers/common/BUILD
@@ -29,7 +29,6 @@ envoy_cc_test(
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
-        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/data/accesslog/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -16,7 +16,6 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
-#include "test/test_common/test_runtime.h"
 
 using testing::_;
 using testing::InSequence;

--- a/test/extensions/clusters/original_dst/BUILD
+++ b/test/extensions/clusters/original_dst/BUILD
@@ -28,7 +28,6 @@ envoy_cc_test(
         "//test/mocks/server:instance_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],

--- a/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
+++ b/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
@@ -25,7 +25,6 @@
 #include "test/mocks/server/instance.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/compressor/BUILD
+++ b/test/extensions/filters/http/compressor/BUILD
@@ -27,7 +27,6 @@ envoy_extension_cc_test(
         "//test/mocks/compression/compressor:compressor_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/runtime:runtime_mocks",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -4,7 +4,6 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/stats/mocks.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/connect_grpc_bridge/BUILD
+++ b/test/extensions/filters/http/connect_grpc_bridge/BUILD
@@ -32,7 +32,6 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/connect_grpc_bridge:filter_lib",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:global_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -61,7 +60,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/connect_grpc_bridge:end_stream_response_lib",
         "//test/test_common:global_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
@@ -6,7 +6,6 @@
 #include "test/mocks/http/mocks.h"
 #include "test/test_common/global.h"
 #include "test/test_common/printers.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/connect_grpc_bridge/end_stream_response_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/end_stream_response_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/test_common/global.h"
 #include "test/test_common/printers.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/cors/BUILD
+++ b/test/extensions/filters/http/cors/BUILD
@@ -38,7 +38,6 @@ envoy_extension_cc_test(
         "//test/integration:http_integration_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:upstream_mocks",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/cors/cors_filter_integration_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_integration_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/integration/http_integration.h"
 #include "test/mocks/http/mocks.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/grpc_http1_bridge/BUILD
+++ b/test/extensions/filters/http/grpc_http1_bridge/BUILD
@@ -22,7 +22,6 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/grpc_http1_bridge:http1_bridge_filter_lib",
         "//test/mocks/http:http_mocks",
         "//test/test_common:global_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -11,7 +11,6 @@
 #include "test/mocks/http/mocks.h"
 #include "test/test_common/global.h"
 #include "test/test_common/printers.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/health_check/BUILD
+++ b/test/extensions/filters/http/health_check/BUILD
@@ -20,7 +20,6 @@ envoy_extension_cc_test(
         "//source/common/http:header_utility_lib",
         "//source/extensions/filters/http/health_check:health_check_lib",
         "//test/mocks/server:factory_context_mocks",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -11,7 +11,6 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/printers.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -171,7 +171,6 @@ envoy_extension_cc_test(
         ":mock_lib",
         ":test_common_lib",
         "//source/extensions/filters/http/jwt_authn:matchers_lib",
-        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/jwt_authn/matcher_test.cc
+++ b/test/extensions/filters/http/jwt_authn/matcher_test.cc
@@ -5,7 +5,6 @@
 
 #include "test/extensions/filters/http/jwt_authn/mock.h"
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
-#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 using envoy::extensions::filters::http::jwt_authn::v3::RequirementRule;

--- a/test/extensions/filters/http/local_ratelimit/BUILD
+++ b/test/extensions/filters/http/local_ratelimit/BUILD
@@ -20,7 +20,6 @@ envoy_extension_cc_test(
         "//test/common/stream_info:test_util",
         "//test/mocks/http:http_mocks",
         "//test/mocks/local_info:local_info_mocks",
-        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/local_ratelimit/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/local_ratelimit/filter_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/filter_test.cc
@@ -4,7 +4,6 @@
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/local_info/mocks.h"
-#include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Clean-up, `test_runtime.h` is not used in some tests.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
