### PR TITLE
Revert "ci/coverage: Temporarily disable coverage requirement (#29112)"

### DIFF
--- a/.azure-pipelines/stage/checks.yml
+++ b/.azure-pipelines/stage/checks.yml
@@ -135,7 +135,7 @@ jobs:
 
 - job: complete
   displayName: "Checks complete"
-  dependsOn: ["bazel"]
+  dependsOn: ["bazel", "coverage"]
   pool: x64-nano
   # This condition ensures that this (required) check passes if all of
   # the preceding checks either pass or are skipped
@@ -144,7 +144,8 @@ jobs:
   condition: |
     and(
       eq(variables['Build.Reason'], 'PullRequest'),
-      in(dependencies.bazel.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
+      in(dependencies.bazel.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
+      in(dependencies.coverage.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   steps:
   - checkout: none
   - bash: |


### PR DESCRIPTION
This reverts commit 8d48ccd79683ba5e2cb2a550c4bb0885a6d78ce6.

Additional Description:
Per discussion with other maintainers, the unblock of coverage is rolled back. Given that the approach of using RBE caches for coverage seems to be  solving the issue, it is ok to block PRs from submitting until the coverage build is restored.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
