### PR TITLE
Fix Symbol::operator== implementation

### DIFF
--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -254,11 +254,6 @@ const absl::string_view NamedOverloadActionSymbolTable::name(Symbol symbol) cons
   return names_.at(symbol.index());
 }
 
-bool operator==(const NamedOverloadActionSymbolTable::Symbol& lhs,
-                const NamedOverloadActionSymbolTable::Symbol& rhs) {
-  return lhs.index() == rhs.index();
-}
-
 OverloadAction::OverloadAction(const envoy::config::overload::v3::OverloadAction& config,
                                Stats::Scope& stats_scope)
     : state_(OverloadActionState::inactive()),

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -106,7 +106,7 @@ public:
     size_t index() const { return index_; }
 
     // Support use as a map key.
-    bool operator==(const Symbol other) { return other.index_ == index_; }
+    bool operator==(const Symbol& other) const { return other.index_ == index_; }
 
     // Support absl::Hash.
     template <typename H>


### PR DESCRIPTION
Commit Message: Fix Symbol::operator== implementation
Additional Description: This causes compilation issue on Windows
Risk Level: zero
Testing:
Docs Changes:
Release Notes: 
Platform Specific Features: