### PR TITLE
Remove ninja run_tests command from fips_genrule script fips compliant boringssl

### DIFF
--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -121,7 +121,7 @@ rm -rf boringssl/build
 cd boringssl
 mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=${HOME}/toolchain -DFIPS=1 -DCMAKE_BUILD_TYPE=Release ..
 ninja
-ninja run_tests
+# To validate boringcrypto compilation, run these tests and make sure they don't fail.
 ./crypto/crypto_test
 
 # Verify correctness of the FIPS build.


### PR DESCRIPTION

The tests should be run using ./crypto/crypto_test instead of ninja run_tests in  boringssl_fips.genrule_cmd script as per the security policy [document](https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4407.pdf) page19

Commit Message: Remove ninja run_tests from fips_genrule script fips compliant boringssl
Additional Description: Fix testing command in   boringssl_fips.genrule_cmd
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:

