### PR TITLE
Include missing header

### DIFF
--- a/envoy/common/io/io_uring.h
+++ b/envoy/common/io/io_uring.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/common/pure.h"
 #include "envoy/network/address.h"
 


### PR DESCRIPTION
Additional Description:
My local build fails with the undefined std::function in the io_uring.h file. Not sure why this works for CI, maybe some slight different in my local setup. 

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
