### PR TITLE
clean up the end_of_stream encoding when sending body to the ext_proc server 

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -221,11 +221,6 @@ message HttpHeaders {
 message HttpBody {
   bytes body = 1;
 
-  // This contains the end_stream flag when Envoy receives data from the client
-  // or upstream server. In normal cases, this flag imply this is the last data
-  // sent to the external processing server, and there will be no trailer after it.
-  // However, if processing mode is set to send trailers, there will be an empty
-  // trailer sent to the external server even this flag is set to true.
   bool end_of_stream = 2;
 }
 

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -221,6 +221,11 @@ message HttpHeaders {
 message HttpBody {
   bytes body = 1;
 
+  // This contains the end_stream flag when Envoy receives data from the client
+  // or upstream server. In normal cases, this flag imply this is the last data
+  // sent to the external processing server, and there will be no trailer after it.
+  // However, if processing mode is set to send trailers, there will be an empty
+  // trailer sent to the external server even this flag is set to true.
   bool end_of_stream = 2;
 }
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -218,10 +218,6 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool end_st
 }
 
 FilterDataStatus Filter::onData(ProcessorState& state, Buffer::Instance& data, bool end_stream) {
-  // Stores the end_stream flag, which will be used when sending body to the external
-  // processing server in later stages.
-  body_end_stream_ = end_stream;
-
   if (end_stream) {
     state.setCompleteBodyAvailable(true);
   }
@@ -472,8 +468,8 @@ FilterTrailersStatus Filter::onTrailers(ProcessorState& state, Http::HeaderMap& 
     }
     // We would like to process the body in a buffered way, but until now the complete
     // body has not arrived. With the arrival of trailers, we now know that the body
-    // has arrived. end_stream is false for data sending as there is trailer behind.
-    sendBufferedData(state, ProcessorState::CallbackState::BufferedBodyCallback, false);
+    // has arrived.
+    sendBufferedData(state, ProcessorState::CallbackState::BufferedBodyCallback, true);
     state.setPaused(true);
     return FilterTrailersStatus::StopIteration;
   }
@@ -558,7 +554,7 @@ void Filter::sendBufferedData(ProcessorState& state, ProcessorState::CallbackSta
   } else {
     // If there is no buffered data, sends an empty body.
     Buffer::OwnedImpl data("");
-    sendBodyChunk(state, data, new_state, true);
+    sendBodyChunk(state, data, new_state, end_stream);
   }
 }
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -262,6 +262,8 @@ public:
 
   void sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers);
 
+  bool bodyEndStream() { return body_end_stream_; }
+
 private:
   void mergePerRouteConfig();
   StreamOpenState openStream();
@@ -303,6 +305,11 @@ private:
 
   // Set to true then the mergePerRouteConfig() method has been called.
   bool route_config_merged_ = false;
+
+  // Stores the end_stream flag in onData() processing. It is used later on
+  // when sending the data to the external processing server during processing
+  // the header response, In that state, the end_stream flag is not availabe.
+  bool body_end_stream_ = false;
 };
 
 extern std::string responseCaseToString(

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -262,6 +262,8 @@ public:
 
   void sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers);
 
+  bool bodyEndStream() { return body_end_stream_; }
+
 private:
   void mergePerRouteConfig();
   StreamOpenState openStream();
@@ -303,6 +305,11 @@ private:
 
   // Set to true then the mergePerRouteConfig() method has been called.
   bool route_config_merged_ = false;
+
+  // Stores the end_stream flag in onData() processing. It is used later on
+  // when sending the data to the external processing server during processing
+  // the header response, In that state, the end_stream flag is not available.
+  bool body_end_stream_ = false;
 };
 
 extern std::string responseCaseToString(

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -262,8 +262,6 @@ public:
 
   void sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers);
 
-  bool bodyEndStream() { return body_end_stream_; }
-
 private:
   void mergePerRouteConfig();
   StreamOpenState openStream();
@@ -305,11 +303,6 @@ private:
 
   // Set to true then the mergePerRouteConfig() method has been called.
   bool route_config_merged_ = false;
