### PR TITLE
Add ClusterLbStats to deferred stats

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -783,6 +783,8 @@ MAKE_STATS_STRUCT(ClusterEndpointStats, ClusterEndpointStatNames, ALL_CLUSTER_EN
  */
 MAKE_STAT_NAMES_STRUCT(ClusterLbStatNames, ALL_CLUSTER_LB_STATS);
 MAKE_STATS_STRUCT(ClusterLbStats, ClusterLbStatNames, ALL_CLUSTER_LB_STATS);
+using DeferredCreationCompatibleClusterLbStats =
+    Stats::DeferredCreationCompatibleStats<ClusterLbStats>;
 
 /**
  * Struct definition for all cluster traffic stats. @see stats_macros.h
@@ -1081,9 +1083,9 @@ public:
   virtual ClusterConfigUpdateStats& configUpdateStats() const PURE;
 
   /**
-   * @return ClusterLbStats& load-balancer-related stats for this cluster.
+   * @return DeferredCreationCompatibleClusterLbStats& load-balancer-related stats for this cluster.
    */
-  virtual ClusterLbStats& lbStats() const PURE;
+  virtual DeferredCreationCompatibleClusterLbStats& lbStats() const PURE;
 
   /**
    * @return ClusterEndpointStats& endpoint related stats for this cluster.

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -138,7 +138,8 @@ LoadBalancerBase::choosePriority(uint64_t hash, const HealthyLoad& healthy_per_p
   return {0, HostAvailability::Healthy};
 }
 
-LoadBalancerBase::LoadBalancerBase(const PrioritySet& priority_set, ClusterLbStats& stats,
+LoadBalancerBase::LoadBalancerBase(const PrioritySet& priority_set,
+                                   DeferredCreationCompatibleClusterLbStats& stats,
                                    Runtime::Loader& runtime, Random::RandomGenerator& random,
                                    uint32_t healthy_panic_threshold)
     : stats_(stats), runtime_(runtime), random_(random),
@@ -411,8 +412,9 @@ LoadBalancerBase::chooseHostSet(LoadBalancerContext* context, uint64_t hash) con
 }
 
 ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
-    const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-    Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+    const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+    DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
+    Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
     const absl::optional<LocalityLbConfig> locality_config)
     : LoadBalancerBase(priority_set, stats, runtime, random, healthy_panic_threshold),
       local_priority_set_(local_priority_set),
@@ -459,7 +461,7 @@ ZoneAwareLoadBalancerBase::ZoneAwareLoadBalancerBase(
 
 void ZoneAwareLoadBalancerBase::regenerateLocalityRoutingStructures() {
   ASSERT(local_priority_set_);
-  stats_.lb_recalculate_zone_structures_.inc();
+  stats_->lb_recalculate_zone_structures_.inc();
   // resizePerPriorityState should ensure these stay in sync.
   ASSERT(per_priority_state_.size() == priority_set_.hostSetsPerPriority().size());
 
@@ -557,14 +559,14 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   // panic mode for local cluster".
   if (!host_set.healthyHostsPerLocality().hasLocalLocality() ||
       host_set.healthyHostsPerLocality().get()[0].empty()) {
-    stats_.lb_local_cluster_not_ok_.inc();
+    stats_->lb_local_cluster_not_ok_.inc();
     return true;
   }
 
   // Same number of localities should be for local and upstream cluster.
   if (host_set.healthyHostsPerLocality().get().size() !=
       localHostSet().healthyHostsPerLocality().get().size()) {
-    stats_.lb_zone_number_differs_.inc();
+    stats_->lb_zone_number_differs_.inc();
     return true;
   }
 
@@ -572,7 +574,7 @@ bool ZoneAwareLoadBalancerBase::earlyExitNonLocalityRouting() {
   const uint64_t min_cluster_size =
       runtime_.snapshot().getInteger(RuntimeMinClusterSize, min_cluster_size_);
   if (host_set.healthyHosts().size() < min_cluster_size) {
-    stats_.lb_zone_cluster_too_small_.inc();
+    stats_->lb_zone_cluster_too_small_.inc();
     return true;
   }
 
@@ -641,7 +643,7 @@ uint32_t ZoneAwareLoadBalancerBase::tryChooseLocalLocalityHosts(const HostSet& h
 
   // Try to push all of the requests to the same locality first.
   if (state.locality_routing_state_ == LocalityRoutingState::LocalityDirect) {
-    stats_.lb_zone_routing_all_directly_.inc();
+    stats_->lb_zone_routing_all_directly_.inc();
     return 0;
   }
 
@@ -650,17 +652,17 @@ uint32_t ZoneAwareLoadBalancerBase::tryChooseLocalLocalityHosts(const HostSet& h
   // If we cannot route all requests to the same locality, we already calculated how much we can
   // push to the local locality, check if we can push to local locality on current iteration.
   if (random_.random() % 10000 < state.local_percent_to_route_) {
-    stats_.lb_zone_routing_sampled_.inc();
+    stats_->lb_zone_routing_sampled_.inc();
     return 0;
   }
 
   // At this point we must route cross locality as we cannot route to the local locality.
-  stats_.lb_zone_routing_cross_zone_.inc();
+  stats_->lb_zone_routing_cross_zone_.inc();
 
   // This is *extremely* unlikely but possible due to rounding errors when calculating
   // locality percentages. In this case just select random locality.
   if (state.residual_capacity_[number_of_localities - 1] == 0) {
-    stats_.lb_zone_no_capacity_left_.inc();
+    stats_->lb_zone_no_capacity_left_.inc();
     return random_.random() % number_of_localities;
   }
 
@@ -693,7 +695,7 @@ ZoneAwareLoadBalancerBase::hostSourceToUse(LoadBalancerContext* context, uint64_
   // If the selected host set has insufficient healthy hosts, return all hosts (unless we should
   // fail traffic on panic, in which case return no host).
   if (per_priority_panic_[hosts_source.priority_]) {
-    stats_.lb_healthy_panic_.inc();
+    stats_->lb_healthy_panic_.inc();
     if (fail_traffic_on_panic_) {
       return absl::nullopt;
     } else {
@@ -751,7 +753,7 @@ ZoneAwareLoadBalancerBase::hostSourceToUse(LoadBalancerContext* context, uint64_
   }
 
   if (isHostSetInPanic(localHostSet())) {
-    stats_.lb_local_cluster_not_ok_.inc();
+    stats_->lb_local_cluster_not_ok_.inc();
     // If the local Envoy instances are in global panic, and we should not fail traffic, do
     // not do locality based routing.
     if (fail_traffic_on_panic_) {
@@ -792,11 +794,14 @@ const HostVector& ZoneAwareLoadBalancerBase::hostSourceToHosts(HostsSource hosts
   PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
-EdfLoadBalancerBase::EdfLoadBalancerBase(
-    const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-    Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
-    const absl::optional<LocalityLbConfig> locality_config,
-    const absl::optional<SlowStartConfig> slow_start_config, TimeSource& time_source)
+EdfLoadBalancerBase::EdfLoadBalancerBase(const PrioritySet& priority_set,
+                                         const PrioritySet* local_priority_set,
+                                         DeferredCreationCompatibleClusterLbStats& stats,
+                                         Runtime::Loader& runtime, Random::RandomGenerator& random,
+                                         uint32_t healthy_panic_threshold,
+                                         const absl::optional<LocalityLbConfig> locality_config,
+                                         const absl::optional<SlowStartConfig> slow_start_config,
+                                         TimeSource& time_source)
     : ZoneAwareLoadBalancerBase(priority_set, local_priority_set, stats, runtime, random,
                                 healthy_panic_threshold, locality_config),
       seed_(random_.random()),

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -123,8 +123,9 @@ protected:
    */
   void recalculateLoadInTotalPanic();
 
-  LoadBalancerBase(const PrioritySet& priority_set, ClusterLbStats& stats, Runtime::Loader& runtime,
-                   Random::RandomGenerator& random, uint32_t healthy_panic_threshold);
+  LoadBalancerBase(const PrioritySet& priority_set, DeferredCreationCompatibleClusterLbStats& stats,
+                   Runtime::Loader& runtime, Random::RandomGenerator& random,
+                   uint32_t healthy_panic_threshold);
 
   // Choose host set randomly, based on the healthy_per_priority_load_ and
   // degraded_per_priority_load_. per_priority_load_ is consulted first, spilling over to
@@ -157,7 +158,7 @@ protected:
     }
   }
 
