### PR TITLE
ci/bazel: Optimize test sizings

### DIFF
--- a/.azure-pipelines/stage/checks.yml
+++ b/.azure-pipelines/stage/checks.yml
@@ -99,7 +99,8 @@ jobs:
   condition: |
     and(not(canceled()),
         eq(${{ parameters.runChecks }}, 'true'))
-  timeoutInMinutes: 300
+  # TODO(phlax): Make this configurable and ratchet down!
+  timeoutInMinutes: 240
   pool: "envoy-x64-large"
   strategy:
     maxParallel: 2

--- a/.bazelrc
+++ b/.bazelrc
@@ -143,6 +143,7 @@ build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/abseil/abseil-cpp/issues/760
 # https://github.com/google/sanitizers/issues/953
 build:clang-tsan --test_env="TSAN_OPTIONS=report_atomic_races=0"
+build:clang-tsan --test_timeout=120,600,1500,4800
 
 # Clang MSAN - this is the base config for remote-msan and docker-msan. To run this config without
 # our build image, follow https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -81,7 +81,6 @@ def envoy_cc_fuzz_test(
         dictionaries = [],
         repository = "",
         size = "medium",
-        shard_count = None,
         deps = [],
         tags = [],
         **kwargs):
@@ -121,7 +120,6 @@ def envoy_cc_fuzz_test(
             "//conditions:default": ["$(locations %s)" % corpus_name],
         }),
         data = [corpus_name],
