### PR TITLE
ci: Update the mobile_release workflow with the changed config options

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -53,7 +53,7 @@ jobs:
           --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
           --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a \
           --define=pom_version="$version" \
-          --config=release-android \
+          --config=mobile-release-android \
           --linkopt=-fuse-ld=lld \
           //:android_dist
     - name: 'Tar artifacts'


### PR DESCRIPTION
The mobile Bazel options were updated in
https://github.com/envoyproxy/envoy/pull/28856, but the mobile_release workflow wasn't updated to use mobile-release-android. It was probably not caught by CI because it is a scheduled workflow that is run once a week as opposed to running on every PR.