### PR TITLE
CVE/http: Fix memory leak in nghttp2 codec

### DIFF
--- a/bazel/foreign_cc/nghttp2.patch
+++ b/bazel/foreign_cc/nghttp2.patch
@@ -15,3 +15,37 @@ diff -u -r a/CMakeLists.txt b/CMakeLists.txt
  # AC_TYPE_UINT8_T
  # AC_TYPE_UINT16_T
 Only in b: CMakeLists.txt.orig
+--- a/lib/nghttp2_session.c	2023-06-14 00:17:10.311464189 +0000
++++ b/lib/nghttp2_session.c	2023-06-14 00:18:49.551376483 +0000
+@@ -3294,6 +3294,7 @@
+         break;
+       }
+       if (rv < 0) {
++        int rv2 = 0;
+         int32_t opened_stream_id = 0;
+         uint32_t error_code = NGHTTP2_INTERNAL_ERROR;
+ 
+@@ -3338,19 +3339,18 @@
+         }
+         if (opened_stream_id) {
+           /* careful not to override rv */
+-          int rv2;
+           rv2 = nghttp2_session_close_stream(session, opened_stream_id,
+                                              error_code);
+-
+-          if (nghttp2_is_fatal(rv2)) {
+-            return rv2;
+-          }
+         }
+ 
+         nghttp2_outbound_item_free(item, mem);
+         nghttp2_mem_free(mem, item);
+         active_outbound_item_reset(aob, mem);
+ 
++        if (nghttp2_is_fatal(rv2)) {
++          return rv2;
++        }
++        
+         if (rv == NGHTTP2_ERR_HEADER_COMP) {
+           /* If header compression error occurred, should terminiate
+              connection. */

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -211,6 +211,10 @@ bug_fixes:
 - area: redis
   change: |
     Fixes a bug where redis transactions do not work properly when redis traffic is mirrored.
+- area: http2
+  change: |
+    Fix memory leak in nghttp2 when scheduled requests are cancelled due to the ``GOAWAY`` frame being received from the
+    upstream service.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/test/integration/filters/test_socket_interface.cc
+++ b/test/integration/filters/test_socket_interface.cc
@@ -58,6 +58,16 @@ IoHandlePtr TestIoSocketHandle::duplicate() {
                                               domain_);
 }
 
