### PR TITLE
Revert "coverage: Use upstream coverage collect script (#28802)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -194,7 +194,6 @@ build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
 # Coverage options
 coverage --config=coverage
 coverage --build_tests_only
-
 build:coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
 build:coverage --action_env=GCOV=llvm-profdata
 build:coverage --copt=-DNDEBUG
@@ -203,12 +202,13 @@ build:coverage --test_timeout=390,750,1500,5700
 build:coverage --define=dynamic_link_tests=true
 build:coverage --define=ENVOY_CONFIG_COVERAGE=1
 build:coverage --cxxopt="-DENVOY_CONFIG_COVERAGE=1"
+build:coverage --coverage_support=@envoy//bazel/coverage:coverage_support
+build:coverage --test_env=CC_CODE_COVERAGE_SCRIPT=bazel/coverage/collect_cc_coverage.sh
 build:coverage --test_env=HEAPCHECK=
 build:coverage --combined_report=lcov
 build:coverage --strategy=TestRunner=sandboxed,local
 build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
-build:coverage --experimental_generate_llvm_lcov
 build:coverage --collect_code_coverage
 build:coverage --instrumentation_filter="^//source(?!/common/quic/platform)[/:],^//envoy[/:],^//contrib(?!/.*/test)[/:]"
 build:coverage --remote_download_toplevel

--- a/bazel/coverage/BUILD
+++ b/bazel/coverage/BUILD
@@ -1,3 +1,9 @@
 licenses(["notice"])  # Apache 2
 
+# TODO(lizan): Add test for this and upstream to upstream Bazel.
+filegroup(
+    name = "coverage_support",
+    srcs = ["collect_cc_coverage.sh"],
+)
+
 exports_files(["fuzz_coverage_wrapper.sh"])

