### PR TITLE
ci/github: Add `do_ci.sh` `workflow_call`

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -1,0 +1,95 @@
+name: Envoy CI
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+      rbe:
+        type: boolean
+        default: true
+      managed:
+        type: boolean
+        default: true
+
+      auth_bazel_rbe:
+        type: string
+        default: ''
+
+      bazel_extra:
+        type: string
+        default:
+      bazel_local_cache:
+        type: string
+        default:
+      bazel_rbe_cache:
+        type: string
+        default: grpcs://remotebuildexecution.googleapis.com
+      bazel_rbe_instance:
+        type: string
+        default: projects/envoy-ci/instances/default_instance
+      bazel_rbe_jobs:
+        type: number
+        default: 75
+
+      cache_build_image:
+        type: string
+
+      command_prefix:
+        type: string
+        default: ./ci/run_envoy_docker.sh
+      command_ci:
+        type: string
+        default: ./ci/do_ci.sh
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-ci-${{ inputs.target }}
+  cancel-in-progress: true
+
+jobs:
+  do_ci:
+    runs-on: ubuntu-22.04
+    name: do_ci.sh ${{ inputs.target }}
+    steps:
+    - uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@e6cfe0f035611bfb18126985263fff8f35aa430d
+      with:
+        image_tag: ${{ inputs.cache_build_image }}
+    - uses: actions/checkout@v3
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy/envoy
+    - id: do_ci
+      name: 'Run CI target ${{ inputs.target }}'
+      run: |
+        if [[ "${{ inputs.rbe }}" == 'true' ]]; then
+            export ENVOY_RBE=1
+            export GCP_SERVICE_ACCOUNT_KEY=${{ inputs.auth_bazel_rbe }}
+            export BAZEL_BUILD_EXTRA_OPTIONS="--config=remote-ci --jobs=${{ inputs.bazel_rbe_jobs }} ${{ inputs.bazel_extra }}"
+            export BAZEL_REMOTE_CACHE=${{ inputs.bazel_rbe_cache }}"
+            export BAZEL_REMOTE_INSTANCE=${{ inputs.bazel_rbe_instance }}"
+        else
+            export BAZEL_BUILD_EXTRA_OPTIONS="--config=ci ${{ inputs.bazel_extra }}"
+            export BAZEL_REMOTE_CACHE="${{ inputs.bazel_local_cache }}"
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                export BAZEL_REMOTE_INSTANCE_BRANCH="${{ github.event.base.ref }}"
+            else
+                export BAZEL_REMOTE_INSTANCE_BRANCH="${{ github.ref }}"
+            fi
+        fi
+
+        if [[ -n "${{ inputs.command_prefix }}" ]]; then
+            ${{ inputs.command_prefix }} '${{ inputs.command_ci }} ${{ inputs.target }}'
+        else
+            ${{ inputs.command_ci }} ${{ inputs.target }}
+        fi
+
+        if [[ ${{ github.event_name }} == "pull_request" ]]; then
+            export BAZEL_FAKE_SCM_REVISION=e3b4a6e9570da15ac1caffdded17a8bebdc7dfc9
+            export CI_TARGET_BRANCH="${{ github.event.base.ref }}"
+        else
+            export CI_TARGET_BRANCH="${{ github.ref }}"
+        fi
+
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ENVOY_DOCKER_BUILD_DIR: ${{ runner.temp }}


### PR DESCRIPTION
This ~replicates the functionality of `.azure-pipelines/bazel.yml` for github workflows - allowing us to run do_ci.sh commands with ~the same env vars/args between azp <> gh

This is not used in this PR but i will follow up to make use of it immediately

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
