### PR TITLE
route_check_tool: add new detailed-coverage flag

### DIFF
--- a/docs/root/operations/tools/route_table_check_tool.rst
+++ b/docs/root/operations/tools/route_table_check_tool.rst
@@ -43,6 +43,9 @@ Usage
     --disable-deprecation-check
       Disables the deprecation check for RouteConfiguration proto.
 
+    --detailed-coverage
+      Enables displaying of not covered routes for non-comprehensive code coverage mode.
+
     -h,  --help
       Displays usage information and exits.
 

--- a/test/tools/router_check/coverage.h
+++ b/test/tools/router_check/coverage.h
@@ -49,13 +49,15 @@ public:
   void markHostRewriteCovered(const Envoy::Router::Route& route);
   void markRedirectPathCovered(const Envoy::Router::Route& route);
   void markRedirectCodeCovered(const Envoy::Router::Route& route);
-  double report();
-  double detailedReport();
+  double report(bool detailed_coverage_report);
+  double comprehensiveReport();
 
 private:
   RouteCoverage& coveredRoute(const Envoy::Router::Route& route);
   void printMissingTests(const std::set<std::string>& all_route_names,
                          const std::set<std::string>& covered_route_names);
+  void printNotCoveredRouteNames(const std::set<std::string>& all_route_names,
+                                 const std::set<std::string>& covered_route_names);
   std::vector<std::unique_ptr<RouteCoverage>> covered_routes_;
   const envoy::config::route::v3::RouteConfiguration route_config_;
 };

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -20,6 +20,8 @@
 
 #include "test/test_common/printers.h"
 
