### PR TITLE
C++20 build config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -169,6 +169,10 @@ build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
 build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread
 build:libc++ --define force_libcpp=enabled
 
+build:libc++20 --config=libc++
+# gRPC has a lot of deprecated-enum-enum-conversion warning. Remove once it is addressed
+build:libc++20 --cxxopt=-std=c++20 --copt=-Wno-error=deprecated-enum-enum-conversion
+
 # Optimize build for binary size reduction.
 build:sizeopt -c opt --copt -Os
 

--- a/bazel/io_opentracing_cpp.patch
+++ b/bazel/io_opentracing_cpp.patch
@@ -130,3 +130,30 @@ index c57dc9f..587bf0e 100644
 -    rm -rf $$TEMP_DIR
 -    """,
 -)
+diff --git a/3rd_party/include/opentracing/variant/variant.hpp b/3rd_party/include/opentracing/variant/variant.hpp
+--- a/3rd_party/include/opentracing/variant/variant.hpp	2023-07-11 17:17:48.563874883 +0000
++++ b/3rd_party/include/opentracing/variant/variant.hpp	2023-07-11 17:45:38.558235212 +0000
+@@ -167,7 +167,11 @@
+ template <typename F, typename V, typename Enable = void>
+ struct result_of_unary_visit
+ {
++#if __cplusplus >= 202002L
++    using type = typename std::invoke_result<F, V&>::type;
++#else
+     using type = typename std::result_of<F(V&)>::type;
++#endif
+ };
+ 
+ template <typename F, typename V>
+@@ -179,7 +183,11 @@
+ template <typename F, typename V, typename Enable = void>
+ struct result_of_binary_visit
+ {
++#if __cplusplus >= 202002L
++    using type = typename std::invoke_result<F, V&, V&>::type;
++#else
+     using type = typename std::result_of<F(V&, V&)>::type;
++#endif
+ };
+ 
+ template <typename F, typename V>

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -343,8 +343,8 @@ case $CI_TARGET in
             "--@envoy//bazel:http3=False"
             "--@envoy//source/extensions/filters/http/kill_request:enabled"
             "--test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true"
-            "--remote_download_minimal")
-        ENVOY_STDLIB="${ENVOY_STDLIB:-libstdc++}"
+            "--remote_download_minimal"
+            "--config=libc++20")
         setup_clang_toolchain
         # This doesn't go into CI but is available for developer convenience.
         echo "bazel with different compiletime options build with tests..."

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -555,7 +555,7 @@ public:
   do {                                                                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
       ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,               \
+                          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT), \
                           ##__VA_ARGS__);                                                          \
     }                                                                                              \
   } while (0)
@@ -565,7 +565,7 @@ public:
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
       TAGS.emplace("ConnectionId", std::to_string((CONNECTION).id()));                             \
       ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,               \
+                          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT), \
                           ##__VA_ARGS__);                                                          \
     }                                                                                              \
   } while (0)
@@ -577,7 +577,7 @@ public:
                    (STREAM).connection() ? std::to_string((STREAM).connection()->id()) : "0");     \
       TAGS.emplace("StreamId", std::to_string((STREAM).streamId()));                               \
       ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          ::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT,               \
+                          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT), \
                           ##__VA_ARGS__);                                                          \
     }                                                                                              \
   } while (0)
@@ -587,9 +587,10 @@ public:
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
       std::map<std::string, std::string> log_tags;                                                 \
       log_tags.emplace("ConnectionId", std::to_string((CONNECTION).id()));                         \
-      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          ::Envoy::Logger::Utility::serializeLogTags(log_tags) + FORMAT,           \
-                          ##__VA_ARGS__);                                                          \
+      ENVOY_LOG_TO_LOGGER(                                                                         \
+          LOGGER, LEVEL,                                                                           \
+          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(log_tags) + FORMAT),             \
+          ##__VA_ARGS__);                                                                          \
     }                                                                                              \
   } while (0)
 
@@ -600,9 +601,10 @@ public:
       log_tags.emplace("ConnectionId",                                                             \
                        (STREAM).connection() ? std::to_string((STREAM).connection()->id()) : "0"); \
       log_tags.emplace("StreamId", std::to_string((STREAM).streamId()));                           \
-      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          ::Envoy::Logger::Utility::serializeLogTags(log_tags) + FORMAT,           \
-                          ##__VA_ARGS__);                                                          \
+      ENVOY_LOG_TO_LOGGER(                                                                         \
+          LOGGER, LEVEL,                                                                           \
+          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(log_tags) + FORMAT),             \
+          ##__VA_ARGS__);                                                                          \
     }                                                                                              \
   } while (0)
 

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -93,7 +93,7 @@ std::string SignerImpl::createContentHash(Http::RequestMessage& message, bool si
 
 std::string SignerImpl::createCredentialScope(absl::string_view short_date,
                                               absl::string_view override_region) const {
-  return fmt::format(SignatureConstants::get().CredentialScopeFormat, short_date,
+  return fmt::format(fmt::runtime(SignatureConstants::get().CredentialScopeFormat), short_date,
                      override_region.empty() ? region_ : override_region, service_name_);
 }
 
@@ -102,7 +102,7 @@ std::string SignerImpl::createStringToSign(absl::string_view canonical_request,
                                            absl::string_view credential_scope) const {
   auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
   return fmt::format(
-      SignatureConstants::get().StringToSignFormat, long_date, credential_scope,
+      fmt::runtime(SignatureConstants::get().StringToSignFormat), long_date, credential_scope,
       Hex::encode(crypto_util.getSha256Digest(Buffer::OwnedImpl(canonical_request))));
 }
 
@@ -129,8 +129,8 @@ SignerImpl::createAuthorizationHeader(absl::string_view access_key_id,
                                       const std::map<std::string, std::string>& canonical_headers,
                                       absl::string_view signature) const {
   const auto signed_headers = Utility::joinCanonicalHeaderNames(canonical_headers);
-  return fmt::format(SignatureConstants::get().AuthorizationHeaderFormat, access_key_id,
-                     credential_scope, signed_headers, signature);
+  return fmt::format(fmt::runtime(SignatureConstants::get().AuthorizationHeaderFormat),
+                     access_key_id, credential_scope, signed_headers, signature);
 }
 
 } // namespace Aws

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -20,8 +20,8 @@ constexpr absl::string_view QUERY_SEPERATOR = "&";
 constexpr absl::string_view QUERY_SPLITTER = "?";
 constexpr absl::string_view RESERVED_CHARS = "-._~";
 constexpr absl::string_view S3_SERVICE_NAME = "s3";
-const std::string URI_ENCODE = "%{:02X}";
-const std::string URI_DOUBLE_ENCODE = "%25{:02X}";
+constexpr absl::string_view URI_ENCODE = "%{:02X}";
+constexpr absl::string_view URI_DOUBLE_ENCODE = "%25{:02X}";
 
 std::map<std::string, std::string>
 Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers,

--- a/source/extensions/filters/common/rbac/matchers/upstream_ip_port.cc
+++ b/source/extensions/filters/common/rbac/matchers/upstream_ip_port.cc
@@ -60,10 +60,10 @@ bool UpstreamIpPortMatcher::matches(const Network::Connection&,
   if (port_) {
     const auto port = address_obj->address_->ip()->port();
     if (port >= port_->start() && port <= port_->end()) {
-      ENVOY_LOG(debug, "UpstreamIpPort matcher for port range: {{}, {}} evaluated to: true",
+      ENVOY_LOG(debug, "UpstreamIpPort matcher for port range: [{}, {}] evaluated to: true",
                 port_->start(), port_->end());
     } else {
-      ENVOY_LOG(debug, "UpstreamIpPort matcher for port range: {{}, {}} evaluated to: false",
+      ENVOY_LOG(debug, "UpstreamIpPort matcher for port range: [{}, {}] evaluated to: false",
                 port_->start(), port_->end());
       return false;
     }

--- a/source/extensions/filters/network/mongo_proxy/codec_impl.h
+++ b/source/extensions/filters/network/mongo_proxy/codec_impl.h
@@ -45,6 +45,9 @@ public:
 
   // Mongo::GetMoreMessage
   bool operator==(const GetMoreMessage& rhs) const override;
+  bool operator==(const GetMoreMessageImpl& rhs) const {
+    return operator==(static_cast<const GetMoreMessage&>(rhs));
+  }
   const std::string& fullCollectionName() const override { return full_collection_name_; }
   void fullCollectionName(const std::string& name) override { full_collection_name_ = name; }
   int32_t numberToReturn() const override { return number_to_return_; }
@@ -72,6 +75,9 @@ public:
 
   // Mongo::InsertMessage
   bool operator==(const InsertMessage& rhs) const override;
+  bool operator==(const InsertMessageImpl& rhs) const {
+    return operator==(static_cast<const InsertMessage&>(rhs));
+  }
   int32_t flags() const override { return flags_; }
   void flags(int32_t flags) override { flags_ = flags; }
   const std::string& fullCollectionName() const override { return full_collection_name_; }
@@ -99,6 +105,9 @@ public:
 
   // Mongo::KillCursorsMessage
   bool operator==(const KillCursorsMessage& rhs) const override;
+  bool operator==(const KillCursorsMessageImpl& rhs) const {
+    return operator==(static_cast<const KillCursorsMessage&>(rhs));
+  }
   int32_t numberOfCursorIds() const override { return number_of_cursor_ids_; }
   void numberOfCursorIds(int32_t number_of_cursor_ids) override {
     number_of_cursor_ids_ = number_of_cursor_ids;
@@ -127,6 +136,9 @@ public:
 
   // Mongo::QueryMessage
   bool operator==(const QueryMessage& rhs) const override;
+  bool operator==(const QueryMessageImpl& rhs) const {
+    return operator==(static_cast<const QueryMessage&>(rhs));
+  }
   int32_t flags() const override { return flags_; }
   void flags(int32_t flags) override { flags_ = flags; }
   const std::string& fullCollectionName() const override { return full_collection_name_; }
@@ -167,6 +179,9 @@ public:
 
   // Mongo::ReplyMessage
   bool operator==(const ReplyMessage& rhs) const override;
+  bool operator==(const ReplyMessageImpl& rhs) const {
+    return operator==(static_cast<const ReplyMessage&>(rhs));
+  }
   int32_t flags() const override { return flags_; }
   void flags(int32_t flags) override { flags_ = flags; }
   int64_t cursorId() const override { return cursor_id_; }
@@ -199,6 +214,9 @@ public:
 
   // CommandMessageImpl accessors.
   bool operator==(const CommandMessage& rhs) const override;
+  bool operator==(const CommandMessageImpl& rhs) const {
+    return operator==(static_cast<const CommandMessage&>(rhs));
+  }
   std::string database() const override { return database_; }
   void database(std::string database) override { database_ = database; }
   std::string commandName() const override { return command_name_; }
@@ -233,6 +251,9 @@ public:
 
   // CommandMessageReplyImpl accessors.
   bool operator==(const CommandReplyMessage& rhs) const override;
+  bool operator==(const CommandReplyMessageImpl& rhs) const {
+    return operator==(static_cast<const CommandReplyMessage&>(rhs));
+  }
   const Bson::Document* metadata() const override { return metadata_.get(); }
   void metadata(Bson::DocumentSharedPtr&& metadata) override { metadata_ = std::move(metadata); }
   const Bson::Document* commandReply() const override { return command_reply_.get(); }

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -43,7 +43,7 @@ AccessLog::AccessLog(const std::string& file_name, Envoy::AccessLog::AccessLogMa
 
 void AccessLog::logMessage(const Message& message, bool full,
                            const Upstream::HostDescription* upstream_host) {
-  static const std::string log_format =
+  static constexpr absl::string_view log_format =
       "{{\"time\": \"{}\", \"message\": {}, \"upstream_host\": \"{}\"}}\n";
 
   SystemTime now = time_source_.systemTime();

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -38,8 +38,8 @@ sockaddr_un HotRestartingBase::createDomainSocketAddress(uint64_t id, const std:
   id = id % MaxConcurrentProcesses;
   sockaddr_un address;
   initDomainSocketAddress(&address);
-  Network::Address::PipeInstance addr(fmt::format(socket_path + "_{}_{}", role, base_id_ + id),
-                                      socket_mode, nullptr);
+  Network::Address::PipeInstance addr(
+      fmt::format(fmt::runtime(socket_path + "_{}_{}"), role, base_id_ + id), socket_mode, nullptr);
   safeMemcpy(&address, &(addr.getSockAddr()));
   fchmod(my_domain_socket_, socket_mode);
 

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1247,7 +1247,7 @@ typed_config:
 }
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterValues) {
-  const std::string yaml_template = R"EOF(
+  constexpr absl::string_view yaml_template = R"EOF(
 name: accesslog
 filter:
   grpc_status_filter:
@@ -1317,7 +1317,7 @@ typed_config:
 }
 
 TEST_F(AccessLogImplTest, GrpcStatusFilterHttpCodes) {
-  const std::string yaml_template = R"EOF(
+  constexpr absl::string_view yaml_template = R"EOF(
 name: accesslog
 filter:
   grpc_status_filter:

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
@@ -29,7 +29,7 @@ public:
   void TearDown() override { fake_upstream_connection_.reset(); }
 
   void setupLambdaFilter(bool passthrough) {
-    const std::string filter =
+    constexpr absl::string_view filter =
         R"EOF(
             name: envoy.filters.http.aws_lambda
             typed_config:

--- a/test/extensions/filters/http/bandwidth_limit/filter_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/filter_test.cc
@@ -63,7 +63,7 @@ public:
 };
 
 TEST_F(FilterTest, Disabled) {
-  const std::string config_yaml = R"(
+  constexpr absl::string_view config_yaml = R"(
   stat_prefix: test
   runtime_enabled:
     default_value: false
@@ -92,7 +92,7 @@ TEST_F(FilterTest, Disabled) {
 }
 
 TEST_F(FilterTest, LimitOnDecode) {
-  const std::string config_yaml = R"(
+  constexpr absl::string_view config_yaml = R"(
   stat_prefix: test
   runtime_enabled:
     default_value: true
@@ -215,7 +215,7 @@ TEST_F(FilterTest, LimitOnDecode) {
 }
 
 TEST_F(FilterTest, LimitOnEncode) {
-  const std::string config_yaml = R"(
+  constexpr absl::string_view config_yaml = R"(
   stat_prefix: test
   runtime_enabled:
     default_value: true
@@ -339,7 +339,7 @@ TEST_F(FilterTest, LimitOnEncode) {
 }
 
 TEST_F(FilterTest, LimitOnDecodeAndEncode) {
-  const std::string config_yaml = R"(
+  constexpr absl::string_view config_yaml = R"(
   stat_prefix: test
   runtime_enabled:
     default_value: true
@@ -477,7 +477,7 @@ TEST_F(FilterTest, LimitOnDecodeAndEncode) {
 }
 
 TEST_F(FilterTest, WithTrailers) {
-  const std::string config_yaml = R"(
+  constexpr absl::string_view config_yaml = R"(
   stat_prefix: test
   runtime_enabled:
     default_value: true
@@ -553,7 +553,7 @@ TEST_F(FilterTest, WithTrailers) {
 }
 
 TEST_F(FilterTest, WithTrailersNoEndStream) {
-  const std::string config_yaml = R"(
+  constexpr absl::string_view config_yaml = R"(
   stat_prefix: test
   runtime_enabled:
     default_value: true

--- a/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_integration_test.cc
@@ -117,7 +117,7 @@ typed_config:
           - any: true
 )EOF";
 
-const std::string RBAC_CONFIG_HEADER_MATCH_CONDITION = R"EOF(
+constexpr absl::string_view RBAC_CONFIG_HEADER_MATCH_CONDITION = R"EOF(
 name: rbac
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -65,7 +65,7 @@ public:
   void setupMatcher(std::string action, std::string on_no_match_action) {
     envoy::extensions::filters::http::rbac::v3::RBAC config;
 
-    const std::string matcher_yaml = R"EOF(
+    constexpr absl::string_view matcher_yaml = R"EOF(
 matcher_list:
   matchers:
   - predicate:
@@ -112,7 +112,7 @@ on_no_match:
       name: none
       action: {}
 )EOF";
-    const std::string shadow_matcher_yaml = R"EOF(
+    constexpr absl::string_view shadow_matcher_yaml = R"EOF(
 matcher_list:
   matchers:
   - predicate:

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -137,7 +137,7 @@ public:
 
   void verifyStaticFilePerTap(const std::string& filter_config) {
     const std::string path_prefix = getTempPathPrefix();
-    initializeFilter(fmt::format(filter_config, path_prefix));
+    initializeFilter(fmt::format(fmt::runtime(filter_config), path_prefix));
 
     // Initial request/response with tap.
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
@@ -460,7 +460,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapContent) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   makeRequest(request_headers_tap_, {}, nullptr, response_headers_no_tap_, {}, nullptr);
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -509,7 +509,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapConcurrent) {
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -591,7 +591,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapTimeout) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   makeRequest(request_headers_tap_, {}, nullptr, response_headers_no_tap_, {}, nullptr);
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -645,7 +645,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapLongTimeout) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   makeRequest(request_headers_tap_, {}, nullptr, response_headers_no_tap_, {}, nullptr);
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -690,7 +690,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapConsecutive) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   makeRequest(request_headers_tap_, {}, nullptr, response_headers_no_tap_, {}, nullptr);
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -772,7 +772,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapBuffering) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   makeRequest(request_headers_tap_, {}, nullptr, response_headers_no_tap_, {}, nullptr);
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -819,7 +819,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapEmptyResponse) {
   // Initial request / response with no tap
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -859,7 +859,7 @@ TEST_P(TapIntegrationTest, AdminBufferedTapOverBuffering) {
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   makeRequest(request_headers_tap_, {}, nullptr, response_headers_no_tap_, {}, nullptr);
 
-  const std::string admin_request_yaml = R"EOF(
+  constexpr absl::string_view admin_request_yaml = R"EOF(
 config_id: test_config_id
 tap_config:
   match:
@@ -1034,7 +1034,7 @@ tap_config:
 // Verify a static configuration with a request header matcher, writing to a streamed file per tap
 // sink.
 TEST_P(TapIntegrationTest, StaticFilePerTapStreaming) {
-  const std::string filter_config =
+  constexpr absl::string_view filter_config =
       R"EOF(
 name: tap
 typed_config:
@@ -1081,7 +1081,7 @@ typed_config:
 // Verify a static configuration with a response header matcher, writing to a streamed file per tap
 // sink. This verifies request buffering.
 TEST_P(TapIntegrationTest, StaticFilePerTapStreamingWithRequestBuffering) {
-  const std::string filter_config =
+  constexpr absl::string_view filter_config =
       R"EOF(
 name: tap
 typed_config:

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
@@ -227,7 +227,7 @@ TEST_F(LocalRateLimitSharedTokenBucketTest, Shared) {
 // Test that the Key from SharedRateLimitSingleton::get() is valid/stable even if
 // many entries are added and the hash table is rehashed.
 TEST_F(LocalRateLimitSharedTokenBucketTest, RehashPointerStability) {
-  const char* yaml_template = R"EOF(
+  constexpr absl::string_view yaml_template = R"EOF(
 stat_prefix: local_rate_limit_stats
 share_key: key_{}
 token_bucket:

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -37,7 +37,7 @@ public:
   }
 
   void validateMatcher(const std::string& matcher_yaml) {
-    checkMatcher(fmt::format(matcher_yaml, header_key, header_value));
+    checkMatcher(fmt::format(fmt::runtime(matcher_yaml), header_key, header_value));
   }
 
 private:

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -72,7 +72,7 @@ public:
     config.set_shadow_rules_stat_prefix("prefix_");
 
     if (with_matcher) {
-      const std::string matcher_yaml = R"EOF(
+      constexpr absl::string_view matcher_yaml = R"EOF(
 matcher_list:
   matchers:
   - predicate:
@@ -109,7 +109,7 @@ on_no_match:
       name: none
       action: {}
 )EOF";
-      const std::string shadow_matcher_yaml = R"EOF(
+      constexpr absl::string_view shadow_matcher_yaml = R"EOF(
 matcher_list:
   matchers:
   - predicate:

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -1688,7 +1688,7 @@ TEST_P(ThriftRouterPassthroughTest, PassthroughEnable) {
   std::tie(downstream_transport_type, downstream_protocol_type, upstream_transport_type,
            upstream_protocol_type) = GetParam();
 
-  const std::string yaml_string = R"EOF(
+  constexpr absl::string_view yaml_string = R"EOF(
   transport: {}
   protocol: {}
   )EOF";

--- a/test/extensions/filters/network/thrift_proxy/trds_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/trds_integration_test.cc
@@ -125,7 +125,7 @@ static_resources:
 TEST_F(ThriftTrdsIntegrationTest, Basic) {
   initialize();
 
-  const char test_route[] = R"EOF(
+  constexpr absl::string_view test_route = R"EOF(
 name: test_route
 routes:
   - match:

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -128,7 +128,7 @@ TEST_F(OpenTelemetryDriverTest, ParseSpanContextFromHeadersTest) {
   auto sampled_tracestate_entry = request_headers.get(OpenTelemetryConstants::get().TRACE_STATE);
   EXPECT_EQ(sampled_tracestate_entry.size(), 1);
   EXPECT_EQ(sampled_tracestate_entry[0]->value().getStringView(), "test=foo");
-  const std::string request_yaml = R"(
+  constexpr absl::string_view request_yaml = R"(
 resource_spans:
   resource:
     attributes:
@@ -370,7 +370,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithAttributes) {
   span->setTag("first_tag_name", "first_tag_new_value");
 
   // Note the placeholders for the bytes - cleaner to manually set after.
-  const std::string request_yaml = R"(
+  constexpr absl::string_view request_yaml = R"(
 resource_spans:
   resource:
     attributes:
@@ -476,7 +476,7 @@ TEST_F(OpenTelemetryDriverTest, ExportSpanWithCustomServiceName) {
                                              operation_name_, {Tracing::Reason::Sampling, true});
   EXPECT_NE(span.get(), nullptr);
 
-  const std::string request_yaml = R"(
+  constexpr absl::string_view request_yaml = R"(
 resource_spans:
   resource:
     attributes:

--- a/test/fuzz/validated_input_generator.h
+++ b/test/fuzz/validated_input_generator.h
@@ -49,7 +49,7 @@ public:
   template <typename T, auto FIELDGETTER, auto FIELDSETTER, auto REPGETTER, auto REPSETTER,
             auto FIELDADDER, auto RULEGETTER,
             auto TYPEHANDLER = &handleNumericRules<
-                T, typename std::result_of<decltype(RULEGETTER)(validate::FieldRules)>::type>>
+                T, typename std::invoke_result<decltype(RULEGETTER), validate::FieldRules>::type>>
   void handleIntrinsicTypedField(Protobuf::Message& msg, const Protobuf::FieldDescriptor& field,
                                  const Protobuf::Reflection* reflection,
                                  const validate::FieldRules& rules, bool force);

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -1003,6 +1003,9 @@ public:
   // HeaderMap
   bool operator==(const HeaderMap& rhs) const override { return header_map_->operator==(rhs); }
   bool operator!=(const HeaderMap& rhs) const override { return header_map_->operator!=(rhs); }
+
+  bool operator==(const TestHeaderMapImplBase& rhs) const { return header_map_->operator==(rhs); }
+  bool operator!=(const TestHeaderMapImplBase& rhs) const { return header_map_->operator!=(rhs); }
   void addViaMove(HeaderString&& key, HeaderString&& value) override {
     header_map_->addViaMove(std::move(key), std::move(value));
     header_map_->verifyByteSizeInternalForTest();


### PR DESCRIPTION
Additional Description:
First step for enabling C++20. For now just enabled for compile-options build to prevent bit rot. No effect on production binary.

This PR fixes the bad merge of the original PR #28337 and reverts the #28372 revert.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Part of #27757