### PR TITLE
Add a RequestDecoderHandle type which is effectively a weak reference to a RequestDecoder

### DIFF
--- a/envoy/http/api_listener.h
+++ b/envoy/http/api_listener.h
@@ -6,7 +6,7 @@ namespace Envoy {
 namespace Http {
 
 class RequestDecoderHandle {
- public:
+public:
   virtual ~RequestDecoderHandle() = default;
 
   /**
@@ -40,7 +40,7 @@ public:
    *   decoding events.
    */
   virtual RequestDecoderHandlePtr newStreamHandle(ResponseEncoder& response_encoder,
-                                               bool is_internally_created = false) PURE;
+                                                  bool is_internally_created = false) PURE;
 };
 
 using ApiListenerPtr = std::unique_ptr<ApiListener>;

--- a/envoy/http/api_listener.h
+++ b/envoy/http/api_listener.h
@@ -5,6 +5,22 @@
 namespace Envoy {
 namespace Http {
 
+class RequestDecoderHandle {
+ public:
+  virtual ~RequestDecoderHandle() = default;
+
+  /**
+   * @return true if the underlying decoder is still valid.
+   */
+  virtual bool isValid() PURE;
+
+  /**
+   * @return a reference to the underlying decoder if it is still valid.
+   */
+  virtual OptRef<RequestDecoder> get() PURE;
+};
+using RequestDecoderHandlePtr = std::unique_ptr<RequestDecoderHandle>;
+
 /**
  * ApiListener that allows consumers to interact with HTTP streams via API calls.
  */
@@ -20,11 +36,11 @@ public:
    *                         response are backed by the same Stream object.
    * @param is_internally_created indicates if this stream was originated by a
    *   client, or was created by Envoy, by example as part of an internal redirect.
-   * @return RequestDecoder& supplies the decoder callbacks to fire into for stream
+   * @return RequestDecoderHandle supplies the decoder callbacks to fire into for stream
    *   decoding events.
    */
-  virtual RequestDecoder& newStream(ResponseEncoder& response_encoder,
-                                    bool is_internally_created = false) PURE;
+  virtual RequestDecoderHandlePtr newStreamHandle(ResponseEncoder& response_encoder,
+                                               bool is_internally_created = false) PURE;
 };
 
 using ApiListenerPtr = std::unique_ptr<ApiListener>;

--- a/envoy/http/api_listener.h
+++ b/envoy/http/api_listener.h
@@ -10,11 +10,6 @@ public:
   virtual ~RequestDecoderHandle() = default;
 
   /**
-   * @return true if the underlying decoder is still valid.
-   */
-  virtual bool isValid() PURE;
-
-  /**
    * @return a reference to the underlying decoder if it is still valid.
    */
   virtual OptRef<RequestDecoder> get() PURE;

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -53,9 +53,10 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
 
   // Capture some metadata before potentially closing the stream.
   absl::string_view alpn = "";
-  if (direct_stream_.request_decoder_) {
+  OptRef<RequestDecoder> request_decoder = direct_stream_.requestDecoder();
+  if (request_decoder) {
     direct_stream_.saveLatestStreamIntel();
-    const auto& info = direct_stream_.request_decoder_->streamInfo();
+    const auto& info = request_decoder->streamInfo();
     // Set the initial number of bytes consumed for the non terminal callbacks.
     direct_stream_.stream_intel_.consumed_bytes_from_response =
         info.getUpstreamBytesMeter() ? info.getUpstreamBytesMeter()->headerBytesReceived() : 0;
@@ -380,7 +381,11 @@ envoy_final_stream_intel& Client::DirectStreamCallbacks::finalStreamIntel() {
 }
 
 void Client::DirectStream::saveLatestStreamIntel() {
-  const auto& info = request_decoder_->streamInfo();
+  OptRef<RequestDecoder> request_decoder = requestDecoder();
+  if (!request_decoder) {
+    return;
+  }
+  const auto& info = request_decoder->streamInfo();
   if (info.upstreamInfo()) {
     stream_intel_.connection_id = info.upstreamInfo()->upstreamConnectionId().value_or(-1);
   }
@@ -389,16 +394,21 @@ void Client::DirectStream::saveLatestStreamIntel() {
 }
 
 void Client::DirectStream::saveFinalStreamIntel() {
-  if (!request_decoder_ || !parent_.getStream(stream_handle_, ALLOW_ONLY_FOR_OPEN_STREAMS)) {
+  OptRef<RequestDecoder> request_decoder = requestDecoder();
+  if (!request_decoder || !parent_.getStream(stream_handle_, ALLOW_ONLY_FOR_OPEN_STREAMS)) {
     return;
   }
-  StreamInfo::setFinalStreamIntel(request_decoder_->streamInfo(), parent_.dispatcher_.timeSource(),
+  StreamInfo::setFinalStreamIntel(request_decoder->streamInfo(), parent_.dispatcher_.timeSource(),
                                   envoy_final_stream_intel_);
 }
 
 envoy_error Client::DirectStreamCallbacks::streamError() {
-  const auto& info = direct_stream_.request_decoder_->streamInfo();
   envoy_error error{};
+  OptRef<RequestDecoder> request_decoder = direct_stream_.requestDecoder();
+  if (!request_decoder) {
+    return error;
+  }
+  const auto& info = request_decoder->streamInfo();
 
   if (info.responseCode().has_value()) {
     error.error_code = Bridge::Utility::errorCodeFromLocalStatus(
@@ -476,7 +486,7 @@ void Client::startStream(envoy_stream_t new_stream_handle, envoy_http_callbacks 
   // Note: streams created by Envoy Mobile are tagged as is_internally_created. This means that
   // the Http::ConnectionManager _will not_ sanitize headers when creating a stream.
   direct_stream->request_decoder_ =
-      &api_listener_->newStream(*direct_stream->callbacks_, true /* is_internally_created */);
+      api_listener_->newStreamHandle(*direct_stream->callbacks_, true /* is_internally_created */);
 
   streams_.emplace(new_stream_handle, std::move(direct_stream));
   ENVOY_LOG(debug, "[S{}] start stream", new_stream_handle);
@@ -493,7 +503,14 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
   // first place. Additionally it is possible to get a nullptr due to bogus envoy_stream_t
   // from the caller.
   // https://github.com/envoyproxy/envoy-mobile/issues/301
-  if (direct_stream) {
+  if (!direct_stream) {
+    return;
+  }
+  OptRef<RequestDecoder> request_decoder = direct_stream->requestDecoder();
+  if (!request_decoder) {
+    return;
+  }
+
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     RequestHeaderMapPtr internal_headers = Utility::toRequestHeaders(headers);
 
@@ -501,7 +518,7 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
     // is a no-op for other platforms.
     if (internal_headers->getSchemeValue() != "https" &&
         !SystemHelper::getInstance().isCleartextPermitted(internal_headers->getHostValue())) {
-      direct_stream->request_decoder_->sendLocalReply(
+      request_decoder->sendLocalReply(
           Http::Code::BadRequest, "Cleartext is not permitted", nullptr, absl::nullopt, "");
       return;
     }
@@ -523,8 +540,7 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
     internal_headers->setReferenceForwardedProto(Headers::get().SchemeValues.Https);
     ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
               *internal_headers);
-    direct_stream->request_decoder_->decodeHeaders(std::move(internal_headers), end_stream);
-  }
+    request_decoder->decodeHeaders(std::move(internal_headers), end_stream);
 }
 
 void Client::readData(envoy_stream_t stream, size_t bytes_to_read) {
@@ -550,7 +566,14 @@ void Client::sendData(envoy_stream_t stream, envoy_data data, bool end_stream) {
   // first place. Additionally it is possible to get a nullptr due to bogus envoy_stream_t
   // from the caller.
   // https://github.com/envoyproxy/envoy-mobile/issues/301
-  if (direct_stream) {
+  if (!direct_stream) {
+    return;
+  }
+  OptRef<RequestDecoder> request_decoder = direct_stream->requestDecoder();
+  if (!request_decoder) {
+    return;
+  }
+
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     // The buffer is moved internally, in a synchronous fashion, so we don't need the lifetime
     // of the InstancePtr to outlive this function call.
@@ -558,7 +581,7 @@ void Client::sendData(envoy_stream_t stream, envoy_data data, bool end_stream) {
 
     ENVOY_LOG(debug, "[S{}] request data for stream (length={} end_stream={})\n", stream,
               data.length, end_stream);
-    direct_stream->request_decoder_->decodeData(*buf, end_stream);
+    request_decoder->decodeData(*buf, end_stream);
 
     if (direct_stream->explicit_flow_control_ && !end_stream) {
       if (direct_stream->read_disable_count_ == 0) {
@@ -577,7 +600,7 @@ void Client::sendData(envoy_stream_t stream, envoy_data data, bool end_stream) {
         direct_stream->wants_write_notification_ = true;
       }
     }
-  }
+
 }
 
 void Client::sendMetadata(envoy_stream_t, envoy_headers) { PANIC("not implemented"); }
@@ -593,12 +616,17 @@ void Client::sendTrailers(envoy_stream_t stream, envoy_headers trailers) {
   // first place. Additionally it is possible to get a nullptr due to bogus envoy_stream_t
   // from the caller.
   // https://github.com/envoyproxy/envoy-mobile/issues/301
-  if (direct_stream) {
+  if (!direct_stream) {
+    return;
+  }
+  OptRef<RequestDecoder> request_decoder = direct_stream->requestDecoder();
+  if (!request_decoder) {
+    return;
+  }
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     RequestTrailerMapPtr internal_trailers = Utility::toRequestTrailers(trailers);
     ENVOY_LOG(debug, "[S{}] request trailers for stream:\n{}", stream, *internal_trailers);
-    direct_stream->request_decoder_->decodeTrailers(std::move(internal_trailers));
-  }
+    request_decoder->decodeTrailers(std::move(internal_trailers));
 }
 
 void Client::cancelStream(envoy_stream_t stream) {

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -306,10 +306,17 @@ private:
       }
     }
 
+    OptRef<RequestDecoder> requestDecoder() {
+      if (!request_decoder_) {
+        return {};
+      }
+      return request_decoder_->get();
+    }
+
     const envoy_stream_t stream_handle_;
 
     // Used to issue outgoing HTTP stream operations.
-    RequestDecoder* request_decoder_;
+    RequestDecoderHandlePtr request_decoder_;
     // Used to receive incoming HTTP stream operations.
     DirectStreamCallbacksPtr callbacks_;
     Client& parent_;

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -46,20 +46,17 @@ ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
 }
 
 class TestHandle : public RequestDecoderHandle {
- public:
+public:
   explicit TestHandle(MockRequestDecoder& decoder) : decoder_(decoder) {}
 
   ~TestHandle() override = default;
 
   bool isValid() override { return true; }
 
-  OptRef<RequestDecoder> get() override {
-    return { decoder_ };
-  }
+  OptRef<RequestDecoder> get() override { return {decoder_}; }
 
- private:
+private:
   MockRequestDecoder& decoder_;
-
 };
 
 class ClientTest : public testing::TestWithParam<bool> {

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -45,6 +45,23 @@ ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   return transformed_headers;
 }
 
+class TestHandle : public RequestDecoderHandle {
+ public:
+  explicit TestHandle(MockRequestDecoder& decoder) : decoder_(decoder) {}
+
+  ~TestHandle() override = default;
+
+  bool isValid() override { return true; }
+
+  OptRef<RequestDecoder> get() override {
+    return { decoder_ };
+  }
+
+ private:
+  MockRequestDecoder& decoder_;
+
+};
+
 class ClientTest : public testing::TestWithParam<bool> {
 public:
   typedef struct {
@@ -131,10 +148,10 @@ public:
     // Grab the response encoder in order to dispatch responses on the stream.
     // Return the request decoder to make sure calls are dispatched to the decoder via the
     // dispatcher API.
-    EXPECT_CALL(*api_listener_, newStream(_, _))
-        .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+    EXPECT_CALL(*api_listener_, newStreamHandle(_, _))
+        .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoderHandlePtr {
           response_encoder_ = &encoder;
-          return *request_decoder_;
+          return std::make_unique<TestHandle>(*request_decoder_);
         }));
     http_client_.startStream(stream_, bridge_callbacks_, explicit_flow_control_, 0);
   }
@@ -425,10 +442,10 @@ TEST_P(ClientTest, MultipleStreams) {
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
-  EXPECT_CALL(*api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+  EXPECT_CALL(*api_listener_, newStreamHandle(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoderHandlePtr {
         response_encoder2 = &encoder;
-        return request_decoder2;
+        return std::make_unique<TestHandle>(request_decoder2);
       }));
   http_client_.startStream(stream2, bridge_callbacks_2, explicit_flow_control_, 0);
 
@@ -686,10 +703,10 @@ TEST_P(ClientTest, NullAccessors) {
   // Grab the response encoder in order to dispatch responses on the stream.
   // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
   // API.
-  EXPECT_CALL(*api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+  EXPECT_CALL(*api_listener_, newStreamHandle(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoderHandlePtr {
         response_encoder_ = &encoder;
-        return *request_decoder_;
+        return std::make_unique<TestHandle>(*request_decoder_);
       }));
   http_client_.startStream(stream, bridge_callbacks, explicit_flow_control_, 0);
 

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -51,8 +51,6 @@ public:
 
   ~TestHandle() override = default;
 
-  bool isValid() override { return true; }
-
   OptRef<RequestDecoder> get() override { return {decoder_}; }
 
 private:

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -346,7 +346,7 @@ void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
 }
 
 RequestDecoderHandlePtr ConnectionManagerImpl::newStreamHandle(ResponseEncoder& response_encoder,
-                                                            bool is_internally_created) {
+                                                               bool is_internally_created) {
   RequestDecoder& decoder = newStream(response_encoder, is_internally_created);
   return std::make_unique<ActiveStreamHandle>(static_cast<ActiveStream&>(decoder));
 }
@@ -371,8 +371,8 @@ RequestDecoder& ConnectionManagerImpl::newStream(ResponseEncoder& response_encod
     response_encoder.getStream().setAccount(downstream_stream_account);
   }
 
-  auto new_stream = std::make_unique<ActiveStream>(*this, response_encoder.getStream().bufferLimit(),
-                                                   std::move(downstream_stream_account));
+  auto new_stream = std::make_unique<ActiveStream>(
+      *this, response_encoder.getStream().bufferLimit(), std::move(downstream_stream_account));
 
   accumulated_requests_++;
   if (config_.maxRequestsPerConnection() > 0 &&

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -345,6 +345,12 @@ void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
   }
 }
 
+RequestDecoderHandlePtr ConnectionManagerImpl::newStreamHandle(ResponseEncoder& response_encoder,
+                                                            bool is_internally_created) {
+  RequestDecoder& decoder = newStream(response_encoder, is_internally_created);
+  return std::make_unique<ActiveStreamHandle>(static_cast<ActiveStream&>(decoder));
+}
+
 RequestDecoder& ConnectionManagerImpl::newStream(ResponseEncoder& response_encoder,
                                                  bool is_internally_created) {
   TRACE_EVENT("core", "ConnectionManagerImpl::newStream");
@@ -365,8 +371,8 @@ RequestDecoder& ConnectionManagerImpl::newStream(ResponseEncoder& response_encod
     response_encoder.getStream().setAccount(downstream_stream_account);
   }
 
-  ActiveStreamPtr new_stream(new ActiveStream(*this, response_encoder.getStream().bufferLimit(),
-                                              std::move(downstream_stream_account)));
+  auto new_stream = std::make_unique<ActiveStream>(*this, response_encoder.getStream().bufferLimit(),
+                                                   std::move(downstream_stream_account));
 
   accumulated_requests_++;
   if (config_.maxRequestsPerConnection() > 0 &&

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -98,10 +98,10 @@ public:
 
   // Http::ServerConnectionCallbacks
   RequestDecoder& newStream(ResponseEncoder& response_encoder,
-                                 bool is_internally_created = false) override;
+                            bool is_internally_created = false) override;
 
   RequestDecoderHandlePtr newStreamHandle(ResponseEncoder& response_encoder,
-                                       bool is_internally_created = false) override;
+                                          bool is_internally_created = false) override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -413,9 +413,7 @@ private:
     // HTTP connection manager configuration, then the entire connection is closed.
     bool validateTrailers();
 
-    std::weak_ptr<bool> stillAlive() {
-      return std::weak_ptr<bool>(still_alive_);
-    }
+    std::weak_ptr<bool> stillAlive() { return std::weak_ptr<bool>(still_alive_); }
 
     ConnectionManagerImpl& connection_manager_;
     OptRef<const TracingConnectionManagerConfig> connection_manager_tracing_config_;
@@ -510,16 +508,13 @@ private:
   using ActiveStreamPtr = std::unique_ptr<ActiveStream>;
 
   class ActiveStreamHandle : public RequestDecoderHandle {
-   public:
+  public:
     explicit ActiveStreamHandle(ActiveStream& stream)
-        : valid_(stream.stillAlive()),
-          stream_(stream) {}
+        : valid_(stream.stillAlive()), stream_(stream) {}
 
     ~ActiveStreamHandle() override = default;
 
-    bool isValid() override {
-      return !valid_.expired();
-    }
+    bool isValid() override { return !valid_.expired(); }
 
     OptRef<RequestDecoder> get() override {
       if (valid_.expired()) {
@@ -528,7 +523,7 @@ private:
       return stream_;
     }
 
-   private:
+  private:
     std::weak_ptr<bool> valid_;
     ActiveStream& stream_;
   };

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -98,7 +98,10 @@ public:
 
   // Http::ServerConnectionCallbacks
   RequestDecoder& newStream(ResponseEncoder& response_encoder,
-                            bool is_internally_created = false) override;
+                                 bool is_internally_created = false) override;
+
+  RequestDecoderHandlePtr newStreamHandle(ResponseEncoder& response_encoder,
+                                       bool is_internally_created = false) override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -410,6 +413,10 @@ private:
     // HTTP connection manager configuration, then the entire connection is closed.
     bool validateTrailers();
 
+    std::weak_ptr<bool> stillAlive() {
+      return std::weak_ptr<bool>(still_alive_);
+    }
+
     ConnectionManagerImpl& connection_manager_;
     OptRef<const TracingConnectionManagerConfig> connection_manager_tracing_config_;
     // TODO(snowp): It might make sense to move this to the FilterManager to avoid storing it in
@@ -496,9 +503,35 @@ private:
     const Tracing::CustomTagMap* customTags() const override;
     bool verbose() const override;
     uint32_t maxPathTagLength() const override;
+
+    std::shared_ptr<bool> still_alive_ = std::make_shared<bool>(true);
   };
 
   using ActiveStreamPtr = std::unique_ptr<ActiveStream>;
+
+  class ActiveStreamHandle : public RequestDecoderHandle {
+   public:
+    explicit ActiveStreamHandle(ActiveStream& stream)
+        : valid_(stream.stillAlive()),
+          stream_(stream) {}
+
+    ~ActiveStreamHandle() override = default;
+
+    bool isValid() override {
+      return !valid_.expired();
+    }
+
+    OptRef<RequestDecoder> get() override {
+      if (valid_.expired()) {
+        return {};
+      }
+      return stream_;
+    }
+
+   private:
+    std::weak_ptr<bool> valid_;
+    ActiveStream& stream_;
+  };
 
   class HttpStreamIdProviderImpl : public StreamInfo::StreamIdProvider {
   public:

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -514,8 +514,6 @@ private:
 
     ~ActiveStreamHandle() override = default;
 
-    bool isValid() override { return !valid_.expired(); }
-
     OptRef<RequestDecoder> get() override {
       if (valid_.expired()) {
         return {};

--- a/source/server/api_listener_impl.cc
+++ b/source/server/api_listener_impl.cc
@@ -38,10 +38,10 @@ HttpApiListener::ApiListenerWrapper::~ApiListenerWrapper() {
   read_callbacks_.connection_.raiseConnectionEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-Http::RequestDecoder&
-HttpApiListener::ApiListenerWrapper::newStream(Http::ResponseEncoder& response_encoder,
+Http::RequestDecoderHandlePtr
+HttpApiListener::ApiListenerWrapper::newStreamHandle(Http::ResponseEncoder& response_encoder,
                                                bool is_internally_created) {
-  return http_connection_manager_->newStream(response_encoder, is_internally_created);
+  return http_connection_manager_->newStreamHandle(response_encoder, is_internally_created);
 }
 
 HttpApiListener::HttpApiListener(const envoy::config::listener::v3::Listener& config,

--- a/source/server/api_listener_impl.cc
+++ b/source/server/api_listener_impl.cc
@@ -40,7 +40,7 @@ HttpApiListener::ApiListenerWrapper::~ApiListenerWrapper() {
 
 Http::RequestDecoderHandlePtr
 HttpApiListener::ApiListenerWrapper::newStreamHandle(Http::ResponseEncoder& response_encoder,
-                                               bool is_internally_created) {
+                                                     bool is_internally_created) {
   return http_connection_manager_->newStreamHandle(response_encoder, is_internally_created);
 }
 

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -209,8 +209,8 @@ public:
           http_connection_manager_(parent.http_connection_manager_factory_(read_callbacks_)) {}
     ~ApiListenerWrapper() override;
 
-    Http::RequestDecoder& newStream(Http::ResponseEncoder& response_encoder,
-                                    bool is_internally_created = false) override;
+    Http::RequestDecoderHandlePtr newStreamHandle(Http::ResponseEncoder& response_encoder,
+                                                  bool is_internally_created = false) override;
 
     SyntheticReadCallbacks& readCallbacks() { return read_callbacks_; }
 

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -96,7 +96,7 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
     ASSERT_TRUE(http_api_listener != nullptr);
 
     ON_CALL(stream_encoder_, getStream()).WillByDefault(ReturnRef(stream_encoder_.stream_));
-    auto& stream_decoder = http_api_listener->newStream(stream_encoder_);
+    auto stream_decoder = http_api_listener->newStreamHandle(stream_encoder_);
 
     // The AutonomousUpstream responds with 200 OK and a body of 10 bytes.
     // In the http1 codec the end stream is encoded with encodeData and 0 bytes.
@@ -106,7 +106,7 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
     EXPECT_CALL(stream_encoder_, encodeData(BufferStringEqual(""), true)).WillOnce(Notify(&done));
 
     // Send a headers-only request
-    stream_decoder.decodeHeaders(
+    stream_decoder->get()->decodeHeaders(
         Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         true);
@@ -136,10 +136,10 @@ TEST_P(ApiListenerIntegrationTest, DestroyWithActiveStreams) {
     ASSERT_TRUE(http_api_listener != nullptr);
 
     ON_CALL(stream_encoder_, getStream()).WillByDefault(ReturnRef(stream_encoder_.stream_));
-    auto& stream_decoder = http_api_listener->newStream(stream_encoder_);
+    auto stream_decoder = http_api_listener->newStreamHandle(stream_encoder_);
 
     // Send a headers-only request
-    stream_decoder.decodeHeaders(
+    stream_decoder->get()->decodeHeaders(
         Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         false);
@@ -184,7 +184,7 @@ TEST_P(ApiListenerIntegrationTest, FromWorkerThread) {
     ASSERT_TRUE(http_api_listener != nullptr);
 
     ON_CALL(stream_encoder_, getStream()).WillByDefault(ReturnRef(stream_encoder_.stream_));
-    auto& stream_decoder = http_api_listener->newStream(stream_encoder_);
+    auto stream_decoder = http_api_listener->newStreamHandle(stream_encoder_);
 
     // The AutonomousUpstream responds with 200 OK and a body of 10 bytes.
     // In the http1 codec the end stream is encoded with encodeData and 0 bytes.
@@ -194,7 +194,7 @@ TEST_P(ApiListenerIntegrationTest, FromWorkerThread) {
     EXPECT_CALL(stream_encoder_, encodeData(BufferStringEqual(""), true)).WillOnce(Notify(&done));
 
     // Send a headers-only request
-    stream_decoder.decodeHeaders(
+    stream_decoder->get()->decodeHeaders(
         Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         true);

--- a/test/mocks/http/api_listener.h
+++ b/test/mocks/http/api_listener.h
@@ -12,7 +12,7 @@ public:
   ~MockApiListener() override;
 
   // Http::ApiListener
-  MOCK_METHOD(RequestDecoder&, newStream,
+  MOCK_METHOD(RequestDecoderHandlePtr, newStreamHandle,
               (ResponseEncoder & response_encoder, bool is_internally_created));
 };
 


### PR DESCRIPTION
Add a RequestDecoderHandle type which is effectively a weak reference to a RequestDecoder. 
Attempt to clarify the lifetime of RequestDecoder in mobile.

Risk Level: Low - mobile only
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
