### PR TITLE
application_logs: serialize ENVOY_CONN_LOG connection id as tags

### DIFF
--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -458,22 +458,27 @@ public:
         .WillRepeatedly(Return(makeOptRef(dynamic_cast<const Network::Connection&>(connection_))));
   }
 
-  void logMessageWithPreCreatedTags() { ENVOY_TAGGED_LOG(info, tags_, "fake message {}", "val"); }
+  void logTaggedMessageWithPreCreatedTags() {
+    ENVOY_TAGGED_LOG(info, tags_, "fake message {}", "val");
+  }
 
-  void logMessageWithInlineTags() {
+  void logTaggedMessageWithInlineTags() {
     ENVOY_TAGGED_LOG(info, (std::map<std::string, std::string>{{"key_inline", "val"}}),
                      "fake message {}", "val");
   }
 
-  void logMessageWithEscaping() {
+  void logTaggedMessageWithEscaping() {
     ENVOY_TAGGED_LOG(info, tags_with_escaping_, "fake me\"ssage {}", "val");
   }
 
-  void logMessageWithConnection(std::map<std::string, std::string>& tags) {
+  void logMessageWithConnection() { ENVOY_CONN_LOG(info, "fake message", connection_); }
+  void logMessageWithStream() { ENVOY_STREAM_LOG(info, "fake message", stream_); }
+
+  void logTaggedMessageWithConnection(std::map<std::string, std::string>& tags) {
     ENVOY_TAGGED_CONN_LOG(info, tags, connection_, "fake message");
   }
 
-  void logMessageWithStream(std::map<std::string, std::string>& tags) {
+  void logTaggedMessageWithStream(std::map<std::string, std::string>& tags) {
     ENVOY_TAGGED_STREAM_LOG(info, tags, stream_, "fake message");
   }
 
@@ -504,9 +509,9 @@ TEST(TaggedLogTest, TestTaggedLog) {
       }));
 
   ClassForTaggedLog object;
-  object.logMessageWithPreCreatedTags();
-  object.logMessageWithInlineTags();
-  object.logMessageWithEscaping();
+  object.logTaggedMessageWithPreCreatedTags();
+  object.logTaggedMessageWithInlineTags();
+  object.logTaggedMessageWithEscaping();
 }
 
 TEST(TaggedLogTest, TestTaggedConnLog) {
@@ -533,9 +538,25 @@ TEST(TaggedLogTest, TestTaggedConnLog) {
   std::map<std::string, std::string> tags_with_conn_id{{"ConnectionId", "105"}};
 
   ClassForTaggedLog object;
-  object.logMessageWithConnection(empty_tags);
-  object.logMessageWithConnection(tags);
-  object.logMessageWithConnection(tags_with_conn_id);
+  object.logTaggedMessageWithConnection(empty_tags);
+  object.logTaggedMessageWithConnection(tags);
+  object.logTaggedMessageWithConnection(tags_with_conn_id);
+}
+
+TEST(TaggedLogTest, TestConnLog) {
+  Envoy::Logger::Registry::setLogFormat("%v");
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(msg, HasSubstr("[Tags: \"ConnectionId\":\"200\"] fake message"));
+      }));
+
+  ClassForTaggedLog object;
+  object.logMessageWithConnection();
 }
 
 TEST(TaggedLogTest, TestTaggedStreamLog) {
@@ -565,9 +586,26 @@ TEST(TaggedLogTest, TestTaggedStreamLog) {
   std::map<std::string, std::string> tags_with_stream_id{{"StreamId", "405"}};
 
   ClassForTaggedLog object;
-  object.logMessageWithStream(empty_tags);
-  object.logMessageWithStream(tags);
-  object.logMessageWithStream(tags_with_stream_id);
+  object.logTaggedMessageWithStream(empty_tags);
+  object.logTaggedMessageWithStream(tags);
+  object.logTaggedMessageWithStream(tags_with_stream_id);
+}
+
+TEST(TaggedLogTest, TestStreamLog) {
+  Envoy::Logger::Registry::setLogFormat("%v");
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_THAT(
+            msg, HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"300\"] fake message"));
+      }));
+
+  ClassForTaggedLog object;
+  object.logMessageWithStream();
 }
 
 TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {
@@ -599,8 +637,8 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {
       }));
 
   ClassForTaggedLog object;
