### PR TITLE
cleanup: moving checkApiConfigSourceNames to unnamed namespace

### DIFF
--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -90,8 +90,14 @@ void Utility::checkFilesystemSubscriptionBackingPath(const std::string& path, Ap
   }
 }
 
-void Utility::checkApiConfigSourceNames(
-    const envoy::config::core::v3::ApiConfigSource& api_config_source) {
+namespace {
+/**
+ * Check the grpc_services and cluster_names for API config sanity. Throws on error.
+ * @param api_config_source the config source to validate.
+ * @throws EnvoyException when an API config has the wrong number of gRPC
+ * services or cluster names, depending on expectations set by its API type.
+ */
+void checkApiConfigSourceNames(const envoy::config::core::v3::ApiConfigSource& api_config_source) {
   const bool is_grpc =
       (api_config_source.api_type() == envoy::config::core::v3::ApiConfigSource::GRPC ||
        api_config_source.api_type() == envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
@@ -126,6 +132,7 @@ void Utility::checkApiConfigSourceNames(
     }
   }
 }
+} // namespace
 
 void Utility::validateClusterName(const Upstream::ClusterManager::ClusterSet& primary_clusters,
                                   const std::string& cluster_name,
@@ -148,7 +155,7 @@ void Utility::checkApiConfigSourceSubscriptionBackingCluster(
           envoy::config::core::v3::ApiConfigSource::AGGREGATED_DELTA_GRPC) {
     return;
   }
-  Utility::checkApiConfigSourceNames(api_config_source);
+  checkApiConfigSourceNames(api_config_source);
 
   const bool is_grpc =
       (api_config_source.api_type() == envoy::config::core::v3::ApiConfigSource::GRPC);
@@ -246,7 +253,7 @@ Grpc::AsyncClientFactoryPtr Utility::factoryForGrpcApiConfigSource(
     Grpc::AsyncClientManager& async_client_manager,
     const envoy::config::core::v3::ApiConfigSource& api_config_source, Stats::Scope& scope,
     bool skip_cluster_check) {
-  Utility::checkApiConfigSourceNames(api_config_source);
+  checkApiConfigSourceNames(api_config_source);
 
   if (api_config_source.api_type() != envoy::config::core::v3::ApiConfigSource::GRPC &&
       api_config_source.api_type() != envoy::config::core::v3::ApiConfigSource::DELTA_GRPC) {

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -161,15 +161,6 @@ public:
   static void checkFilesystemSubscriptionBackingPath(const std::string& path, Api::Api& api);
 
   /**
-   * Check the grpc_services and cluster_names for API config sanity. Throws on error.
-   * @param api_config_source the config source to validate.
-   * @throws EnvoyException when an API config has the wrong number of gRPC
-   * services or cluster names, depending on expectations set by its API type.
-   */
-  static void
-  checkApiConfigSourceNames(const envoy::config::core::v3::ApiConfigSource& api_config_source);
-
-  /**
    * Check the validity of a cluster backing an api config source. Throws on error.
    * @param primary_clusters the API config source eligible clusters.
    * @param cluster_name the cluster name to validate.


### PR DESCRIPTION
Commit Message: cleanup: moving checkApiConfigSourceNames to unnamed namespace
Additional Description:
Minor cleanup moving checkApiConfigSourceNames to unnamed namespace.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A