### PR TITLE
ci/github: Add build image caching

### DIFF
--- a/.github/workflows/_cache_docker.yml
+++ b/.github/workflows/_cache_docker.yml
@@ -1,0 +1,31 @@
+name: Cache (docker)
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        type: string
+
+concurrency:
+  group: cache_docker-${{ inputs.image_tag }}
+
+## Docker cache
+#
+# This workflow will only prime the cache, and should be done separately first, prior
+# to any jobs that require it.
+#
+# For a job that does, you can restore with something like:
+#
+#    steps:
+#    - uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.0.5
+#      with:
+#        key: "${{ needs.env.outputs.build_image_ubuntu }}"
+#
+
+jobs:
+  docker:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@actions-v0.0.5
+      with:
+        image_tag: "${{ inputs.image_tag }}"


### PR DESCRIPTION
This just adds a workflow/job to cache the Docker build image in github, similar to how we do already in azp

Its not used in this PR, but will follow up immediately to make use of it

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
