### PR TITLE
CEL Attributes: Check status header for response code if not set on stream info

### DIFF
--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -152,7 +152,14 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
   }
   auto value = key.StringOrDie().value();
   if (value == Code) {
-    auto code = info_.responseCode();
+    absl::optional<uint32_t> code;
+    uint32_t maybecode;
+    if (info_.responseCode().has_value()) {
+      code.emplace(info_.responseCode().value());
+    } else if (headers_.value_ != nullptr &&
+               absl::SimpleAtoi(headers_.value_->getStatusValue(), &maybecode)) {
+      code.emplace(maybecode);
+    }
     if (code.has_value()) {
       return CelValue::CreateInt64(code.value());
     }


### PR DESCRIPTION
Commit Message:
When processing CEL expressions, it is possible for the `info_` field to be set to a stream_info which does not contain the response code. This change allows the expression context to check status header for response code if it is not set on `info_`.
Additional Description:
Risk Level: Low
Testing: TODO
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
