### PR TITLE
fix(hermeticity): do not leak PATH to actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,11 +23,15 @@ build --copt=-DABSL_MIN_LOG_LEVEL=4
 build --define envoy_mobile_listener=enabled
 build --experimental_repository_downloader_retries=2
 
-# Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
+# Pass CC, CXX and LLVM_CONFIG variables from the environment.
+# We assume they have stable values, so this won't cause action cache misses.
 build --action_env=CC --host_action_env=CC
 build --action_env=CXX --host_action_env=CXX
 build --action_env=LLVM_CONFIG --host_action_env=LLVM_CONFIG
-build --action_env=PATH --host_action_env=PATH
+# Do not pass through PATH however.
+# It tends to have machine-specific values, such as dynamically created temp folders.
+# This would make it impossible to share remote action cache hits among machines.
+# build --action_env=PATH --host_action_env=PATH
 
 # Allow stamped caches to bust when local filesystem changes.
 # Requires setting `BAZEL_VOLATILE_DIRTY` in the env.

--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,7 @@ build --platform_mappings=bazel/platform_mappings
 build --copt=-DABSL_MIN_LOG_LEVEL=4
 build --define envoy_mobile_listener=enabled
 build --experimental_repository_downloader_retries=2
+build --enable_platform_specific_config
 
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.
@@ -32,6 +33,8 @@ build --action_env=LLVM_CONFIG --host_action_env=LLVM_CONFIG
 # It tends to have machine-specific values, such as dynamically created temp folders.
 # This would make it impossible to share remote action cache hits among machines.
 # build --action_env=PATH --host_action_env=PATH
+# To make our own CI green, we do need that flag on Windows though.
+build:windows --action_env=PATH --host_action_env=PATH
 
 # Allow stamped caches to bust when local filesystem changes.
 # Requires setting `BAZEL_VOLATILE_DIRTY` in the env.
@@ -41,7 +44,6 @@ build --action_env=BAZEL_VOLATILE_DIRTY --host_action_env=BAZEL_VOLATILE_DIRTY
 # Requires setting `BAZEL_FAKE_SCM_REVISION` in the env.
 build --action_env=BAZEL_FAKE_SCM_REVISION --host_action_env=BAZEL_FAKE_SCM_REVISION
 
-build --enable_platform_specific_config
 build --test_summary=terse
 
 # TODO(keith): Remove once these 2 are the default


### PR DESCRIPTION
I have a client who vendored this file into their Bazel workspace, and it caused every new machine to have a non-incremental build with all cache misses, due to the CI system (CircleCI in that case) injecting an unstable value into the PATH (`/tmp/circleci-launch-agent150557664/circleci-agent/1.0.193225-b3de599b/linux/amd64`)


Commit Message: Above
Additional Description:
Risk Level: Unsure
Testing: Not familiar with this project, so whatever tests you normally run? The client says this change is green for them.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
