### PR TITLE
ci/github: Fix repo contexts

### DIFF
--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -172,11 +172,12 @@ jobs:
       - script: ci/run_envoy_docker.sh 'ci/do_ci.sh verify.trigger'
         # Please see `ci/do_ci.sh` for notes on required vars.
         env:
-          ENVOY_HEAD_REF: "$(Build.SourceBranchName)"
           ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+            ENVOY_HEAD_REF: "$(Build.SourceBranch)"
             ENVOY_BRANCH: "$(System.PullRequest.TargetBranch)"
             ENVOY_COMMIT: "$(System.PullRequest.SourceCommitId)"
           ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+            ENVOY_HEAD_REF: "$(Build.SourceBranchName)"
             ENVOY_BRANCH: "$(Build.SourceBranch)"
           # github auth
           GITHUB_TOKEN: "$(key.value)"

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -169,13 +169,13 @@ jobs:
           KEY="$(cat $(WorkflowTriggerKey.secureFilePath) | base64 -w0)"
           echo "##vso[task.setvariable variable=value;isoutput=true]$KEY"
         name: key
-      - script: ci/run_envoy_docker.sh 'ci/do_ci.sh verify.trigger' || echo "trigger not ready yet ..."
+      - script: ci/run_envoy_docker.sh 'ci/do_ci.sh verify.trigger'
         # Please see `ci/do_ci.sh` for notes on required vars.
         env:
+          ENVOY_HEAD_REF: "$(Build.SourceBranchName)"
           ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
             ENVOY_BRANCH: "$(System.PullRequest.TargetBranch)"
             ENVOY_COMMIT: "$(System.PullRequest.SourceCommitId)"
-            ENVOY_HEAD_REF: "$(Build.SourceBranch)"
           ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
             ENVOY_BRANCH: "$(Build.SourceBranch)"
           # github auth

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -1,18 +1,21 @@
 inputs:
-  # Authoritative configuration for build image/s
-  # TODO(phlax): Move to config
-  build_image_repo:
-    type: string
-    default: envoyproxy/envoy-build-ubuntu
-  build_image_sha:
-    type: string
-    default: 50337314a150ed12447c87c1622eac6f611a069888722fb9a426e21ed161cc26
-  build_image_mobile_sha:
-    type: string
-    default: ca26ff05bd3f3a09468242faaf38ae48315e57f0a87c102352162f95ac620e6f
   build_image_tag:
     type: string
-    default: 41c5a05d708972d703661b702a63ef5060125c33
+    required: true
+  build_image_repo:
+    type: string
+    required: true
+  build_image_mobile_sha:
+    type: string
+    required: true
+  build_image_sha:
+    type: string
+    required: true
+
+  repo_ref_sha:
+    type: string
+  repo_name:
+    type: string
 
   trusted_bots:
     type: string
@@ -25,9 +28,10 @@ inputs:
 
 outputs:
   build_image_ubuntu:
-    value: ${{ steps.build_image.outputs.build_image_ubuntu }}
+    value: ${{ steps.build.outputs.build_image_ubuntu }}
   build_image_ubuntu_mobile:
-    value: ${{ steps.build_image.outputs.build_image_ubuntu_mobile }}
+    value: ${{ steps.build.outputs.build_image_ubuntu_mobile }}
+
   mobile_android_build:
     value: ${{ steps.should_run.outputs.mobile_android_build }}
   mobile_android_build_all:
@@ -54,6 +58,12 @@ outputs:
     value: ${{ steps.should_run.outputs.mobile_release_validation }}
   mobile_tsan:
     value: ${{ steps.should_run.outputs.mobile_tsan }}
+  repo_ref_name:
+    value: ${{ steps.context.outputs.repo_ref_name }}
+  repo_ref_sha:
+    value: ${{ steps.context.outputs.repo_ref_sha }}
+  repo_ref_sha_short:
+    value: ${{ steps.context.outputs.repo_ref_sha_short }}
   trusted:
     value: ${{ steps.trusted.outputs.trusted }}
   version_dev:
@@ -64,20 +74,6 @@ outputs:
 runs:
   using: composite
   steps:
-  - id: build_image
-    name: 'Check current build images'
-    run: |
-      {
-          echo "build_image_ubuntu=${BUILD_IMAGE_UBUNTU_REPO}:${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_SHA}"
-          echo "build_image_ubuntu_mobile=${BUILD_IMAGE_UBUNTU_REPO}:mobile-${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_MOBILE_SHA}"
-      } >> "$GITHUB_OUTPUT"
-    env:
-      # TODO(phlax): derive these from a config file
-      BUILD_IMAGE_UBUNTU_REPO: ${{ inputs.build_image_repo }}
-      BUILD_IMAGE_UBUNTU: ${{ inputs.build_image_tag }}
-      BUILD_IMAGE_UBUNTU_SHA: ${{ inputs.build_image_sha }}
-      BUILD_IMAGE_UBUNTU_MOBILE_SHA: ${{ inputs.build_image_mobile_sha }}
-    shell: bash
 
   - if: ${{ inputs.check_mobile_run != 'false' }}
     id: should_run
