### PR TITLE
Update check_request_utils.cc: In the `check_request` to `ext_authz`,…

### DIFF
--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -213,6 +213,7 @@ void CheckRequestUtils::createHttpCheck(
 
   if (include_tls_session) {
     if (cb->connection()->ssl() != nullptr) {
+      attrs->mutable_tls_session();
       if (!cb->connection()->ssl()->sni().empty()) {
         const std::string server_name(cb->connection()->ssl()->sni());
         attrs->mutable_tls_session()->set_sni(server_name);

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -50,8 +50,9 @@ public:
     EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
   }
 
-  void callHttpCheckAndValidateRequestAttributes(bool include_peer_certificate,
-                                                 const envoy::service::auth::v3::AttributeContext_TLSSession* want_tls_session) {
+  void callHttpCheckAndValidateRequestAttributes(
+      bool include_peer_certificate,
+      const envoy::service::auth::v3::AttributeContext_TLSSession* want_tls_session) {
     Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-downstream-service-cluster", "foo"},
                                                    {":path", "/bar"}};
     envoy::service::auth::v3::CheckRequest request;
@@ -68,8 +69,8 @@ public:
     CheckRequestUtils::createHttpCheck(&callbacks_, request_headers, std::move(context_extensions),
                                        std::move(metadata_context), request,
                                        /*max_request_bytes=*/0, /*pack_as_bytes=*/false,
-                                       include_peer_certificate, want_tls_session != nullptr, labels,
-                                       nullptr);
+                                       include_peer_certificate, want_tls_session != nullptr,
+                                       labels, nullptr);
 
     EXPECT_EQ("source", request.attributes().source().principal());
     EXPECT_EQ("destination", request.attributes().destination().principal());
@@ -92,11 +93,9 @@ public:
       EXPECT_EQ(0, request.attributes().source().certificate().size());
     }
 
-    EXPECT_EQ(want_tls_session != nullptr,
-              request.attributes().has_tls_session());
+    EXPECT_EQ(want_tls_session != nullptr, request.attributes().has_tls_session());
     if (want_tls_session != nullptr) {
-      EXPECT_EQ(want_tls_session->sni(),
-                request.attributes().tls_session().sni());
+      EXPECT_EQ(want_tls_session->sni(), request.attributes().tls_session().sni());
     }
   }
 
@@ -447,9 +446,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
   want_tls_session.set_sni(sni_);
-  EXPECT_CALL(*ssl_, sni())
-      .Times(2)
-      .WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
@@ -459,27 +456,20 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(callbacks_, connection())
       .Times(4)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
-  connection_.stream_info_.downstream_connection_info_provider_
-      ->setRemoteAddress(addr_);
-  connection_.stream_info_.downstream_connection_info_provider_
-      ->setLocalAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
   EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
   EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
-  EXPECT_CALL(req_info_, protocol())
-      .Times(2)
-      .WillRepeatedly(ReturnPointee(&protocol_));
+  EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
   EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
 
-  EXPECT_CALL(*ssl_, uriSanPeerCertificate())
-      .WillOnce(Return(std::vector<std::string>{"source"}));
+  EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni())
-      .Times(1)
-      .WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).Times(1).WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -469,7 +469,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni()).Times(1).WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -51,7 +51,7 @@ public:
   }
 
   void callHttpCheckAndValidateRequestAttributes(bool include_peer_certificate,
-                                                 bool include_tls_session) {
+                                                 const envoy::service::auth::v3::AttributeContext_TLSSession* want_tls_session) {
     Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-downstream-service-cluster", "foo"},
                                                    {":path", "/bar"}};
     envoy::service::auth::v3::CheckRequest request;
@@ -68,7 +68,7 @@ public:
     CheckRequestUtils::createHttpCheck(&callbacks_, request_headers, std::move(context_extensions),
                                        std::move(metadata_context), request,
                                        /*max_request_bytes=*/0, /*pack_as_bytes=*/false,
-                                       include_peer_certificate, include_tls_session, labels,
+                                       include_peer_certificate, want_tls_session != nullptr, labels,
                                        nullptr);
 
     EXPECT_EQ("source", request.attributes().source().principal());
