### PR TITLE
ci/caching: Optimize bazel cache/fetch

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -2,7 +2,7 @@ parameters:
 - name: ciTarget
   displayName: "CI target"
   type: string
-  default: bazel.release
+  default: release
 - name: artifactSuffix
   displayName: "Suffix of artifact"
   type: string
@@ -18,6 +18,9 @@ parameters:
 - name: pathCacheTemp
   type: string
   default: $(pathCacheTemp)
+- name: cacheName
+  type: string
+  default:
 
 - name: tmpfsCacheDisabled
   type: string
@@ -145,19 +148,25 @@ steps:
 - bash: |
     set -e
     CACHE_DIRS=(
+        "$(Build.StagingDirectory)/envoy"
         "$(Build.StagingDirectory)/.cache/"
         "$(Build.StagingDirectory)/bazel_root/install/"
         "$(Build.StagingDirectory)/repository_cache/"
         "$(Build.StagingDirectory)/bazel_root/base/external")
     sudo mkdir -p "${CACHE_DIRS[@]}"
-    sudo chown -R vsts:vsts "${CACHE_DIRS[@]}" $(Build.StagingDirectory)/bazel_root/
-    echo "Created bazel cache directories: "${CACHE_DIRS[*]}""
+    if id -u vsts &> /dev/null; then
+        sudo chown -R vsts:vsts "${CACHE_DIRS[@]}" $(Build.StagingDirectory)/bazel_root/
+    else
+        sudo chown -R azure-pipelines:azure-pipelines "${CACHE_DIRS[@]}" $(Build.StagingDirectory)/bazel_root/
+    fi
+    echo "Created bazel directories: "${CACHE_DIRS[*]}""
   displayName: "Create bazel directories"
-  condition: and(succeeded(), eq('${{ parameters.managedAgent }}', true), eq('${{ parameters.tmpfsDockerDisabled }}', true))
+  condition: and(succeeded(), eq('${{ parameters.tmpfsDockerDisabled }}', true))
 
 # Caching
 - template: cached.yml
   parameters:
+    cacheName: "${{ parameters.cacheName }}"
     keyBazel: "${{ parameters.cacheKeyBazel }}"
     keyDocker: "${{ parameters.cacheKeyDocker }}"
     pathDockerBind: "${{ parameters.pathDockerBind }}"
@@ -166,6 +175,36 @@ steps:
     tmpfsDisabled: "${{ parameters.tmpfsCacheDisabled }}"
     tmpfsDockerDisabled: "${{ parameters.tmpfsDockerDisabled }}"
 
+- script: |
+    if [[ "${{ parameters.bazelUseBES }}" == 'false' ]]; then
+        unset GOOGLE_BES_PROJECT_ID
+    fi
+    ci/run_envoy_docker.sh 'ci/do_ci.sh fetch-${{ parameters.ciTarget }}'
+  condition: and(not(canceled()), not(failed()), ne('${{ parameters.cacheName }}', ''), ne(variables.CACHE_RESTORED, 'true'))
+  workingDirectory: $(Build.SourcesDirectory)
+  env:
+    ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+    GITHUB_TOKEN: "${{ parameters.authGithub }}"
+    BAZEL_STARTUP_EXTRA_OPTIONS: "${{ parameters.bazelStartupExtraOptions }}"
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      CI_TARGET_BRANCH: "origin/$(System.PullRequest.TargetBranch)"
+    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      CI_TARGET_BRANCH: "origin/$(Build.SourceBranchName)"
+    # Any PR or CI run in envoy-presubmit uses the fake SCM hash
+    ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'envoy-presubmit')) }}:
+      # sha1sum of `ENVOY_PULL_REQUEST`
+      BAZEL_FAKE_SCM_REVISION: e3b4a6e9570da15ac1caffdded17a8bebdc7dfc9
+    ${{ if parameters.rbe }}:
+      GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
+      ENVOY_RBE: "1"
+      BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelConfigRBE }} ${{ parameters.bazelBuildExtraOptions }}"
+    ${{ if eq(parameters.rbe, false) }}:
+      BAZEL_BUILD_EXTRA_OPTIONS: "--config=ci ${{ parameters.bazelBuildExtraOptions }}"
+      BAZEL_REMOTE_CACHE: $(LocalBuildCache)
+    ${{ each var in parameters.env }}:
+      ${{ var.key }}: ${{ var.value }}
+  displayName: "Fetch assets (${{ parameters.ciTarget }})"
+
 - ${{ each step in parameters.stepsPre }}:
   - ${{ each pair in step }}:
       ${{ pair.key }}: ${{ pair.value }}
