### PR TITLE
set_metadata: Implement filter creation from server factory context

### DIFF
--- a/source/extensions/filters/http/set_metadata/config.cc
+++ b/source/extensions/filters/http/set_metadata/config.cc
@@ -25,6 +25,17 @@ Http::FilterFactoryCb SetMetadataConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
+Http::FilterFactoryCb SetMetadataConfig::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext&) {
+  ConfigSharedPtr filter_config(std::make_shared<Config>(proto_config));
+
+  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(
+        Http::StreamDecoderFilterSharedPtr{new SetMetadataFilter(filter_config)});
+  };
+}
+
 REGISTER_FACTORY(SetMetadataConfig, Server::Configuration::NamedHttpFilterConfigFactory);
 
 } // namespace SetMetadataFilter

--- a/source/extensions/filters/http/set_metadata/config.h
+++ b/source/extensions/filters/http/set_metadata/config.h
@@ -22,6 +22,11 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& server_context) override;
 };
 
 } // namespace SetMetadataFilter

--- a/test/extensions/filters/http/set_metadata/config_test.cc
+++ b/test/extensions/filters/http/set_metadata/config_test.cc
@@ -42,6 +42,29 @@ value:
   cb(filter_callbacks);
 }
 
+TEST(SetMetadataFilterConfigTest, SimpleConfigServerContext) {
+  const std::string yaml = R"EOF(
+metadata_namespace: thenamespace
+value:
+  mynumber: 20
+  mylist: ["b"]
+  tags:
+    mytag1: 1
+  )EOF";
+
+  SetMetadataProtoConfig proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  SetMetadataConfig factory;
+
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
+  cb(filter_callbacks);
+}
+
 } // namespace SetMetadataFilter
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
Implements `createFilterFactoryFromProtoWithServerContextTyped` API for set_metadata filter. Actually this filter doesn't care/use the context object