### PR TITLE
Fix HTTP ext_authz filter partial request buffering off-by-one error

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -130,14 +130,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
 Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
   if (buffer_data_ && !skip_check_) {
-    const bool buffer_is_full = isBufferFull();
+    const bool buffer_is_full = isBufferFull(data.length());
     if (end_stream || buffer_is_full) {
       ENVOY_STREAM_LOG(debug, "ext_authz filter finished buffering the request since {}",
                        *decoder_callbacks_, buffer_is_full ? "buffer is full" : "stream is ended");
-      if (!buffer_is_full) {
-        // Make sure data is available in initiateCall.
-        decoder_callbacks_->addDecodedData(data, true);
-      }
+      // Make sure data is available in initiateCall.
+      decoder_callbacks_->addDecodedData(data, true);
       initiateCall(*request_headers_);
       return filter_return_ == FilterReturn::StopDecoding
                  ? Http::FilterDataStatus::StopIterationAndWatermark
@@ -432,12 +430,18 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
   }
 }
 
-bool Filter::isBufferFull() const {
-  const auto* buffer = decoder_callbacks_->decodingBuffer();
-  if (config_->allowPartialMessage() && buffer != nullptr) {
-    return buffer->length() >= config_->maxRequestBytes();
+bool Filter::isBufferFull(uint64_t num_bytes_processing) const {
+  if (!config_->allowPartialMessage()) {
+    return false;
   }
-  return false;
+
+  uint64_t num_bytes_buffered = num_bytes_processing;
+  const auto* buffer = decoder_callbacks_->decodingBuffer();
+  if (buffer != nullptr) {
+    num_bytes_buffered += buffer->length();
+  }
+
+  return num_bytes_buffered >= config_->maxRequestBytes();
 }
 
 void Filter::continueDecoding() {

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -319,7 +319,7 @@ private:
   void addResponseHeaders(Http::HeaderMap& header_map, const Http::HeaderVector& headers);
   void initiateCall(const Http::RequestHeaderMap& headers);
   void continueDecoding();
-  bool isBufferFull() const;
+  bool isBufferFull(uint64_t num_bytes_processing) const;
 
   // This holds a set of flags defined in per-route configuration.
   struct PerRouteFlags {

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -13,6 +13,10 @@
 
 #include "absl/strings/str_format.h"
 #include "gtest/gtest.h"
+#include <cstdint>
+#include <string>
+#include <sys/types.h>
+#include <unistd.h>
 
 using testing::AssertionResult;
 using testing::Not;
@@ -266,14 +270,16 @@ public:
           upstream_request_->headers().get(Http::LowerCaseString{header_to_remove.first}).empty());
     }
 
+    ENVOY_LOG(trace, "waiting for end stream");
     ASSERT_TRUE(response_->waitForEndStream());
-
+    ENVOY_LOG(trace, "done waiting. Checking that upstream request is complete.");
     EXPECT_TRUE(upstream_request_->complete());
     EXPECT_EQ(request_body_.length(), upstream_request_->bodyLength());
-
+    ENVOY_LOG(trace, "done checking. Checking that downstream request is complete.");
     EXPECT_TRUE(response_->complete());
     EXPECT_EQ(expected_response_code, response_->headers().getStatusValue());
     EXPECT_EQ(response_size_, response_->body().size());
+    ENVOY_LOG(trace, "done checking.");
   }
 
   void sendExtAuthzResponse(const Headers& headers_to_add, const Headers& headers_to_append,
@@ -374,7 +380,7 @@ public:
     cleanupUpstreamAndDownstream();
   }
 
-  const std::string expectedCheckRequest(Http::CodecType downstream_protocol) {
+  const std::string expectedCheckRequest(Http::CodecType downstream_protocol, absl::optional<uint64_t> override_expected_size = absl::nullopt) {
     const std::string expected_downstream_protocol =
         downstream_protocol == Http::CodecType::HTTP1 ? "HTTP/1.1" : "HTTP/2";
     constexpr absl::string_view expected_format = R"EOF(
@@ -389,7 +395,8 @@ attributes:
       protocol: %s
 )EOF";
 
-    return absl::StrFormat(expected_format, request_body_.length(), expectedRequestBody(),
+    uint64_t expected_size = override_expected_size.has_value() ? override_expected_size.value() : request_body_.length();
+    return absl::StrFormat(expected_format, expected_size, expectedRequestBody(),
                            expected_downstream_protocol);
   }
 
@@ -767,6 +774,61 @@ TEST_P(ExtAuthzGrpcIntegrationTest, DenyAtDisable) {
 
 TEST_P(ExtAuthzGrpcIntegrationTest, DenyAtDisableWithMetadata) {
   expectFilterDisableCheck(/*deny_at_disable=*/true, /*disable_with_metadata=*/true, "403");
+}
+
+TEST_P(ExtAuthzGrpcIntegrationTest, CheckAfterBufferingComplete) {
+  // Set up ext_authz filter.
+  initializeConfig();
+  
+  // Use h1, set up the test.
+  setDownstreamProtocol(Http::CodecType::HTTP1);
+  HttpIntegrationTest::initialize();
+
+  // Start a client connection and start request.
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"},           {":path", "/test"},
+      {":scheme", "http"},           {":authority", "host"},
+      {"x-duplicate", "one"},        {"x-duplicate", "two"},
+      {"x-duplicate", "three"},      {"allowed-prefix-one", "one"},
+      {"allowed-prefix-two", "two"}, {"not-allowed", "nope"},
+      {"regex-food", "food"},        {"regex-fool", "fool"}};
+
+  auto conn = makeClientConnection(lookupPort("http"));
+    codec_client_ = makeHttpConnection(std::move(conn));
+
+  auto encoder_decoder =
+    codec_client_->startRequest(headers);
+  response_ = std::move(encoder_decoder.second);
+
+  // Split the request body into two parts
+  TestUtility::feedBufferWithRandomCharacters(request_body_, 10000);
+  std::string initial_body = request_body_.toString().substr(0, 2000);
+  std::string final_body = request_body_.toString().substr(2000, 8000);
+
+  // Send the first part of the request body without ending the stream
+  codec_client_->sendData(encoder_decoder.first, initial_body, false);
+
+  // Expect that since the buffer is full, the request is sent to the authorization server
+  waitForExtAuthzRequest(expectedCheckRequest(Http::CodecType::HTTP1, 2000));
+
+  sendExtAuthzResponse(
+      Headers{}, Headers{}, Headers{}, Http::TestRequestHeaderMapImpl{},
+      Http::TestRequestHeaderMapImpl{}, Headers{}, Headers{});
+  
+  // Send the rest of the data and end the stream
+  codec_client_->sendData(encoder_decoder.first, final_body, true);
+
+  // Expect a 200 OK response
+  waitForSuccessfulUpstreamResponse("200");
+
+  const std::string expected_body(response_size_, 'a');
+  verifyResponse(std::move(response_), "200",
+                 Http::TestResponseHeaderMapImpl{{":status", "200"},
+                                                 {"replaceable", "set-by-upstream"},
+                                                 {"set-cookie", "cookie1=snickerdoodle"}},
+                 expected_body);
+
+  cleanup();
 }
 
 TEST_P(ExtAuthzGrpcIntegrationTest, DownstreamHeadersOnSuccess) {

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -272,16 +272,14 @@ public:
           upstream_request_->headers().get(Http::LowerCaseString{header_to_remove.first}).empty());
     }
 
-    ENVOY_LOG(trace, "waiting for end stream");
     ASSERT_TRUE(response_->waitForEndStream());
-    ENVOY_LOG(trace, "done waiting. Checking that upstream request is complete.");
+
     EXPECT_TRUE(upstream_request_->complete());
     EXPECT_EQ(request_body_.length(), upstream_request_->bodyLength());
-    ENVOY_LOG(trace, "done checking. Checking that downstream request is complete.");
+
     EXPECT_TRUE(response_->complete());
     EXPECT_EQ(expected_response_code, response_->headers().getStatusValue());
     EXPECT_EQ(response_size_, response_->body().size());
-    ENVOY_LOG(trace, "done checking.");
   }
 
   void sendExtAuthzResponse(const Headers& headers_to_add, const Headers& headers_to_append,

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -586,6 +586,9 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
+    data_.add(data);
+  }));
   EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -594,17 +597,20 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
