### PR TITLE
Fix UAF bug in connection limit filter.

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: connection limit
+  change: |
+    fixed a use-after-free bug in the connection limit filter.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/network/connection_limit/connection_limit.cc
+++ b/source/extensions/filters/network/connection_limit/connection_limit.cc
@@ -80,7 +80,6 @@ Network::FilterStatus Filter::onNewConnection() {
     absl::optional<std::chrono::milliseconds> duration = config_->delay();
     if (duration.has_value() && duration.value() > std::chrono::milliseconds(0)) {
       delay_timer_ = read_callbacks_->connection().dispatcher().createTimer([this]() -> void {
-        resetTimerState();
         read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
       });
       delay_timer_->enableTimer(duration.value());


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix UAF bug in connection limit filter.
Additional Description:

Thanks to Haoruo Lei <haoruolei@microsoft.com> for pointing out the issue.

The issue is that the lambda's body deletes the timer which owns the lambda, and the lambda owners __this which is accessed in the next line. This is the fix as it should not mather if there's a delay what action we do when closing the connection -- the close event also handles resetting the time.

This is an issue that really should have been caught by ASAN but unfortunately due to the dtor of the lambda being trivial it won't do anything and no code will be emitted for it.

You can see simplified reproduction copies of this situation in the following:
1. We can see the __this is saved by the lambda in https://cppinsights.io/s/2559fe02
2. We can see the generated ASAN assembly: https://godbolt.org/z/bPo6xKsEh

I modified the lambda to trivially copy copy an int by value and modify it after the lambda is freed e.g.

```
-      delay_timer_ = read_callbacks_->connection().dispatcher().createTimer([this]() -> void {
-        resetTimerState();
-        read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
-      });
+      int foo_bar = 0;
+      delay_timer_ =
+          read_callbacks_->connection().dispatcher().createTimer([this, foo_bar]() -> void {
+            resetTimerState();
+            // This should kaboom since the timer should be dead now.
+            std::cerr << "kbaichoo: value of foo_bar" << foo_bar << std::endl;
+            read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);

```

and was able to generate the expected use-after-free report below:

```
kbaichoo: value of foo_bar=================================================================
==12==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040001b9820 at pc 0x000003c5da2e bp 0x7f5d9c1f4890 sp 0x7f5d9c1f4888
READ of size 4 at 0x6040001b9820 thread T9
error: failed to decompress '.debug_aranges', zlib is not available
error: failed to decompress '.debug_info', zlib is not available
error: failed to decompress '.debug_abbrev', zlib is not available
error: failed to decompress '.debug_line', zlib is not available
error: failed to decompress '.debug_str', zlib is not available
error: failed to decompress '.debug_line_str', zlib is not available
error: failed to decompress '.debug_loclists', zlib is not available
error: failed to decompress '.debug_rnglists', zlib is not available
        #0 0x3c5da2d in std::_Function_handler<void (), Envoy::Extensions::NetworkFilters::ConnectionLimitFilter::Filter::onNewConnection()::$_1>::_M_invoke(std::_Any_data const&) connection_limit.cc
        #1 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #2 0x7cedcf6 in std::_Function_handler<void (), Envoy::Event::DispatcherImpl::createTimerInternal(std::function<void ()>)::$_7>::_M_invoke(std::_Any_data const&) dispatcher_impl.cc
        #3 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #4 0x7b7f372 in Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::runReadyAlarms() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b7f372)
        #5 0x7b8e95b in std::enable_if<is_invocable_r_v<void, Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()&>, void>::type std::__invoke_r<void, Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()&>(Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b8e95b)
        #6 0x7b8e86f in std::_Function_handler<void (), Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()>::_M_invoke(std::_Any_data const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b8e86f)
        #7 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #8 0x82cb4a8 in Envoy::Event::SchedulableCallbackImpl::SchedulableCallbackImpl(Envoy::CSmartPtr<event_base, &(event_base_free)>&, std::function<void ()>)::$_0::__invoke(int, short, void*) schedulable_cb_impl.cc
        #9 0x92d095e in event_process_active_single_queue event.c
        #10 0x92b1f52 in event_base_loop (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x92b1f52)
        #11 0x82c7b8e in Envoy::Event::LibeventScheduler::run(Envoy::Event::Dispatcher::RunType) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x82c7b8e)
        #12 0x7ce6d28 in Envoy::Event::DispatcherImpl::run(Envoy::Event::Dispatcher::RunType) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7ce6d28)
        #13 0x5474561 in Envoy::Server::WorkerImpl::threadRoutine(Envoy::Server::GuardDog&, std::function<void ()> const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x5474561)
        #14 0x5476551 in std::_Function_handler<void (), Envoy::Server::WorkerImpl::start(Envoy::Server::GuardDog&, std::function<void ()> const&)::$_6>::_M_invoke(std::_Any_data const&) worker_impl.cc
        #15 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #16 0x92754d8 in Envoy::Thread::ThreadImplPosix::ThreadImplPosix(std::function<void ()>, std::optional<Envoy::Thread::Options> const&)::'lambda'(void*)::__invoke(void*) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x92754d8)
        #17 0x7f5da38a7fd3  (/lib/x86_64-linux-gnu/libc.so.6+0x88fd3) (BuildId: cc9a368c5548818d3889c4c5f44d90cf5766857d)
        #18 0x7f5da39285bb  (/lib/x86_64-linux-gnu/libc.so.6+0x1095bb) (BuildId: cc9a368c5548818d3889c4c5f44d90cf5766857d)

0x6040001b9820 is located 16 bytes inside of 40-byte region [0x6040001b9810,0x6040001b9838)
freed by thread T9 here:
        #0 0x3b7be52 in free (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3b7be52)
        #1 0x7cede7c in std::_Function_handler<void (), Envoy::Event::DispatcherImpl::createTimerInternal(std::function<void ()>)::$_7>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) dispatcher_impl.cc
        #2 0x3c19573 in std::_Function_base::~_Function_base() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3c19573)
        #3 0x7b80990 in Envoy::Event::SimulatedTimeSystemHelper::Alarm::~Alarm() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b80990)
        #4 0x7b809dd in Envoy::Event::SimulatedTimeSystemHelper::Alarm::~Alarm() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b809dd)
        #5 0x3c5f931 in std::__uniq_ptr_impl<Envoy::Event::Timer, std::default_delete<Envoy::Event::Timer> >::reset(Envoy::Event::Timer*) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3c5f931)
        #6 0x3c5b8d6 in Envoy::Extensions::NetworkFilters::ConnectionLimitFilter::Filter::resetTimerState() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3c5b8d6)
        #7 0x3c5d7f8 in std::_Function_handler<void (), Envoy::Extensions::NetworkFilters::ConnectionLimitFilter::Filter::onNewConnection()::$_1>::_M_invoke(std::_Any_data const&) connection_limit.cc
        #8 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #9 0x7cedcf6 in std::_Function_handler<void (), Envoy::Event::DispatcherImpl::createTimerInternal(std::function<void ()>)::$_7>::_M_invoke(std::_Any_data const&) dispatcher_impl.cc
        #10 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #11 0x7b7f372 in Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::runReadyAlarms() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b7f372)
        #12 0x7b8e95b in std::enable_if<is_invocable_r_v<void, Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()&>, void>::type std::__invoke_r<void, Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()&>(Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b8e95b)
        #13 0x7b8e86f in std::_Function_handler<void (), Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::SimulatedScheduler(Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&)::'lambda'()>::_M_invoke(std::_Any_data const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b8e86f)
        #14 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #15 0x82cb4a8 in Envoy::Event::SchedulableCallbackImpl::SchedulableCallbackImpl(Envoy::CSmartPtr<event_base, &(event_base_free)>&, std::function<void ()>)::$_0::__invoke(int, short, void*) schedulable_cb_impl.cc
        #16 0x92d095e in event_process_active_single_queue event.c
        #17 0x92b1f52 in event_base_loop (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x92b1f52)
        #18 0x82c7b8e in Envoy::Event::LibeventScheduler::run(Envoy::Event::Dispatcher::RunType) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x82c7b8e)
        #19 0x7ce6d28 in Envoy::Event::DispatcherImpl::run(Envoy::Event::Dispatcher::RunType) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7ce6d28)
        #20 0x5474561 in Envoy::Server::WorkerImpl::threadRoutine(Envoy::Server::GuardDog&, std::function<void ()> const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x5474561)
        #21 0x5476551 in std::_Function_handler<void (), Envoy::Server::WorkerImpl::start(Envoy::Server::GuardDog&, std::function<void ()> const&)::$_6>::_M_invoke(std::_Any_data const&) worker_impl.cc
        #22 0x3d0e104 in std::function<void ()>::operator()() const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d0e104)
        #23 0x92754d8 in Envoy::Thread::ThreadImplPosix::ThreadImplPosix(std::function<void ()>, std::optional<Envoy::Thread::Options> const&)::'lambda'(void*)::__invoke(void*) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x92754d8)
        #24 0x7f5da38a7fd3  (/lib/x86_64-linux-gnu/libc.so.6+0x88fd3) (BuildId: cc9a368c5548818d3889c4c5f44d90cf5766857d)

previously allocated by thread T9 here:
        #0 0x3b7c0fe in malloc (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3b7c0fe)
        #1 0x7f5da3aa958b in operator new(unsigned long) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xa958b) (BuildId: da7a43b9a9187f8d6fd68c66590dfe908423be34)
        #2 0x3d5aea6 in std::function<void ()>::function(std::function<void ()> const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3d5aea6)
        #3 0x7b82d2c in std::__detail::_MakeUniq<Envoy::Event::SimulatedTimeSystemHelper::Alarm>::__single_object std::make_unique<Envoy::Event::SimulatedTimeSystemHelper::Alarm, Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler&, Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&, std::function<void ()> const&>(Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler&, Envoy::Event::SimulatedTimeSystemHelper&, Envoy::Event::CallbackScheduler&, std::function<void ()> const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b82d2c)
        #4 0x7b7dace in Envoy::Event::SimulatedTimeSystemHelper::SimulatedScheduler::createTimer(std::function<void ()> const&, Envoy::Event::Dispatcher&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7b7dace)
        #5 0x7ce39ca in Envoy::Event::DispatcherImpl::createTimerInternal(std::function<void ()>) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7ce39ca)
        #6 0x7ce3279 in Envoy::Event::DispatcherImpl::createTimer(std::function<void ()>) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7ce3279)
        #7 0x3c5cbe8 in Envoy::Extensions::NetworkFilters::ConnectionLimitFilter::Filter::onNewConnection() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x3c5cbe8)
        #8 0x7d802eb in Envoy::Network::FilterManagerImpl::initializeReadFilters() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7d802eb)
        #9 0x7d65715 in Envoy::Network::ServerConnectionImpl::initializeReadFilters() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7d65715)
        #10 0x7d657a9 in virtual thunk to Envoy::Network::ServerConnectionImpl::initializeReadFilters() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7d657a9)
        #11 0x6895885 in Envoy::Server::Configuration::FilterChainUtility::buildFilterChain(Envoy::Network::FilterManager&, std::vector<std::unique_ptr<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> >, std::default_delete<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> > > >, std::allocator<std::unique_ptr<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> >, std::default_delete<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> > > > > > const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x6895885)
        #12 0x663f62f in non-virtual thunk to Envoy::Server::ListenerImpl::createNetworkFilterChain(Envoy::Network::Connection&, std::vector<std::unique_ptr<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> >, std::default_delete<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> > > >, std::allocator<std::unique_ptr<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> >, std::default_delete<Envoy::Config::ExtensionConfigProvider<std::function<void (Envoy::Network::FilterManager&)> > > > > > const&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x663f62f)
        #13 0x67452a4 in Envoy::Server::ActiveStreamListenerBase::newConnection(std::unique_ptr<Envoy::Network::ConnectionSocket, std::default_delete<Envoy::Network::ConnectionSocket> >&&, std::unique_ptr<Envoy::StreamInfo::StreamInfo, std::default_delete<Envoy::StreamInfo::StreamInfo> >) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x67452a4)
        #14 0x6755e32 in Envoy::Server::ActiveTcpSocket::newConnection() (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x6755e32)
        #15 0x675786a in Envoy::Server::ActiveTcpSocket::continueFilterChain(bool) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x675786a)
        #16 0x673cfe4 in Envoy::Server::ActiveStreamListenerBase::onSocketAccepted(std::unique_ptr<Envoy::Server::ActiveTcpSocket, std::default_delete<Envoy::Server::ActiveTcpSocket> >) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x673cfe4)
        #17 0x67387e2 in Envoy::Server::ActiveTcpListener::onAcceptWorker(std::unique_ptr<Envoy::Network::ConnectionSocket, std::default_delete<Envoy::Network::ConnectionSocket> >&&, bool, bool) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x67387e2)
        #18 0x673784b in Envoy::Server::ActiveTcpListener::onAccept(std::unique_ptr<Envoy::Network::ConnectionSocket, std::default_delete<Envoy::Network::ConnectionSocket> >&&) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x673784b)
        #19 0x7da52b2 in Envoy::Network::TcpListenerImpl::onSocketEvent(short) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7da52b2)
        #20 0x7da88b3 in std::_Function_handler<void (unsigned int), Envoy::Network::TcpListenerImpl::TcpListenerImpl(Envoy::Event::DispatcherImpl&, Envoy::Random::RandomGenerator&, Envoy::Runtime::Loader&, std::shared_ptr<Envoy::Network::Socket>, Envoy::Network::TcpListenerCallbacks&, bool, bool, unsigned int)::$_0>::_M_invoke(std::_Any_data const&, unsigned int&&) tcp_listener_impl.cc
        #21 0x47bb018 in std::function<void (unsigned int)>::operator()(unsigned int) const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x47bb018)
        #22 0x7ced6c1 in std::_Function_handler<void (unsigned int), Envoy::Event::DispatcherImpl::createFileEvent(int, std::function<void (unsigned int)>, Envoy::Event::FileTriggerType, unsigned int)::$_5>::_M_invoke(std::_Any_data const&, unsigned int&&) dispatcher_impl.cc
        #23 0x47bb018 in std::function<void (unsigned int)>::operator()(unsigned int) const (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x47bb018)
        #24 0x7cfdcfd in Envoy::Event::FileEventImpl::mergeInjectedEventsAndRunCb(unsigned int) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7cfdcfd)
        #25 0x7cfe396 in Envoy::Event::FileEventImpl::assignEvents(unsigned int, event_base*)::$_1::__invoke(int, short, void*) file_event_impl.cc
        #26 0x92d1740 in event_process_active_single_queue event.c
        #27 0x92b1f52 in event_base_loop (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x92b1f52)
        #28 0x82c7b8e in Envoy::Event::LibeventScheduler::run(Envoy::Event::Dispatcher::RunType) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x82c7b8e)
        #29 0x7ce6d28 in Envoy::Event::DispatcherImpl::run(Envoy::Event::Dispatcher::RunType) (/usr/local/google/home/kbaichoo/.cache/bazel/_bazel_kbaichoo/0434f7065b1519fd28538459dc0d7c38/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/connection_limit/connection_limit_integration_test+0x7ce6d28)

...

SUMMARY: AddressSanitizer: heap-use-after-free connection_limit.cc in std::_Function_handler<void (), Envoy::Extensions::NetworkFilters::ConnectionLimitFilter::Filter::onNewConnection()::$_1>::_M_invoke(std::_Any_data const&)
Shadow bytes around the buggy address:
  0x0c088002f2b0: fa fa fd fd fd fd fd fd fa fa 00 00 00 00 00 00
  0x0c088002f2c0: fa fa fd fd fd fd fd fa fa fa 00 00 00 00 00 fa
  0x0c088002f2d0: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c088002f2e0: fa fa 00 00 00 00 00 fa fa fa 00 00 00 00 00 00
  0x0c088002f2f0: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
=>0x0c088002f300: fa fa fd fd[fd]fd fd fa fa fa 00 00 00 00 00 00
  0x0c088002f310: fa fa fd fd fd fd fd fa fa fa 00 00 00 00 00 fa
  0x0c088002f320: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c088002f330: fa fa 00 00 00 00 00 fa fa fa 00 00 00 00 00 00
  0x0c088002f340: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x0c088002f350: fa fa 00 00 00 00 00 fa fa fa 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==12==ABORTING
```

With the fix this does not occur.


Risk Level: low
Testing: ran with and without fix triggering asan without fix -- needed to help asan along to catch the issue since due to the lambda's trivial dtor it won't find it otherwise.
Docs Changes: na
Release Notes: na
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
