### PR TITLE
docs: Fix duplicate rst label

### DIFF
--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -92,7 +92,7 @@ Envoy will attempt to create a QUIC connection, then if the QUIC handshake is no
 will kick off a TCP connection, and will use whichever is established first.
 
 .. tip::
-   See :ref:`here <arch_overview_http3_upstream>` for more information about HTTP/3 connection pooling, including
+   See :ref:`here <arch_overview_http3_pooling_upstream>` for more information about HTTP/3 connection pooling, including
    detailed information of where QUIC will be used, and how it fails over to TCP when QUIC use is configured to be optional.
 
    An example upstream HTTP/3 configuration file can be found :repo:`here </configs/google_com_http3_upstream_proxy.yaml>`.

--- a/docs/root/intro/arch_overview/upstream/connection_pooling.rst
+++ b/docs/root/intro/arch_overview/upstream/connection_pooling.rst
@@ -61,7 +61,7 @@ For Envoy acting as a forward proxy, the preferred configuration is the
 :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>`.
 By default it will use TCP and ALPN to select the best available protocol of HTTP/2 and HTTP/1.1.
 
-.. _arch_overview_http3_upstream:
+.. _arch_overview_http3_pooling_upstream:
 
 For auto-http with HTTP/3, an alternate protocol cache must be configured via
 :ref:`alternate_protocols_cache_options <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.AutoHttpConfig.alternate_protocols_cache_options>`.  HTTP/3 connections will only be attempted to servers which


### PR DESCRIPTION
This should be failing on `main` not sure why its not - we defo have an error in our rst

This triggered the expected CI fail when reopening the 1.26 branch - confusing that its only happening there, and a bit troubling - seems like a sphinx bug, most likely in multicore support 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
