### PR TITLE
fix the memory leak in skywalking trace reporter

### DIFF
--- a/source/extensions/tracers/skywalking/trace_segment_reporter.cc
+++ b/source/extensions/tracers/skywalking/trace_segment_reporter.cc
@@ -48,6 +48,11 @@ void TraceSegmentReporter::report(TracingContextPtr tracing_context) {
   ENVOY_LOG(trace, "Try to report segment to SkyWalking Server:\n{}", request.DebugString());
 
   if (stream_ != nullptr) {
+    if (stream_->isAboveWriteBufferHighWatermark()) {
+      ENVOY_LOG(debug, "Failed to report segment to SkyWalking Server since buffer is over limit");
+      tracing_stats_->segments_dropped_.inc();
+      return;
+    }
     tracing_stats_->segments_sent_.inc();
     stream_->sendMessage(request, false);
     return;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix the memory leak in skywalking trace reporter
Additional Description: The flow control based on `onAboveWriteBufferHighWatermark` did not work before. When the skywalking server does not read data, the grpc stream will always accumulate tracing data until OOM.
Risk Level: Mid
Testing: Unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
