### PR TITLE
ci/github: Fixes/cleanups for env and workflows

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -1,0 +1,124 @@
+inputs:
+  # Authoritative configuration for build image/s
+  # TODO(phlax): Move to config
+  build_image_repo:
+    type: string
+    default: envoyproxy/envoy-build-ubuntu
+  build_image_sha:
+    type: string
+    default: 50337314a150ed12447c87c1622eac6f611a069888722fb9a426e21ed161cc26
+  build_image_mobile_sha:
+    type: string
+    default: ca26ff05bd3f3a09468242faaf38ae48315e57f0a87c102352162f95ac620e6f
+  build_image_tag:
+    type: string
+    default: 41c5a05d708972d703661b702a63ef5060125c33
+
+  trusted_bots:
+    type: string
+    default: |
+      trigger-release-envoy[bot]
+
+  check_mobile_run:
+    type: boolean
+    default: true
+
+outputs:
+  build_image_ubuntu:
+    value: ${{ steps.build_image.outputs.build_image_ubuntu }}
+  build_image_ubuntu_mobile:
+    value: ${{ steps.build_image.outputs.build_image_ubuntu_mobile }}
+  mobile_android_build:
+    value: ${{ steps.should_run.outputs.mobile_android_build }}
+  mobile_android_build_all:
+    value: ${{ steps.should_run.outputs.mobile_android_build_all }}
+  mobile_android_tests:
+    value: ${{ steps.should_run.outputs.mobile_android_tests }}
+  mobile_asan:
+    value: ${{ steps.should_run.outputs.mobile_asan }}
+  mobile_cc_tests:
+    value: ${{ steps.should_run.outputs.mobile_cc_tests }}
+  mobile_compile_time_options:
+    value: ${{ steps.should_run.outputs.mobile_compile_time_options }}
+  mobile_coverage:
+    value: ${{ steps.should_run.outputs.mobile_coverage }}
+  mobile_formatting:
+    value: ${{ steps.should_run.outputs.mobile_formatting }}
+  mobile_ios_build:
+    value: ${{ steps.should_run.outputs.mobile_ios_build }}
+  mobile_ios_build_all:
+    value: ${{ steps.should_run.outputs.mobile_ios_build_all }}
+  mobile_ios_tests:
+    value: ${{ steps.should_run.outputs.mobile_ios_tests }}
+  mobile_release_validation:
+    value: ${{ steps.should_run.outputs.mobile_release_validation }}
+  mobile_tsan:
+    value: ${{ steps.should_run.outputs.mobile_tsan }}
+  trusted:
+    value: ${{ steps.trusted.outputs.trusted }}
+  version_dev:
+    value: ${{ steps.context.outputs.version_dev }}
+  version_patch:
+    value: ${{ steps.context.outputs.version_patch }}
+
+runs:
+  using: composite
+  steps:
+  - id: build_image
+    name: 'Check current build images'
+    run: |
+      {
+          echo "build_image_ubuntu=${BUILD_IMAGE_UBUNTU_REPO}:${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_SHA}"
+          echo "build_image_ubuntu_mobile=${BUILD_IMAGE_UBUNTU_REPO}:mobile-${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_MOBILE_SHA}"
+      } >> "$GITHUB_OUTPUT"
+    env:
+      # TODO(phlax): derive these from a config file
+      BUILD_IMAGE_UBUNTU_REPO: ${{ inputs.build_image_repo }}
+      BUILD_IMAGE_UBUNTU: ${{ inputs.build_image_tag }}
+      BUILD_IMAGE_UBUNTU_SHA: ${{ inputs.build_image_sha }}
+      BUILD_IMAGE_UBUNTU_MOBILE_SHA: ${{ inputs.build_image_mobile_sha }}
+    shell: bash
+
+  - if: ${{ inputs.check_mobile_run != 'false' }}
+    id: should_run
+    name: 'Check what to run'
+    run: ./mobile/tools/what_to_run.sh
+    shell: bash
+
+  - id: context
+    name: 'CI context'
+    run: |
+      VERSION_DEV="$(cat VERSION.txt | cut -d- -f2)"
+      VERSION_PATCH="$(cat VERSION.txt | cut -d- -f1 | rev | cut -d. -f1 | rev)"
+      {
+          echo "version_dev=$VERSION_DEV"
+          echo "version_patch=$VERSION_PATCH"
+      } >> "$GITHUB_OUTPUT"
+    shell: bash
+
+  - id: trusted
+    name: 'Check if its a trusted run'
+    run: |
+      TRUSTED=1
+      ACTOR="${{ github.actor }}"
+      if [[ "$ACTOR" =~ \[bot\] ]]; then
+          TRUSTED_BOT=
+          TRUSTED_BOTS=(${{ inputs.trusted_bots }})
+          for bot in ${TRUSTED_BOTS[@]}; do
+              if [[ "$bot" == "$ACTOR" ]]; then
+                  # Trusted bot account, ie non-PR
+                  TRUSTED_BOT=1
+                  break
+              fi
+          done
+          if [[ -z "$TRUSTED_BOT" ]]; then
+              echo "Not trusted bot account"
+              TRUSTED=
+          fi
+      fi
+      if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "Not trusted pull_request event"
+          TRUSTED=
+      fi
+      echo "trusted=$TRUSTED" >> "$GITHUB_OUTPUT"
+    shell: bash

