### PR TITLE
local-rate-limit: Fix doc comment for response_headers_to_add

### DIFF
--- a/api/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
+++ b/api/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
@@ -71,7 +71,7 @@ message LocalRateLimit {
       [(validate.rules).repeated = {max_items: 10}];
 
   // Specifies a list of HTTP headers that should be added to each response for requests that
-  // have been rate limited. This occurs when the filter is either enabled or fully enforced.
+  // have been rate limited. This occurs when the filter is enabled and fully enforced.
   repeated config.core.v3.HeaderValueOption response_headers_to_add = 6
       [(validate.rules).repeated = {max_items: 10}];
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Response headers are applied only when requests are rate-limited and filter is enforced. Currently doc comment was ambiguous in the sense that it was mentioning `either enabled or enforced` and also mentioning that `requests that have been rate-limited`.  
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
