### PR TITLE
WIP: generic proxy: access log and formatter support

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/BUILD
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/accesslog/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/extensions/filters/network/http_connection_manager/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.network.generic_proxy.v3;
 
 import "contrib/envoy/extensions/filters/network/generic_proxy/v3/route.proto";
+import "envoy/config/accesslog/v3/accesslog.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/extension.proto";
 import "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto";
@@ -23,7 +24,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // Generic proxy.
 // [#extension: envoy.filters.network.generic_proxy]
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message GenericProxy {
   // The human readable prefix to use when emitting statistics.
   string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
@@ -51,6 +52,9 @@ message GenericProxy {
 
   // Tracing configuration for the generic proxy.
   http_connection_manager.v3.HttpConnectionManager.Tracing tracing = 6;
+
+  // Configuration for :ref:`access logs <arch_overview_access_logs>` emitted by generic proxy.
+  repeated config.accesslog.v3.AccessLog access_log = 7;
 }
 
 message GenericRds {

--- a/contrib/generic_proxy/filters/network/source/BUILD
+++ b/contrib/generic_proxy/filters/network/source/BUILD
@@ -131,3 +131,16 @@ envoy_cc_library(
         "//envoy/upstream:thread_local_cluster_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "access_log_base_lib",
+    srcs = [
+        "access_log_base.cc",
+    ],
+    hdrs = [
+        "access_log_base.h",
+    ],
+    deps = [
+        "//envoy/access_log:access_log",
+    ]
+)

--- a/contrib/generic_proxy/filters/network/source/BUILD
+++ b/contrib/generic_proxy/filters/network/source/BUILD
@@ -133,14 +133,69 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "access_log_base_lib",
-    srcs = [
-        "access_log_base.cc",
+    name = "formatter_base_lib",
+    hdrs = [
+        "formatter_base.h",
     ],
+    deps = [
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "formatter_impl_base_lib",
+    hdrs = [
+        "formatter_impl_base.h",
+    ],
+    deps = [
+        ":formatter_base_lib",
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/config:datasource_lib",
+        "//source/common/config:utility_lib",
+        "//source/common/formatter:substitution_formatter_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "access_log_base_lib",
     hdrs = [
         "access_log_base.h",
     ],
     deps = [
-        "//envoy/access_log:access_log",
-    ]
+        "//envoy/access_log:access_log_interface",
+        "//envoy/server:factory_context_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "file_access_log_base_lib",
+    hdrs = [
+        "file_access_log_base.h",
+    ],
+    deps = [
+        ":access_log_base_lib",
+        ":formatter_impl_base_lib",
+        "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "access_log_lib",
+    srcs = [
+        "access_log.cc",
+    ],
+    hdrs = [
+        "access_log.h",
+    ],
+    deps = [
+        ":access_log_base_lib",
+        ":file_access_log_base_lib",
+        ":formatter_base_lib",
+        ":formatter_impl_base_lib",
+        "//contrib/generic_proxy/filters/network/source/interface:stream_interface",
+    ],
 )

--- a/contrib/generic_proxy/filters/network/source/access_log.cc
+++ b/contrib/generic_proxy/filters/network/source/access_log.cc
@@ -1,0 +1,128 @@
+#include "contrib/generic_proxy/filters/network/source/access_log.h"
+
+#include "envoy/registry/registry.h"
+
+#include "formatter_impl_base.h"
+#include "google/protobuf/struct.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+class SimpleCommandParser : public GenericProxyCommandParser {
+public:
+  using SimpleStringFormatterProvider = StringValueFormatterProvider<GenericProxyFormatterContext>;
+
+  using ProviderFunc = std::function<GenericProxyFormatterProviderPtr(
+      absl::string_view, absl::optional<size_t> max_length)>;
+  using ProviderFuncTable = absl::flat_hash_map<std::string, ProviderFunc>;
+
+  // GenericProxyCommandParser
+  GenericProxyFormatterProviderPtr parse(absl::string_view command, absl::string_view command_arg,
+                                         absl::optional<size_t> max_length) const override {
+    const auto& provider_func_table = providerFuncTable();
+    const auto func_iter = provider_func_table.find(std::string(command));
+    if (func_iter == provider_func_table.end()) {
+      return nullptr;
+    }
+    return func_iter->second(command_arg, max_length);
+  }
+
+private:
+  static const ProviderFuncTable& providerFuncTable() {
+    CONSTRUCT_ON_FIRST_USE(
+        ProviderFuncTable,
+        {
+            {"METHOD",
+             [](absl::string_view, absl::optional<size_t>) -> GenericProxyFormatterProviderPtr {
+               return std::make_unique<SimpleStringFormatterProvider>(
+                   [](const GenericProxyFormatterContext& context,
+                      const StreamInfo::StreamInfo&) -> absl::optional<std::string> {
+                     if (context.request_) {
+                       return std::string(context.request_->method());
+                     }
+                     return absl::nullopt;
+                   });
+             }},
+            {"HOST",
+             [](absl::string_view, absl::optional<size_t>) -> GenericProxyFormatterProviderPtr {
+               return std::make_unique<SimpleStringFormatterProvider>(
+                   [](const GenericProxyFormatterContext& context,
+                      const StreamInfo::StreamInfo&) -> absl::optional<std::string> {
+                     if (context.request_) {
+                       return std::string(context.request_->host());
+                     }
+                     return absl::nullopt;
+                   });
+             }},
+            {"PATH",
+             [](absl::string_view, absl::optional<size_t>) -> GenericProxyFormatterProviderPtr {
+               return std::make_unique<SimpleStringFormatterProvider>(
+                   [](const GenericProxyFormatterContext& context,
+                      const StreamInfo::StreamInfo&) -> absl::optional<std::string> {
+                     if (context.request_) {
+                       return std::string(context.request_->path());
+                     }
+                     return absl::nullopt;
+                   });
+             }},
+            {"PROTOCOL",
+             [](absl::string_view, absl::optional<size_t>) -> GenericProxyFormatterProviderPtr {
+               return std::make_unique<SimpleStringFormatterProvider>(
+                   [](const GenericProxyFormatterContext& context,
+                      const StreamInfo::StreamInfo&) -> absl::optional<std::string> {
+                     if (context.request_) {
+                       return std::string(context.request_->protocol());
+                     }
+                     return absl::nullopt;
+                   });
+             }},
+            {"REQUEST_PROPERTY",
+             [](absl::string_view command_arg,
+                absl::optional<size_t>) -> GenericProxyFormatterProviderPtr {
+               return std::make_unique<SimpleStringFormatterProvider>(
+                   [key = std::string(command_arg)](
+                       const GenericProxyFormatterContext& context,
+                       const StreamInfo::StreamInfo&) -> absl::optional<std::string> {
+                     if (!context.request_) {
+                       return absl::nullopt;
+                     }
+                     auto optional_view = context.request_->getByKey(key);
+                     if (!optional_view.has_value()) {
+                       return absl::nullopt;
+                     }
+                     return std::string(optional_view.value());
+                   });
+             }},
+            {"RESPONSE_PROPERTY",
+             [](absl::string_view command_arg,
+                absl::optional<size_t>) -> GenericProxyFormatterProviderPtr {
+               return std::make_unique<SimpleStringFormatterProvider>(
+                   [key = std::string(command_arg)](
+                       const GenericProxyFormatterContext& context,
+                       const StreamInfo::StreamInfo&) -> absl::optional<std::string> {
+                     if (!context.response_) {
+                       return absl::nullopt;
+                     }
+                     auto optional_view = context.response_->getByKey(key);
+                     if (!optional_view.has_value()) {
+                       return absl::nullopt;
+                     }
+                     return std::string(optional_view.value());
+                   });
+             }},
+        });
+  }
+};
+
+// Regiter the built-in command parsers for the GenericProxyFormatterContext.
+REGISTER_BUILT_IN_COMMAND_PARSER(GenericProxyFormatterContext, SimpleCommandParser);
+
+// Register the access log for the GenericProxyFormatterContext.
+REGISTER_FACTORY(GenericProxyFileAccessLogFactory, GenericProxyAccessLogInstanceFactory);
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/access_log.h
+++ b/contrib/generic_proxy/filters/network/source/access_log.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "contrib/generic_proxy/filters/network/source/file_access_log_base.h"
+#include "contrib/generic_proxy/filters/network/source/formatter_impl_base.h"
+#include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+struct GenericProxyFormatterContext {
+  const Request* request_{};
+  const Response* response_{};
+
+  static constexpr absl::string_view category() { return "generic_proxy"; }
+};
+
+using GenericProxyFormatter = Formatter<GenericProxyFormatterContext>;
+using GenericProxyFormatterProvider = FormatterProvider<GenericProxyFormatterContext>;
+using GenericProxyFormatterProviderPtr = std::unique_ptr<GenericProxyFormatterProvider>;
+using GenericProxyCommandParser = CommandParser<GenericProxyFormatterContext>;
+using GenericProxyCommandParserFactory = CommandParserFactory<GenericProxyFormatterContext>;
+using GenericProxyBuiltInCommandParsers = BuiltInCommandParsers<GenericProxyFormatterContext>;
+
+using GenericProxyAccessLogInstance = AccessLogInstance<GenericProxyFormatterContext>;
+using GenericProxyAccessLogInstanceSharedPtr = std::shared_ptr<GenericProxyAccessLogInstance>;
+using GenericProxyAccessLogInstanceFactory = AccessLogInstanceFactory<GenericProxyFormatterContext>;
+using GenericProxyFileAccessLog = FileAccessLog<GenericProxyFormatterContext>;
+using GenericProxyFileAccessLogFactory = FileAccessLogFactory<GenericProxyFormatterContext>;
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/access_log_base.h
+++ b/contrib/generic_proxy/filters/network/source/access_log_base.h
@@ -3,9 +3,9 @@
 #include <string>
 
 #include "envoy/access_log/access_log.h"
+#include "envoy/server/factory_context.h"
 #include "envoy/stream_info/stream_info.h"
 
-#include "envoy/server/factory_context.h"
 #include "source/common/config/utility.h"
 
 #include "absl/strings/string_view.h"

--- a/contrib/generic_proxy/filters/network/source/access_log_base.h
+++ b/contrib/generic_proxy/filters/network/source/access_log_base.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/access_log/access_log.h"
+#include "envoy/stream_info/stream_info.h"
+
+#include "envoy/server/factory_context.h"
+#include "source/common/config/utility.h"
+
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+template <class FormatterContext> class AccessLogFilter {
+public:
+  virtual ~AccessLogFilter() = default;
+
+  /**
+   * @return bool whether the filter should be applied to the given stream.
+   */
+  virtual bool evaluate(const FormatterContext& context,
+                        const StreamInfo::StreamInfo& info) const PURE;
+};
+
+template <class FormatterContext>
+using AccessLogFilterPtr = std::unique_ptr<AccessLogFilter<FormatterContext>>;
+
+template <class FormatterContext> class AccessLogFilterFactory : public Config::TypedFactory {
+public:
+  virtual AccessLogFilterPtr<FormatterContext>
+  createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
+               Server::Configuration::CommonFactoryContext& context) PURE;
+
+  std::string category() const override {
+    return fmt::format("envoy.{}.access_loggers.extension_filters", FormatterContext::category());
+  }
+};
+
+/**
+ * Abstract access logger for requests and connections.
+ */
+template <class FormatterContext> class AccessLogInstance {
+public:
+  virtual ~AccessLogInstance() = default;
+
+  /**
+   * Log a completed request.
+   * @param request_headers supplies the incoming request headers after filtering.
+   * @param response_headers supplies response headers.
+   * @param response_trailers supplies response trailers.
+   * @param stream_info supplies additional information about the request not
+   * contained in the request headers.
+   * @param access_log_type supplies additional information about the type of the
+   * log record, i.e the location in the code which recorded the log.
+   */
+  virtual void log(const FormatterContext& context, const StreamInfo::StreamInfo& info) PURE;
+};
+
+template <class FormatterContext>
+using AccessLogInstanceSharedPtr = std::shared_ptr<AccessLogInstance<FormatterContext>>;
+
+template <class FormatterContext> class AccessLogInstanceFactory : public Config::TypedFactory {
+public:
+  AccessLogInstanceFactory()
+      : category_(fmt::format("envoy.{}.access_loggers", FormatterContext::category())) {}
+
+  /**
+   * Create a particular AccessLog::Instance implementation from a config proto. If the
+   * implementation is unable to produce a factory with the provided parameters, it should throw an
+   * EnvoyException. The returned pointer should never be nullptr.
+   * @param config the custom configuration for this access log type.
+   * @param filter filter to determine whether a particular request should be logged. If no filter
+   * was specified in the configuration, argument will be nullptr.
+   * @param context general filter context through which persistent resources can be accessed.
+   */
+  virtual AccessLogInstanceSharedPtr<FormatterContext>
+  createAccessLogInstance(const Protobuf::Message& config,
+                          AccessLogFilterPtr<FormatterContext>&& filter,
+                          Server::Configuration::CommonFactoryContext& context) PURE;
+  std::string category() const override { return category_; }
+
+  /**
+   * Create a particular AccessLog::Instance implementation from a config proto. If the
+   * implementation is unable to produce a factory with the provided parameters, it should throw an
+   * EnvoyException. The returned pointer should never be nullptr.
+   */
+  static AccessLogInstanceSharedPtr<FormatterContext>
+  fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+            Server::Configuration::CommonFactoryContext& context) {
+
+    auto& factory =
+        Config::Utility::getAndCheckFactory<AccessLogInstanceFactory<FormatterContext>>(config);
+    ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+        config, context.messageValidationVisitor(), factory);
+
+    // TODO(wbpcode): add filter support.
+    return factory.createAccessLogInstance(*message, nullptr, context);
+  }
+
+private:
+  const std::string category_;
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/file_access_log_base.h
+++ b/contrib/generic_proxy/filters/network/source/file_access_log_base.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "contrib/generic_proxy/filters/network/source/access_log_base.h"
+#include "contrib/generic_proxy/filters/network/source/formatter_impl_base.h"
+
+#include "envoy/extensions/access_loggers/file/v3/file.pb.h"
+#include "envoy/extensions/access_loggers/file/v3/file.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+template <class FormatterContext>
+class FileAccessLogImpl : public AccessLogInstance<FormatterContext> {
+public:
+  FileAccessLogImpl(const Filesystem::FilePathAndType& access_log_file_info,
+                    AccessLogFilterPtr<FormatterContext>&& filter,
+                    FormatterPtr<FormatterContext>&& formatter,
+                    AccessLog::AccessLogManager& log_manager)
+      : filter_(std::move(filter)), formatter_(std::move(formatter)) {
+    log_file_ = log_manager.createAccessLog(access_log_file_info);
+  }
+
+  void log(const FormatterContext& context, const StreamInfo::StreamInfo& stream_info) override {
+    if (filter_ != nullptr && !filter_->evaluate(context, stream_info)) {
+      return;
+    }
+    log_file_->write(formatter_->format(context, stream_info));
+  }
+
+private:
+  AccessLog::AccessLogFileSharedPtr log_file_;
+  AccessLogFilterPtr<FormatterContext> filter_;
+  FormatterPtr<FormatterContext> formatter_;
+};
+
+template <class FormatterContext>
+class FileAccessLogFactory : public AccessLogInstanceFactory<FormatterContext> {
+public:
+  FileAccessLogFactory()
+      : name_(fmt::format("envoy.{}.access_loggers.file", FormatterContext::category())) {}
+  AccessLogInstanceSharedPtr<FormatterContext>
+  createAccessLogInstance(const Protobuf::Message& config,
+                          AccessLogFilterPtr<FormatterContext>&& filter,
+                          Server::Configuration::CommonFactoryContext& context) override {
+    const auto& typed_config = MessageUtil::downcastAndValidate<
+        const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
+        config, context.messageValidationVisitor());
+
+    FormatterPtr<FormatterContext> formatter;
+
+    switch (typed_config.access_log_format_case()) {
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kFormat:
+      if (typed_config.format().empty()) {
+        formatter = getDefaultFormatter();
+        if (formatter == nullptr) {
+          throw EnvoyException("Access log: no format and no default format for file access log");
+        }
+      } else {
+        envoy::config::core::v3::SubstitutionFormatString sff_config;
+        sff_config.mutable_text_format_source()->set_inline_string(typed_config.format());
+        formatter =
+            SubstitutionFormatStringUtils::fromProtoConfig<FormatterContext>(sff_config, context);
+      }
+      break;
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+        kJsonFormat:
+      formatter = SubstitutionFormatStringUtils::createJsonFormatter<FormatterContext>(
+          typed_config.json_format(), false, false);
+      break;
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+        kTypedJsonFormat: {
+      envoy::config::core::v3::SubstitutionFormatString sff_config;
+      *sff_config.mutable_json_format() = typed_config.typed_json_format();
+      formatter =
+          SubstitutionFormatStringUtils::fromProtoConfig<FormatterContext>(sff_config, context);
+      break;
+    }
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+        kLogFormat:
+      formatter = SubstitutionFormatStringUtils::fromProtoConfig<FormatterContext>(
+          typed_config.log_format(), context);
+      break;
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+        ACCESS_LOG_FORMAT_NOT_SET:
+      formatter = getDefaultFormatter();
+      if (formatter == nullptr) {
+        throw EnvoyException("Access log: no format and no default format for file access log");
+      }
+      break;
+    }
+
+    Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, typed_config.path()};
+    return std::make_shared<FileAccessLogImpl<FormatterContext>>(
+        file_info, std::move(filter), std::move(formatter), context.accessLogManager());
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{
+        new envoy::extensions::access_loggers::file::v3::FileAccessLog()};
+  }
+
+  std::string name() const override { return name_; }
+
+protected:
+  virtual FormatterPtr<FormatterContext> getDefaultFormatter() const { return nullptr; }
+
+private:
+  const std::string name_;
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/file_access_log_base.h
+++ b/contrib/generic_proxy/filters/network/source/file_access_log_base.h
@@ -1,23 +1,22 @@
 #pragma once
 
