### PR TITLE
Fixing ext_proc integration test timeout issue.

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -2269,7 +2269,7 @@ TEST_P(ExtProcIntegrationTest, SendHeaderAndSmallChunkBodyStreamedMode) {
   IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
   processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
   const uint32_t chunk_size = 1;
-  const uint32_t chunk_number = 100;
+  const uint32_t chunk_number = 10;
   for (uint32_t i = 0; i < chunk_number; i++) {
     ENVOY_LOG_MISC(debug, "Sending chunk of {} bytes", chunk_size);
     codec_client_->sendData(*request_encoder_, chunk_size, false);

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -2253,35 +2253,6 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersAndTrailersWithAllowedHeader) {
   verifyDownstreamResponse(*response, 200);
 }
 
-// Send a request with headers, large body with small chunks, and trailers.
-TEST_P(ExtProcIntegrationTest, SendHeaderAndSmallChunkBodyStreamedMode) {
-  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
-  proto_config_.mutable_processing_mode()->set_request_trailer_mode(ProcessingMode::SEND);
-  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
-  initializeConfig();
-  HttpIntegrationTest::initialize();
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-  Http::TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  auto encoder_decoder = codec_client_->startRequest(headers);
-  request_encoder_ = &encoder_decoder.first;
-  IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
-  processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
-  const uint32_t chunk_size = 1;
-  const uint32_t chunk_number = 10;
-  for (uint32_t i = 0; i < chunk_number; i++) {
-    codec_client_->sendData(*request_encoder_, chunk_size, false);
-    processRequestBodyMessage(*grpc_upstreams_[0], false, absl::nullopt);
-  }
-  Http::TestRequestTrailerMapImpl request_trailers{{"request", "trailer"}};
-  codec_client_->sendTrailers(*request_encoder_, request_trailers);
-  processRequestTrailersMessage(*grpc_upstreams_[0], false, absl::nullopt);
-
-  handleUpstreamRequest();
-  verifyDownstreamResponse(*response, 200);
-}
-
 // Test the filter with header disallow list set and allow list empty and verify
 // the disallowed headers are not sent to the ext_proc server.
 TEST_P(ExtProcIntegrationTest, GetAndSetHeadersAndTrailersWithDisallowedHeader) {

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -2271,7 +2271,6 @@ TEST_P(ExtProcIntegrationTest, SendHeaderAndSmallChunkBodyStreamedMode) {
   const uint32_t chunk_size = 1;
   const uint32_t chunk_number = 10;
   for (uint32_t i = 0; i < chunk_number; i++) {
-    ENVOY_LOG_MISC(debug, "Sending chunk of {} bytes", chunk_size);
     codec_client_->sendData(*request_encoder_, chunk_size, false);
     processRequestBodyMessage(*grpc_upstreams_[0], false, absl::nullopt);
   }

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -1342,7 +1342,7 @@ TEST_F(HttpFilterTest, StreamingDataSmallChunk) {
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
   processRequestHeaders(false, absl::nullopt);
 
-  const uint32_t chunk_number = 100;
+  const uint32_t chunk_number = 20;
   sendChunkRequestData(chunk_number, true);
   EXPECT_EQ(FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers_));
   processRequestTrailers(absl::nullopt, true);


### PR DESCRIPTION
This is to address https://github.com/envoyproxy/envoy/issues/28568.

https://github.com/envoyproxy/envoy/pull/27812 added a streaming body test in ext_proc_integration_test.cc.   That test case is not really needed for that PR since all the gRPC call stats related test cases are already added in the filter_test.cc.  Removing that test from ext_proc_integration_test.cc for now.


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
