### PR TITLE
golang filter: add VirtualClusterName getter

### DIFF
--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -115,6 +115,8 @@ type StreamInfo interface {
 	UpstreamClusterName() (string, bool)
 	// FilterState return the filter state interface.
 	FilterState() FilterState
+	// VirtualClusterName returns the name of the virtual cluster which got matched
+	VirtualClusterName() (string, bool)
 }
 
 type StreamFilterCallbacks interface {

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -55,6 +55,7 @@ const (
 	ValueDownstreamRemoteAddress = 8
 	ValueUpstreamHostAddress     = 9
 	ValueUpstreamClusterName     = 10
+	ValueVirtualClusterName      = 11
 )
 
 type httpCApiImpl struct{}

--- a/contrib/golang/filters/http/source/go/pkg/http/filter.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filter.go
@@ -209,6 +209,10 @@ func (s *streamInfo) UpstreamClusterName() (string, bool) {
 	return cAPI.HttpGetStringValue(unsafe.Pointer(s.request), ValueUpstreamClusterName)
 }
 
+func (s *streamInfo) VirtualClusterName() (string, bool) {
+	return cAPI.HttpGetStringValue(unsafe.Pointer(s.request), ValueVirtualClusterName)
+}
+
 type filterState struct {
 	request *httpRequest
 }

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1009,6 +1009,12 @@ CAPIStatus Filter::getStringValue(int id, GoString* value_str) {
       return CAPIStatus::CAPIValueNotFound;
     }
     break;
+  case EnvoyValue::VirtualClusterName:
+    if (!state.streamInfo().virtualClusterName().has_value()) {
+      return CAPIStatus::CAPIValueNotFound;
+    }
+    req_->strValue = state.streamInfo().virtualClusterName().value();
+    break;
   default:
     RELEASE_ASSERT(false, absl::StrCat("invalid string value id: ", id));
   }

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -107,6 +107,7 @@ enum class EnvoyValue {
   DownstreamRemoteAddress,
   UpstreamHostAddress,
   UpstreamClusterName,
+  VirtualClusterName,
 };
 
 struct httpRequestInternal;

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -152,6 +152,15 @@ typed_config:
           hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0)->set_name(
               "test-route-name");
           hcm.mutable_route_config()->mutable_virtual_hosts(0)->set_domains(0, domain);
+
+          auto* virtual_cluster =
+              hcm.mutable_route_config()->mutable_virtual_hosts(0)->add_virtual_clusters();
+          virtual_cluster->set_name("test_vcluster");
+          auto* headers = virtual_cluster->add_headers();
+          // use test_vcluster if presents
+          headers->set_name("existed-header");
+          headers->set_present_match(true);
+
           hcm.mutable_route_config()
               ->mutable_virtual_hosts(0)
               ->mutable_routes(0)
@@ -371,6 +380,9 @@ typed_config:
 
     // check response attempt count in encode phase
     EXPECT_EQ("1", getHeader(response->headers(), "rsp-attempt-count"));
+
+    // check virtual cluster name
+    EXPECT_EQ("test_vcluster", getHeader(response->headers(), "rsp-virtual-cluster-name"));
 
     // verify response status
     EXPECT_EQ("200", getHeader(response->headers(), "rsp-status"));

--- a/contrib/golang/filters/http/test/test_data/basic/filter.go
+++ b/contrib/golang/filters/http/test/test_data/basic/filter.go
@@ -293,6 +293,11 @@ func (f *filter) encodeHeaders(header api.ResponseHeaderMap, endStream bool) api
 	header.Set("rsp-route-name", f.callbacks.StreamInfo().GetRouteName())
 	header.Set("rsp-filter-chain-name", f.callbacks.StreamInfo().FilterChainName())
 	header.Set("rsp-attempt-count", strconv.Itoa(int(f.callbacks.StreamInfo().AttemptCount())))
+	if name, ok := f.callbacks.StreamInfo().VirtualClusterName(); ok {
+		header.Set("rsp-virtual-cluster-name", name)
+	} else {
+		header.Set("rsp-virtual-cluster-name", "not found")
+	}
 
 	if f.panic == "encode-header" {
 		badcode()


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: golang filter: add VirtualClusterName getter
Additional Description: Add a new method to get matched virtual cluster name
Risk Level: Low
Testing: Integration
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
