### PR TITLE
ci: GCS postsubmit uploads use redirect

### DIFF
--- a/ci/upload_gcs_artifact.sh
+++ b/ci/upload_gcs_artifact.sh
@@ -38,17 +38,20 @@ if [ ! -d "${SOURCE_DIRECTORY}" ]; then
     exit 1
 fi
 
-if [[ "$BUILD_REASON" == "PullRequest" ]] || [[ "$TARGET_SUFFIX" == "docs" ]] || [[ "$TARGET_SUFFIX" == "docker" ]]; then
-    # upload to the last commit sha (first 7 chars), either
-    # - docs/docker build on main, eg docs
-    #      -> https://storage.googleapis.com/envoy-postsubmit/$UPLOAD_PATH/docs/envoy-docs-rst.tar.gz
-    # - PR build (commit sha from the developers branch)
-    #      -> https://storage.googleapis.com/envoy-pr/$UPLOAD_PATH/$TARGET_SUFFIX
-    UPLOAD_PATH="$(git rev-parse HEAD | head -c7)"
-else
-    UPLOAD_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
-fi
+# Upload to the last commit sha (first 7 chars)
+# the bucket is either `envoy-postsubmit` or `envoy-pr`
+#
+# For example, docs might be uploaded to:
+#
+#   https://storage.googleapis.com/envoy-pr/20b4893/docs/index.html
+#
+# With a redirect from the PR to the latest build:
+#
+#   https://storage.googleapis.com/envoy-pr/28462/docs/index.html
+#
 
+UPLOAD_PATH="$(git rev-parse HEAD | head -c7)"
+REDIRECT_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
 GCS_LOCATION="${GCS_ARTIFACT_BUCKET}/${UPLOAD_PATH}/${TARGET_SUFFIX}"
 
 echo "Uploading to gs://${GCS_LOCATION} ..."
@@ -58,22 +61,18 @@ bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" \
          -dr "${SOURCE_DIRECTORY}" \
          "gs://${GCS_LOCATION}"
 
-# For PR uploads, add a redirect `PR_NUMBER` -> `COMMIT_SHA`
-if [[ "$BUILD_REASON" == "PullRequest" ]]; then
-    REDIRECT_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
-    TMP_REDIRECT="/tmp/redirect/${REDIRECT_PATH}/${TARGET_SUFFIX}"
-    mkdir -p "$TMP_REDIRECT"
-    echo "<meta http-equiv=\"refresh\" content=\"0; URL='https://storage.googleapis.com/${GCS_LOCATION}/index.html'\" />" \
-         >  "${TMP_REDIRECT}/index.html"
-    GCS_REDIRECT="${GCS_ARTIFACT_BUCKET}/${REDIRECT_PATH}/${TARGET_SUFFIX}"
-    echo "Uploading redirect to gs://${GCS_REDIRECT} ..."
-    bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" \
-          //tools/gsutil \
-          -- -h "Cache-Control:no-cache,max-age=0" \
-             -mq rsync \
-             -dr "${TMP_REDIRECT}" \
-             "gs://${GCS_REDIRECT}"
-fi
+TMP_REDIRECT="/tmp/redirect/${REDIRECT_PATH}/${TARGET_SUFFIX}"
+mkdir -p "$TMP_REDIRECT"
+echo "<meta http-equiv=\"refresh\" content=\"0; URL='https://storage.googleapis.com/${GCS_LOCATION}/index.html'\" />" \
+     >  "${TMP_REDIRECT}/index.html"
+GCS_REDIRECT="${GCS_ARTIFACT_BUCKET}/${REDIRECT_PATH}/${TARGET_SUFFIX}"
+echo "Uploading redirect to gs://${GCS_REDIRECT} ..."
+bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" \
+      //tools/gsutil \
+      -- -h "Cache-Control:no-cache,max-age=0" \
+         -mq rsync \
+         -dr "${TMP_REDIRECT}" \
+         "gs://${GCS_REDIRECT}"
 
 if [[ "${COVERAGE_FAILED}" -eq 1 ]]; then
     echo "##vso[task.logissue type=error]Coverage failed, check artifact at: https://storage.googleapis.com/${GCS_LOCATION}/index.html"


### PR DESCRIPTION
This makes postsubmit work similar to how PRs currently work - ie uploads (docs/coverage/etc) are pushed to a path using the current commit hash, and the a redirect from the branch name is added

This will resolve a recent issue where coverage was failing in postsubmit but we lost the record of why

It also fixes github postsubmit publishing which is looking for the tarball in the wrong place

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