@@ -173,6 +212,13 @@ steps:
 - bash: |
     echo "disk space at beginning of build:"
     df -h
+    if [[ -e "$(Build.StagingDirectory)/bazel_root/base/external" ]]; then
+        du -sh "$(Build.StagingDirectory)/bazel_root/base/external"
+    fi
+    if [[ -e "$(Build.StagingDirectory)/repository_cache" ]]; then
+        du -sh "$(Build.StagingDirectory)/repository_cache"
+    fi
+
   displayName: "Check disk space at beginning"
 
 - bash: |
@@ -228,6 +274,9 @@ steps:
         cp -a $hprof $(Build.StagingDirectory)/envoy/hprof
     done
 
+    du -sh "$(Build.StagingDirectory)"/bazel_root/base/external
+    du -sh "$(Build.StagingDirectory)"/repository_cache
+
     cp -a "$(Build.StagingDirectory)/bazel_root/base/server/jvm.out" $(Build.StagingDirectory)/envoy
 
     if [[ "${{ parameters.artifactSuffix }}" == ".arm64" ]]; then
@@ -246,6 +295,18 @@ steps:
 - ${{ each step in parameters.stepsPost }}:
   - ${{ each pair in step }}:
       ${{ pair.key }}: ${{ pair.value }}
+
+- script: |
+    set -e
+    sudo .azure-pipelines/docker/save_cache.sh "$(Build.StagingDirectory)" /mnt/cache/all true true
+    if id -u vsts &> /dev/null; then
+        sudo chown -R vsts:vsts /mnt/cache/all
+    else
+        sudo chown -R azure-pipelines:azure-pipelines /mnt/cache/all
+    fi
+
+  displayName: "Cache/save (${{ parameters.cacheName}})"
+  condition: and(succeeded(), ne('${{ parameters.cacheName }}', ''), ne(variables.CACHE_RESTORED, 'true'))
 
 - task: PublishTestResults@2
   inputs:

--- a/.azure-pipelines/cached.yml
+++ b/.azure-pipelines/cached.yml
@@ -1,14 +1,14 @@
 
 parameters:
-- name: name
-  type: string
-  default: $(cacheKeyName)
 - name: arch
   type: string
   default: ""
 - name: version
   type: string
   default: $(cacheKeyVersion)
+- name: cacheName
+  type: string
+  default:
 
 - name: keyDocker
   type: string
@@ -45,20 +45,32 @@ steps:
   displayName: "Cache/prepare"
 
 - task: Cache@2
+  condition: and(not(canceled()), ne('${{ parameters.cacheName }}', ''))
+  env:
+    VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: "${{ parameters.cacheTimeoutWorkaround }}"
+  displayName: "Cache (${{ parameters.cacheName }})"
+  inputs:
+    key: '${{ parameters.cacheName }} | "${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyDocker }} | ${{ parameters.keyBazel }}'
+    path: "${{ parameters.pathTemp }}/all"
+    cacheHitVar: CACHE_RESTORED
+
+- task: Cache@2
+  condition: and(not(canceled()), not(failed()), or(ne(variables.CACHE_RESTORED, 'true'), eq('${{ parameters.cacheName }}', '')))
   env:
     VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: "${{ parameters.cacheTimeoutWorkaround }}"
   displayName: "Cache (Docker)"
   inputs:
-    key: '${{ parameters.name }} | "${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyDocker }}'
+    key: '"${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyDocker }} | docker'
     path: "${{ parameters.pathTemp }}/docker"
     cacheHitVar: DOCKER_CACHE_RESTORED
 
 - task: Cache@2
+  condition: and(not(canceled()), not(failed()), or(ne(variables.CACHE_RESTORED, 'true'), eq('${{ parameters.cacheName }}', '')))
   env:
     VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: "${{ parameters.cacheTimeoutWorkaround }}"
   displayName: "Cache (Bazel)"
   inputs:
