### PR TITLE
Fix http cache crash on config reload (part 1)

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -33,7 +33,7 @@ using CacheResponseCodeDetails = ConstSingleton<CacheResponseCodeDetailValues>;
 
 CacheFilter::CacheFilter(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
                          const std::string&, Stats::Scope&, TimeSource& time_source,
-                         OptRef<HttpCache> http_cache)
+                         std::shared_ptr<HttpCache> http_cache)
     : time_source_(time_source), cache_(http_cache),
       vary_allow_list_(config.allowed_vary_headers()) {}
 
@@ -148,7 +148,7 @@ Http::FilterHeadersStatus CacheFilter::encodeHeaders(Http::ResponseHeaderMap& he
       // so they're thread-safe. During CacheFilter::onDestroy the queue is given ownership
       // of itself and all the callbacks are cancelled, so they are also filter-destruction-safe.
       insert_queue_ =
-          std::make_unique<CacheInsertQueue>(*encoder_callbacks_, std::move(insert_context),
+          std::make_unique<CacheInsertQueue>(cache_, *encoder_callbacks_, std::move(insert_context),
                                              // Cache aborted callback.
                                              [this]() {
                                                insert_queue_ = nullptr;

--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -55,7 +55,7 @@ class CacheFilter : public Http::PassThroughFilter,
 public:
   CacheFilter(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
               const std::string& stats_prefix, Stats::Scope& scope, TimeSource& time_source,
-              OptRef<HttpCache> http_cache);
+              std::shared_ptr<HttpCache> http_cache);
   // Http::StreamFilterBase
   void onDestroy() override;
   void onStreamComplete() override;
@@ -132,7 +132,7 @@ private:
   // while the necessary cache write operations complete.
   std::unique_ptr<CacheInsertQueue> insert_queue_;
   TimeSource& time_source_;
-  OptRef<HttpCache> cache_;
+  std::shared_ptr<HttpCache> cache_;
   LookupContextPtr lookup_;
   LookupResultPtr lookup_result_;
 

--- a/source/extensions/filters/http/cache/cache_insert_queue.cc
+++ b/source/extensions/filters/http/cache/cache_insert_queue.cc
@@ -66,12 +66,13 @@ private:
   std::unique_ptr<Http::ResponseTrailerMap> trailers_;
 };
 
-CacheInsertQueue::CacheInsertQueue(Http::StreamEncoderFilterCallbacks& encoder_callbacks,
+CacheInsertQueue::CacheInsertQueue(std::shared_ptr<HttpCache> cache,
+                                   Http::StreamEncoderFilterCallbacks& encoder_callbacks,
                                    InsertContextPtr insert_context, AbortInsertCallback abort)
     : dispatcher_(encoder_callbacks.dispatcher()), insert_context_(std::move(insert_context)),
       low_watermark_bytes_(encoder_callbacks.encoderBufferLimit() / 2),
       high_watermark_bytes_(encoder_callbacks.encoderBufferLimit()),
-      encoder_callbacks_(encoder_callbacks), abort_callback_(abort) {}
+      encoder_callbacks_(encoder_callbacks), abort_callback_(abort), cache_(cache) {}
 
 void CacheInsertQueue::insertHeaders(const Http::ResponseHeaderMap& response_headers,
                                      const ResponseMetadata& metadata, bool end_stream) {

--- a/source/extensions/filters/http/cache/cache_insert_queue.h
+++ b/source/extensions/filters/http/cache/cache_insert_queue.h
@@ -34,7 +34,8 @@ class CacheInsertFragment;
 // to receive more data.
 class CacheInsertQueue {
 public:
-  CacheInsertQueue(Http::StreamEncoderFilterCallbacks& encoder_callbacks,
+  CacheInsertQueue(std::shared_ptr<HttpCache> cache,
+                   Http::StreamEncoderFilterCallbacks& encoder_callbacks,
                    InsertContextPtr insert_context, AbortInsertCallback abort);
   void insertHeaders(const Http::ResponseHeaderMap& response_headers,
                      const ResponseMetadata& metadata, bool end_stream);
@@ -72,6 +73,10 @@ private:
   // will remove its self-ownership (thereby deleting itself) upon
   // completion of its work.
   std::unique_ptr<CacheInsertQueue> self_ownership_;
+  // The queue needs to keep a copy of the cache alive; if only the filter
+  // keeps the cache alive then it's possible for the filter to be deleted while
+  // a cache action is still in flight.
+  std::shared_ptr<HttpCache> cache_;
 };
 
 } // namespace Cache

--- a/source/extensions/filters/http/cache/cache_insert_queue.h
+++ b/source/extensions/filters/http/cache/cache_insert_queue.h
@@ -74,8 +74,9 @@ private:
   // completion of its work.
   std::unique_ptr<CacheInsertQueue> self_ownership_;
   // The queue needs to keep a copy of the cache alive; if only the filter
-  // keeps the cache alive then it's possible for the filter to be deleted while
-  // a cache action is still in flight.
+  // keeps the cache alive then it's possible for the filter config to be deleted
+  // while a cache action is still in flight, which can cause the cache to be
+  // deleted prematurely.
   std::shared_ptr<HttpCache> cache_;
 };
 

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -29,8 +29,7 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
   return [config, stats_prefix, &context,
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
-                                                            context.timeSource(),
-                                                            cache ? *cache : OptRef<HttpCache>{}));
+                                                            context.timeSource(), cache));
   };
 }
 

