### PR TITLE
[WIP] http conn man: Add `http1.protocol_error` counter 

### DIFF
--- a/docs/root/configuration/http/http_conn_man/stats.rst
+++ b/docs/root/configuration/http/http_conn_man/stats.rst
@@ -148,6 +148,7 @@ On the upstream side all http1 statistics are rooted at ``cluster.<name>.http1.`
    ``metadata_not_supported_error``, Counter, Total number of metadata dropped during HTTP/1 encoding
    ``response_flood``, Counter, Total number of connections closed due to response flooding
    ``requests_rejected_with_underscores_in_headers``, Counter, Total numbers of rejected requests due to header names containing underscores. This action is configured by setting the :ref:`headers_with_underscores_action config setting <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.headers_with_underscores_action>`.
+   ``protocol_error``, Counter, Total number of requests that resulted in an error in the http_parser internals.
 
 HTTP/2 codec statistics
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -637,8 +637,15 @@ Http::Status ClientConnectionImpl::dispatch(Buffer::Instance& data) {
   if (status.ok() && data.length() > 0) {
     // The HTTP/1.1 codec pauses dispatch after a single response is complete. Extraneous data
     // after a response is complete indicates an error.
+    stats_.protocol_error_.inc();
     return codecProtocolError("http/1.1 protocol error: extraneous data after response complete");
   }
+
+  if (!status.ok()) {
+    ASSERT(isCodecProtocolError(status.status()));
+    stats_.protocol_error_.inc();
+  }
+
   return status;
 }
 

--- a/source/common/http/http1/codec_stats.h
+++ b/source/common/http/http1/codec_stats.h
@@ -17,7 +17,8 @@ namespace Http1 {
   COUNTER(dropped_headers_with_underscores)                                                        \
   COUNTER(metadata_not_supported_error)                                                            \
   COUNTER(requests_rejected_with_underscores_in_headers)                                           \
-  COUNTER(response_flood)
+  COUNTER(response_flood)                                                                          \
+  COUNTER(protocol_error)
 
 /**
  * Wrapper struct for the HTTP/1 codec stats. @see stats_macros.h

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4820,6 +4820,7 @@ TEST_P(Http1ServerConnectionImplTest, Char22InHeaderValue) {
   auto status = codec_->dispatch(buffer);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.message(), "http/1.1 protocol error: header value contains invalid chars");
+  EXPECT_EQ(1, store_.counter("http1.protocol_error").value());
 }
 
 TEST_P(Http1ClientConnectionImplTest, MultipleContentLength) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
