### PR TITLE
[balsa] Validate trailers even if not enabled.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -145,7 +145,8 @@ bool isHeaderNameValid(absl::string_view name) {
 
 BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t max_header_length,
                          bool enable_trailers, bool allow_custom_methods)
-    : message_type_(type), connection_(connection), allow_custom_methods_(allow_custom_methods) {
+    : message_type_(type), connection_(connection), enable_trailers_(enable_trailers),
+      allow_custom_methods_(allow_custom_methods) {
   ASSERT(connection_ != nullptr);
 
   quiche::HttpValidationPolicy http_validation_policy;
@@ -159,9 +160,7 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   framer_.set_http_validation_policy(http_validation_policy);
 
   framer_.set_balsa_headers(&headers_);
-  if (enable_trailers) {
-    framer_.set_balsa_trailer(&trailers_);
-  }
+  framer_.set_balsa_trailer(&trailers_);
   framer_.set_balsa_visitor(this);
   framer_.set_max_header_length(max_header_length);
   framer_.set_invalid_chars_level(quiche::BalsaFrame::InvalidCharsLevel::kError);
@@ -274,10 +273,10 @@ void BalsaParser::OnTrailerInput(absl::string_view /*input*/) {}
 void BalsaParser::OnHeader(absl::string_view /*key*/, absl::string_view /*value*/) {}
 
 void BalsaParser::ProcessHeaders(const BalsaHeaders& headers) {
-  processHeadersOrTrailersImpl(headers);
+  validateAndProcessHeadersOrTrailersImpl(headers, /* trailers = */ false);
 }
 void BalsaParser::ProcessTrailers(const BalsaHeaders& trailer) {
-  processHeadersOrTrailersImpl(trailer);
+  validateAndProcessHeadersOrTrailersImpl(trailer, /* trailers = */ true);
 }
 
 void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,
@@ -389,7 +388,8 @@ void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode error_code) {
   }
 }
 
-void BalsaParser::processHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers) {
+void BalsaParser::validateAndProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers,
+                                                          bool trailers) {
   for (const std::pair<absl::string_view, absl::string_view>& key_value : headers.lines()) {
     if (status_ == ParserStatus::Error) {
       return;
@@ -400,6 +400,10 @@ void BalsaParser::processHeadersOrTrailersImpl(const quiche::BalsaHeaders& heade
       status_ = ParserStatus::Error;
       error_message_ = "HPE_INVALID_HEADER_TOKEN";
       return;
+    }
+
+    if (trailers && !enable_trailers_) {
+      continue;
     }
 
     status_ = convertResult(connection_->onHeaderField(key.data(), key.length()));

--- a/source/common/http/http1/balsa_parser.h
+++ b/source/common/http/http1/balsa_parser.h
@@ -62,7 +62,7 @@ private:
   void HandleWarning(quiche::BalsaFrameEnums::ErrorCode error_code) override;
 
   // Shared implementation for ProcessHeaders() and ProcessTrailers().
-  void processHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers);
+  void validateAndProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers, bool trailers);
 
   // Return ParserStatus::Error if `result` is CallbackResult::Error.
   // Return current value of `status_` otherwise.
@@ -75,6 +75,7 @@ private:
 
   const MessageType message_type_ = MessageType::Request;
   ParserCallbacks* connection_ = nullptr;
+  const bool enable_trailers_ = false;
   const bool allow_custom_methods_ = false;
   bool first_byte_processed_ = false;
   bool headers_done_ = false;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -188,7 +188,7 @@ public:
   void testRequestHeadersExceedLimit(std::string header_string, std::string error_message,
                                      absl::string_view details);
   void testTrailersExceedLimit(std::string trailer_string, std::string error_message,
-                               bool enable_trailers);
+                               bool enable_trailers, bool expect_error);
   void testRequestHeadersAccepted(std::string header_string);
   // Used to test if trailers are decoded/encoded
   void expectTrailersTest(bool enable_trailers);