-  data_.add("foo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer1("foo");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(buffer1, false));
+  data_.add(buffer1.toString());
 
-  data_.add("bar");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer2("bar");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(buffer2, false));
+  data_.add(buffer2.toString());
 
-  data_.add("barfoo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer3("barfoo");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer3, false));
+  data_.add(buffer3.toString());
 
-  data_.add("more data after watermark is set is possible");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+  Buffer::OwnedImpl buffer4("more data after watermark is set is possible");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer4, true));
 
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
 }
@@ -629,6 +635,9 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessageThenContinueDecoding) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
+    data_.add(data);
+  }));
   EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -645,24 +654,28 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessageThenContinueDecoding) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
-  data_.add("foo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer1("foo");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(buffer1, false));
+  data_.add(buffer1.toString());
 
-  data_.add("bar");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer2("bar");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(buffer2, false));
+  data_.add(buffer2.toString());
 
-  data_.add("barfoo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer3("barfoo");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer3, false));
+  // data added by the previous decodeData call.
 
-  data_.add("more data after watermark is set is possible");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer4("more data after watermark is set is possible");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer4, false));
+  data_.add(buffer4.toString());
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
   request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
 
-  data_.add("more data after calling check request");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, true));
+  Buffer::OwnedImpl buffer5("more data after calling check request");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer5, true));
 
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
 }
