### PR TITLE
ecds: fix upstream filters dynamic flows by explicitly passing ClusterManager object

### DIFF
--- a/envoy/filter/BUILD
+++ b/envoy/filter/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
         "//envoy/config:dynamic_extension_config_provider_interface",
         "//envoy/init:manager_interface",
         "//envoy/server:filter_config_interface",
+        "//envoy/upstream:cluster_manager_interface",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/envoy/filter/config_provider_manager.h
+++ b/envoy/filter/config_provider_manager.h
@@ -4,6 +4,7 @@
 #include "envoy/config/dynamic_extension_config_provider.h"
 #include "envoy/init/manager.h"
 #include "envoy/server/filter_config.h"
+#include "envoy/upstream/cluster_manager.h"
 
 #include "absl/types/optional.h"
 
@@ -50,7 +51,8 @@ public:
       const envoy::config::core::v3::ExtensionConfigSource& config_source,
       const std::string& filter_config_name,
       Server::Configuration::ServerFactoryContext& server_context, FactoryCtx& factory_context,
-      bool last_filter_in_filter_chain, const std::string& filter_chain_type,
+      Upstream::ClusterManager& cluster_manager, bool last_filter_in_filter_chain,
+      const std::string& filter_chain_type,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher) PURE;
 
   /**

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -344,6 +344,7 @@ public:
   FilterConfigSubscription(const envoy::config::core::v3::ConfigSource& config_source,
                            const std::string& filter_config_name,
                            Server::Configuration::ServerFactoryContext& factory_context,
+                           Upstream::ClusterManager& cluster_manager,
                            const std::string& stat_prefix,
                            FilterConfigProviderManagerImplBase& filter_config_provider_manager,
                            const std::string& subscription_id);
@@ -438,9 +439,11 @@ public:
              Server::Configuration::ServerFactoryContext& factory_context) const PURE;
 
 protected:
-  std::shared_ptr<FilterConfigSubscription> getSubscription(
-      const envoy::config::core::v3::ConfigSource& config_source, const std::string& name,
-      Server::Configuration::ServerFactoryContext& server_context, const std::string& stat_prefix);
+  std::shared_ptr<FilterConfigSubscription>
+  getSubscription(const envoy::config::core::v3::ConfigSource& config_source,
+                  const std::string& name,
+                  Server::Configuration::ServerFactoryContext& server_context,
+                  Upstream::ClusterManager& cluster_manager, const std::string& stat_prefix);
   void applyLastOrDefaultConfig(std::shared_ptr<FilterConfigSubscription>& subscription,
                                 DynamicFilterConfigProviderImplBase& provider,
                                 const std::string& filter_config_name);
@@ -502,7 +505,8 @@ public:
       const envoy::config::core::v3::ExtensionConfigSource& config_source,
       const std::string& filter_config_name,
       Server::Configuration::ServerFactoryContext& server_context, FactoryCtx& factory_context,
-      bool last_filter_in_filter_chain, const std::string& filter_chain_type,
+      Upstream::ClusterManager& cluster_manager, bool last_filter_in_filter_chain,
+      const std::string& filter_chain_type,
       const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher) override {
     std::string subscription_stat_prefix;
     absl::string_view provider_stat_prefix;
@@ -511,7 +515,7 @@ public:
     provider_stat_prefix = subscription_stat_prefix;
 
     auto subscription = getSubscription(config_source.config_source(), filter_config_name,
-                                        server_context, subscription_stat_prefix);
+                                        server_context, cluster_manager, subscription_stat_prefix);
     // For warming, wait until the subscription receives the first response to indicate readiness.
     // Otherwise, mark ready immediately and start the subscription on initialization. A default
     // config is expected in the latter case.

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -55,10 +55,11 @@ public:
 
   FilterChainHelper(FilterConfigProviderManager& filter_config_provider_manager,
                     Server::Configuration::ServerFactoryContext& server_context,
-                    FilterCtx& factory_context, const std::string& stats_prefix)
+                    Upstream::ClusterManager& cluster_manager, FilterCtx& factory_context,
+                    const std::string& stats_prefix)
       : filter_config_provider_manager_(filter_config_provider_manager),
-        server_context_(server_context), factory_context_(factory_context),
-        stats_prefix_(stats_prefix) {}
+        server_context_(server_context), cluster_manager_(cluster_manager),
+        factory_context_(factory_context), stats_prefix_(stats_prefix) {}
 
   using FiltersList = Protobuf::RepeatedPtrField<
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>;
@@ -148,13 +149,14 @@ private:
     }
 
     auto filter_config_provider = filter_config_provider_manager_.createDynamicFilterConfigProvider(
-        config_discovery, name, server_context_, factory_context_, last_filter_in_current_config,
-        filter_chain_type, nullptr);
+        config_discovery, name, server_context_, factory_context_, cluster_manager_,
+        last_filter_in_current_config, filter_chain_type, nullptr);
     filter_factories.push_back(std::move(filter_config_provider));
   }
 
   FilterConfigProviderManager& filter_config_provider_manager_;
   Server::Configuration::ServerFactoryContext& server_context_;
+  Upstream::ClusterManager& cluster_manager_;
   FilterCtx& factory_context_;
   const std::string& stats_prefix_;
 };

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -266,7 +266,8 @@ public:
           server_factory_ctx, context.initManager(), context.scope());
       Http::FilterChainHelper<Server::Configuration::UpstreamHttpFactoryContext,
                               Server::Configuration::UpstreamHttpFilterConfigFactory>
-          helper(*filter_config_provider_manager, server_factory_ctx, *upstream_ctx_, prefix);
+          helper(*filter_config_provider_manager, server_factory_ctx, context.clusterManager(),
+                 *upstream_ctx_, prefix);
       helper.processFilters(upstream_http_filters, "router upstream http", "router upstream http",
                             upstream_http_filter_factories_);
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1256,7 +1256,7 @@ ClusterInfoImpl::ClusterInfoImpl(
     Http::FilterChainHelper<Server::Configuration::UpstreamHttpFactoryContext,
                             Server::Configuration::UpstreamHttpFilterConfigFactory>
         helper(*filter_config_provider_manager, upstream_context_.getServerFactoryContext(),
-               upstream_context_, prefix);
+               factory_context.clusterManager(), upstream_context_, prefix);
     helper.processFilters(http_filters, "upstream http", "upstream http", http_filter_factories_);
   }
 }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -627,8 +627,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
 
   Http::FilterChainHelper<Server::Configuration::FactoryContext,
                           Server::Configuration::NamedHttpFilterConfigFactory>
-      helper(filter_config_provider_manager_, context_.getServerFactoryContext(), context_,
-             stats_prefix_);
+      helper(filter_config_provider_manager_, context_.getServerFactoryContext(),
+             context_.clusterManager(), context_, stats_prefix_);
   helper.processFilters(config.http_filters(), "http", "http", filter_factories_);
 
   for (const auto& upgrade_config : config.upgrade_configs()) {

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -94,7 +94,7 @@ Filter::NetworkFilterFactoriesList ProdListenerComponentFactory::createNetworkFi
       ret.push_back(config_provider_manager.createDynamicFilterConfigProvider(
           proto_config.config_discovery(), proto_config.name(),
           filter_chain_factory_context.getServerFactoryContext(), filter_chain_factory_context,
-          is_terminal, "network", nullptr));
+          filter_chain_factory_context.clusterManager(), is_terminal, "network", nullptr));
       continue;
     }
 
@@ -157,8 +157,8 @@ ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
         }
       }
       auto filter_config_provider = config_provider_manager.createDynamicFilterConfigProvider(
-          config_discovery, name, context.getServerFactoryContext(), context, false, "listener",
-          createListenerFilterMatcher(proto_config));
+          config_discovery, name, context.getServerFactoryContext(), context,
+          context.clusterManager(), false, "listener", createListenerFilterMatcher(proto_config));
       ret.push_back(std::move(filter_config_provider));
     } else {
       ENVOY_LOG(debug, "  config: {}",

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -191,8 +191,9 @@ public:
     }
 
     return filter_config_provider_manager_->createDynamicFilterConfigProvider(
-        config_source, name, server_factory_context_, factory_context_, last_filter_config,
-        getFilterType(), getMatcher());
+        config_source, name, server_factory_context_, factory_context_,
+        server_factory_context_.cluster_manager_, last_filter_config, getFilterType(),
+        getMatcher());
   }
 
   void setup(bool warm = true, bool default_configuration = false, bool last_filter_config = true) {
@@ -576,8 +577,9 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, WrongDefaultConfig) {
   EXPECT_THROW_WITH_MESSAGE(
       config_discovery_test.filter_config_provider_manager_->createDynamicFilterConfigProvider(
           config_source, "foo", config_discovery_test.server_factory_context_,
-          config_discovery_test.factory_context_, true, config_discovery_test.getFilterType(),
-          config_discovery_test.getMatcher()),
+          config_discovery_test.factory_context_,
+          config_discovery_test.server_factory_context_.cluster_manager_, true,
+          config_discovery_test.getFilterType(), config_discovery_test.getMatcher()),
       EnvoyException,
       "Error: cannot find filter factory foo for default filter "
       "configuration with type URL "


### PR DESCRIPTION
Additional Description: As described in: #28795, upstream filters use invalid reference to ``Upstream::ClusterManager`` which is a known issue by #26653. It seems like lack of ECDS with upstream HTTP filter integration tests did not capture this issue. A follow up will be adding integration tests for upstream HTTP filters with ECDS. Resolves #28795.
Risk Level: low
Testing: Unit tests, integration tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None