### PR TITLE
json_to_metadata: apply on_missing for all rules for  non-object json payload

### DIFF
--- a/docs/root/configuration/http/http_filters/json_to_metadata_filter.rst
+++ b/docs/root/configuration/http/http_filters/json_to_metadata_filter.rst
@@ -46,7 +46,7 @@ comes from the owning HTTP connection manager.
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  rq_success, Counter, Total requests that succeed to parse the json body
+  rq_success, Counter, Total requests that succeed to parse the json body. Note that a pure string or number body is treated as a successful json body which increases this counter.
   rq_mismatched_content_type, Counter, Total requests that mismatch the content type
   rq_no_body, Counter, Total requests without content body
   rq_invalid_json_body, Counter, Total requests with invalid json body

--- a/source/extensions/filters/http/json_to_metadata/filter.cc
+++ b/source/extensions/filters/http/json_to_metadata/filter.cc
@@ -289,6 +289,15 @@ void Filter::processBody(const Buffer::Instance* body, const Rules& rules,
   }
 
   Json::ObjectSharedPtr body_json = std::move(result.value());
+  // A pure string or number is considered as a valid application/json body, so we should
+  // treat this case as on_missing for all rules but a successful json body.
+  if (!body_json) {
+    ENVOY_LOG(debug, "a valid non-object json body which is error prone");
+    handleAllOnMissing(rules, request_processing_finished_);
+    success.inc();
+    return;
+  }
+
   StructMap struct_map;
   for (const auto& rule : rules) {
     const auto& keys = rule.keys_;

--- a/source/extensions/filters/http/json_to_metadata/filter.cc
+++ b/source/extensions/filters/http/json_to_metadata/filter.cc
@@ -289,11 +289,15 @@ void Filter::processBody(const Buffer::Instance* body, const Rules& rules,
   }
 
   Json::ObjectSharedPtr body_json = std::move(result.value());
-  // A pure string or number is considered as a valid application/json body, so we should
-  // treat this case as on_missing for all rules but a successful json body.
+  // A pure string or number is considered a valid application/json body, but it is not a JSON
+  // object. Therefore, we treat this case as 'on_missing' for all rules in the absence of any
+  // key-value pairs to match.
   if (!body_json) {
-    ENVOY_LOG(debug, "a valid non-object json body which is error prone");
+    ENVOY_LOG(
+        debug,
+        "Apply on_missing for all rules on a valid application/json body but not a json object.");
     handleAllOnMissing(rules, request_processing_finished_);
+    // This JSON body is valid and successfully parsed.
     success.inc();
     return;
   }


### PR DESCRIPTION
Commit Message:
Pure number or string is considered as a valid json body.
It that case, we should apply on_missing for all rules for  non-object json payload.

Risk Level: low
Testing: unit