-#include "contrib/generic_proxy/filters/network/source/access_log_base.h"
-#include "contrib/generic_proxy/filters/network/source/formatter_impl_base.h"
-
 #include "envoy/extensions/access_loggers/file/v3/file.pb.h"
 #include "envoy/extensions/access_loggers/file/v3/file.pb.validate.h"
+
+#include "contrib/generic_proxy/filters/network/source/access_log_base.h"
+#include "contrib/generic_proxy/filters/network/source/formatter_impl_base.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
 
-template <class FormatterContext>
-class FileAccessLogImpl : public AccessLogInstance<FormatterContext> {
+template <class FormatterContext> class FileAccessLog : public AccessLogInstance<FormatterContext> {
 public:
-  FileAccessLogImpl(const Filesystem::FilePathAndType& access_log_file_info,
-                    AccessLogFilterPtr<FormatterContext>&& filter,
-                    FormatterPtr<FormatterContext>&& formatter,
-                    AccessLog::AccessLogManager& log_manager)
+  FileAccessLog(const Filesystem::FilePathAndType& access_log_file_info,
+                AccessLogFilterPtr<FormatterContext>&& filter,
+                FormatterPtr<FormatterContext>&& formatter,
+                AccessLog::AccessLogManager& log_manager)
       : filter_(std::move(filter)), formatter_(std::move(formatter)) {
     log_file_ = log_manager.createAccessLog(access_log_file_info);
   }
@@ -92,7 +91,7 @@ public:
     }
 
     Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, typed_config.path()};