-        shard_count = shard_count,
         # No fuzzing on macOS or Windows
         deps = select({
             "@envoy//bazel:apple": [repository + "//test:dummy_main"],

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -265,7 +265,6 @@ envoy_cc_test(
         "conn_manager_impl_test.cc",
         "conn_manager_impl_test_2.cc",
     ],
-    shard_count = 3,
     deps = [
         ":conn_manager_impl_test_base_lib",
         ":custom_header_extension_lib",

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -13,6 +13,7 @@ envoy_package()
 
 envoy_cc_test(
     name = "codec_impl_test",
+    size = "large",
     srcs = ["codec_impl_test.cc"],
     external_deps = [
         "quiche_http2_adapter",

--- a/test/extensions/clusters/redis/BUILD
+++ b/test/extensions/clusters/redis/BUILD
@@ -94,9 +94,6 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["redis_cluster_integration_test.cc"],
     extension_names = ["envoy.clusters.redis"],
-    # This test takes a while to run specially under tsan.
-    # Shard it to avoid test timeout.
-    shard_count = 2,
     deps = [
         "//source/extensions/clusters/redis:redis_cluster",
         "//source/extensions/clusters/redis:redis_cluster_lb",

--- a/test/extensions/filters/http/buffer/BUILD
+++ b/test/extensions/filters/http/buffer/BUILD
@@ -37,7 +37,7 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["buffer_filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.buffer"],
-    shard_count = 16,
+    shard_count = 4,
     deps = [
         "//source/extensions/filters/http/buffer:config",
         "//test/config:utility_lib",

--- a/test/extensions/filters/http/cache/BUILD
+++ b/test/extensions/filters/http/cache/BUILD
@@ -125,7 +125,6 @@ envoy_extension_cc_test(
         "cache_filter_integration_test.cc",
     ],
     extension_names = ["envoy.filters.http.cache"],
-    shard_count = 2,
     deps = [
         "//source/extensions/filters/http/cache:config",
         "//source/extensions/filters/http/cache:http_cache_lib",

--- a/test/extensions/filters/http/csrf/BUILD
+++ b/test/extensions/filters/http/csrf/BUILD
@@ -32,9 +32,6 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["csrf_filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.csrf"],
-    # TODO(kbaichoo): remove when deferred processing is enabled by default and the
-    # test is no longer parameterized by it.
-    shard_count = 4,
     deps = [
         "//source/extensions/filters/http/csrf:config",
         "//test/config:utility_lib",

--- a/test/extensions/filters/http/custom_response/BUILD
+++ b/test/extensions/filters/http/custom_response/BUILD
@@ -81,7 +81,6 @@ envoy_extension_cc_test(
         "custom_response_integration_test.cc",
     ],
     extension_names = ["envoy.filters.http.custom_response"],
-    shard_count = 4,
     tags = [
         "cpu:3",
     ],

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -118,7 +118,6 @@ envoy_extension_cc_test(
     size = "large",  # This test can take a while under tsan.
     srcs = ["ext_proc_integration_test.cc"],
     extension_names = ["envoy.filters.http.ext_proc"],
-    shard_count = 4,
     tags = [
         "cpu:3",
     ],

--- a/test/extensions/filters/http/fault/BUILD
+++ b/test/extensions/filters/http/fault/BUILD
@@ -55,7 +55,6 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["fault_filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.fault"],
-    shard_count = 2,
     deps = [
         "//source/extensions/filters/http/fault:config",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/http/file_system_buffer/BUILD
+++ b/test/extensions/filters/http/file_system_buffer/BUILD
@@ -47,7 +47,6 @@ envoy_extension_cc_test(
         "filter_integration_test.cc",
     ],
     extension_names = ["envoy.filters.http.file_system_buffer"],
-    shard_count = 2,
     tags = [
         "cpu:3",
         "skip_on_windows",

--- a/test/extensions/filters/http/grpc_field_extraction/BUILD
+++ b/test/extensions/filters/http/grpc_field_extraction/BUILD
@@ -55,7 +55,6 @@ envoy_extension_cc_test(
     ],
     data = ["//test/proto:apikeys_proto_descriptor"],
     extension_names = ["envoy.filters.http.grpc_field_extraction"],
-    shard_count = 2,
     deps = [
         "//source/extensions/filters/http/grpc_field_extraction:config",
         "//test/extensions/filters/http/grpc_field_extraction/message_converter:message_converter_test_lib",

--- a/test/extensions/filters/http/health_check/BUILD
+++ b/test/extensions/filters/http/health_check/BUILD
@@ -45,7 +45,6 @@ envoy_extension_cc_test(
         "health_check_integration_test.cc",
     ],
     extension_names = ["envoy.filters.http.health_check"],
-    shard_count = 4,
     deps = [
         "//source/extensions/filters/http/buffer:config",
         "//source/extensions/filters/http/health_check:config",

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -146,7 +146,7 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.jwt_authn"],
-    shard_count = 6,
+    shard_count = 4,
     tags = [
         "cpu:3",
     ],

--- a/test/extensions/filters/http/kill_request/BUILD
+++ b/test/extensions/filters/http/kill_request/BUILD
@@ -56,7 +56,7 @@ envoy_cc_test(
     name = "crash_integration_test",
     size = "large",
     srcs = ["crash_integration_test.cc"],
-    shard_count = 16,  # This is really slow on coverage.
+    shard_count = 8,
     deps = [
         "//source/extensions/filters/http/kill_request:kill_request_config",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/http/rbac/BUILD
+++ b/test/extensions/filters/http/rbac/BUILD
@@ -51,7 +51,6 @@ envoy_extension_cc_test(
     size = "large",
     srcs = ["rbac_filter_integration_test.cc"],
     extension_names = ["envoy.filters.http.rbac"],
-    shard_count = 16,
     deps = [
         "//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "//source/extensions/filters/http/dynamic_forward_proxy:config",

--- a/test/extensions/filters/http/tap/BUILD
+++ b/test/extensions/filters/http/tap/BUILD
@@ -54,7 +54,6 @@ envoy_extension_cc_test(
     size = "large",
     srcs = envoy_select_admin_functionality(["tap_filter_integration_test.cc"]),
     extension_names = ["envoy.filters.http.tap"],
-    shard_count = 4,
     deps = [
         "//source/extensions/filters/http/tap:config",
         "//test/extensions/common/tap:common",

--- a/test/extensions/filters/http/wasm/BUILD
+++ b/test/extensions/filters/http/wasm/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test(
     ]),
     extension_names = ["envoy.filters.http.wasm"],
     shard_count = 50,
+    tags = ["cpu:4"],
     deps = [
         "//source/common/http:message_lib",
         "//source/extensions/filters/http/wasm:wasm_filter_lib",
@@ -57,7 +58,7 @@ envoy_extension_cc_test(
         "//test/extensions/filters/http/wasm/test_data:test_cpp.wasm",
     ]),
     extension_names = ["envoy.filters.http.wasm"],
-    shard_count = 50,
+    shard_count = 16,
     deps = [
         "//source/common/common:base64_lib",
         "//source/common/common:hex_lib",

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -18,9 +18,6 @@ envoy_extension_cc_test(
     name = "command_splitter_impl_test",
     srcs = ["command_splitter_impl_test.cc"],
     extension_names = ["envoy.filters.network.redis_proxy"],
-    # This test takes a while to run specially under tsan.
-    # Shard it to avoid test timeout.
-    shard_count = 2,
     deps = [
         ":redis_mocks",
         "//source/common/stats:isolated_store_lib",

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -345,7 +345,6 @@ envoy_extension_cc_test(
         "//test/extensions/filters/network/thrift_proxy/driver:generate_fixture",
     ],
     extension_names = ["envoy.filters.network.thrift_proxy"],
-    shard_count = 12,
     tags = ["skip_on_windows"],
     deps = [
         ":integration_lib",
@@ -364,7 +363,6 @@ envoy_extension_cc_test(
         "//test/extensions/filters/network/thrift_proxy/driver:generate_fixture",
     ],
     extension_names = ["envoy.filters.network.thrift_proxy"],
-    shard_count = 4,
     deps = [
         ":integration_lib",
         ":utility_lib",

--- a/test/extensions/listener_managers/listener_manager/BUILD
+++ b/test/extensions/listener_managers/listener_manager/BUILD
@@ -50,7 +50,6 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "listener_manager_impl_test",
     srcs = ["listener_manager_impl_test.cc"],
-    shard_count = 4,
     deps = [
         ":listener_manager_impl_test_lib",
         "//source/common/api:os_sys_calls_lib",

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -26,7 +26,6 @@ envoy_cc_test(
         "//test/extensions/transport_sockets/tls/test_data:certs",
     ],
     external_deps = ["ssl"],
-    shard_count = 4,
     deps = [
         ":test_private_key_method_provider_test_lib",
         "//envoy/network:transport_socket_interface",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -53,7 +53,7 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "ads_integration_test",
-    size = "enormous",
+    size = "large",
     srcs = envoy_select_admin_functionality(
         ["ads_integration_test.cc"],
     ),
@@ -327,7 +327,6 @@ envoy_cc_test(
     srcs = envoy_select_admin_functionality([
         "drain_close_integration_test.cc",
     ]),
-    shard_count = 2,
     tags = [
         "cpu:3",
     ],
@@ -356,7 +355,7 @@ envoy_cc_test_binary(
 
 envoy_sh_test(
     name = "hotrestart_test",
-    size = "enormous",
+    size = "large",
     srcs = select({
         "//bazel:disable_hot_restart_or_admin": [],
         "//conditions:default": ["hotrestart_test.sh"],
@@ -464,7 +463,7 @@ envoy_cc_test(
     srcs = [
         "http2_flood_integration_test.cc",
     ],
-    shard_count = 8,
+    shard_count = 4,
     tags = [
         "cpu:3",
     ],
@@ -492,7 +491,7 @@ envoy_cc_test(
     srcs = [
         "multiplexed_integration_test.cc",
     ],
-    shard_count = 16,
+    shard_count = 8,
     tags = [
         "cpu:3",
     ],
@@ -570,7 +569,6 @@ envoy_cc_test(
     srcs = [
         "buffer_accounting_integration_test.cc",
     ],
-    shard_count = 4,
     tags = [
         "cpu:3",
     ],
@@ -699,7 +697,7 @@ envoy_cc_test(
     srcs = envoy_select_admin_functionality([
         "filter_integration_test.cc",
     ]),
-    shard_count = 16,
+    shard_count = 8,
     tags = [
         "cpu:3",
     ],
@@ -776,7 +774,7 @@ envoy_cc_test(
     ],
     # As this test has many H1/H2/v4/v6 tests it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
-    shard_count = 48,
+    shard_count = 8,
     tags = [
         "cpu:3",
     ],
@@ -802,7 +800,6 @@ envoy_cc_test(
     srcs = [
         "multiplexed_upstream_integration_test.cc",
     ],
-    shard_count = 4,
     tags = [
         "cpu:3",
     ],
@@ -925,7 +922,7 @@ envoy_cc_test(
     srcs = ["idle_timeout_integration_test.cc"],
     # As this test has many pauses for idle timeouts, it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
-    shard_count = 8,
+    shard_count = 4,
     tags = [
         "cpu:3",
     ],
@@ -1255,7 +1252,6 @@ envoy_cc_test(
         "integration_test.cc",
         "integration_test.h",
     ],
-    shard_count = 2,
     tags = [
         "cpu:3",
     ],
@@ -1289,7 +1285,6 @@ envoy_cc_test(
     srcs = [
         "redirect_integration_test.cc",
     ],
-    shard_count = 8,
     tags = [
         "cpu:3",
         "nofips",
@@ -1323,7 +1318,6 @@ envoy_cc_test(
         "websocket_integration_test.cc",
         "websocket_integration_test.h",
     ],
-    shard_count = 4,
     tags = [
         "cpu:3",
     ],
@@ -1357,8 +1351,6 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     # The symbol table cluster memory tests take a while to run specially under tsan.
-    # Shard it to avoid test timeout.
-    shard_count = 2,
     deps = [
         ":integration_lib",
         "//source/common/memory:stats_lib",
@@ -1399,7 +1391,6 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    shard_count = 2,
     tags = [
         "cpu:3",
     ],
@@ -1472,7 +1463,7 @@ envoy_cc_test(
     name = "overload_integration_test",
     size = "large",
     srcs = ["overload_integration_test.cc"],
-    shard_count = 8,
+    shard_count = 4,
     tags = [
         "cpu:3",
     ],
@@ -1672,7 +1663,6 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    shard_count = 2,
     tags = [
         "cpu:3",
     ],
@@ -1709,7 +1699,6 @@ envoy_cc_test(
     srcs = [
         "tcp_proxy_many_connections_test.cc",
     ],
-    shard_count = 1,
     tags = [
         "cpu:3",
     ],
@@ -1742,7 +1731,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    shard_count = 16,
+    shard_count = 8,
     tags = [
         "cpu:3",
     ],
@@ -1768,7 +1757,6 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    shard_count = 16,
     deps = [
         ":http_integration_lib",
         ":http_protocol_integration_lib",
@@ -2190,7 +2178,6 @@ envoy_cc_test(
     srcs = [
         "local_reply_integration_test.cc",
     ],
-    shard_count = 2,
     tags = [
         "cpu:2",
     ],
@@ -2265,7 +2252,7 @@ envoy_cc_test(
         "//conditions:default": ["quic_protocol_integration_test.cc"],
     }),
     data = ["//test/config/integration/certs"],
-    shard_count = 24,
+    shard_count = 16,
     tags = [
         "cpu:4",
         "nofips",
@@ -2296,7 +2283,6 @@ envoy_cc_test(
         "//conditions:default": ["quic_http_integration_test.cc"],
     }),
     data = ["//test/config/integration/certs"],
-    shard_count = 6,
     # TODO(envoyproxy/windows-dev): Diagnose failure shown only on clang-cl build, see:
     #   https://gist.github.com/wrowe/a152cb1d12c2f751916122aed39d8517
     # TODO(envoyproxy/windows-dev): Diagnose timeout, why opt build test under Windows GCP RBE


### PR DESCRIPTION
Sharding can help speed up bazel CI especially in the RBE case, but especially in the non-RBE case it can slow things done as it prevents jobs from running concurrently/together that otherwise could

One problem in envoy's ci is that a lot of tests have been configured to the slowest test-case - ie `tsan` - despite a lot of the tests not requiring the same limits/constraints/resources

This PR is the product of removing all of the bazel sizing attributes in a mostly non-cached environment and then selectively readding them as required

It brings the time for an uncached coverage run from ~4.5h -> <3h - the arm job is likely to similarly benefit

We can tweak the settings if we experience further flakes or for optimizing the RBE case in follow ups 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
