### PR TITLE
upstream filters: change upstream factory context to fit network filters

### DIFF
--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -321,11 +321,11 @@ public:
 using ProtocolOptionsFactoryContext = Server::Configuration::TransportSocketFactoryContext;
 
 /**
- * FactoryContext for upstream HTTP filters.
+ * FactoryContext for upstream filters.
  */
-class UpstreamHttpFactoryContext {
+class UpstreamFactoryContext {
 public:
-  virtual ~UpstreamHttpFactoryContext() = default;
+  virtual ~UpstreamFactoryContext() = default;
 
   /**
    * @return ServerFactoryContext which lifetime is no shorter than the server.

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -150,8 +150,9 @@ public:
    * unable to produce a factory with the provided parameters, it should throw an EnvoyException in
    * the case of general error. The returned callback should always be initialized.
    */
-  virtual Network::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
-                                                                CommonFactoryContext& context) PURE;
+  virtual Network::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& config,
+                               UpstreamFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.filters.upstream_network"; }
 
@@ -291,7 +292,7 @@ public:
    */
   virtual Http::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
-                               Server::Configuration::UpstreamHttpFactoryContext& context) PURE;
+                               Server::Configuration::UpstreamFactoryContext& context) PURE;
 };
 
 } // namespace Configuration

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -651,9 +651,9 @@ protected:
 class UpstreamHttpFilterConfigProviderManagerImpl
     : public FilterConfigProviderManagerImpl<
           Server::Configuration::UpstreamHttpFilterConfigFactory, NamedHttpFilterFactoryCb,
-          Server::Configuration::UpstreamHttpFactoryContext,
+          Server::Configuration::UpstreamFactoryContext,
           HttpDynamicFilterConfigProviderImpl<