-    return std::make_shared<FileAccessLogImpl<FormatterContext>>(
+    return std::make_shared<FileAccessLog<FormatterContext>>(
         file_info, std::move(filter), std::move(formatter), context.accessLogManager());
   }
 

--- a/contrib/generic_proxy/filters/network/source/formatter_base.h
+++ b/contrib/generic_proxy/filters/network/source/formatter_base.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/stream_info/stream_info.h"
+
+#include "source/common/config/utility.h"
+
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+/**
+ * Interface for substitution formatter.
+ * Formatters provide a complete substitution output line for the given context and stream info.
+ */
+template <class FormatterContext> class Formatter {
+public:
+  virtual ~Formatter() = default;
+
+  /**
+   * Extract a value from the provided context and stream info.
+   * @param context supplies the context, which may be a request, response, or some other context.
+   * @param info supplies the protocol independent stream info.
+   * @return absl::optional<std::string> optional string containing a single value extracted from
+   *         the given context and stream info.
+   */
+  virtual std::string format(const FormatterContext& context,
+                             const StreamInfo::StreamInfo& info) const PURE;
+};
+
+template <class FormatterContext> using FormatterPtr = std::unique_ptr<Formatter<FormatterContext>>;
+template <class FormatterContext>
+using FormatterConstSharedPtr = std::shared_ptr<const Formatter<FormatterContext>>;
+
+/**
+ * Interface for substitution provider.
+ * FormatterProviders extract information from the given context and stream info.
+ */
+template <class FormatterContext> class FormatterProvider {
+public:
+  virtual ~FormatterProvider() = default;
+
+  /**
+   * Extract a value from the provided context and stream info.
+   * @param context supplies the context, which may be a request, response, or some other context.
+   * @param info supplies the protocol independent stream info.
+   * @return absl::optional<std::string> optional string containing a single value extracted from
+   *         the given context and stream info.
+   */
+  virtual absl::optional<std::string> format(const FormatterContext& context,
+                                             const StreamInfo::StreamInfo& info) const PURE;
+
+  /**
+   * Extract a value from the provided context and stream info.
+   * @param context supplies the context, which may be a request, response, or some other context.
+   * @param info supplies the protocol independent stream info.
+   * @return ProtobufWkt::Value value containing a single value extracted from the given context and
+   *         stream info.
+   */
+  virtual ProtobufWkt::Value formatValue(const FormatterContext& context,
+                                         const StreamInfo::StreamInfo& info) const PURE;
+};
+template <class FormatterContext>
+using FormatterProviderPtr = std::unique_ptr<FormatterProvider<FormatterContext>>;
+
+template <class FormatterContext> class CommandParser {
+public:
+  virtual ~CommandParser() = default;
+
+  /**
+   * Return a FormatterProviderPtr if command arg and max_length are correct for the formatter
+   * provider associated with command.
+   * @param command command name.
+   * @param command_arg command specific argument. Empty if no argument is provided.
+   * @param max_length length to which the output produced by FormatterProvider
+   *                   should be truncated to (optional).
+   *
+   * @return FormattterProviderPtr substitution provider for the parsed command.
+   */
+  virtual FormatterProviderPtr<FormatterContext>
+  parse(absl::string_view command, absl::string_view command_arg,
+        absl::optional<size_t> max_length) const PURE;
+};
+
+template <class FormatterContext>
+using CommandParserSharedPtr = std::shared_ptr<CommandParser<FormatterContext>>;
+
+template <class FormatterContext>
+using CommandParsers = std::vector<CommandParserSharedPtr<FormatterContext>>;
+
+template <class FormatterContext> class CommandParserFactory : public Config::TypedFactory {
+public:
+  /**
+   * Creates a particular CommandParser implementation.
+   *
+   * @param config supplies the configuration for the command parser.
+   * @param context supplies the factory context.
+   * @return CommandParserPtr the CommandParser which will be used in
+   * SubstitutionFormatParser::parse() when evaluating an access log format string.
+   */
+  virtual CommandParserSharedPtr<FormatterContext>
+  createCommandParserFromProto(const Protobuf::Message& config,
+                               Server::Configuration::CommonFactoryContext& context) PURE;
+
+  std::string category() const override {
+    return fmt::format("envoy.{}.formatters", FormatterContext::category());
+  }
+};
+
+template <class FormatterContext> class BuiltInCommandParsers {
+public:
+  static CommandParserSharedPtr<FormatterContext>
+  parseCommandParser(const std::string& command, const std::string& subcommand,
+                     absl::optional<size_t>& max_length);
+
+  static void addCommandParser(CommandParserSharedPtr<FormatterContext> parser) {
+    mutableCommandParsers().push_back(parser);
+  }
+
+  static const CommandParsers<FormatterContext>& commandParsers() {
+    return mutableCommandParsers();
+  }
+
+private:
+  static CommandParsers<FormatterContext>& mutableCommandParsers() {
+    MUTABLE_CONSTRUCT_ON_FIRST_USE(CommandParsers<FormatterContext>);
+  }
+};
+
+template <class FormatterContext> struct BuiltInCommandPaserRegister {
+  BuiltInCommandPaserRegister(CommandParserSharedPtr<FormatterContext> parser) {
+    BuiltInCommandParsers<FormatterContext>::addCommandParser(parser);
+  }
+};
+
+#define REGISTER_BUILT_IN_COMMAND_PARSER(context, parser)                                          \
+  static BuiltInCommandPaserRegister<context> register_##context##_##parser(parser);
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/formatter_base.h
+++ b/contrib/generic_proxy/filters/network/source/formatter_base.h
@@ -114,10 +114,6 @@ public:
 
 template <class FormatterContext> class BuiltInCommandParsers {
 public:
-  static CommandParserSharedPtr<FormatterContext>
-  parseCommandParser(const std::string& command, const std::string& subcommand,
-                     absl::optional<size_t>& max_length);
-
   static void addCommandParser(CommandParserSharedPtr<FormatterContext> parser) {
     mutableCommandParsers().push_back(parser);
   }
@@ -139,7 +135,8 @@ template <class FormatterContext> struct BuiltInCommandPaserRegister {
 };
 
 #define REGISTER_BUILT_IN_COMMAND_PARSER(context, parser)                                          \
-  static BuiltInCommandPaserRegister<context> register_##context##_##parser(parser);
+  static BuiltInCommandPaserRegister<context> register_##context##_##parser{                       \
+      std::make_shared<parser>()};
 
 } // namespace GenericProxy
 } // namespace NetworkFilters

