### PR TITLE
ci/caching: Simplify bazel cache

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -9,9 +9,6 @@ parameters:
   default: ""
 
 # caching
-- name: cacheKeyBazelisk
-  type: string
-  default: .bazelversion
 - name: cacheKeyDocker
   type: string
   default: ".devcontainer/Dockerfile"
@@ -152,7 +149,6 @@ steps:
 - template: cached.yml
   parameters:
     keyBazel: "${{ parameters.cacheKeyBazel }}"
-    keyBazelisk: "${{ parameters.cacheKeyBazelisk }}"
     keyDocker: "${{ parameters.cacheKeyDocker }}"
     pathDockerBind: "${{ parameters.pathDockerBind }}"
     arch: "${{ parameters.artifactSuffix }}"

--- a/.azure-pipelines/cached.yml
+++ b/.azure-pipelines/cached.yml
@@ -16,9 +16,6 @@ parameters:
 - name: keyBazel
   type: string
   default: $(cacheKeyBazel)
-- name: keyBazelisk
-  type: string
-  default: $(cacheKeyBazelisk)
 
 - name: pathTemp
   type: string
@@ -59,15 +56,6 @@ steps:
 - task: Cache@2
   env:
     VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: "${{ parameters.cacheTimeoutWorkaround }}"
-  displayName: "Cache (Bazelisk)"
-  inputs:
-    key: '${{ parameters.name }} | bazelisk | "${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyBazelisk }}'
-    path: "${{ parameters.pathTemp }}/bazelisk"
-    cacheHitVar: BAZELISK_CACHE_RESTORED
-
-- task: Cache@2
-  env:
-    VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: "${{ parameters.cacheTimeoutWorkaround }}"
   displayName: "Cache (Bazel)"
   inputs:
     key: '${{ parameters.name }} | bazel | "${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyBazel }}'
@@ -78,11 +66,10 @@ steps:
 - script: .azure-pipelines/docker/prime_cache.sh "$(Build.StagingDirectory)" "${{ parameters.pathTemp }}" "${{ parameters.arch }}"
   env:
     DOCKER_RESTORED: $(DOCKER_CACHE_RESTORED)
-    BAZELISK_RESTORED: $(BAZELISK_CACHE_RESTORED)
     BAZEL_RESTORED: $(BAZEL_CACHE_RESTORED)
   displayName: "Cache/prime (${{ parameters.name }})"
   # TODO(phlax): figure if there is a way to test cache without downloading it
-  condition: and(not(canceled()), eq(${{ parameters.prime }}, true), or(ne(variables.DOCKER_CACHE_RESTORED, 'true'), ne(variables.BAZELISK_CACHE_RESTORED, 'true'), ne(variables.BAZEL_CACHE_RESTORED, 'true')))
+  condition: and(not(canceled()), eq(${{ parameters.prime }}, true), or(ne(variables.DOCKER_CACHE_RESTORED, 'true'), ne(variables.BAZEL_CACHE_RESTORED, 'true')))
 
 # Load the caches for a job
 - script: sudo .azure-pipelines/docker/load_caches.sh "$(Build.StagingDirectory)" "${{ parameters.pathTemp }}" "${{ parameters.pathDockerBind }}" "${{ parameters.tmpfsDockerDisabled }}"

--- a/.azure-pipelines/docker/load_caches.sh
+++ b/.azure-pipelines/docker/load_caches.sh
@@ -17,9 +17,6 @@ DOCKER_CACHE_TARBALL="${DOCKER_CACHE_PATH}/docker.tar.zst"
 BAZEL_CACHE_PATH="${CACHE_PATH}/bazel"
 BAZEL_CACHE_TARBALL="${BAZEL_CACHE_PATH}/bazel.tar.zst"
 
-BAZELISK_CACHE_PATH="${CACHE_PATH}/bazelisk"
-BAZELISK_CACHE_TARBALL="${BAZELISK_CACHE_PATH}/bazelisk.tar.zst"
-
 echo "Stopping Docker daemon ..."
 systemctl stop docker docker.socket
 
@@ -68,15 +65,6 @@ if [[ -e "${BAZEL_CACHE_TARBALL}" ]]; then
     zstd --stdout -d "$BAZEL_CACHE_TARBALL" | tar --warning=no-timestamp -xf - -C "${ENVOY_DOCKER_BUILD_DIR}"
 else
     echo "No bazel cache to restore, starting bazel with no data"
-fi
-
-mkdir -p "${ENVOY_DOCKER_BUILD_DIR}/.cache/bazelisk"
-
-if [[ -e "${BAZELISK_CACHE_TARBALL}" ]]; then
-    echo "Extracting bazelisk cache ${BAZELISK_CACHE_TARBALL} -> ${ENVOY_DOCKER_BUILD_DIR}/.cache/bazelisk ..."
-    zstd --stdout -d "$BAZELISK_CACHE_TARBALL" | tar --warning=no-timestamp -xf - -C "${ENVOY_DOCKER_BUILD_DIR}/.cache/bazelisk"
-else
-    echo "No bazelisk cache to restore, starting bazelisk with no data"
 fi
 
 if mountpoint -q "${CACHE_PATH}"; then

