### PR TITLE
CODEOWNERS: removes @mathetake from Wasm extensions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -93,17 +93,17 @@ extensions/filters/common/original_src @klarose @mattklein123
 # attribute context
 /*/extensions/filters/common/expr @kyessenov @yangminzhu @lizan
 # webassembly access logger extensions
-/*/extensions/access_loggers/wasm @mpwarres @mathetake @lizan
+/*/extensions/access_loggers/wasm @mpwarres @lizan
 # webassembly bootstrap extensions
-/*/extensions/bootstrap/wasm @mpwarres @mathetake @lizan
+/*/extensions/bootstrap/wasm @mpwarres @lizan
 # webassembly http extensions
-/*/extensions/filters/http/wasm @mpwarres @mathetake @lizan
+/*/extensions/filters/http/wasm @mpwarres @lizan
 # webassembly network extensions
-/*/extensions/filters/network/wasm @mpwarres @mathetake @lizan
+/*/extensions/filters/network/wasm @mpwarres @lizan
 # webassembly common extension
-/*/extensions/common/wasm @mpwarres @mathetake @lizan
+/*/extensions/common/wasm @mpwarres @lizan
 # webassembly runtimes
-/*/extensions/wasm_runtime/ @mpwarres @mathetake @lizan
+/*/extensions/wasm_runtime/ @mpwarres @lizan
 # common matcher
 /*/extensions/common/matcher @mattklein123 @yangminzhu
 /*/extensions/common/proxy_protocol @alyssawilk @wez470
@@ -127,7 +127,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 /*/extensions/stat_sinks/metrics_service @ramaraochavali @jmarantz
 /*/extensions/stat_sinks/open_telemetry @ohadvano @mattklein123
 # webassembly stat-sink extensions
-/*/extensions/stat_sinks/wasm @mpwarres @mathetake @lizan
+/*/extensions/stat_sinks/wasm @mpwarres @lizan
 /*/extensions/resource_monitors/injected_resource @eziskind @htuch
 /*/extensions/resource_monitors/common @eziskind @htuch
 /*/extensions/resource_monitors/fixed_heap @eziskind @htuch


### PR DESCRIPTION
I am no longer able to work on the Wasm-related codebase.

cc @lizan @mpwarres 

ref https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/360