--- a/bazel/coverage/collect_cc_coverage.sh
+++ b/bazel/coverage/collect_cc_coverage.sh
@@ -1,0 +1,175 @@
+#!/bin/bash -e
+#
+# This is a fork of https://github.com/bazelbuild/bazel/blob/3.1.0/tools/test/collect_cc_coverage.sh
+# to cover most of use cases in Envoy.
+# TODO(lizan): Move this to upstream Bazel
+#
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script collects code coverage data for C++ sources, after the tests
+# were executed.
+#
+# Bazel C++ code coverage collection support is poor and limited. There is
+# an ongoing effort to improve this (tracking issue #1118).
+#
+# Bazel uses the lcov tool for gathering coverage data. There is also
+# an experimental support for clang llvm coverage, which uses the .profraw
+# data files to compute the coverage report.
+#
+# This script assumes the following environment variables are set:
+# - COVERAGE_DIR            Directory containing metadata files needed for
+#                           coverage collection (e.g. gcda files, profraw).
+# - COVERAGE_MANIFEST       Location of the instrumented file manifest.
+# - COVERAGE_GCOV_PATH      Location of gcov. This is set by the TestRunner.
+# - COVERAGE_GCOV_OPTIONS   Additional options to pass to gcov.
+# - ROOT                    Location from where the code coverage collection
+#                           was invoked.
+#
+# The script looks in $COVERAGE_DIR for the C++ metadata coverage files (either
+# gcda or profraw) and uses either lcov or gcov to get the coverage data.
+# The coverage data is placed in $COVERAGE_OUTPUT_FILE.
+
+read -ra COVERAGE_GCOV_OPTIONS <<< "${COVERAGE_GCOV_OPTIONS:-}"
+
+# Checks if clang llvm coverage should be used instead of lcov.
+function uses_llvm() {
+  if stat "${COVERAGE_DIR}"/*.profraw >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+# Returns 0 if gcov must be used, 1 otherwise.
+function uses_gcov() {
+  [[ "$GCOV_COVERAGE" -eq "1"  ]] && return 0
+  return 1
+}
+
+function init_gcov() {
+  # Symlink the gcov tool such with a link called gcov. Clang comes with a tool
+  # called llvm-cov, which behaves like gcov if symlinked in this way (otherwise
+  # we would need to invoke it with "llvm-cov gcov").
+  # For more details see https://llvm.org/docs/CommandGuide/llvm-cov.html.
+  GCOV="${COVERAGE_DIR}/gcov"
+  ln -s "${COVERAGE_GCOV_PATH}" "${GCOV}"
+}
+
+# Computes code coverage data using the clang generated metadata found under
+# $COVERAGE_DIR.
+# Writes the collected coverage into the given output file.
+function llvm_coverage() {
+  local output_file="${1}" object_file object_files object_param=()
+  shift
+  export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
+  "${COVERAGE_GCOV_PATH}" merge -output "${output_file}.data" \
+      "${COVERAGE_DIR}"/*.profraw
+
+
+  object_files="$(find -L "${RUNFILES_DIR}" -type f -exec file -L {} \; \
+       | grep ELF | grep -v "LSB core" | sed 's,:.*,,')"
+
+  for object_file in ${object_files}; do
+    object_param+=(-object "${object_file}")
+  done
+
+  llvm-cov export -instr-profile "${output_file}.data" -format=lcov \
+      -ignore-filename-regex='.*external/.+' \
+      -ignore-filename-regex='/tmp/.+' \
+      "${object_param[@]}" | sed 's#/proc/self/cwd/##' > "${output_file}"
+}
+
+# Generates a code coverage report in gcov intermediate text format by invoking
+# gcov and using the profile data (.gcda) and notes (.gcno) files.
+#
+# The profile data files are expected to be found under $COVERAGE_DIR.
+# The notes file are expected to be found under $ROOT.
+#
+# - output_file     The location of the file where the generated code coverage
+#                   report is written.
+function gcov_coverage() {
+  local gcda gcno_path line output_file="${1}"
+  shift
+
+  # Copy .gcno files next to their corresponding .gcda files in $COVERAGE_DIR
+  # because gcov expects them to be in the same directory.
+  while read -r line; do
+    if [[ ${line: -4} == "gcno" ]]; then
+      gcno_path=${line}
+      gcda="${COVERAGE_DIR}/$(dirname "${gcno_path}")/$(basename "${gcno_path}" .gcno).gcda"
+      # If the gcda file was not found we skip generating coverage from the gcno
+      # file.
+      if [[ -f "$gcda" ]]; then
+          # gcov expects both gcno and gcda files to be in the same directory.
+          # We overcome this by copying the gcno to $COVERAGE_DIR where the gcda
+          # files are expected to be.
+          if [ ! -f "${COVERAGE_DIR}/${gcno_path}" ]; then
+              mkdir -p "${COVERAGE_DIR}/$(dirname "${gcno_path}")"
+              cp "$ROOT/${gcno_path}" "${COVERAGE_DIR}/${gcno_path}"
+          fi
+          # Invoke gcov to generate a code coverage report with the flags:
+          # -i              Output gcov file in an intermediate text format.
+          #                 The output is a single .gcov file per .gcda file.
+          #                 No source code is required.
+          # -o directory    The directory containing the .gcno and
+          #                 .gcda data files.
+          # "${gcda"}       The input file name. gcov is looking for data files
+          #                 named after the input filename without its extension.
+          # gcov produces files called <source file name>.gcov in the current
+          # directory. These contain the coverage information of the source file
+          # they correspond to. One .gcov file is produced for each source
+          # (or header) file containing code which was compiled to produce the
+          # .gcda files.
+          # Don't generate branch coverage (-b) because of a gcov issue that
+          # segfaults when both -i and -b are used (see
+          # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84879).
+          "${GCOV}" -i "${COVERAGE_GCOV_OPTIONS[@]}" -o "$(dirname "${gcda}")" "${gcda}"
+
+          # Append all .gcov files in the current directory to the output file.
+          cat ./*.gcov >> "$output_file"
+          # Delete the .gcov files.
+          rm ./*.gcov
+      fi
+    fi
+  done < "${COVERAGE_MANIFEST}"
+}
+
+function main() {
+  init_gcov
+
+  # If llvm code coverage is used, we output the raw code coverage report in
+  # the $COVERAGE_OUTPUT_FILE. This report will not be converted to any other
+  # format by LcovMerger.
+  # TODO(#5881): Convert profdata reports to lcov.
+  if uses_llvm; then
+    BAZEL_CC_COVERAGE_TOOL="PROFDATA"
+  fi
+
+  # When using either gcov or lcov, have an output file specific to the test
+  # and format used. For lcov we generate a ".dat" output file and for gcov
+  # a ".gcov" output file. It is important that these files are generated under
+  # COVERAGE_DIR.
+  # When this script is invoked by tools/test/collect_coverage.sh either of
+  # these two coverage reports will be picked up by LcovMerger and their
+  # content will be converted and/or merged with other reports to an lcov
+  # format, generating the final code coverage report.
+  case "$BAZEL_CC_COVERAGE_TOOL" in
+        ("GCOV") gcov_coverage "$COVERAGE_DIR/_cc_coverage.gcov" ;;
+        ("PROFDATA") llvm_coverage "$COVERAGE_DIR/_cc_coverage.dat" ;;
+        (*) echo "Coverage tool $BAZEL_CC_COVERAGE_TOOL not supported" \
+            && exit 1
+  esac
+}
+
+main

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -217,7 +217,10 @@ build:mobile-remote-ci-linux-coverage --strategy=CoverageReport=local,remote
 # Bazel remote caching is incompatible with C++ LLVM coverage so we need to deactivate it for coverage builds
 # TODO(lfpino): Reference upstream Bazel issue here on the incompatibility of remote caching and LLVM coverage.
 build:mobile-remote-ci-linux-coverage --noremote_accept_cached
+build:mobile-remote-ci-linux-coverage --remote_download_toplevel
+build:mobile-remote-ci-linux-coverage --build_runfile_links
 build:mobile-remote-ci-linux-coverage --legacy_important_outputs=false
+build:mobile-remote-ci-linux-coverage --test_env=CC_CODE_COVERAGE_SCRIPT=external/envoy/bazel/coverage/collect_cc_coverage.sh
 build:mobile-remote-ci-linux-coverage --nocache_test_results
 build:mobile-remote-ci-linux-coverage --config=ci
 build:mobile-remote-ci-linux-coverage --config=remote

--- a/test/extensions/tracers/dynamic_ot/BUILD
+++ b/test/extensions/tracers/dynamic_ot/BUILD
@@ -13,7 +13,6 @@ envoy_package()
 
 envoy_extension_cc_test(
     name = "dynamic_opentracing_driver_impl_test",
-    size = "large",
     srcs = [
         "dynamic_opentracing_driver_impl_test.cc",
     ],
@@ -36,7 +35,6 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "config_test",
-    size = "large",
     srcs = ["config_test.cc"],
     data = [
         "@io_opentracing_cpp//mocktracer:libmocktracer_plugin.so",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -463,7 +463,7 @@ envoy_cc_test(
     srcs = [
         "http2_flood_integration_test.cc",
     ],
-    shard_count = 6,
+    shard_count = 4,
     tags = [
         "cpu:3",
     ],

--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -72,7 +72,6 @@ BAZEL_OUTPUT_BASE="$(bazel "${BAZEL_STARTUP_OPTIONS[@]}" info "${BAZEL_BUILD_OPT
 echo "Running bazel coverage with:"
 echo "  Options: ${BAZEL_BUILD_OPTIONS[*]} ${BAZEL_COVERAGE_OPTIONS[*]}"
 echo "  Targets: ${COVERAGE_TARGETS[*]}"
-
 bazel "${BAZEL_STARTUP_OPTIONS[@]}" coverage "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_COVERAGE_OPTIONS[@]}" "${COVERAGE_TARGETS[@]}"
 
 echo "Collecting profile and testlogs"
@@ -81,9 +80,6 @@ if [[ -n "${ENVOY_BUILD_PROFILE}" ]]; then
 fi
 
 if [[ -n "${ENVOY_BUILD_DIR}" ]]; then
-    if [[ -e "${ENVOY_BUILD_DIR}/testlogs.tar.zst" ]]; then
-        rm -f "${ENVOY_BUILD_DIR}/testlogs.tar.zst"
-    fi
     find bazel-testlogs/ -name test.log \
         | tar cf - -T - \
         | bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
@@ -121,10 +117,6 @@ if [[ "${FUZZ_COVERAGE}" == "true" ]]; then
                     - -T0 -o "${ENVOY_FUZZ_COVERAGE_ARTIFACT}"
     fi
 elif [[ -n "${ENVOY_COVERAGE_ARTIFACT}" ]]; then
-    if [[ -e "${ENVOY_COVERAGE_ARTIFACT}" ]]; then
-        rm "${ENVOY_COVERAGE_ARTIFACT}"
-    fi
-
      tar cf - -C "${COVERAGE_DIR}" --transform 's/^\./coverage/' . \
          | bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //tools/zstd -- \
                  - -T0 -o "${ENVOY_COVERAGE_ARTIFACT}"

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -158,7 +158,6 @@ envoy_cc_test_library(
 
 envoy_cc_fuzz_test(
     name = "xds_fuzz_test",
-    size = "large",
     srcs = ["xds_fuzz_test.cc"],
     corpus = "xds_corpus",
     deps = [


### PR DESCRIPTION
This reverts commit 8004b60fc9902f65b58c4a9153eb065d1a4152dc.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