@@ -92,8 +92,11 @@ public:
       EXPECT_EQ(0, request.attributes().source().certificate().size());
     }
 
-    if (include_tls_session) {
-      EXPECT_EQ(sni_, request.attributes().tls_session().sni());
+    EXPECT_EQ(want_tls_session != nullptr,
+              request.attributes().has_tls_session());
+    if (want_tls_session != nullptr) {
+      EXPECT_EQ(want_tls_session->sni(),
+                request.attributes().tls_session().sni());
     }
   }
 
@@ -362,7 +365,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeer) {
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
 
-  callHttpCheckAndValidateRequestAttributes(false, false);
+  callHttpCheckAndValidateRequestAttributes(false, nullptr);
 }
 
 // Verify that createHttpCheck extract the attributes from the HTTP request into CheckRequest
@@ -374,7 +377,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerUriSans) {
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
 
-  callHttpCheckAndValidateRequestAttributes(false, false);
+  callHttpCheckAndValidateRequestAttributes(false, nullptr);
 }
 
 // Verify that createHttpCheck extract the attributes from the HTTP request into CheckRequest
@@ -392,7 +395,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerDnsSans) {
   Protobuf::Map<std::string, std::string> context_extensions;
   context_extensions["key"] = "value";
 
-  callHttpCheckAndValidateRequestAttributes(false, false);
+  callHttpCheckAndValidateRequestAttributes(false, nullptr);
 }
 
 // Verify that createHttpCheck extract the attributes from the HTTP request into CheckRequest
@@ -410,7 +413,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextSubject) {
   std::string subject_local = "destination";
   EXPECT_CALL(*ssl_, subjectLocalCertificate()).WillOnce(ReturnRef(subject_local));
 
-  callHttpCheckAndValidateRequestAttributes(false, false);
+  callHttpCheckAndValidateRequestAttributes(false, nullptr);
 }
 
 // Verify that the source certificate is populated correctly.
@@ -422,7 +425,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerCertificate) {
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   EXPECT_CALL(*ssl_, urlEncodedPemEncodedPeerCertificate()).WillOnce(ReturnRef(cert_data_));
 
-  callHttpCheckAndValidateRequestAttributes(true, false);
+  callHttpCheckAndValidateRequestAttributes(true, nullptr);
 }
 
 // Verify that the SNI is populated correctly.
@@ -442,9 +445,43 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
-  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(sni_));
+  envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
+  want_tls_session.set_sni(sni_);
+  EXPECT_CALL(*ssl_, sni())
+      .Times(2)
+      .WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
-  callHttpCheckAndValidateRequestAttributes(false, true);
+  callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
+}
+
+// Verify that the SNI is populated correctly.
+TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
+  EXPECT_CALL(callbacks_, connection())
+      .Times(4)
+      .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
+  connection_.stream_info_.downstream_connection_info_provider_
+      ->setRemoteAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_
+      ->setLocalAddress(addr_);
+  EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
+  EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
+  EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_, protocol())
+      .Times(2)
+      .WillRepeatedly(ReturnPointee(&protocol_));
+  EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
+
+  EXPECT_CALL(*ssl_, uriSanPeerCertificate())
+      .WillOnce(Return(std::vector<std::string>{"source"}));
+  EXPECT_CALL(*ssl_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"destination"}));
+  envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
+  EXPECT_CALL(*ssl_, sni())
+      .Times(1)
+      .WillRepeatedly(ReturnRef(want_tls_session.sni()));
+
+  callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
 
 } // namespace


### PR DESCRIPTION
… when `tls_session` is set, but `sni` is empty, Envoy sends an non-nullptr tls_session.

For example, `curl https://1.2.3.4/`, the req is secure, but doesn't come with sni, since it is using IP addr other than hostname.

In the existing implementation, check_request's tls_session is nullptr.

ext_authz's grpc_service can't tell whether the req is secure or not.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