-  object.logMessageWithPreCreatedTags();
-  object.logMessageWithEscaping();
+  object.logTaggedMessageWithPreCreatedTags();
+  object.logTaggedMessageWithEscaping();
 }
 
 TEST(TaggedLogTest, TestTaggedConnLogWithJsonFormat) {
@@ -635,8 +673,33 @@ TEST(TaggedLogTest, TestTaggedConnLogWithJsonFormat) {
   std::map<std::string, std::string> tags{{"key", "val"}};
 
   ClassForTaggedLog object;
-  object.logMessageWithConnection(empty_tags);
-  object.logMessageWithConnection(tags);
+  object.logTaggedMessageWithConnection(empty_tags);
+  object.logTaggedMessageWithConnection(tags);
+}
+
+TEST(TaggedLogTest, TestConnLogWithJsonFormat) {
+  ProtobufWkt::Struct log_struct;
+  (*log_struct.mutable_fields())["Level"].set_string_value("%l");
+  (*log_struct.mutable_fields())["Message"].set_string_value("%j");
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  EXPECT_TRUE(Envoy::Logger::Registry::setJsonLogFormat(log_struct).ok());
+  EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
+
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
+      }));
+
+  ClassForTaggedLog object;
+  object.logMessageWithConnection();
 }
 
 TEST(TaggedLogTest, TestTaggedStreamLogWithJsonFormat) {
@@ -673,8 +736,34 @@ TEST(TaggedLogTest, TestTaggedStreamLogWithJsonFormat) {
   std::map<std::string, std::string> tags{{"key", "val"}};
 
   ClassForTaggedLog object;
-  object.logMessageWithStream(empty_tags);
-  object.logMessageWithStream(tags);
+  object.logTaggedMessageWithStream(empty_tags);
+  object.logTaggedMessageWithStream(tags);
+}
+
+TEST(TaggedLogTest, TestStreamLogWithJsonFormat) {
+  ProtobufWkt::Struct log_struct;
+  (*log_struct.mutable_fields())["Level"].set_string_value("%l");
+  (*log_struct.mutable_fields())["Message"].set_string_value("%j");
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  EXPECT_TRUE(Envoy::Logger::Registry::setJsonLogFormat(log_struct).ok());
+  EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
+
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        // Using the mock connection write a log, skipping it.
+        EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
+      }))
+      .WillOnce(Invoke([](auto msg, auto&) {
+        EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
+        EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"StreamId\":\"300\""));
+        EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
+      }));
+
+  ClassForTaggedLog object;
+  object.logMessageWithStream();
 }
 
 TEST(TaggedLogTest, TestTaggedLogWithJsonFormatMultipleJFlags) {
@@ -701,7 +790,7 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormatMultipleJFlags) {
       }));
 
   ClassForTaggedLog object;
-  object.logMessageWithPreCreatedTags();
+  object.logTaggedMessageWithPreCreatedTags();
 }
 
 } // namespace

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -471,8 +471,9 @@ public:
     ENVOY_TAGGED_LOG(info, tags_with_escaping_, "fake me\"ssage {}", "val");
   }
 
-  void logMessageWithConnection() { ENVOY_CONN_LOG(info, "fake message", connection_); }
-  void logMessageWithStream() { ENVOY_STREAM_LOG(info, "fake message", stream_); }
+  void logMessageWithConnection() { ENVOY_CONN_LOG(info, "fake message {}", connection_, "val"); }
+
+  void logMessageWithStream() { ENVOY_STREAM_LOG(info, "fake message {}", stream_, "val"); }
 
   void logTaggedMessageWithConnection(std::map<std::string, std::string>& tags) {
     ENVOY_TAGGED_CONN_LOG(info, tags, connection_, "fake message");
@@ -552,7 +553,7 @@ TEST(TaggedLogTest, TestConnLog) {
         EXPECT_THAT(msg, HasSubstr("TestRandomGenerator"));
       }))
       .WillOnce(Invoke([](auto msg, auto&) {
-        EXPECT_THAT(msg, HasSubstr("[Tags: \"ConnectionId\":\"200\"] fake message"));
+        EXPECT_THAT(msg, HasSubstr("[Tags: \"ConnectionId\":\"200\"] fake message val"));
       }));
 
   ClassForTaggedLog object;
@@ -601,7 +602,8 @@ TEST(TaggedLogTest, TestStreamLog) {
       }))
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_THAT(
-            msg, HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"300\"] fake message"));
+            msg,
+            HasSubstr("[Tags: \"ConnectionId\":\"200\",\"StreamId\":\"300\"] fake message val"));
       }));
 
   ClassForTaggedLog object;
@@ -694,7 +696,7 @@ TEST(TaggedLogTest, TestConnLogWithJsonFormat) {
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
         EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
-        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message val\""));
         EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
       }));
 
@@ -757,7 +759,7 @@ TEST(TaggedLogTest, TestStreamLogWithJsonFormat) {
       .WillOnce(Invoke([](auto msg, auto&) {
         EXPECT_NO_THROW(Json::Factory::loadFromString(std::string(msg)));
         EXPECT_THAT(msg, HasSubstr("\"Level\":\"info\""));
-        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message\""));
+        EXPECT_THAT(msg, HasSubstr("\"Message\":\"fake message val\""));
         EXPECT_THAT(msg, HasSubstr("\"StreamId\":\"300\""));
         EXPECT_THAT(msg, HasSubstr("\"ConnectionId\":\"200\""));
       }));


### PR DESCRIPTION
Additional Description: Resolves #28307. Following the addition of ``ENVOY_TAGGED_LOG`` and it's derivatives, this PR changes ``ENVOY_CONN_LOG`` and ``ENVOY_STREAM_LOG`` to print connection and stream IDs as tags. Examples below.
Risk Level: Medium
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None

When JSON logs are not enabled:
Log line: ``ENVOY_CONN_LOG(info, "fake message {}", connection_, "val");``
Expected log: ``[Tags: "ConnectionId":"52"] fake message val``

When JSON logs are enabled:
Log line: ``ENVOY_CONN_LOG(info, "fake message {}", connection_, "val");``
Expected log: ``{"Message":"fake message val","ConnectionId":"52"}``