+Api::SysCallIntResult TestIoSocketHandle::connect(Address::InstanceConstSharedPtr address) {
+  if (write_override_) {
+    auto result = write_override_(this, nullptr, 0);
+    if (result.has_value()) {
+      return Api::SysCallIntResult{-1, EINPROGRESS};
+    }
+  }
+  return Test::IoSocketHandlePlatformImpl::connect(address);
+}
+
 IoHandlePtr TestSocketInterface::makeSocket(int socket_fd, bool socket_v6only,
                                             absl::optional<int> domain) const {
   return std::make_unique<TestIoSocketHandle>(write_override_proc_, socket_fd, socket_v6only,

--- a/test/integration/filters/test_socket_interface.h
+++ b/test/integration/filters/test_socket_interface.h
@@ -68,6 +68,7 @@ public:
 
 private:
   IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen) override;
+  Api::SysCallIntResult connect(Address::InstanceConstSharedPtr address) override;
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
   Api::IoCallUint64Result sendmsg(const Buffer::RawSlice* slices, uint64_t num_slice, int flags,
                                   const Address::Ip* self_ip,

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -1569,4 +1569,62 @@ TEST_P(Http2FloodMitigationTest, UpstreamRstStreamStormOnDownstreamCloseRegressi
   EXPECT_EQ(2, test_server_->gauge("cluster.cluster_0.upstream_cx_active")->value());
 }
 
+// This test validates fix for memory leak in nghttp2 that occurs when
+// nghttp2 processes RST_STREAM and GO_AWAY in the same I/O operation.
+// Max concurrent request should be limited to 1.
+// nghttp2 leaks HEADERS frame and bookkeeping structure.
+// The failure occurs in the ASAN build only due to leak checker.
+#ifndef WIN32
+// Windows does not support override of the socket connect() call
+TEST_P(Http2FloodMitigationTest, GoAwayAfterRequestReset) {
+  if (std::get<1>(GetParam()) != Http2Impl::Nghttp2) {
+    return;
+  }
+  setDownstreamProtocol(Http::CodecType::HTTP2);
+  setUpstreamProtocol(Http::CodecType::HTTP2);
+  // Limit concurrent requests to the upstream to 1
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    ConfigHelper::HttpProtocolOptions protocol_options;
+    auto* http_protocol_options =
+        protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+    http_protocol_options->mutable_max_concurrent_streams()->set_value(1);
+    ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
+                                     protocol_options);
+  });
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response_1 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+
+  // After we've got the first request at the upstream, make the connect() call return EAGAIN (and
+  // never connect). This will make the second request to hang in Envoy waiting for either the first
+  // connection to free up capacity (i.e. finish with the first request) or the second connection to
+  // connect, which will never happen.
+  auto* upstream = fake_upstreams_.front().get();
+  write_matcher_->setDestinationPort(upstream->localAddress()->ip()->port());
+  write_matcher_->setConnectBlock(true);
+
+  auto response_2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  // The RST_STREAM will cause the capacity to free up on the first connection and the second
+  // request to be scheduled on the first connection.
+  // The GOAWAY frame will cause nghttp2 to not send any more requests. Without the fix this
+  // leaks scheduled request and it is detected by ASAN run.
+  const auto rst_stream = Http2Frame::makeResetStreamFrame(Http2Frame::makeClientStreamId(0),
+                                                           Http2Frame::ErrorCode::NoError);
+  const auto go_away = Http2Frame::makeEmptyGoAwayFrame(0, Http2Frame::ErrorCode::NoError);
+  std::string buf(static_cast<std::string>(rst_stream));
+  buf.append(static_cast<std::string>(go_away));
+  ASSERT_TRUE(upstream->rawWriteConnection(0, buf));
+
+  ASSERT_TRUE(response_1->waitForEndStream());
+  ASSERT_TRUE(response_2->waitForEndStream());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+
+  EXPECT_EQ("503", response_1->headers().getStatusValue());
+  EXPECT_EQ("503", response_2->headers().getStatusValue());
+}
+#endif
+
 } // namespace Envoy

--- a/test/integration/socket_interface_swap.cc
+++ b/test/integration/socket_interface_swap.cc
@@ -9,12 +9,22 @@ SocketInterfaceSwap::SocketInterfaceSwap(Network::Socket::Type socket_type)
   Envoy::Network::SocketInterfaceSingleton::clear();
   test_socket_interface_loader_ = std::make_unique<Envoy::Network::SocketInterfaceLoader>(
       std::make_unique<Envoy::Network::TestSocketInterface>(
-          [write_matcher = write_matcher_](Envoy::Network::TestIoSocketHandle* io_handle,
-                                           const Buffer::RawSlice*,
-                                           uint64_t) -> absl::optional<Api::IoCallUint64Result> {
-            Network::IoSocketError* error_override = write_matcher->returnOverride(io_handle);
-            if (error_override) {
-              return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
+          [write_matcher = write_matcher_](
+              Envoy::Network::TestIoSocketHandle* io_handle, const Buffer::RawSlice* slices,
+              uint64_t size) -> absl::optional<Api::IoCallUint64Result> {
+            // TODO(yanavlasov): refactor into separate method after CVE is public.
+            if (slices == nullptr && size == 0) {
+              // This is connect override check
+              Network::IoSocketError* error_override =
+                  write_matcher->returnConnectOverride(io_handle);
+              if (error_override) {
+                return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
+              }
+            } else {
+              Network::IoSocketError* error_override = write_matcher->returnOverride(io_handle);
+              if (error_override) {
+                return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
+              }
             }
             return absl::nullopt;
           }));

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -24,6 +24,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/thread:0.0" # Death tests don't report LCOV
 "source/common/watchdog:58.6" # Death tests don't report LCOV
 "source/exe:94.9"
+"source/extensions/access_loggers/grpc:95.8"
 "source/extensions/access_loggers/wasm:93.5"
 "source/extensions/clusters/common:91.5" # This can be increased again once `#24903` lands
 "source/extensions/common:93.0" #flaky: be careful adjusting


### PR DESCRIPTION
Fix memory leak in nghttp2 when it processes pending requests after receiving the GOAWAY frame.

Fix https://github.com/envoyproxy/envoy/security/advisories/GHSA-jfxv-29pc-x22r

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