+#include "absl/strings/str_format.h"
+
 namespace {
 
 const std::string toString(envoy::type::matcher::v3::StringMatcher::MatchPatternCase pattern) {
@@ -151,7 +153,8 @@ void RouterCheckTool::assignUniqueRouteNames(
   Random::RandomGeneratorImpl random;
   for (auto& host : *route_config.mutable_virtual_hosts()) {
     for (auto& route : *host.mutable_routes()) {
-      route.set_name(random.uuid());
+      std::string name = absl::StrFormat("%s-%s", route.name(), random.uuid());
+      route.set_name(name);
     }
   }
 }
@@ -634,6 +637,8 @@ Options::Options(int argc, char** argv) {
       "o", "output-path", "Path to output file to write test results", false, "", "string", cmd);
   TCLAP::UnlabeledMultiArg<std::string> unlabelled_configs(
       "unlabelled-configs", "unlabelled configs", false, "unlabelledConfigStrings", cmd);
+  TCLAP::SwitchArg detailed_coverage(
+      "", "detailed-coverage", "Show detailed coverage with routes without tests", cmd, false);
   try {
     cmd.parse(argc, argv);
   } catch (TCLAP::ArgException& e) {
@@ -646,6 +651,7 @@ Options::Options(int argc, char** argv) {
   fail_under_ = fail_under.getValue();
   comprehensive_coverage_ = comprehensive_coverage.getValue();
   disable_deprecation_check_ = disable_deprecation_check.getValue();
+  detailed_coverage_report_ = detailed_coverage.getValue();
 
   config_path_ = config_path.getValue();
   test_path_ = test_path.getValue();

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -85,8 +85,14 @@ public:
    */
   void setOnlyShowFailures() { only_show_failures_ = true; }
 
-  float coverage(bool detailed) {
-    return detailed ? coverage_.detailedReport() : coverage_.report();
+  /**
+   * Set whether to print out detailed coverage report.
+   */
+  void setDetailedCoverageReport() { detailed_coverage_report_ = true; }
+
+  float coverage(bool comprehensive_coverage) {
+    return comprehensive_coverage ? coverage_.comprehensiveReport()
+                                  : coverage_.report(detailed_coverage_report_);
   }
 
 private:
@@ -177,6 +183,8 @@ private:
 
   bool only_show_failures_{false};
 
+  bool detailed_coverage_report_{false};
+
   // The first member of each pair is the name of the test.
   // The second member is a list of any failing results for that test as strings.
   std::vector<std::pair<std::string, std::vector<std::string>>> tests_;
@@ -233,6 +241,11 @@ public:
   bool disableDeprecationCheck() const { return disable_deprecation_check_; }
 
   /**
+   * @return true if detailed coverage report is displayed.
+   */
+  bool detailedCoverageReport() const { return detailed_coverage_report_; }
+
+  /**
    * @return the path to save tests results.
    */
   const std::string& outputPath() const { return output_path_; }
@@ -245,6 +258,7 @@ private:
   bool is_detailed_;
   bool only_show_failures_;
   bool disable_deprecation_check_;
+  bool detailed_coverage_report_;
   std::string output_path_;
 };
 } // namespace Envoy

--- a/test/tools/router_check/router_check.cc
+++ b/test/tools/router_check/router_check.cc
@@ -44,6 +44,10 @@ int main(int argc, char* argv[]) {
       checktool.setOnlyShowFailures();
     }
 
+    if (options.detailedCoverageReport()) {
+      checktool.setDetailedCoverageReport();
+    }
+
     const std::vector<envoy::RouterCheckToolSchema::ValidationItemResult> test_results =
         checktool.compareEntries(options.testPath());
     if (!options.outputPath().empty()) {

--- a/test/tools/router_check/test/config/DetailedCoverage.golden.proto.json
+++ b/test/tools/router_check/test/config/DetailedCoverage.golden.proto.json
@@ -1,0 +1,27 @@
+{
+  "tests": [
+    {
+      "test_name": "TEST_NEW_ENDPOINT_ROUTE_1",
+      "input": {
+        "authority": "example.com",
+        "path": "/new_endpoint",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "www2",
+        "path_rewrite": "/api/new_endpoint"
+      }
+    },
+    {
+      "test_name": "TEST_ROOT_ROUTE",
+      "input": {
+        "authority": "example.com",
+        "path": "/root",
+        "method": "GET"
+      },
+      "validate": {
+        "cluster_name": "www2"
+      }
+    }
+  ]
+}

--- a/test/tools/router_check/test/config/DetailedCoverage.yaml
+++ b/test/tools/router_check/test/config/DetailedCoverage.yaml
@@ -1,0 +1,24 @@
+virtual_hosts:
+- name: localhost
+  domains:
+  - example.com
+  routes:
+  - name: new_endpoint
+    match:
+      prefix: /new_endpoint
+    route:
+      cluster: www2
+      prefix_rewrite: /api/new_endpoint
+  - name: new_endpoint2
+    match:
+      path: /new_endpoint2
+    route:
+      cluster: root_www2
+  - match:
+      prefix: /root
+    route:
+      cluster: www2
+  - match:
+      prefix: /no_name
+    route:
+      cluster: www3

--- a/test/tools/router_check/test/route_tests.sh
+++ b/test/tools/router_check/test/route_tests.sh
@@ -111,3 +111,23 @@ MISSING_OUTPUT=$("${PATH_BIN}" "-c" "${PATH_CONFIG}/TestRoutes.yaml" "-t" "${PAT
 if [[ "${MISSING_OUTPUT}" != *"Missing test for host: www2_staging, route: prefix: \"/\""*"Missing test for host: default, route: prefix: \"/api/application_data\""* ]]; then
   exit 1
 fi
+
+# Detaied coverage flag
+echo "test report should contain missing tests with detailed coverage flag"
+MISSING_OUTPUT=$("${PATH_BIN}" "-c" "${PATH_CONFIG}/DetailedCoverage.yaml" "-t" "${PATH_CONFIG}/DetailedCoverage.golden.proto.json" "--detailed-coverage" 2>&1) ||
+  echo "${MISSING_OUTPUT:-no-output}"
+if ! echo "${MISSING_OUTPUT}" | grep -qE "Missing test for host: localhost, route name: new_endpoint2-.+"; then
+  exit 1
+fi
+
+if ! echo "${MISSING_OUTPUT}" | grep -qE "Missing test for host: localhost, route name: -.+"; then
+  exit 1
+fi
+
+echo "test report shoud not contain missing tests without detailed coverage flag"
+MISSING_OUTPUT=$("${PATH_BIN}" "-c" "${PATH_CONFIG}/DetailedCoverage.yaml" "-t" "${PATH_CONFIG}/DetailedCoverage.golden.proto.json" 2>&1) ||
+  echo "${MISSING_OUTPUT:-no-output}"
+if echo "${MISSING_OUTPUT}" | grep -qE "Missing test for host:.+"; then
+  echo "Error"
+  exit 1
+fi


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

### Commit Message:
 route_check_tool: add new detailed-coverage flag
### Additional Description:
 Add a new flag to enable displaying/printing not covered routes in non-comprehensive code coverage mode. 
Currently,  you can see missing tests/not covered routes only if you use comprehensive code coverage mode (--covall). These changes enable this feature for non-comprehensive mode.
### Docs Changes:
`route_table_check_tool.rst` has been updated

Fixes #28709

