### PR TITLE
Split out optref into a dedicated target

### DIFF
--- a/envoy/common/BUILD
+++ b/envoy/common/BUILD
@@ -12,11 +12,10 @@ envoy_package()
 envoy_basic_cc_library(
     name = "base_includes",
     hdrs = [
-        "optref.h",
         "platform.h",
         "pure.h",
     ],
-    external_deps = ["abseil_optional"],
+    external_deps = ["abseil_strings"],
 )
 
 envoy_basic_cc_library(
@@ -24,6 +23,14 @@ envoy_basic_cc_library(
     hdrs = [
         "exception.h",
     ],
+)
+
+envoy_basic_cc_library(
+    name = "optref_lib",
+    hdrs = [
+        "optref.h",
+    ],
+    external_deps = ["abseil_optional"],
 )
 
 envoy_cc_library(

--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -184,6 +184,7 @@ envoy_cc_library(
     name = "header_formatter_interface",
     hdrs = ["header_formatter.h"],
     deps = [
+        "//envoy/common:optref_lib",
         "//envoy/config:typed_config_interface",
     ],
 )

--- a/envoy/stats/BUILD
+++ b/envoy/stats/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
     deps = [
         ":refcount_ptr_interface",
         "//envoy/common:interval_set_interface",
+        "//envoy/common:optref_lib",
         "//envoy/common:time_interface",
     ],
 )

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -467,6 +467,7 @@ envoy_cc_library(
         ":upstream_server_name_lib",
         ":upstream_subject_alt_names_lib",
         "//envoy/common:hashable_interface",
+        "//envoy/common:optref_lib",
         "//envoy/network:proxy_protocol_options_lib",
         "//envoy/network:transport_socket_interface",
         "//envoy/stream_info:filter_state_interface",

--- a/source/extensions/access_loggers/common/BUILD
+++ b/source/extensions/access_loggers/common/BUILD
@@ -27,7 +27,7 @@ envoy_cc_library(
     srcs = ["grpc_access_logger_utils.cc"],
     hdrs = ["grpc_access_logger_utils.h"],
     deps = [
-        "//envoy/common:base_includes",
+        "//envoy/common:optref_lib",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
     ],
 )


### PR DESCRIPTION
Commit Message:
This makes the targets that need it more explicit.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
