### PR TITLE
Implement header forwarding disallow list feature for ext_proc filter.

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -221,7 +221,6 @@ message HeaderForwardingRules {
 
   // If set, specifically disallow any header in this list to be forwarded to the external
   // processing server. This overrides the above ``allowed_headers`` if a header matches both.
-  // [#not-implemented-hide:]
   type.matcher.v3.ListStringMatcher disallowed_headers = 2;
 }
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -188,7 +188,7 @@ FilterHeadersStatus Filter::onHeaders(ProcessorState& state,
   state.setHasNoBody(end_stream);
   ProcessingRequest req;
   auto* headers_req = state.mutableHeaders(req);
-  MutationUtils::headersToProto(headers, config_->headerMatchers(),
+  MutationUtils::headersToProto(headers, config_->allowedHeaders(), config_->disallowedHeaders(),
                                 *headers_req->mutable_headers());
   headers_req->set_end_of_stream(end_stream);
   state.onStartProcessorCall(std::bind(&Filter::onMessageTimeout, this), config_->messageTimeout(),
@@ -561,7 +561,7 @@ void Filter::sendBufferedData(ProcessorState& state, ProcessorState::CallbackSta
 void Filter::sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers) {
   ProcessingRequest req;
   auto* trailers_req = state.mutableTrailers(req);
-  MutationUtils::headersToProto(trailers, config_->headerMatchers(),
+  MutationUtils::headersToProto(trailers, config_->allowedHeaders(), config_->disallowedHeaders(),
                                 *trailers_req->mutable_trailers());
   state.onStartProcessorCall(std::bind(&Filter::onMessageTimeout, this), config_->messageTimeout(),
                              ProcessorState::CallbackState::TrailersCallback);

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -150,7 +150,7 @@ private:
     return {ALL_EXT_PROC_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
   }
   const std::vector<Matchers::StringMatcherPtr>
-  initHeaderMatchers(const envoy::type::matcher::v3::ListStringMatcher header_list) {
+  initHeaderMatchers(const envoy::type::matcher::v3::ListStringMatcher& header_list) {
     std::vector<Matchers::StringMatcherPtr> header_matchers;
     for (const auto& matcher : header_list.patterns()) {
       header_matchers.push_back(

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -113,7 +113,8 @@ public:
         processing_mode_(config.processing_mode()), mutation_checker_(config.mutation_rules()),
         filter_metadata_(config.filter_metadata()),
         allow_mode_override_(config.allow_mode_override()),
-        header_matchers_(initHeaderMatchers(config)) {}
+        allowed_headers_(initHeaderMatchers(config.forward_rules().allowed_headers())),
+        disallowed_headers_(initHeaderMatchers(config.forward_rules().disallowed_headers())) {}
 
   bool failureModeAllow() const { return failure_mode_allow_; }
 
@@ -135,7 +136,10 @@ public:
 
   bool disableClearRouteCache() const { return disable_clear_route_cache_; }
 
-  const std::vector<Matchers::StringMatcherPtr>& headerMatchers() const { return header_matchers_; }
+  const std::vector<Matchers::StringMatcherPtr>& allowedHeaders() const { return allowed_headers_; }
+  const std::vector<Matchers::StringMatcherPtr>& disallowedHeaders() const {
+    return disallowed_headers_;
+  }
 
   const Envoy::ProtobufWkt::Struct& filterMetadata() const { return filter_metadata_; }
 
@@ -145,10 +149,10 @@ private:
     const std::string final_prefix = absl::StrCat(prefix, "ext_proc.", filter_stats_prefix);
     return {ALL_EXT_PROC_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
   }
-  const std::vector<Matchers::StringMatcherPtr> initHeaderMatchers(
-      const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& config) {
+  const std::vector<Matchers::StringMatcherPtr>
+  initHeaderMatchers(const envoy::type::matcher::v3::ListStringMatcher header_list) {
     std::vector<Matchers::StringMatcherPtr> header_matchers;
-    for (const auto& matcher : config.forward_rules().allowed_headers().patterns()) {
+    for (const auto& matcher : header_list.patterns()) {
       header_matchers.push_back(
           std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
               matcher));
@@ -167,8 +171,10 @@ private:
   const Envoy::ProtobufWkt::Struct filter_metadata_;
   // If set to true, allow the processing mode to be modified by the ext_proc response.
   const bool allow_mode_override_;
-  // Empty header_matchers_ means allow all.
-  const std::vector<Matchers::StringMatcherPtr> header_matchers_;
+  // Empty allowed_header_ means allow all.
+  const std::vector<Matchers::StringMatcherPtr> allowed_headers_;
+  // Empty disallowed_header_ means disallow nothing, i.e, allow all.
+  const std::vector<Matchers::StringMatcherPtr> disallowed_headers_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/source/extensions/filters/http/ext_proc/mutation_utils.h
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.h
@@ -19,7 +19,8 @@ class MutationUtils : public Logger::Loggable<Logger::Id::ext_proc> {
 public:
   // Convert a header map into a protobuf
   static void headersToProto(const Http::HeaderMap& headers_in,
-                             const std::vector<Matchers::StringMatcherPtr>& header_matchers,
+                             const std::vector<Matchers::StringMatcherPtr>& allowed_headers,
+                             const std::vector<Matchers::StringMatcherPtr>& disallowed_headers,
                              envoy::config::core::v3::HeaderMap& proto_out);
 
   // Modify header map based on a set of mutations from a protobuf. An error will be
@@ -41,9 +42,14 @@ public:
   static bool isValidHttpStatus(int code);
 
 private:
-  // Check whether header:key is in header_matchers.
-  static bool headerInAllowList(absl::string_view key,
-                                const std::vector<Matchers::StringMatcherPtr>& header_matchers);
+  // Check whether header:key is in the header_matchers.
+  static bool headerInMatcher(absl::string_view key,
+                              const std::vector<Matchers::StringMatcherPtr>& header_matchers);
+  static bool
+  headerCanBeForwarded(absl::string_view key,
+                       const std::vector<Matchers::StringMatcherPtr>& allowed_headers,
+                       const std::vector<Matchers::StringMatcherPtr>& disallowed_headers);
+
   // Check whether the header mutations in the response is over the HCM size config.
   static absl::Status
   responseHeaderSizeCheck(const Http::HeaderMap& headers,


### PR DESCRIPTION
This is a follow up commit for : https://github.com/envoyproxy/envoy/pull/28468.

It is to implement header forwarding disallow list feature for ext_proc filter.


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
