### PR TITLE
Remove redundant queue from FileSystemHttpCache

### DIFF
--- a/source/extensions/http/cache/file_system_http_cache/insert_context.cc
+++ b/source/extensions/http/cache/file_system_http_cache/insert_context.cc
@@ -25,127 +25,26 @@ std::string writeFailureMessage(absl::string_view kind, absl::StatusOr<size_t> r
 
 FileInsertContext::FileInsertContext(std::shared_ptr<FileSystemHttpCache> cache,
                                      std::unique_ptr<FileLookupContext> lookup_context)
-    : lookup_context_(std::move(lookup_context)),
-      queue_(std::make_shared<InsertOperationQueue>(
-          std::move(cache), lookup_context_->lookup().key(),
-          lookup_context_->lookup().requestHeaders(), lookup_context_->lookup().varyAllowList())) {}
+    : lookup_context_(std::move(lookup_context)), key_(lookup_context_->lookup().key()),
+      cache_(std::move(cache)) {}
 
 void FileInsertContext::insertHeaders(const Http::ResponseHeaderMap& response_headers,
                                       const ResponseMetadata& metadata,
                                       InsertCallback insert_complete, bool end_stream) {
-  queue_->insertHeaders(queue_, response_headers, metadata, insert_complete, end_stream);
-}
-
-void FileInsertContext::insertBody(const Buffer::Instance& chunk,
-                                   InsertCallback ready_for_next_chunk, bool end_stream) {
-  queue_->insertBody(queue_, chunk, ready_for_next_chunk, end_stream);
-}
-
-void FileInsertContext::insertTrailers(const Http::ResponseTrailerMap& trailers,
-                                       InsertCallback insert_complete) {
-  queue_->insertTrailers(queue_, trailers, insert_complete);
-}
-
-void FileInsertContext::onDestroy() { queue_->cancelIfIncomplete(queue_); }
-
-void InsertOperationQueue::cancelIfIncomplete(std::shared_ptr<InsertOperationQueue> p) {
-  absl::MutexLock lock(&mu_);
-  if (seen_end_stream_) {
-    return;
-  }
-  cancelInsert(p, "InsertContext destroyed prematurely");
-}
-
-void InsertOperationQueue::writeChunk(std::shared_ptr<InsertOperationQueue> p,
-                                      QueuedFileChunk&& chunk) {
-  mu_.AssertHeld();
-  callback_in_flight_ = chunk.done_callback;
-  if (chunk.type == QueuedFileChunk::Type::Trailer) {
-    size_t sz = chunk.chunk.length();
-    auto queued = file_handle_->write(
-        chunk.chunk, header_block_.offsetToTrailers(),
-        [this, p, sz](absl::StatusOr<size_t> write_result) {
-          absl::MutexLock lock(&mu_);
-          cancel_action_in_flight_ = nullptr;
-          if (!write_result.ok() || write_result.value() != sz) {
-            cancelInsert(p, writeFailureMessage("trailer chunk", write_result, sz));
-            return;
-          }
-          header_block_.setTrailersSize(sz);
-          commit(p, callback_in_flight_);
-        });
-    ASSERT(queued.ok(), queued.status().ToString());
-    cancel_action_in_flight_ = queued.value();
-  } else {
-    size_t sz = chunk.chunk.length();
-    bool end_stream = chunk.end_stream;
-    auto queued = file_handle_->write(
-        chunk.chunk, header_block_.offsetToBody() + header_block_.bodySize(),
-        [this, p, sz, end_stream](absl::StatusOr<size_t> write_result) {
-          absl::MutexLock lock(&mu_);
-          cancel_action_in_flight_ = nullptr;
-          if (!write_result.ok() || write_result.value() != sz) {
-            cancelInsert(p, writeFailureMessage("body chunk", write_result, sz));
-            return;
-          }
-          header_block_.setBodySize(header_block_.bodySize() + sz);
-          if (end_stream) {
-            commit(p, callback_in_flight_);
-          } else {
-            callback_in_flight_(true);
-            callback_in_flight_ = nullptr;
-            writeNextChunk(p);
-          }
-        });
-    ASSERT(queued.ok(), queued.status().ToString());
-    cancel_action_in_flight_ = queued.value();
-  }
-}
-
-void InsertOperationQueue::writeNextChunk(std::shared_ptr<InsertOperationQueue> p) {
-  mu_.AssertHeld();
-  if (queue_.empty()) {
-    ASSERT(cancel_action_in_flight_ == nullptr);
-    return;
-  }
-  auto chunk = std::move(queue_.front());
-  queue_.pop_front();
-  writeChunk(p, std::move(chunk));
-}
-
-void InsertOperationQueue::push(std::shared_ptr<InsertOperationQueue> p, QueuedFileChunk&& chunk) {
-  absl::MutexLock lock(&mu_);
-  if (!cleanup_) {
-    // Already cancelled, do nothing, return failure.
-    chunk.done_callback(false);
-    return;
-  }
-  if (chunk.end_stream) {
-    seen_end_stream_ = true;
-  }
-  if (!cancel_action_in_flight_) {
-    writeChunk(p, std::move(chunk));
-  } else {
-    queue_.push_back(std::move(chunk));
-  }
-}
-
-void InsertOperationQueue::insertHeaders(std::shared_ptr<InsertOperationQueue> p,
-                                         const Envoy::Http::ResponseHeaderMap& response_headers,
-                                         const ResponseMetadata& metadata,
-                                         InsertCallback insert_complete, bool end_stream) {
   absl::MutexLock lock(&mu_);
   callback_in_flight_ = insert_complete;
+  const VaryAllowList& vary_allow_list = lookup_context_->lookup().varyAllowList();
+  const Http::RequestHeaderMap& request_headers = lookup_context_->lookup().requestHeaders();
   if (VaryHeaderUtils::hasVary(response_headers)) {
     auto vary_header_values = VaryHeaderUtils::getVaryValues(response_headers);
     Key old_key = key_;
-    const auto vary_identifier = VaryHeaderUtils::createVaryIdentifier(
-        vary_allow_list_, vary_header_values, request_headers_);
+    const auto vary_identifier =
+        VaryHeaderUtils::createVaryIdentifier(vary_allow_list, vary_header_values, request_headers);
     if (vary_identifier.has_value()) {
       key_.add_custom_fields(vary_identifier.value());
     } else {
       // No error for this cancel, it's just an entry that's ineligible for insertion.
-      cancelInsert(p);
+      cancelInsert();
       return;
     }
     cleanup_ = cache_->setCacheEntryToVary(old_key, response_headers, key_, cleanup_);
@@ -154,18 +53,17 @@ void InsertOperationQueue::insertHeaders(std::shared_ptr<InsertOperationQueue> p
   }
   if (!cleanup_) {
     // No error for this cancel, someone else just got there first.
-    cancelInsert(p);
+    cancelInsert();
     return;
   }
   auto header_proto = makeCacheFileHeaderProto(key_, response_headers, metadata);
   // Open the file.
   cancel_action_in_flight_ = cache_->asyncFileManager()->createAnonymousFile(
-      cache_->cachePath(),
-      [this, p, end_stream, header_proto](absl::StatusOr<AsyncFileHandle> open_result) {
+      cache_->cachePath(), [this, end_stream, header_proto,
+                            insert_complete](absl::StatusOr<AsyncFileHandle> open_result) {
         absl::MutexLock lock(&mu_);
-        cancel_action_in_flight_ = nullptr;
         if (!open_result.ok()) {
-          cancelInsert(p, "failed to create anonymous file");
+          cancelInsert("failed to create anonymous file");
           return;
         }
         file_handle_ = std::move(open_result.value());
@@ -173,34 +71,33 @@ void InsertOperationQueue::insertHeaders(std::shared_ptr<InsertOperationQueue> p
         header_block_.serializeToBuffer(unset_header);
         // Write an empty header block.
         auto queued = file_handle_->write(
-            unset_header, 0,
-            [this, p, end_stream, header_proto](absl::StatusOr<size_t> write_result) {
+            unset_header, 0, [this, end_stream, header_proto](absl::StatusOr<size_t> write_result) {
               absl::MutexLock lock(&mu_);
               cancel_action_in_flight_ = nullptr;
               if (!write_result.ok() || write_result.value() != CacheFileFixedBlock::size()) {
-                cancelInsert(p, writeFailureMessage("empty header block", write_result,
-                                                    CacheFileFixedBlock::size()));
+                cancelInsert(writeFailureMessage("empty header block", write_result,
+                                                 CacheFileFixedBlock::size()));
                 return;
               }
               auto buf = bufferFromProto(header_proto);
               auto sz = buf.length();
               auto queued = file_handle_->write(
                   buf, header_block_.offsetToHeaders(),
-                  [this, p, end_stream, sz](absl::StatusOr<size_t> write_result) {
+                  [this, end_stream, sz](absl::StatusOr<size_t> write_result) {
                     absl::MutexLock lock(&mu_);
                     cancel_action_in_flight_ = nullptr;
                     if (!write_result.ok() || write_result.value() != sz) {
-                      cancelInsert(p, writeFailureMessage("headers", write_result, sz));
+                      cancelInsert(writeFailureMessage("headers", write_result, sz));
                       return;
                     }
                     header_block_.setHeadersSize(sz);
                     if (end_stream) {
-                      commit(p, callback_in_flight_);
+                      commit(callback_in_flight_);
                       return;
                     }
-                    callback_in_flight_(true);
+                    auto cb = callback_in_flight_;
                     callback_in_flight_ = nullptr;
-                    writeNextChunk(p);
+                    cb(true);
                   });
               ASSERT(queued.ok(), queued.status().ToString());
               cancel_action_in_flight_ = queued.value();
@@ -210,94 +107,138 @@ void InsertOperationQueue::insertHeaders(std::shared_ptr<InsertOperationQueue> p
       });
 }
 
-void InsertOperationQueue::insertBody(std::shared_ptr<InsertOperationQueue> p,
-                                      const Buffer::Instance& chunk,
-                                      InsertCallback ready_for_next_chunk, bool end_stream) {
-  push(p, QueuedFileChunk{QueuedFileChunk::Type::Body, chunk, ready_for_next_chunk, end_stream});
-}
-
-void InsertOperationQueue::insertTrailers(std::shared_ptr<InsertOperationQueue> p,
-                                          const Http::ResponseTrailerMap& response_trailers,
-                                          InsertCallback insert_complete) {
-  CacheFileTrailer file_trailer = makeCacheFileTrailerProto(response_trailers);
-  push(p, QueuedFileChunk{QueuedFileChunk::Type::Trailer, bufferFromProto(file_trailer),
-                          insert_complete, true});
-}
-
-void InsertOperationQueue::commit(std::shared_ptr<InsertOperationQueue> p,
-                                  InsertCallback callback) {
-  mu_.AssertHeld();
-  // Write the file header block now that we know the sizes of the pieces.
-  Buffer::OwnedImpl block_buffer;
-  callback_in_flight_ = callback;
-  header_block_.serializeToBuffer(block_buffer);
-  auto queued =
-      file_handle_->write(block_buffer, 0, [this, p](absl::StatusOr<size_t> write_result) {
+void FileInsertContext::insertBody(const Buffer::Instance& fragment,
+                                   InsertCallback ready_for_next_fragment, bool end_stream) {
+  absl::MutexLock lock(&mu_);
+  if (!cleanup_) {
+    // Already cancelled, do nothing, return failure.
+    ready_for_next_fragment(false);
+    return;
+  }
+  ASSERT(!cancel_action_in_flight_, "should be no actions in flight when receiving new data");
+  callback_in_flight_ = ready_for_next_fragment;
+  size_t sz = fragment.length();
+  Buffer::OwnedImpl consumable_fragment(fragment);
+  auto queued = file_handle_->write(
+      consumable_fragment, header_block_.offsetToBody() + header_block_.bodySize(),
+      [this, sz, end_stream](absl::StatusOr<size_t> write_result) {
         absl::MutexLock lock(&mu_);
         cancel_action_in_flight_ = nullptr;
-        if (!write_result.ok() || write_result.value() != CacheFileFixedBlock::size()) {
-          cancelInsert(
-              p, writeFailureMessage("header block", write_result, CacheFileFixedBlock::size()));
+        if (!write_result.ok() || write_result.value() != sz) {
+          cancelInsert(writeFailureMessage("body chunk", write_result, sz));
           return;
         }
-        // Unlink any existing cache entry with this filename.
-        cancel_action_in_flight_ = cache_->asyncFileManager()->stat(
-            absl::StrCat(cache_->cachePath(), cache_->generateFilename(key_)),
-            [this, p](absl::StatusOr<struct stat> stat_result) {
-              absl::MutexLock lock(&mu_);
-              cancel_action_in_flight_ = nullptr;
-              size_t file_size = 0;
-              if (stat_result.ok()) {
-                file_size = stat_result.value().st_size;
-              }
-              cancel_action_in_flight_ = cache_->asyncFileManager()->unlink(
-                  absl::StrCat(cache_->cachePath(), cache_->generateFilename(key_)),
-                  [this, file_size, p](absl::Status unlink_result) {
-                    if (unlink_result.ok()) {
-                      cache_->trackFileRemoved(file_size);
-                    }
-                    // We can ignore failure of unlink - the file may or may not have previously
-                    // existed.
-                    absl::MutexLock lock(&mu_);
-                    cancel_action_in_flight_ = nullptr;
-                    // Link the file to its filename.
-                    auto queued = file_handle_->createHardLink(
-                        absl::StrCat(cache_->cachePath(), cache_->generateFilename(key_)),
-                        [this, p](absl::Status link_result) {
-                          absl::MutexLock lock(&mu_);
-                          cancel_action_in_flight_ = nullptr;
-                          if (!link_result.ok()) {
-                            cancelInsert(p, absl::StrCat("failed to link file (",
-                                                         link_result.ToString(),
-                                                         "): ", cache_->cachePath(),
-                                                         cache_->generateFilename(key_)));
-                            return;
-                          }
-                          ENVOY_LOG(debug, "created cache file {}", cache_->generateFilename(key_));
-                          callback_in_flight_(true);
-                          callback_in_flight_ = nullptr;
-                          uint64_t file_size =
-                              header_block_.offsetToTrailers() + header_block_.trailerSize();
-                          cache_->trackFileAdded(file_size);
-                          // By clearing cleanup before destructor, we prevent logging an error.
-                          cleanup_ = nullptr;
-                        });
-                    ASSERT(queued.ok(), queued.status().ToString());
-                    cancel_action_in_flight_ = queued.value();
-                  });
-            });
+        header_block_.setBodySize(header_block_.bodySize() + sz);
+        if (end_stream) {
+          commit(callback_in_flight_);
+        } else {
+          auto cb = callback_in_flight_;
+          callback_in_flight_ = nullptr;
+          cb(true);
+        }
       });
   ASSERT(queued.ok(), queued.status().ToString());
   cancel_action_in_flight_ = queued.value();
 }
 
-InsertOperationQueue::~InsertOperationQueue() {
+void FileInsertContext::insertTrailers(const Http::ResponseTrailerMap& trailers,
+                                       InsertCallback insert_complete) {
   absl::MutexLock lock(&mu_);
-  cancelInsert(nullptr, "destroyed before completion");
+  if (!cleanup_) {
+    // Already cancelled, do nothing, return failure.
+    insert_complete(false);
+    return;
+  }
+  ASSERT(!cancel_action_in_flight_, "should be no actions in flight when receiving new data");
+  callback_in_flight_ = insert_complete;
+  CacheFileTrailer file_trailer = makeCacheFileTrailerProto(trailers);
+  Buffer::OwnedImpl consumable_buffer = bufferFromProto(file_trailer);
+  size_t sz = consumable_buffer.length();
+  auto queued =
+      file_handle_->write(consumable_buffer, header_block_.offsetToTrailers(),
+                          [this, sz](absl::StatusOr<size_t> write_result) {
+                            absl::MutexLock lock(&mu_);
+                            cancel_action_in_flight_ = nullptr;
+                            if (!write_result.ok() || write_result.value() != sz) {
+                              cancelInsert(writeFailureMessage("trailer chunk", write_result, sz));
+                              return;
+                            }
+                            header_block_.setTrailersSize(sz);
+                            commit(callback_in_flight_);
+                          });
+  ASSERT(queued.ok(), queued.status().ToString());
+  cancel_action_in_flight_ = queued.value();
 }
 
-void InsertOperationQueue::cancelInsert(std::shared_ptr<InsertOperationQueue>,
-                                        absl::string_view error) {
+void FileInsertContext::onDestroy() {
+  absl::MutexLock lock(&mu_);
+  cancelInsert("InsertContext destroyed prematurely");
+}
+
+void FileInsertContext::commit(InsertCallback callback) {
+  mu_.AssertHeld();
+  // Write the file header block now that we know the sizes of the pieces.
+  Buffer::OwnedImpl block_buffer;
+  callback_in_flight_ = callback;
+  header_block_.serializeToBuffer(block_buffer);
+  auto queued = file_handle_->write(block_buffer, 0, [this](absl::StatusOr<size_t> write_result) {
+    absl::MutexLock lock(&mu_);
+    cancel_action_in_flight_ = nullptr;
+    if (!write_result.ok() || write_result.value() != CacheFileFixedBlock::size()) {
+      cancelInsert(writeFailureMessage("header block", write_result, CacheFileFixedBlock::size()));
+      return;
+    }
+    // Unlink any existing cache entry with this filename.
+    cancel_action_in_flight_ = cache_->asyncFileManager()->stat(
+        absl::StrCat(cache_->cachePath(), cache_->generateFilename(key_)),
+        [this](absl::StatusOr<struct stat> stat_result) {
+          absl::MutexLock lock(&mu_);
+          cancel_action_in_flight_ = nullptr;
+          size_t file_size = 0;
+          if (stat_result.ok()) {
+            file_size = stat_result.value().st_size;
+          }
+          cancel_action_in_flight_ = cache_->asyncFileManager()->unlink(
+              absl::StrCat(cache_->cachePath(), cache_->generateFilename(key_)),
+              [this, file_size](absl::Status unlink_result) {
+                if (unlink_result.ok()) {
+                  cache_->trackFileRemoved(file_size);
+                }
+                // We can ignore failure of unlink - the file may or may not have previously
+                // existed.
+                absl::MutexLock lock(&mu_);
+                cancel_action_in_flight_ = nullptr;
+                // Link the file to its filename.
+                auto queued = file_handle_->createHardLink(
+                    absl::StrCat(cache_->cachePath(), cache_->generateFilename(key_)),
+                    [this](absl::Status link_result) {
+                      absl::MutexLock lock(&mu_);
+                      cancel_action_in_flight_ = nullptr;
+                      if (!link_result.ok()) {
+                        cancelInsert(absl::StrCat("failed to link file (", link_result.ToString(),
+                                                  "): ", cache_->cachePath(),
+                                                  cache_->generateFilename(key_)));
+                        return;
+                      }
+                      ENVOY_LOG(debug, "created cache file {}", cache_->generateFilename(key_));
+                      callback_in_flight_(true);
+                      callback_in_flight_ = nullptr;
+                      uint64_t file_size =
+                          header_block_.offsetToTrailers() + header_block_.trailerSize();
+                      cache_->trackFileAdded(file_size);
+                      // By clearing cleanup before destructor, we prevent logging an error.
+                      cleanup_ = nullptr;
+                    });
+                ASSERT(queued.ok(), queued.status().ToString());
+                cancel_action_in_flight_ = queued.value();
+              });
+        });
+  });
+  ASSERT(queued.ok(), queued.status().ToString());
+  cancel_action_in_flight_ = queued.value();
+}
+
+void FileInsertContext::cancelInsert(absl::string_view error) {
   mu_.AssertHeld();
   if (cancel_action_in_flight_) {
     cancel_action_in_flight_();
@@ -306,13 +247,6 @@ void InsertOperationQueue::cancelInsert(std::shared_ptr<InsertOperationQueue>,
   if (callback_in_flight_) {
     callback_in_flight_(false);
     callback_in_flight_ = nullptr;
-  }
-  while (!queue_.empty()) {
-    auto chunk = std::move(queue_.front());
-    queue_.pop_front();
-    if (chunk.done_callback) {
-      chunk.done_callback(false);
-    }
   }
   if (cleanup_) {
     cleanup_ = nullptr;

--- a/source/extensions/http/cache/file_system_http_cache/insert_context.cc
+++ b/source/extensions/http/cache/file_system_http_cache/insert_context.cc
@@ -62,6 +62,7 @@ void FileInsertContext::insertHeaders(const Http::ResponseHeaderMap& response_he
       cache_->cachePath(), [this, end_stream, header_proto,
                             insert_complete](absl::StatusOr<AsyncFileHandle> open_result) {
         absl::MutexLock lock(&mu_);
+        cancel_action_in_flight_ = nullptr;
         if (!open_result.ok()) {
           cancelInsert("failed to create anonymous file");
           return;

--- a/source/extensions/http/cache/file_system_http_cache/insert_context.h
+++ b/source/extensions/http/cache/file_system_http_cache/insert_context.h
@@ -19,174 +19,6 @@ using ::Envoy::Extensions::Common::AsyncFiles::CancelFunction;
 class FileLookupContext;
 class FileSystemHttpCache;
 
-/**
- * Because the cache filter implementation doesn't use the "ready" callback from
- * insertHeaders or insertBody, it's possible for a body chunk to come in before
- * the cache implementation is ready to insert body chunks.
- * This struct allows us to queue up body chunks and trailers to be pushed on
- * completion of the header insert chain of actions, or prior body chunks.
- *
- * If the cache filter implementation later is changed to only deliver actions
- * when the cache implementation is ready to receive them, this could be simplified
- * significantly.
- */
-struct QueuedFileChunk {
-  enum class Type { Body, Trailer };
-  QueuedFileChunk(Type t, const Buffer::Instance& b, InsertCallback c, bool end)
-      : type(t), done_callback(c), end_stream(end) {
-    // We must copy the buffer, not move it, because the original instance is being
-    // consumed by streaming to the client.
-    chunk.add(b);
-  }
-  Type type;
-  Buffer::OwnedImpl chunk;
-  InsertCallback done_callback;
-  bool end_stream;
-};
-
-/**
- * The cache filter doesn't actually support async insertion; splitting off a
- * shared_ptr<InsertOperationQueue> to control the actual write allows the
- * queue-chain to keep itself alive until the write is completed, even after the
- * filter instance is destroyed.
- */
-class InsertOperationQueue : public Logger::Loggable<Logger::Id::cache_filter> {
-public:
-  InsertOperationQueue(std::shared_ptr<FileSystemHttpCache>&& cache, const Key& key,
-                       const Http::RequestHeaderMap& request_headers,
-                       const VaryAllowList& vary_allow_list)
-      : key_(key), cache_(std::move(cache)), request_headers_(request_headers),
-        vary_allow_list_(vary_allow_list) {}
-  /**
-   * insertHeaders starts opening a cache file for write, and writing the headers
-   * to it. After that write completes, if there are more write operations in the
-   * queue, the next one begins. insert_complete is called when the header write
-   * is complete, fails, or is cancelled.
-   * If end_stream is true and the write completes, commit is also called.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   * @param response_headers the http headers to be written to the cache file.
-   * @param metadata the metadata to be written to the cache file.
-   * @param insert_complete is called with true when the header write completes,
-   *     or with false if file-open or any of the writes fail.
-   * @param end_stream true if the cache entry is header-only.
-   */
-  void insertHeaders(std::shared_ptr<InsertOperationQueue> p,
-                     const Http::ResponseHeaderMap& response_headers,
-                     const ResponseMetadata& metadata, InsertCallback insert_complete,
-                     bool end_stream);
-  /**
-   * insertBody queues writing a body chunk to the cache file previously opened
-   * in insertHeaders. If there were previously no operations in the queue, that
-   * write operation begins. After that write completes, if there are more operations
-   * in the queue, the next operation begins. ready_for_next_chunk is called
-   * when the write completes, fails, or is cancelled.
-   * If end_stream is true and the write completes, commit is also called.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   * @param chunk a buffer of body data to be written to the cache file.
-   * @param ready_for_next_chunk is called with true when the chunk write completes,
-   *     or with false if the write fails.
-   * @param end_stream true if this is the last body chunk and there are no trailers.
-   */
-  void insertBody(std::shared_ptr<InsertOperationQueue> p, const Buffer::Instance& chunk,
-                  InsertCallback ready_for_next_chunk, bool end_stream);
-  /**
-   * insertTrailers queues writing the trailers to the cache file previously opened
-   * in insertHeaders. If there were previously no operations in the queue, that
-   * write operation begins. After that write completes, commit is called.
-   * insert_complete is called when the write completes, fails, or is cancelled.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   * @param response_trailers the trailers to be written to the cache file.
-   * @param insert_complete is called with true when the commit completes,
-   *     or with false if any part of the commit fails or if it was not called.
-   */
-  void insertTrailers(std::shared_ptr<InsertOperationQueue> p,
-                      const Http::ResponseTrailerMap& response_trailers,
-                      InsertCallback insert_complete);
-
-  /**
-   * If seen_end_stream_ is not true (i.e. InsertContext has not yet delivered the
-   * entire response), cancel insertion. Called by InsertContext onDestroy.
-   */
-  void cancelIfIncomplete(std::shared_ptr<InsertOperationQueue> p);
-
-  /**
-   * Takes the mutex and calls cancelInsert.
-   */
-  ~InsertOperationQueue();
-
-private:
-  /**
-   * Puts an operation into the queue, or, if the queue is empty and no operation
-   * is in flight, starts the operation immediately.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   * @param chunk the data to be written.
-   */
-  void push(std::shared_ptr<InsertOperationQueue> p, QueuedFileChunk&& chunk)
-      ABSL_LOCKS_EXCLUDED(mu_);
-
-  /**
-   * Cancels any action in flight, calls any uncalled completion callbacks with false,
-   * and closes the file if open.
-   * @param p a shared_ptr to 'this'. Not actually used during cancelInsert, but taken
-   *     as a parameter to enforce that the caller must have the shared_ptr. May be
-   *     nullptr if called from the destructor.
-   * @param err a string to log with the failure.
-   */
-  void cancelInsert(std::shared_ptr<InsertOperationQueue> p, absl::string_view err = "")
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-
-  /**
-   * Starts asynchronously performing the final write operations for the cache file;
-   * writing the correct FixedCacheHeaderBlock, and giving the file its name.
-   * On success, removes cleanup_, so the subsequent call to cancelInsert during
-   * the destructor does not act as an error.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   * @param callback is called with true if the commit completes successfully,
-   *     with false if failed or cancelled.
-   */
-  void commit(std::shared_ptr<InsertOperationQueue> p, InsertCallback callback)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  /**
-   * Starts async-writing a chunk of data.
-   * Calls the chunk's callback on completion, failure or cancellation.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   * @param chunk contains the data to be written, and the metadata about where
-   *     to write it.
-   */
-  void writeChunk(std::shared_ptr<InsertOperationQueue> p, QueuedFileChunk&& chunk)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  /**
-   * Starts async-writing a previously queued chunk of data.
-   * Calls the chunk's callback on completion, failure or cancellation.
-   * If the queue is empty, does nothing.
-   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
-   *     'this' still exists when the lambda is called.
-   */
-  void writeNextChunk(std::shared_ptr<InsertOperationQueue> p) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  absl::Mutex mu_;
-  std::shared_ptr<Cleanup> cleanup_ ABSL_GUARDED_BY(mu_);
-  std::deque<QueuedFileChunk> queue_ ABSL_GUARDED_BY(mu_);
-  AsyncFileHandle file_handle_ ABSL_GUARDED_BY(mu_);
-  CancelFunction cancel_action_in_flight_ ABSL_GUARDED_BY(mu_);
-  std::function<void(bool)> callback_in_flight_ ABSL_GUARDED_BY(mu_);
-  CacheFileFixedBlock header_block_ ABSL_GUARDED_BY(mu_);
-  CacheFileHeader header_proto_ ABSL_GUARDED_BY(mu_);
-  bool seen_end_stream_ ABSL_GUARDED_BY(mu_) = false;
-  // key_ may be updated to a varyKey during insertHeaders.
-  Key key_ ABSL_GUARDED_BY(mu_);
-  const std::shared_ptr<FileSystemHttpCache> cache_;
-  // Request-related values. These are only used during the header callback, so they
-  // can be a reference as they exist in the filter which cannot be destroyed before that.
-  const Http::RequestHeaderMap& request_headers_;
-  const VaryAllowList& vary_allow_list_;
-};
-
 class DontInsertContext : public InsertContext {
 public:
   void insertHeaders(const Http::ResponseHeaderMap&, const ResponseMetadata&,
@@ -202,7 +34,7 @@ public:
   void onDestroy() override{};
 };
 
-class FileInsertContext : public InsertContext {
+class FileInsertContext : public InsertContext, public Logger::Loggable<Logger::Id::cache_filter> {
 public:
   FileInsertContext(std::shared_ptr<FileSystemHttpCache> cache,
                     std::unique_ptr<FileLookupContext> lookup_context);
@@ -217,7 +49,39 @@ public:
 
 private:
   std::unique_ptr<FileLookupContext> lookup_context_;
-  std::shared_ptr<InsertOperationQueue> queue_;
+  Key key_;
+  std::shared_ptr<FileSystemHttpCache> cache_;
+  absl::Mutex mu_; // guards file operations
+  std::shared_ptr<Cleanup> cleanup_ ABSL_GUARDED_BY(mu_);
+  AsyncFileHandle file_handle_ ABSL_GUARDED_BY(mu_);
+  std::function<void(bool)> callback_in_flight_ ABSL_GUARDED_BY(mu_);
+  CancelFunction cancel_action_in_flight_ ABSL_GUARDED_BY(mu_);
+  CacheFileFixedBlock header_block_ ABSL_GUARDED_BY(mu_);
+
+  /**
+   * If seen_end_stream_ is not true (i.e. InsertContext has not yet delivered the
+   * entire response), cancel insertion. Called by InsertContext onDestroy.
+   */
+  void cancelIfIncomplete();
+
+  /**
+   * Cancels any action in flight, calls any uncalled completion callbacks with false,
+   * and closes the file if open.
+   * @param err a string to log with the failure.
+   */
+  void cancelInsert(absl::string_view err = "") ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /**
+   * Starts asynchronously performing the final write operations for the cache file;
+   * writing the correct FixedCacheHeaderBlock, and giving the file its name.
+   * On success, removes cleanup_, so the subsequent call to cancelInsert during
+   * the destructor does not act as an error.
+   * @param p a shared_ptr to 'this', so it can be captured in lambdas to ensure
+   *     'this' still exists when the lambda is called.
+   * @param callback is called with true if the commit completes successfully,
+   *     with false if failed or cancelled.
+   */
+  void commit(InsertCallback callback) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 };
 
 } // namespace FileSystemHttpCache

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -478,56 +478,6 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, DuplicateInsertWhileInsertInProgres
   EXPECT_OK(mock_async_file_handle_->close([](absl::Status) {}));
 }
 
-// The documentation for cache_filter suggests it will wait for ready_for_next_chunk to be
-// called before sending another chunk, but it does not. This test verifies that the cache
-// doesn't rely on the documented behavior, and can cope with receiving two insertBody
-// calls without completion callbacks being called in between.
-TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertWithMultipleChunksBeforeCallbackWorks) {
-  auto inserter = testInserter();
-  absl::Cleanup destroy_inserter{[&inserter]() { inserter->onDestroy(); }};
-  EXPECT_CALL(*mock_async_file_manager_, createAnonymousFile(_, _));
-  inserter->insertHeaders(response_headers_, metadata_, expect_true_callback_, false);
-  absl::string_view body1 = "herp";
-  absl::string_view body2 = "derp";
-  inserter->insertBody(Buffer::OwnedImpl(body1), expect_true_callback_, false);
-  inserter->insertBody(Buffer::OwnedImpl(body2), expect_true_callback_, false);
-  inserter->insertTrailers(response_trailers_, expect_true_callback_);
-  EXPECT_EQ(0, true_callbacks_called_);
-  EXPECT_CALL(*mock_async_file_handle_, write(_, _, _)).Times(6);
-  EXPECT_CALL(*mock_async_file_manager_, stat(_, _));
-  EXPECT_CALL(*mock_async_file_manager_, unlink(_, _));
-  EXPECT_CALL(*mock_async_file_handle_, createHardLink(_, _));
-  // Open file
-  mock_async_file_manager_->nextActionCompletes(
-      absl::StatusOr<AsyncFileHandle>{mock_async_file_handle_});
-  // Empty pre-header
-  mock_async_file_manager_->nextActionCompletes(
-      absl::StatusOr<size_t>(CacheFileFixedBlock::size()));
-  // Headers
-  mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(headers_size_));
-  // Body1
-  mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(body1.size()));
-  // Body2
-  mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(body2.size()));
-  // Trailers
-  mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(trailers_size_));
-  // Updated pre-header (which triggers stat/unlink/createHardLink sequence)
-  mock_async_file_manager_->nextActionCompletes(
-      absl::StatusOr<size_t>(CacheFileFixedBlock::size()));
-  // Stat
-  mock_async_file_manager_->nextActionCompletes(
-      absl::StatusOr<struct stat>{absl::UnknownError("intentionally failed stat")});
-  // Unlink
-  mock_async_file_manager_->nextActionCompletes(absl::UnknownError("intentionally failed unlink"));
-  // createHardLink
-  mock_async_file_manager_->nextActionCompletes(absl::OkStatus());
-  // Should have been 4 callbacks; insertHeaders, insertBody, insertBody, insertTrailers.
-  EXPECT_EQ(true_callbacks_called_, 4);
-  EXPECT_EQ(cache_->stats().size_bytes_.value(), headers_size_ + body1.size() + body2.size() +
-                                                     trailers_size_ + CacheFileFixedBlock::size());
-  EXPECT_EQ(cache_->stats().size_count_.value(), 1);
-}
-
 TEST_F(FileSystemHttpCacheTestWithMockFiles, FailedOpenForReadReturnsMiss) {
   auto lookup = testLookupContext();
   absl::Cleanup destroy_lookup([&lookup]() { lookup->onDestroy(); });
@@ -754,21 +704,17 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles,
   EXPECT_OK(mock_async_file_handle_->close([](absl::Status) {}));
 }
 
-TEST_F(FileSystemHttpCacheTestWithMockFiles,
-       InsertAbortsOnFailureToWriteEmptyHeaderBlockAndCancelsEntireQueue) {
+TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertAbortsOnFailureToWriteEmptyHeaderBlock) {
   auto inserter = testInserter();
   absl::Cleanup destroy_inserter([&inserter]() { inserter->onDestroy(); });
   EXPECT_CALL(*mock_async_file_manager_, createAnonymousFile(_, _));
   EXPECT_CALL(*mock_async_file_handle_, write(_, _, _));
   inserter->insertHeaders(response_headers_, metadata_, expect_false_callback_, false);
-  inserter->insertBody(Buffer::OwnedImpl("woop"), expect_false_callback_, false);
-  inserter->insertBody(Buffer::OwnedImpl("woop"), expect_false_callback_, false);
-  inserter->insertBody(Buffer::OwnedImpl("woop"), expect_false_callback_, true);
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<AsyncFileHandle>(mock_async_file_handle_));
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(
       absl::UnknownError("intentionally failed write to empty header block")));
-  EXPECT_EQ(false_callbacks_called_, 4);
+  EXPECT_EQ(false_callbacks_called_, 1);
 }
 
 TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertAbortsOnFailureToWriteHeaderChunk) {
@@ -792,12 +738,13 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertAbortsOnFailureToWriteBodyChu
   EXPECT_CALL(*mock_async_file_manager_, createAnonymousFile(_, _));
   EXPECT_CALL(*mock_async_file_handle_, write(_, _, _)).Times(3);
   inserter->insertHeaders(response_headers_, metadata_, expect_true_callback_, false);
-  inserter->insertBody(Buffer::OwnedImpl("woop"), expect_false_callback_, false);
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<AsyncFileHandle>(mock_async_file_handle_));
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<size_t>(CacheFileFixedBlock::size()));
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(headers_size_));
+  EXPECT_EQ(true_callbacks_called_, 1);
+  inserter->insertBody(Buffer::OwnedImpl("woop"), expect_false_callback_, false);
   // Intentionally undersized write of body chunk.
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(1));
   EXPECT_EQ(false_callbacks_called_, 1);
@@ -810,14 +757,16 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertAbortsOnFailureToWriteTrailer
   EXPECT_CALL(*mock_async_file_handle_, write(_, _, _)).Times(4);
   inserter->insertHeaders(response_headers_, metadata_, expect_true_callback_, false);
   const absl::string_view body = "woop";
-  inserter->insertBody(Buffer::OwnedImpl(body), expect_true_callback_, false);
-  inserter->insertTrailers(response_trailers_, expect_false_callback_);
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<AsyncFileHandle>(mock_async_file_handle_));
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<size_t>(CacheFileFixedBlock::size()));
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(headers_size_));
+  EXPECT_EQ(true_callbacks_called_, 1);
+  inserter->insertBody(Buffer::OwnedImpl(body), expect_true_callback_, false);
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(body.size()));
+  EXPECT_EQ(true_callbacks_called_, 2);
+  inserter->insertTrailers(response_trailers_, expect_false_callback_);
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<size_t>(absl::UnknownError("intentionally failed write of trailer chunk")));
   EXPECT_EQ(false_callbacks_called_, 1);
@@ -829,15 +778,17 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertAbortsOnFailureToWriteUpdated
   EXPECT_CALL(*mock_async_file_manager_, createAnonymousFile(_, _));
   EXPECT_CALL(*mock_async_file_handle_, write(_, _, _)).Times(5);
   inserter->insertHeaders(response_headers_, metadata_, expect_true_callback_, false);
-  const absl::string_view body = "woop";
-  inserter->insertBody(Buffer::OwnedImpl(body), expect_true_callback_, false);
-  inserter->insertTrailers(response_trailers_, expect_false_callback_);
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<AsyncFileHandle>(mock_async_file_handle_));
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<size_t>(CacheFileFixedBlock::size()));
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(headers_size_));
+  EXPECT_EQ(true_callbacks_called_, 1);
+  const absl::string_view body = "woop";
+  inserter->insertBody(Buffer::OwnedImpl(body), expect_true_callback_, false);
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(body.size()));
+  EXPECT_EQ(true_callbacks_called_, 2);
+  inserter->insertTrailers(response_trailers_, expect_false_callback_);
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(trailers_size_));
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(
       absl::UnknownError("intentionally failed write of updated header block")));
