### PR TITLE
ci/github: Shift dependency check/s to github

### DIFF
--- a/.azure-pipelines/env.yml
+++ b/.azure-pipelines/env.yml
@@ -105,16 +105,6 @@ jobs:
       echo "##vso[task.setvariable variable=docsOnly;isoutput=true]${CHANGED_DOCS_ONLY}"
       echo "##vso[task.setvariable variable=examplesOnly;isoutput=true]${CHANGED_EXAMPLES_ONLY}"
 
-      CHANGED_REQUIREMENT_PATHS="$(git diff --name-only ${CHANGE_TARGET}...HEAD | grep -E '\.*requirements.*\.txt$|go.mod$|\.*\.bzl$|^WORKSPACE$' || echo '')"
-
-      if [[ -n "$CHANGED_REQUIREMENT_PATHS" ]]; then
-          CHANGED_REQUIREMENTS=true
-      else
-          CHANGED_REQUIREMENTS=false
-      fi
-
-      echo "##vso[task.setvariable variable=requirements;isoutput=true]${CHANGED_REQUIREMENTS}"
-
     displayName: "Detect repo changes"
     workingDirectory: $(Build.SourcesDirectory)
     name: changed
@@ -235,8 +225,6 @@ jobs:
       echo "env.outputs['changed.mobileOnly']: $(changed.mobileOnly)"
       echo "env.outputs['changed.docsOnly']: $(changed.docsOnly)"
       echo "env.outputs['changed.examplesOnly']: $(changed.examplesOnly)"
-      echo
-      echo "env.outputs['changed.requirements']: $(changed.requirements)"
       echo
       echo "env.outputs['state.isDev']: $(state.isDev)"
       echo "env.outputs['state.versionPatch']: $(state.versionPatch)"

--- a/.azure-pipelines/stage/prechecks.yml
+++ b/.azure-pipelines/stage/prechecks.yml
@@ -11,11 +11,6 @@ parameters:
   type: boolean
   default: true
 
-- name: checkDeps
-  displayName: "Run dependency checker"
-  type: string
-  default: false
-
 # Auth
 - name: authGithub
   type: string
@@ -161,27 +156,9 @@ jobs:
           GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
         condition: eq(variables['CI_TARGET'], 'docs')
 
-- job: dependencies
-  displayName: Precheck dependencies
-  timeoutInMinutes: 20
-  pool:
-    vmImage: $(agentUbuntu)
-  condition: |
-    and(not(canceled()),
-        eq(${{ parameters.checkDeps }}, 'true'))
-  steps:
-  - template: ../bazel.yml
-    parameters:
-      ciTarget: deps
-      cacheTestResults: ${{ parameters.cacheTestResults }}
-      cacheVersion: $(cacheKeyBazel)
-      publishEnvoy: false
-      publishTestResults: false
-      authGithub: ${{ parameters.authGithub }}
-
 - job: prechecked
   displayName: Prechecked
-  dependsOn: ["prechecks", "dependencies"]
+  dependsOn: ["prechecks"]
   pool: x64-nano
   # This condition ensures that this (required) job passes if all of
   # the preceeding jobs either pass or are skipped
@@ -190,7 +167,6 @@ jobs:
   condition: |
     and(
       eq(variables['Build.Reason'], 'PullRequest'),
-      in(dependencies.dependencies.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
       in(dependencies.prechecks.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   steps:
   - checkout: none

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -60,8 +60,6 @@ stages:
 - stage: prechecks
   displayName: Prechecks
   dependsOn: ["env"]
-  variables:
-    CHECK_DEPS: $[stageDependencies.env.repo.outputs['changed.requirements']]
   jobs:
   - template: stage/prechecks.yml
     parameters:
@@ -73,7 +71,6 @@ stages:
       authGPGKey: $(MaintainerGPGKeySecureFileDownloadPath)
       authGPGPath: $(MaintainerGPGKey.secureFilePath)
       bucketGCP: $(GcsArtifactBucket)
-      checkDeps: variables['CHECK_DEPS']
 
 - stage: linux_x64
   displayName: Linux x64

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -1,0 +1,51 @@
+name: Envoy/prechecks
+
+on:
+  push:
+    branches:
+    - main
+    - release/v*
+  pull_request:
+    paths:
+    - '**/requirements*.txt'
+    - '**/go.mod'
+    - '**/*.bzl'
+    - 'WORKSPACE'
+    - '.github/workflows/envoy-prechecks.yml'
+    - '.github/workflows/_*.yml'
+
+concurrency:
+  group: ${{ github.event.inputs.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  env:
+    uses: ./.github/workflows/_env.yml
+  cache:
+    needs:
+    - env
+    uses: ./.github/workflows/_cache_docker.yml
+    with:
+      image_tag: "${{ needs.env.outputs.build_image_ubuntu }}"
+
+  prechecks:
+    needs:
+    - env
+    - cache
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - target: deps
+          rbe: false
+          managed: true
+    uses: ./.github/workflows/_ci.yml
+    name: CI ${{ matrix.target }}
+    with:
+      target: ${{ matrix.target }}
+      rbe: ${{ matrix.rbe }}
+      managed: ${{ matrix.managed }}
+      cache_build_image: ${{ needs.env.outputs.build_image_ubuntu }}


### PR DESCRIPTION
This shifts the dep-check job gh -> azp

It means that for now errors in this check wont block azp - we probably do want to make it required tho 

This check is currently quite error prone and this may/not help with that, certainly wont fix

With the implementation so far this doesnt use RBE, but i can follow up straight away to add it

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
