### PR TITLE
cert_validator: Pass the callback through extra validation context 

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -47,7 +47,7 @@ class CertValidator {
 public:
   // Wraps cert validation parameters added from time to time.
   struct ExtraValidationContext {
-    // Transport socket callbacks.
+    // The pointer to transport socket callbacks.
     Network::TransportSocketCallbacks* callbacks;
   };
 

--- a/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/cert_validator.h
@@ -47,8 +47,8 @@ class CertValidator {
 public:
   // Wraps cert validation parameters added from time to time.
   struct ExtraValidationContext {
-    // Local address of the calling endpoint (optional field).
-    Envoy::Network::Address::InstanceConstSharedPtr local_address;
+    // Transport socket callbacks.
+    Network::TransportSocketCallbacks* callbacks;
   };
 
   virtual ~CertValidator() = default;

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -516,11 +516,8 @@ ValidationResults ContextImpl::customVerifyCertChain(
   const char* host_name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
 
   CertValidator::ExtraValidationContext validation_ctx;
-  auto callbacks =
+  validation_ctx.callbacks =
       static_cast<Network::TransportSocketCallbacks*>(SSL_get_ex_data(ssl, sslSocketIndex()));
-  if (callbacks != nullptr) {
-    validation_ctx.local_address = callbacks->connection().connectionInfoProvider().localAddress();
-  }
 
   ValidationResults result = cert_validator_->doVerifyCertChain(
       *cert_chain, extended_socket_info->createValidateResultCallback(), transport_socket_options,

--- a/test/extensions/transport_sockets/tls/cert_validator/timed_cert_validator.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/timed_cert_validator.cc
@@ -24,8 +24,9 @@ ValidationResults TimedCertValidator::doVerifyCertChain(
   }
   if (expected_local_address_.has_value()) {
     ASSERT_TRUE(validation_ctx.callbacks != nullptr);
-    EXPECT_EQ(expected_local_address_.value(),
-              validation_ctx.callbacks->connection().connectionInfoProvider().localAddress());
+    EXPECT_EQ(
+        expected_local_address_.value(),
+        validation_ctx.callbacks->connection().connectionInfoProvider().localAddress()->asString());
   }
   // Store cert chain for the delayed validation.
   for (size_t i = 0; i < sk_X509_num(&cert_chain); i++) {

--- a/test/extensions/transport_sockets/tls/cert_validator/timed_cert_validator.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/timed_cert_validator.cc
@@ -23,10 +23,11 @@ ValidationResults TimedCertValidator::doVerifyCertChain(
     EXPECT_EQ(expected_host_name_.value(), host_name);
   }
   if (expected_local_address_.has_value()) {
-    ASSERT_TRUE(validation_ctx.callbacks != nullptr);
-    EXPECT_EQ(
-        expected_local_address_.value(),
-        validation_ctx.callbacks->connection().connectionInfoProvider().localAddress()->asString());
+    ASSERT(validation_context.callbacks != nullptr);
+    EXPECT_EQ(expected_local_address_.value(), validation_context.callbacks->connection()
+                                                   .connectionInfoProvider()
+                                                   .localAddress()
+                                                   ->asString());
   }
   // Store cert chain for the delayed validation.
   for (size_t i = 0; i < sk_X509_num(&cert_chain); i++) {

--- a/test/extensions/transport_sockets/tls/cert_validator/timed_cert_validator.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/timed_cert_validator.cc
@@ -23,8 +23,9 @@ ValidationResults TimedCertValidator::doVerifyCertChain(
     EXPECT_EQ(expected_host_name_.value(), host_name);
   }
   if (expected_local_address_.has_value()) {
-    ASSERT(validation_context.local_address != nullptr);
-    EXPECT_EQ(expected_local_address_.value(), validation_context.local_address->asString());
+    ASSERT_TRUE(validation_ctx.callbacks != nullptr);
+    EXPECT_EQ(expected_local_address_.value(),
+              validation_ctx.callbacks->connection().connectionInfoProvider().localAddress());
   }
   // Store cert chain for the delayed validation.
   for (size_t i = 0; i < sk_X509_num(&cert_chain); i++) {


### PR DESCRIPTION
Callback can provide all the needed information besides existing address, such as stream info for logging and communication between extension point.
 
Pass the pointer to long lived object throughout the handshake (e.g., valid in [shutdownSsl](https://github.com/envoyproxy/envoy/blob/5fde158a3ae3d80a51bb826781e777dd781bd63f/source/extensions/transport_sockets/tls/ssl_socket.cc#L321)) .  PS: `ExtraValidationContext` is only a wrapper for passing argument. 