-
-  // Stores the end_stream flag in onData() processing. It is used later on
-  // when sending the data to the external processing server during processing
-  // the header response, In that state, the end_stream flag is not available.
-  bool body_end_stream_ = false;
 };
 
 extern std::string responseCaseToString(

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -130,8 +130,7 @@ absl::Status ProcessorState::handleHeadersResponse(const HeadersResponse& respon
         // here then the whole body is in the buffer and we can proceed as if the
         // "buffered" processing mode was set.
         ENVOY_LOG(debug, "Sending buffered request body message");
-        filter_.sendBufferedData(*this, ProcessorState::CallbackState::BufferedBodyCallback,
-                                 filter_.bodyEndStream());
+        filter_.sendBufferedData(*this, ProcessorState::CallbackState::BufferedBodyCallback, true);
         clearWatermark();
         return absl::OkStatus();
       } else if (body_mode_ == ProcessingMode::BUFFERED) {

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -130,7 +130,8 @@ absl::Status ProcessorState::handleHeadersResponse(const HeadersResponse& respon
         // here then the whole body is in the buffer and we can proceed as if the
         // "buffered" processing mode was set.
         ENVOY_LOG(debug, "Sending buffered request body message");
-        filter_.sendBufferedData(*this, ProcessorState::CallbackState::BufferedBodyCallback, true);
+        filter_.sendBufferedData(*this, ProcessorState::CallbackState::BufferedBodyCallback,
+                                 filter_.bodyEndStream());
         clearWatermark();
         return absl::OkStatus();
       } else if (body_mode_ == ProcessingMode::BUFFERED) {

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -989,8 +989,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersOnResponsePartialBuffered)
 
   // Should get just one message with the body
   processResponseBodyMessage(
-      *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& body_resp) {
-        EXPECT_TRUE(body.end_of_stream());
+      *grpc_upstreams_[0], false, [](const HttpBody&, BodyResponse& body_resp) {
         auto* header_mut = body_resp.mutable_response()->mutable_header_mutation();
         auto* header_add = header_mut->add_set_headers();
         header_add->mutable_header()->set_key("x-testing-response-header");
@@ -1018,7 +1017,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyAndHeadersAndTrailersOnResponse) {
 
   // Should get just one message with the body
   processResponseBodyMessage(*grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse&) {
-    EXPECT_FALSE(body.end_of_stream());
+    EXPECT_TRUE(body.end_of_stream());
     return true;
   });
 
@@ -1434,8 +1433,7 @@ TEST_P(ExtProcIntegrationTest, GetAndIncorrectlyModifyHeaderOnBody) {
   auto response = sendDownstreamRequestWithBody("Original body", absl::nullopt);
   processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
   processRequestBodyMessage(
-      *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& response) {
-        EXPECT_TRUE(body.end_of_stream());
+      *grpc_upstreams_[0], false, [](const HttpBody&, BodyResponse& response) {
         auto* mut = response.mutable_response()->mutable_header_mutation()->add_set_headers();
         mut->mutable_header()->set_key(":scheme");
         mut->mutable_header()->set_value("tcp");
@@ -1456,8 +1454,7 @@ TEST_P(ExtProcIntegrationTest, GetAndIncorrectlyModifyHeaderOnBodyPartialBuffer)
   auto response = sendDownstreamRequestWithBody("Original body", absl::nullopt);
   processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
   processRequestBodyMessage(
-      *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& response) {
-        EXPECT_TRUE(body.end_of_stream());
+      *grpc_upstreams_[0], false, [](const HttpBody&, BodyResponse& response) {
         auto* mut = response.mutable_response()->mutable_header_mutation()->add_set_headers();
         mut->mutable_header()->set_key(":scheme");
         mut->mutable_header()->set_value("tcp");
@@ -2416,8 +2413,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetBodyOnBothWithClearRouteCache) {
       });
   upstream_request_->encodeData(100, true);
   processResponseBodyMessage(
-      *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& body_resp) {
-        EXPECT_TRUE(body.end_of_stream());
+      *grpc_upstreams_[0], false, [](const HttpBody&, BodyResponse& body_resp) {
         auto* header_mut = body_resp.mutable_response()->mutable_header_mutation();
         auto* header_add = header_mut->add_set_headers();
         header_add->mutable_header()->set_key("x-testing-response-header");
@@ -2475,7 +2471,7 @@ TEST_P(ExtProcIntegrationTest, HeaderMutationCheckPassWithHcmSizeConfig) {
       });
   processRequestBodyMessage(
       *grpc_upstreams_[0], false, [this](const HttpBody& body, BodyResponse& body_resp) {
-        EXPECT_FALSE(body.end_of_stream());
+        EXPECT_TRUE(body.end_of_stream());
         addMutationSetHeaders(20, *body_resp.mutable_response()->mutable_header_mutation());
         return true;
       });
@@ -2493,7 +2489,7 @@ TEST_P(ExtProcIntegrationTest, HeaderMutationCheckPassWithHcmSizeConfig) {
       });
   processResponseBodyMessage(
       *grpc_upstreams_[0], false, [this](const HttpBody& body, BodyResponse& body_resp) {
-        EXPECT_FALSE(body.end_of_stream());
+        EXPECT_TRUE(body.end_of_stream());
         addMutationSetHeaders(20, *body_resp.mutable_response()->mutable_header_mutation());
         return true;
       });
@@ -2598,8 +2594,7 @@ TEST_P(ExtProcIntegrationTest, RemoveHeaderMutationFailWithResponseBody) {
   handleUpstreamRequest();
   processResponseHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
   processResponseBodyMessage(
-      *grpc_upstreams_[0], false, [this](const HttpBody& body, BodyResponse& body_resp) {
-        EXPECT_TRUE(body.end_of_stream());
+      *grpc_upstreams_[0], false, [this](const HttpBody&, BodyResponse& body_resp) {
         addMutationRemoveHeaders(60, *body_resp.mutable_response()->mutable_header_mutation());
         return true;
       });


### PR DESCRIPTION
clean up the end_of_stream encoding when sending body to the ext_proc server.

It is observed that in different scenarios, Envoy ext_proc filter received the data with end_stream flag false, however, the data is sent to ext_proc server with end_of_stream true in the HttpBody message.  And the end_of_stream is not set consistently.  Fortunately this end_of_stream flag is not used in the ext_proc filter state machine, thus it is not causing functional issues in Envoy.  But it may confuse the ext_proc server and cause it misbehaves.



<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
