### PR TITLE
Fix checks for absl::optional state

### DIFF
--- a/test/extensions/config_subscription/grpc/grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/grpc_mux_impl_test.cc
@@ -1003,13 +1003,13 @@ TEST_F(GrpcMuxImplTest, BadLocalInfoEmptyNodeName) {
 TEST_F(GrpcMuxImplTest, EdsResourcesCacheForEds) {
   eds_resources_cache_ = new NiceMock<MockEdsResourcesCache>();
   setup();
-  EXPECT_NE({}, grpc_mux_->edsResourcesCache());
+  EXPECT_TRUE(grpc_mux_->edsResourcesCache().has_value());
 }
 
 // Validates that the EDS cache getter returns empty if there is no cache.
 TEST_F(GrpcMuxImplTest, EdsResourcesCacheForEdsNoCache) {
   setup();
-  EXPECT_EQ({}, grpc_mux_->edsResourcesCache());
+  EXPECT_FALSE(grpc_mux_->edsResourcesCache().has_value());
 }
 
 // Validate that an EDS resource is cached if there's a cache.

--- a/test/extensions/config_subscription/grpc/new_grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/new_grpc_mux_impl_test.cc
@@ -569,13 +569,13 @@ TEST_P(NewGrpcMuxImplTest, Shutdown) {
 TEST_P(NewGrpcMuxImplTest, EdsResourcesCacheForEds) {
   eds_resources_cache_ = new NiceMock<MockEdsResourcesCache>();
   setup();
-  EXPECT_NE({}, grpc_mux_->edsResourcesCache());
+  EXPECT_TRUE(grpc_mux_->edsResourcesCache().has_value());
 }
 
 // Validates that the EDS cache getter returns empty if there is no cache.
 TEST_P(NewGrpcMuxImplTest, EdsResourcesCacheForEdsNoCache) {
   setup();
-  EXPECT_EQ({}, grpc_mux_->edsResourcesCache());
+  EXPECT_FALSE(grpc_mux_->edsResourcesCache().has_value());
 }
 
 // Validate that an EDS resource is cached if there's a cache.

--- a/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
@@ -1075,13 +1075,13 @@ TEST_F(GrpcMuxImplTest, AllMuxesStateTest) {
 TEST_F(GrpcMuxImplTest, EdsResourcesCacheForEds) {
   eds_resources_cache_ = new NiceMock<MockEdsResourcesCache>();
   setup();
-  EXPECT_NE({}, grpc_mux_->edsResourcesCache());
+  EXPECT_TRUE(grpc_mux_->edsResourcesCache().has_value());
 }
 
 // Validates that the EDS cache getter returns empty if there is no cache.
 TEST_F(GrpcMuxImplTest, EdsResourcesCacheForEdsNoCache) {
   setup();
-  EXPECT_EQ({}, grpc_mux_->edsResourcesCache());
+  EXPECT_FALSE(grpc_mux_->edsResourcesCache().has_value());
 }
 
 // Validate that an EDS resource is cached if there's a cache.


### PR DESCRIPTION
Additional Description:
Otherwise this code fails with newer gtest

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
