### PR TITLE
tls: Update the preprocessor macro check

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -568,14 +568,18 @@ void ContextImpl::logHandshake(SSL* ssl) const {
     stats_.no_certificate_.inc();
   }
 
-#ifndef BORINGSSL_FIPS
+#if defined(BORINGSSL_FIPS) && BORINGSSL_API_VERSION >= 18
+#error "Delete preprocessor check below; no longer needed"
+#endif
+
+#if BORINGSSL_API_VERSION >= 18
   // Increment the `was_key_usage_invalid_` stats to indicate the given cert would have triggered an
   // error but is allowed because the enforcement that rsa key usage and tls usage need to be
   // matched has been disabled.
   if (SSL_was_key_usage_invalid(ssl)) {
     stats_.was_key_usage_invalid_.inc();
   }
-#endif
+#endif // BORINGSSL_API_VERSION
 }
 
 std::vector<Ssl::PrivateKeyMethodProviderSharedPtr> ContextImpl::getPrivateKeyMethodProviders() {


### PR DESCRIPTION
It was reverted in #28334, but it appears to be unrelated to coverage drop (which lead to reversion)