### PR TITLE
ci/github: Improve PR/commit info in `env`

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -60,6 +60,8 @@ outputs:
     value: ${{ steps.should_run.outputs.mobile_tsan }}
   repo_ref_name:
     value: ${{ steps.context.outputs.repo_ref_name }}
+  repo_ref_pr_number:
+    value: ${{ steps.context.outputs.repo_ref_pr_number }}
   repo_ref_sha:
     value: ${{ steps.context.outputs.repo_ref_sha }}
   repo_ref_sha_short:
@@ -123,7 +125,11 @@ runs:
       REF_NAME=${{ inputs.repo_ref_name || github.ref_name }}
       if [[ "$REF_NAME" =~ ^refs/pull/ ]]; then
           REF_NAME="${REF_NAME:10}"
+          REF_PR_NUMBER="$(echo "${REF_NAME}" | cut -d/ -f1)"
+      elif [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+          REF_PR_NUMBER="$(echo "${REF_NAME}" | cut -d/ -f1)"
       fi
+      echo "SET PR NUMBER: ${REF_PR_NUMBER}"
 
       REF_SHA=${{ inputs.repo_ref_sha || github.event.pull_request.head.sha || github.sha }}
       REF_SHA_SHORT="${REF_SHA:0:7}"
@@ -134,6 +140,7 @@ runs:
       REF_TITLE="$(printf %s "${REF_TITLE[@]}" $'\n')"
       {
           echo "repo_ref_name=$REF_NAME"
+          echo "repo_ref_pr_number=$REF_PR_NUMBER"
           echo "repo_ref_sha=$REF_SHA"
           echo "repo_ref_title=$REF_TITLE"
           echo "repo_ref_sha_short=$REF_SHA_SHORT"

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -141,11 +141,16 @@ jobs:
         echo "version_patch=${{ steps.env.outputs.version_patch }}"
         echo "trusted=${{ steps.env.outputs.trusted }}"
         echo "repo_ref_name=${{ steps.env.outputs.repo_ref_name }}"
+        echo "repo_ref_pr_number=${{ steps.env.outputs.repo_ref_pr_number }}"
         echo "repo_ref_sha=${{ steps.env.outputs.repo_ref_sha }}"
         echo "repo_ref_sha_short=${{ steps.env.outputs.repo_ref_sha_short }}"
         echo "repo_ref_title=${{ steps.env.outputs.repo_ref_title }}"
         echo "build_image_ubuntu=${{ steps.env.outputs.build_image_ubuntu }}"
         echo "build_image_ubuntu_mobile=${{ steps.env.outputs.build_image_ubuntu_mobile }}"
+        echo
+        if [[ -n "${{ steps.env.outputs.repo_ref_pr_number }}" ]]; then
+            echo "PR: https://github.com/envoyproxy/envoy/pull/${{ steps.env.outputs.repo_ref_pr_number }}"
+        fi
 
   check:
     if: ${{ inputs.start_check_status && github.event_name != 'pull_request' }}


### PR DESCRIPTION
Currently its quite hard to associate a CI run <> PR 

This adds a link in the `env/repo::Print env` step to the PR and provides the environment with a pr number where appropriate 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
