### PR TITLE
[QUIC]update comments on QUIC connection options protos

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -96,11 +96,11 @@ message QuicProtocolOptions {
   QuicKeepAliveSettings connection_keepalive = 5;
 
   // A comma-separated list of strings representing QUIC connection options defined in
-  // QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h> and to be sent by upstream connections.
+  // `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>` and to be sent by upstream connections.
   string connection_options = 6;
 
   // A comma-separated list of strings representing QUIC client connection options defined in
-  // QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h> and to be sent by upstream connections.
+  // `QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h>` and to be sent by upstream connections.
   string client_connection_options = 7;
 }
 

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -96,11 +96,11 @@ message QuicProtocolOptions {
   QuicKeepAliveSettings connection_keepalive = 5;
 
   // A comma-separated list of strings representing QUIC connection options defined in
-  // https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h and to be sent by upstream connections.
+  // QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h> and to be sent by upstream connections.
   string connection_options = 6;
 
   // A comma-separated list of strings representing QUIC client connection options defined in
-  // https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h and to be sent by upstream connections.
+  // QUICHE <https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h> and to be sent by upstream connections.
   string client_connection_options = 7;
 }
 

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -95,10 +95,12 @@ message QuicProtocolOptions {
   // If absent, use the default keepalive behavior of which a client connection sends PINGs every 15s, and a server connection doesn't do anything.
   QuicKeepAliveSettings connection_keepalive = 5;
 
-  // An array of QUIC connection options represented in a serialized string, separated by commas.
+  // A comma-separated list of strings representing QUIC connection options defined in
+  // https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h and to be sent by upstream connections.
   string connection_options = 6;
 
-  // An array of QUIC client connection options represented in a serialized string, separated by commas.
+  // A comma-separated list of strings representing QUIC client connection options defined in
+  // https://github.com/google/quiche/blob/main/quiche/quic/core/crypto/crypto_protocol.h and to be sent by upstream connections.
   string client_connection_options = 7;
 }
 


### PR DESCRIPTION
Commit Message:update comments on QUIC connection options protos
Additional Description: The new comments refer to where the connections options are defined.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