@@ -90,7 +86,13 @@ runs:
     run: |
       VERSION_DEV="$(cat VERSION.txt | cut -d- -f2)"
       VERSION_PATCH="$(cat VERSION.txt | cut -d- -f1 | rev | cut -d. -f1 | rev)"
+      # TODO: strip merge from pr names
+      REF_NAME=${{ inputs.repo_ref_name || github.ref_name }}
+      REF_SHA=${{ inputs.repo_ref_sha || github.sha }}
       {
+          echo "repo_ref_name=$REF_NAME"
+          echo "repo_ref_sha=$REF_SHA"
+          echo "repo_ref_sha_short=${REF_SHA:0:7}"
           echo "version_dev=$VERSION_DEV"
           echo "version_patch=$VERSION_PATCH"
       } >> "$GITHUB_OUTPUT"
@@ -121,4 +123,19 @@ runs:
           TRUSTED=
       fi
       echo "trusted=$TRUSTED" >> "$GITHUB_OUTPUT"
+    shell: bash
+
+  - id: build
+    name: 'Check current build images'
+    run: |
+      {
+          echo "build_image_ubuntu=${BUILD_IMAGE_UBUNTU_REPO}:${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_SHA}"
+          echo "build_image_ubuntu_mobile=${BUILD_IMAGE_UBUNTU_REPO}:mobile-${BUILD_IMAGE_UBUNTU}@sha256:${BUILD_IMAGE_UBUNTU_MOBILE_SHA}"
+      } >> "$GITHUB_OUTPUT"
+    env:
+      # TODO(phlax): derive these from a config file
+      BUILD_IMAGE_UBUNTU_REPO: ${{ inputs.build_image_repo }}
+      BUILD_IMAGE_UBUNTU: ${{ inputs.build_image_tag }}
+      BUILD_IMAGE_UBUNTU_SHA: ${{ inputs.build_image_sha }}
+      BUILD_IMAGE_UBUNTU_MOBILE_SHA: ${{ inputs.build_image_mobile_sha }}
     shell: bash

--- a/.github/workflows/_cache_docker.yml
+++ b/.github/workflows/_cache_docker.yml
@@ -1,13 +1,24 @@
-name: Cache (docker)
+name: Cache prime (docker)
 
 permissions:
   contents: read
 
 on:
   workflow_call:
+    inputs:
+      image_tag:
+        type: string
+        required: true
+      image_repo:
+        type: string
+        required: true
+      image_sha:
+        type: string
+        required: true
 
 concurrency:
   group: cache_docker-${{ inputs.image_tag }}
+  cancel-in-progress: false
 
 ## Docker cache
 #
@@ -26,11 +37,6 @@ jobs:
   docker:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: ./.github/actions/env
-      id: env
-      with:
-        check_mobile_run: false
     - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@actions-v0.0.10
       with:
-        image_tag: "${{ steps.env.outputs.build_image_ubuntu }}"
+        image_tag: "${{ inputs.image_repo }}:${{ inputs.image_tag }}@sha256:${{ inputs.image_sha }}"

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -84,7 +84,7 @@ jobs:
   do_ci:
     if: ${{ ! inputs.skip }}
     runs-on: ubuntu-22.04
-    name: do_ci.sh ${{ inputs.target }}
+    name: ${{ inputs.command_ci }} (${{ inputs.target }})
     steps:
     - if: ${{ inputs.cache_build_image }}
       uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@actions-v0.0.10

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -6,6 +6,20 @@ permissions:
 on:
   workflow_call:
     inputs:
+      # Authoritative configuration for build image/s
+      build_image_repo:
+        type: string
+        default: envoyproxy/envoy-build-ubuntu
+      build_image_sha:
+        type: string
+        default: 50337314a150ed12447c87c1622eac6f611a069888722fb9a426e21ed161cc26
+      build_image_mobile_sha:
+        type: string
+        default: ca26ff05bd3f3a09468242faaf38ae48315e57f0a87c102352162f95ac620e6f
+      build_image_tag:
+        type: string
+        default: 41c5a05d708972d703661b702a63ef5060125c33
+
       check_mobile_run:
         type: boolean
         default: true
@@ -14,6 +28,13 @@ on:
         default: false
 
       start_check_status:
+        type: string
+        default:
+
+      repo_ref_sha:
+        type: string
+        default:
+      repo_ref_name:
         type: string
         default:
 
@@ -51,6 +72,13 @@ on:
       mobile_tsan:
         value: ${{ jobs.repo.outputs.mobile_tsan }}
 
