### PR TITLE
cluster: return nullptr when tls shutdown for thread local cluster

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -986,6 +986,10 @@ void ClusterManagerImpl::updateClusterCounts() {
 }
 
 ThreadLocalCluster* ClusterManagerImpl::getThreadLocalCluster(absl::string_view cluster) {
+  // If the thread local begins to shutdown, then return nullptr.
+  if (tls_.isShutdown()) {
+    return nullptr;
+  }
   ThreadLocalClusterManagerImpl& cluster_manager = *tls_;
 
   auto entry = cluster_manager.thread_local_clusters_.find(cluster);

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -670,6 +670,8 @@ TEST_F(ClusterManagerImplTest, LocalClusterDefined) {
   checkStats(3 /*added*/, 0 /*modified*/, 0 /*removed*/, 3 /*active*/, 0 /*warming*/);
 
   factory_.tls_.shutdownThread();
+
+  EXPECT_EQ(nullptr, cluster_manager_->getThreadLocalCluster("cluster_1"));
 }
 
 TEST_F(ClusterManagerImplTest, DuplicateCluster) {


### PR DESCRIPTION
Commit Message: cluster: return nullptr when tls shutdown for thread local cluster
Additional Description:
After the tls shutdown, `ClusterManagerImpl::getThreadLocalCluster` shouldn't access the tls anymore. Add check for tls shutdown and return nullptr when tls shutdown.

Risk Level: low
Testing: unittest added
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #29054
Related to https://github.com/envoyproxy/envoy/issues/28395