-    key: '${{ parameters.name }} | bazel | "${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyBazel }}'
+    key: '"${{ parameters.version }}" | "${{ parameters.arch }}" | ${{ parameters.keyBazel }} | bazel'
     path: "${{ parameters.pathTemp }}/bazel"
     cacheHitVar: BAZEL_CACHE_RESTORED
 
@@ -67,9 +79,9 @@ steps:
   env:
     DOCKER_RESTORED: $(DOCKER_CACHE_RESTORED)
     BAZEL_RESTORED: $(BAZEL_CACHE_RESTORED)
-  displayName: "Cache/prime (${{ parameters.name }})"
+  displayName: "Cache/prime (Docker/Bazel)"
   # TODO(phlax): figure if there is a way to test cache without downloading it
-  condition: and(not(canceled()), eq(${{ parameters.prime }}, true), or(ne(variables.DOCKER_CACHE_RESTORED, 'true'), ne(variables.BAZEL_CACHE_RESTORED, 'true')))
+  condition: and(not(canceled()), eq(${{ parameters.prime }}, true), eq('${{ parameters.cacheName }}', ''), or(ne(variables.DOCKER_CACHE_RESTORED, 'true'), ne(variables.BAZEL_CACHE_RESTORED, 'true')))
 
 # Load the caches for a job
 - script: sudo .azure-pipelines/docker/load_caches.sh "$(Build.StagingDirectory)" "${{ parameters.pathTemp }}" "${{ parameters.pathDockerBind }}" "${{ parameters.tmpfsDockerDisabled }}"

--- a/.azure-pipelines/docker/create_cache.sh
+++ b/.azure-pipelines/docker/create_cache.sh
@@ -3,7 +3,8 @@
 set -o pipefail
 
 CACHE_TARBALL="${1}"
-shift
+ROOT_DIR="${2}"
+shift 2
 
 echo "Exporting ${*} -> ${CACHE_TARBALL}"
 
@@ -12,9 +13,15 @@ mkdir -p "$CACHE_PATH"
 
 CACHE_ARGS=()
 for path in "$@"; do
-    total="$(du -sh "$path" | cut -f1)"
-    echo "Adding cache dir (${path}): ${total}"
-    CACHE_ARGS+=(-C "$path" .)
+    if [[ "$ROOT_DIR" == "." ]]; then
+        total="$(du -sh "$path" | cut -f1)"
+        echo "Adding cache dir (${path}): ${total}"
+        CACHE_ARGS+=(-C "$path" .)
+    else
+        total="$(du -sh "${ROOT_DIR}/$path" | cut -f1)"
+        echo "Adding cache dir (${ROOT_DIR}/${path}): ${total}"
+        CACHE_ARGS+=(-C "$ROOT_DIR" "$path")
+    fi
 done
 
 tar cf - "${CACHE_ARGS[@]}" | zstd - -q -T0 -o "$CACHE_TARBALL"

--- a/.azure-pipelines/docker/prepare_cache.sh
+++ b/.azure-pipelines/docker/prepare_cache.sh
@@ -3,7 +3,6 @@
 DOCKER_CACHE_PATH="$1"
 NO_MOUNT_TMPFS="${2:-}"
 DOCKER_CACHE_OWNERSHIP="vsts:vsts"
-TMPFS_SIZE=5G
 
 if [[ -z "$DOCKER_CACHE_PATH" ]]; then
     echo "prepare_docker_cache called without path arg" >&2
@@ -13,6 +12,14 @@ fi
 if ! id -u vsts &> /dev/null; then
     DOCKER_CACHE_OWNERSHIP=azure-pipelines
 fi
+
+tmpfs_size () {
+    # Make this 2/3 of total memory
+    total_mem="$(grep MemTotal /proc/meminfo  | cut -d' ' -f2- | xargs | cut -d' ' -f1)"
+    bc <<< "$total_mem"*2/3*1024
+}
+
+TMPFS_SIZE="$(tmpfs_size)"
 
 echo "Creating cache directory (${DOCKER_CACHE_PATH}) ..."
 mkdir -p "${DOCKER_CACHE_PATH}"

--- a/.azure-pipelines/docker/prime_cache.sh
+++ b/.azure-pipelines/docker/prime_cache.sh
@@ -65,11 +65,11 @@ echo "================ Save caches ======================"
 if [[ "$DOCKER_RESTORED" != "true" ]]; then
     echo "Stopping docker"
     sudo systemctl stop docker docker.socket
