### PR TITLE
golang filter: move log funcs to global scope

### DIFF
--- a/contrib/golang/common/go/api/BUILD
+++ b/contrib/golang/common/go/api/BUILD
@@ -1,15 +1,36 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
 
 licenses(["notice"])  # Apache 2
 
 go_library(
     name = "api",
     srcs = [
+        "api.h",
         "capi.go",
         "cgocheck.go",
         "filter.go",
+        "logger.go",
         "type.go",
     ],
+    cgo = True,
+    clinkopts = select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "-Wl,-unresolved-symbols=ignore-all",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "-Wl,-undefined,dynamic_lookup",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "-Wl,-undefined,dynamic_lookup",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "-Wl,-unresolved-symbols=ignore-all",
+        ],
+        "//conditions:default": [],
+    }),
     importpath = "github.com/envoyproxy/envoy/contrib/golang/common/go/api",
     visibility = ["//visibility:public"],
     deps = [

--- a/contrib/golang/common/go/api/api.h
+++ b/contrib/golang/common/go/api/api.h
@@ -65,8 +65,8 @@ CAPIStatus envoyGoFilterHttpGetIntegerValue(void* r, int id, void* value);
 CAPIStatus envoyGoFilterHttpGetDynamicMetadata(void* r, void* name, void* hand);
 CAPIStatus envoyGoFilterHttpSetDynamicMetadata(void* r, void* name, void* key, void* buf);
 
-void envoyGoFilterHttpLog(uint32_t level, void* message);
-uint32_t envoyGoFilterHttpLogLevel();
+void envoyGoFilterLog(uint32_t level, void* message);
+uint32_t envoyGoFilterLogLevel();
 
 void envoyGoFilterHttpFinalize(void* r, int reason);
 

--- a/contrib/golang/common/go/api/logger.go
+++ b/contrib/golang/common/go/api/logger.go
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+/*
+// ref https://github.com/golang/go/issues/25832
+
+#cgo linux LDFLAGS: -Wl,-unresolved-symbols=ignore-all
+#cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "api.h"
+
+*/
+import "C"
+import "unsafe"
+
+func LogTrace(message string) {
+	C.envoyGoFilterLog(C.uint32_t(Trace), unsafe.Pointer(&message))
+}
+
+func LogDebug(message string) {
+	C.envoyGoFilterLog(C.uint32_t(Debug), unsafe.Pointer(&message))
+}
+
+func LogInfo(message string) {
+	C.envoyGoFilterLog(C.uint32_t(Info), unsafe.Pointer(&message))
+}
+
+func LogWarn(message string) {
+	C.envoyGoFilterLog(C.uint32_t(Warn), unsafe.Pointer(&message))
+}
+
+func LogError(message string) {
+	C.envoyGoFilterLog(C.uint32_t(Error), unsafe.Pointer(&message))
+}
+
+func LogCritical(message string) {
+	C.envoyGoFilterLog(C.uint32_t(Critical), unsafe.Pointer(&message))
+}

--- a/contrib/golang/common/log/BUILD
+++ b/contrib/golang/common/log/BUILD
@@ -1,0 +1,22 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+envoy_cc_library(
+    name = "log_lib",
+    srcs = ["cgo.cc"],
+    hdrs = [
+        "cgo.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//contrib/golang/common/dso:dso_lib",
+        "//source/common/common:utility_lib",
+    ],
+)

--- a/contrib/golang/common/log/cgo.cc
+++ b/contrib/golang/common/log/cgo.cc
@@ -1,0 +1,72 @@
+#include "contrib/golang/common/log/cgo.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace Golang {
+
+/* FilterLogger */
+void FilterLogger::log(uint32_t level, absl::string_view message) const {
+  switch (static_cast<spdlog::level::level_enum>(level)) {
+  case spdlog::level::trace:
+    ENVOY_LOG(trace, "{}", message);
+    return;
+  case spdlog::level::debug:
+    ENVOY_LOG(debug, "{}", message);
+    return;
+  case spdlog::level::info:
+    ENVOY_LOG(info, "{}", message);
+    return;
+  case spdlog::level::warn:
+    ENVOY_LOG(warn, "{}", message);
+    return;
+  case spdlog::level::err:
+    ENVOY_LOG(error, "{}", message);
+    return;
+  case spdlog::level::critical:
+    ENVOY_LOG(critical, "{}", message);
+    return;
+  case spdlog::level::off:
+    // means not logging
+    return;
+  case spdlog::level::n_levels:
+    PANIC("not implemented");
+  }
+
+  ENVOY_LOG(error, "undefined log level {} with message '{}'", level, message);
+
+  PANIC_DUE_TO_CORRUPT_ENUM;
+}
+
+uint32_t FilterLogger::level() const { return static_cast<uint32_t>(ENVOY_LOGGER().level()); }
+
+const FilterLogger& getFilterLogger() { CONSTRUCT_ON_FIRST_USE(FilterLogger); }
+
+// The returned absl::string_view only refer to the GoString, won't copy the string content into
+// C++, should not use it after the current cgo call returns.
+absl::string_view referGoString(void* str) {
+  if (str == nullptr) {
+    return "";
+  }
+  auto go_str = reinterpret_cast<GoString*>(str);
+  return {go_str->p, static_cast<size_t>(go_str->n)};
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void envoyGoFilterLog(uint32_t level, void* message) {
+  auto mesg = referGoString(message);
+  getFilterLogger().log(level, mesg);
+}
+
+uint32_t envoyGoFilterLogLevel() { return getFilterLogger().level(); }
+
+#ifdef __cplusplus
+}
+#endif
+} // namespace Golang
+} // namespace Common
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/golang/common/log/cgo.h
+++ b/contrib/golang/common/log/cgo.h
@@ -9,7 +9,7 @@ namespace Extensions {
 namespace Common {
 namespace Golang {
 
-class FilterLogger : Logger::Loggable<Logger::Id::http> {
+class FilterLogger : Logger::Loggable<Logger::Id::golang> {
 public:
   FilterLogger() = default;
 

--- a/contrib/golang/common/log/cgo.h
+++ b/contrib/golang/common/log/cgo.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "source/common/common/utility.h"
+
+#include "contrib/golang/common/dso/dso.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace Golang {
+
+class FilterLogger : Logger::Loggable<Logger::Id::http> {
+public:
+  FilterLogger() = default;
+
+  void log(uint32_t level, absl::string_view message) const;
+  uint32_t level() const;
+};
+
+} // namespace Golang
+} // namespace Common
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/golang/filters/http/source/BUILD
+++ b/contrib/golang/filters/http/source/BUILD
@@ -66,6 +66,7 @@ envoy_cc_library(
     ],
     deps = [
         "//contrib/golang/common/dso:dso_lib",
+        "//contrib/golang/common/log:log_lib",
         "//envoy/http:codes_interface",
         "//envoy/http:filter_interface",
         "//source/common/buffer:watermark_buffer_lib",

--- a/contrib/golang/filters/http/source/cgo.cc
+++ b/contrib/golang/filters/http/source/cgo.cc
@@ -58,8 +58,6 @@ std::vector<std::string> stringsFromGoSlice(void* slice) {
   return list;
 }
 
-const FilterLogger& getFilterLogger() { CONSTRUCT_ON_FIRST_USE(FilterLogger); }
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -198,11 +196,6 @@ CAPIStatus envoyGoFilterHttpGetIntegerValue(void* r, int id, void* value) {
   });
 }
 
-void envoyGoFilterHttpLog(uint32_t level, void* message) {
-  auto mesg = referGoString(message);
-  getFilterLogger().log(level, mesg);
-}
-
 CAPIStatus envoyGoFilterHttpGetDynamicMetadata(void* r, void* name, void* buf) {
   return envoyGoFilterHandlerWrapper(r, [name, buf](std::shared_ptr<Filter>& filter) -> CAPIStatus {
     auto name_str = copyGoString(name);
@@ -210,7 +203,6 @@ CAPIStatus envoyGoFilterHttpGetDynamicMetadata(void* r, void* name, void* buf) {
     return filter->getDynamicMetadata(name_str, buf_slice);
   });
 }
-uint32_t envoyGoFilterHttpLogLevel() { return getFilterLogger().level(); }
 
 CAPIStatus envoyGoFilterHttpSetDynamicMetadata(void* r, void* name, void* key, void* buf) {
   return envoyGoFilterHandlerWrapper(

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -279,11 +279,11 @@ func (c *httpCApiImpl) HttpSetDynamicMetadata(r unsafe.Pointer, filterName strin
 }
 
 func (c *httpCApiImpl) HttpLog(level api.LogType, message string) {
-	C.envoyGoFilterHttpLog(C.uint32_t(level), unsafe.Pointer(&message))
+	C.envoyGoFilterLog(C.uint32_t(level), unsafe.Pointer(&message))
 }
 
 func (c *httpCApiImpl) HttpLogLevel() api.LogType {
-	return api.LogType(C.envoyGoFilterHttpLogLevel())
+	return api.LogType(C.envoyGoFilterLogLevel())
 }
 
 func (c *httpCApiImpl) HttpFinalize(r unsafe.Pointer, reason int) {

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1382,41 +1382,6 @@ ProcessorState& Filter::getProcessorState() {
                          : dynamic_cast<ProcessorState&>(decoding_state_);
 };
 
-/* FilterLogger */
-void FilterLogger::log(uint32_t level, absl::string_view message) const {
-  switch (static_cast<spdlog::level::level_enum>(level)) {
-  case spdlog::level::trace:
-    ENVOY_LOG(trace, "{}", message);
-    return;
-  case spdlog::level::debug:
-    ENVOY_LOG(debug, "{}", message);
-    return;
-  case spdlog::level::info:
-    ENVOY_LOG(info, "{}", message);
-    return;
-  case spdlog::level::warn:
-    ENVOY_LOG(warn, "{}", message);
-    return;
-  case spdlog::level::err:
-    ENVOY_LOG(error, "{}", message);
-    return;
-  case spdlog::level::critical:
-    ENVOY_LOG(critical, "{}", message);
-    return;
-  case spdlog::level::off:
-    // means not logging
-    return;
-  case spdlog::level::n_levels:
-    PANIC("not implemented");
-  }
-
-  ENVOY_LOG(error, "undefined log level {} with message '{}'", level, message);
-
-  PANIC_DUE_TO_CORRUPT_ENUM;
-}
-
-uint32_t FilterLogger::level() const { return static_cast<uint32_t>(ENVOY_LOGGER().level()); }
-
 } // namespace Golang
 } // namespace HttpFilters
 } // namespace Extensions

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -263,14 +263,6 @@ struct httpRequestInternal : httpRequest {
   std::weak_ptr<Filter> weakFilter() { return filter_; }
 };
 
-class FilterLogger : Logger::Loggable<Logger::Id::http> {
-public:
-  FilterLogger() = default;
-
-  void log(uint32_t level, absl::string_view message) const;
-  uint32_t level() const;
-};
-
 class GoStringFilterState : public StreamInfo::FilterState::Object {
 public:
   GoStringFilterState(absl::string_view value) : value_(value) {}

--- a/contrib/golang/filters/http/test/test_data/basic/config.go
+++ b/contrib/golang/filters/http/test/test_data/basic/config.go
@@ -8,6 +8,7 @@ import (
 const Name = "basic"
 
 func init() {
+	api.LogCritical("init")
 	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, nil)
 }
 

--- a/contrib/golang/filters/http/test/test_data/basic/filter.go
+++ b/contrib/golang/filters/http/test/test_data/basic/filter.go
@@ -105,6 +105,12 @@ func (f *filter) decodeHeaders(header api.RequestHeaderMap, endStream bool) api.
 	f.callbacks.Log(api.Warn, "log test")
 	f.callbacks.Log(api.Error, "log test")
 	f.callbacks.Log(api.Critical, "log test")
+	api.LogTrace("log test")
+	api.LogDebug("log test")
+	api.LogInfo("log test")
+	api.LogWarn("log test")
+	api.LogError("log test")
+	api.LogCritical("log test")
 
 	if f.sleep {
 		time.Sleep(time.Millisecond * 100) // sleep 100 ms

--- a/contrib/golang/filters/network/source/BUILD
+++ b/contrib/golang/filters/network/source/BUILD
@@ -81,6 +81,7 @@ envoy_cc_contrib_extension(
     ],
     deps = [
         "//contrib/golang/common/dso:dso_lib",
+        "//contrib/golang/common/log:log_lib",
         "//envoy/buffer:buffer_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/network:connection_interface",


### PR DESCRIPTION
Now we can log sth without the HTTP request.

Some projects, like https://github.com/mosn/envoy-go-waf, require this feature so they can work properly.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: move log funcs to global scope
Additional Description:
Risk Level: Low
Testing: Integration
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