@@ -337,7 +337,8 @@ void Http1ServerConnectionImplTest::expectTrailersTest(bool enable_trailers) {
 
 void Http1ServerConnectionImplTest::testTrailersExceedLimit(std::string trailer_string,
                                                             std::string error_message,
-                                                            bool enable_trailers) {
+                                                            bool enable_trailers,
+                                                            bool expect_error) {
   initialize();
   // Make a new 'codec' with the right settings
   codec_settings_.enable_trailers_ = enable_trailers;
@@ -349,7 +350,7 @@ void Http1ServerConnectionImplTest::testTrailersExceedLimit(std::string trailer_
   NiceMock<MockRequestDecoder> decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  if (enable_trailers) {
+  if (expect_error) {
     EXPECT_CALL(decoder, decodeHeaders_(_, false));
     EXPECT_CALL(decoder, decodeData(_, false));
   } else {
@@ -365,7 +366,7 @@ void Http1ServerConnectionImplTest::testTrailersExceedLimit(std::string trailer_
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(status.ok());
   buffer = Buffer::OwnedImpl(trailer_string);
-  if (enable_trailers) {
+  if (expect_error) {
     EXPECT_CALL(decoder, sendLocalReply(Http::Code::RequestHeaderFieldsTooLarge,
                                         "Request Header Fields Too Large", _, _, _));
     status = codec_->dispatch(buffer);
@@ -1171,69 +1172,6 @@ TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_HEADER_TOKEN");
-}
-
-TEST_P(Http1ServerConnectionImplTest, Http11InvalidTrailersIgnored) {
-  if (parser_impl_ == Http1ParserImpl::HttpParser) {
-    // HttpParser signals error even if `enable_trailers_` is false.
-    return;
-  }
-
-  initialize();
-  StrictMock<MockRequestDecoder> decoder;
-
-  // First request contains invalid trailers.
-  // Trailers are ignored by default, therefore processing can continue.
-  {
-    Buffer::OwnedImpl buffer("POST /foobar HTTP/1.1\r\n"
-                             "Host: www.somewhere.com\r\n"
-                             "connection: keep-alive\r\n"
-                             "Transfer-Encoding: chunked\r\n\r\n"
-                             "5\r\ndata1\r\n"
-                             "0\r\n"
-                             "invalid-trailer\r\n\r\n");
-
-    Http::ResponseEncoder* response_encoder = nullptr;
-    EXPECT_CALL(callbacks_, newStream(_, _))
-        .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-          response_encoder = &encoder;
-          return decoder;
-        }));
-
-    EXPECT_CALL(decoder, decodeHeaders_(_, false));
-    EXPECT_CALL(decoder, decodeData(BufferStringEqual("data1"), false));
-    EXPECT_CALL(decoder, decodeData(BufferStringEqual(""), true));
-
-    auto status = codec_->dispatch(buffer);
-    EXPECT_TRUE(status.ok());
-
-    std::string output;
-    ON_CALL(connection_, write(_, _)).WillByDefault(AddBufferToString(&output));
-    TestResponseHeaderMapImpl headers{{":status", "200"}};
-    response_encoder->encodeHeaders(headers, true);
-    EXPECT_EQ("HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n", output);
-  }
-
-  testing::Mock::VerifyAndClearExpectations(&decoder);
-
-  // Second request is successfully parsed.
-  {
-    Buffer::OwnedImpl buffer("POST /foobar HTTP/1.1\r\n"
-                             "Host: www.somewhere.com\r\n"
-                             "connection: keep-alive\r\n"
-                             "Transfer-Encoding: chunked\r\n\r\n"
-                             "5\r\ndata2\r\n"
-                             "0\r\n\r\n");
-
-    EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
-
-    EXPECT_CALL(decoder, decodeHeaders_(_, false));
-    EXPECT_CALL(decoder, decodeData(BufferStringEqual("data2"), false));
-    EXPECT_CALL(decoder, decodeData(BufferStringEqual(""), true));
-
-    auto status = codec_->dispatch(buffer);
-    EXPECT_TRUE(status.ok());
-  }
 }
 
 TEST_P(Http1ServerConnectionImplTest, Http11AbsolutePathNoSlash) {
@@ -3317,14 +3255,14 @@ TEST_P(Http1ClientConnectionImplTest, LowWatermarkDuringClose) {
 TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejected) {
   // Default limit of 60 KiB
   std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
-  testTrailersExceedLimit(long_string, "http/1.1 protocol error: trailers size exceeds limit",
+  testTrailersExceedLimit(long_string, "http/1.1 protocol error: trailers size exceeds limit", true,
                           true);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejected) {
   // Construct partial headers with a long field name that exceeds the default limit of 60KiB.
   std::string long_string = "bigfield" + std::string(60 * 1024, 'q');
-  testTrailersExceedLimit(long_string, "http/1.1 protocol error: trailers size exceeds limit",
+  testTrailersExceedLimit(long_string, "http/1.1 protocol error: trailers size exceeds limit", true,
                           true);
 }
 
@@ -3332,28 +3270,28 @@ TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejected) {
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersRejected) {
   // Send a request with 101 headers.
   testTrailersExceedLimit(createHeaderFragment(101) + "\r\n\r\n",
-                          "http/1.1 protocol error: trailers count exceeds limit", true);
+                          "http/1.1 protocol error: trailers count exceeds limit", true, true);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejectedIgnored) {
   // Default limit of 60 KiB
   std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
   testTrailersExceedLimit(long_string, "http/1.1 protocol error: trailers size exceeds limit",
-                          false);
+                          false, /* expect_error = */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejectedIgnored) {
   // Default limit of 60 KiB
   std::string long_string = "bigfield" + std::string(60 * 1024, 'q') + ": value\r\n\r\n\r\n";
   testTrailersExceedLimit(long_string, "http/1.1 protocol error: trailers size exceeds limit",
-                          false);
+                          false, /* expect_error = */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
 // Tests that the default limit for the number of request headers is 100.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersIgnored) {
   // Send a request with 101 headers.
   testTrailersExceedLimit(createHeaderFragment(101) + "\r\n\r\n",
-                          "http/1.1 protocol error: trailers count exceeds limit", false);
+                          "http/1.1 protocol error: trailers count exceeds limit", false, false);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeRequestUrlRejected) {
@@ -4820,6 +4758,54 @@ TEST_P(Http1ServerConnectionImplTest, Char22InHeaderValue) {
   auto status = codec_->dispatch(buffer);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.message(), "http/1.1 protocol error: header value contains invalid chars");
+}
+
+TEST_P(Http1ClientConnectionImplTest, MalformedTrailerLine) {
+  initialize();
+
+  NiceMock<MockResponseDecoder> response_decoder;
+  Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
+  EXPECT_CALL(response_decoder, decodeData(BufferStringEqual("foo"), false));
+
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\n"
+                             "transfer-encoding: chunked\r\n"
+                             "\r\n"
+                             "3\r\n"
+                             "foo\r\n"
+                             "0\r\n"
+                             "invalid-trailer-line\r\n\r\n");
+
+  auto status = codec_->dispatch(response);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_HEADER_TOKEN");
+}
+
+TEST_P(Http1ClientConnectionImplTest, InvalidCharacterInTrailerName) {
+  initialize();
+
+  NiceMock<MockResponseDecoder> response_decoder;
+  Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
+  EXPECT_CALL(response_decoder, decodeData(BufferStringEqual("foo"), false));
+
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\n"
+                             "transfer-encoding: chunked\r\n"
+                             "\r\n"
+                             "3\r\n"
+                             "foo\r\n"
+                             "0\r\n"
+                             "föö: bar\r\n\r\n");
+
+  auto status = codec_->dispatch(response);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_HEADER_TOKEN");
 }
 
 } // namespace Http


### PR DESCRIPTION
This brings BalsaParser trailer validation (format and characters) in alignment with http-parser behavior. The downside is that this change makes BalsaParser enforce the header size limit (both on individual lines and on total size of trailer block) even when trailers are not enabled, whereas http-parser does not restrict size at all when trailers are not enabled.

Tracking issue: #21245

Signed-off-by: Bence Béky bnc@google.com

Commit Message: [balsa] Validate trailers even if not enabled.
Additional Description:
Risk Level: low, changed code protected by existing default-false runtime flag.
Testing: //test/common/http/http1:codec_impl_test
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser