### PR TITLE
golang filter: clean up unused args in SendLocalReply

### DIFF
--- a/contrib/golang/filters/http/test/test_data/basic/filter.go
+++ b/contrib/golang/filters/http/test/test_data/basic/filter.go
@@ -82,7 +82,7 @@ func (f *filter) initRequest(header api.RequestHeaderMap) {
 
 func (f *filter) fail(msg string, a ...any) api.StatusType {
 	body := fmt.Sprintf(msg, a...)
-	f.callbacks.SendLocalReply(500, body, nil, -1, "")
+	f.callbacks.SendLocalReply(500, body, nil, 0, "")
 	return api.LocalReply
 }
 
@@ -92,7 +92,7 @@ func (f *filter) sendLocalReply(phase string) api.StatusType {
 		"test-phase":   phase,
 	}
 	body := fmt.Sprintf("forbidden from go in %s\r\n", phase)
-	f.callbacks.SendLocalReply(403, body, headers, -1, "test-from-go")
+	f.callbacks.SendLocalReply(403, body, headers, 0, "")
 	return api.LocalReply
 }
 

--- a/contrib/golang/filters/http/test/test_data/echo/filter.go
+++ b/contrib/golang/filters/http/test/test_data/echo/filter.go
@@ -16,11 +16,10 @@ type filter struct {
 }
 
 func (f *filter) sendLocalReply() api.StatusType {
-	headers := make(map[string]string)
 	echoBody := f.config.echoBody
 	{
 		body := fmt.Sprintf("%s, path: %s\r\n", echoBody, f.path)
-		f.callbacks.SendLocalReply(403, body, headers, -1, "test-from-go")
+		f.callbacks.SendLocalReply(403, body, nil, 0, "")
 	}
 	// Force GC to free the body string.
 	// For the case that C++ shouldn't touch the memory of the body string,

--- a/examples/golang/simple/filter.go
+++ b/examples/golang/simple/filter.go
@@ -18,9 +18,8 @@ type filter struct {
 }
 
 func (f *filter) sendLocalReplyInternal() api.StatusType {
-	headers := make(map[string]string)
 	body := fmt.Sprintf("%s, path: %s\r\n", f.config.echoBody, f.path)
-	f.callbacks.SendLocalReply(200, body, headers, -1, "test-from-go")
+	f.callbacks.SendLocalReply(200, body, nil, 0, "")
 	return api.LocalReply
 }
 


### PR DESCRIPTION
Some plugins in wild set headers and grpc args even they don't use the args. Clean up the unused args in the example to show these args are not required.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: clean up unused args in SendLocalReply
Additional Description: Some plugins in wild set headers and grpc args even they don't use the args. Clean up the unused args in the example to show these args are not required.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
