### PR TITLE
ci/github: Prevent github CI from staying `pending` (again)

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -12,6 +12,8 @@ inputs:
     type: string
     required: true
 
+  repo_ref:
+    type: string
   repo_ref_sha:
     type: string
   repo_ref_name:
@@ -58,6 +60,8 @@ outputs:
     value: ${{ steps.should_run.outputs.mobile_release_validation }}
   mobile_tsan:
     value: ${{ steps.should_run.outputs.mobile_tsan }}
+  repo_ref:
+    value: ${{ steps.context.outputs.repo_ref }}
   repo_ref_name:
     value: ${{ steps.context.outputs.repo_ref_name }}
   repo_ref_pr_number:
@@ -131,6 +135,7 @@ runs:
       fi
       echo "SET PR NUMBER: ${REF_PR_NUMBER}"
 
+      REF="${{ steps.trusted.outputs.trusted != 'true' && inputs.repo_ref || '' }}"
       REF_SHA=${{ inputs.repo_ref_sha || github.event.pull_request.head.sha || github.sha }}
       REF_SHA_SHORT="${REF_SHA:0:7}"
       REF_TITLE=(
@@ -139,6 +144,7 @@ runs:
           "@${REF_SHA_SHORT}")
       REF_TITLE="$(printf %s "${REF_TITLE[@]}" $'\n')"
       {
+          echo "repo_ref=$REF"
           echo "repo_ref_name=$REF_NAME"
           echo "repo_ref_pr_number=$REF_PR_NUMBER"
           echo "repo_ref_sha=$REF_SHA"

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -31,6 +31,9 @@ on:
         type: string
         default:
 
+      repo_ref:
+        type: string
+        default:
       repo_ref_sha:
         type: string
         default:
@@ -72,6 +75,8 @@ on:
       mobile_tsan:
         value: ${{ jobs.repo.outputs.mobile_tsan }}
 
+      repo_ref:
+        value: ${{ jobs.repo.outputs.repo_ref }}
       repo_ref_name:
         value: ${{ jobs.repo.outputs.repo_ref_name }}
       repo_ref_sha:
@@ -113,6 +118,7 @@ jobs:
       mobile_ios_tests: ${{ steps.env.outputs.mobile_ios_tests }}
       mobile_release_validation: ${{ steps.env.outputs.mobile_release_validation }}
       mobile_tsan: ${{ steps.env.outputs.mobile_tsan }}
+      repo_ref: ${{ steps.env.outputs.repo_ref }}
       repo_ref_name: ${{ steps.env.outputs.repo_ref_name }}
       repo_ref_sha: ${{ steps.env.outputs.repo_ref_sha }}
       repo_ref_sha_short: ${{ steps.env.outputs.repo_ref_sha_short }}
@@ -128,6 +134,7 @@ jobs:
       id: env
       with:
         check_mobile_run: ${{ inputs.check_mobile_run }}
+        repo_ref: ${{ inputs.repo_ref }}
         repo_ref_name: ${{ inputs.repo_ref_name }}
         repo_ref_sha: ${{ inputs.repo_ref_sha }}
         build_image_repo: ${{ inputs.build_image_repo }}
@@ -140,6 +147,7 @@ jobs:
         echo "version_dev=${{ steps.env.outputs.version_dev }}"
         echo "version_patch=${{ steps.env.outputs.version_patch }}"
         echo "trusted=${{ steps.env.outputs.trusted }}"
+        echo "repo_ref=${{ steps.env.outputs.repo_ref }}"
         echo "repo_ref_name=${{ steps.env.outputs.repo_ref_name }}"
         echo "repo_ref_pr_number=${{ steps.env.outputs.repo_ref_pr_number }}"
         echo "repo_ref_sha=${{ steps.env.outputs.repo_ref_sha }}"
@@ -160,6 +168,7 @@ jobs:
       statuses: write
     with:
       workflow_name: ${{ inputs.start_check_status }}
+      sha: ${{ inputs.repo_ref }}
 
   cache:
     if: ${{ inputs.prime_build_image }}

--- a/.github/workflows/_workflow-start.yml
+++ b/.github/workflows/_workflow-start.yml
@@ -11,6 +11,9 @@ on:
       workflow_name:
         required: true
         type: string
+      sha:
+        required: true
+        type: string
 
 jobs:
   start:
@@ -40,7 +43,7 @@ jobs:
       run: |
         mkdir -p ./sha
         echo $STATE_SHA > ./sha/state_sha
-    - if: ${{ ! steps.env.outputs.trusted }}
+    - if: ${{ steps.env.outputs.trusted != 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: state_sha

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -32,6 +32,7 @@ jobs:
       check_mobile_run: false
       prime_build_image: true
       start_check_status: Verify/examples
+      repo_ref: ${{ inputs.ref }}
       repo_ref_sha: ${{ inputs.sha }}
       repo_ref_name: ${{ inputs.head_ref }}
 
@@ -61,4 +62,4 @@ jobs:
     with:
       trusted: ${{ needs.env.outputs.trusted == 'true' && true || false }}
       given_ref: ${{ inputs.ref }}
-      repo_ref: ${{ needs.env.outputs.trusted != 'true' && inputs.ref || '' }}
+      repo_ref: ${{ needs.env.outputs.trusted != 'true' && needs.env.outputs.repo_ref || '' }}


### PR DESCRIPTION
Unfortunately, ~the check was either not fixed previously or~ i broke it again - this should fix and prevent Prs from always showing pending for the `Verify/examples` stage

This also tightens the code for trusted runs by unsetting the checkout sha earlier in ci 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
