### PR TITLE
ecds: no terminal check for upstream network filters

### DIFF
--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -313,7 +313,7 @@ class NetworkUpstreamFilterConfigDiscoveryImplTest
           Server::Configuration::NamedUpstreamNetworkFilterConfigFactory,
           Server::Configuration::MockFactoryContext> {
 public:
-  const std::string getFilterType() const override { return "network"; }
+  const std::string getFilterType() const override { return "upstream_network"; }
   const std::string getConfigReloadCounter() const override {
     return "extension_config_discovery.upstream_network_filter.foo.config_reload";
   }
@@ -585,11 +585,12 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, WrongDefaultConfig) {
 }
 
 // Raise exception when filter is not the last filter in filter chain, but the filter is terminal
-// filter. This test does not apply to listener filter.
+// filter. This test does not apply to listener filter and upstream network filter.
 TYPED_TEST(FilterConfigDiscoveryImplTestParameter, TerminalFilterInvalid) {
   InSequence s;
   TypeParam config_discovery_test;
-  if (config_discovery_test.getFilterType() == "listener") {
+  if (config_discovery_test.getFilterType() == "listener" ||
+      config_discovery_test.getFilterType() == "upstream_network") {
     return;
   }
 

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -589,10 +589,6 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, WrongDefaultConfig) {
 TYPED_TEST(FilterConfigDiscoveryImplTestParameter, TerminalFilterInvalid) {
   InSequence s;
   TypeParam config_discovery_test;
-  if (config_discovery_test.getFilterType() == "listener" ||
-      config_discovery_test.getFilterType() == "upstream_network") {
-    return;
-  }
 
   config_discovery_test.setup(true, false, false);
   const std::string response_yaml = R"EOF(
@@ -608,6 +604,14 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, TerminalFilterInvalid) {
   const auto decoded_resources =
       TestUtility::decodeResources<envoy::config::core::v3::TypedExtensionConfig>(response);
   EXPECT_CALL(config_discovery_test.init_watcher_, ready());
+
+  if (config_discovery_test.getFilterType() == "listener" ||
+      config_discovery_test.getFilterType() == "upstream_network") {
+    EXPECT_NO_THROW(config_discovery_test.callbacks_->onConfigUpdate(decoded_resources.refvec_,
+                                                                     response.version_info()));
+    return;
+  }
+
   EXPECT_THROW_WITH_MESSAGE(
       config_discovery_test.callbacks_->onConfigUpdate(decoded_resources.refvec_,
                                                        response.version_info()),

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -584,8 +584,9 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, WrongDefaultConfig) {
       "type.googleapis.com/test.integration.filters.Bogus.");
 }
 
-// Raise exception when filter is not the last filter in filter chain, but the filter is terminal
-// filter. This test does not apply to listener filter and upstream network filter.
+// For filters which are not listener and upstream network, raise exception when filter is not the
+// last filter in filter chain, but the filter is terminal. For listener and upstream network filter
+// check that there is no exception raised.
 TYPED_TEST(FilterConfigDiscoveryImplTestParameter, TerminalFilterInvalid) {
   InSequence s;
   TypeParam config_discovery_test;


### PR DESCRIPTION
Additional Description: Upstream network filters don't use the concept of terminal/non-terminal network filters. Separating downstream/upstream config provider implementations so that upstream don't validate terminal conditions.
Risk Level: low
Testing: Unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None