### PR TITLE
ext_authz: fix handling of non-UTF-8 bodies calling http_service

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -208,6 +208,11 @@ message BufferSettings {
   // field of HTTP request attribute context. Otherwise, :ref:`body
   // <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
   // with UTF-8 string request body.
+  //
+  // This field only affects configurations using a :ref:`grpc_service
+  // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`. In configurations that use
+  // an :ref:`http_service <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`, this
+  // has no effect.
   bool pack_as_bytes = 3;
 }
 

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -211,7 +211,7 @@ message BufferSettings {
   //
   // This field only affects configurations using a :ref:`grpc_service
   // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`. In configurations that use
-  // an :ref:`http_service <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`, this
+  // an :ref:`http_service <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.http_service>`, this
   // has no effect.
   bool pack_as_bytes = 3;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -150,6 +150,11 @@ bug_fixes:
     Fix a bug where the ext_authz filter will ignore the request body when the
     :ref:`pack_as_bytes <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.BufferSettings.pack_as_bytes>` is set to true and
     HTTP authorization service is configured.
+- area: ext_authz
+  change: |
+    Fix a bug where the ext_authz filter will remove non UTF-8 characters from the body of a request when configured
+    to use :ref:`http_service <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.http_service>`, if configured
+    to send the body.
 - area: router
   change: |
     Fixed the bug that updating :ref:`scope_key_builder

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -62,7 +62,12 @@ public:
         failure_mode_allow_(config.failure_mode_allow()),
         clear_route_cache_(config.clear_route_cache()),
         max_request_bytes_(config.with_request_body().max_request_bytes()),
-        pack_as_bytes_(config.with_request_body().pack_as_bytes()),
+
+        // `pack_as_bytes_` should be true when configured with an http service because there is no
+        // difference to where the body is written in http requests, and a value of false here will
+        // cause non UTF-8 body content to be changed when it doesn't need to.
+        pack_as_bytes_(config.has_http_service() || config.with_request_body().pack_as_bytes()),
+
         status_on_error_(toErrorCode(config.status_on_error().code())), scope_(scope),
         runtime_(runtime), http_context_(http_context),
         filter_enabled_(config.has_filter_enabled()

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -480,7 +480,7 @@ public:
   void initiateClientConnection() {
     auto conn = makeClientConnection(lookupPort("http"));
     codec_client_ = makeHttpConnection(std::move(conn));
-    response_ = codec_client_->makeHeaderOnlyRequest(
+    const auto headers =
         Http::TestRequestHeaderMapImpl{{":method", "GET"},
                                        {":path", "/"},
                                        {":scheme", "http"},
@@ -497,7 +497,12 @@ public:
                                        {"not-allowed", "nope"},
                                        {"authorization", "legit"},
                                        {"regex-food", "food"},
-                                       {"regex-fool", "fool"}});
+                                       {"regex-fool", "fool"}};
+    if (client_request_body_.empty()) {
+      response_ = codec_client_->makeHeaderOnlyRequest(headers);
+    } else {
+      response_ = codec_client_->makeRequestWithBody(headers, client_request_body_, true);
+    }
   }
 
   void waitForExtAuthzRequest() {
@@ -641,6 +646,7 @@ public:
   FakeHttpConnectionPtr fake_ext_authz_connection_;
   FakeStreamPtr ext_authz_request_;
   IntegrationStreamDecoderPtr response_;
+  std::string client_request_body_;
   const Http::LowerCaseString case_sensitive_header_name_{"x-case-sensitive-header"};
   const std::string case_sensitive_header_value_{"Case-Sensitive"};
   const std::string legacy_default_config_ = R"EOF(
@@ -698,6 +704,9 @@ public:
         - exact: bat
         - prefix: x-append
   failure_mode_allow: true
+  with_request_body:
+    max_request_bytes: 1024
+    allow_partial_message: true
   )EOF";
 };
 
@@ -918,6 +927,23 @@ TEST_P(ExtAuthzHttpIntegrationTest, DefaultCaseSensitiveStringMatcher) {
   setup(false);
   const auto header_entry = ext_authz_request_->headers().get(case_sensitive_header_name_);
   ASSERT_TRUE(header_entry.empty());
+}
+
+// Verifies that by default HTTP service uses the case-sensitive string matcher
+// (uses new config for allowed_headers).
+TEST_P(ExtAuthzHttpIntegrationTest, Body) {
+  client_request_body_ = "the request body";
+  setup(false);
+  EXPECT_EQ(ext_authz_request_->body().toString(), client_request_body_);
+}
+
+TEST_P(ExtAuthzHttpIntegrationTest, BodyNonUtf8) {
+  client_request_body_ = "valid_prefix";
+  client_request_body_.append(1, char(0xc3));
+  client_request_body_.append(1, char(0x28));
+  client_request_body_.append("valid_suffix");
+  setup(false);
+  EXPECT_EQ(ext_authz_request_->body().toString(), client_request_body_);
 }
 
 // (uses new config for allowed_headers).


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Commit 664f3fce4730544f34ae767e10150fb6be11cdc6 changed how this data is handled, but was only intended to apply when calling grpc_service.

Additional Description:
Risk Level: low
Testing: added new tests
Docs Changes: updated
Release Notes: added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #27386
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
