### PR TITLE
stream_info: encapsulate response_code_

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -301,7 +301,7 @@ void AsyncRequestSharedImpl::onComplete() {
 
 void AsyncRequestSharedImpl::onHeaders(ResponseHeaderMapPtr&& headers, bool) {
   const uint64_t response_code = Http::Utility::getResponseStatus(*headers);
-  streamInfo().response_code_ = response_code;
+  streamInfo().setResponseCode(response_code);
   response_ = std::make_unique<ResponseMessageImpl>(std::move(headers));
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -932,7 +932,7 @@ void ConnectionManagerImpl::ActiveStream::onStreamMaxDurationReached() {
 
 void ConnectionManagerImpl::ActiveStream::chargeStats(const ResponseHeaderMap& headers) {
   uint64_t response_code = Utility::getResponseStatus(headers);
-  filter_manager_.streamInfo().response_code_ = response_code;
+  filter_manager_.streamInfo().setResponseCode(response_code);
 
   if (filter_manager_.streamInfo().health_check_request_) {
     return;

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -283,7 +283,7 @@ void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool e
   if (!parent_.config().upstream_logs_.empty()) {
     upstream_headers_ = Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*headers);
   }
-  stream_info_.response_code_ = static_cast<uint32_t>(response_code);
+  stream_info_.setResponseCode(static_cast<uint32_t>(response_code));
 
   maybeHandleDeferredReadDisable();
   ASSERT(headers.get());

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -410,7 +410,11 @@ struct StreamInfoImpl : public StreamInfo {
   absl::optional<MonotonicTime> final_time_;
 
   absl::optional<Http::Protocol> protocol_;
+
+private:
   absl::optional<uint32_t> response_code_;
+
+public:
   absl::optional<std::string> response_code_details_;
   absl::optional<std::string> connection_termination_details_;
   uint64_t response_flags_{};

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -277,7 +277,7 @@ typed_config:
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
            AccessLog::AccessLogType::NotSet);
 
-  stream_info_.response_code_ = 200;
+  stream_info_.setResponseCode(200);
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
            AccessLog::AccessLogType::NotSet);
 }
@@ -317,11 +317,11 @@ typed_config:
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
            AccessLog::AccessLogType::NotSet);
 
-  stream_info_.response_code_ = 500;
+  stream_info_.setResponseCode(500);
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
            AccessLog::AccessLogType::NotSet);
 
-  stream_info_.response_code_ = 200;
+  stream_info_.setResponseCode(200);
   stream_info_.end_time_ =
       stream_info_.startTimeMonotonic() + std::chrono::microseconds(1001000000000000);
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
@@ -599,7 +599,7 @@ typed_config:
   )EOF";
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
-  stream_info_.response_code_ = 500;
+  stream_info_.setResponseCode(500);
 
   {
     EXPECT_CALL(*file_, write(_));
@@ -682,7 +682,7 @@ typed_config:
   )EOF";
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
-  stream_info_.response_code_ = 500;
+  stream_info_.setResponseCode(500);
 
   {
     EXPECT_CALL(*file_, write(_));
@@ -801,7 +801,7 @@ status_code_filter:
   Http::TestResponseTrailerMapImpl response_trailers;
   TestStreamInfo info(time_source);
 
-  info.response_code_ = 400;
+  info.setResponseCode(400);
   EXPECT_CALL(runtime.snapshot_, getInteger("key", 300)).WillOnce(Return(350));
   EXPECT_TRUE(filter.evaluate(info, request_headers, response_headers, response_trailers,
                               AccessLog::AccessLogType::NotSet));
@@ -828,13 +828,13 @@ typed_config:
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
-  stream_info_.response_code_ = 499;
+  stream_info_.setResponseCode(499);
   EXPECT_CALL(runtime_.snapshot_, getInteger("hello", 499)).WillOnce(Return(499));
   EXPECT_CALL(*file_, write(_));
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
            AccessLog::AccessLogType::NotSet);
 
-  stream_info_.response_code_ = 500;
+  stream_info_.setResponseCode(500);
   EXPECT_CALL(runtime_.snapshot_, getInteger("hello", 499)).WillOnce(Return(499));
   EXPECT_CALL(*file_, write(_)).Times(0);
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
@@ -1338,7 +1338,7 @@ typed_config:
       {"UNAVAILABLE", 502},       {"UNAVAILABLE", 503}, {"UNAVAILABLE", 504}};
 
   for (const auto& [response_string, response_code] : statusMapping) {
-    stream_info_.response_code_ = response_code;
+    stream_info_.setResponseCode(response_code);
 
     const InstanceSharedPtr log = AccessLogFactory::fromProto(
         parseAccessLogFromV3Yaml(fmt::format(yaml_template, response_string)), context_);
@@ -1844,7 +1844,7 @@ typed_config:
   InstanceSharedPtr logger = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   request_headers_.addCopy("log", "true");
-  stream_info_.response_code_ = 404;
+  stream_info_.setResponseCode(404);
   EXPECT_CALL(*file_, write(_));
   logger->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
               AccessLog::AccessLogType::NotSet);

