### PR TITLE
original_dst cluster: post deletion to main

### DIFF
--- a/source/extensions/clusters/original_dst/original_dst_cluster.h
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.h
@@ -39,6 +39,23 @@ using HostMultiMap = absl::flat_hash_map<std::string, HostsForAddressSharedPtr>;
 using HostMultiMapSharedPtr = std::shared_ptr<HostMultiMap>;
 using HostMultiMapConstSharedPtr = std::shared_ptr<const HostMultiMap>;
 
+class OriginalDstCluster;
+
+// Handle object whose sole purpose is to ensure that the destructor of the inner OriginalDstCluster
+// is called on the main thread.
+class OriginalDstClusterHandle {
+public:
+  OriginalDstClusterHandle(std::shared_ptr<OriginalDstCluster> cluster)
+      : cluster_(std::move(cluster)) {}
+  ~OriginalDstClusterHandle();
+
+private:
+  const std::shared_ptr<OriginalDstCluster> cluster_;
+  friend class OriginalDstCluster;
+};
+
+using OriginalDstClusterHandleSharedPtr = std::shared_ptr<OriginalDstClusterHandle>;
+
 /**
  * The OriginalDstCluster is a dynamic cluster that automatically adds hosts as needed based on the
  * original destination address of the downstream connection. These hosts are also automatically
@@ -50,7 +67,10 @@ public:
   OriginalDstCluster(const envoy::config::cluster::v3::Cluster& config,
                      ClusterFactoryContext& context);
 
-  ~OriginalDstCluster() override { cleanup_timer_->disableTimer(); }
+  ~OriginalDstCluster() override {
+    ASSERT_IS_MAIN_OR_TEST_THREAD();
+    cleanup_timer_->disableTimer();
+  }
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
@@ -68,10 +88,11 @@ public:
    */
   class LoadBalancer : public Upstream::LoadBalancer {
   public:
-    LoadBalancer(const std::shared_ptr<OriginalDstCluster>& parent)
-        : parent_(parent), http_header_name_(parent->httpHeaderName()),
-          metadata_key_(parent->metadataKey()), port_override_(parent->portOverride()),
-          host_map_(parent->getCurrentHostMap()) {}
+    LoadBalancer(const OriginalDstClusterHandleSharedPtr& parent)
+        : parent_(parent), http_header_name_(parent->cluster_->httpHeaderName()),
+          metadata_key_(parent->cluster_->metadataKey()),
+          port_override_(parent->cluster_->portOverride()),
+          host_map_(parent->cluster_->getCurrentHostMap()) {}
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -94,7 +115,7 @@ public:
     Network::Address::InstanceConstSharedPtr metadataOverrideHost(LoadBalancerContext* context);
 
   private:
-    const std::shared_ptr<OriginalDstCluster> parent_;
+    const OriginalDstClusterHandleSharedPtr parent_;
     // The optional original host provider that extracts the address from HTTP header map.
     const absl::optional<Http::LowerCaseString>& http_header_name_;
     const absl::optional<Config::MetadataKey>& metadata_key_;
@@ -108,25 +129,18 @@ public:
 
 private:
   struct LoadBalancerFactory : public Upstream::LoadBalancerFactory {
-    LoadBalancerFactory(const std::shared_ptr<OriginalDstCluster>& cluster) : cluster_(cluster) {}
-
-    ~LoadBalancerFactory() override {
-      // Ensure that the parent cluster and its timer are destroyed on the main thread.
-      std::shared_ptr<OriginalDstCluster> cluster = std::move(cluster_);
-      cluster->dispatcher_.post([cluster]() mutable { cluster.reset(); });
-    }
+    LoadBalancerFactory(const OriginalDstClusterHandleSharedPtr& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancerFactory
     Upstream::LoadBalancerPtr create(Upstream::LoadBalancerParams) override {
       return std::make_unique<LoadBalancer>(cluster_);
     }
 
-    const std::shared_ptr<OriginalDstCluster> cluster_;
+    const OriginalDstClusterHandleSharedPtr cluster_;
   };
 
   struct ThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBalancer {
-    ThreadAwareLoadBalancer(const std::shared_ptr<OriginalDstCluster>& cluster)
-        : cluster_(cluster) {}
+    ThreadAwareLoadBalancer(const OriginalDstClusterHandleSharedPtr& cluster) : cluster_(cluster) {}
 
     // Upstream::ThreadAwareLoadBalancer
     Upstream::LoadBalancerFactorySharedPtr factory() override {
@@ -134,7 +148,7 @@ private:
     }
     void initialize() override {}
 
-    const std::shared_ptr<OriginalDstCluster> cluster_;
+    const OriginalDstClusterHandleSharedPtr cluster_;
   };
 
   HostMultiMapConstSharedPtr getCurrentHostMap() {
@@ -163,9 +177,8 @@ private:
   absl::optional<Config::MetadataKey> metadata_key_;
   absl::optional<uint32_t> port_override_;
   friend class OriginalDstClusterFactory;
+  friend class OriginalDstClusterHandle;
 };
-
-using OriginalDstClusterSharedPtr = std::shared_ptr<OriginalDstCluster>;
 
 class OriginalDstClusterFactory : public ClusterFactoryImplBase {
 public:


### PR DESCRIPTION
Commit Message: Ensure original dst cluster is deleted on the main thread since it owns a main timer.
Risk Level: low, fixes violation of deletion on worker
Testing: regression
Docs Changes: none
Release Notes: none

CC @howardjohn 