### PR TITLE
perf: move weighted clusters config instead of copy

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -600,8 +600,9 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
       throw EnvoyException("Sum of weights in the weighted_cluster must be greater than 0.");
     }
 
-    weighted_clusters_config_ = std::make_unique<WeightedClustersConfig>(
-        weighted_clusters, total_weight, route.route().weighted_clusters().header_name());
+    weighted_clusters_config_ =
+        std::make_unique<WeightedClustersConfig>(std::move(weighted_clusters), total_weight,
+                                                 route.route().weighted_clusters().header_name());
 
   } else if (route.route().cluster_specifier_case() ==
              envoy::config::route::v3::RouteAction::ClusterSpecifierCase::

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1052,10 +1052,11 @@ public:
   // We keep them in a separate data structure to avoid memory overhead for the routes that do not
   // use weighted clusters.
   struct WeightedClustersConfig {
-    WeightedClustersConfig(const std::vector<WeightedClusterEntrySharedPtr>& weighted_clusters,
+    WeightedClustersConfig(const std::vector<WeightedClusterEntrySharedPtr>&& weighted_clusters,
                            uint64_t total_cluster_weight,
                            const std::string& random_value_header_name)
-        : weighted_clusters_(weighted_clusters), total_cluster_weight_(total_cluster_weight),
+        : weighted_clusters_(std::move(weighted_clusters)),
+          total_cluster_weight_(total_cluster_weight),
           random_value_header_name_(random_value_header_name) {}
     const std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
     const uint64_t total_cluster_weight_;


### PR DESCRIPTION
Commit Message: perf: move weighted clusters config instead of copy
Additional Description:
Move a data-structure instead of copying it.

Risk Level: low
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
