### PR TITLE
[balsa] Disallow invalid character in response header names.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -155,6 +155,7 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   http_validation_policy.disallow_transfer_encoding_with_content_length = false;
   http_validation_policy.validate_transfer_encoding = false;
   http_validation_policy.require_content_length_if_body_required = false;
+  http_validation_policy.disallow_invalid_header_characters_in_response = true;
   framer_.set_http_validation_policy(http_validation_policy);
 
   framer_.set_balsa_headers(&headers_);


### PR DESCRIPTION
Tracking issue: #21245

Signed-off-by: Bence Béky <bnc@google.com>

Commit Message: [balsa] Disallow invalid character in response header names.
Additional Description: This is for consistency with http-parser behavior.
Risk Level: low, changed code protected by existing default-false runtime flag.
Testing: //test/common/http/http1:codec_impl_test
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser