### PR TITLE
bazel/ci: Improve flags/config

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -195,9 +195,7 @@ steps:
     ${{ if parameters.rbe }}:
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
       ENVOY_RBE: "1"
-      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) ${{ parameters.bazelBuildExtraOptions }}"
-      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs) ${{ parameters.bazelBuildExtraOptions }}"
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "--config=ci ${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)

--- a/.azure-pipelines/stage/prechecks.yml
+++ b/.azure-pipelines/stage/prechecks.yml
@@ -121,9 +121,7 @@ jobs:
         env:
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_RBE: "1"
-          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
-          BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-          BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
           GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
           GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
         condition: eq(variables['CI_TARGET'], 'docs')
@@ -153,9 +151,7 @@ jobs:
         env:
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_RBE: "1"
-          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
-          BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-          BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
           GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
           GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
         condition: eq(variables['CI_TARGET'], 'docs')

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -252,9 +252,7 @@ jobs:
         env:
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_RBE: "1"
-          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
-          BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-          BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
           GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
           GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
           DOCKERHUB_USERNAME: ${{ parameters.authDockerUser }}
@@ -270,9 +268,7 @@ jobs:
         env:
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_RBE: "1"
-          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs)"
-          BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-          BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
           GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
           GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
       - script: ci/run_envoy_docker.sh 'ci/do_ci.sh docs-publish-latest'

--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -29,8 +29,7 @@ jobs:
       ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
       ENVOY_DOCKER_IN_DOCKER: 1
       ENVOY_RBE: 1
-      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
       GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
     displayName: "Verify packages"
 
@@ -54,8 +53,7 @@ jobs:
       ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
       ENVOY_DOCKER_IN_DOCKER: 1
       ENVOY_RBE: 1
-      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
       GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
     displayName: "Verify packages"
 

--- a/.azure-pipelines/stage/windows.yml
+++ b/.azure-pipelines/stage/windows.yml
@@ -32,9 +32,7 @@ jobs:
       CI_TARGET: "windows"
       ENVOY_DOCKER_BUILD_DIR: "$(Build.StagingDirectory)"
       ENVOY_RBE: "true"
-      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=remote-msvc-cl --jobs=$(RbeJobs) --flaky_test_attempts=2"
-      BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-      BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --config=remote-msvc-cl --jobs=$(RbeJobs) --flaky_test_attempts=2"
       GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
 
   - task: PublishTestResults@2

--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,7 @@ startup --host_jvm_args=-Xmx3g
 run --color=yes
 
 build --color=yes
+build --jobs=HOST_CPUS-1
 build --workspace_status_command="bash bazel/get_workspace_status"
 build --incompatible_strict_action_env
 build --java_runtime_version=remotejdk_11
@@ -69,8 +70,6 @@ build --@com_googlesource_googleurl//build_config:system_icu=0
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled
 build:sanitizer --linkopt -ldl
-build:sanitizer --build_tag_filters=-no_san
-build:sanitizer --test_tag_filters=-no_san
 
 # Common flags for Clang
 build:clang --action_env=BAZEL_COMPILER=clang
@@ -90,6 +89,8 @@ build:asan --config=sanitizer
 # ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
 build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
+build:asan --build_tag_filters=-no_san
+build:asan --test_tag_filters=-no_san
 build:asan --copt -fsanitize=address,undefined
 build:asan --linkopt -fsanitize=address,undefined
 # vptr and function sanitizer are enabled in clang-asan if it is set up via bazel/setup_clang.sh.
@@ -150,6 +151,8 @@ build:clang-tsan --test_timeout=120,600,1500,4800
 # with libc++ instruction and provide corresponding `--copt` and `--linkopt` as well.
 build:clang-msan --action_env=ENVOY_MSAN=1
 build:clang-msan --config=sanitizer
+build:clang-msan --build_tag_filters=-no_san
+build:clang-msan --test_tag_filters=-no_san
 build:clang-msan --define ENVOY_CONFIG_MSAN=1
 build:clang-msan --copt -fsanitize=memory
 build:clang-msan --linkopt -fsanitize=memory
@@ -199,12 +202,14 @@ build:coverage --strategy=TestRunner=sandboxed,local
 build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
-build:coverage --test_tag_filters=-nocoverage
 build:coverage --instrumentation_filter="//source(?!/common/quic/platform)[/:],//envoy[/:],//contrib(?!/.*/test)[/:]"
+
 build:test-coverage --test_arg="-l trace"
 build:test-coverage --test_arg="--log-path /dev/null"
+build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
+build:fuzz-coverage --test_tag_filters=-nocoverage
 
 # Remote execution: https://docs.bazel.build/versions/master/remote-execution.html
 build:rbe-toolchain --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
@@ -264,10 +269,6 @@ build:remote --spawn_strategy=remote,sandboxed,local
 build:remote --strategy=Javac=remote,sandboxed,local
 build:remote --strategy=Closure=remote,sandboxed,local
 build:remote --strategy=Genrule=remote,sandboxed,local
-build:remote --remote_timeout=7200
-build:remote --google_default_credentials=true
-build:remote --remote_download_toplevel
-build:remote --nobuild_runfile_links
 
 # Windows bazel does not allow sandboxed as a spawn strategy
 build:remote-windows --spawn_strategy=remote,local
@@ -307,6 +308,25 @@ build:remote-clang-cl --config=remote-windows
 build:remote-clang-cl --config=clang-cl
 build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
+## Compile-time-options testing
+# Right now, none of the available compile-time options conflict with each other. If this
+# changes, this build type may need to be broken up.
+build:compile-time-options --define=admin_html=disabled
+build:compile-time-options --define=signal_trace=disabled
+build:compile-time-options --define=hot_restart=disabled
+build:compile-time-options --define=google_grpc=disabled
+build:compile-time-options --define=boringssl=fips
+build:compile-time-options --define=log_debug_assert_in_release=enabled
+build:compile-time-options --define=path_normalization_by_default=true
+build:compile-time-options --define=deprecated_features=disabled
+build:compile-time-options --define=tcmalloc=gperftools
+build:compile-time-options --define=zlib=ng
+build:compile-time-options --define=uhv=enabled
+build:compile-time-options --config=libc++20
+build:compile-time-options --test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true
+build:compile-time-options --@envoy//bazel:http3=False
+build:compile-time-options --@envoy//source/extensions/filters/http/kill_request:enabled
+
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
 build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:41c5a05d708972d703661b702a63ef5060125c33
@@ -340,16 +360,13 @@ build:docker-tsan --config=rbe-toolchain-clang-libc++
 build:docker-tsan --config=rbe-toolchain-tsan
 
 # CI configurations
-build:remote-ci --remote_cache=grpcs://remotebuildexecution.googleapis.com
-build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 build:remote-ci --config=ci
+build:remote-ci --remote_download_minimal
+
 # Note this config is used by mobile CI also.
 build:ci --noshow_progress
 build:ci --noshow_loading_progress
-
-# Build Event Service
-build:google-bes --bes_backend=grpcs://buildeventservice.googleapis.com
-build:google-bes --bes_results_url=https://source.cloud.google.com/results/invocations/
+build:ci --test_output=errors
 
 # Fuzz builds
 
@@ -439,6 +456,50 @@ build:windows --features=compiler_param_file
 build:windows --features=fully_static_link
 build:windows --features=static_link_msvcrt
 build:windows --dynamic_mode=off
+
+# RBE (Google)
+build:rbe-google --google_default_credentials=true
+build:rbe-google --remote_cache=grpcs://remotebuildexecution.googleapis.com
+build:rbe-google --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:rbe-google --remote_timeout=7200
+build:rbe-google --remote_instance_name=projects/envoy-ci/instances/default_instance
+
+build:rbe-google-bes --bes_backend=grpcs://buildeventservice.googleapis.com
+build:rbe-google-bes --bes_results_url=https://source.cloud.google.com/results/invocations/
+
+# RBE (Engflow mobile)
+build:rbe-engflow --google_default_credentials=false
+build:rbe-engflow --remote_cache=grpcs://envoy.cluster.engflow.com
+build:rbe-engflow --remote_executor=grpcs://envoy.cluster.engflow.com
+build:rbe-engflow --bes_backend=grpcs://envoy.cluster.engflow.com/
+build:rbe-engflow --bes_results_url=https://envoy.cluster.engflow.com/invocation/
+build:rbe-engflow --experimental_credential_helper=%workspace%/bazel/engflow-bazel-credential-helper.sh
+build:rbe-engflow --grpc_keepalive_time=30s
+build:rbe-engflow --remote_timeout=3600s
+build:rbe-engflow --bes_timeout=3600s
+build:rbe-engflow --bes_upload_mode=fully_async
+
+#############################################################################
+# debug: Various Bazel debugging flags
+#############################################################################
+# debug/bazel
+common:debug-bazel --announce_rc
+common:debug-bazel -s
+# debug/sandbox
+common:debug-sandbox --verbose_failures
+common:debug-sandbox --sandbox_debug
+# debug/coverage
+common:debug-coverage --action_env=VERBOSE_COVERAGE=true
+common:debug-coverage --test_env=VERBOSE_COVERAGE=true
+common:debug-coverage --test_env=DISPLAY_LCOV_CMD=true
+common:debug-coverage --config=debug-tests
+# debug/tests
+common:debug-tests --test_output=all
+# debug/everything
+common:debug --config=debug-bazel
+common:debug --config=debug-sandbox
+common:debug --config=debug-coverage
+common:debug --config=debug-tests
 
 try-import %workspace%/clang.bazelrc
 try-import %workspace%/user.bazelrc

--- a/.github/actions/diskspace/action.yml
+++ b/.github/actions/diskspace/action.yml
@@ -1,0 +1,27 @@
+inputs:
+  to_remove:
+    type: string
+    default: |
+      /opt/hostedtoolcache
+      /usr/local/lib/android
+      /usr/local/.ghcup
+
+runs:
+  using: composite
+  steps:
+  - id: remove_cruft
+    name: Cruft removal
+    run: |
+      echo "Disk space before cruft removal"
+      df -h
+
+      TO_REMOVE=(${{ inputs.to_remove }})
+
+      for removal in "${TO_REMOVE[@]}"; do
+          echo "Removing: ${removal} ..."
+          sudo rm -rf "$removal"
+      done
+
+      echo "Disk after before cruft removal"
+      df -h
+    shell: bash

--- a/.github/workflows/POLICY.md
+++ b/.github/workflows/POLICY.md
@@ -40,7 +40,7 @@ Do not allow any bots or app users to do so, unless this is specifically require
 For example, you could add a `job` condition to prevent any bots from triggering the workflow:
 
 ```yaml
-    if: |
+    if: >-
       ${{
           github.repository == 'envoyproxy/envoy'
           && (github.event.schedule

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -115,20 +115,7 @@ jobs:
       run: git config --global --add safe.directory /__w/envoy/envoy
 
     - if: ${{ inputs.diskspace_hack }}
-      name: Cruft removal
-      run: |
-        echo "Disk space before cruft removal"
-        df -h
-
-        TO_REMOVE=(
-            /opt/hostedtoolcache
-            /usr/local/lib/android
-            /usr/local/.ghcup)
-
-        for removal in "${TO_REMOVE[@]}"; do
-            echo "Removing: ${removal} ..."
-            sudo rm -rf "$removal"
-        done
+      uses: ./.github/actions/diskspace
     - run: |
         echo "disk space at beginning of build:"
         df -h

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -42,6 +42,8 @@ on:
         default:
 
     outputs:
+      debug:
+        value: false
       agent_ubuntu:
         value: ubuntu-22.04
       build_image_ubuntu:

--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -1,16 +1,17 @@
 name: Check dependencies
 
+permissions:
+  contents: read
+
 on:
   schedule:
-    - cron: '0 8 * * *'
+  - cron: '0 8 * * *'
   workflow_dispatch:
-
-permissions: read-all
 
 jobs:
   build:
     runs-on: ubuntu-22.04
-    if: |
+    if: >-
       ${{
           github.repository == 'envoyproxy/envoy'
           && (github.event.schedule

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -1,5 +1,8 @@
 name: Publish & verify
 
+permissions:
+  contents: read
+
 on:
   # This runs untrusted code, do not expose secrets in the verify job
   workflow_dispatch:
@@ -18,9 +21,6 @@ concurrency:
         || github.run_id
     }}-${{ github.workflow }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
 
 jobs:
   env:

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -1,5 +1,8 @@
 name: android_build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   androidbuild:
     if: ${{ needs.env.outputs.mobile_android_build == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: android_build
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 90
@@ -35,8 +43,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-          $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
+        cd mobile
+        ./bazelw build \
+          --config=mobile-remote-ci \
           --fat_apk_cpu=x86_64 \
           --linkopt=-fuse-ld=lld \
           //:android_dist
@@ -46,6 +55,9 @@ jobs:
     needs:
     - env
     - androidbuild
+    permissions:
+      contents: read
+      packages: read
     name: java_helloworld
     runs-on: macos-12
     timeout-minutes: 50
@@ -57,7 +69,9 @@ jobs:
         java-package: jdk
         architecture: x64
         distribution: zulu
-    - run: cd mobile && ./ci/mac_ci_setup.sh --android
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh --android
       name: 'Install dependencies'
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
@@ -72,12 +86,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-ci-macos \
             --fat_apk_cpu=x86_64 \
             //examples/java/hello_world:hello_envoy
-          adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
-          adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
+        adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
+        adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
     - name: 'Check connectivity'
       run: |
         timeout 30 adb logcat -e "received headers with status 301" -m 1 || {
@@ -87,11 +102,15 @@ jobs:
             }
             exit 1
         }
+
   kotlinhelloworld:
     if: ${{ needs.env.outputs.mobile_android_build == 'true' }}
     needs:
     - env
     - androidbuild
+    permissions:
+      contents: read
+      packages: read
     name: kotlin_helloworld
     runs-on: macos-12
     timeout-minutes: 50
@@ -104,7 +123,9 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh --android
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh --android
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
@@ -118,12 +139,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-ci-macos \
             --fat_apk_cpu=x86_64 \
             //examples/kotlin/hello_world:hello_envoy_kt
-          adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
-          adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
+        adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
+        adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
     - name: 'Check connectivity'
       run: |
         timeout 30 adb logcat -e "received headers with status 200" -m 1 || {
@@ -139,6 +161,9 @@ jobs:
     needs:
     - env
     - androidbuild
+    permissions:
+      contents: read
+      packages: read
     name: kotlin_baseline_app
     runs-on: macos-12
     timeout-minutes: 50
@@ -151,7 +176,9 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh --android
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh --android
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
@@ -165,12 +192,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-ci-macos \
             --fat_apk_cpu=x86_64 \
             //test/kotlin/apps/baseline:hello_envoy_kt
-          adb install -r --no-incremental bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
-          adb shell am start -n io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
+        adb install -r --no-incremental bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
+        adb shell am start -n io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
     - name: 'Check connectivity'
       run: |
         timeout 30 adb logcat -e "received headers with status 301" -m 1 || {
@@ -180,11 +208,15 @@ jobs:
             }
             exit 1
         }
+
   kotlinexperimentalapp:
     if: ${{ needs.env.outputs.mobile_android_build_all == 'true' }}
     needs:
     - env
     - androidbuild
+    permissions:
+      contents: read
+      packages: read
     name: kotlin_experimental_app
     runs-on: macos-12
     timeout-minutes: 50
@@ -197,7 +229,9 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh --android
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh --android
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
@@ -211,13 +245,14 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-ci-macos \
             --fat_apk_cpu=x86_64 \
             --define envoy_mobile_listener=enabled \
             //test/kotlin/apps/experimental:hello_envoy_kt
-          adb install -r --no-incremental bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
-          adb shell am start -n io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity
+        adb install -r --no-incremental bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
+        adb shell am start -n io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity
     - name: 'Check connectivity'
       run: |
         timeout 30 adb logcat -e "received headers with status 200" -m 1 || {

--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -1,5 +1,8 @@
 name: android_tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -13,11 +16,16 @@ concurrency:
 jobs:
   env:
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   kotlintestsmac:
     if: ${{ needs.env.outputs.mobile_android_tests == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     # revert to //test/kotlin/... once fixed
     # https://github.com/envoyproxy/envoy-mobile/issues/1932
     name: kotlin_tests_mac
@@ -33,20 +41,26 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
     - name: 'Run Kotlin library tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test \
-            --test_output=all \
+        cd mobile
+        ./bazelw test \
             --build_tests_only \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             --define=signal_trace=disabled \
             //test/kotlin/io/...
+
   javatestsmac:
     if: ${{ needs.env.outputs.mobile_android_tests == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: java_tests_mac
     runs-on: macos-12
     timeout-minutes: 120
@@ -60,23 +74,29 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
     - name: 'Run Java library tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test \
-            --test_output=all \
+        cd mobile
+        ./bazelw test \
             --build_tests_only \
             --config test-android \
             --define envoy_mobile_listener=enabled \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             --define=signal_trace=disabled \
             --define=system-helper=android \
             //test/java/...
+
   kotlintestslinux:
     if: ${{ needs.env.outputs.mobile_android_tests == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     # Only kotlin tests are executed since with linux:
     # https://github.com/envoyproxy/envoy-mobile/issues/1418.
     name: kotlin_tests_linux
@@ -95,10 +115,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test \
-            --test_output=all \
+        cd mobile
+        ./bazelw test \
             --build_tests_only \
             --config test-android \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
+            --config=mobile-remote-ci \
             --define=signal_trace=disabled \
             //test/kotlin/...

--- a/.github/workflows/mobile-asan.yml
+++ b/.github/workflows/mobile-asan.yml
@@ -1,5 +1,8 @@
 name: mobile_asan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   asan:
     if: ${{ needs.env.outputs.mobile_asan == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: asan
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 180
@@ -35,7 +43,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test --test_output=all \
+        cd mobile
+        ./bazelw test \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-asan") \
+            --config=mobile-remote-ci-linux-asan \
             //test/common/...

--- a/.github/workflows/mobile-cc_tests.yml
+++ b/.github/workflows/mobile-cc_tests.yml
@@ -1,5 +1,8 @@
 name: mobile_cc_tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   cctests:
     if: ${{ needs.env.outputs.mobile_cc_tests == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: cc_tests
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
@@ -33,9 +41,9 @@ jobs:
       name: 'Run tests'
         # Regression test using the new API listener. TODO(#2711) clean up.
       run: |
-        cd mobile && ./bazelw test \
+        cd mobile
+        ./bazelw test \
             --action_env=LD_LIBRARY_PATH \
-            --test_output=all \
             --copt=-DUSE_API_LISTENER \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
+            --config=mobile-remote-ci \
             //test/cc/...

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -1,5 +1,8 @@
 name: mobile_compile_time_options
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,10 +17,15 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   cc_test_no_yaml:
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: cc_test_no_yaml
     runs-on: ubuntu-20.04
     timeout-minutes: 120
@@ -34,13 +42,16 @@ jobs:
       run: |
         cd mobile
         ./bazelw test \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
-            --config=ci \
+            --config=mobile-remote-ci \
             --define=envoy_yaml=disabled \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-            //test/common/integration:client_integration_test --test_output=all
+            //test/common/integration:client_integration_test
+
   cc_test:
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: cc_test
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
@@ -55,25 +66,31 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile
+        TARGETS=$(bazel query --noshow_progress --noshow_loading_progress //test/cc/... + //test/common/... except //test/common/integration:client_integration_test)
         ./bazelw test \
             --test_output=all \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
-            --config=ci \
+            --config=mobile-remote-ci \
             --define=signal_trace=disabled \
             --define=envoy_mobile_request_compression=disabled \
             --define=envoy_enable_http_datagrams=disabled \
             --define=google_grpc=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
-            $(bazel query //test/cc/... + //test/common/... except //test/common/integration:client_integration_test)
+            $TARGETS
+
   swift_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: swift_build
     runs-on: macos-12
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build Swift library'
       env:
@@ -83,7 +100,7 @@ jobs:
         ./bazelw shutdown
         ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             --define=signal_trace=disabled \
             --define=envoy_mobile_request_compression=disabled \
             --define=envoy_mobile_stats_reporting=disabled \
@@ -93,9 +110,13 @@ jobs:
             --@envoy//bazel:http3=False \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             //library/swift:ios_framework
+
   kotlin_build:
     if: ${{ needs.env.outputs.mobile_compile_time_options == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: kotlin_build
     runs-on: macos-12
     timeout-minutes: 120
@@ -108,14 +129,16 @@ jobs:
         architecture: x64
         distribution: zulu
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh --android
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh --android
     - name: 'Build Kotlin library'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd mobile
         ./bazelw build \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             --fat_apk_cpu=x86_64 \
             --define=signal_trace=disabled \
             --define=envoy_mobile_request_compression=disabled \

--- a/.github/workflows/mobile-core.yml
+++ b/.github/workflows/mobile-core.yml
@@ -1,5 +1,8 @@
 name: mobile_core
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   unittests:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: unit_tests
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
@@ -34,11 +42,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test \
+        cd mobile
+        ./bazelw test \
             --build_tests_only \
             --action_env=LD_LIBRARY_PATH \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-            --test_output=all \
             --define envoy_mobile_listener=disabled \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
+            --config=mobile-remote-ci \
             //test/common/...

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -1,5 +1,8 @@
 name: mobile_coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   coverage:
     if: ${{ needs.env.outputs.mobile_coverage == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: coverage
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
@@ -35,13 +43,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && BAZEL_BUILD_OPTION_LIST="--config=remote-ci-linux-coverage" \
+        cd mobile
+        export BAZEL_BUILD_OPTION_LIST="--config=mobile-remote-ci-linux-coverage" \
             PATH=/opt/llvm/bin:${PATH} \
-            COVERAGE_THRESHOLD=76 \
-            ../test/run_envoy_bazel_coverage.sh //test/common/... //test/cc/...
+            COVERAGE_THRESHOLD=76
+        ../test/run_envoy_bazel_coverage.sh //test/common/... //test/cc/...
     - name: 'Package coverage'
       run: |
-        cd mobile && tar -czf coverage.tar.gz generated/coverage
+        cd mobile
+        tar -czf coverage.tar.gz generated/coverage
     - name: 'Upload report'
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mobile-docs.yml
+++ b/.github/workflows/mobile-docs.yml
@@ -1,5 +1,8 @@
 name: mobile_docs
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   docs:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 20
     container:

--- a/.github/workflows/mobile-format.yml
+++ b/.github/workflows/mobile-format.yml
@@ -1,5 +1,8 @@
 name: mobile_format
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   formatall:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: format_all
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 45
@@ -34,10 +42,16 @@ jobs:
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
     - name: 'Run formatters'
-      run: cd mobile && ./tools/check_format.sh
+      run: |
+        cd mobile
+        ./tools/check_format.sh
+
   precommit:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: precommit
     runs-on: macos-12
     timeout-minutes: 45
@@ -46,10 +60,16 @@ jobs:
     - name: 'Install precommit'
       run: brew install pre-commit
     - name: 'Run precommit'
-      run: cd mobile && find mobile/* | pre-commit run --files
+      run: |
+        cd mobile
+        find mobile/* | pre-commit run --files
+
   swiftlint:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: swift_lint
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 5
@@ -60,9 +80,13 @@ jobs:
     - name: 'Run Swift Lint (SwiftLint)'
       run: swiftlint lint --strict
       working-directory: mobile
+
   drstring:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: drstring
     runs-on: macos-12
     timeout-minutes: 10
@@ -71,10 +95,16 @@ jobs:
     - name: 'Run DrString'
       env:
         DEVELOPER_DIR: /Applications/Xcode_14.1.app
-      run: cd mobile && ./bazelw run @DrString//:drstring check
+      run: |
+        cd mobile
+        ./bazelw run --config=remote-ci @DrString//:drstring check
+
   kotlinlint:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: kotlin_lint
     runs-on: macos-12
     timeout-minutes: 45
@@ -86,15 +116,20 @@ jobs:
         java-package: jdk
         architecture: x64
         distribution: zulu
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Run Kotlin Lint (Detekt)'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-ci-macos \
             //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
             //examples/kotlin/hello_world:hello_envoy_kt_lint
     - name: 'Run Kotlin Formatter (ktlint)'
-      run: cd mobile && ./bazelw build kotlin_format
+      run: |
+        cd mobile
+        ./bazelw build --config=remote-ci kotlin_format

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -1,5 +1,8 @@
 name: ios_build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,46 +17,61 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   iosbuild:
     if: ${{ needs.env.outputs.mobile_ios_build == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: ios_build
     runs-on: macos-12
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build Envoy.framework distributable'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw shutdown
-          ./bazelw build \
+        cd mobile
+        ./bazelw shutdown
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //library/swift:ios_framework
+
   swifthelloworld:
     if: ${{ needs.env.outputs.mobile_ios_build == 'true' }}
     name: swift_helloworld
     needs:
     - env
     - iosbuild
+    permissions:
+      contents: read
+      packages: read
     runs-on: macos-12
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build app'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //examples/swift/hello_world:app
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start simulator'
@@ -66,34 +84,43 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw run \
+        cd mobile
+        ./bazelw run \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //examples/swift/hello_world:app &> /tmp/envoy.log &
-    - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+    - run: |
+        sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
+
   swiftbaselineapp:
     if: ${{ needs.env.outputs.mobile_ios_build_all == 'true' }}
     needs:
     - env
     - iosbuild
+    permissions:
+      contents: read
+      packages: read
     name: swift_baseline_app
     runs-on: macos-12
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build app'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //test/swift/apps/baseline:app
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start simulator'
@@ -106,34 +133,43 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw run \
+        cd mobile
+        ./bazelw run \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //test/swift/apps/baseline:app &> /tmp/envoy.log &
-    - run: sed '/received headers with status 301/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+    - run: |
+        sed '/received headers with status 301/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
+
   swiftexperimentalapp:
     if: ${{ needs.env.outputs.mobile_ios_build_all == 'true' }}
     needs:
     - env
     - iosbuild
+    permissions:
+      contents: read
+      packages: read
     name: swift_experimental_app
     runs-on: macos-12
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build app'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             --define=admin_functionality=enabled \
             --define envoy_mobile_listener=enabled \
             //test/swift/apps/experimental:app
@@ -148,36 +184,45 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw run \
+        cd mobile
+        ./bazelw run \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             --define=admin_functionality=enabled \
             --define envoy_mobile_listener=enabled \
             //test/swift/apps/experimental:app &> /tmp/envoy.log &
-    - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+    - run: |
+        sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
       name: 'Check connectivity'
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
+
   swiftasyncawait:
     if: ${{ needs.env.outputs.mobile_ios_build_all == 'true' }}
     needs:
     - env
     - iosbuild
+    permissions:
+      contents: read
+      packages: read
     name: swift_async_await
     runs-on: macos-12
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build app'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //examples/swift/async_await:app
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start simulator'
@@ -190,9 +235,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw run \
+        cd mobile
+        ./bazelw run \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //examples/swift/async_await:app &> /tmp/envoy.log &
     - run: |
         checklogs () {
@@ -216,25 +262,32 @@ jobs:
     - run: cat /tmp/envoy.log
       if: ${{ failure() || cancelled() }}
       name: 'Log app run'
+
   objchelloworld:
     if: ${{ needs.env.outputs.mobile_ios_build_all == 'true' }}
     needs:
     - env
     - iosbuild
+    permissions:
+      contents: read
+      packages: read
     name: objc_helloworld
     runs-on: macos-12
     timeout-minutes: 50
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build app'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //examples/objective-c/hello_world:app
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start simulator'
@@ -247,9 +300,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw run \
+        cd mobile
+        ./bazelw run \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //examples/objective-c/hello_world:app &> /tmp/envoy.log &
     - run: sed '/received headers with status 301/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
       name: 'Check connectivity'

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -1,5 +1,8 @@
 name: ios_tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,49 +17,62 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   swifttests:
     if: ${{ needs.env.outputs.mobile_ios_tests == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: swift_tests
     runs-on: macos-12
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
     - name: 'Run swift library tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # runs with the listener enabled due to IdleTimeoutTest not setting up a test backend.
       run: |
-        cd mobile && ./bazelw test \
+        cd mobile
+        ./bazelw test \
             --experimental_ui_max_stdouterr_bytes=10485760 \
-            --test_output=all \
             --config=ios \
             --define envoy_mobile_listener=enabled \
             --build_tests_only \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //test/swift/...
+
   objctests:
     if: ${{ needs.env.outputs.mobile_ios_tests == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: c_and_objc_tests
     runs-on: macos-12
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
     - name: 'Install dependencies'
-      run: cd mobile && ./ci/mac_ci_setup.sh
+      run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
     - name: 'Run Objective-C library tests'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test \
-            --test_output=all \
+        cd mobile
+        ./bazelw test \
             --config=ios \
             --build_tests_only \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //test/objective-c/...  \
             //test/cc/unit:envoy_config_test

--- a/.github/workflows/mobile-perf.yml
+++ b/.github/workflows/mobile-perf.yml
@@ -1,5 +1,8 @@
 name: mobile_perf
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -13,6 +16,9 @@ concurrency:
 jobs:
   sizecurrent:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
+    permissions:
+      contents: read
+      packages: read
     name: size_current
     runs-on: ubuntu-22.04
     timeout-minutes: 120
@@ -29,17 +35,20 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
-            --config=sizeopt \
-            --config=release-common \
-            --config=remote-ci-linux-clang \
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-release-clang \
             //test/performance:test_binary_size
     - uses: actions/upload-artifact@v3
       with:
         name: sizecurrent
         path: mobile/bazel-bin/test/performance/test_binary_size
+
   sizemain:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
+    permissions:
+      contents: read
+      packages: read
     name: size_main
     runs-on: ubuntu-22.04
     timeout-minutes: 90
@@ -50,6 +59,12 @@ jobs:
         CXX: /opt/llvm/bin/clang++
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: main
+    # TODO(phlax): remove once the bazel config is on main
+    - uses: actions/checkout@v3
+      with:
+        path: current
     - name: Add safe directory
       run: |
         git config --global --add safe.directory /__w/envoy/envoy
@@ -57,21 +72,26 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        git checkout main && git pull origin main
-          cd mobile && ./bazelw build \
-            --config=sizeopt \
-            --config=release-common \
-            --config=remote-ci-linux-clang \
+        # TODO(phlax): remove once the bazel config is on main
+        cp -a current/.bazelrc .
+        cp -a current/mobile/.bazelrc mobile/
+        cd mobile
+        ./bazelw build \
+            --config=mobile-remote-release-clang \
             //test/performance:test_binary_size
     - uses: actions/upload-artifact@v3
       with:
         name: sizemain
         path: mobile/bazel-bin/test/performance/test_binary_size
+
   sizecompare:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     needs:
     - sizecurrent
     - sizemain
+    permissions:
+      contents: read
+      packages: read
     name: size_compare
     runs-on: ubuntu-22.04
     timeout-minutes: 30
@@ -95,4 +115,6 @@ jobs:
         zip -9 dist/main.zip dist/main.stripped
         zip -9 dist/current.zip dist/current.stripped
     - name: 'Test size regression'
-      run: cd mobile && ./ci/test_size_regression.sh ../dist/main.zip ../dist/current.zip
+      run: |
+        cd mobile
+        ./ci/test_size_regression.sh ../dist/main.zip ../dist/current.zip

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,5 +1,8 @@
 name: mobile_release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:
@@ -10,7 +13,9 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   android_release_artifacts:
     if: |
@@ -20,6 +25,9 @@ jobs:
               || !contains(github.actor, '[bot]'))
       }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: android_release_artifacts
     runs-on: ubuntu-22.04
     timeout-minutes: 120
@@ -41,7 +49,7 @@ jobs:
       run: |
         version="0.5.0.$(date '+%Y%m%d')"
         ./bazelw build \
-          $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
+          --config=mobile-remote-release-clang \
           --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
           --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a \
           --define=pom_version="$version" \
@@ -60,9 +68,13 @@ jobs:
       with:
         name: envoy_android_aar_sources
         path: mobile/envoy_android_aar_sources.tar.gz
+
   android_release_deploy:
     name: android_release_deploy
     needs: android_release_artifacts
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -1,5 +1,8 @@
 name: mobile_release_validation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,29 +17,43 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   validate_swiftpm_example:
     if: ${{ needs.env.outputs.mobile_release_validation == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: validate_swiftpm_example
     runs-on: macos-12
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
-    - run: cd mobile && ./ci/mac_ci_setup.sh
+    - run: |
+        cd mobile
+        ./ci/mac_ci_setup.sh
       name: 'Install dependencies'
     - name: 'Build xcframework'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw build \
+        cd mobile
+        ./bazelw build \
             --config=ios \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --config=mobile-remote-ci-macos \
             //:ios_xcframework
     # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
-    - run: unzip mobile/bazel-bin/library/swift/Envoy.xcframework.zip -d mobile/examples/swift/swiftpm/Packages || true
+    - run: |
+        unzip mobile/bazel-bin/library/swift/Envoy.xcframework.zip \
+              -d mobile/examples/swift/swiftpm/Packages \
+            || :
       name: 'Unzip xcframework'
-    - run: xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 14 Pro Max,OS=16.1"
+    - run: |
+        xcodebuild -project mobile/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj \
+                   -scheme EnvoySwiftPMExample \
+                   -destination platform="iOS Simulator,name=iPhone 14 Pro Max,OS=16.1"
       name: 'Build app'
     # TODO(jpsim): Run app and inspect logs to validate

--- a/.github/workflows/mobile-traffic_director.yml
+++ b/.github/workflows/mobile-traffic_director.yml
@@ -1,5 +1,8 @@
 name: mobile_traffic_director
 
+permissions:
+  contents: read
+
 on:
   schedule:
   # Once a day at midnight.
@@ -7,16 +10,13 @@ on:
   # Allows manual triggering in the UI. Makes it easier to test.
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-github.workflow
   cancel-in-progress: true
 
 jobs:
   cc_test:
-    if: |
+    if: >-
       ${{
           github.repository == 'envoyproxy/envoy'
           && (github.event.schedule
@@ -24,6 +24,7 @@ jobs:
       }}
     name: cc_test
     permissions:
+      contents: read
       packages: read
     runs-on: ubuntu-20.04
     timeout-minutes: 120
@@ -40,7 +41,6 @@ jobs:
       run: |
         cd mobile
         ./bazelw run \
-            --config=remote-ci-linux \
+            --config=mobile-remote-ci \
             --config=ci \
-            --test_output=all \
             //test/non_hermetic:gcp_traffic_director_integration_test

--- a/.github/workflows/mobile-tsan.yml
+++ b/.github/workflows/mobile-tsan.yml
@@ -1,5 +1,8 @@
 name: mobile_tsan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,11 +17,16 @@ jobs:
   env:
     if: ${{ github.repository == 'envoyproxy/envoy' }}
     uses: ./.github/workflows/_env.yml
-    secrets: inherit
+    permissions:
+      contents: read
+      statuses: write
 
   tsan:
     if: ${{ needs.env.outputs.mobile_tsan == 'true' }}
     needs: env
+    permissions:
+      contents: read
+      packages: read
     name: tsan
     runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 90
@@ -35,8 +43,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd mobile && ./bazelw test \
-            --test_output=all \
+        cd mobile
+        ./bazelw test \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-tsan") \
+            --config=mobile-remote-ci-linux-tsan \
             //test/common/...

--- a/.github/workflows/pr_notifier.yml
+++ b/.github/workflows/pr_notifier.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: read  # for pr_notifier.py
     name: PR Notifier
     runs-on: ubuntu-22.04
-    if: |
+    if: >-
       ${{
           github.repository == 'envoyproxy/envoy'
           && (github.event.schedule

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,8 @@
+name: Prune stale
+
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:
@@ -5,17 +10,17 @@ on:
 
 jobs:
   prune_stale:
-    permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
-    name: Prune Stale
-    runs-on: ubuntu-22.04
-    if: |
+    if: >-
       ${{
           github.repository == 'envoyproxy/envoy'
           && (github.event.schedule
               || !contains(github.actor, '[bot]'))
       }}
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    name: Prune stale
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Prune Stale

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -134,7 +134,6 @@ BAZEL_BUILD_OPTIONS=(
   "${BAZEL_GLOBAL_OPTIONS[@]}"
   "--verbose_failures"
   "--experimental_generate_json_trace_profile"
-  "--test_output=errors"
   "--action_env=CLANG_FORMAT"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -326,25 +326,7 @@ case $CI_TARGET in
         ;;
 
     compile_time_options)
-        # Right now, none of the available compile-time options conflict with each other. If this
-        # changes, this build type may need to be broken up.
-        COMPILE_TIME_OPTIONS=(
-            "--define" "admin_html=disabled"
-            "--define" "signal_trace=disabled"
-            "--define" "hot_restart=disabled"
-            "--define" "google_grpc=disabled"
-            "--define" "boringssl=fips"
-            "--define" "log_debug_assert_in_release=enabled"
-            "--define" "path_normalization_by_default=true"
-            "--define" "deprecated_features=disabled"
-            "--define" "tcmalloc=gperftools"
-            "--define" "zlib=ng"
-            "--define" "uhv=enabled"
-            "--@envoy//bazel:http3=False"
-            "--@envoy//source/extensions/filters/http/kill_request:enabled"
-            "--test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true"
-            "--remote_download_minimal"
-            "--config=libc++20")
+        # See `compile-time-options` in `.bazelrc`
         setup_clang_toolchain
         # This doesn't go into CI but is available for developer convenience.
         echo "bazel with different compiletime options build with tests..."
@@ -354,8 +336,8 @@ case $CI_TARGET in
         echo "Building and testing with wasm=wamr: ${TEST_TARGETS[*]}"
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
+            --config=compile-time-options \
             --define wasm=wamr \
-            "${COMPILE_TIME_OPTIONS[@]}" \
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
             --test_tag_filters=-nofips \
@@ -363,10 +345,9 @@ case $CI_TARGET in
         echo "Building and testing with wasm=wasmtime: and admin_functionality and admin_html disabled ${TEST_TARGETS[*]}"
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
+            --config=compile-time-options \
             --define wasm=wasmtime \
-            --define admin_html=disabled \
             --define admin_functionality=disabled \
-            "${COMPILE_TIME_OPTIONS[@]}" \
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
             --test_tag_filters=-nofips \
@@ -374,8 +355,8 @@ case $CI_TARGET in
         echo "Building and testing with wasm=wavm: ${TEST_TARGETS[*]}"
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
+            --config=compile-time-options \
             --define wasm=wavm \
-            "${COMPILE_TIME_OPTIONS[@]}" \
             -c fastbuild \
             "${TEST_TARGETS[@]}" \
             --test_tag_filters=-nofips \
@@ -384,28 +365,28 @@ case $CI_TARGET in
         # these tests under "-c opt" to save time in CI.
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
+            --config=compile-time-options \
             --define wasm=wavm \
-            "${COMPILE_TIME_OPTIONS[@]}" \
             -c opt \
             @envoy//test/common/common:assert_test \
             @envoy//test/server:server_test
         # "--define log_fast_debug_assert_in_release=enabled" must be tested with a release build, so run only these tests under "-c opt" to save time in CI. This option will test only ASSERT()s without SLOW_ASSERT()s, so additionally disable "--define log_debug_assert_in_release" which compiles in both.
         bazel_with_collection \
             test "${BAZEL_BUILD_OPTIONS[@]}" \
+            --config=compile-time-options \
             --define wasm=wavm \
-            "${COMPILE_TIME_OPTIONS[@]}" \
             -c opt \
             @envoy//test/common/common:assert_test \
             --define log_fast_debug_assert_in_release=enabled \
             --define log_debug_assert_in_release=disabled
         echo "Building binary with wasm=wavm... and logging disabled"
         bazel build "${BAZEL_BUILD_OPTIONS[@]}" \
-              --define wasm=wavm \
-              --define enable_logging=disabled \
-              "${COMPILE_TIME_OPTIONS[@]}" \
-              -c fastbuild \
-              @envoy//source/exe:envoy-static \
-              --build_tag_filters=-nofips
+            --config=compile-time-options \
+            --define wasm=wavm \
+            --define enable_logging=disabled \
+            -c fastbuild \
+            @envoy//source/exe:envoy-static \
+            --build_tag_filters=-nofips
         collect_build_profile build
         ;;
 
@@ -560,6 +541,7 @@ case $CI_TARGET in
     dockerhub-readme)
         setup_clang_toolchain
         bazel build "${BAZEL_BUILD_OPTIONS[@]}" \
+              --remote_download_toplevel \
               //distribution/dockerhub:readme
         cat bazel-bin/distribution/dockerhub/readme.md
         ;;
@@ -662,7 +644,9 @@ case $CI_TARGET in
             "${BAZEL_RELEASE_OPTIONS[@]}" \
             "${TEST_TARGETS[@]}"
         # Build release binaries
-        bazel build "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_RELEASE_OPTIONS[@]}" \
+        bazel build "${BAZEL_BUILD_OPTIONS[@]}" \
+              "${BAZEL_RELEASE_OPTIONS[@]}" \
+              --remote_download_outputs=toplevel \
               //distribution/binary:release
         # Copy release binaries to binary export directory
         cp -a \

--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -16,10 +16,10 @@ ENVOY_FILTER_EXAMPLE_TESTS=(
 
 if [[ ! -d "${ENVOY_FILTER_EXAMPLE_SRCDIR}/.git" ]]; then
   rm -rf "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
-  git clone https://github.com/envoyproxy/envoy-filter-example.git "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
+  git clone -q https://github.com/envoyproxy/envoy-filter-example.git "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
 fi
 
-(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch origin && git checkout -f "${ENVOY_FILTER_EXAMPLE_GITSHA}")
+(cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}" && git fetch -q origin && git checkout -q -f "${ENVOY_FILTER_EXAMPLE_GITSHA}")
 sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter.example > "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/WORKSPACE
 
 mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -1,3 +1,6 @@
+## Any new configs - ie that are not defined in Envoy's bazelrc ...
+#    **should be prefixed with mobile-**
+
 # Envoy Mobile Bazel build/test options.
 try-import ../.bazelrc
 
@@ -46,9 +49,9 @@ build:rules_xcodeproj --features=-swift.use_global_index_store
 # Override PGV validation with NOP functions
 build --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=nop
 
-build:dbg-common --compilation_mode=dbg
+build:mobile-dbg-common --compilation_mode=dbg
 # Enable source map for debugging in IDEs
-build:dbg-common --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
+build:mobile-dbg-common --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 
 # Default flags for builds targeting iOS
 # Manual stamping is necessary in order to get versioning information in the iOS
@@ -62,12 +65,12 @@ build:ios --test_timeout=390,750,1500,5700
 build:android --define=logger=android
 
 # Default flags for Android debug builds
-build:dbg-android --config=dbg-common
-build:dbg-android --config=android
+build:mobile-dbg-android --config=mobile-dbg-common
+build:mobile-dbg-android --config=android
 
 # Default flags for iOS debug builds
-build:dbg-ios --config=dbg-common
-build:dbg-ios --config=ios
+build:mobile-dbg-ios --config=mobile-dbg-common
+build:mobile-dbg-ios --config=ios
 
 # Default flags for Android tests
 # TODO(jpsim): Explicitly register test extensions for Android tests
@@ -77,193 +80,165 @@ build:test-android --define=static_extension_registration=enabled
 # Locally-runnable ASAN config for MacOS & Linux with standard dev environment
 # See also:
 # https://github.com/bazelbuild/bazel/issues/6932
-build:asan-dev --strip=never
-build:asan-dev --copt -Wno-macro-redefined # ASAN sets _FORTIFY_SOURCE=0
-build:asan-dev --copt -DADDRESS_SANITIZER
-build:asan-dev --copt -D_LIBCPP_HAS_NO_ASAN
-build:asan-dev --copt -g
-build:asan-dev --copt -fno-omit-frame-pointer
-build:asan-dev --copt -fno-optimize-sibling-calls
-build:asan-dev --copt -fsanitize=address
-build:asan-dev --linkopt -fsanitize=address
-build:asan-dev --platform_suffix=-asan
+build:mobile-asan-dev --strip=never
+build:mobile-asan-dev --copt -Wno-macro-redefined # ASAN sets _FORTIFY_SOURCE=0
+build:mobile-asan-dev --copt -DADDRESS_SANITIZER
+build:mobile-asan-dev --copt -D_LIBCPP_HAS_NO_ASAN
+build:mobile-asan-dev --copt -g
+build:mobile-asan-dev --copt -fno-omit-frame-pointer
+build:mobile-asan-dev --copt -fno-optimize-sibling-calls
+build:mobile-asan-dev --copt -fsanitize=address
+build:mobile-asan-dev --linkopt -fsanitize=address
+build:mobile-asan-dev --platform_suffix=-asan
 
 build:clang-asan --linkopt --rtlib=compiler-rt
 build:clang-asan --linkopt --unwindlib=libgcc
 
 # Locally-runnable TSAN config
-build:tsan-dev --features=tsan
-build:tsan-dev --copt -fsanitize=thread
-build:tsan-dev --linkopt -fsanitize=thread
-build:tsan-dev --test_env=ENVOY_IP_TEST_VERSIONS=v4only
-build:tsan-dev --platform_suffix=-tsan
+build:mobile-tsan-dev --features=tsan
+build:mobile-tsan-dev --copt -fsanitize=thread
+build:mobile-tsan-dev --linkopt -fsanitize=thread
+build:mobile-tsan-dev --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+build:mobile-tsan-dev --platform_suffix=-tsan
 # Needed due to https://github.com/libevent/libevent/issues/777
-build:tsan-dev --copt -DEVENT__DISABLE_DEBUG_MODE
+build:mobile-tsan-dev --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/abseil/abseil-cpp/issues/760
 # https://github.com/google/sanitizers/issues/953
-build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
+build:mobile-tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 
 # Exclude debug info from the release binary since it makes it too large to fit
 # into a zip file. This shouldn't affect crash reports.
-build:release-common --define=no_debug_info=1
+build:mobile-release-common --define=no_debug_info=1
+
+# order matters here to ensure downloads
+build:mobile-remote-release-clang --config=mobile-remote-ci-linux-clang
+build:mobile-remote-release-clang --config=mobile-release-common
+build:mobile-remote-release-clang --remote_download_toplevel
+build:mobile-remote-release-clang --config=ci
+build:mobile-remote-release-clang --config=remote
 
 # Compile releases optimizing for size (eg -Os, etc).
-build:release-common --config=sizeopt
+build:mobile-release-common --config=sizeopt
 
 # Set default symbols visibility to hidden to reduce .dynstr and the symbol table size
-build:release-common --copt=-fvisibility=hidden
+build:mobile-release-common --copt=-fvisibility=hidden
 
 # Disable google_grpc in production by default
-build:release-common --define=google_grpc=disabled
+build:mobile-release-common --define=google_grpc=disabled
 
 # Enable automatic extension factory registration for release builds
-build:release-common --define=static_extension_registration=enabled
+build:mobile-release-common --define=static_extension_registration=enabled
 
 # Flags for release builds targeting iOS
-build:release-ios --config=ios
-build:release-ios --config=release-common
-build:release-ios --compilation_mode=opt
+build:mobile-release-ios --config=ios
+build:mobile-release-ios --config=mobile-release-common
+build:mobile-release-ios --compilation_mode=opt
 
 # Flags for release builds targeting Android or the JVM
 # Release does not use the option --define=logger=android
-build:release-android --config=release-common
-build:release-android --compilation_mode=opt
+build:mobile-release-android --config=mobile-release-common
+build:mobile-release-android --compilation_mode=opt
 
 # Instrument Envoy Mobile's C++ code for coverage
-build:coverage --instrumentation_filter="//library/common[/:]"
+coverage --instrumentation_filter="//library/common[/:]"
 
 #############################################################################
 # Experimental EngFlow Remote Execution Configs
 #############################################################################
-# remote-ci-common: These options are valid for any platform, use the configs below
+# mobile-remote-ci-common: These options are valid for any platform, use the configs below
 # to add platform-specific options. Avoid using this config directly and
 # instead use a platform-specific config
 #############################################################################
-build:remote-ci-common --config=ci
-build:remote-ci-common --config=remote
-build:remote-ci-common --google_default_credentials=false
-build:remote-ci-common --remote_cache=grpcs://envoy.cluster.engflow.com
-build:remote-ci-common --remote_executor=grpcs://envoy.cluster.engflow.com
-build:remote-ci-common --bes_backend=grpcs://envoy.cluster.engflow.com/
-build:remote-ci-common --bes_results_url=https://envoy.cluster.engflow.com/invocation/
-build:remote-ci-common --experimental_credential_helper=%workspace%/bazel/engflow-bazel-credential-helper.sh
-build:remote-ci-common --jobs=40
-build:remote-ci-common --verbose_failures
-build:remote-ci-common --spawn_strategy=remote,sandboxed,local
-build:remote-ci-common --grpc_keepalive_time=30s
-build:remote-ci-common --remote_timeout=3600s
-build:remote-ci-common --bes_timeout=3600s
-build:remote-ci-common --bes_upload_mode=fully_async
+build:mobile-remote-ci-common --config=rbe-engflow
+build:mobile-remote-ci-common --experimental_credential_helper=%workspace%/bazel/engflow-bazel-credential-helper.sh
+build:mobile-remote-ci-common --jobs=40
+build:mobile-remote-ci-common --verbose_failures
+build:mobile-remote-ci-common --spawn_strategy=remote,sandboxed,local
+
 #############################################################################
-# remote-ci-linux: These options are linux-only using GCC by default
+# mobile-remote-ci-linux: These options are linux-only using GCC by default
 #############################################################################
 # Common Engflow flags
-build:remote-ci-linux --define=EXECUTOR=remote
-build:remote-ci-linux --disk_cache=
-build:remote-ci-linux --incompatible_strict_action_env=true
+build:mobile-remote-ci-linux --define=EXECUTOR=remote
+build:mobile-remote-ci-linux --disk_cache=
+build:mobile-remote-ci-linux --incompatible_strict_action_env=true
 # GCC toolchain options
-build:remote-ci-linux --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:remote-ci-linux --crosstool_top=//third_party/rbe_configs/cc:toolchain
-build:remote-ci-linux --extra_execution_platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain
-build:remote-ci-linux --host_platform=//third_party/rbe_configs/config:platform
-build:remote-ci-linux --platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux --config=remote-ci-common
+build:mobile-remote-ci-linux --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:mobile-remote-ci-linux --crosstool_top=//third_party/rbe_configs/cc:toolchain
+build:mobile-remote-ci-linux --extra_execution_platforms=//third_party/rbe_configs/config:platform
+build:mobile-remote-ci-linux --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain
+build:mobile-remote-ci-linux --host_platform=//third_party/rbe_configs/config:platform
+build:mobile-remote-ci-linux --platforms=//third_party/rbe_configs/config:platform
+build:mobile-remote-ci-linux --config=mobile-remote-ci-common
+
 #############################################################################
-# remote-ci-linux-clang: These options are linux-only using Clang by default
+# mobile-remote-ci-linux-clang: These options are linux-only using Clang by default
 #############################################################################
-build:remote-ci-linux-clang --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:remote-ci-linux-clang --action_env=CC=/opt/llvm/bin/clang
-build:remote-ci-linux-clang --action_env=CXX=/opt/llvm/bin/clang++
-build:remote-ci-linux-clang --crosstool_top=//third_party/rbe_configs/cc:toolchain
-build:remote-ci-linux-clang --extra_execution_platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-clang --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain
-build:remote-ci-linux-clang --host_platform=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-clang --platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-clang --config=remote-ci-common
+build:mobile-remote-ci-linux-clang --action_env=CC=/opt/llvm/bin/clang
+build:mobile-remote-ci-linux-clang --action_env=CXX=/opt/llvm/bin/clang++
+build:mobile-remote-ci-linux-clang --config=mobile-remote-ci-linux
+
 #############################################################################
-# remote-ci-linux-asan: These options are Linux-only using Clang and AddressSanitizer
+# mobile-remote-ci-linux-asan: These options are Linux-only using Clang and AddressSanitizer
 #############################################################################
-build:remote-ci-linux-asan --config=clang-asan
-build:remote-ci-linux-asan --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:remote-ci-linux-asan --action_env=CC=/opt/llvm/bin/clang
-build:remote-ci-linux-asan --action_env=CXX=/opt/llvm/bin/clang++
-build:remote-ci-linux-asan --crosstool_top=//third_party/rbe_configs/cc:toolchain
-build:remote-ci-linux-asan --extra_execution_platforms=//third_party/rbe_configs/config:platform-asan
-build:remote-ci-linux-asan --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain
-build:remote-ci-linux-asan --host_platform=//third_party/rbe_configs/config:platform-asan
-build:remote-ci-linux-asan --platforms=//third_party/rbe_configs/config:platform-asan
-build:remote-ci-linux-asan --config=remote-ci-common
+build:mobile-remote-ci-linux-asan --config=clang-asan
+build:mobile-remote-ci-linux-asan --config=mobile-remote-ci-linux-clang
+build:mobile-remote-ci-linux-asan --config=remote-ci
+
 #############################################################################
-# remote-ci-linux-tsan: These options are Linux-only using Clang and ThreadSanitizer
+# mobile-remote-ci-linux-tsan: These options are Linux-only using Clang and ThreadSanitizer
 #############################################################################
-build:remote-ci-linux-tsan --config=clang-tsan
-build:remote-ci-linux-tsan --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:remote-ci-linux-tsan --action_env=CC=/opt/llvm/bin/clang
-build:remote-ci-linux-tsan --action_env=CXX=/opt/llvm/bin/clang++
-build:remote-ci-linux-tsan --crosstool_top=//third_party/rbe_configs/cc:toolchain
-build:remote-ci-linux-tsan --extra_execution_platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-tsan --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain
-build:remote-ci-linux-tsan --host_platform=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-tsan --platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-tsan --config=remote-ci-common
+build:mobile-remote-ci-linux-tsan --config=clang-tsan
+build:mobile-remote-ci-linux-tsan --config=mobile-remote-ci-linux-clang
+build:mobile-remote-ci-linux-tsan --config=remote-ci
+
 #############################################################################
-# remote-ci-linux-coverage: These options are Linux-only using Clang and LLVM coverage
+# ci-linux-coverage: These options are Linux-only using Clang and LLVM coverage
 #############################################################################
 # Clang environment variables (keep in sync with //third_party/rbe_configs)
-build:remote-ci-linux-coverage --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:remote-ci-linux-coverage --action_env=CC=/opt/llvm/bin/clang
-build:remote-ci-linux-coverage --test_env=CC=/opt/llvm/bin/clang
-build:remote-ci-linux-coverage --action_env=CXX=/opt/llvm/bin/clang++
-build:remote-ci-linux-coverage --test_env=CXX=/opt/llvm/bin/clang++
 # Coverage environment variables (keep in sync with //third_party/rbe_configs)
-build:remote-ci-linux-coverage --action_env=GCOV=/opt/llvm/bin/llvm-profdata
-build:remote-ci-linux-coverage --test_env=GCOV=/opt/llvm/bin/llvm-profdata
-build:remote-ci-linux-coverage --action_env=BAZEL_LLVM_COV=/opt/llvm/bin/llvm-cov
-build:remote-ci-linux-coverage --test_env=BAZEL_LLVM_COV=/opt/llvm/bin/llvm-cov
-build:remote-ci-linux-coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
-build:remote-ci-linux-coverage --test_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
-# Toolchain flags (Java is required for C++ coverage due to Bazel's LCOV merger)
-build:remote-ci-linux-coverage --crosstool_top=//third_party/rbe_configs/cc:toolchain
-build:remote-ci-linux-coverage --extra_execution_platforms=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-coverage --extra_toolchains=//third_party/rbe_configs/config:cc-toolchain
-build:remote-ci-linux-coverage --host_platform=//third_party/rbe_configs/config:platform
-build:remote-ci-linux-coverage --platforms=//third_party/rbe_configs/config:platform
+build:mobile-ci-linux-coverage --action_env=GCOV=/opt/llvm/bin/llvm-profdata
+build:mobile-ci-linux-coverage --test_env=GCOV=/opt/llvm/bin/llvm-profdata
+build:mobile-ci-linux-coverage --action_env=BAZEL_LLVM_COV=/opt/llvm/bin/llvm-cov
+build:mobile-ci-linux-coverage --test_env=BAZEL_LLVM_COV=/opt/llm/bin/llvm-cov
+build:mobile-ci-linux-coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
+build:mobile-ci-linux-coverage --test_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
+
+#############################################################################
+# mobile-remote-ci-linux-coverage: These options are Linux-only using Clang and LLVM coverage
+#############################################################################
+# Clang environment variables (keep in sync with //third_party/rbe_configs)
+# Coverage environment variables (keep in sync with //third_party/rbe_configs)
 # Flags to run tests locally which are necessary since Bazel C++ LLVM coverage isn't fully supported for remote builds
 # TODO(lfpino): Reference upstream Bazel issue here on the incompatibility of remote test execution and LLVM coverage.
-build:remote-ci-linux-coverage --remote_download_outputs=all
-build:remote-ci-linux-coverage --strategy=TestRunner=local,remote
-build:remote-ci-linux-coverage --strategy=CoverageReport=local,remote
+build:mobile-remote-ci-linux-coverage --config=mobile-ci-linux-coverage
+build:mobile-remote-ci-linux-coverage --config=mobile-remote-ci-linux-clang
+build:mobile-remote-ci-linux-coverage --strategy=TestRunner=local,remote
+build:mobile-remote-ci-linux-coverage --strategy=CoverageReport=local,remote
 # Bazel remote caching is incompatible with C++ LLVM coverage so we need to deactivate it for coverage builds
 # TODO(lfpino): Reference upstream Bazel issue here on the incompatibility of remote caching and LLVM coverage.
-build:remote-ci-linux-coverage --noremote_accept_cached
-build:remote-ci-linux-coverage --config=remote-ci-common
-build:remote-ci-linux-coverage --build_runfile_links
-build:remote-ci-linux-coverage --legacy_important_outputs=false
-build:remote-ci-linux-coverage --test_env=CC_CODE_COVERAGE_SCRIPT=external/envoy/bazel/coverage/collect_cc_coverage.sh
-build:remote-ci-linux-coverage --nocache_test_results
+build:mobile-remote-ci-linux-coverage --noremote_accept_cached
+build:mobile-remote-ci-linux-coverage --remote_download_toplevel
+build:mobile-remote-ci-linux-coverage --build_runfile_links
+build:mobile-remote-ci-linux-coverage --legacy_important_outputs=false
+build:mobile-remote-ci-linux-coverage --test_env=CC_CODE_COVERAGE_SCRIPT=external/envoy/bazel/coverage/collect_cc_coverage.sh
+build:mobile-remote-ci-linux-coverage --nocache_test_results
+build:mobile-remote-ci-linux-coverage --config=ci
+build:mobile-remote-ci-linux-coverage --config=remote
 
 # IPv6 tests fail on CI
-build:remote-ci-linux-coverage --test_env=ENVOY_IP_TEST_VERSIONS=v4only
+build:mobile-remote-ci-linux-coverage --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 #############################################################################
-# remote-ci-macos: These options are macOS-only
+# mobile-remote-ci-macos: These options are macOS-only
 #############################################################################
-build:remote-ci-macos --config=remote-ci-common
-build:remote-ci-macos --host_platform=//ci/platform:macos
-build:remote-ci-macos --platforms=//ci/platform:macos
-build:remote-ci-macos --extra_execution_platforms=//ci/platform:macos
-build:remote-ci-macos --xcode_version_config=//ci:xcode_config
-#############################################################################
-# remote-ci-debug: Various Bazel debugging flags
-#############################################################################
-common:remote-ci-debug --announce_rc
-common:remote-ci-debug -s
-common:remote-ci-debug -c dbg
-common:remote-ci-debug --verbose_failures
-common:remote-ci-debug --sandbox_debug
-common:remote-ci-debug --action_env=VERBOSE_COVERAGE=true
-common:remote-ci-debug --test_env=VERBOSE_COVERAGE=true
-common:remote-ci-debug --test_env=DISPLAY_LCOV_CMD=true
-#############################################################################
-# Experimental EngFlow Remote Execution Configs.
-#############################################################################
+build:mobile-remote-ci-macos --config=mobile-remote-ci-common
+build:mobile-remote-ci-macos --host_platform=//ci/platform:macos
+build:mobile-remote-ci-macos --platforms=//ci/platform:macos
+build:mobile-remote-ci-macos --extra_execution_platforms=//ci/platform:macos
+build:mobile-remote-ci-macos --xcode_version_config=//ci:xcode_config
+build:mobile-remote-ci-macos --remote_download_toplevel
+build:mobile-remote-ci-macos --config=ci
+build:mobile-remote-ci-macos --config=remote
+
+build:mobile-remote-ci --config=mobile-remote-ci-linux-clang
+build:mobile-remote-ci --config=remote-ci

--- a/mobile/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/mobile/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//examples/java/hello_world:hello_envoy</blaze-target>
         <Profilers>

--- a/mobile/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/mobile/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
         <blaze-target>//examples/java/hello_world:hello_envoy</blaze-target>
         <Profilers>

--- a/mobile/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/mobile/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/mobile/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/mobile/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/mobile/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/mobile/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//test/kotlin/apps/baseline:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/mobile/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/mobile/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
         <blaze-target>//test/kotlin/apps/baseline:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/mobile/test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/mobile/test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//test/kotlin/apps/experimental:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/mobile/test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/mobile/test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
+        <blaze-user-flag>--config=mobile-dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
         <blaze-target>//test/kotlin/apps/experimental:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -59,12 +59,10 @@ if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
     while read -r line; do COVERAGE_TARGETS+=("$line"); done \
         <<< "$_targets"
     BAZEL_COVERAGE_OPTIONS+=(
-        "--config=fuzz-coverage"
-        "--test_tag_filters=-nocoverage")
+        "--config=fuzz-coverage")
 else
     BAZEL_COVERAGE_OPTIONS+=(
-        "--config=test-coverage"
-        "--test_tag_filters=-nocoverage,-fuzz_target")
+        "--config=test-coverage")
 fi
 
 # Output unusually long logs due to trace logging.


### PR DESCRIPTION
Currently our bazel flags are not very well structured

- lots of duplicate flags (-> indeterminate outcomes)
- not well setup for both rbe <> local
- not such good separation of responsibility

the problem is 10x worse in mobile, which also hijacks quite a few flags from envoys config

this rinses out duplicates in the config, separates mobile config to its own ~namespace and gets rid of related warnings

this also quietens mobile CI and standardizes the RBE config which will allow adding more complex setups (#28814 )

also removes github mobile token condition that would never be hit and tightens workflow permissions generally

also separates github workflow diskspace cleanup code to an action

and switches default (mostly) for remote exec to `--remote_download_minimal`, updating any ci that requires more downloads, runfiles, etc

more generally moves/consolidates config to the .bazelrc file to make it easier to manage them

broadly, its some first steps to addressing the issues posted above in terms of separating responsibility

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