--- a/test/common/local_reply/local_reply_test.cc
+++ b/test/common/local_reply/local_reply_test.cc
@@ -51,7 +51,7 @@ TEST_F(LocalReplyTest, TestEmptyConfig) {
 
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
-  EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
+  EXPECT_EQ(stream_info_.responseCode(), static_cast<uint32_t>(TestInitCode));
   EXPECT_EQ(response_headers_.Status()->value().getStringView(),
             std::to_string(enumToInt(TestInitCode)));
   EXPECT_EQ(body_, TestInitBody);
@@ -64,7 +64,7 @@ TEST_F(LocalReplyTest, TestDefaultLocalReply) {
 
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
-  EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
+  EXPECT_EQ(stream_info_.responseCode(), static_cast<uint32_t>(TestInitCode));
   EXPECT_EQ(response_headers_.Status()->value().getStringView(),
             std::to_string(enumToInt(TestInitCode)));
   EXPECT_EQ(body_, TestInitBody);
@@ -114,7 +114,7 @@ TEST_F(LocalReplyTest, TestDefaultTextFormatter) {
 
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
-  EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
+  EXPECT_EQ(stream_info_.responseCode(), static_cast<uint32_t>(TestInitCode));
   EXPECT_EQ(response_headers_.Status()->value().getStringView(),
             std::to_string(enumToInt(TestInitCode)));
   EXPECT_EQ(body_, "Init body text 200");
@@ -136,7 +136,7 @@ TEST_F(LocalReplyTest, TestDefaultJsonFormatter) {
 
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
-  EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
+  EXPECT_EQ(stream_info_.responseCode(), static_cast<uint32_t>(TestInitCode));
   EXPECT_EQ(response_headers_.Status()->value().getStringView(),
             std::to_string(enumToInt(TestInitCode)));
   EXPECT_EQ(content_type_, "application/json");
@@ -205,7 +205,7 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
   resetData(400);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(401));
-  EXPECT_EQ(stream_info_.response_code_, 401U);
+  EXPECT_EQ(stream_info_.responseCode(), 401U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "401");
   EXPECT_EQ(body_, "400 body text");
   EXPECT_EQ(content_type_, "text/plain");
@@ -215,7 +215,7 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
   body_ = "original body text";
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(403));
-  EXPECT_EQ(stream_info_.response_code_, 403U);
+  EXPECT_EQ(stream_info_.responseCode(), 403U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "403");
   EXPECT_EQ(body_, "");
   EXPECT_EQ(content_type_, "text/plain");
@@ -224,7 +224,7 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
   resetData(410);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(410));
-  EXPECT_EQ(stream_info_.response_code_, 410U);
+  EXPECT_EQ(stream_info_.responseCode(), 410U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "410");
   EXPECT_EQ(body_, "410 body text");
   EXPECT_EQ(content_type_, "text/plain");
@@ -233,7 +233,7 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
   resetData(420);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(421));
-  EXPECT_EQ(stream_info_.response_code_, 421U);
+  EXPECT_EQ(stream_info_.responseCode(), 421U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "421");
   EXPECT_EQ(body_, TestInitBody);
   EXPECT_EQ(content_type_, "text/plain");
@@ -242,7 +242,7 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
   resetData(430);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(430));
-  EXPECT_EQ(stream_info_.response_code_, 430U);
+  EXPECT_EQ(stream_info_.responseCode(), 430U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "430");
   EXPECT_EQ(body_, TestInitBody);
   EXPECT_EQ(content_type_, "text/plain");
