### PR TITLE
mobile: Remove bogus target in mobile/examples/cc/fetch_client/BUILD

### DIFF
--- a/mobile/examples/cc/fetch_client/BUILD
+++ b/mobile/examples/cc/fetch_client/BUILD
@@ -43,27 +43,3 @@ cc_binary(
         "@envoy//source/exe:process_wide_lib",
     ],
 )
-
-cc_test(
-    name = "fetch_client_test",
-    srcs = ["fetch_client_test.cc"],
-    tags = [
-        "requires-net:external",
-        "requires-net:ipv4",
-    ],
-    deps = [
-        ":fetch_client_lib",
-        "//testing/base/public:gunit_main",
-        "//third_party/envoy/src/mobile/envoy_build_config:extension_registry",
-        "//third_party/envoy/src/mobile/library/cc:envoy_engine_cc_lib_no_stamp",
-        "//third_party/envoy/src/source/common/api:api_lib",
-        "//third_party/envoy/src/source/common/common:random_generator_lib",
-        "//third_party/envoy/src/source/common/common:thread_lib",
-        "//third_party/envoy/src/source/common/event:real_time_system_lib",
-        "//third_party/envoy/src/source/common/stats:allocator_lib",
-        "//third_party/envoy/src/source/common/stats:thread_local_store_lib",
-        "//third_party/envoy/src/source/exe:platform_header_lib",
-        "//third_party/envoy/src/source/exe:platform_impl_lib",
-        "//third_party/envoy/src/source/exe:process_wide_lib",
-    ],
-)


### PR DESCRIPTION
mobile: Remove bogus target in mobile/examples/cc/fetch_client/BUILD

Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A