### PR TITLE
[postgres] improve docs

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -55,6 +55,8 @@ message PostgresProxy {
   // Postgres filter is able to read Postgres payload in clear-text. It happens when
   // a client established a clear-text connection to Envoy or when a client established
   // SSL connection to Envoy and Postgres filter is configured to terminate SSL.
+  // In order for upstream encryption to work, the corresponding cluster must be configured to use
+  // :ref:`starttls transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.StartTlsConfig>`.
   // Defaults to SSL_DISABLE.
   SSLMode upstream_ssl = 4;
 }

--- a/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -56,7 +56,7 @@ message PostgresProxy {
   // a client established a clear-text connection to Envoy or when a client established
   // SSL connection to Envoy and Postgres filter is configured to terminate SSL.
   // In order for upstream encryption to work, the corresponding cluster must be configured to use
-  // :ref:`starttls transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.StartTlsConfig>`.
+  // :ref:`starttls transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.UpstreamStartTlsConfig>`.
   // Defaults to SSL_DISABLE.
   SSLMode upstream_ssl = 4;
 }

--- a/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -57,6 +57,6 @@ message PostgresProxy {
   // SSL connection to Envoy and Postgres filter is configured to terminate SSL.
   // In order for upstream encryption to work, the corresponding cluster must be configured to use
   // :ref:`starttls transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.UpstreamStartTlsConfig>`.
-  // Defaults to SSL_DISABLE.
+  // Defaults to ``SSL_DISABLE``.
   SSLMode upstream_ssl = 4;
 }

--- a/docs/root/intro/arch_overview/other_protocols/postgres.rst
+++ b/docs/root/intro/arch_overview/other_protocols/postgres.rst
@@ -13,6 +13,7 @@ offers the following features:
 
 * Decode non SSL traffic, ignore SSL traffic.
 * Decode session information.
+* Encode incoming non SSL traffic before forwarding upstream.
 * Capture transaction information, including commits and rollbacks.
 * Expose counters for different types of statements (INSERTs, DELETEs, UPDATEs, etc).
   The counters are updated based on decoding backend CommandComplete messages not by decoding SQL statements sent by a client.


### PR DESCRIPTION
* note that upstream encryption is available in the overview
* mention the starttls transport socket requirement for upstream encryption

Signed-off-by: Raul Gutierrez Segales <rsegales@nvidia.com>