-              Server::Configuration::UpstreamHttpFactoryContext,
+              Server::Configuration::UpstreamFactoryContext,
               Server::Configuration::UpstreamHttpFilterConfigFactory>> {
 public:
   absl::string_view statPrefix() const override { return "upstream_http_filter."; }
@@ -705,9 +705,9 @@ protected:
 class UpstreamNetworkFilterConfigProviderManagerImpl
     : public FilterConfigProviderManagerImpl<
           Server::Configuration::NamedUpstreamNetworkFilterConfigFactory, Network::FilterFactoryCb,
-          Server::Configuration::CommonFactoryContext,
+          Server::Configuration::UpstreamFactoryContext,
           UpstreamNetworkDynamicFilterConfigProviderImpl<
-              Server::Configuration::CommonFactoryContext,
+              Server::Configuration::UpstreamFactoryContext,
               Server::Configuration::NamedUpstreamNetworkFilterConfigFactory>> {
 public:
   absl::string_view statPrefix() const override { return "upstream_network_filter."; }

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -18,7 +18,7 @@ using DownstreamFilterConfigProviderManager =
                                         Server::Configuration::FactoryContext>;
 using UpstreamFilterConfigProviderManager =
     Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
-                                        Server::Configuration::UpstreamHttpFactoryContext>;
+                                        Server::Configuration::UpstreamFactoryContext>;
 
 class FilterChainUtility : Logger::Loggable<Logger::Id::config> {
 public:

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -335,7 +335,7 @@ envoy_cc_library(
         "//source/common/stream_info:uint32_accessor_lib",
         "//source/common/tracing:http_tracer_lib",
         "//source/common/upstream:load_balancer_lib",
-        "//source/common/upstream:upstream_http_factory_context_lib",
+        "//source/common/upstream:upstream_factory_context_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -42,7 +42,7 @@
 #include "source/common/stats/symbol_table.h"
 #include "source/common/stream_info/stream_info_impl.h"
 #include "source/common/upstream/load_balancer_impl.h"
-#include "source/common/upstream/upstream_http_factory_context_impl.h"
+#include "source/common/upstream/upstream_factory_context_impl.h"
 
 namespace Envoy {
 namespace Router {
@@ -262,9 +262,9 @@ public:
           Http::FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(
               server_factory_ctx);
       std::string prefix = context.scope().symbolTable().toString(context.scope().prefix());
-      upstream_ctx_ = std::make_unique<Upstream::UpstreamHttpFactoryContextImpl>(
+      upstream_ctx_ = std::make_unique<Upstream::UpstreamFactoryContextImpl>(
           server_factory_ctx, context.initManager(), context.scope());
-      Http::FilterChainHelper<Server::Configuration::UpstreamHttpFactoryContext,
+      Http::FilterChainHelper<Server::Configuration::UpstreamFactoryContext,
                               Server::Configuration::UpstreamHttpFilterConfigFactory>
           helper(*filter_config_provider_manager, server_factory_ctx, context.clusterManager(),
                  *upstream_ctx_, prefix);
@@ -320,7 +320,7 @@ public:
   Http::Context& http_context_;
   Stats::StatName zone_name_;
   Stats::StatName empty_stat_name_;
-  std::unique_ptr<Server::Configuration::UpstreamHttpFactoryContext> upstream_ctx_;
+  std::unique_ptr<Server::Configuration::UpstreamFactoryContext> upstream_ctx_;
   Http::FilterChainUtility::FilterFactoriesList upstream_http_filter_factories_;
 
 private:

--- a/source/common/router/upstream_codec_filter.h
+++ b/source/common/router/upstream_codec_filter.h
@@ -115,7 +115,7 @@ public:
   std::string category() const override { return "envoy.filters.http.upstream"; }
   Http::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
-                               Server::Configuration::UpstreamHttpFactoryContext&) override {
+                               Server::Configuration::UpstreamFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(std::make_shared<UpstreamCodecFilter>());
     };

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -557,8 +557,8 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "upstream_http_factory_context_lib",
-    hdrs = ["upstream_http_factory_context_impl.h"],
+    name = "upstream_factory_context_lib",
+    hdrs = ["upstream_factory_context_impl.h"],
     deps = [
         "//envoy/init:manager_interface",
         "//envoy/server:factory_context_interface",

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -453,7 +453,7 @@ envoy_cc_library(
     deps = [
         ":load_balancer_lib",
         ":resource_manager_lib",
-        ":upstream_http_factory_context_lib",
+        ":upstream_factory_context_lib",
         "//envoy/event:timer_interface",
         "//envoy/local_info:local_info_interface",
         "//envoy/network:dns_interface",

--- a/source/common/upstream/upstream_factory_context_impl.h
+++ b/source/common/upstream/upstream_factory_context_impl.h
@@ -11,9 +11,9 @@ namespace Upstream {
  * Upstream Factory Context used by both Clusters and Routers to configure
  * upstream filters.
  */
-class UpstreamHttpFactoryContextImpl : public Server::Configuration::UpstreamHttpFactoryContext {
+class UpstreamFactoryContextImpl : public Server::Configuration::UpstreamFactoryContext {
 public:
-  UpstreamHttpFactoryContextImpl(Server::Configuration::ServerFactoryContext& context,
+  UpstreamFactoryContextImpl(Server::Configuration::ServerFactoryContext& context,
                                  Init::Manager& init_manager, Stats::Scope& scope)
       : server_context_(context), init_manager_(init_manager), scope_(scope) {}
 

--- a/source/common/upstream/upstream_factory_context_impl.h
+++ b/source/common/upstream/upstream_factory_context_impl.h
@@ -14,7 +14,7 @@ namespace Upstream {
 class UpstreamFactoryContextImpl : public Server::Configuration::UpstreamFactoryContext {
 public:
   UpstreamFactoryContextImpl(Server::Configuration::ServerFactoryContext& context,
-                                 Init::Manager& init_manager, Stats::Scope& scope)
+                             Init::Manager& init_manager, Stats::Scope& scope)
       : server_context_(context), init_manager_(init_manager), scope_(scope) {}
 
   Server::Configuration::ServerFactoryContext& getServerFactoryContext() const override {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1253,7 +1253,7 @@ ClusterInfoImpl::ClusterInfoImpl(
     }
 
     std::string prefix = stats_scope_->symbolTable().toString(stats_scope_->prefix());
-    Http::FilterChainHelper<Server::Configuration::UpstreamHttpFactoryContext,
+    Http::FilterChainHelper<Server::Configuration::UpstreamFactoryContext,
                             Server::Configuration::UpstreamHttpFilterConfigFactory>
         helper(*http_filter_config_provider_manager_, upstream_context_.getServerFactoryContext(),
                factory_context.clusterManager(), upstream_context_, prefix);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1233,7 +1233,7 @@ ClusterInfoImpl::ClusterInfoImpl(
     Config::Utility::translateOpaqueConfig(proto_config.typed_config(),
                                            factory_context.messageValidationVisitor(), *message);
     Network::FilterFactoryCb callback =
-        factory.createFilterFactoryFromProto(*message, *factory_context_);
+        factory.createFilterFactoryFromProto(*message, upstream_context_);
     filter_factories_.push_back(network_config_provider_manager_.createStaticFilterConfigProvider(
         callback, proto_config.name()));
   }

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -60,7 +60,7 @@
 #include "source/common/upstream/load_balancer_impl.h"
 #include "source/common/upstream/resource_manager_impl.h"
 #include "source/common/upstream/transport_socket_match_impl.h"
-#include "source/common/upstream/upstream_http_factory_context_impl.h"
+#include "source/common/upstream/upstream_factory_context_impl.h"
 #include "source/extensions/upstreams/http/config.h"
 #include "source/extensions/upstreams/tcp/config.h"
 #include "source/server/transport_socket_config_impl.h"
@@ -1125,7 +1125,7 @@ private:
   mutable Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
   mutable Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   mutable Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
-  UpstreamHttpFactoryContextImpl upstream_context_;
+  UpstreamFactoryContextImpl upstream_context_;
 
   // Keep small values like bools and enums at the end of the class to reduce
   // overhead via alignment

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -104,7 +104,7 @@ public:
       : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
 
   struct DualInfo {
-    DualInfo(Server::Configuration::UpstreamHttpFactoryContext& context)
+    DualInfo(Server::Configuration::UpstreamFactoryContext& context)
         : init_manager(context.initManager()), scope(context.scope()) {}
     DualInfo(Server::Configuration::FactoryContext& context)
         : init_manager(context.initManager()), scope(context.scope()) {}
@@ -122,9 +122,10 @@ public:
                                              context.getServerFactoryContext());
   }
 
-  Envoy::Http::FilterFactoryCb createFilterFactoryFromProto(
-      const Protobuf::Message& proto_config, const std::string& stats_prefix,
-      Server::Configuration::UpstreamHttpFactoryContext& context) override {
+  Envoy::Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::UpstreamFactoryContext& context) override {
     return createFilterFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(
             proto_config, context.getServerFactoryContext().messageValidationVisitor()),

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -312,7 +312,7 @@ class NetworkUpstreamFilterConfigDiscoveryImplTest
           Network::FilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
           UpstreamNetworkFilterConfigProviderManagerImpl, TestNetworkFilterFactory,
           Server::Configuration::NamedUpstreamNetworkFilterConfigFactory,
-          Server::Configuration::MockFactoryContext> {
+          Server::Configuration::MockUpstreamFactoryContext> {
 public:
   const std::string getFilterType() const override { return "upstream_network"; }
   const std::string getConfigReloadCounter() const override {

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -58,7 +58,7 @@ public:
   }
   Http::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
-                               Server::Configuration::UpstreamHttpFactoryContext&) override {
+                               Server::Configuration::UpstreamFactoryContext&) override {
     created_ = true;
     return [](Http::FilterChainFactoryCallbacks&) -> void {};
   }
@@ -85,7 +85,7 @@ public:
   }
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&,
-                               Server::Configuration::CommonFactoryContext&) override {
+                               Server::Configuration::UpstreamFactoryContext&) override {
     created_ = true;
     return [](Network::FilterManager&) -> void {};
   }
@@ -275,10 +275,10 @@ public:
 // HTTP upstream filter test
 class HttpUpstreamFilterConfigDiscoveryImplTest
     : public FilterConfigDiscoveryImplTest<
-          NamedHttpFilterFactoryCb, Server::Configuration::UpstreamHttpFactoryContext,
+          NamedHttpFilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
           UpstreamHttpFilterConfigProviderManagerImpl, TestHttpFilterFactory,
           Server::Configuration::UpstreamHttpFilterConfigFactory,
-          Server::Configuration::MockUpstreamHttpFactoryContext> {
+          Server::Configuration::MockUpstreamFactoryContext> {
 public:
   const std::string getFilterType() const override { return "http"; }
   const std::string getConfigReloadCounter() const override {

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -309,7 +309,7 @@ public:
 // Network upstream filter test
 class NetworkUpstreamFilterConfigDiscoveryImplTest
     : public FilterConfigDiscoveryImplTest<
-          Network::FilterFactoryCb, Server::Configuration::CommonFactoryContext,
+          Network::FilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
           UpstreamNetworkFilterConfigProviderManagerImpl, TestNetworkFilterFactory,
           Server::Configuration::NamedUpstreamNetworkFilterConfigFactory,
           Server::Configuration::MockFactoryContext> {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -4444,7 +4444,7 @@ class TestUpstreamNetworkFilterConfigFactory
 public:
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&,
-                               Server::Configuration::CommonFactoryContext&) override {
+                               Server::Configuration::UpstreamFactoryContext&) override {
     return [](Network::FilterManager& filter_manager) -> void {
       filter_manager.addWriteFilter(std::make_shared<TestUpstreamNetworkFilter>());
     };

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -50,7 +50,7 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProtoUpstreamFactory) {
   envoy::extensions::filters::http::buffer::v3::Buffer config;
   config.mutable_max_request_bytes()->set_value(1028);
 
-  NiceMock<Server::Configuration::MockUpstreamHttpFactoryContext> context;
+  NiceMock<Server::Configuration::MockUpstreamFactoryContext> context;
   BufferFilterFactory factory;
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/filters/http/common/empty_http_filter_config.h
+++ b/test/extensions/filters/http/common/empty_http_filter_config.h
@@ -50,9 +50,9 @@ public:
   createDualFilter(const std::string& stat_prefix,
                    Server::Configuration::ServerFactoryContext& context) PURE;
 
-  Http::FilterFactoryCb createFilterFactoryFromProto(
-      const Protobuf::Message&, const std::string& stat_prefix,
-      Server::Configuration::UpstreamHttpFactoryContext& context) override {
+  Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message&, const std::string& stat_prefix,
+                               Server::Configuration::UpstreamFactoryContext& context) override {
     return createDualFilter(stat_prefix, context.getServerFactoryContext());
   }
 };

--- a/test/integration/cluster_filter_integration_test.cc
+++ b/test/integration/cluster_filter_integration_test.cc
@@ -79,7 +79,7 @@ public:
 
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                               Server::Configuration::CommonFactoryContext&) override {
+                               Server::Configuration::UpstreamFactoryContext&) override {
     auto config = dynamic_cast<const ProtobufWkt::StringValue&>(proto_config);
     return [this, config](Network::FilterManager& filter_manager) -> void {
       filter_manager.addFilter(std::make_shared<PoliteFilter>(test_parent_, config));

--- a/test/integration/filters/add_header_filter.cc
+++ b/test/integration/filters/add_header_filter.cc
@@ -68,9 +68,9 @@ public:
     return std::make_unique<test::integration::filters::AddHeaderFilterConfig>();
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProto(
-      const Protobuf::Message& config, const std::string&,
-      Server::Configuration::UpstreamHttpFactoryContext& context) override {
+  Http::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& config, const std::string&,
+                               Server::Configuration::UpstreamFactoryContext& context) override {
 
     const auto& proto_config =
         MessageUtil::downcastAndValidate<const test::integration::filters::AddHeaderFilterConfig&>(

--- a/test/mocks/server/factory_context.cc
+++ b/test/mocks/server/factory_context.cc
@@ -47,7 +47,7 @@ MockFactoryContext::MockFactoryContext()
 
 MockFactoryContext::~MockFactoryContext() = default;
 
-MockUpstreamHttpFactoryContext::MockUpstreamHttpFactoryContext() {
+MockUpstreamFactoryContext::MockUpstreamFactoryContext() {
   ON_CALL(*this, getServerFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
   ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));

--- a/test/mocks/server/factory_context.h
+++ b/test/mocks/server/factory_context.h
@@ -84,9 +84,9 @@ public:
   testing::NiceMock<Api::MockApi> api_;
 };
 
-class MockUpstreamHttpFactoryContext : public UpstreamHttpFactoryContext {
+class MockUpstreamFactoryContext : public UpstreamFactoryContext {
 public:
-  MockUpstreamHttpFactoryContext();
+  MockUpstreamFactoryContext();
 
   MOCK_METHOD(ServerFactoryContext&, getServerFactoryContext, (), (const));
   MOCK_METHOD(Init::Manager&, initManager, ());


### PR DESCRIPTION
Additional Description: Rename ``UpstreamHttpFactoryContext`` to ``UpstreamFactoryContext`` and change upstream network filters factory to use ``UpstreamFactoryContext``. The goal is saving from code duplication and creating a factory context for network filters which is not needed.
Risk Level: low
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None