### PR TITLE
grpc-patch: fix for oss-fuzz build

### DIFF
--- a/bazel/grpc.patch
+++ b/bazel/grpc.patch
@@ -1,6 +1,8 @@
---- a/BUILD	2021-09-03 23:20:52.000000000 +0000
-+++ b/BUILD	2022-08-15 18:03:01.635257570 +0000
-@@ -28,7 +28,7 @@
+diff --git a/BUILD b/BUILD
+index 06b69411a8..05cd878ae8 100644
+--- a/BUILD
++++ b/BUILD
+@@ -29,7 +29,7 @@ licenses(["reciprocal"])
  package(
      default_visibility = ["//visibility:public"],
      features = [
@@ -9,3 +11,16 @@
          "-parse_headers",
      ],
  )
+diff --git a/src/core/BUILD b/src/core/BUILD
+index 1bb970e049..81265483e9 100644
+--- a/src/core/BUILD
++++ b/src/core/BUILD
+@@ -24,7 +24,7 @@ licenses(["reciprocal"])
+ package(
+     default_visibility = ["//:__subpackages__"],
+     features = [
+-        "layering_check",
++        "-layering_check",
+     ],
+ )
+


### PR DESCRIPTION
Commit Message: grpc-patch: fix for oss-fuzz build
Additional Description:
Currently oss-fuzz cannot build the fuzzers (probably started after #28075 as it updated the gRPC version to 1.55.0).
The errors are due to incorrect build of the gRPC core library, and have the following form:
```
ERROR: ^[[0m/root/.cache/bazel/_bazel_root/4e9824db8e7d11820cfa25090ed4ed10/external/com_github_grpc_grpc/src/core/BUILD:219:16: Compiling src/core/lib/gprpp/linux/env.cc failed: undeclared inclusion(s) in rule '@com_github_grpc_grpc//src/core:env':
Step #3 - "compile-honggfuzz-address-x86_64": this rule is missing dependency declarations for the following files included by 'src/core/lib/gprpp/linux/env.cc':
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/config.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/core_headers.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/atomic_hook.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/errno_saver.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/log_severity.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/raw_logging_internal.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/types/bad_optional_access.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/meta/type_traits.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/base/base_internal.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/memory/memory.cppmap'
Step #3 - "compile-honggfuzz-address-x86_64":   'bazel-out/k8-fastbuild-ST-b38856f70c06/bin/external/com_google_absl/absl/utility/utility.cppmap'
```

The current PR patches gRPC's /src/core/BUILD file to remove the layering_check bazel flag which solves this problem.

Note that the previous gRPC version that was used (v.1.49.2) did not have the /src/core/BUILD file, and only /BUILD was used.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
