### PR TITLE
[WIP] ci/github: Ensure postsubmit verify/publish uses correct checkout

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -12,17 +12,14 @@ inputs:
     type: string
     required: true
 
-  repo_ref:
-    type: string
+  trusted:
+    type: boolean
+    required: true
+
   repo_ref_sha:
     type: string
   repo_ref_name:
     type: string
-
-  trusted_bots:
-    type: string
-    default: |
-      trigger-release-envoy[bot]
 
   check_mobile_run:
     type: boolean
@@ -72,8 +69,6 @@ outputs:
     value: ${{ steps.context.outputs.repo_ref_sha_short }}
   repo_ref_title:
     value: ${{ steps.context.outputs.repo_ref_title }}
-  trusted:
-    value: ${{ steps.trusted.outputs.trusted }}
   version_dev:
     value: ${{ steps.context.outputs.version_dev }}
   version_patch:
@@ -87,37 +82,6 @@ runs:
     id: should_run
     name: 'Check what to run'
     run: ./mobile/tools/what_to_run.sh
-    shell: bash
-
-  - id: trusted
-    name: 'Check if its a trusted run'
-    run: |
-      TRUSTED=1
-      ACTOR="${{ github.actor }}"
-      if [[ "$ACTOR" =~ \[bot\] ]]; then
-          TRUSTED_BOT=
-          TRUSTED_BOTS=(${{ inputs.trusted_bots }})
-          for bot in ${TRUSTED_BOTS[@]}; do
-              if [[ "$bot" == "$ACTOR" ]]; then
-                  # Trusted bot account, ie non-PR
-                  TRUSTED_BOT=1
-                  break
-              fi
-          done
-          if [[ -z "$TRUSTED_BOT" ]]; then
-              echo "Not trusted bot account"
-              TRUSTED=
-          fi
-      fi
-      if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          echo "Not trusted pull_request event"
-          TRUSTED=
-      fi
-      if [[ -n "$TRUSTED" ]]; then
-          echo "trusted=true" >> "$GITHUB_OUTPUT"
-      else
-          echo "trusted=false" >> "$GITHUB_OUTPUT"
-      fi
     shell: bash
 
   - id: context
@@ -139,16 +103,14 @@ runs:
       fi
       echo "SET PR NUMBER: ${REF_PR_NUMBER}"
 
