### PR TITLE
Make waitForDisconnect more responsive

### DIFF
--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -94,6 +94,9 @@ AssertionResult IntegrationTcpClient::waitForData(size_t length,
 }
 
 void IntegrationTcpClient::waitForDisconnect(bool ignore_spurious_events) {
+  if (disconnected_) {
+    return;
+  }
   Event::TimerPtr timeout_timer =
       connection_->dispatcher().createTimer([this]() -> void { connection_->dispatcher().exit(); });
   timeout_timer->enableTimer(TestUtility::DefaultTimeout);


### PR DESCRIPTION
Commit Message:
Return from waitForDisconnect immediately if connection was already disconnected.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
