### PR TITLE
add a new MOBILE_RELEASE_ASSERT macro to implement assertion for Envoy Mobile only

### DIFF
--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -167,9 +167,9 @@ void resetEnvoyBugCountersForTest();
  * clients but has no effect for Envoy as a server.
  */
 #if TARGET_OS_IOS || defined(__ANDROID_API__)
-#define MOBILE_RELEASE_ASSERT(X,DETAILS) RELEASE_ASSERT(X, DETAILS)
+#define MOBILE_RELEASE_ASSERT(X, DETAILS) RELEASE_ASSERT(X, DETAILS)
 #else
-#define MOBILE_RELEASE_ASSERT(X,DETAILS)
+#define MOBILE_RELEASE_ASSERT(X, DETAILS)
 #endif
 
 /**

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -163,6 +163,16 @@ void resetEnvoyBugCountersForTest();
 #define RELEASE_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, ::abort(), DETAILS)
 
 /**
+ * Assert macro intended for Envoy Mobile. It creates enforcement for mobile
+ * clients but has no effect for Envoy as a server.
+ */
+#if TARGET_OS_IOS || defined(__ANDROID_API__)
+#define MOBILE_RELEASE_ASSERT(X,DETAILS) _ASSERT_IMPL(X, #X, ::abort(), DETAILS)
+#else
+#define MOBILE_RELEASE_ASSERT(X,DETAILS)
+#endif
+
+/**
  * Assert macro intended for security guarantees. It has the same functionality
  * as RELEASE_ASSERT, but is intended for memory bounds-checking.
  */

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -167,7 +167,7 @@ void resetEnvoyBugCountersForTest();
  * clients but has no effect for Envoy as a server.
  */
 #if TARGET_OS_IOS || defined(__ANDROID_API__)
-#define MOBILE_RELEASE_ASSERT(X,DETAILS) _ASSERT_IMPL(X, #X, ::abort(), DETAILS)
+#define MOBILE_RELEASE_ASSERT(X,DETAILS) RELEASE_ASSERT(X, DETAILS)
 #else
 #define MOBILE_RELEASE_ASSERT(X,DETAILS)
 #endif


### PR DESCRIPTION
Commit Message: Add a new MOBILE_RELEASE_ASSERT macro to implement assertion for Envoy Mobile only
Additional Description: Sometimes when investigating an Envoy Mobile issue, it's helpful to add some assertions to make sure invariables are respected. Doing a normal RELEASE_ASSERT affects servers and puts a lot more at stake.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Envoy mobile feature
