### PR TITLE
docs/config: Exclude sds configs from tests

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -31,6 +31,8 @@ filegroup(
             "root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml",
             "root/configuration/other_features/_include/dlb.yaml",
             "root/intro/arch_overview/security/_include/ssl.yaml",
+            "root/configuration/overview/_include/xds_api/oauth-sds-example.yaml",
+            "root/configuration/security/_include/sds-source-example.yaml",
         ],
     ) + select({
         "//bazel:windows_x86_64": [],


### PR DESCRIPTION
In #28104 the sds configs were separated into yaml files - these seem to fail when tested - not sure how they got through presubmit

testing locally and it reliably fails, but only for the 2 configs excluded here

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
