### PR TITLE
UHV: harmonize check for %00 with legacy path normalization

### DIFF
--- a/envoy/http/header_validator_errors.h
+++ b/envoy/http/header_validator_errors.h
@@ -22,6 +22,7 @@ struct UhvResponseCodeDetailValues {
   const std::string InvalidHostDeprecatedUserInfo = "uhv.invalid_host_deprecated_user_info";
   const std::string FragmentInUrlPath = "uhv.fragment_in_url_path";
   const std::string EscapedSlashesInPath = "uhv.escaped_slashes_in_url_path";
+  const std::string Percent00InPath = "uhv.percent_00_in_url_path";
 };
 
 using UhvResponseCodeDetail = ConstSingleton<UhvResponseCodeDetailValues>;

--- a/source/extensions/http/header_validators/envoy_default/config_overrides.h
+++ b/source/extensions/http/header_validators/envoy_default/config_overrides.h
@@ -11,8 +11,21 @@ namespace EnvoyDefault {
 struct ConfigOverrides {
   ConfigOverrides() = default;
   ConfigOverrides(const Envoy::Runtime::Snapshot& snapshot)
-      : preserve_url_encoded_case_(
+      : reject_percent_00_(snapshot.getBoolean("envoy.uhv.reject_percent_00", true)),
+        preserve_url_encoded_case_(
             snapshot.getBoolean("envoy.uhv.preserve_url_encoded_case", true)) {}
+
+  // This flag enables check for the %00 sequence in the URL path. If this sequence is
+  // found request is rejected as invalid. This check requires path normalization to be
+  // enabled to occur.
+  // https://datatracker.ietf.org/doc/html/rfc3986#section-2.1 allows %00 sequence, and
+  // this check is implemented for backward compatibility with legacy path normalization
+  // only.
+  //
+  // This option currently is `true` by default and can be overridden using the
+  // "envoy.uhv.reject_percent_00" runtime value. Note that the default value
+  // will be changed to `false` in the future to make it RFC compliant.
+  const bool reject_percent_00_{true};
 
   // This flag enables preservation of the case of percent-encoded triplets in URL path for
   // compatibility with legacy path normalization.

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -177,6 +177,19 @@ protected:
   PathNormalizer::PathNormalizationResult
   sanitizeEncodedSlashes(::Envoy::Http::RequestHeaderMap& header_map);
 
+  /**
+   * Transform URL path according to configuration (i.e. apply path normalization).
+   */
+  PathNormalizer::PathNormalizationResult
+  transformUrlPath(::Envoy::Http::RequestHeaderMap& header_map);
+
+  /**
+   * Check for presence of %00 sequence based on configuration.
+   * Reject request if %00 sequence was found.
+   */
+  HeaderValueValidationResult
+  checkForPercent00InUrlPath(const ::Envoy::Http::RequestHeaderMap& header_map);
+
   const envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       config_;
   ::Envoy::Http::Protocol protocol_;

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -309,18 +309,9 @@ ServerHttp1HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeader
   sanitizeContentLength(header_map);
   sanitizeHeadersWithUnderscores(header_map);
   sanitizePathWithFragment(header_map);
-  if (!config_.uri_path_normalization_options().skip_path_normalization()) {
-    auto path_result = path_normalizer_.normalizePathUri(header_map);
-    if (!path_result.ok()) {
-      return path_result;
-    }
-  } else {
-    // Path normalization includes sanitization of encoded slashes for performance reasons.
-    // If normalization is disabled, sanitize encoded slashes here
-    auto result = sanitizeEncodedSlashes(header_map);
-    if (!result.ok()) {
-      return result;
-    }
+  auto path_result = transformUrlPath(header_map);
+  if (!path_result.ok()) {
+    return path_result;
   }
   return ::Envoy::Http::ServerHeaderValidator::RequestHeadersTransformationResult::success();
 }

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -430,18 +430,9 @@ ValidationResult Http2HeaderValidator::validateResponseTrailers(
 ServerHttp2HeaderValidator::transformRequestHeaders(::Envoy::Http::RequestHeaderMap& header_map) {
   sanitizeHeadersWithUnderscores(header_map);
   sanitizePathWithFragment(header_map);
-  if (!config_.uri_path_normalization_options().skip_path_normalization()) {
-    auto path_result = path_normalizer_.normalizePathUri(header_map);
-    if (!path_result.ok()) {
-      return path_result;
-    }
-  } else {
-    // Path normalization includes sanitization of encoded slashes for performance reasons.
-    // If normalization is disabled, sanitize encoded slashes here
-    auto result = sanitizeEncodedSlashes(header_map);
-    if (!result.ok()) {
-      return result;
-    }
+  auto path_result = transformUrlPath(header_map);
+  if (!path_result.ok()) {
+    return path_result;
   }
 
   // Transform H/2 extended CONNECT to H/1 UPGRADE, so that request processing always observes H/1

--- a/test/extensions/http/header_validators/envoy_default/http_common_validation_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http_common_validation_test.cc
@@ -27,16 +27,16 @@ protected:
         typed_config;
     TestUtility::loadFromYaml(std::string(config_yaml), typed_config);
 
+    ConfigOverrides overrides(scoped_runtime_.loader().snapshot());
     if (GetParam() == Protocol::Http11) {
       return std::make_unique<ServerHttp1HeaderValidator>(typed_config, Protocol::Http11, stats_,
-                                                          overrides_);
+                                                          overrides);
     }
     return std::make_unique<ServerHttp2HeaderValidator>(typed_config, GetParam(), stats_,
-                                                        overrides_);
+                                                        overrides);
   }
 
   TestScopedRuntime scoped_runtime_;
-  ConfigOverrides overrides_;
 };
 
 std::string protocolTestParamsToString(const ::testing::TestParamInfo<Protocol>& params) {
@@ -165,6 +165,28 @@ TEST_P(HttpCommonValidationTest, RejectEncodedSlashes) {
   EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
   EXPECT_REJECT_WITH_DETAILS(uhv->transformRequestHeaders(headers),
                              "uhv.escaped_slashes_in_url_path");
+}
+
+TEST_P(HttpCommonValidationTest, RejectPercent00ByDefault) {
+  ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
+                                                  {":method", "GET"},
+                                                  {":path", "/dir1%00dir2"},
+                                                  {":authority", "envoy.com"}};
+  auto uhv = createUhv(empty_config);
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
+  EXPECT_REJECT_WITH_DETAILS(uhv->transformRequestHeaders(headers), "uhv.percent_00_in_url_path");
+}
+
+TEST_P(HttpCommonValidationTest, AllowPercent00WithOverride) {
+  scoped_runtime_.mergeValues({{"envoy.uhv.reject_percent_00", "false"}});
+  ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
+                                                  {":method", "GET"},
+                                                  {":path", "/dir1%00dir2"},
+                                                  {":authority", "envoy.com"}};
+  auto uhv = createUhv(empty_config);
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
+  EXPECT_ACCEPT(uhv->transformRequestHeaders(headers));
+  EXPECT_EQ(headers.path(), "/dir1%00dir2");
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message:
Make UHV reject requests with %00 sequence in URL path for backward compatibility with the legacy path normalization.

Additional Description:
Refactor common code from some methods.

Risk Level: Low, build flag protected
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Part of #26642