@@ -273,7 +273,7 @@ TEST_F(LocalReplyTest, DEPRECATED_FEATURE_TEST(TestMapperRewriteDeprecatedTextFo
   body_ = "original body text";
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(404));
-  EXPECT_EQ(stream_info_.response_code_, 404U);
+  EXPECT_EQ(stream_info_.responseCode(), 404U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "404");
   EXPECT_EQ(body_, "");
   EXPECT_EQ(content_type_, "text/plain");
@@ -321,7 +321,7 @@ TEST_F(LocalReplyTest, TestMapperFormat) {
   resetData(400);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(401));
-  EXPECT_EQ(stream_info_.response_code_, 401U);
+  EXPECT_EQ(stream_info_.responseCode(), 401U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "401");
   EXPECT_EQ(content_type_, "application/json");
 
@@ -338,7 +338,7 @@ TEST_F(LocalReplyTest, TestMapperFormat) {
   resetData(410);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(411));
-  EXPECT_EQ(stream_info_.response_code_, 411U);
+  EXPECT_EQ(stream_info_.responseCode(), 411U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "411");
   EXPECT_EQ(body_, "411 body text 411 default formatter");
   EXPECT_EQ(content_type_, "text/plain");
@@ -381,7 +381,7 @@ TEST_F(LocalReplyTest, TestHeaderAddition) {
   local->rewrite(&request_headers_with_req_id, response_headers_, stream_info_, code_, body_,
                  content_type_);
   EXPECT_EQ(code_, TestInitCode);
-  EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
+  EXPECT_EQ(stream_info_.responseCode(), static_cast<uint32_t>(TestInitCode));
   EXPECT_EQ(content_type_, "text/plain");
 
   EXPECT_EQ(response_headers_.get_("foo-1"), "bar1");
@@ -448,7 +448,7 @@ TEST_F(LocalReplyTest, TestMapperWithContentType) {
   resetData(400);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(401));
-  EXPECT_EQ(stream_info_.response_code_, 401U);
+  EXPECT_EQ(stream_info_.responseCode(), 401U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "401");
   EXPECT_EQ(body_, "<h1>401 body text</h1>");
   EXPECT_EQ(content_type_, "text/html; charset=UTF-8");
@@ -459,7 +459,7 @@ TEST_F(LocalReplyTest, TestMapperWithContentType) {
   resetData(410);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(411));
-  EXPECT_EQ(stream_info_.response_code_, 411U);
+  EXPECT_EQ(stream_info_.responseCode(), 411U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "411");
   EXPECT_EQ(body_, "<h1>411 body text</h1> 411 default formatter");
   EXPECT_EQ(content_type_, "text/html; charset=UTF-8");
@@ -470,7 +470,7 @@ TEST_F(LocalReplyTest, TestMapperWithContentType) {
   resetData(420);
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(421));
-  EXPECT_EQ(stream_info_.response_code_, 421U);
+  EXPECT_EQ(stream_info_.responseCode(), 421U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "421");
   EXPECT_EQ(body_, "421 body text");
   EXPECT_EQ(content_type_, "text/plain");

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -166,7 +166,7 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     EXPECT_EQ(Http::Protocol::Http10, stream_info.protocol().value());
 
     EXPECT_FALSE(stream_info.responseCode());
-    stream_info.response_code_ = 200;
+    stream_info.setResponseCode(200);
     ASSERT_TRUE(stream_info.responseCode());
     EXPECT_EQ(200, stream_info.responseCode().value());
 

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -64,7 +64,7 @@ public:
         TestUtility::parseTime("Dec 18 01:50:34 2018 GMT", "%b %e %H:%M:%S %Y GMT");
     stream_info_.start_time_ = absl::ToChronoTime(abslStartTime);
     stream_info_.upstreamInfo()->setUpstreamHost(nullptr);
-    stream_info_.response_code_ = 200;
+    stream_info_.setResponseCode(200);
 
     EXPECT_CALL(*file, write(_)).WillOnce(Invoke([expected, is_json](absl::string_view got) {
       if (is_json) {

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -317,7 +317,7 @@ response: {}
     stream_info.protocol_ = Http::Protocol::Http10;
     stream_info.addBytesReceived(10);
     stream_info.addBytesSent(20);
-    stream_info.response_code_ = 200;
+    stream_info.setResponseCode(200);
     stream_info.response_code_details_ = "via_upstream";
     absl::string_view route_name_view("route-name-test");
     stream_info.setRouteName(route_name_view);

--- a/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
@@ -108,7 +108,7 @@ TEST_F(AccessLogTest, Marshalling) {
   stream_info.downstream_timing_.onLastDownstreamRxByteReceived(time_system);
   stream_info.protocol_ = Http::Protocol::Http10;
   stream_info.addBytesReceived(10);
-  stream_info.response_code_ = 200;
+  stream_info.setResponseCode(200);
 
   Http::TestRequestHeaderMapImpl request_headers{
       {"x-request-header", "test-request-header"},

--- a/test/extensions/access_loggers/stream/stream_test_base.h
+++ b/test/extensions/access_loggers/stream/stream_test_base.h
@@ -43,7 +43,7 @@ protected:
         TestUtility::parseTime("Dec 18 01:50:34 2018 GMT", "%b %e %H:%M:%S %Y GMT");
     stream_info_.start_time_ = absl::ToChronoTime(abslStartTime);
     stream_info_.upstreamInfo()->setUpstreamHost(nullptr);
-    stream_info_.response_code_ = 200;
+    stream_info_.setResponseCode(200);
 
     EXPECT_CALL(*file, write(_)).WillOnce(Invoke([expected, is_json](absl::string_view got) {
       if (is_json) {

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -151,7 +151,7 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
           : stream_info.start_time() / 1000;
   test_stream_info->start_time_ = SystemTime(std::chrono::microseconds(start_time));
   if (stream_info.has_response_code()) {
-    test_stream_info->response_code_ = stream_info.response_code().value();
+    test_stream_info->setResponseCode(stream_info.response_code().value());
   }
   auto upstream_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
   auto upstream_metadata = std::make_shared<envoy::config::core::v3::Metadata>(


### PR DESCRIPTION
Commit Message: Use the existing accessors instead of the direct field.
Risk Level: low
Testing: 
Docs Changes: none
Release Notes: none