### PR TITLE
bazel: Switch `exec_tools` -> `tools`

### DIFF
--- a/bazel/external/boringssl_fips.BUILD
+++ b/bazel/external/boringssl_fips.BUILD
@@ -30,5 +30,5 @@ genrule(
         "ssl/libssl.a",
     ],
     cmd = "$(location {}) $(location crypto/libcrypto.a) $(location ssl/libssl.a)".format("@envoy//bazel/external:boringssl_fips.genrule_cmd"),
-    exec_tools = ["@envoy//bazel/external:boringssl_fips.genrule_cmd"],
+    tools = ["@envoy//bazel/external:boringssl_fips.genrule_cmd"],
 )

--- a/contrib/vcl/source/BUILD
+++ b/contrib/vcl/source/BUILD
@@ -85,7 +85,7 @@ genrule(
         && find . -name "*.a" | xargs -I{} cp -a {} $$EXTERNAL_DIR \
         && find . -name "vppcom.h" | xargs -I{} cp -a {} $$EXTERNAL_DIR
     """,
-    exec_tools = [":build"],
+    tools = [":build"],
 )
 
 envoy_cc_library(

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -113,12 +113,12 @@ genrule(
         -m arm64/envoy-contrib:bin/envoy-contrib-$${VERSION}-linux-aarch_64 \
            --out $@
     """ % VERSION,
+    tags = ["no-remote"],
     tools = [
         ":arm64-packages",
-        ":x64-packages",
         ":arm64-release",
+        ":x64-packages",
         ":x64-release",
         "//tools/distribution:sign",
     ],
-    tags = ["no-remote"],
 )

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -113,7 +113,7 @@ genrule(
         -m arm64/envoy-contrib:bin/envoy-contrib-$${VERSION}-linux-aarch_64 \
            --out $@
     """ % VERSION,
-    exec_tools = [
+    tools = [
         ":arm64-packages",
         ":x64-packages",
         ":arm64-release",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -247,14 +247,14 @@ genrule(
          $(location rst) \
          $@
     """,
+    stamp = 1,
     tools = [
-        "//bazel:volatile_env",
-        "//tools/docs:sphinx_runner",
         ":rst",
         "//:VERSION.txt",
+        "//bazel:volatile_env",
+        "//tools/docs:sphinx_runner",
         "@envoy_api//:v3_proto_set",
     ],
-    stamp = 1,
 )
 
 # No git stamping, speeds up local dev switching branches
@@ -270,9 +270,9 @@ genrule(
          $@
     """,
     tools = [
-        "//tools/docs:sphinx_runner",
         ":rst",
         "//:VERSION.txt",
+        "//tools/docs:sphinx_runner",
         "@envoy_api//:v3_proto_set",
     ],
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -71,7 +71,7 @@ genrule(
         $(location //source/extensions:extensions_metadata.yaml) \\
         $(location //contrib:extensions_metadata.yaml) $@
     """,
-    exec_tools = ["//tools/docs:generate_extensions_security_rst"],
+    tools = ["//tools/docs:generate_extensions_security_rst"],
 )
 
 genrule(
@@ -82,7 +82,7 @@ genrule(
         $(location //bazel:all_repository_locations) \
         $@
     """,
-    exec_tools = [
+    tools = [
         "//bazel:all_repository_locations",
         "//tools/docs:generate_external_deps_rst",
     ],
@@ -108,7 +108,7 @@ genrule(
     cmd = """
     cat $(location :v3_proto_srcs) $(location :xds_proto_srcs)  > $@
     """,
-    exec_tools = [
+    tools = [
         ":v3_proto_srcs",
         ":xds_proto_srcs",
     ],
@@ -122,7 +122,7 @@ genrule(
     $(location //tools/protodoc:generate_empty) \\
         $(location empty_extensions.json) $@
     """,
-    exec_tools = ["//tools/protodoc:generate_empty"],
+    tools = ["//tools/protodoc:generate_empty"],
 )
 
 genrule(
@@ -136,7 +136,7 @@ genrule(
     $(location //tools/docs:generate_api_rst) \\
         $(location proto_srcs) $(locations //tools/protodoc:api_v3_protodoc) $@
     """,
-    exec_tools = ["//tools/docs:generate_api_rst"],
+    tools = ["//tools/docs:generate_api_rst"],
 )
 
 pkg_files(
@@ -178,7 +178,7 @@ genrule(
     cmd = """
     $(location //tools/docs:generate_version_histories) $@
     """,
-    exec_tools = [
+    tools = [
         ":versions.yaml",
         "//:VERSION.txt",
         "//changelogs",
@@ -247,7 +247,7 @@ genrule(
          $(location rst) \
          $@
     """,
-    exec_tools = [
+    tools = [
         "//bazel:volatile_env",
         "//tools/docs:sphinx_runner",
         ":rst",
@@ -269,7 +269,7 @@ genrule(
          $(location :rst) \
          $@
     """,
-    exec_tools = [
+    tools = [
         "//tools/docs:sphinx_runner",
         ":rst",
         "//:VERSION.txt",

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -183,7 +183,7 @@ def envoy_jinja_env(
                > $@
         """ % (template_arg, load_args),
         outs = [name_env_py],
-        exec_tools = [name_templates],
+        tools = [name_templates],
     )
 
     py_library(

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -67,7 +67,7 @@ genrule(
         --download_cves $@ \
         --repository_locations=$(location //bazel:all_repository_locations)
     """,
-    exec_tools = [
+    tools = [
         ":cve_download",
         "//bazel:all_repository_locations",
     ],

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -107,7 +107,7 @@ genrule(
         --build_file=$(location //tools/type_whisperer:api_build_file) \
         --protoprinted=$(location //tools/protoprint:protoprinted) \
     """,
-    exec_tools = [
+    tools = [
         ":format_api",
         ":xformed",
         "//tools/type_whisperer:api_build_file",

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -110,8 +110,8 @@ genrule(
     tools = [
         ":format_api",
         ":xformed",
-        "//tools/type_whisperer:api_build_file",
         "//tools/protoprint:protoprinted",
+        "//tools/type_whisperer:api_build_file",
     ],
 )
 


### PR DESCRIPTION
These parameters have been merged, with `exec_tools` the current behaviour

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