-      REF="${{ steps.trusted.outputs.trusted != 'true' && inputs.repo_ref || '' }}"
       REF_SHA=${{ inputs.repo_ref_sha || github.event.pull_request.head.sha || github.sha }}
       REF_SHA_SHORT="${REF_SHA:0:7}"
       REF_TITLE=(
-          "${{ steps.trusted.outputs.trusted == 'true' && 'postsubmit' || 'pr' }}/"
+          "${{ inputs.trusted == 'true' && 'postsubmit' || 'pr' }}/"
           "${REF_NAME}"
           "@${REF_SHA_SHORT}")
       REF_TITLE="$(printf %s "${REF_TITLE[@]}" $'\n')"
       {
-          echo "repo_ref=$REF"
           echo "repo_ref_name=$REF_NAME"
           echo "repo_ref_pr_number=$REF_PR_NUMBER"
           echo "repo_ref_sha=$REF_SHA"

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -96,21 +96,14 @@ jobs:
       with:
         image_tag: ${{ inputs.cache_build_image }}
 
-    # If the run is "trusted" (ie has access to secrets) then it should
-    # **not** set the ref and should use the code of the calling context.
-    - if: ${{ inputs.repo_ref && inputs.trusted }}
-      run: |
-        echo '`repo_ref` should not be set for trusted CI runs'
-        exit 1
-
     - uses: actions/checkout@v3
       name: Checkout Envoy repository
       with:
         fetch-depth: ${{ inputs.repo_fetch_depth }}
         # WARNING: This allows untrusted code to run!!!
-        #  If this is set, then anything before or after in the job should be regarded as
+        #  If this is set to untrusted code, then anything before or after in the job should be regarded as
         #  compromised.
-        ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
+        ref: ${{ inputs.repo_ref }}
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
 

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -41,6 +41,11 @@ on:
         type: string
         default:
 
+      trusted_bots:
+        type: string
+        default: |
+          trigger-release-envoy[bot]
+
     outputs:
       agent_ubuntu:
         value: ubuntu-22.04
@@ -75,8 +80,6 @@ on:
       mobile_tsan:
         value: ${{ jobs.repo.outputs.mobile_tsan }}
 
-      repo_ref:
-        value: ${{ jobs.repo.outputs.repo_ref }}
       repo_ref_name:
         value: ${{ jobs.repo.outputs.repo_ref_name }}
       repo_ref_sha:
@@ -122,38 +125,69 @@ jobs:
       mobile_ios_tests: ${{ steps.env.outputs.mobile_ios_tests }}
       mobile_release_validation: ${{ steps.env.outputs.mobile_release_validation }}
       mobile_tsan: ${{ steps.env.outputs.mobile_tsan }}
-      repo_ref: ${{ steps.env.outputs.repo_ref }}
       repo_ref_name: ${{ steps.env.outputs.repo_ref_name }}
       repo_ref_sha: ${{ steps.env.outputs.repo_ref_sha }}
       repo_ref_sha_short: ${{ steps.env.outputs.repo_ref_sha_short }}
       repo_ref_title: ${{ steps.env.outputs.repo_ref_title }}
-      trusted: ${{ steps.env.outputs.trusted }}
+      trusted: ${{ steps.trusted.outputs.trusted }}
       version_dev: ${{ steps.env.outputs.version_dev }}
       version_patch: ${{ steps.env.outputs.version_patch }}
     steps:
+    - id: trusted
+      name: 'Check if its a trusted run'
+      run: |
+        TRUSTED=1
+        ACTOR="${{ github.actor }}"
+        if [[ "$ACTOR" =~ \[bot\] ]]; then
+            TRUSTED_BOT=
+            TRUSTED_BOTS=(${{ inputs.trusted_bots }})
+            for bot in ${TRUSTED_BOTS[@]}; do
+                if [[ "$bot" == "$ACTOR" ]]; then
+                    # Trusted bot account, ie non-PR
+                    TRUSTED_BOT=1
+                    break
+                fi
+            done
+            if [[ -z "$TRUSTED_BOT" ]]; then
+                echo "Not trusted bot account"
+                TRUSTED=
+            fi
+        fi
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Not trusted pull_request event"
+            TRUSTED=
+        fi
+        if [[ -n "$TRUSTED" ]]; then
+            echo "trusted=true" >> "$GITHUB_OUTPUT"
+        else
+            echo "trusted=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - uses: actions/checkout@v3
       name: Checkout Envoy repository
       with:
+        # Only trusted runs should be allowed to check out specific commits
+        ref: ${{ ! steps.trusted.outputs.trusted == 'true' && inputs.repo_ref || '' }}
         fetch-depth: ${{ ! inputs.check_mobile_run && 1 || 0 }}
     - uses: ./.github/actions/env
       name: Generate environment variables
       id: env
       with:
         check_mobile_run: ${{ inputs.check_mobile_run }}
-        repo_ref: ${{ inputs.repo_ref }}
         repo_ref_name: ${{ inputs.repo_ref_name }}
         repo_ref_sha: ${{ inputs.repo_ref_sha }}
         build_image_repo: ${{ inputs.build_image_repo }}
         build_image_tag: ${{ inputs.build_image_tag }}
         build_image_mobile_sha: ${{ inputs.build_image_mobile_sha }}
         build_image_sha: ${{ inputs.build_image_sha }}
+        trusted: ${{ steps.trusted.outputs.trusted == 'true' && true || false }}
 
     - name: 'Print env'
       run: |
         echo "version_dev=${{ steps.env.outputs.version_dev }}"
         echo "version_patch=${{ steps.env.outputs.version_patch }}"
-        echo "trusted=${{ steps.env.outputs.trusted }}"
-        echo "repo_ref=${{ steps.env.outputs.repo_ref }}"
+        echo "trusted=${{ steps.trusted.outputs.trusted }}"
+        echo "repo_ref=${{ inputs.repo_ref }}"
         echo "repo_ref_name=${{ steps.env.outputs.repo_ref_name }}"
         echo "repo_ref_pr_number=${{ steps.env.outputs.repo_ref_pr_number }}"
         echo "repo_ref_sha=${{ steps.env.outputs.repo_ref_sha }}"

--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -26,8 +26,6 @@ on:
         default: ''
       repo_ref:
         type: string
-      given_ref:
-        type: string
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}-publish
@@ -45,7 +43,7 @@ jobs:
           name: github
           run_pre: ./.github/actions/publish/release/setup
           run_pre_with: |