--- a/.github/actions/verify/examples/setup/action.yml
+++ b/.github/actions/verify/examples/setup/action.yml
@@ -16,15 +16,15 @@ runs:
     env:
       REF: ${{ inputs.ref }}
     shell: bash
-  - uses: envoyproxy/toolshed/gh-actions/docker/fetch@actions-v0.0.8
+  - uses: envoyproxy/toolshed/gh-actions/docker/fetch@actions-v0.0.10
     with:
       url: "${{ steps.url.outputs.base }}/envoy.tar"
       variant: dev
-  - uses: envoyproxy/toolshed/gh-actions/docker/fetch@actions-v0.0.8
+  - uses: envoyproxy/toolshed/gh-actions/docker/fetch@actions-v0.0.10
     with:
       url: "${{ steps.url.outputs.base }}/envoy-contrib.tar"
       variant: contrib-dev
-  - uses: envoyproxy/toolshed/gh-actions/docker/fetch@actions-v0.0.8
+  - uses: envoyproxy/toolshed/gh-actions/docker/fetch@actions-v0.0.10
     with:
       url: "${{ steps.url.outputs.base }}/envoy-google-vrp.tar"
       variant: google-vrp-dev

--- a/.github/workflows/_cache_docker.yml
+++ b/.github/workflows/_cache_docker.yml
@@ -1,10 +1,10 @@
 name: Cache (docker)
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
-    inputs:
-      image_tag:
-        type: string
 
 concurrency:
   group: cache_docker-${{ inputs.image_tag }}
@@ -26,6 +26,11 @@ jobs:
   docker:
     runs-on: ubuntu-22.04
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@actions-v0.0.7
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/env
+      id: env
       with:
-        image_tag: "${{ inputs.image_tag }}"
+        check_mobile_run: false
+    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@actions-v0.0.10
+      with:
+        image_tag: "${{ steps.env.outputs.build_image_ubuntu }}"

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -61,7 +61,15 @@ on:
         type: string
         default:
 
+      repo_fetch_depth:
+        type: number
+        default: 1
+      repo_ref:
+        type: string
       skip:
+        type: boolean
+        default: false
+      trusted:
         type: boolean
         default: false
 
@@ -79,10 +87,24 @@ jobs:
     name: do_ci.sh ${{ inputs.target }}
     steps:
     - if: ${{ inputs.cache_build_image }}
-      uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.0.8
+      uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.0.10
       with:
         image_tag: ${{ inputs.cache_build_image }}
+
+    # If the run is "trusted" (ie has access to secrets) then it should
+    # **not** set the ref and should use the code of the calling context.
+    - if: ${{ inputs.repo_ref && inputs.trusted }}
+      run: |
+        echo '`repo_ref` should not be set for trusted CI runs'
+        exit 1
+
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: ${{ inputs.repo_fetch_depth }}
+        # WARNING: This allows untrusted code to run!!!
+        #  If this is set, then anything before or after in the job should be regarded as
+        #  compromised.
+        ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
 
@@ -107,7 +129,7 @@ jobs:
       name: "Check disk space at beginning"
 
     - if: ${{ inputs.run_pre }}
-      uses: envoyproxy/toolshed/gh-actions/using/recurse@actions-v0.0.8
+      uses: envoyproxy/toolshed/gh-actions/using/recurse@actions-v0.0.10
       with:
         uses: ${{ inputs.run_pre }}
         with: ${{ inputs.run_pre_with }}
