### PR TITLE
ecds: fix network ecds flaky test

### DIFF
--- a/test/integration/network_extension_discovery_integration_test.cc
+++ b/test/integration/network_extension_discovery_integration_test.cc
@@ -779,6 +779,8 @@ TEST_P(NetworkExtensionDiscoveryIntegrationTest, ConfigUpdateDoesNotApplyExistin
       "extension_config_discovery.network_filter." + filter_name_ + ".config_reload", 1);
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort(port_name_));
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
 
   // Send 2nd config update to have filter drain 3 bytes of data.
   sendXdsResponse(filter_name_, "2", 3);
@@ -786,8 +788,6 @@ TEST_P(NetworkExtensionDiscoveryIntegrationTest, ConfigUpdateDoesNotApplyExistin
       "extension_config_discovery.network_filter." + filter_name_ + ".config_reload", 2);
 
   ASSERT_TRUE(tcp_client->write(data_));
-  FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
   std::string received_data;
   // Expect drained bytes to be 5 as the 2nd config update was performed after new connection
   // establishment.


### PR DESCRIPTION
Additional Description: Fix flaky test by waiting for upstream connection before writing data
Risk Level: low
Testing: integration tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none