### PR TITLE
signal: set altstack size a multiple of page size

### DIFF
--- a/source/common/signal/signal_action.h
+++ b/source/common/signal/signal_action.h
@@ -52,7 +52,9 @@ class SignalAction : NonCopyable {
 public:
   SignalAction()
       : guard_size_(sysconf(_SC_PAGE_SIZE)),
-        altstack_size_(std::max(guard_size_ * 4, static_cast<size_t>(MINSIGSTKSZ))) {
+        altstack_size_(
+            std::max(guard_size_ * 4, (static_cast<size_t>(MINSIGSTKSZ) + guard_size_ - 1) /
+                                          guard_size_ * guard_size_)) {
     mapAndProtectStackMemory();
     installSigHandlers();
   }


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: signal: set altstack size a multiple of page size
Additional Description:

We use `mprotect` to protect address space for signal handling, and `mprotect` requires its arguments (`altstack_` + `guard_size_` + `altstack_size_`) to be aligned to a page boundary. Here, `guard_size_` is the system page size and `altstack_size_` is a multiple of page size. `altstack_size_` is initialized as the maximum of `4 * guard_size_` and `MINSIGSTKSZ` while `MINSIGSTKSZ` may **NOT** be a multiple of page size.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
