### PR TITLE
Add deduction guides to support compilers with ctad-maybe-unsupported warning enabled

### DIFF
--- a/test/extensions/common/async_files/mocks.h
+++ b/test/extensions/common/async_files/mocks.h
@@ -104,6 +104,17 @@ public:
                Api::OsSysCalls* substitute_posix_file_operations));
 };
 
+// Add deduction guides for comping with the ctad-maybe-unsupported warning
+TypedMockAsyncFileAction(std::function<void(absl::Status)>)
+    ->TypedMockAsyncFileAction<std::function<void(absl::Status)>>;
+TypedMockAsyncFileAction(std::function<void(absl::StatusOr<Buffer::InstancePtr>)>)
+    ->TypedMockAsyncFileAction<std::function<void(absl::StatusOr<Buffer::InstancePtr>)>>;
+TypedMockAsyncFileAction(std::function<void(absl::StatusOr<size_t>)>)
+    ->TypedMockAsyncFileAction<std::function<void(absl::StatusOr<size_t>)>>;
+TypedMockAsyncFileAction(std::function<void(absl::StatusOr<std::shared_ptr<AsyncFileContext>>)>)
+    ->TypedMockAsyncFileAction<
+        std::function<void(absl::StatusOr<std::shared_ptr<AsyncFileContext>>)>>;
+
 } // namespace AsyncFiles
 } // namespace Common
 } // namespace Extensions

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -632,6 +632,7 @@ cryptographic
 cryptographically
 cstate
 cstring
+ctad
 ctor
 ctrl
 customizations


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