--- a/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.h
+++ b/source/extensions/http/cache/file_system_http_cache/file_system_http_cache.h
@@ -27,8 +27,11 @@ struct CacheShared;
 
 /**
  * An instance of a cache. There may be multiple caches in a single envoy configuration.
- * Caches are owned by filter configurations, and jointly own the CacheSingleton; if all
- * cache instances are destroyed, the CacheSingleton is destroyed.
+ * Caches are jointly owned by filters using the cache and the filter configurations.
+ * When the filter configurations are destroyed and all cache actions from those filters
+ * are resolved, the cache instance is destroyed.
+ * Cache instances jointly own the CacheSingleton.
+ * If all cache instances are destroyed, the CacheSingleton is destroyed.
  *
  * See DESIGN.md for details of cache behavior.
  */

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -1150,20 +1150,23 @@ TEST_F(CacheFilterDeathTest, StreamTimeoutDuringLookup) {
 }
 
 TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndInitialIsBug) {
+  GTEST_SKIP(); // TODO(issue #29217): Remove skip.
   EXPECT_ENVOY_BUG(
       CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation, FilterState::Initial),
       "Unexpected filter state in requestCacheStatus");
 }
 
-TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDestroyedIsBug) {
+TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDecodeServingFromCacheIsBug) {
+  GTEST_SKIP(); // TODO(issue #29217): Remove skip.
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
-                                                    FilterState::Destroyed),
+                                                    FilterState::DecodeServingFromCache),
                    "Unexpected filter state in requestCacheStatus");
 }
 
-TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDecodeServingFromCacheIsBug) {
+TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDestroyedIsBug) {
+  GTEST_SKIP(); // TODO(issue #29217): Remove skip.
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
-                                                    FilterState::DecodeServingFromCache),
+                                                    FilterState::Destroyed),
                    "Unexpected filter state in requestCacheStatus");
 }
 

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -1149,13 +1149,19 @@ TEST_F(CacheFilterDeathTest, StreamTimeoutDuringLookup) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
-TEST(LookupStatusDeathTest, ResolveLookupStatusBugFilterStates) {
+TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndInitialIsBug) {
   EXPECT_ENVOY_BUG(
       CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation, FilterState::Initial),
       "Unexpected filter state in requestCacheStatus");
+}
+
+TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDecodeServingFromCacheIsBug) {
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
                                                     FilterState::DecodeServingFromCache),
                    "Unexpected filter state in requestCacheStatus");
+}
+
+TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDestroyedIsBug) {
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
                                                     FilterState::Destroyed),
                    "Unexpected filter state in requestCacheStatus");

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -1155,15 +1155,15 @@ TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndInitialIsBug)
       "Unexpected filter state in requestCacheStatus");
 }
 
-TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDecodeServingFromCacheIsBug) {
-  EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
-                                                    FilterState::DecodeServingFromCache),
-                   "Unexpected filter state in requestCacheStatus");
-}
-
 TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDestroyedIsBug) {
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
                                                     FilterState::Destroyed),
+                   "Unexpected filter state in requestCacheStatus");
+}
+
+TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDecodeServingFromCacheIsBug) {
+  EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
+                                                    FilterState::DecodeServingFromCache),
                    "Unexpected filter state in requestCacheStatus");
 }
 

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -11,9 +11,7 @@
 
 #include "gtest/gtest.h"
 
-using testing::ContainerEq;
 using testing::TestWithParam;
-using testing::ValuesIn;
 
 namespace Envoy {
 namespace Extensions {


### PR DESCRIPTION
Commit Message: Fix http cache crash on config reload (part 1)
Additional Description:
With the presence of a queue, it is no longer enough for a cache to outlive the filter, it must also outlive the queue that can outlive the filter.

This was already a problem for file_system_http_cache because it already contained a queue that could outlive the filter, but it has just been noticed in #29064 which I guess is the first time the cache has been used in conjunction with a dynamic configuration that causes the cache instance to be removed and re-added.

This change fixes it so that a cache shared pointer is persisted into the queue object, ensuring its lifetime is long enough for all actions to complete. The cleanup in which file_system_http_cache's now redundant queue is removed will still need to happen before the reported crash is no longer a risk.

Risk Level: Low; a small impact change to a WIP extension.
Testing: Added validation that the shared_ptr lives on in the queue.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