--- a/contrib/generic_proxy/filters/network/source/formatter_impl_base.h
+++ b/contrib/generic_proxy/filters/network/source/formatter_impl_base.h
@@ -1,0 +1,563 @@
+#pragma once
+
+#include <regex>
+
+#include "envoy/config/core/v3/substitution_format_string.pb.h"
+
+#include "contrib/generic_proxy/filters/network/source/formatter_base.h"
+
+#include "source/common/config/datasource.h"
+#include "source/common/config/utility.h"
+#include "source/common/formatter/substitution_formatter.h"
+
+#include "absl/strings/str_format.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+inline constexpr absl::string_view DefaultUnspecifiedValueString = "-";
+
+/**
+ * FormatterProvider for string literals. It ignores headers and stream info and returns string by
+ * which it was initialized.
+ */
+template <class FormatterContext>
+class PlainStringFormatterProvider : public FormatterProvider<FormatterContext> {
+public:
+  PlainStringFormatterProvider(absl::string_view str) { str_.set_string_value(str); }
+
+  // FormatterProvider
+  absl::optional<std::string> format(const FormatterContext&,
+                                     const StreamInfo::StreamInfo&) const override {
+    return str_.string_value();
+  }
+  ProtobufWkt::Value formatValue(const FormatterContext&,
+                                 const StreamInfo::StreamInfo&) const override {
+    return str_;
+  }
+
+private:
+  ProtobufWkt::Value str_;
+};
+
+/**
+ * FormatterProvider for numbers.
+ */
+template <class FormatterContext>
+class PlainNumberFormatterProvider : public FormatterProvider<FormatterContext> {
+public:
+  PlainNumberFormatterProvider(double num);
+
+  // FormatterProvider
+  absl::optional<std::string> format(const FormatterContext&,
+                                     const StreamInfo::StreamInfo&) const override {
+    std::string str = absl::StrFormat("%g", num_.number_value());
+    return str;
+  }
+  ProtobufWkt::Value formatValue(const FormatterContext&,
+                                 const StreamInfo::StreamInfo&) const override {
+    return num_;
+  }
+
+private:
+  ProtobufWkt::Value num_;
+};
+
+template <class FormatterContext>
+class StreamInfoFormatterProvider : public FormatterProvider<FormatterContext> {
+public:
+  StreamInfoFormatterProvider(const std::string& command, const std::string& sub_command,
+                              absl::optional<size_t> max_length) {
+    const auto& extractors = Envoy::Formatter::StreamInfoFormatter::getKnownFieldExtractors();
+
+    auto it = extractors.find(command);
+
+    if (it == extractors.end()) {
+      throw EnvoyException(fmt::format("Not supported field in StreamInfo: {}", command));
+    }
+
+    // Check flags for the command.
+    Envoy::Formatter::CommandSyntaxChecker::verifySyntax((*it).second.first, command, sub_command,
+                                                         max_length);
+
+    // Create a pointer to the formatter by calling a function
+    // associated with formatter's name.
+    field_extractor_ = (*it).second.second(sub_command, max_length);
+  }
+
+  // FormatterProvider
+  absl::optional<std::string> format(const FormatterContext&,
+                                     const StreamInfo::StreamInfo& info) const override {
+    field_extractor_->extract(info);
+  }
+  ProtobufWkt::Value formatValue(const FormatterContext&,
+                                 const StreamInfo::StreamInfo& info) const override {
+    return field_extractor_->extractValue(info);
+  }
+
+private:
+  Envoy::Formatter::StreamInfoFormatter::FieldExtractorPtr field_extractor_;
+};
+
+template <class FormatterContext> class SubstitutionFormatParser {
+public:
+  std::vector<FormatterProviderPtr<FormatterContext>>
+  parse(absl::string_view format, const CommandParsers<FormatterContext>& command_parsers) {
+    std::string current_token;
+    std::vector<FormatterProviderPtr<FormatterContext>> formatters;
+
+    // The following regex is used to check validity of the formatter command and to
+    // extract groups.
+    // The formatter command has the following format:
+    //    % COMMAND(SUBCOMMAND):LENGTH%
+    // % signs at the beginning and end are used by parser to find next COMMAND.
+    // COMMAND must always be present and must consist of characters: "A-Z", "0-9" or "_".
+    // SUBCOMMAND presence depends on the COMMAND. Format is flexible but cannot contain ")".:
+    // - for some commands SUBCOMMAND is not allowed (for example %PROTOCOL%)
+    // - for some commands SUBCOMMAND is required (for example %REQ(:AUTHORITY)%, just %REQ% will
+    // cause error)
+    // - for some commands SUBCOMMAND is optional (for example %START_TIME% and
+    // %START_TIME(%f.%1f.%2f.%3f)% are both correct).
+    // LENGTH presence depends on the command. Some
+    // commands allow LENGTH to be specified, so not. Regex is used to validate the syntax and also
+    // to extract values for COMMAND, SUBCOMMAND and LENGTH.
+    //
+    // Below is explanation of capturing and non-capturing groups. Non-capturing groups are used
+    // to specify that certain part of the formatter command is optional and should contain specific
+    // characters. Capturing groups are used to extract the values when regex is matched against
+    // formatter command string.
+    //
+    // clang-format off
+  // Non-capturing group specifying optional :LENGTH -------------------------------------
+  //                                                                                      |
+  // Non-capturing group specifying optional (SUBCOMMAND)------------------               |
+  //                                                                       |              |
+  // Non-capturing group specifying mandatory COMMAND                      |              |
+  //  which uses only A-Z, 0-9 and _ characters     -----                  |              |
+  //  Group is used only to specify allowed characters.  |                 |              |
+  //                                                     |                 |              |
+  //                                                     |                 |              |
+  //                                             _________________  _______________  _____________
+  //                                             |               |  |             |  |           |
+  const std::regex command_w_args_regex(R"EOF(^%((?:[A-Z]|[0-9]|_)+)(?:\(([^\)]*)\))?(?::([0-9]+))?%)EOF");
+  //                                            |__________________|     |______|        |______|
+  //                                                     |                   |              |
+  // Capturing group specifying COMMAND -----------------                    |              |
+  // The index of this group is 1.                                           |              |
+  //                                                                         |              |
+  // Capturing group for SUBCOMMAND. If present, it will --------------------               |
+  // contain SUBCOMMAND without "(" and ")". The index                                      |
+  // of SUBCOMMAND group is 2.                                                              |
+  //                                                                                        |
+  // Capturing group for LENGTH. If present, it will ----------------------------------------
+  // contain just number without ":". The index of
+  // LENGTH group is 3.
+    // clang-format on
+
+    for (size_t pos = 0; pos < format.size(); ++pos) {
+      if (format[pos] != '%') {
+        current_token += format[pos];
+        continue;
+      }
+
+      // escape '%%'
+      if (format.size() > pos + 1) {
+        if (format[pos + 1] == '%') {
+          current_token += '%';
+          pos++;
+          continue;
+        }
+      }
+
+      if (!current_token.empty()) {
+        formatters.emplace_back(FormatterProviderPtr<FormatterContext>{
+            new PlainStringFormatterProvider<FormatterContext>(current_token)});
+        current_token = "";
+      }
+
+      std::smatch m;
+      const std::string search_space = std::string(format.substr(pos));
+      if (!std::regex_search(search_space, m, command_w_args_regex)) {
+        throw EnvoyException(
+            fmt::format("Incorrect configuration: {}. Couldn't find valid command at position {}",
+                        format, pos));
+      }
+
+      const std::string match = m.str(0);
+      // command is at at index 1.
+      const std::string command = m.str(1);
+      // subcommand is at index 2.
+      const std::string subcommand = m.str(2);
+      // optional length is at index 3. If present, validate that it is valid integer.
+      absl::optional<size_t> max_length;
+      if (m.str(3).length() != 0) {
+        size_t length_value;
+        if (!absl::SimpleAtoi(m.str(3), &length_value)) {
+          throw EnvoyException(absl::StrCat("Length must be an integer, given: ", m.str(3)));
+        }
+        max_length = length_value;
+      }
+      std::vector<std::string> path;
+
+      const size_t command_end_position = pos + m.str(0).length() - 1;
+
+      bool added = false;
+      for (const auto& cmd : command_parsers) {
+        auto formatter = cmd->parse(command, subcommand, max_length);
+        if (formatter) {
+          formatters.push_back(std::move(formatter));
+          added = true;
+          break;
+        }
+      }
+
+      if (!added) {
+        formatters.emplace_back(FormatterProviderPtr<FormatterContext>{
+            new StreamInfoFormatterProvider<FormatterContext>(command, subcommand, max_length)});
+      }
+
+      pos = command_end_position;
+    }
+
+    if (!current_token.empty() || format.empty()) {
+      // Create a PlainStringFormatterProvider with the final string literal. If the format string
+      // was empty, this creates a PlainStringFormatterProvider with an empty string.
+      formatters.emplace_back(FormatterProviderPtr<FormatterContext>{
+          new PlainStringFormatterProvider<FormatterContext>(current_token)});
+    }
+
+    return formatters;
+  }
+};
+
+template <class FormatterContext> class FormatterImpl : public Formatter<FormatterContext> {
+public:
+  FormatterImpl(absl::string_view format, bool omit_empty_values,
+                const CommandParsers<FormatterContext>& command_parsers)
+      : empty_value_string_(omit_empty_values ? absl::string_view{}
+                                              : DefaultUnspecifiedValueString) {
+    providers_ = SubstitutionFormatParser<FormatterContext>::parse(format, command_parsers);
+  }
+
+  // Formatter
+  std::string format(const FormatterContext& context,
+                     const StreamInfo::StreamInfo& info) const override {
+    std::string log_line;
+    log_line.reserve(256);
+
+    for (const FormatterProviderPtr<FormatterContext>& provider : providers_) {
+      const auto bit = provider->format(context, info);
+      log_line += bit.value_or(empty_value_string_);
+    }
+
+    return log_line;
+  }
+
+private:
+  const absl::string_view empty_value_string_;
+  std::vector<FormatterProviderPtr<FormatterContext>> providers_;
+};
+
+// Helper classes for StructFormatter::StructFormatMapVisitor.
+template <class... Ts> struct StructFormatMapVisitorHelper : Ts... { using Ts::operator()...; };
+template <class... Ts> StructFormatMapVisitorHelper(Ts...) -> StructFormatMapVisitorHelper<Ts...>;
+
+/**
+ * An formatter for structured log formats, which returns a Struct proto that
+ * can be converted easily into multiple formats.
+ */
+template <class FormatterContext> class StructFormatter {
+public:
+  StructFormatter(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
+                  bool omit_empty_values, const CommandParsers<FormatterContext>& commands)
+      : omit_empty_values_(omit_empty_values), preserve_types_(preserve_types),
+        empty_value_(omit_empty_values_ ? std::string() : DefaultUnspecifiedValueString),
+        struct_output_format_(FormatBuilder(commands).toFormatMapValue(format_mapping)) {}
+
+  ProtobufWkt::Struct format(const FormatterContext& context,
+                             const StreamInfo::StreamInfo& info) const {
+    StructFormatMapVisitor visitor{
+        [&](const std::vector<FormatterProviderPtr<FormatterContext>>& providers) {
+          return providersCallback(providers, context, info);
+        },
+        [&, this](const StructFormatter::StructFormatMapWrapper& format_map) {
+          return structFormatMapCallback(format_map, visitor);
+        },
+        [&, this](const StructFormatter::StructFormatListWrapper& format_list) {
+          return structFormatListCallback(format_list, visitor);
+        },
+    };
+    return structFormatMapCallback(struct_output_format_, visitor).struct_value();
+  }
+
+private:
+  struct StructFormatMapWrapper;
+  struct StructFormatListWrapper;
+  using StructFormatValue =
+      absl::variant<const std::vector<FormatterProviderPtr<FormatterContext>>,
+                    const StructFormatMapWrapper, const StructFormatListWrapper>;
+  // Although not required for Struct/JSON, it is nice to have the order of
+  // properties preserved between the format and the log entry, thus std::map.
+  using StructFormatMap = std::map<std::string, StructFormatValue>;
+  using StructFormatMapPtr = std::unique_ptr<StructFormatMap>;
+  struct StructFormatMapWrapper {
+    StructFormatMapPtr value_;
+  };
+
+  using StructFormatList = std::list<StructFormatValue>;
+  using StructFormatListPtr = std::unique_ptr<StructFormatList>;
+  struct StructFormatListWrapper {
+    StructFormatListPtr value_;
+  };
+
+  using StructFormatMapVisitor = StructFormatMapVisitorHelper<
+      const std::function<ProtobufWkt::Value(
+          const std::vector<FormatterProviderPtr<FormatterContext>>&)>,
+      const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatMapWrapper&)>,
+      const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatListWrapper&)>>;
+
+  // Methods for building the format map.
+  class FormatBuilder {
+  public:
+    explicit FormatBuilder(const CommandParsers<FormatterContext>& commands)
+        : commands_(commands) {}
+    explicit FormatBuilder() : commands_(absl::nullopt) {}
+    std::vector<FormatterProviderPtr<FormatterContext>>
+    toFormatStringValue(const std::string& string_format) const {
+      return SubstitutionFormatParser<FormatterContext>::parse(string_format, commands_);
+    }
+    std::vector<FormatterProviderPtr<FormatterContext>> toFormatNumberValue(double value) const {
+      std::vector<FormatterProviderPtr<FormatterContext>> formatters;
+      formatters.emplace_back(FormatterProviderPtr<FormatterContext>{
+          new PlainNumberFormatterProvider<FormatterContext>(value)});
+      return formatters;
+    }
+    StructFormatMapWrapper toFormatMapValue(const ProtobufWkt::Struct& struct_format) const {
+      auto output = std::make_unique<StructFormatMap>();
+      for (const auto& pair : struct_format.fields()) {
+        switch (pair.second.kind_case()) {
+        case ProtobufWkt::Value::kStringValue:
+          output->emplace(pair.first, toFormatStringValue(pair.second.string_value()));
+          break;
+
+        case ProtobufWkt::Value::kStructValue:
+          output->emplace(pair.first, toFormatMapValue(pair.second.struct_value()));
+          break;
+
+        case ProtobufWkt::Value::kListValue:
+          output->emplace(pair.first, toFormatListValue(pair.second.list_value()));
+          break;
+
+        case ProtobufWkt::Value::kNumberValue:
+          output->emplace(pair.first, toFormatNumberValue(pair.second.number_value()));
+          break;
+
+        default:
+          throw EnvoyException(
+              "Only string values, nested structs, list values and number values are "
+              "supported in structured access log format.");
+        }
+      }
+      return {std::move(output)};
+    }
+    StructFormatListWrapper
+    toFormatListValue(const ProtobufWkt::ListValue& list_value_format) const {
+      auto output = std::make_unique<StructFormatList>();
+      for (const auto& value : list_value_format.values()) {
+        switch (value.kind_case()) {
+        case ProtobufWkt::Value::kStringValue:
+          output->emplace_back(toFormatStringValue(value.string_value()));
+          break;
+
+        case ProtobufWkt::Value::kStructValue:
+          output->emplace_back(toFormatMapValue(value.struct_value()));
+          break;
+
+        case ProtobufWkt::Value::kListValue:
+          output->emplace_back(toFormatListValue(value.list_value()));
+          break;
+
+        case ProtobufWkt::Value::kNumberValue:
+          output->emplace_back(toFormatNumberValue(value.number_value()));
+          break;
+
+        default:
+          throw EnvoyException(
+              "Only string values, nested structs, list values and number values are "
+              "supported in structured access log format.");
+        }
+      }
+      return {std::move(output)};
+    }
+
+  private:
+    const CommandParsers<FormatterContext>& commands_;
+  };
+
+  // Methods for doing the actual formatting.
+  ProtobufWkt::Value
+  providersCallback(const std::vector<FormatterProviderPtr<FormatterContext>>& providers,
+                    const FormatterContext& context,
+                    const StreamInfo::StreamInfo& stream_info) const {
+    ASSERT(!providers.empty());
+    if (providers.size() == 1) {
+      const auto& provider = providers.front();
+      if (preserve_types_) {
+        return provider->formatValue(context, stream_info);
+      }
+
+      if (omit_empty_values_) {
+        return ValueUtil::optionalStringValue(provider->format(context, stream_info));
+      }
+
+      const auto str = provider->format(context, stream_info);
+      return ValueUtil::stringValue(str.value_or(DefaultUnspecifiedValueString));
+    }
+    // Multiple providers forces string output.
+    std::string str;
+    for (const auto& provider : providers) {
+      const auto bit = provider->format(context, stream_info);
+      str += bit.value_or(empty_value_);
+    }
+    return ValueUtil::stringValue(str);
+  }
+  ProtobufWkt::Value
+  structFormatMapCallback(const StructFormatter::StructFormatMapWrapper& format_map,
+                          const StructFormatMapVisitor& visitor) const {
+    ProtobufWkt::Struct output;
+    auto* fields = output.mutable_fields();
+    for (const auto& pair : *format_map.value_) {
+      ProtobufWkt::Value value = absl::visit(visitor, pair.second);
+      if (omit_empty_values_ && value.kind_case() == ProtobufWkt::Value::kNullValue) {
+        continue;
+      }
+      (*fields)[pair.first] = value;
+    }
+    if (omit_empty_values_ && output.fields().empty()) {
+      return ValueUtil::nullValue();
+    }
+    return ValueUtil::structValue(output);
+  }
+  ProtobufWkt::Value
+  structFormatListCallback(const StructFormatter::StructFormatListWrapper& format_list,
+                           const StructFormatMapVisitor& visitor) const {
+    std::vector<ProtobufWkt::Value> output;
+    for (const auto& val : *format_list.value_) {
+      ProtobufWkt::Value value = absl::visit(visitor, val);
+      if (omit_empty_values_ && value.kind_case() == ProtobufWkt::Value::kNullValue) {
+        continue;
+      }
+      output.push_back(value);
+    }
+    return ValueUtil::listValue(output);
+  }
+
+  const bool omit_empty_values_;
+  const bool preserve_types_;
+  const std::string empty_value_;
+
+  const StructFormatMapWrapper struct_output_format_;
+};
+
+template <class FormatterContext>
+using StructFormatterPtr = std::unique_ptr<StructFormatter<FormatterContext>>;
+
+template <class FormatterContext> class JsonFormatterImpl : public Formatter<FormatterContext> {
+public:
+  JsonFormatterImpl(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
+                    bool omit_empty_values, const CommandParsers<FormatterContext>& commands)
+      : struct_formatter_(format_mapping, preserve_types, omit_empty_values, commands) {}
+
+  // Formatter::format
+  std::string format(const FormatterContext& context,
+                     const StreamInfo::StreamInfo& info) const override {
+    const ProtobufWkt::Struct output_struct = struct_formatter_.format(context, info);
+
+#ifdef ENVOY_ENABLE_YAML
+    const std::string log_line =
+        MessageUtil::getJsonStringFromMessageOrError(output_struct, false, true);
+#else
+    IS_ENVOY_BUG("Json support compiled out");
+    const std::string log_line = "";
+#endif
+    return absl::StrCat(log_line, "\n");
+  }
+
+private:
+  const StructFormatter<FormatterContext> struct_formatter_;
+};
+
+class SubstitutionFormatStringUtils {
+public:
+  /**
+   * Generate a formatter object from config SubstitutionFormatString.
+   */
+  template <class FormatterContext>
+  static FormatterPtr<FormatterContext>
+  fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config,
+                  Server::Configuration::CommonFactoryContext& context) {
+
+    auto commands_ref = std::ref(BuiltInCommandParsers<FormatterContext>::commandParsers());
+
+    // Try instantiate formatter extensions if exist.
+    CommandParsers<FormatterContext> final_commands;
+    if (!config.formatters().empty()) {
+      // If there are configured formatters, then copy the built-in commands into the
+      // final map first.
+      final_commands = BuiltInCommandParsers<FormatterContext>::commandParsers();
+      commands_ref = std::ref(final_commands);
+    }
+
+    for (const auto& formatter : config.formatters()) {
+      auto* factory =
+          Envoy::Config::Utility::getFactory<CommandParserFactory<FormatterContext>>(formatter);
+      if (!factory) {
+        throw EnvoyException(absl::StrCat("Formatter not found: ", formatter.name()));
+      }
+      auto typed_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
+          formatter.typed_config(), context.messageValidationVisitor(), *factory);
+      auto parser = factory->createCommandParserFromProto(*typed_config, context);
+      if (!parser) {
+        throw EnvoyException(absl::StrCat("Failed to create command parser: ", formatter.name()));
+      }
+      // The configured command parsers may override the built-in command parsers.
+      final_commands.push_back(std::move(parser));
+    }
+
+    switch (config.format_case()) {
+    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
+      return std::make_unique<FormatterImpl>(config.text_format(), config.omit_empty_values(),
+                                             commands_ref.get());
+    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat:
+      return std::make_unique<JsonFormatterImpl>(config.json_format(), true,
+                                                 config.omit_empty_values(), commands_ref.get());
+    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormatSource:
+      return std::make_unique<FormatterImpl>(
+          Config::DataSource::read(config.text_format_source(), true, context.api()), false,
+          commands_ref.get());
+    case envoy::config::core::v3::SubstitutionFormatString::FormatCase::FORMAT_NOT_SET:
+      PANIC_DUE_TO_PROTO_UNSET;
+    }
+
+    return nullptr;
+  }
+
+  /**
+   * Generate a Json formatter object from proto::Struct config
+   */
+  template <class FormatterContext>
+  static FormatterPtr<FormatterContext>
+  createJsonFormatter(const ProtobufWkt::Struct& struct_format, bool preserve_types,
+                      bool omit_empty_values) {
+    return std::make_unique<JsonFormatterImpl>(
+        struct_format, preserve_types, omit_empty_values,
+        BuiltInCommandParsers<FormatterContext>::commandParsers());
+  }
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/interface/BUILD
+++ b/contrib/generic_proxy/filters/network/source/interface/BUILD
@@ -95,6 +95,7 @@ envoy_cc_library(
         ":codec_interface",
         ":filter_interface",
         ":route_interface",
+        "//contrib/generic_proxy/filters/network/source:access_log_lib",
         "//envoy/tracing:trace_config_interface",
         "//envoy/tracing:tracer_interface",
     ],

