### PR TITLE
logs: fix tagged logs macros for inline usage

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -563,22 +563,26 @@ public:
 #define ENVOY_TAGGED_CONN_LOG_TO_LOGGER(LOGGER, LEVEL, TAGS, CONNECTION, FORMAT, ...)              \
   do {                                                                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
-      TAGS.emplace("ConnectionId", std::to_string((CONNECTION).id()));                             \
-      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT), \
-                          ##__VA_ARGS__);                                                          \
+      std::map<std::string, std::string> log_tags = TAGS;                                          \
+      log_tags.emplace("ConnectionId", std::to_string((CONNECTION).id()));                         \
+      ENVOY_LOG_TO_LOGGER(                                                                         \
+          LOGGER, LEVEL,                                                                           \
+          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(log_tags) + FORMAT),             \
+          ##__VA_ARGS__);                                                                          \
     }                                                                                              \
   } while (0)
 
 #define ENVOY_TAGGED_STREAM_LOG_TO_LOGGER(LOGGER, LEVEL, TAGS, STREAM, FORMAT, ...)                \
   do {                                                                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
-      TAGS.emplace("ConnectionId",                                                                 \
-                   (STREAM).connection() ? std::to_string((STREAM).connection()->id()) : "0");     \
-      TAGS.emplace("StreamId", std::to_string((STREAM).streamId()));                               \
-      ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL,                                                           \
-                          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(TAGS) + FORMAT), \
-                          ##__VA_ARGS__);                                                          \
+      std::map<std::string, std::string> log_tags = TAGS;                                          \
+      log_tags.emplace("ConnectionId",                                                             \
+                       (STREAM).connection() ? std::to_string((STREAM).connection()->id()) : "0"); \
+      log_tags.emplace("StreamId", std::to_string((STREAM).streamId()));                           \
+      ENVOY_LOG_TO_LOGGER(                                                                         \
+          LOGGER, LEVEL,                                                                           \
+          fmt::runtime(::Envoy::Logger::Utility::serializeLogTags(log_tags) + FORMAT),             \
+          ##__VA_ARGS__);                                                                          \
     }                                                                                              \
   } while (0)
 


### PR DESCRIPTION
Additional Description: in case ``ENVOY_TAGGED_STREAM_LOG_TO_LOGGER`` and ``ENVOY_TAGGED_CONN_LOG_TO_LOGGER`` are used with inline tags, e.g., ``ENVOY_TAGGED_CONN_LOG(info, (std::map<std::string, std::string>{{"key_inline", "val"}}), connection_, "fake message")``, the printed log will only include tags from the inline map, and will not include the connection/stream ID tags. The PR fixes this so both the inline tags as well as the connection/stream ID are included in the output tags.
Risk Level: low 
Testing: unit tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None