### PR TITLE
tracing: Deprecate OpenTracing

### DIFF
--- a/api/envoy/config/trace/v3/dynamic_ot.proto
+++ b/api/envoy/config/trace/v3/dynamic_ot.proto
@@ -29,9 +29,9 @@ message DynamicOtConfig {
 
   // Dynamic library implementing the `OpenTracing API
   // <https://github.com/opentracing/opentracing-cpp>`_.
-  string library = 1 [(validate.rules).string = {min_len: 1}];
+  string library = 1 [(validate.rules).string = {min_len: 1}, deprecated = true];
 
   // The configuration to use when creating a tracer from the given dynamic
   // library.
-  google.protobuf.Struct config = 2;
+  google.protobuf.Struct config = 2 [deprecated = true];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -2,6 +2,9 @@ date: Pending
 
 behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+- area: tracing
+  change: |
+    OpenTracing is now deprecated since the upstream project has been abandoned.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/extensions/tracers/dynamic_ot/config.cc
+++ b/source/extensions/tracers/dynamic_ot/config.cc
@@ -18,6 +18,8 @@ DynamicOpenTracingTracerFactory::DynamicOpenTracingTracerFactory()
 Tracing::DriverSharedPtr DynamicOpenTracingTracerFactory::createTracerDriverTyped(
     const envoy::config::trace::v3::DynamicOtConfig& proto_config,
     Server::Configuration::TracerFactoryContext& context) {
+  ENVOY_LOG_MISC(warn, "OpenTracing is deprecated and will be removed soon.");
+
   const std::string& library = proto_config.library();
   const ProtobufWkt::Struct& config_struct = proto_config.config();
   absl::StatusOr<std::string> json_or_error = MessageUtil::getJsonStringFromMessage(config_struct);


### PR DESCRIPTION
The OpenTracing upstream project has been abandoned, as noted in #27401.
Consequently this library is not receiving security updates and is not compatible
with Envoy. 

Risk Level: N/A
Testing: N/A
Docs Changes: Changelog updated
Release Notes: Changelog updated