### PR TITLE
Avoid send empty body to ext_proc server if decodeData() not called

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -51,16 +51,15 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * Whether subsequent HTTP requests are transmitted synchronously or whether they are
 //   sent asynchronously.
 // * To modify request or response trailers if they already exist
-// * To add request or response trailers where they are not present
 //
 // The filter supports up to six different processing steps. Each is represented by
 // a gRPC stream message that is sent to the external processor. For each message, the
 // processor must send a matching response.
 //
 // * Request headers: Contains the headers from the original HTTP request.
-// * Request body: Sent in a single message if the BUFFERED or BUFFERED_PARTIAL
-//   mode is chosen, in multiple messages if the STREAMED mode is chosen, and not
-//   at all otherwise.
+// * Request body: Delivered if they are present and sent in a single message if
+//   the BUFFERED or BUFFERED_PARTIAL mode is chosen, in multiple messages if the
+//   STREAMED mode is chosen, and not at all otherwise.
 // * Request trailers: Delivered if they are present and if the trailer mode is set
 //   to SEND.
 // * Response headers: Contains the headers from the HTTP response. Keep in mind

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -275,9 +275,6 @@ public:
   void onMessageTimeout();
   void onNewTimeout(const ProtobufWkt::Duration& override_message_timeout);
 
-  void sendBufferedData(ProcessorState& state, ProcessorState::CallbackState new_state,
-                        bool end_stream);
-
   void sendBodyChunk(ProcessorState& state, const Buffer::Instance& data,
                      ProcessorState::CallbackState new_state, bool end_stream);
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
