### PR TITLE
Revert "ext_proc logging is consuming too much memory. (#27812)"

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -55,36 +55,15 @@ public:
   explicit ExtProcLoggingInfo(const Envoy::ProtobufWkt::Struct& filter_metadata)
       : filter_metadata_(filter_metadata) {}
 
-  // gRPC call stats for headers and trailers.
   struct GrpcCall {
-    GrpcCall(const std::chrono::microseconds latency, const Grpc::Status::GrpcStatus call_status)
-        : latency_(latency), call_status_(call_status) {}
+    GrpcCall(const std::chrono::microseconds latency, const Grpc::Status::GrpcStatus status,
+             const ProcessorState::CallbackState callback_state)
+        : latency_(latency), status_(status), callback_state_(callback_state) {}
     const std::chrono::microseconds latency_;
-    const Grpc::Status::GrpcStatus call_status_;
+    const Grpc::Status::GrpcStatus status_;
+    const ProcessorState::CallbackState callback_state_;
   };
-
-  // gRPC call stats for body.
-  struct GrpcCallBody {
-    GrpcCallBody(const uint32_t call_count, const Grpc::Status::GrpcStatus call_status,
-                 const std::chrono::microseconds total_latency,
-                 const std::chrono::microseconds max_latency,
-                 const std::chrono::microseconds min_latency)
-        : call_count_(call_count), last_call_status_(call_status), total_latency_(total_latency),
-          max_latency_(max_latency), min_latency_(min_latency) {}
-    uint32_t call_count_;
-    Grpc::Status::GrpcStatus last_call_status_;
-    std::chrono::microseconds total_latency_;
-    std::chrono::microseconds max_latency_;
-    std::chrono::microseconds min_latency_;
-  };
-
-  struct GrpcCallStats {
-    std::unique_ptr<GrpcCall> header_stats_;
-    std::unique_ptr<GrpcCall> trailer_stats_;
-    std::unique_ptr<GrpcCallBody> body_stats_;
-  };
-
-  using GrpcCalls = struct GrpcCallStats;
+  using GrpcCalls = std::vector<GrpcCall>;
 
   void recordGrpcCall(std::chrono::microseconds latency, Grpc::Status::GrpcStatus call_status,
                       ProcessorState::CallbackState callback_state,

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -2253,36 +2253,6 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersAndTrailersWithAllowedHeader) {
   verifyDownstreamResponse(*response, 200);
 }
 
-// Send a request with headers, large body with small chunks, and trailers.
-TEST_P(ExtProcIntegrationTest, SendHeaderAndSmallChunkBodyStreamedMode) {
-  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
-  proto_config_.mutable_processing_mode()->set_request_trailer_mode(ProcessingMode::SEND);
-  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
-  initializeConfig();
-  HttpIntegrationTest::initialize();
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-  Http::TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  auto encoder_decoder = codec_client_->startRequest(headers);
-  request_encoder_ = &encoder_decoder.first;
-  IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
-  processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
-  const uint32_t chunk_size = 1;
-  const uint32_t chunk_number = 100;
-  for (uint32_t i = 0; i < chunk_number; i++) {
-    ENVOY_LOG_MISC(debug, "Sending chunk of {} bytes", chunk_size);
-    codec_client_->sendData(*request_encoder_, chunk_size, false);
-    processRequestBodyMessage(*grpc_upstreams_[0], false, absl::nullopt);
-  }
-  Http::TestRequestTrailerMapImpl request_trailers{{"request", "trailer"}};
-  codec_client_->sendTrailers(*request_encoder_, request_trailers);
-  processRequestTrailersMessage(*grpc_upstreams_[0], false, absl::nullopt);
-
-  handleUpstreamRequest();
-  verifyDownstreamResponse(*response, 200);
-}
-
 // Test the filter with header disallow list set and allow list empty and verify
 // the disallowed headers are not sent to the ext_proc server.
 TEST_P(ExtProcIntegrationTest, GetAndSetHeadersAndTrailersWithDisallowedHeader) {


### PR DESCRIPTION
This reverts commit fc17a1cd1e29ae59476fa4182e75620d4e4a9d5a.

Fix #28568 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