+      repo_ref_name:
+        value: ${{ jobs.repo.outputs.repo_ref_name }}
+      repo_ref_sha:
+        value: ${{ jobs.repo.outputs.repo_ref_sha }}
+      repo_ref_sha_short:
+        value: ${{ jobs.repo.outputs.repo_ref_sha_short }}
+
       trusted:
         value: ${{ jobs.repo.outputs.trusted }}
 
@@ -83,6 +111,9 @@ jobs:
       mobile_ios_tests: ${{ steps.env.outputs.mobile_ios_tests }}
       mobile_release_validation: ${{ steps.env.outputs.mobile_release_validation }}
       mobile_tsan: ${{ steps.env.outputs.mobile_tsan }}
+      repo_ref_name: ${{ steps.env.outputs.repo_ref_name }}
+      repo_ref_sha: ${{ steps.env.outputs.repo_ref_sha }}
+      repo_ref_sha_short: ${{ steps.env.outputs.repo_ref_sha_short }}
       trusted: ${{ steps.env.outputs.trusted }}
       version_dev: ${{ steps.env.outputs.version_dev }}
       version_patch: ${{ steps.env.outputs.version_patch }}
@@ -94,19 +125,19 @@ jobs:
       id: env
       with:
         check_mobile_run: ${{ inputs.check_mobile_run }}
+        repo_ref_sha: ${{ inputs.repo_ref_sha }}
+        build_image_repo: ${{ inputs.build_image_repo }}
+        build_image_tag: ${{ inputs.build_image_tag }}
+        build_image_mobile_sha: ${{ inputs.build_image_mobile_sha }}
+        build_image_sha: ${{ inputs.build_image_sha }}
 
     - name: 'Print env'
       run: |
         echo "version_dev=${{ steps.env.outputs.version_dev }}"
         echo "version_patch=${{ steps.env.outputs.version_patch }}"
+        echo "trusted=${{ steps.env.outputs.trusted }}"
         echo "build_image_ubuntu=${{ steps.env.outputs.build_image_ubuntu }}"
         echo "build_image_ubuntu_mobile=${{ steps.env.outputs.build_image_ubuntu_mobile }}"
-        echo "trusted=${{ steps.env.outputs.trusted }}"
-
-  cache:
-    if: ${{ inputs.prime_build_image }}
-    # This uses a separate job to ensure correct concurrency
-    uses: ./.github/workflows/_cache_docker.yml
 
   check:
     if: ${{ inputs.start_check_status && github.event_name != 'pull_request' }}
@@ -116,3 +147,11 @@ jobs:
       statuses: write
     with:
       workflow_name: ${{ inputs.start_check_status }}
+
+  cache:
+    if: ${{ inputs.prime_build_image }}
+    uses: ./.github/workflows/_cache_docker.yml
+    with:
+      image_repo: ${{ inputs.build_image_repo }}
+      image_tag: ${{ inputs.build_image_tag }}
+      image_sha: ${{ inputs.build_image_sha }}

--- a/.github/workflows/_stage_verify.yml
+++ b/.github/workflows/_stage_verify.yml
@@ -19,12 +19,13 @@ concurrency:
 
 jobs:
   verify:
-    name: "Verify (${{ matrix.target }}) ${{ inputs.trusted && 'postsubmit' || 'pr' }}:${{ github.ref_name }}"
+    name: ${{ matrix.name || matrix.target }}
     strategy:
       fail-fast: false
       matrix:
         include:
         - target: verify_examples
+          name: examples
           rbe: false
           managed: true
           cache_build_image: ""

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -32,14 +32,18 @@ jobs:
       check_mobile_run: false
       prime_build_image: true
       start_check_status: Verify/examples
+      repo_ref_sha: ${{ inputs.ref_sha }}
+      repo_ref_name: ${{ inputs.head_ref }}
+
     permissions:
       contents: read
       statuses: write
 
   verify:
     uses: ./.github/workflows/_stage_verify.yml
+    name: Verify (${{ inputs.trusted && 'postsubmit' || 'pr' }}:${{ needs.env.outputs.repo_ref_name }}@${{ needs.env.outputs.repo_ref_sha_short }})
     needs:
     - env
     with:
       trusted: ${{ needs.env.outputs.trusted && true || false }}
-      repo_ref: ${{ ! needs.env.outputs.trusted && inputs.repo_ref || '' }}
+      repo_ref: ${{ needs.env.outputs.trusted == 'false' && inputs.ref || '' }}


### PR DESCRIPTION
- Improve names in newer/triggered github CI
- Attempt to ensure untrusted code is able to run in triggered (only correct) CI
- Dont checkout the repo for build image
- Remove fail supression from azp trigger
- make `.github/workflows/_env.yml` the authoritative source for build image config (doesnt require repo checkout)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