-    sudo ./.azure-pipelines/docker/create_cache.sh "${DOCKER_CACHE_TARBALL}" /var/lib/docker
+    sudo ./.azure-pipelines/docker/create_cache.sh "${DOCKER_CACHE_TARBALL}" . /var/lib/docker
 fi
 
 if [[ "$BAZEL_RESTORED" != "true" ]]; then
-    sudo ./.azure-pipelines/docker/create_cache.sh "${BAZEL_CACHE_TARBALL}" "${BAZEL_PATH}"
+    sudo ./.azure-pipelines/docker/create_cache.sh "${BAZEL_CACHE_TARBALL}" . "${BAZEL_PATH}"
 fi
 sudo chmod o+r -R "${CACHE_PATH}"
 echo "==================================================="

--- a/.azure-pipelines/docker/save_cache.sh
+++ b/.azure-pipelines/docker/save_cache.sh
@@ -1,37 +1,42 @@
 #!/bin/bash -e
 
 set -o pipefail
+ENVOY_DOCKER_BUILD_DIR="$1"
+CACHE_PATH="$2"
+NO_MOUNT_TMPFS="${3:-}"
+CACHE_BAZEL="${4:-}"
 
-DOCKER_CACHE_PATH="$1"
-NO_MOUNT_TMPFS="${2:-}"
-
-if [[ -z "$DOCKER_CACHE_PATH" ]]; then
+if [[ -z "$CACHE_PATH" ]]; then
     echo "prime_docker_cache called without path arg" >&2
     exit 1
 fi
 
-if [[ -e /tmp/DOCKER_CACHE_RESTORED ]]; then
-    echo "Not saving cache as it was restored"
-    exit 0
-fi
-
-DOCKER_CACHE_TARBALL="${DOCKER_CACHE_PATH}/docker.tar.zst"
+DOCKER_CACHE_TARBALL="${CACHE_PATH}/docker.tar.zst"
+BAZEL_CACHE_TARBALL="${CACHE_PATH}/bazel.tar.zst"
 
 docker images
 
 echo "Stopping Docker ..."
-systemctl stop docker
+systemctl stop docker docker.socket
 
-echo "Creating directory to save tarball: ${DOCKER_CACHE_PATH}"
-mkdir -p "$DOCKER_CACHE_PATH"
+echo "Creating directory to save tarball: ${CACHE_PATH}"
+mkdir -p "$CACHE_PATH"
 
 if [[ -z "$NO_MOUNT_TMPFS" ]]; then
-    echo "Mount tmpfs directory: ${DOCKER_CACHE_PATH}"
-    mount -t tmpfs none "$DOCKER_CACHE_PATH"
+    echo "Mount tmpfs directory: ${CACHE_PATH}"
+    mount -t tmpfs none "$CACHE_PATH"
 fi
 
-echo "Creating tarball: /var/lib/docker -> ${DOCKER_CACHE_TARBALL}"
-tar cf - -C /var/lib/docker . | zstd - -T0 -o "$DOCKER_CACHE_TARBALL"
+./.azure-pipelines/docker/create_cache.sh \
+    "${DOCKER_CACHE_TARBALL}" \
+    . \
+    /var/lib/docker
 
-echo "Docker cache tarball created: ${DOCKER_CACHE_TARBALL}"
-ls -lh "$DOCKER_CACHE_TARBALL"
+if [[ "$CACHE_BAZEL" == "true" ]]; then
+    ./.azure-pipelines/docker/create_cache.sh \
+        "${BAZEL_CACHE_TARBALL}" \
+        "${ENVOY_DOCKER_BUILD_DIR}" \
+        bazel_root/install \
+        bazel_root/base/external \
+        repository_cache
+fi

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -44,20 +44,12 @@ variables:
 
 ## Variable settings
 # Caches (tip: append a version suffix while testing caches)
-- name: cacheKeyName
-  value: envoy
 - name: cacheKeyVersion
-  value: v2
+  value: v0
 - name: cacheKeyBazel
   value: '.bazelversion | ./WORKSPACE | **/*.bzl, !mobile/**, !envoy-docs/**'
 - name: cacheKeyDocker
   value: ".bazelrc"
