### PR TITLE
config: metadata life time with Any conversion

### DIFF
--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -62,9 +62,9 @@ public:
   virtual bool hasResource() const PURE;
 
   /**
-   * @return optional ref<envoy::config::core::v3::Metadata> of a resource.
+   * @return optional envoy::config::core::v3::Metadata of a resource.
    */
-  virtual const OptRef<const envoy::config::core::v3::Metadata> metadata() const PURE;
+  virtual const absl::optional<envoy::config::core::v3::Metadata> metadata() const PURE;
 };
 
 using DecodedResourcePtr = std::unique_ptr<DecodedResource>;

--- a/envoy/config/subscription.h
+++ b/envoy/config/subscription.h
@@ -62,9 +62,9 @@ public:
   virtual bool hasResource() const PURE;
 
   /**
-   * @return optional envoy::config::core::v3::Metadata of a resource.
+   * @return optional ref<envoy::config::core::v3::Metadata> of a resource.
    */
-  virtual const absl::optional<envoy::config::core::v3::Metadata> metadata() const PURE;
+  virtual const OptRef<const envoy::config::core::v3::Metadata> metadata() const PURE;
 };
 
 using DecodedResourcePtr = std::unique_ptr<DecodedResource>;

--- a/source/common/config/decoded_resource_impl.h
+++ b/source/common/config/decoded_resource_impl.h
@@ -85,7 +85,7 @@ private:
                       const Protobuf::RepeatedPtrField<std::string>& aliases,
                       const ProtobufWkt::Any& resource, bool has_resource,
                       const std::string& version, absl::optional<std::chrono::milliseconds> ttl,
-                      const absl::optional<envoy::config::core::v3::Metadata> metadata)
+                      const absl::optional<envoy::config::core::v3::Metadata>& metadata)
       : resource_(resource_decoder.decodeResource(resource)), has_resource_(has_resource),
         name_(name ? *name : resource_decoder.resourceName(*resource_)),
         aliases_(repeatedPtrFieldToVector(aliases)), version_(version), ttl_(ttl),

--- a/source/common/config/decoded_resource_impl.h
+++ b/source/common/config/decoded_resource_impl.h
@@ -58,7 +58,7 @@ public:
             resource.has_ttl() ? absl::make_optional(std::chrono::milliseconds(
                                      DurationUtil::durationToMilliseconds(resource.ttl())))
                                : absl::nullopt,
-            resource.has_metadata() ? makeOptRef(resource.metadata()) : absl::nullopt) {}
+            resource.has_metadata() ? absl::make_optional(resource.metadata()) : absl::nullopt) {}
   DecodedResourceImpl(OpaqueResourceDecoder& resource_decoder,
                       const xds::core::v3::CollectionEntry::InlineEntry& inline_entry)
       : DecodedResourceImpl(resource_decoder, inline_entry.name(),
@@ -76,7 +76,7 @@ public:
   const Protobuf::Message& resource() const override { return *resource_; };
   bool hasResource() const override { return has_resource_; }
   absl::optional<std::chrono::milliseconds> ttl() const override { return ttl_; }
-  const OptRef<const envoy::config::core::v3::Metadata> metadata() const override {
+  const absl::optional<envoy::config::core::v3::Metadata> metadata() const override {
     return metadata_;
   }
 
@@ -85,7 +85,7 @@ private:
                       const Protobuf::RepeatedPtrField<std::string>& aliases,
                       const ProtobufWkt::Any& resource, bool has_resource,
                       const std::string& version, absl::optional<std::chrono::milliseconds> ttl,
-                      const OptRef<const envoy::config::core::v3::Metadata> metadata)
+                      const absl::optional<envoy::config::core::v3::Metadata> metadata)
       : resource_(resource_decoder.decodeResource(resource)), has_resource_(has_resource),
         name_(name ? *name : resource_decoder.resourceName(*resource_)),
         aliases_(repeatedPtrFieldToVector(aliases)), version_(version), ttl_(ttl),
@@ -101,7 +101,7 @@ private:
 
   // This is the metadata info under the Resource wrapper.
   // It is intended to be consumed in the xds_config_tracker extension.
