### PR TITLE
git: Dont ignore go.sum files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ cscope.*
 *.pyc
 **/pyformat
 SOURCE_VERSION
-*.sw*
+*.swap*
 tags
 TAGS
 /test/coverage/BUILD

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ cscope.*
 *.pyc
 **/pyformat
 SOURCE_VERSION
-*.s??
+*.sw*
 tags
 TAGS
 /test/coverage/BUILD


### PR DESCRIPTION
In c7850756ae1bf42b6117804b11b592d7a0c12890 the exclusion for swap files was changed to exclude `.s??`

This broke the original intention of the exclusion - ie `.swap` would not be ignored, but it also broke gitignore for any other file with a 3-letter extension starting with `s` (eg `go.sum`)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
