### PR TITLE
mobile: Remove -Xcheck:jni from kotlin tests

### DIFF
--- a/mobile/bazel/kotlin_test.bzl
+++ b/mobile/bazel/kotlin_test.bzl
@@ -36,7 +36,9 @@ def jvm_flags(lib_name):
     return [
         "-Djava.library.path=library/common/jni:test/common/jni",
         "-Denvoy_jni_library_name={}".format(lib_name),
-        "-Xcheck:jni",
+        # TODO(RyanTheOptimist): Uncomment this when when
+        # https://github.com/envoyproxy/envoy/issues/28981 is fixed.
+        # "-Xcheck:jni",
     ]
 
 # A basic macro to make it easier to declare and run kotlin tests which depend on a JNI lib


### PR DESCRIPTION
Remove -Xcheck:jni from kotlin tests
As noted in #28981, //test/kotlin/integration:filter_throwing_exception_test produces tons of warnings which is causing tests to fail with new rules_java.

Risk Level: Low - Test only
Testing: Existing
Docs Changes: N/A
Release Notes: N/A