### PR TITLE
config subscription: make grpc_mux_lib an extension

### DIFF
--- a/source/extensions/config_subscription/grpc/BUILD
+++ b/source/extensions/config_subscription/grpc/BUILD
@@ -22,7 +22,7 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_library(
+envoy_cc_extension(
     name = "grpc_mux_lib",
     srcs = ["grpc_mux_impl.cc"],
     hdrs = ["grpc_mux_impl.h"],


### PR DESCRIPTION
Commit Message: config subscription: make grpc_mux_lib an extension
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A


My envoy deployment overrides `extensions_build_config.bzl`. After upgrading from v1.25 v1.27, we saw the following error when starting envoy
```
2023-08-16_06:40:39.05042 [2023-08-16 06:40:39.050][123041][critical][main] [external/envoy/source/server/server.cc:134] error initializing config 'config.yaml': envoy.config_mux.grpc_mux_factory not found
```
This PR makes `grpc_mux_lib` an extension so that we can include `envoy.config_mux.grpc_mux_factory` in our `extensions_build_config.bzl`, which resolves the error.