-            ref: ${{ inputs.given_ref }}
+            ref: ${{ inputs.repo_ref }}
             bucket: envoy-pr
           env: |
             export ENVOY_PUBLISH_DRY_RUN=1
@@ -74,7 +72,7 @@ jobs:
           name: github
           run_pre: ./.github/actions/publish/release/setup
           run_pre_with: |
-            ref: ${{ inputs.given_ref }}
+            ref: ${{ inputs.repo_ref }}
             bucket: envoy-postsubmit
           env: |
             if [[ '${{ inputs.version_dev }}' != '' ]]; then

--- a/.github/workflows/_stage_verify.yml
+++ b/.github/workflows/_stage_verify.yml
@@ -11,8 +11,6 @@ on:
         default: false
       repo_ref:
         type: string
-      given_ref:
-        type: string
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}-verify
@@ -35,7 +33,7 @@ jobs:
           run_pre: ./.github/actions/verify/examples/setup
           run_pre_with: |
             bucket: envoy-${{ inputs.trusted && 'postsubmit' || 'pr' }}
-            ref: ${{ inputs.given_ref }}
+            ref: ${{ inputs.repo_ref }}
           env: |
             export NO_BUILD_SETUP=1
     uses: ./.github/workflows/_ci.yml
@@ -50,4 +48,4 @@ jobs:
       run_pre_with: ${{ matrix.run_pre_with }}
       env: ${{ matrix.env }}
       trusted: ${{ inputs.trusted }}
-      repo_ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
+      repo_ref: ${{ inputs.repo_ref }}

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -53,8 +53,7 @@ jobs:
       build_image_ubuntu: ${{ needs.env.outputs.build_image_ubuntu }}
       trusted: ${{ needs.env.outputs.trusted == 'true' && true || false }}
       version_dev: ${{ needs.env.outputs.version_dev }}
-      given_ref: ${{ inputs.ref }}
-      repo_ref: ${{ needs.env.outputs.trusted != 'true' && inputs.ref || '' }}
+      repo_ref: ${{ inputs.ref }}
     permissions:
       contents: write
 
@@ -65,5 +64,4 @@ jobs:
     - env
     with:
       trusted: ${{ needs.env.outputs.trusted == 'true' && true || false }}
-      given_ref: ${{ inputs.ref }}
-      repo_ref: ${{ needs.env.outputs.trusted != 'true' && needs.env.outputs.repo_ref || '' }}
+      repo_ref: ${{ inputs.ref }}


### PR DESCRIPTION
The initial implementation of this only allowed untrusted runs to checkout specific commits - ie untrusted code

This was due to the fact that the trusted ci run have access to secrets and permissions and therefore they should not be allowed to run anything other than the the current branch head (ie where the workflow was checked out)

The problem with this is that the target branch (ie `main`, `release/v...` ) can have moved on since the commit the ci that is being tested/run landed

This PR allows trusted code to checkout specific commits

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
