### PR TITLE
Remove implicit deps on fmt_lib

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -130,9 +130,7 @@ def envoy_cc_library(
         textual_hdrs = textual_hdrs,
         deps = deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//envoy/common:base_includes",
-            repository + "//source/common/common:fmt_lib",
             envoy_external_dep_path("abseil_strings"),
-            envoy_external_dep_path("fmtlib"),
         ] + envoy_pch_deps(repository, "//source/common/common:common_pch"),
         alwayslink = alwayslink,
         linkstatic = envoy_linkstatic(),

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -5150,6 +5150,7 @@ envoy_quiche_platform_impl_cc_library(
     ],
     deps = [
         ":quiche_common_platform_export",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 

--- a/envoy/stream_info/BUILD
+++ b/envoy/stream_info/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
     hdrs = ["filter_state.h"],
     external_deps = ["abseil_optional"],
     deps = [
+        "//source/common/common:fmt_lib",
         "//source/common/common:utility_lib",
         "//source/common/protobuf",
     ],

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -210,6 +210,7 @@ envoy_cc_library(
     external_deps = ["abseil_synchronization"],
     deps = [
         ":base_logger_lib",
+        ":fmt_lib",
         ":lock_guard_lib",
         ":macros",
         ":non_copyable",

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -25,6 +25,7 @@ envoy_cc_win32_library(
     strip_include_prefix = "win32",
     deps = [
         "//envoy/filesystem:filesystem_interface",
+        "//source/common/common:fmt_lib",
     ],
 )
 

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -58,7 +58,10 @@ envoy_quiche_platform_impl_cc_library(
     name = "quiche_time_utils_impl_lib",
     srcs = ["quiche_time_utils_impl.cc"],
     hdrs = ["quiche_time_utils_impl.h"],
-    external_deps = ["abseil_base"],
+    external_deps = [
+        "abseil_base",
+        "abseil_time",
+    ],
 )
 
 envoy_quiche_platform_impl_cc_library(

--- a/source/extensions/filters/http/admission_control/evaluators/BUILD
+++ b/source/extensions/filters/http/admission_control/evaluators/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
     deps = [
         "//envoy/grpc:status",
         "//source/common/common:enum_to_int",
+        "//source/common/common:fmt_lib",
         "@envoy_api//envoy/extensions/filters/http/admission_control/v3:pkg_cc_proto",
     ],
 )


### PR DESCRIPTION
Commit Message:
Replaces implicit dependency on fmt_lib that is added to every target with explicit to just the targets that need it.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