-  ClusterLbStats& stats_;
+  DeferredCreationCompatibleClusterLbStats& stats_;
   Runtime::Loader& runtime_;
   std::deque<uint64_t> stashed_random_;
   Random::RandomGenerator& random_;
@@ -257,8 +258,9 @@ public:
 protected:
   // Both priority_set and local_priority_set if non-null must have at least one host set.
   ZoneAwareLoadBalancerBase(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-                            ClusterLbStats& stats, Runtime::Loader& runtime,
-                            Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+                            DeferredCreationCompatibleClusterLbStats& stats,
+                            Runtime::Loader& runtime, Random::RandomGenerator& random,
+                            uint32_t healthy_panic_threshold,
                             const absl::optional<LocalityLbConfig> locality_config);
 
   // When deciding which hosts to use on an LB decision, we need to know how to index into the
@@ -472,7 +474,7 @@ public:
   using SlowStartConfig = envoy::extensions::load_balancing_policies::common::v3::SlowStartConfig;
 
   EdfLoadBalancerBase(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-                      ClusterLbStats& stats, Runtime::Loader& runtime,
+                      DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
                       Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
                       const absl::optional<LocalityLbConfig> locality_config,
                       const absl::optional<SlowStartConfig> slow_start_config,
@@ -540,8 +542,9 @@ protected:
 class RoundRobinLoadBalancer : public EdfLoadBalancerBase {
 public:
   RoundRobinLoadBalancer(
-      const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-      Runtime::Loader& runtime, Random::RandomGenerator& random,
+      const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+      DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
+      Random::RandomGenerator& random,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
       OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> round_robin_config,
       TimeSource& time_source)
@@ -558,8 +561,9 @@ public:
   }
 
   RoundRobinLoadBalancer(
-      const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-      Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+      const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+      DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
+      Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
       const envoy::extensions::load_balancing_policies::round_robin::v3::RoundRobin&
           round_robin_config,
       TimeSource& time_source)
@@ -632,8 +636,9 @@ private:
 class LeastRequestLoadBalancer : public EdfLoadBalancerBase {
 public:
   LeastRequestLoadBalancer(
-      const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-      Runtime::Loader& runtime, Random::RandomGenerator& random,
+      const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+      DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
+      Random::RandomGenerator& random,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config,
       OptRef<const envoy::config::cluster::v3::Cluster::LeastRequestLbConfig> least_request_config,
       TimeSource& time_source)
@@ -660,8 +665,9 @@ public:
   }
 
   LeastRequestLoadBalancer(
-      const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-      Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+      const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+      DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
+      Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
       const envoy::extensions::load_balancing_policies::least_request::v3::LeastRequest&
           least_request_config,
       TimeSource& time_source)
@@ -718,7 +724,7 @@ private:
 class RandomLoadBalancer : public ZoneAwareLoadBalancerBase {
 public:
   RandomLoadBalancer(const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-                     ClusterLbStats& stats, Runtime::Loader& runtime,
+                     DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
                      Random::RandomGenerator& random,
                      const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
       : ZoneAwareLoadBalancerBase(
@@ -728,8 +734,9 @@ public:
             LoadBalancerConfigHelper::localityLbConfigFromCommonLbConfig(common_config)) {}
 
   RandomLoadBalancer(
-      const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterLbStats& stats,
-      Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+      const PrioritySet& priority_set, const PrioritySet* local_priority_set,
+      DeferredCreationCompatibleClusterLbStats& stats, Runtime::Loader& runtime,
+      Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
       const envoy::extensions::load_balancing_policies::random::v3::Random& random_config)
       : ZoneAwareLoadBalancerBase(
             priority_set, local_priority_set, stats, runtime, random, healthy_panic_threshold,

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -159,7 +159,7 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
           .first;
   const auto& per_priority_state = (*per_priority_state_)[priority];
   if (per_priority_state->global_panic_) {
-    stats_.lb_healthy_panic_.inc();
+    stats_->lb_healthy_panic_.inc();
   }
 
   const uint32_t max_attempts = context ? context->hostSelectionRetryCount() + 1 : 1;

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -106,7 +106,8 @@ public:
   }
 
 protected:
-  ThreadAwareLoadBalancerBase(const PrioritySet& priority_set, ClusterLbStats& stats,
+  ThreadAwareLoadBalancerBase(const PrioritySet& priority_set,
+                              DeferredCreationCompatibleClusterLbStats& stats,
                               Runtime::Loader& runtime, Random::RandomGenerator& random,
                               uint32_t healthy_panic_threshold, bool locality_weighted_balancing)
       : LoadBalancerBase(priority_set, stats, runtime, random, healthy_panic_threshold),
@@ -121,7 +122,8 @@ private:
   using PerPriorityStatePtr = std::unique_ptr<PerPriorityState>;
 
   struct LoadBalancerImpl : public LoadBalancer {
-    LoadBalancerImpl(ClusterLbStats& stats, Random::RandomGenerator& random)
+    LoadBalancerImpl(DeferredCreationCompatibleClusterLbStats& stats,
+                     Random::RandomGenerator& random)
         : stats_(stats), random_(random) {}
 
     // Upstream::LoadBalancer
@@ -138,7 +140,7 @@ private:
       return {};
     }
 
-    ClusterLbStats& stats_;
+    DeferredCreationCompatibleClusterLbStats& stats_;
     Random::RandomGenerator& random_;
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_;
     std::shared_ptr<HealthyLoad> healthy_per_priority_load_;
@@ -146,14 +148,15 @@ private:
   };
 
   struct LoadBalancerFactoryImpl : public LoadBalancerFactory {
-    LoadBalancerFactoryImpl(ClusterLbStats& stats, Random::RandomGenerator& random)
+    LoadBalancerFactoryImpl(DeferredCreationCompatibleClusterLbStats& stats,
+                            Random::RandomGenerator& random)
         : stats_(stats), random_(random) {}
 
     // Upstream::LoadBalancerFactory
     // Ignore the params for the thread-aware LB.
     LoadBalancerPtr create(LoadBalancerParams) override;
 
-    ClusterLbStats& stats_;
+    DeferredCreationCompatibleClusterLbStats& stats_;
     Random::RandomGenerator& random_;
     absl::Mutex mutex_;
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_ ABSL_GUARDED_BY(mutex_);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1052,7 +1052,9 @@ ClusterInfoImpl::ClusterInfoImpl(
                                    server_context.statsConfig().enableDeferredCreationStats())),
       config_update_stats_(factory_context.clusterManager().clusterConfigUpdateStatNames(),
                            *stats_scope_),
-      lb_stats_(factory_context.clusterManager().clusterLbStatNames(), *stats_scope_),
+      lb_stats_(Stats::createDeferredCompatibleStats<ClusterLbStats>(
+          stats_scope_, factory_context.clusterManager().clusterLbStatNames(),
+          server_context.statsConfig().enableDeferredCreationStats())),
       endpoint_stats_(factory_context.clusterManager().clusterEndpointStatNames(), *stats_scope_),
       load_report_stats_store_(stats_scope_->symbolTable()),
       load_report_stats_(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -916,7 +916,7 @@ public:
     return traffic_stats_;
   }
   ClusterConfigUpdateStats& configUpdateStats() const override { return config_update_stats_; }
-  ClusterLbStats& lbStats() const override { return lb_stats_; }
+  DeferredCreationCompatibleClusterLbStats& lbStats() const override { return lb_stats_; }
   ClusterEndpointStats& endpointStats() const override { return endpoint_stats_; }
   Stats::Scope& statsScope() const override { return *stats_scope_; }
 
@@ -1061,7 +1061,7 @@ private:
   Stats::ScopeSharedPtr stats_scope_;
   mutable DeferredCreationCompatibleClusterTrafficStats traffic_stats_;
   mutable ClusterConfigUpdateStats config_update_stats_;
-  mutable ClusterLbStats lb_stats_;
+  mutable DeferredCreationCompatibleClusterLbStats lb_stats_;
   mutable ClusterEndpointStats endpoint_stats_;
   Stats::IsolatedStoreImpl load_report_stats_store_;
   mutable ClusterLoadReportStats load_report_stats_;

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -9,6 +9,7 @@
 #include "envoy/upstream/thread_local_cluster.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/stats/deferred_creation.h"
 #include "source/common/upstream/cluster_factory_impl.h"
 #include "source/common/upstream/upstream_impl.h"
 #include "source/extensions/clusters/aggregate/lb_context.h"
@@ -87,7 +88,8 @@ private:
   // priority set could be empty, we cannot initialize LoadBalancerBase when priority set is empty.
   class LoadBalancerImpl : public Upstream::LoadBalancerBase {
   public:
-    LoadBalancerImpl(const PriorityContext& priority_context, Upstream::ClusterLbStats& lb_stats,
+    LoadBalancerImpl(const PriorityContext& priority_context,
+                     Upstream::DeferredCreationCompatibleClusterLbStats& lb_stats,
                      Runtime::Loader& runtime, Random::RandomGenerator& random,
                      const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
         : Upstream::LoadBalancerBase(priority_context.priority_set_, lb_stats, runtime, random,

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
@@ -274,8 +274,8 @@ uint64_t MaglevTable::permutation(const TableBuildEntry& entry) {
 }
 
 MaglevLoadBalancer::MaglevLoadBalancer(
-    const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-    Runtime::Loader& runtime, Random::RandomGenerator& random,
+    const PrioritySet& priority_set, DeferredCreationCompatibleClusterLbStats& stats,
+    Stats::Scope& scope, Runtime::Loader& runtime, Random::RandomGenerator& random,
     OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> config,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
     : ThreadAwareLoadBalancerBase(priority_set, stats, runtime, random,
@@ -300,8 +300,9 @@ MaglevLoadBalancer::MaglevLoadBalancer(
 }
 
 MaglevLoadBalancer::MaglevLoadBalancer(
-    const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-    Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+    const PrioritySet& priority_set, DeferredCreationCompatibleClusterLbStats& stats,
+    Stats::Scope& scope, Runtime::Loader& runtime, Random::RandomGenerator& random,
+    uint32_t healthy_panic_threshold,
     const envoy::extensions::load_balancing_policies::maglev::v3::Maglev& config)
     : ThreadAwareLoadBalancerBase(priority_set, stats, runtime, random, healthy_panic_threshold,
                                   config.has_locality_weighted_lb_config()),

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.h
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.h
@@ -146,12 +146,14 @@ private:
  */
 class MaglevLoadBalancer : public ThreadAwareLoadBalancerBase {
 public:
-  MaglevLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
+  MaglevLoadBalancer(const PrioritySet& priority_set,
+                     DeferredCreationCompatibleClusterLbStats& stats, Stats::Scope& scope,
                      Runtime::Loader& runtime, Random::RandomGenerator& random,
                      OptRef<const envoy::config::cluster::v3::Cluster::MaglevLbConfig> config,
                      const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
 
-  MaglevLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
+  MaglevLoadBalancer(const PrioritySet& priority_set,
+                     DeferredCreationCompatibleClusterLbStats& stats, Stats::Scope& scope,
                      Runtime::Loader& runtime, Random::RandomGenerator& random,
                      uint32_t healthy_panic_threshold,
                      const envoy::extensions::load_balancing_policies::maglev::v3::Maglev& config);

--- a/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.cc
+++ b/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.cc
@@ -17,8 +17,8 @@ namespace Envoy {
 namespace Upstream {
 
 RingHashLoadBalancer::RingHashLoadBalancer(
-    const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-    Runtime::Loader& runtime, Random::RandomGenerator& random,
+    const PrioritySet& priority_set, DeferredCreationCompatibleClusterLbStats& stats,
+    Stats::Scope& scope, Runtime::Loader& runtime, Random::RandomGenerator& random,
     OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> config,
     const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config)
     : ThreadAwareLoadBalancerBase(priority_set, stats, runtime, random,
@@ -50,8 +50,9 @@ RingHashLoadBalancer::RingHashLoadBalancer(
 }
 
 RingHashLoadBalancer::RingHashLoadBalancer(
-    const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-    Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+    const PrioritySet& priority_set, DeferredCreationCompatibleClusterLbStats& stats,
+    Stats::Scope& scope, Runtime::Loader& runtime, Random::RandomGenerator& random,
+    uint32_t healthy_panic_threshold,
     const envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash& config)
     : ThreadAwareLoadBalancerBase(priority_set, stats, runtime, random, healthy_panic_threshold,
                                   config.has_locality_weighted_lb_config()),

--- a/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.h
+++ b/source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.h
@@ -41,14 +41,16 @@ struct RingHashLoadBalancerStats {
  */
 class RingHashLoadBalancer : public ThreadAwareLoadBalancerBase {
 public:
-  RingHashLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
+  RingHashLoadBalancer(const PrioritySet& priority_set,
+                       DeferredCreationCompatibleClusterLbStats& stats, Stats::Scope& scope,
                        Runtime::Loader& runtime, Random::RandomGenerator& random,
                        OptRef<const envoy::config::cluster::v3::Cluster::RingHashLbConfig> config,
                        const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
 
   RingHashLoadBalancer(
-      const PrioritySet& priority_set, ClusterLbStats& stats, Stats::Scope& scope,
-      Runtime::Loader& runtime, Random::RandomGenerator& random, uint32_t healthy_panic_threshold,
+      const PrioritySet& priority_set, DeferredCreationCompatibleClusterLbStats& stats,
+      Stats::Scope& scope, Runtime::Loader& runtime, Random::RandomGenerator& random,
+      uint32_t healthy_panic_threshold,
       const envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash& config);
 
   const RingHashLoadBalancerStats& stats() const { return stats_; }

--- a/source/extensions/load_balancing_policies/subset/config.cc
+++ b/source/extensions/load_balancing_policies/subset/config.cc
@@ -87,8 +87,9 @@ public:
 
   std::pair<Upstream::ThreadAwareLoadBalancerPtr, Upstream::LoadBalancerPtr>
   createLoadBalancer(const Upstream::PrioritySet& child_priority_set, const Upstream::PrioritySet*,
-                     Upstream::ClusterLbStats&, Stats::Scope&, Runtime::Loader& runtime,
-                     Random::RandomGenerator& random, TimeSource& time_source) override {
+                     Upstream::DeferredCreationCompatibleClusterLbStats&, Stats::Scope&,
+                     Runtime::Loader& runtime, Random::RandomGenerator& random,
+                     TimeSource& time_source) override {
     return {subset_config_.createLoadBalancer(cluster_info_, child_priority_set, runtime, random,
                                               time_source),
             nullptr};

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -39,8 +39,9 @@ public:
 
   virtual std::pair<ThreadAwareLoadBalancerPtr, LoadBalancerPtr>
   createLoadBalancer(const PrioritySet& child_priority_set, const PrioritySet* local_priority_set,
-                     ClusterLbStats& stats, Stats::Scope& scope, Runtime::Loader& runtime,
-                     Random::RandomGenerator& random, TimeSource& time_source) PURE;
+                     DeferredCreationCompatibleClusterLbStats& stats, Stats::Scope& scope,
+                     Runtime::Loader& runtime, Random::RandomGenerator& random,
+                     TimeSource& time_source) PURE;
 };
 using ChildLoadBalancerCreatorPtr = std::unique_ptr<ChildLoadBalancerCreator>;
 
@@ -56,8 +57,9 @@ public:
 
   std::pair<Upstream::ThreadAwareLoadBalancerPtr, Upstream::LoadBalancerPtr>
   createLoadBalancer(const Upstream::PrioritySet& child_priority_set,
-                     const Upstream::PrioritySet* local_priority_set, ClusterLbStats& stats,
-                     Stats::Scope& scope, Runtime::Loader& runtime, Random::RandomGenerator& random,
+                     const Upstream::PrioritySet* local_priority_set,
+                     DeferredCreationCompatibleClusterLbStats& stats, Stats::Scope& scope,
+                     Runtime::Loader& runtime, Random::RandomGenerator& random,
                      TimeSource& time_source) override;
 
   OptRef<const envoy::config::cluster::v3::Cluster::RoundRobinLbConfig> lbRoundRobinConfig() const {
@@ -165,8 +167,9 @@ class SubsetLoadBalancer : public LoadBalancer, Logger::Loggable<Logger::Id::ups
 public:
   SubsetLoadBalancer(const LoadBalancerSubsetInfo& subsets, ChildLoadBalancerCreatorPtr child_lb,
                      const PrioritySet& priority_set, const PrioritySet* local_priority_set,
-                     ClusterLbStats& stats, Stats::Scope& scope, Runtime::Loader& runtime,
-                     Random::RandomGenerator& random, TimeSource& time_source);
+                     DeferredCreationCompatibleClusterLbStats& stats, Stats::Scope& scope,
+                     Runtime::Loader& runtime, Random::RandomGenerator& random,
+                     TimeSource& time_source);
   ~SubsetLoadBalancer() override;
 
   // Upstream::LoadBalancer
@@ -490,7 +493,7 @@ private:
   const ProtobufWkt::Value* getMetadataFallbackList(LoadBalancerContext* context) const;
   LoadBalancerContextWrapper removeMetadataFallbackList(LoadBalancerContext* context);
 
-  ClusterLbStats& stats_;
+  DeferredCreationCompatibleClusterLbStats& stats_;
   Stats::Scope& scope_;
   Runtime::Loader& runtime_;
   Random::RandomGenerator& random_;

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -6,6 +6,7 @@
 
 #include "source/common/common/random_generator.h"
 #include "source/common/memory/stats.h"
+#include "source/common/stats/deferred_creation.h"
 #include "source/common/upstream/upstream_impl.h"
 #include "source/extensions/load_balancing_policies/maglev/maglev_lb.h"
 #include "source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.h"
@@ -73,7 +74,9 @@ public:
   Stats::IsolatedStoreImpl stats_store_;
   Stats::Scope& stats_scope_{*stats_store_.rootScope()};
   ClusterLbStatNames stat_names_{stats_store_.symbolTable()};
-  ClusterLbStats stats_{stat_names_, stats_scope_};
+  DeferredCreationCompatibleClusterLbStats stats_{
+      Stats::createDeferredCompatibleStats<ClusterLbStats>(stats_store_.rootScope(), stat_names_,
+                                                           false)};
   NiceMock<Runtime::MockLoader> runtime_;
   Random::RandomGeneratorImpl random_;
   envoy::config::cluster::v3::Cluster::CommonLbConfig common_config_;

--- a/test/common/upstream/load_balancer_fuzz_base.h
+++ b/test/common/upstream/load_balancer_fuzz_base.h
@@ -2,6 +2,7 @@
 
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
+#include "source/common/stats/deferred_creation.h"
 #include "source/common/upstream/load_balancer_impl.h"
 
 #include "test/common/upstream/load_balancer_fuzz.pb.validate.h"
@@ -21,7 +22,9 @@ namespace Upstream {
 class LoadBalancerFuzzBase {
 public:
   LoadBalancerFuzzBase()
-      : stat_names_(stats_store_.symbolTable()), stats_(stat_names_, *stats_store_.rootScope()){};
+      : stat_names_(stats_store_.symbolTable()),
+        stats_(Stats::createDeferredCompatibleStats<ClusterLbStats>(stats_store_.rootScope(),
+                                                                    stat_names_, true)){};
 
   // Initializes load balancer components shared amongst every load balancer, random_, and
   // priority_set_
@@ -42,7 +45,7 @@ public:
   // balancers in specific load balancer fuzz classes
   Stats::IsolatedStoreImpl stats_store_;
   ClusterLbStatNames stat_names_;
-  ClusterLbStats stats_;
+  DeferredCreationCompatibleClusterLbStats stats_;
   NiceMock<Runtime::MockLoader> runtime_;
   Random::PsuedoRandomGenerator64 random_;
   NiceMock<MockPrioritySet> priority_set_;

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -7,6 +7,7 @@
 #include "envoy/router/router.h"
 
 #include "source/common/network/utility.h"
+#include "source/common/stats/deferred_creation.h"
 #include "source/common/upstream/upstream_impl.h"
 #include "source/extensions/load_balancing_policies/ring_hash/ring_hash_lb.h"
 
@@ -59,7 +60,9 @@ class RingHashLoadBalancerTest : public Event::TestUsingSimulatedTime,
                                  public testing::TestWithParam<bool> {
 public:
   RingHashLoadBalancerTest()
-      : stat_names_(stats_store_.symbolTable()), stats_(stat_names_, *stats_store_.rootScope()) {}
+      : stat_names_(stats_store_.symbolTable()),
+        stats_(Stats::createDeferredCompatibleStats<ClusterLbStats>(stats_store_.rootScope(),
+                                                                    stat_names_, false)) {}
 
   void init(bool locality_weighted_balancing = false) {
     if (locality_weighted_balancing) {
@@ -91,7 +94,7 @@ public:
   std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
   Stats::IsolatedStoreImpl stats_store_;
   ClusterLbStatNames stat_names_;
-  ClusterLbStats stats_;
+  DeferredCreationCompatibleClusterLbStats stats_;
   absl::optional<envoy::config::cluster::v3::Cluster::RingHashLbConfig> config_;
   envoy::config::cluster::v3::Cluster::CommonLbConfig common_config_;
   NiceMock<Runtime::MockLoader> runtime_;
@@ -210,7 +213,7 @@ TEST_P(RingHashLoadBalancerTest, Basic) {
     EXPECT_CALL(random_, random()).WillOnce(Return(16117243373044804880UL));
     EXPECT_EQ(hostSet().hosts_[0], lb->chooseHost(nullptr));
   }
-  EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(0UL, stats_->lb_healthy_panic_.value());
 
   hostSet().healthy_hosts_.clear();
   hostSet().runCallbacks({}, {});
@@ -219,7 +222,7 @@ TEST_P(RingHashLoadBalancerTest, Basic) {
     TestLoadBalancerContext context(0);
     EXPECT_EQ(hostSet().hosts_[4], lb->chooseHost(&context));
   }
-  EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(1UL, stats_->lb_healthy_panic_.value());
 }
 
 // Ensure if all the hosts with priority 0 unhealthy, the next priority hosts are used.
@@ -316,7 +319,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMurmur2) {
     EXPECT_CALL(random_, random()).WillOnce(Return(10150910876324007730UL));
     EXPECT_EQ(hostSet().hosts_[2], lb->chooseHost(nullptr));
   }
-  EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(0UL, stats_->lb_healthy_panic_.value());
 }
 
 // Expect reasonable results with hostname.
@@ -379,7 +382,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
     EXPECT_EQ(hostSet().hosts_[3], lb->chooseHost(&context));
   }
   { EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(nullptr)); }
-  EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(0UL, stats_->lb_healthy_panic_.value());
 
   hostSet().healthy_hosts_.clear();
   hostSet().runCallbacks({}, {});
@@ -388,7 +391,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
     TestLoadBalancerContext context(0);
     EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
   }
-  EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(1UL, stats_->lb_healthy_panic_.value());
 }
 
 // Expect reasonable results with metadata hash_key.
@@ -451,7 +454,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMetadataHashKey) {
     EXPECT_EQ(hostSet().hosts_[3], lb->chooseHost(&context));
   }
   { EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(nullptr)); }
-  EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(0UL, stats_->lb_healthy_panic_.value());
 
   hostSet().healthy_hosts_.clear();
   hostSet().runCallbacks({}, {});
@@ -460,7 +463,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMetadataHashKey) {
     TestLoadBalancerContext context(0);
     EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
   }
-  EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
+  EXPECT_EQ(1UL, stats_->lb_healthy_panic_.value());
 }
 
 // Test the same ring as Basic but exercise retry host predicate behavior.

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -65,7 +65,8 @@ MockClusterInfo::MockClusterInfo()
       traffic_stats_(
           ClusterInfoImpl::generateStats(stats_store_.rootScope(), traffic_stat_names_, false)),
       config_update_stats_(config_update_stats_names_, *stats_store_.rootScope()),
-      lb_stats_(lb_stat_names_, *stats_store_.rootScope()),
+      lb_stats_(Stats::createDeferredCompatibleStats<ClusterLbStats>(stats_store_.rootScope(),
+                                                                     lb_stat_names_, false)),
       endpoint_stats_(endpoint_stat_names_, *stats_store_.rootScope()),
       transport_socket_matcher_(new NiceMock<Upstream::MockTransportSocketMatcher>()),
       load_report_stats_(ClusterInfoImpl::generateLoadReportStats(

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -17,6 +17,7 @@
 #include "source/common/http/http1/codec_stats.h"
 #include "source/common/http/http2/codec_stats.h"
 #include "source/common/http/http3/codec_stats.h"
+#include "source/common/stats/deferred_creation.h"
 #include "source/common/upstream/upstream_impl.h"
 
 #include "test/mocks/runtime/mocks.h"
@@ -153,7 +154,7 @@ public:
   MOCK_METHOD(ResourceManager&, resourceManager, (ResourcePriority priority), (const));
   MOCK_METHOD(TransportSocketMatcher&, transportSocketMatcher, (), (const));
   MOCK_METHOD(DeferredCreationCompatibleClusterTrafficStats&, trafficStats, (), (const));
-  MOCK_METHOD(ClusterLbStats&, lbStats, (), (const));
+  MOCK_METHOD(DeferredCreationCompatibleClusterLbStats&, lbStats, (), (const));
   MOCK_METHOD(ClusterEndpointStats&, endpointStats, (), (const));
   MOCK_METHOD(ClusterConfigUpdateStats&, configUpdateStats, (), (const));
   MOCK_METHOD(Stats::Scope&, statsScope, (), (const));
@@ -215,7 +216,7 @@ public:
   ClusterTimeoutBudgetStatNames cluster_timeout_budget_stat_names_;
   mutable DeferredCreationCompatibleClusterTrafficStats traffic_stats_;
   ClusterConfigUpdateStats config_update_stats_;
-  ClusterLbStats lb_stats_;
+  DeferredCreationCompatibleClusterLbStats lb_stats_;
   ClusterEndpointStats endpoint_stats_;
   Upstream::TransportSocketMatcherPtr transport_socket_matcher_;
   NiceMock<Stats::MockIsolatedStatsStore> load_report_stats_store_;


### PR DESCRIPTION
Commit Message: Makes clusterLBStats deferred compatible
Additional Description: This makes it so that if enabled, these stats will not load immediately, which will help save memory for instances where there are a lot of unused clusters.
Risk Level: Low
