### PR TITLE
unhide config discovery option for network filters

### DIFF
--- a/api/envoy/config/listener/v3/listener_components.proto
+++ b/api/envoy/config/listener/v3/listener_components.proto
@@ -45,7 +45,6 @@ message Filter {
     // Configuration source specifier for an extension configuration discovery
     // service. In case of a failure and without the default configuration, the
     // listener closes the connections.
-    // [#not-implemented-hide:]
     core.v3.ExtensionConfigSource config_discovery = 5;
   }
 }


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/28407 implemented config discovery for network filters. This PR unhides it from api
Commit Message: unhide config discovery option for network filters
Additional Description: unhide config discovery option for network filters
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
