### PR TITLE
[bp/1.25] CVE/http: Fix memory leak in nghttp2 codec

### DIFF
--- a/bazel/foreign_cc/nghttp2.patch
+++ b/bazel/foreign_cc/nghttp2.patch
@@ -15,3 +15,37 @@ diff -u -r a/CMakeLists.txt b/CMakeLists.txt
  # AC_TYPE_UINT8_T
  # AC_TYPE_UINT16_T
 Only in b: CMakeLists.txt.orig
+--- a/lib/nghttp2_session.c	2023-06-14 00:17:10.311464189 +0000
++++ b/lib/nghttp2_session.c	2023-06-14 00:18:49.551376483 +0000
+@@ -3294,6 +3294,7 @@
+         break;
+       }
+       if (rv < 0) {
++        int rv2 = 0;
+         int32_t opened_stream_id = 0;
+         uint32_t error_code = NGHTTP2_INTERNAL_ERROR;
+ 
+@@ -3338,19 +3339,18 @@
+         }
+         if (opened_stream_id) {
+           /* careful not to override rv */
+-          int rv2;
+           rv2 = nghttp2_session_close_stream(session, opened_stream_id,
+                                              error_code);
+-
+-          if (nghttp2_is_fatal(rv2)) {
+-            return rv2;
+-          }
+         }
+ 
+         nghttp2_outbound_item_free(item, mem);
+         nghttp2_mem_free(mem, item);
+         active_outbound_item_reset(aob, mem);
+ 
++        if (nghttp2_is_fatal(rv2)) {
++          return rv2;
++        }
++        
+         if (rv == NGHTTP2_ERR_HEADER_COMP) {
+           /* If header compression error occurred, should terminiate
+              connection. */

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -12,6 +12,10 @@ bug_fixes:
   change: |
     Fixes an issue with the ORIGINAL_DST cluster cleanup timer lifetime, which
     can occur if the cluster is removed while the timer is armed.
+- area: http2
+  change: |
+    Fix memory leak in nghttp2 when scheduled requests are cancelled due to the ``GOAWAY`` frame being received from the
+    upstream service. Fix `CVE-2023-35945 <https://nvd.nist.gov/vuln/detail/CVE-2023-35945>`_.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/test/integration/filters/test_socket_interface.cc
+++ b/test/integration/filters/test_socket_interface.cc
@@ -58,6 +58,16 @@ IoHandlePtr TestIoSocketHandle::duplicate() {
                                               domain_);
 }
 
+Api::SysCallIntResult TestIoSocketHandle::connect(Address::InstanceConstSharedPtr address) {
+  if (write_override_) {
+    auto result = write_override_(this, nullptr, 0);
+    if (result.has_value()) {
+      return Api::SysCallIntResult{-1, EINPROGRESS};
+    }
+  }
+  return Test::IoSocketHandlePlatformImpl::connect(address);
+}
+
 IoHandlePtr TestSocketInterface::makeSocket(int socket_fd, bool socket_v6only,
                                             absl::optional<int> domain) const {
   return std::make_unique<TestIoSocketHandle>(write_override_proc_, socket_fd, socket_v6only,

--- a/test/integration/filters/test_socket_interface.h
+++ b/test/integration/filters/test_socket_interface.h
@@ -61,6 +61,7 @@ public:
 
 private:
   IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen) override;
+  Api::SysCallIntResult connect(Address::InstanceConstSharedPtr address) override;
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
   Api::IoCallUint64Result sendmsg(const Buffer::RawSlice* slices, uint64_t num_slice, int flags,
                                   const Address::Ip* self_ip,

--- a/test/integration/socket_interface_swap.cc
+++ b/test/integration/socket_interface_swap.cc
@@ -8,12 +8,22 @@ SocketInterfaceSwap::SocketInterfaceSwap() {
   Envoy::Network::SocketInterfaceSingleton::clear();
   test_socket_interface_loader_ = std::make_unique<Envoy::Network::SocketInterfaceLoader>(
       std::make_unique<Envoy::Network::TestSocketInterface>(
-          [write_matcher = write_matcher_](Envoy::Network::TestIoSocketHandle* io_handle,
-                                           const Buffer::RawSlice*,
-                                           uint64_t) -> absl::optional<Api::IoCallUint64Result> {
-            Network::IoSocketError* error_override = write_matcher->returnOverride(io_handle);
-            if (error_override) {
-              return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
+          [write_matcher = write_matcher_](
+              Envoy::Network::TestIoSocketHandle* io_handle, const Buffer::RawSlice* slices,
+              uint64_t size) -> absl::optional<Api::IoCallUint64Result> {
+            // TODO(yanavlasov): refactor into separate method after CVE is public.
+            if (slices == nullptr && size == 0) {
+              // This is connect override check
+              Network::IoSocketError* error_override =
+                  write_matcher->returnConnectOverride(io_handle);
+              if (error_override) {
+                return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
+              }
+            } else {
+              Network::IoSocketError* error_override = write_matcher->returnOverride(io_handle);
+              if (error_override) {
+                return Api::IoCallUint64Result(0, Api::IoErrorPtr(error_override, preserveIoError));
+              }
             }
             return absl::nullopt;
           }));


### PR DESCRIPTION
Fix memory leak in nghttp2 when it processes pending requests after receiving the GOAWAY frame.

Fix https://github.com/envoyproxy/envoy/security/advisories/GHSA-jfxv-29pc-x22r

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
