### PR TITLE
fix go network extension close without reason

### DIFF
--- a/contrib/golang/filters/network/source/golang.cc
+++ b/contrib/golang/filters/network/source/golang.cc
@@ -32,7 +32,7 @@ void Filter::close(Network::ConnectionCloseType close_type) {
   }
   ENVOY_CONN_LOG(debug, "close addr: {}, type: {}", read_callbacks_->connection(), addr_,
                  static_cast<int>(close_type));
-  read_callbacks_->connection().close(close_type);
+  read_callbacks_->connection().close(close_type, "go_downstream_close");
 }
 
 void Filter::write(Buffer::Instance& buf, bool end_stream) {

--- a/contrib/golang/filters/network/source/upstream.cc
+++ b/contrib/golang/filters/network/source/upstream.cc
@@ -114,7 +114,7 @@ void UpstreamConn::close(Network::ConnectionCloseType close_type) {
   ENVOY_CONN_LOG(debug, "close addr: {}, type: {}", conn_->connection(), addr_,
                  static_cast<int>(close_type));
   ASSERT(conn_ != nullptr);
-  conn_->connection().close(close_type);
+  conn_->connection().close(close_type, "go_upstream_close");
 }
 
 void UpstreamConn::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn,

--- a/contrib/golang/filters/network/test/filter_test.cc
+++ b/contrib/golang/filters/network/test/filter_test.cc
@@ -105,7 +105,7 @@ TEST_F(FilterTest, WriteAndClose) {
   EXPECT_CALL(filter_callbacks_.connection_, write(_, false));
   filter_->write(someData, false);
 
-  EXPECT_CALL(filter_callbacks_.connection_, close(_));
+  EXPECT_CALL(filter_callbacks_.connection_, close(_, "go_downstream_close"));
   EXPECT_CALL(*dso_.get(), envoyGoFilterOnDownstreamEvent(_, _));
   filter_->close(Network::ConnectionCloseType::NoFlush);
 

--- a/contrib/golang/filters/network/test/upstream_test.cc
+++ b/contrib/golang/filters/network/test/upstream_test.cc
@@ -112,7 +112,7 @@ TEST_F(UpstreamConnTest, WriteAndClose) {
   EXPECT_CALL(upstream_connection_, write(_, false));
   upConn_->write(someData, false);
 
-  EXPECT_CALL(upstream_connection_, close(_));
+  EXPECT_CALL(upstream_connection_, close(_, "go_upstream_close"));
   EXPECT_CALL(*dso_.get(), envoyGoFilterOnUpstreamEvent(_, _));
   upConn_->close(Network::ConnectionCloseType::NoFlush);
   upConn_->onEvent(Network::ConnectionEvent::RemoteClose);


### PR DESCRIPTION
Commit Message: fix go network extension close without reason
Additional Description: N/A
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