@@ -129,7 +151,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - if: ${{ inputs.run_post }}
-      uses: envoyproxy/toolshed/gh-actions/using/recurse@actions-v0.0.8
+      uses: envoyproxy/toolshed/gh-actions/using/recurse@actions-v0.0.10
       with:
         uses: ${{ inputs.run_post }}
         with: ${{ inputs.run_post_with }}

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -1,5 +1,8 @@
 name: Environment
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -10,10 +13,9 @@ on:
         type: boolean
         default: false
 
-      trusted_bots:
+      start_check_status:
         type: string
-        default: |
-          trigger-release-envoy[bot]
+        default:
 
     outputs:
       agent_ubuntu:
@@ -66,100 +68,51 @@ jobs:
     if: github.repository == 'envoyproxy/envoy'
     runs-on: ubuntu-22.04
     outputs:
-      build_image_ubuntu: ${{ steps.build_image.outputs.build_image_ubuntu }}
-      build_image_ubuntu_mobile: ${{ steps.build_image.outputs.build_image_ubuntu_mobile }}
-      mobile_android_build: ${{ steps.should_run.outputs.mobile_android_build }}
-      mobile_android_build_all: ${{ steps.should_run.outputs.mobile_android_build_all }}
-      mobile_android_tests: ${{ steps.should_run.outputs.mobile_android_tests }}
-      mobile_asan: ${{ steps.should_run.outputs.mobile_asan }}
-      mobile_cc_tests: ${{ steps.should_run.outputs.mobile_cc_tests }}
-      mobile_compile_time_options: ${{ steps.should_run.outputs.mobile_compile_time_options }}
-      mobile_coverage: ${{ steps.should_run.outputs.mobile_coverage }}
-      mobile_formatting: ${{ steps.should_run.outputs.mobile_formatting }}
-      mobile_ios_build: ${{ steps.should_run.outputs.mobile_ios_build }}
-      mobile_ios_build_all: ${{ steps.should_run.outputs.mobile_ios_build_all }}
-      mobile_ios_tests: ${{ steps.should_run.outputs.mobile_ios_tests }}
-      mobile_release_validation: ${{ steps.should_run.outputs.mobile_release_validation }}
-      mobile_tsan: ${{ steps.should_run.outputs.mobile_tsan }}
-      trusted: ${{ steps.trusted.outputs.trusted }}
-      version_dev: ${{ steps.context.outputs.version_dev }}
-      version_patch: ${{ steps.context.outputs.version_patch }}
+      build_image_ubuntu: ${{ steps.env.outputs.build_image_ubuntu }}
+      build_image_ubuntu_mobile: ${{ steps.env.outputs.build_image_ubuntu_mobile }}
+      mobile_android_build: ${{ steps.env.outputs.mobile_android_build }}
+      mobile_android_build_all: ${{ steps.env.outputs.mobile_android_build_all }}
+      mobile_android_tests: ${{ steps.env.outputs.mobile_android_tests }}
+      mobile_asan: ${{ steps.env.outputs.mobile_asan }}
+      mobile_cc_tests: ${{ steps.env.outputs.mobile_cc_tests }}
+      mobile_compile_time_options: ${{ steps.env.outputs.mobile_compile_time_options }}
+      mobile_coverage: ${{ steps.env.outputs.mobile_coverage }}
+      mobile_formatting: ${{ steps.env.outputs.mobile_formatting }}
+      mobile_ios_build: ${{ steps.env.outputs.mobile_ios_build }}
+      mobile_ios_build_all: ${{ steps.env.outputs.mobile_ios_build_all }}
+      mobile_ios_tests: ${{ steps.env.outputs.mobile_ios_tests }}
+      mobile_release_validation: ${{ steps.env.outputs.mobile_release_validation }}
+      mobile_tsan: ${{ steps.env.outputs.mobile_tsan }}
+      trusted: ${{ steps.env.outputs.trusted }}
+      version_dev: ${{ steps.env.outputs.version_dev }}
+      version_patch: ${{ steps.env.outputs.version_patch }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: ${{ ! inputs.check_mobile_run && 1 || 0 }}
-    - name: Add safe directory
-      run: git config --global --add safe.directory /__w/envoy/envoy
-
-    - id: build_image
-      name: 'Check current build images'
-      run: |
-        {
-            echo "build_image_ubuntu=${BUILD_IMAGE_UBUNTU_REPO}:${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_SHA}"
-            echo "build_image_ubuntu_mobile=${BUILD_IMAGE_UBUNTU_REPO}:mobile-${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_MOBILE_SHA}"
-        } >> "$GITHUB_OUTPUT"
-      env:
-        # TODO(phlax): derive these from a config file
-        BUILD_IMAGE_UBUNTU_REPO: envoyproxy/envoy-build-ubuntu
-        BUILD_IMAGE_UBUNTU: 41c5a05d708972d703661b702a63ef5060125c33
-        BUILD_IMAGE_UBUNTU_SHA: 50337314a150ed12447c87c1622eac6f611a069888722fb9a426e21ed161cc26
-        BUILD_IMAGE_UBUNTU_MOBILE_SHA: ca26ff05bd3f3a09468242faaf38ae48315e57f0a87c102352162f95ac620e6f
-
-    - if: ${{ inputs.check_mobile_run }}
-      id: should_run
-      name: 'Check what to run'
-      run: |
-        ./mobile/tools/what_to_run.sh
-
-    - id: context
-      name: 'CI context'
-      run: |
-        VERSION_DEV="$(cat VERSION.txt | cut -d- -f2)"
-        VERSION_PATCH="$(cat VERSION.txt | cut -d- -f1 | rev | cut -d. -f1 | rev)"
-        {
-            echo "version_dev=$VERSION_DEV"
-            echo "version_patch=$VERSION_PATCH"
-        } >> "$GITHUB_OUTPUT"
-
-    - id: trusted
-      name: 'Check if its a trusted run'
-      run: |
-        TRUSTED=1
-        ACTOR="${{ github.actor }}"
-        if [[ "$ACTOR" =~ \[bot\] ]]; then
-            TRUSTED_BOT=
-            TRUSTED_BOTS=(${{ inputs.trusted_bots }})
-            for bot in ${TRUSTED_BOTS[@]}; do
-                if [[ "$bot" == "$ACTOR" ]]; then
-                    # Trusted bot account, ie non-PR
-                    TRUSTED_BOT=1
-                    break
-                fi
-            done
-            if [[ -z "$TRUSTED_BOT" ]]; then
-                echo "Not trusted bot account"
-                TRUSTED=
-            fi
-        fi
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Not trusted pull_request event"
-            TRUSTED=
-        fi
-        echo "trusted=$TRUSTED" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/env
+      id: env
+      with:
+        check_mobile_run: ${{ inputs.check_mobile_run }}
 
     - name: 'Print env'
       run: |
-        echo "version_dev=${{ steps.context.outputs.version_dev }}"
-        echo "version_patch=${{ steps.context.outputs.version_patch }}"
-        echo "build_image_ubuntu=${{ steps.build_image.outputs.build_image_ubuntu }}"
-        echo "build_image_ubuntu_mobile=${{ steps.build_image.outputs.build_image_ubuntu_mobile }}"
-        echo "trusted=${{ steps.trusted.outputs.trusted }}"
+        echo "version_dev=${{ steps.env.outputs.version_dev }}"
+        echo "version_patch=${{ steps.env.outputs.version_patch }}"
+        echo "build_image_ubuntu=${{ steps.env.outputs.build_image_ubuntu }}"
+        echo "build_image_ubuntu_mobile=${{ steps.env.outputs.build_image_ubuntu_mobile }}"
+        echo "trusted=${{ steps.env.outputs.trusted }}"
 
   cache:
     if: ${{ inputs.prime_build_image }}
-    needs:
-    - repo
     # This uses a separate job to ensure correct concurrency
     uses: ./.github/workflows/_cache_docker.yml
+
+  check:
+    if: ${{ inputs.start_check_status && github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/_workflow-start.yml
+    permissions:
+      contents: read
+      statuses: write
     with:
-      image_tag: "${{ needs.repo.outputs.build_image_ubuntu }}"
+      workflow_name: ${{ inputs.start_check_status }}

--- a/.github/workflows/_stage_verify.yml
+++ b/.github/workflows/_stage_verify.yml
@@ -9,25 +9,17 @@ on:
       trusted:
         type: boolean
         default: false
+      repo_ref:
+        type: string
+        default:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}-verify
   cancel-in-progress: true
 
 jobs:
-  check:
-    if: ${{ ! inputs.trusted }}
-    uses: ./.github/workflows/_workflow-start.yml
-    permissions:
-      contents: read
-      statuses: write
-    with:
-      workflowName: Verify/examples
-
   verify:
     name: "Verify (${{ matrix.target }}) ${{ inputs.trusted && 'postsubmit' || 'pr' }}:${{ github.ref_name }}"
-    needs:
-    - check
     strategy:
       fail-fast: false
       matrix:
@@ -55,3 +47,5 @@ jobs:
       run_pre: ${{ matrix.run_pre }}
       run_pre_with: ${{ matrix.run_pre_with }}
       env: ${{ matrix.env }}
+      trusted: ${{ inputs.trusted }}
+      repo_ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}

--- a/.github/workflows/_workflow-start.yml
+++ b/.github/workflows/_workflow-start.yml
@@ -2,15 +2,15 @@ name: Workflow start
 # This workflow is only required for externally triggered jobs that need to manually
 # set the check status for a commit/PR
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
-      workflowName:
+      workflow_name:
         required: true
         type: string
-
-permissions:
-  contents: read
 
 jobs:
   start:
@@ -18,21 +18,30 @@ jobs:
     permissions:
       statuses: write
     steps:
-    - name: Start status check
-      uses: envoyproxy/toolshed/gh-actions/status@actions-v0.0.7
+    - uses: actions/checkout@v3
+    - uses: ./.github/actions/env
+      id: env
+      with:
+        check_mobile_run: false
+
+    - if: ${{ ! steps.env.outputs.trusted }}
+      name: Start status check
+      uses: envoyproxy/toolshed/gh-actions/status@actions-v0.0.10
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: ${{ inputs.workflowName }}
+        context: ${{ inputs.workflow_name }}
         state: 'pending'
         sha: ${{ inputs.sha }}
         target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-    - name: Save the SHA
+    - if: ${{ ! steps.env.outputs.trusted }}
+      name: Save the SHA
       env:
         STATE_SHA: ${{ inputs.sha }}
       run: |
         mkdir -p ./sha
         echo $STATE_SHA > ./sha/state_sha
-    - uses: actions/upload-artifact@v3
+    - if: ${{ ! steps.env.outputs.trusted }}
+      uses: actions/upload-artifact@v3
       with:
         name: state_sha
         path: sha/

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -22,6 +22,6 @@ jobs:
       pull-requests: write
       actions: write
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/retest@actions-v0.0.7
+    - uses: envoyproxy/toolshed/gh-actions/retest@actions-v0.0.10
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -1,5 +1,8 @@
 name: Envoy/prechecks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -18,15 +21,15 @@ concurrency:
   group: ${{ github.event.inputs.head_ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   env:
     uses: ./.github/workflows/_env.yml
     with:
       prime_build_image: true
       check_mobile_run: false
+    permissions:
+      contents: read
+      statuses: write
 
   prechecks:
     needs:

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -31,6 +31,10 @@ jobs:
     with:
       check_mobile_run: false
       prime_build_image: true
+      start_check_status: Verify/examples
+    permissions:
+      contents: read
+      statuses: write
 
   verify:
     uses: ./.github/workflows/_stage_verify.yml
@@ -38,6 +42,3 @@ jobs:
     - env
     with:
       trusted: ${{ needs.env.outputs.trusted && true || false }}
-    permissions:
-      contents: read
-      statuses: write

--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -27,7 +27,7 @@ jobs:
         - envoy-filter-example
         - data-plane-api
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.0.7
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.0.10
       with:
         repository: "envoyproxy/${{ matrix.downstream }}"
         ref: main

--- a/.github/workflows/workflow-complete.yml
+++ b/.github/workflows/workflow-complete.yml
@@ -2,6 +2,9 @@ name: Workflow complete
 # This workflow is only required for externally triggered jobs that have manually
 # set the check status for a commit/PR
 
+permissions:
+  contents: read
+
 on:
   # Do not run untrusted code here
   workflow_run:
@@ -10,11 +13,9 @@ on:
     types:
     - completed
 
-permissions:
-  contents: read
-
 jobs:
   complete:
+    if: ${{ github.actor == 'trigger-workflow-envoy[bot]' }}
     runs-on: ubuntu-22.04
     permissions:
       statuses: write
@@ -52,7 +53,7 @@ jobs:
         echo "state=${STATE}" >> "$GITHUB_OUTPUT"
       id: job
     - name: Complete status check
-      uses: envoyproxy/toolshed/gh-actions/status@actions-v0.0.7
+      uses: envoyproxy/toolshed/gh-actions/status@actions-v0.0.10
       with:
         authToken: ${{ secrets.GITHUB_TOKEN }}
         context: Verify/examples


### PR DESCRIPTION
- reenable untrusted code checkout in prs
- fix wf check dependency
- separate env to an action, and run initial jobs concurrently
- fix workflow-complete handling

Currently the v/examples job always runs with the current `main` (ie doesnt correctly check out the pr commit)

This fixes that but also opens up the workflow to potential request attacks so defensive coding is applied in various places to ensure that only untrusted ci runs (ie no access to secrets) can run untrusted code

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