-  const OptRef<const envoy::config::core::v3::Metadata> metadata_;
+  const absl::optional<envoy::config::core::v3::Metadata> metadata_;
 };
 
 struct DecodedResourcesWrapper {

--- a/source/common/config/decoded_resource_impl.h
+++ b/source/common/config/decoded_resource_impl.h
@@ -76,8 +76,8 @@ public:
   const Protobuf::Message& resource() const override { return *resource_; };
   bool hasResource() const override { return has_resource_; }
   absl::optional<std::chrono::milliseconds> ttl() const override { return ttl_; }
-  const absl::optional<envoy::config::core::v3::Metadata> metadata() const override {
-    return metadata_;
+  const OptRef<const envoy::config::core::v3::Metadata> metadata() const override {
+    return metadata_.has_value() ? makeOptRef(metadata_.value()) : absl::nullopt;
   }
 
 private:

--- a/test/common/config/decoded_resource_impl_test.cc
+++ b/test/common/config/decoded_resource_impl_test.cc
@@ -72,8 +72,8 @@ TEST(DecodedResourceImplTest, All) {
     EXPECT_EQ(metadata->DebugString(), decoded_resource.metadata()->DebugString());
   }
 
-  // To verify the metadata is decoded as expected for fromResoure variant
-  // with the ProtobufWkt::Any& input.
+  // To verify the metadata is decoded as expected for the fromResource variant
+  // with ProtobufWkt::Any& input.
   {
     envoy::service::discovery::v3::Resource resource_wrapper;
     resource_wrapper.set_name("real_name");

--- a/test/common/config/decoded_resource_impl_test.cc
+++ b/test/common/config/decoded_resource_impl_test.cc
@@ -72,6 +72,30 @@ TEST(DecodedResourceImplTest, All) {
     EXPECT_EQ(metadata->DebugString(), decoded_resource.metadata()->DebugString());
   }
 
+  // To verify the metadata is decoded as expected for fromResoure variant
+  // with the ProtobufWkt::Any& input.
+  {
+    envoy::service::discovery::v3::Resource resource_wrapper;
+    resource_wrapper.set_name("real_name");
+    resource_wrapper.mutable_resource()->MergeFrom(some_opaque_resource);
+    auto metadata = resource_wrapper.mutable_metadata();
+    metadata->mutable_filter_metadata()->insert(
+        {"fake_test_domain", MessageUtil::keyValueStruct("fake_test_key", "fake_test_value")});
+    ProtobufWkt::Any resource_any;
+    resource_any.PackFrom(resource_wrapper);
+    EXPECT_CALL(resource_decoder, decodeResource(ProtoEq(some_opaque_resource)))
+        .WillOnce(InvokeWithoutArgs(
+            []() -> ProtobufTypes::MessagePtr { return std::make_unique<ProtobufWkt::Empty>(); }));
+    EXPECT_CALL(resource_decoder, resourceName(ProtoEq(ProtobufWkt::Empty()))).Times(0);
+    DecodedResourceImplPtr decoded_resource =
+        DecodedResourceImpl::fromResource(resource_decoder, resource_any, "1");
+    EXPECT_EQ("real_name", decoded_resource->name());
+    EXPECT_THAT(decoded_resource->resource(), ProtoEq(ProtobufWkt::Empty()));
+    EXPECT_TRUE(decoded_resource->hasResource());
+    EXPECT_TRUE(decoded_resource->metadata().has_value());
+    EXPECT_EQ(metadata->DebugString(), decoded_resource->metadata()->DebugString());
+  }
+
   {
     envoy::service::discovery::v3::Resource resource_wrapper;
     resource_wrapper.set_name("real_name");
@@ -97,6 +121,9 @@ TEST(DecodedResourceImplTest, All) {
     resource_wrapper.add_aliases("baz");
     resource_wrapper.mutable_resource()->MergeFrom(some_opaque_resource);
     resource_wrapper.set_version("foo");
+    auto metadata = resource_wrapper.mutable_metadata();
+    metadata->mutable_filter_metadata()->insert(
+        {"fake_test_domain", MessageUtil::keyValueStruct("fake_test_key", "fake_test_value")});
     EXPECT_CALL(resource_decoder, decodeResource(ProtoEq(some_opaque_resource)))
         .WillOnce(InvokeWithoutArgs(
             []() -> ProtobufTypes::MessagePtr { return std::make_unique<ProtobufWkt::Empty>(); }));
@@ -108,6 +135,8 @@ TEST(DecodedResourceImplTest, All) {
     EXPECT_EQ("foo", decoded_resource->version());
     EXPECT_THAT(decoded_resource->resource(), ProtoEq(ProtobufWkt::Empty()));
     EXPECT_TRUE(decoded_resource->hasResource());
+    EXPECT_TRUE(decoded_resource->metadata().has_value());
+    EXPECT_EQ(metadata->DebugString(), decoded_resource->metadata()->DebugString());
   }
 
   {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

One fromResource variant is taking the `ProtobufWkt::Any& resource` as the input, and then a temp value is introduced in this static method.
```
      envoy::service::discovery::v3::Resource r;
      MessageUtil::unpackTo(resource, r); 
```
A ref to a temp val can cause `segv` fault when the temp is distroied.

Commit Message: 
Additional Description:
Risk Level: Low
Testing: unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