--- a/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
+++ b/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
@@ -3,6 +3,7 @@
 #include "envoy/tracing/trace_config.h"
 #include "envoy/tracing/tracer.h"
 
+#include "contrib/generic_proxy/filters/network/source/access_log.h"
 #include "contrib/generic_proxy/filters/network/source/interface/codec.h"
 #include "contrib/generic_proxy/filters/network/source/interface/filter.h"
 #include "contrib/generic_proxy/filters/network/source/interface/route.h"
@@ -45,6 +46,11 @@ public:
    * @return connection manager tracing config.
    */
   virtual OptRef<const Tracing::ConnectionManagerTracingConfig> tracingConfig() const PURE;
+
+  /**
+   * @return const std::vector<GenericProxyAccessLogInstanceSharedPtr>& access logs.
+   */
+  virtual const std::vector<GenericProxyAccessLogInstanceSharedPtr>& accessLogs() const PURE;
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -183,6 +183,12 @@ void ActiveStream::completeRequest() {
                                          *this, false);
   }
 
+  for (const auto& access_log : parent_.config_->accessLogs()) {
+    access_log->log(GenericProxyFormatterContext{downstream_request_stream_.get(),
+                                                 local_or_upstream_response_stream_.get()},
+                    stream_info_);
+  }
+
   for (auto& filter : decoder_filters_) {
     filter->filter_->onDestroy();
   }

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -52,11 +52,12 @@ public:
                    Rds::RouteConfigProviderSharedPtr route_config_provider,
                    std::vector<NamedFilterFactoryCb> factories, Tracing::TracerSharedPtr tracer,
                    Tracing::ConnectionManagerTracingConfigPtr tracing_config,
