### PR TITLE
quic: add a runtime guard to reject all traffic 

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -33,6 +33,9 @@ behavior_changes:
     Preserve the active-health check status of a host after a cluster/assignment update. This is now preserved in cases
     where the assignment updates a host's locality. This behavioral change can be temporarily reverted by setting the
     runtime flag ``envoy.reloadable_features.keep_endpoint_active_hc_status_on_locality_update`` to false.
+- area:
+  change: |
+    Add a default-false runtime flag ``envoy.reloadable_features.quic_reject_all`` to disable QUIC listener if needed.
 - area: stats tls
   change: |
     fixed metric tag extraction so that TLS parameters are properly extracted from the stats, both for listeners and clusters.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -33,9 +33,9 @@ behavior_changes:
     Preserve the active-health check status of a host after a cluster/assignment update. This is now preserved in cases
     where the assignment updates a host's locality. This behavioral change can be temporarily reverted by setting the
     runtime flag ``envoy.reloadable_features.keep_endpoint_active_hc_status_on_locality_update`` to false.
-- area:
+- area: quic
   change: |
-    Add a default-false runtime flag ``envoy.reloadable_features.quic_reject_all`` to disable QUIC listener if needed.
+    Add a default false runtime flag ``envoy.reloadable_features.quic_reject_all`` to disable QUIC listener if needed.
 - area: stats tls
   change: |
     fixed metric tag extraction so that TLS parameters are properly extracted from the stats, both for listeners and clusters.

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -89,6 +89,8 @@ private:
   uint32_t packets_to_read_to_connection_count_ratio_;
   EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory_;
   QuicConnectionIdGeneratorPtr connection_id_generator_;
+  // Latches envoy.reloadable_features.quic_reject_all at the beginning of each event loop.
+  bool reject_all_{false};
 };
 
 using ActiveQuicListenerPtr = std::unique_ptr<ActiveQuicListener>;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -118,6 +118,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_always_use_v6);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_include_histograms);
 // TODO(wbpcode) complete remove this feature is no one use it.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_refresh_rtt_after_request);
+// TODO(danzh) false deprecate it once QUICHE has its own enable/disable flag.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -501,6 +501,29 @@ TEST_P(ActiveQuicListenerTest, QuicProcessingDisabledAndEnabled) {
   EXPECT_TRUE(ActiveQuicListenerPeer::enabled(*quic_listener_));
 }
 
+TEST_P(ActiveQuicListenerTest, QuicRejectsAllAndResumes) {
+  initialize();
+  maybeConfigureMocks(/* connection_count = */ 2);
+  EXPECT_FALSE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_reject_all"));
+  sendCHLO(quic::test::TestConnectionId(1));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+  EXPECT_EQ(quic_dispatcher_->NumSessions(), 1);
+
+  // Reject all packet.
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.quic_reject_all", true);
+  sendCHLO(quic::test::TestConnectionId(2));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+  // No new connection was created.
+  EXPECT_EQ(quic_dispatcher_->NumSessions(), 1);
+
+  // Stop rejecting traffic.
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.quic_reject_all", false);
+  sendCHLO(quic::test::TestConnectionId(2));
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+  EXPECT_EQ(quic_dispatcher_->NumSessions(), 2);
+  EXPECT_TRUE(ActiveQuicListenerPeer::enabled(*quic_listener_));
+}
+
 class ActiveQuicListenerEmptyFlagConfigTest : public ActiveQuicListenerTest {
 protected:
   std::string yamlForQuicConfig() override {


### PR DESCRIPTION
Commit Message: add `envoy.reloadable_features.quic_reject_all` runtime guard to allow Envoy stop QUIC processing via Abseil flag --envoy_reloadable_features_quic_reject_all. The flag has default value false.

Additional Description: the runtime guard is a temporary solution which will be deprecated when QUICHE has its own flag to reject all traffic.

Risk Level: low
Testing: added new unit test 
Docs Changes: n/a
Release Notes: edited
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.quic_reject_all
Follow up of #9230