@@ -686,6 +699,9 @@ TEST_F(HttpFilterTest, RequestDataWithSmallBuffer) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
+    data_.add(data);
+  }));
   EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -694,8 +710,9 @@ TEST_F(HttpFilterTest, RequestDataWithSmallBuffer) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
-  data_.add("foo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
+  Buffer::OwnedImpl buffer("foo");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(buffer, false));
+  data_.add(buffer.toString());
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
 }
 
@@ -713,6 +730,9 @@ TEST_F(HttpFilterTest, AuthWithRequestData) {
   )EOF");
 
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
+    data_.add(data);
+  }));
   prepareCheck();
 
   envoy::service::auth::v3::CheckRequest check_request;
@@ -726,10 +746,15 @@ TEST_F(HttpFilterTest, AuthWithRequestData) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
-  data_.add("foo");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
-  data_.add("bar");
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+
+  Buffer::OwnedImpl buffer1("foo");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(buffer1, false));
+  data_.add(buffer1.toString());
+
+  Buffer::OwnedImpl buffer2("bar");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer2, true));
+  // data added by the previous decodeData call.
+
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
 
   EXPECT_EQ(data_.length(), check_request.attributes().request().http().body().size());
@@ -751,6 +776,9 @@ TEST_F(HttpFilterTest, AuthWithNonUtf8RequestData) {
   )EOF");
 
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
+    data_.add(data);
+  }));
   prepareCheck();
 
   envoy::service::auth::v3::CheckRequest check_request;
@@ -768,10 +796,12 @@ TEST_F(HttpFilterTest, AuthWithNonUtf8RequestData) {
   uint8_t raw[1] = {0xc0};
   Buffer::OwnedImpl raw_buffer(raw, 1);
 
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(raw_buffer, false));
   data_.add(raw_buffer);
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data_, false));
-  data_.add(raw_buffer);
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(raw_buffer, true));
+  // data added by the previous decodeData call.
+  
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
 
   EXPECT_EQ(0, check_request.attributes().request().http().body().size());

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -586,9 +586,8 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
-    data_.add(data);
-  }));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) { data_.add(data); }));
   EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -635,9 +634,8 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessageThenContinueDecoding) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
-    data_.add(data);
-  }));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) { data_.add(data); }));
   EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -699,9 +697,8 @@ TEST_F(HttpFilterTest, RequestDataWithSmallBuffer) {
   ON_CALL(decoder_filter_callbacks_, connection())
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
-    data_.add(data);
-  }));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) { data_.add(data); }));
   EXPECT_CALL(decoder_filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -730,9 +727,8 @@ TEST_F(HttpFilterTest, AuthWithRequestData) {
   )EOF");
 
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
-    data_.add(data);
-  }));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) { data_.add(data); }));
   prepareCheck();
 
   envoy::service::auth::v3::CheckRequest check_request;
@@ -776,9 +772,8 @@ TEST_F(HttpFilterTest, AuthWithNonUtf8RequestData) {
   )EOF");
 
   ON_CALL(decoder_filter_callbacks_, decodingBuffer()).WillByDefault(Return(&data_));
-  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke([&](Buffer::Instance& data, bool) {
-    data_.add(data);
-  }));
+  ON_CALL(decoder_filter_callbacks_, addDecodedData(_, _))
+      .WillByDefault(Invoke([&](Buffer::Instance& data, bool) { data_.add(data); }));
   prepareCheck();
 
   envoy::service::auth::v3::CheckRequest check_request;
@@ -799,9 +794,10 @@ TEST_F(HttpFilterTest, AuthWithNonUtf8RequestData) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(raw_buffer, false));
   data_.add(raw_buffer);
 
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(raw_buffer, true));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark,
+            filter_->decodeData(raw_buffer, true));
   // data added by the previous decodeData call.
-  
+
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
 
   EXPECT_EQ(0, check_request.attributes().request().http().body().size());


### PR DESCRIPTION
Commit Message: Fix HTTP ext_authz filter partial request buffering off-by-one error
Additional Description: HTTP ext_authz filter in partial buffering mode would wait one extra call of `processData()` after enough data had been processed before initiating the auth check request.
Risk Level: low
Testing: new integration test added. Unit tests updated.
Docs Changes: none
Release Notes: unsure if needed?
Platform Specific Features: none
Fixes #26650 