-# Docker build uses separate docker cache
-- name: cacheKeyDockerBuild
-  # VERSION.txt is included to refresh Docker images for release
-  value: '"publish_docker" | ci/Dockerfile-envoy | VERSION.txt'
-- name: cacheKeyDockerBuildVersion
-  value: v0
 
 - name: pathCacheTemp
   value: /mnt/cache

--- a/.azure-pipelines/stage/checks.yml
+++ b/.azure-pipelines/stage/checks.yml
@@ -43,43 +43,44 @@ jobs:
     matrix:
       # These are ordered by most time-consuming first.
       coverage:
-        CI_TARGET: "bazel.coverage"
+        CI_TARGET: "coverage"
       fuzz_coverage:
-        CI_TARGET: "bazel.fuzz_coverage"
+        CI_TARGET: "fuzz_coverage"
       compile_time_options:
-        CI_TARGET: "bazel.compile_time_options"
+        CI_TARGET: "compile_time_options"
         ENVOY_FILTER_EXAMPLE: true
       tsan:
-        CI_TARGET: "bazel.tsan"
+        CI_TARGET: "tsan"
       asan:
-        CI_TARGET: "bazel.asan"
+        CI_TARGET: "asan"
         ENVOY_FILTER_EXAMPLE: true
       # Disabled due to https://github.com/envoyproxy/envoy/pull/18218
       # api_compat:
-      #  CI_TARGET: "bazel.api_compat"
+      #  CI_TARGET: "api_compat"
       gcc:
-        CI_TARGET: "bazel.gcc"
+        CI_TARGET: "gcc"
       msan:
-        CI_TARGET: "bazel.msan"
+        CI_TARGET: "msan"
         ENVOY_FILTER_EXAMPLE: true
       #
       # Temporarily disabled to facilitate release CI, should be resolved
       #    as part of https://github.com/envoyproxy/envoy/issues/28566
       #
       # clang_tidy:
-      #   CI_TARGET: "bazel.clang_tidy"
+      #   CI_TARGET: "clang_tidy"
       #   REPO_FETCH_DEPTH: 0
       #   REPO_FETCH_TAGS: true
       #   PUBLISH_TEST_RESULTS: false
       #   PUBLISH_ENVOY: false
       api:
-        CI_TARGET: "bazel.api"
+        CI_TARGET: "api"
   timeoutInMinutes: 180
   pool: envoy-x64-small
   steps:
   - template: ../bazel.yml
     parameters:
       ciTarget: $(CI_TARGET)
+      cacheName: $(CI_TARGET)
       envoyBuildFilterExample: $(ENVOY_FILTER_EXAMPLE)
       cacheTestResults: ${{ parameters.cacheTestResults }}
       managedAgent: false
@@ -95,10 +96,10 @@ jobs:
           pathtoPublish: "$(Build.StagingDirectory)/tmp/lint-fixes"
           artifactName: "$(CI_TARGET).fixes"
         timeoutInMinutes: 10
-        condition: and(failed(), eq(variables['CI_TARGET'], 'bazel.clang_tidy'))
+        condition: and(failed(), eq(variables['CI_TARGET'], 'clang_tidy'))
       - script: ci/run_envoy_docker.sh 'ci/do_ci.sh $(CI_TARGET)-upload'
         displayName: "Upload $(CI_TARGET) Report to GCS"
-        condition: and(not(canceled()), or(eq(variables['CI_TARGET'], 'bazel.coverage'), eq(variables['CI_TARGET'], 'bazel.fuzz_coverage')))
+        condition: and(not(canceled()), or(eq(variables['CI_TARGET'], 'coverage'), eq(variables['CI_TARGET'], 'fuzz_coverage')))
         env:
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_RBE: "1"

--- a/.azure-pipelines/stage/linux.yml
+++ b/.azure-pipelines/stage/linux.yml
@@ -48,7 +48,8 @@ jobs:
   - template: ../bazel.yml
     parameters:
       managedAgent: ${{ parameters.managedAgent }}
-      ciTarget: bazel.release
+      ciTarget: release
+      cacheName: "release"
       bazelBuildExtraOptions: ${{ parameters.bazelBuildExtraOptions }}
       cacheTestResults: ${{ parameters.cacheTestResults }}
       cacheVersion: $(cacheKeyBazel)

--- a/.azure-pipelines/stage/prechecks.yml
+++ b/.azure-pipelines/stage/prechecks.yml
@@ -54,6 +54,7 @@ jobs:
   - template: ../bazel.yml
     parameters:
       ciTarget: $(CI_TARGET)