+                   std::vector<GenericProxyAccessLogInstanceSharedPtr>&& access_logs,
                    Envoy::Server::Configuration::FactoryContext& context)
       : stat_prefix_(stat_prefix), codec_factory_(std::move(codec)),
         route_config_provider_(std::move(route_config_provider)), factories_(std::move(factories)),
         drain_decision_(context.drainDecision()), tracer_(std::move(tracer)),
-        tracing_config_(std::move(tracing_config)) {}
+        tracing_config_(std::move(tracing_config)), access_logs_(std::move(access_logs)) {}
 
   // FilterConfig
   RouteEntryConstSharedPtr routeEntry(const Request& request) const override {
@@ -70,6 +71,9 @@ public:
   }
   OptRef<const Tracing::ConnectionManagerTracingConfig> tracingConfig() const override {
     return makeOptRefFromPtr<const Tracing::ConnectionManagerTracingConfig>(tracing_config_.get());
+  }
+  const std::vector<GenericProxyAccessLogInstanceSharedPtr>& accessLogs() const override {
+    return access_logs_;
   }
 
   // FilterChainFactory
@@ -95,6 +99,8 @@ private:
 
   Tracing::TracerSharedPtr tracer_;
   Tracing::ConnectionManagerTracingConfigPtr tracing_config_;
