### PR TITLE
ci/fuzz: Increase resources for failing fuzz_coverage tests

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -259,9 +259,11 @@ envoy_cc_test(
 
 envoy_cc_fuzz_test(
     name = "server_fuzz_test",
+    size = "enormous",
     srcs = ["server_fuzz_test.cc"],
     corpus = "server_corpus",
-    shard_count = 4,
+    shard_count = 8,
+    tags = ["cpu:16"],
     deps = [
         "//source/common/thread_local:thread_local_lib",
         "//source/server:server_lib",

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -87,9 +87,11 @@ envoy_cc_test(
 
 envoy_cc_fuzz_test(
     name = "config_fuzz_test",
+    size = "enormous",
     srcs = ["config_fuzz_test.cc"],
     corpus = "//test/server:server_fuzz_test_corpus",
-    shard_count = 4,
+    shard_count = 8,
+    tags = ["cpu:16"],
     deps = [
         "//source/common/common:thread_lib",
         "//source/server/config_validation:server_lib",


### PR DESCRIPTION
In #28366 we increased the sharding to resolve timeout issues in Envoy CI

that seems to have worked, but in mirror repos with less caching this is still timing out so this PR increases the sharding further

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
