### PR TITLE
Return NoClientCertificate in DefaultCertValidator

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -289,7 +289,7 @@ ValidationResults DefaultCertValidator::doVerifyCertChain(
     const char* error = "verify cert failed: empty cert chain";
     ENVOY_LOG(debug, error);
     return {ValidationResults::ValidationStatus::Failed,
-            Envoy::Ssl::ClientValidationStatus::NotValidated, absl::nullopt, error};
+            Envoy::Ssl::ClientValidationStatus::NoClientCertificate, absl::nullopt, error};
   }
   Envoy::Ssl::ClientValidationStatus detailed_status =
       Envoy::Ssl::ClientValidationStatus::NotValidated;

--- a/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/default_validator_test.cc
@@ -206,7 +206,7 @@ TEST(DefaultCertValidatorTest, TestCertificateVerificationWithEmptyCertChain) {
       *cert_chain, /*callback=*/nullptr,
       /*transport_socket_options=*/nullptr, *ssl_ctx, {}, false, "");
   EXPECT_EQ(ValidationResults::ValidationStatus::Failed, results.status);
-  EXPECT_EQ(Ssl::ClientValidationStatus::NotValidated, results.detailed_status);
+  EXPECT_EQ(Ssl::ClientValidationStatus::NoClientCertificate, results.detailed_status);
 }
 
 TEST(DefaultCertValidatorTest, NoSanInCert) {


### PR DESCRIPTION
Additional Description:
Have `DefaultCertValidator` return `NoClientCertificate` when `cert_chain` is empty.

Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