+
+  std::vector<GenericProxyAccessLogInstanceSharedPtr> access_logs_;
 };
 
 class ActiveStream : public FilterChainManager,

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -82,7 +82,8 @@ public:
 
     filter_config_ = std::make_shared<FilterConfigImpl>(
         "test_prefix", std::move(codec_factory), route_config_provider_, factories, tracer_,
-        std::move(tracing_config_), factory_context_);
+        std::move(tracing_config_), std::vector<GenericProxyAccessLogInstanceSharedPtr>{},
+        factory_context_);
   }
 
   std::shared_ptr<NiceMock<Tracing::MockTracer>> tracer_;

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -499,6 +499,7 @@ public:
 private:
   FieldExtractorPtr field_extractor_;
 
+public:
   using FieldExtractorLookupTbl =
       absl::flat_hash_map<absl::string_view,
                           std::pair<CommandSyntaxChecker::CommandSyntaxFlags,

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -327,7 +327,7 @@ class FormatChecker:
     def deny_listed_for_exceptions(self, file_path):
         # Returns true when it is a non test header file or the file_path is in DENYLIST or
         # it is under tools/testdata subdirectory.
-        return (file_path.endswith('.h') and not file_path.startswith("./test/") and not file_path in self.config.paths["exception"]["include"]) \
+        return (file_path.endswith('.h') and not file_path.startswith("./test/") and not file_path.startswith("./contrib/") and not file_path in self.config.paths["exception"]["include"]) \
             or (file_path.endswith('.cc') and file_path.startswith("./source/") and not file_path.startswith("./source/extensions/") and not file_path in self.config.paths["exception"]["include"]) \
             or self.is_in_subdir(file_path, 'tools/testdata')
 


### PR DESCRIPTION
Commit Message: generic proxy: access log and formatter support
Additional Description:

This PR mainly contain two different part:
1. One part is a templated `Formatter` and `AccessLog` which could be shared by other modules, like redis, thrift, or others.
2. Access log support for the generic proxy.

Risk Level: low.
Testing: n/a. wait.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.