### PR TITLE
ci/coverage: Increase timeout to 5 hours

### DIFF
--- a/.azure-pipelines/stage/checks.yml
+++ b/.azure-pipelines/stage/checks.yml
@@ -99,7 +99,7 @@ jobs:
   condition: |
     and(not(canceled()),
         eq(${{ parameters.runChecks }}, 'true'))
-  timeoutInMinutes: 240
+  timeoutInMinutes: 300
   pool: "envoy-x64-large"
   strategy:
     maxParallel: 2


### PR DESCRIPTION
currently this is timeouting in low/non-cached CI runs

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
