### PR TITLE
Revert "tls: Update the preprocessor macro check to check against boringssl version (#28296)"

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -559,18 +559,14 @@ void ContextImpl::logHandshake(SSL* ssl) const {
     stats_.no_certificate_.inc();
   }
 
-#if defined(BORINGSSL_FIPS) && BORINGSSL_API_VERSION >= 18
-#error "Delete preprocessor check below; no longer needed"
-#endif
-
-#if BORINGSSL_API_VERSION >= 18
+#ifndef BORINGSSL_FIPS
   // Increment the `was_key_usage_invalid_` stats to indicate the given cert would have triggered an
   // error but is allowed because the enforcement that rsa key usage and tls usage need to be
   // matched has been disabled.
   if (SSL_was_key_usage_invalid(ssl)) {
     stats_.was_key_usage_invalid_.inc();
   }
-#endif // BORINGSSL_API_VERSION
+#endif
 }
 
 std::vector<Ssl::PrivateKeyMethodProviderSharedPtr> ContextImpl::getPrivateKeyMethodProviders() {


### PR DESCRIPTION
Seems to cause coverage to fail.

This reverts commit bd836c22030b20624142c78fc16773d4bb2e582e.
