### PR TITLE
tests: Declare the [quic_]protocol_integration_test `enormous` in Bazel

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -768,7 +768,7 @@ envoy_cc_test_library(
 
 envoy_cc_test(
     name = "protocol_integration_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "instantiate_protocol_integration_test.cc",
     ],
@@ -2246,7 +2246,7 @@ envoy_cc_test(
 # selects.
 envoy_cc_test(
     name = "quic_protocol_integration_test",
-    size = "large",
+    size = "enormous",
     srcs = select({
         "//bazel:disable_http3": [],
         "//bazel:disable_admin_functionality": [],


### PR DESCRIPTION
The tests sometimes time out on CI, for example:
https://dev.azure.com/cncf/envoy/_build/results?buildId=145636&view=logs&j=d1f76054-8f79-554b-6f4a-11d6a63b8e00&t=a193292f-96b1-53c3-0505-a923ddcc3f84&l=4868.

Running `bazel test //test/integration:protocol_integration_test` also times out when I run it locally on my workstation.

Changing the test size from `large` to `enormous` results in the tests no longer timing out for me locally.  Hopefully the same will hold on CI.