@@ -853,15 +804,17 @@ TEST_F(FileSystemHttpCacheTestWithMockFiles, InsertAbortsOnFailureToLinkFile) {
   EXPECT_CALL(*mock_async_file_manager_, unlink(_, _));
   EXPECT_CALL(*mock_async_file_handle_, createHardLink(_, _));
   inserter->insertHeaders(response_headers_, metadata_, expect_true_callback_, false);
-  const absl::string_view body = "woop";
-  inserter->insertBody(Buffer::OwnedImpl(body), expect_true_callback_, false);
-  inserter->insertTrailers(response_trailers_, expect_false_callback_);
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<AsyncFileHandle>(mock_async_file_handle_));
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<size_t>(CacheFileFixedBlock::size()));
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(headers_size_));
+  EXPECT_EQ(true_callbacks_called_, 1);
+  const absl::string_view body = "woop";
+  inserter->insertBody(Buffer::OwnedImpl(body), expect_true_callback_, false);
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(body.size()));
+  EXPECT_EQ(true_callbacks_called_, 2);
+  inserter->insertTrailers(response_trailers_, expect_false_callback_);
   mock_async_file_manager_->nextActionCompletes(absl::StatusOr<size_t>(trailers_size_));
   mock_async_file_manager_->nextActionCompletes(
       absl::StatusOr<size_t>(CacheFileFixedBlock::size()));


### PR DESCRIPTION
Commit Message: Remove redundant queue from FileSystemHttpCache
Additional Description:
Since a queue was added to the http cache filter in #26841, the file system cache implementation no longer needs its own queue. Removing this redundant queue is also necessary to fully address https://github.com/envoyproxy/envoy/issues/29064.
Risk Level: Low; WIP filter and unit test coverage.
Testing: Modified unit tests, removed coverage for things that no longer exist, and ensured existing coverage still applies for what remains.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
