### PR TITLE
tls: validate client cert on session resumption

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -102,6 +102,7 @@ public:
 
 protected:
   friend class ContextImplPeer;
+  friend class SslSocket;
 
   ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& config,
               TimeSource& time_source);


### PR DESCRIPTION
Commit Message: tls: validate client cert on session resumption
Additional Description:

Fix the Lua API peerCertificateValidated() method and the TlsContextMatchOptions validated option (https://github.com/envoyproxy/envoy/issues/21235).

Risk Level: ? (not sure)
Testing: unit test
Docs Changes: na
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
