### PR TITLE
Adding disallowed_headers in the ext_proc header forwarding rule.

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -205,7 +205,7 @@ message ExternalProcessor {
 // The HeaderForwardingRules structure specifies what headers are
 // allowed to be forwarded to the external processing server.
 // This works as below:
-// 1. If neither ``allowed_headers`` or ``disallowed_headers`` is set, all headers are forwarded.
+// 1. If neither ``allowed_headers`` nor ``disallowed_headers`` is set, all headers are forwarded.
 // 2. If both ``allowed_headers`` and ``disallowed_headers`` are set, only headers in the
 //    ``allowed_headers`` but not in the ``disallowed_headers`` are forwarded.
 // 3. If ``allowed_headers`` is set, and ``disallowed_headers`` is not set, only headers in
@@ -216,6 +216,7 @@ message HeaderForwardingRules {
   // If set, specifically allow any header in this list to be forwarded to the external
   // processing server. This can be overridden by the below ``disallowed_headers``.
   type.matcher.v3.ListStringMatcher allowed_headers = 1;
+
   // If set, specifically disallow any header in this list to be forwarded to the external
   // processing server. This overrides the above ``allowed_headers`` if a header matches both.
   type.matcher.v3.ListStringMatcher disallowed_headers = 2;

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -204,9 +204,21 @@ message ExternalProcessor {
 
 // The HeaderForwardingRules structure specifies what headers are
 // allowed to be forwarded to the external processing server.
+// This works as below:
+// 1. If neither ``allowed_headers`` or ``disallowed_headers`` is set, all headers are forwarded.
+// 2. If both ``allowed_headers`` and ``disallowed_headers`` are set, only headers in the
+//    ``allowed_headers`` but not in the ``disallowed_headers`` are forwarded.
+// 3. If ``allowed_headers`` is set, and ``disallowed_headers`` is not set, only headers in
+//    the ``allowed_headers`` are forwarded.
+// 4. If ``disallowed_headers`` is set, and ``allowed_headers`` is not set, all headers except
+//    headers in the ``disallowed_headers`` are forwarded.
 message HeaderForwardingRules {
-  // If not set, all headers are forwarded to the external processing server.
+  // If set, specifically allow any header in this list to be forwarded to the external
+  // processing server. This can be overridden by the below ``disallowed_headers``.
   type.matcher.v3.ListStringMatcher allowed_headers = 1;
+  // If set, specifically disallow any header in this list to be forwarded to the external
+  // processing server. This overrides the above ``allowed_headers`` if a header matches both.
+  type.matcher.v3.ListStringMatcher disallowed_headers = 2;
 }
 
 // Extra settings that may be added to per-route configuration for a

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -204,14 +204,16 @@ message ExternalProcessor {
 
 // The HeaderForwardingRules structure specifies what headers are
 // allowed to be forwarded to the external processing server.
+//
 // This works as below:
-// 1. If neither ``allowed_headers`` nor ``disallowed_headers`` is set, all headers are forwarded.
-// 2. If both ``allowed_headers`` and ``disallowed_headers`` are set, only headers in the
-//    ``allowed_headers`` but not in the ``disallowed_headers`` are forwarded.
-// 3. If ``allowed_headers`` is set, and ``disallowed_headers`` is not set, only headers in
-//    the ``allowed_headers`` are forwarded.
-// 4. If ``disallowed_headers`` is set, and ``allowed_headers`` is not set, all headers except
-//    headers in the ``disallowed_headers`` are forwarded.
+//
+//   1. If neither ``allowed_headers`` nor ``disallowed_headers`` is set, all headers are forwarded.
+//   2. If both ``allowed_headers`` and ``disallowed_headers`` are set, only headers in the
+//      ``allowed_headers`` but not in the ``disallowed_headers`` are forwarded.
+//   3. If ``allowed_headers`` is set, and ``disallowed_headers`` is not set, only headers in
+//      the ``allowed_headers`` are forwarded.
+//   4. If ``disallowed_headers`` is set, and ``allowed_headers`` is not set, all headers except
+//      headers in the ``disallowed_headers`` are forwarded.
 message HeaderForwardingRules {
   // If set, specifically allow any header in this list to be forwarded to the external
   // processing server. This can be overridden by the below ``disallowed_headers``.
@@ -219,6 +221,7 @@ message HeaderForwardingRules {
 
   // If set, specifically disallow any header in this list to be forwarded to the external
   // processing server. This overrides the above ``allowed_headers`` if a header matches both.
+  // [#not-implemented-hide:]
   type.matcher.v3.ListStringMatcher disallowed_headers = 2;
 }
 


### PR DESCRIPTION
Adding disallowed_headers in the ext_proc header forwarding rule.
This is to specifically disallow certain headers to be forwarded to the ext_proc server.

This PR is a follow up PR of https://github.com/envoyproxy/envoy/pull/27333.  It addresses the API changes to add the disallowed_headers.  The actual implementation will follow later.


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
