### PR TITLE
Replace a RELEASE_ASSERT with a sensible default in getLocalAddress

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -229,17 +229,19 @@ Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersio
 
     const Api::SysCallIntResult rc =
         Api::OsSysCallsSingleton::get().getifaddrs(interface_addresses);
-    RELEASE_ASSERT(!rc.return_value_, fmt::format("getifaddrs error: {}", rc.errno_));
-
-    // man getifaddrs(3)
-    for (const auto& interface_address : interface_addresses) {
-      if (!isLoopbackAddress(*interface_address.interface_addr_) &&
-          interface_address.interface_addr_->ip()->version() == version) {
-        ret = interface_address.interface_addr_;
-        if (ret->ip()->version() == Address::IpVersion::v6) {
-          ret = ret->ip()->ipv6()->addressWithoutScopeId();
+    if (!rc.return_value_) {
+      ENVOY_LOG_MISC(debug, fmt::format("getifaddrs error: {}", rc.errno_));
+    } else {
+      // man getifaddrs(3)
+      for (const auto& interface_address : interface_addresses) {
+        if (!isLoopbackAddress(*interface_address.interface_addr_) &&
+            interface_address.interface_addr_->ip()->version() == version) {
+          ret = interface_address.interface_addr_;
+          if (ret->ip()->version() == Address::IpVersion::v6) {
+            ret = ret->ip()->ipv6()->addressWithoutScopeId();
+          }
+          break;
         }
-        break;
       }
     }
   }


### PR DESCRIPTION
On Android, it is possible for getifaddrs() to fail under some circumstance. This results in a RELEASE_ASSERT which crashes the app. Since getLocalAddress() already has a default return value, replace the RELEASE_ASSERT with ENVOY_LOG_MISC(debug) and use the default return value instead.

Risk Level: Low
Testing: 
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A