### PR TITLE
json: introduce getObjectNoThrow and loadFromStringNoThrow

### DIFF
--- a/envoy/json/json_object.h
+++ b/envoy/json/json_object.h
@@ -89,8 +89,19 @@ public:
    * @param allow_empty supplies whether to return an empty object if the key does not
    * exist.
    * @return ObjectObjectSharedPtr the sub-object.
+   * @throws Json::Exception if unable to get the attribute or the type is not an object.
    */
   virtual ObjectSharedPtr getObject(const std::string& name, bool allow_empty = false) const PURE;
+
+  /**
+   * Get a sub-object by name.
+   * @param name supplies the key name.
+   * @param allow_empty supplies whether to return an empty object if the key does not
+   * exist.
+   * @return ObjectObjectSharedPtr the sub-object.
+   */
+  virtual absl::StatusOr<ObjectSharedPtr> getObjectNoThrow(const std::string& name,
+                                                           bool allow_empty = false) const PURE;
 
   /**
    * Determine if an object has type Object.

--- a/source/common/json/json_internal.h
+++ b/source/common/json/json_internal.h
@@ -15,8 +15,14 @@ class Factory {
 public:
   /**
    * Constructs a Json Object from a string.
+   * Throws Json::Exception if unable to parse the string.
    */
   static ObjectSharedPtr loadFromString(const std::string& json);
+
+  /**
+   * Constructs a Json Object from a string.
+   */
+  static absl::StatusOr<ObjectSharedPtr> loadFromStringNoThrow(const std::string& json);
 
   /**
    * Serializes a string in JSON format, throwing an exception if not valid UTF-8.

--- a/source/common/json/json_loader.cc
+++ b/source/common/json/json_loader.cc
@@ -10,5 +10,9 @@ ObjectSharedPtr Factory::loadFromString(const std::string& json) {
   return Nlohmann::Factory::loadFromString(json);
 }
 
+absl::StatusOr<ObjectSharedPtr> Factory::loadFromStringNoThrow(const std::string& json) {
+  return Nlohmann::Factory::loadFromStringNoThrow(json);
+}
+
 } // namespace Json
 } // namespace Envoy

--- a/source/common/json/json_loader.h
+++ b/source/common/json/json_loader.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <list>
 #include <string>
 
 #include "envoy/json/json_object.h"
+
+#include "source/common/common/statusor.h"
 
 namespace Envoy {
 namespace Json {
@@ -12,8 +13,14 @@ class Factory {
 public:
   /**
    * Constructs a Json Object from a string.
+   * Throws Json::Exception if unable to parse the string.
    */
   static ObjectSharedPtr loadFromString(const std::string& json);
+
+  /**
+   * Constructs a Json Object from a string.
+   */
+  static absl::StatusOr<ObjectSharedPtr> loadFromStringNoThrow(const std::string& json);
 };
 
 } // namespace Json


### PR DESCRIPTION
Commit Message:
To pave the road of Http::JsonToMetadata filter without exception on data plane, we introduced `getValue`
for all the value type.
Here we introduce `getObjectNoThrow` and `loadFromStringNoThrow` which should cover most of the cases.


Additional Description: 
Risk Level: low
Testing: unit
Docs Changes: comment