+      cacheName: $(CI_TARGET)
       cacheTestResults: ${{ parameters.cacheTestResults }}
       cacheVersion: $(cacheKeyBazel)
       publishEnvoy: false

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -101,18 +101,16 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.release"
-      itemPattern: "bazel.release/**/bin/*"
+      artifactName: "release"
+      itemPattern: "release/**/bin/*"
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:
       ciTarget: docker-upload
+      cacheName: docker-upload
       publishEnvoy: false
       publishTestResults: false
       pathDockerBind: ""
-      cacheKeyDocker: "$(cacheKeyDockerBuild)"
-      cacheKeyVersion: "$(cacheKeyDockerBuildVersion)"
-      pathCacheTemp: /var/azpcache
       tmpfsCacheDisabled: true
       diskspaceHack: true
       env:
@@ -128,12 +126,12 @@ jobs:
           mkdir -p linux/amd64 linux/arm64
 
           # x64
-          cp -a $(Build.StagingDirectory)/bazel.release/x64/bin/release.tar.zst linux/amd64/release.tar.zst
-          cp -a $(Build.StagingDirectory)/bazel.release/x64/bin/schema_validator_tool linux/amd64/schema_validator_tool
+          cp -a $(Build.StagingDirectory)/release/x64/bin/release.tar.zst linux/amd64/release.tar.zst
+          cp -a $(Build.StagingDirectory)/release/x64/bin/schema_validator_tool linux/amd64/schema_validator_tool
 
           # arm64
-          cp -a $(Build.StagingDirectory)/bazel.release/arm64/bin/release.tar.zst linux/arm64/release.tar.zst
-          cp -a $(Build.StagingDirectory)/bazel.release/arm64/bin/schema_validator_tool linux/arm64/schema_validator_tool
+          cp -a $(Build.StagingDirectory)/release/arm64/bin/release.tar.zst linux/arm64/release.tar.zst
+          cp -a $(Build.StagingDirectory)/release/arm64/bin/schema_validator_tool linux/arm64/schema_validator_tool
 
           # Debug what files appear to have been downloaded
           find linux -type f -name "*" | xargs ls -l
@@ -148,13 +146,6 @@ jobs:
           DOCKERHUB_USERNAME: ${{ parameters.authDockerUser }}
           DOCKERHUB_PASSWORD: ${{ parameters.authDockerPassword }}
           DOCKER_BUILD_TIMEOUT: ${{ parameters.timeoutDockerBuild }}
-      stepsPost:
-      - script: |
-          set -e
-          sudo .azure-pipelines/docker/save_cache.sh /var/azpcache/docker true
-          sudo rm -rf /var/lib/docker
-        displayName: "Cache/save (publish_docker)"
-        condition: and(succeeded(), ne(variables.DOCKER_CACHE_RESTORED, 'true'))
 
 - job: package_x64
   displayName: Linux debs (x64)
@@ -169,12 +160,13 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.release"
-      itemPattern: "bazel.release/x64/bin/*"
+      artifactName: "release"
+      itemPattern: "release/x64/bin/*"
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:
-      ciTarget: bazel.distribution
+      ciTarget: distribution
+      cacheName: distribution
       publishTestResults: false
       stepsPre:
       - template: ../gpg.yml
@@ -201,14 +193,15 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.release"
-      itemPattern: "bazel.release/arm64/bin/*"
+      artifactName: "release"
+      itemPattern: "release/arm64/bin/*"
       targetPath: $(Build.StagingDirectory)
 
   - template: ../bazel.yml
     parameters:
       managedAgent: false
-      ciTarget: bazel.distribution
+      ciTarget: distribution
+      cacheName: distribution
       rbe: false
       artifactSuffix: ".arm64"
       bazelBuildExtraOptions: "--sandbox_base=/tmp/sandbox_base"
@@ -239,6 +232,7 @@ jobs:
   - template: ../bazel.yml
     parameters:
       ciTarget: docs
+      cacheName: docs
       cacheVersion: $(cacheKeyBazel)
       publishEnvoy: false
       publishTestResults: false
