### PR TITLE
ci/github: Remove debug hack from github publishing

### DIFF
--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -45,8 +45,7 @@ jobs:
           name: github
           run_pre: ./.github/actions/publish/release/setup
           run_pre_with: |
-            # ref: ${{ inputs.given_ref }}
-            ref: 5d58edacad73d5ac01edea989fd81c9d817987e8
+            ref: ${{ inputs.given_ref }}
           env: |
             export ENVOY_PUBLISH_DRY_RUN=1
     uses: ./.github/workflows/_ci.yml
@@ -74,8 +73,7 @@ jobs:
           name: github
           run_pre: ./.github/actions/publish/release/setup
           run_pre_with: |
-            # ref: ${{ inputs.given_ref }}
-            ref: 5d58edacad73d5ac01edea989fd81c9d817987e8
+            ref: ${{ inputs.given_ref }}
           env: |
             if [[ '${{ inputs.version_dev }}' != '' ]]; then
                 export ENVOY_PUBLISH_DRY_RUN=1


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
