### PR TITLE
tools: update installation of buildtools

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -252,7 +252,7 @@ class FormatChecker:
                     "{} environment variable to specify the path. Example:\n"
                     "    export {}=`which {}`\n"
                     "If you don't have {} installed, you can install it by:\n"
-                    "    go get -u github.com/bazelbuild/buildtools/{}".format(
+                    "    go install github.com/bazelbuild/buildtools/{}@latest".format(
                         path, name, var, var, name, name, name))
 
         check_bazel_tool('buildifier', self.config.buildifier_path, 'BUILDIFIER_BIN')


### PR DESCRIPTION
`go get -u` is deprecated in this case. Run the previous command will get:
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: update installation of buildtools
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