@@ -315,18 +309,19 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.release"
-      itemPattern: "bazel.release/**/bin/*"
+      artifactName: "release"
+      itemPattern: "release/**/bin/*"
       targetPath: $(Build.StagingDirectory)
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.distribution"
-      itemPattern: "bazel.distribution/**/packages.*.tar.gz"
+      artifactName: "distribution"
+      itemPattern: "distribution/**/packages.*.tar.gz"
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:
       ciTarget: release.signed
+      cacheName: release-signed
       publishTestResults: false
       env:
         GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
@@ -370,6 +365,7 @@ jobs:
   - template: ../bazel.yml
     parameters:
       ciTarget: verify.trigger
+      cacheName: verify-trigger
       authGithub: "$(key.value)"
       cacheVersion: $(cacheKeyBazel)
       publishEnvoy: false

--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -18,13 +18,14 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.distribution"
-      itemPattern: "bazel.distribution/x64/packages.x64.tar.gz"
+      artifactName: "distribution"
+      itemPattern: "distribution/x64/packages.x64.tar.gz"
       downloadType: single
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:
       ciTarget: verify_distro
+      cacheName: verify_distro
       publishTestResults: false
       env:
         ENVOY_DOCKER_IN_DOCKER: 1
@@ -38,14 +39,15 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: current
-      artifactName: "bazel.distribution"
-      itemPattern: "bazel.distribution/arm64/packages.arm64.tar.gz"
+      artifactName: "distribution"
+      itemPattern: "distribution/arm64/packages.arm64.tar.gz"
       downloadType: single
       targetPath: $(Build.StagingDirectory)
   - template: ../bazel.yml
     parameters:
       managedAgent: false
       ciTarget: verify_distro
+      cacheName: verify_distro
       rbe: false
       artifactSuffix: ".arm64"
       publishTestResults: false

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -30,6 +30,44 @@ FETCH_TARGETS=(
     @envoy_api//...
     @envoy_build_tools//...)
 
+FETCH_TARGETS=(
+    @bazel_tools//tools/jdk:remote_jdk11
+    @com_github_bufbuild_buf//:bin/buf
+    @envoy_build_tools//...
+    //docs/...
+    //tools/proto_format/...
+    //tools/zstd
+    //tools/gsutil
+    //tools/code_format/...)
+
+FETCH_BUILD_TARGETS=(
+    @com_github_google_quiche//:ci_tests
+    //contrib/exe/...
+    //distribution/...
+    //source/exe/...
+    //test/tools/schema_validator/...
+    //test/...)
+
+retry () {
+    local n wait iterations
+    wait="${1}"
+    iterations="${2}"
+    shift 2
+    n=0
+    until [ "$n" -ge "$iterations" ]; do
+        "${@}" \
+            && break
+        n=$((n+1))
+        if [[ "$n" -lt "$iterations" ]]; then
+            sleep "$wait"
+            echo "Retrying ..."
+        else
+            echo "Fetch failed"
+            exit 1
+        fi
+    done
+}
+
 
 if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
   BUILD_ARCH_DIR="/linux/amd64"
@@ -181,23 +219,25 @@ function run_ci_verify () {
 CI_TARGET=$1
 shift
 
+if [[ "$CI_TARGET" =~ bazel.* ]]; then
+    ORIG_CI_TARGET="$CI_TARGET"
+    CI_TARGET="$(echo "${CI_TARGET}" | cut -d. -f2-)"
+    echo "Using \`${ORIG_CI_TARGET}\` is deprecated, please use \`${CI_TARGET}\`"
+fi
+
 if [[ $# -ge 1 ]]; then
   COVERAGE_TEST_TARGETS=("$@")
   TEST_TARGETS=("$@")
 else
   # Coverage test will add QUICHE tests by itself.
   COVERAGE_TEST_TARGETS=("//test/...")
-  if [[ "$CI_TARGET" == "bazel.release" ]]; then
+  if [[ "${CI_TARGET}" == "release" ]]; then
     # We test contrib on release only.
     COVERAGE_TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "//contrib/...")
-  elif [[ "${CI_TARGET}" == "bazel.msan" ]]; then
+  elif [[ "${CI_TARGET}" == "msan" ]]; then
     COVERAGE_TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "-//test/extensions/...")
   fi
   TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "@com_github_google_quiche//:ci_tests")
-fi
-
-if [[ "$CI_TARGET" =~ bazel.* ]]; then
-    CI_TARGET="$(echo "${CI_TARGET}" | cut -d. -f2-)"
 fi
 
 case $CI_TARGET in
@@ -509,9 +549,9 @@ case $CI_TARGET in
         # Extract the Envoy binary from the tarball
         mkdir -p distribution/custom
         if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
-            ENVOY_RELEASE_TARBALL="/build/bazel.release/x64/bin/release.tar.zst"
+            ENVOY_RELEASE_TARBALL="/build/release/x64/bin/release.tar.zst"
         else
-            ENVOY_RELEASE_TARBALL="/build/bazel.release/arm64/bin/release.tar.zst"
+            ENVOY_RELEASE_TARBALL="/build/release/arm64/bin/release.tar.zst"
         fi
         bazel run "${BAZEL_BUILD_OPTIONS[@]}" \
               //tools/zstd \
@@ -567,29 +607,31 @@ case $CI_TARGET in
         cat bazel-bin/distribution/dockerhub/readme.md
         ;;
 
-    fetch)
+    fetch|fetch-*)
+        case $CI_TARGET in
+            fetch)
+                targets=("${FETCH_TARGETS[@]}")
+                ;;
+            fetch-release)
+                targets=("${FETCH_BUILD_TARGETS[@]}")
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
         setup_clang_toolchain