--- a/.azure-pipelines/docker/prepare_cache.sh
+++ b/.azure-pipelines/docker/prepare_cache.sh
@@ -22,5 +22,4 @@ if [[ -z "$NO_MOUNT_TMPFS" ]]; then
 fi
 mkdir -p "${DOCKER_CACHE_PATH}/docker"
 mkdir -p "${DOCKER_CACHE_PATH}/bazel"
-mkdir -p "${DOCKER_CACHE_PATH}/bazelisk"
 chown -R "$DOCKER_CACHE_OWNERSHIP" "${DOCKER_CACHE_PATH}"

--- a/.azure-pipelines/docker/prime_cache.sh
+++ b/.azure-pipelines/docker/prime_cache.sh
@@ -5,7 +5,6 @@ CACHE_PATH="$2"
 CACHE_ARCH="$3"
 
 echo "Docker restored: $DOCKER_RESTORED"
-echo "Bazelisk restored: $BAZELISK_RESTORED"
 echo "Bazel restored: $BAZEL_RESTORED"
 
 if [[ -z "$CACHE_PATH" ]]; then
@@ -22,26 +21,15 @@ fi
 DOCKER_CACHE_TARBALL="${CACHE_PATH}/docker/docker.tar.zst"
 BAZEL_CACHE_TARBALL="${CACHE_PATH}/bazel/bazel.tar.zst"
 BAZEL_PATH=/tmp/envoy-docker-build
-BAZELISK_CACHE_TARBALL="${CACHE_PATH}/bazelisk/bazelisk.tar.zst"
-BAZELISK_PATHS=(
-    "${BAZEL_PATH}/.cache/bazelisk"
-    "${BAZEL_PATH}/bazel_root/install")
 
 echo
 echo "================ Load caches ==================="
-if [[ "$DOCKER_RESTORED" == "true" ]] || [[ "$BAZELISK_RESTORED" == "true" ]] || [[ "$BAZEL_RESTORED" == "true" ]]; then
+if [[ "$DOCKER_RESTORED" == "true" ]] || [[ "$BAZEL_RESTORED" == "true" ]]; then
     sudo ./.azure-pipelines/docker/load_caches.sh "$ENVOY_DOCKER_BUILD_DIR" "$CACHE_PATH" "" true
 else
     sudo ./.azure-pipelines/docker/clean_docker.sh
     echo "No caches to restore"
 fi
-echo "==================================================="
-echo
-
-echo
-echo "================ Bazel info ======================="
-# Get bazelisk and print bazel info
-./ci/run_envoy_docker.sh './ci/do_ci.sh info'
 echo "==================================================="
 echo
 
@@ -69,12 +57,7 @@ if [[ "$DOCKER_RESTORED" != "true" ]]; then
     sudo ./.azure-pipelines/docker/create_cache.sh "${DOCKER_CACHE_TARBALL}" /var/lib/docker
 fi
 
-if [[ "$BAZELISK_RESTORED" != "true" ]]; then
-    sudo ./.azure-pipelines/docker/create_cache.sh "${BAZELISK_CACHE_TARBALL}" "${BAZELISK_PATHS[@]}"
-fi
-
 if [[ "$BAZEL_RESTORED" != "true" ]]; then
-    rm -rf "{BAZELISK_PATHS[@]}"
     sudo ./.azure-pipelines/docker/create_cache.sh "${BAZEL_CACHE_TARBALL}" "${BAZEL_PATH}"
 fi
 sudo chmod o+r -R "${CACHE_PATH}"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -50,8 +50,6 @@ variables:
   value: v0
 - name: cacheKeyBazel
   value: '.bazelversion | ./WORKSPACE | **/*.bzl, !mobile/**, !envoy-docs/**'
-- name: cacheKeyBazelisk
-  value: ".bazelversion"
 - name: cacheKeyDocker
   value: ".devcontainer/Dockerfile"
 # Docker build uses separate docker cache

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -625,16 +625,7 @@ case $CI_TARGET in
 
     info)
         setup_clang_toolchain
-        n=0
-        until [ "$n" -ge 10 ]; do
-            bazel info "${BAZEL_GLOBAL_OPTIONS[@]}" \
-                && break
-            n=$((n+1))
-            if [[ "$n" -ne 10 ]]; then
-                sleep 15
-                echo "Retrying fetch ..."
-            fi
-        done
+        bazel info "${BAZEL_GLOBAL_OPTIONS[@]}"
         ;;
 
     msan)


### PR DESCRIPTION
As we cant really expire bazelisk/bazel caches separately its simpler/more optimal to use a single bazel cache

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
