### PR TITLE
mobile: Fix the mobile_release CI workflow

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -15,11 +15,11 @@ jobs:
               || !contains(github.actor, '[bot]'))
       }}
     name: android_release_artifacts
+    uses: ./.github/workflows/_env.yml
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     container:
-      image: envoyproxy/envoy-build-ubuntu:mobile-41c5a05d708972d703661b702a63ef5060125c33
-      # image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}
+      image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}
       env:
         CC: /opt/llvm/bin/clang
         CXX: /opt/llvm/bin/clang++

--- a/.github/workflows/mobile_release.yml
+++ b/.github/workflows/mobile_release.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     container:
-      image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}
+      image: envoyproxy/envoy-build-ubuntu:mobile-41c5a05d708972d703661b702a63ef5060125c33
+      # image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}
       env:
         CC: /opt/llvm/bin/clang
         CXX: /opt/llvm/bin/clang++


### PR DESCRIPTION
The `mobile_release` workflow has been failing the last couple months: https://github.com/envoyproxy/envoy/actions/workflows/mobile_release.yml.  This is likely due to the `_env.yml` file missing from the job config, as the job fails due to clang toolchain failures.

Also, rename the file to `mobile-release.yml` since the convention is to use dashes, not underscores.