### PR TITLE
match_delegate: Add runtime control

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -53,5 +53,10 @@ new_features:
 - area: redis
   change: |
     added support for lmove command.
+- area: match_delegate
+  change: |
+    added runtime guard ``envoy_reloadable_features_enable_extension_with_matcher``.
+    :ref:`ExtensionWithMatcher <envoy_v3_api_msg_extensions.common.matching.v3.ExtensionWithMatcher>` can be disabled by
+    setting this flag to false. The match_delegate filter then will become a passthrough filter.
 
 deprecated:

--- a/source/common/http/match_delegate/config.cc
+++ b/source/common/http/match_delegate/config.cc
@@ -105,8 +105,9 @@ void DelegatingStreamFilter::FilterMatchState::evaluateMatchTree(
     return;
   }
 
-  // If no match tree is set, interpret as a skip.
-  if (!has_match_tree_) {
+  // If no match tree is set or it is disabled by runtime guard, interpret as a skip.
+  if (!has_match_tree_ ||
+      !Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_extension_with_matcher")) {
     skip_filter_ = true;
     match_tree_evaluated_ = true;
     return;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -29,6 +29,7 @@
 // If issues are found that require a runtime feature to be disabled, it should be reported
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
+RUNTIME_GUARD(envoy_reloadable_features_enable_extension_with_matcher);
 RUNTIME_GUARD(envoy_reloadable_features_allow_absolute_url_with_mixed_scheme);
 RUNTIME_GUARD(envoy_reloadable_features_allow_compact_maglev);
 RUNTIME_GUARD(envoy_reloadable_features_append_query_parameters_path_rewriter);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -29,7 +29,6 @@
 // If issues are found that require a runtime feature to be disabled, it should be reported
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
-RUNTIME_GUARD(envoy_reloadable_features_enable_extension_with_matcher);
 RUNTIME_GUARD(envoy_reloadable_features_allow_absolute_url_with_mixed_scheme);
 RUNTIME_GUARD(envoy_reloadable_features_allow_compact_maglev);
 RUNTIME_GUARD(envoy_reloadable_features_append_query_parameters_path_rewriter);
@@ -40,6 +39,7 @@ RUNTIME_GUARD(envoy_reloadable_features_dfp_mixed_scheme);
 RUNTIME_GUARD(envoy_reloadable_features_enable_aws_credentials_file);
 RUNTIME_GUARD(envoy_reloadable_features_enable_compression_bomb_protection);
 RUNTIME_GUARD(envoy_reloadable_features_enable_connect_udp_support);
+RUNTIME_GUARD(envoy_reloadable_features_enable_extension_with_matcher);
 RUNTIME_GUARD(envoy_reloadable_features_enable_intermediate_ca);
 RUNTIME_GUARD(envoy_reloadable_features_enable_update_listener_socket_options);
 RUNTIME_GUARD(envoy_reloadable_features_expand_agnostic_stream_lifetime);

--- a/test/common/http/match_delegate/BUILD
+++ b/test/common/http/match_delegate/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
         "//source/common/http/match_delegate:config",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/http/match_delegate/config_test.cc
+++ b/test/common/http/match_delegate/config_test.cc
@@ -411,12 +411,12 @@ TEST(DelegatingFilterTest, MatchTreeOnNoMatchSkipActionDecodingHeaders) {
   delegating_filter->decodeComplete();
 }
 
-// Test that the DelegatingStreamFilter is skipped when runtime flag is disabled.
+// Test that the DelegatingStreamFilter is skipped when runtime flag is set to false.
 TEST(DelegatingFilterTest, MatchTreeDecodingHeadersSkippedWithRuntimeFlag) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.enable_extension_with_matcher", "false"}});
-  // The filter is added, but will be skipped since the runtime flag above is disabled.
+  // The filter is added, but will be skipped since the runtime flag above is false.
   std::shared_ptr<Envoy::Http::MockStreamDecoderFilter> decoder_filter(
       new Envoy::Http::MockStreamDecoderFilter());
   NiceMock<Envoy::Http::MockStreamDecoderFilterCallbacks> callbacks;

--- a/test/common/http/match_delegate/config_test.cc
+++ b/test/common/http/match_delegate/config_test.cc
@@ -421,6 +421,7 @@ TEST(DelegatingFilterTest, MatchTreeDecodingHeadersSkippedWithRuntimeFlag) {
       new Envoy::Http::MockStreamDecoderFilter());
   NiceMock<Envoy::Http::MockStreamDecoderFilterCallbacks> callbacks;
 
+  // No callback is invoked.
   EXPECT_CALL(*decoder_filter, setDecoderFilterCallbacks(_));
   EXPECT_CALL(*decoder_filter, decodeHeaders(_, _)).Times(0);
   EXPECT_CALL(*decoder_filter, decodeData(_, _)).Times(0);
@@ -442,6 +443,7 @@ TEST(DelegatingFilterTest, MatchTreeDecodingHeadersSkippedWithRuntimeFlag) {
   Buffer::OwnedImpl buffer;
 
   delegating_filter->setDecoderFilterCallbacks(callbacks);
+  // Filter chain iteration has been continued.
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
             delegating_filter->decodeHeaders(*request_headers, false));
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, delegating_filter->decodeData(buffer, false));


### PR DESCRIPTION
Add runtime flag for match_delegate. When flag is set to false, this filter becomes a passthrough filter, the things wrapped under it(i.e. delegate filter) will be skipped as well