-        echo "Fetching ${FETCH_TARGETS[*]} ..."
         FETCH_ARGS=(
             --noshow_progress
             --noshow_loading_progress)
-        # TODO(phlax): separate out retry logic
-        n=0
-        until [ "$n" -ge 10 ]; do
-            bazel fetch "${BAZEL_GLOBAL_OPTIONS[@]}" \
-                  "${FETCH_ARGS[@]}" \
-                  "${FETCH_TARGETS[@]}" \
-                && break
-            n=$((n+1))
-            if [[ "$n" -lt 10 ]]; then
-                sleep 15
-                echo "Retrying fetch ..."
-            else
-                echo "Fetch failed"
-                exit 1
-            fi
-        done
+        echo "Fetching ${targets[*]} ..."
+        retry 15 10 bazel \
+              fetch \
+              "${BAZEL_GLOBAL_OPTIONS[@]}" \
+              "${FETCH_ARGS[@]}" \
+              "${targets[@]}"
         ;;
+
+
 
     fix_proto_format)
         # proto_format.sh needs to build protobuf.
@@ -724,7 +766,7 @@ case $CI_TARGET in
         setup_clang_toolchain
         # The default config expects these files
         mkdir -p distribution/custom
-        cp -a /build/bazel.*/*64 distribution/custom/
+        cp -a /build/*/*64 distribution/custom/
         bazel build "${BAZEL_BUILD_OPTIONS[@]}" //distribution:signed
         cp -a bazel-bin/distribution/release.signed.tar.zst "${BUILD_DIR}/envoy/"
         "${ENVOY_SRCDIR}/ci/upload_gcs_artifact.sh" "${BUILD_DIR}/envoy" release
@@ -774,9 +816,9 @@ case $CI_TARGET in
         # this can be required if any python deps require compilation
         setup_clang_toolchain
         if [[ "${ENVOY_BUILD_ARCH}" == "x86_64" ]]; then
-            PACKAGE_BUILD=/build/bazel.distribution/x64/packages.x64.tar.gz
+            PACKAGE_BUILD=/build/distribution/x64/packages.x64.tar.gz
         else
-            PACKAGE_BUILD=/build/bazel.distribution/arm64/packages.arm64.tar.gz
+            PACKAGE_BUILD=/build/distribution/arm64/packages.arm64.tar.gz
         fi
         bazel run "${BAZEL_BUILD_OPTIONS[@]}" \
               //distribution:verify_packages \


### PR DESCRIPTION
This PR makes a number of changes to CI esp wrt to caching

Essentially it revives per-job caches, but also retains the precaches of docker and a minimal bazel fetch

The bazel precache is slimmed down

Whenever a cache is not available for a job it will instead use either/both of the precaches

As the github download issue is still there it also allows the jobs to run (retriable) bazel fetch before running the actual job

All ci jobs that previously invoked `./ci/do_ci.sh bazel.$JOBNAME` now just invoke with the job name and a deprecation message has been added to `do_ci.sh` - this simplifies a number of things

I have experimented quite a bit to derive the best fetches for precache and individual jobs - this will most likely iterate once we have the framework for pre and per-job caching  

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
