### PR TITLE
formatter: move context independent util function/class to seperated source file

### DIFF
--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
     ],
     external_deps = ["abseil_str_format"],
     deps = [
+        ":substitution_format_utility_lib",
         "//envoy/api:api_interface",
         "//envoy/formatter:substitution_formatter_interface",
         "//envoy/runtime:runtime_interface",
@@ -49,5 +50,19 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/protobuf",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "substitution_format_utility_lib",
+    srcs = ["substitution_format_utility.cc"],
+    hdrs = ["substitution_format_utility.h"],
+    deps = [
+        "//envoy/api:api_interface",
+        "//envoy/http:protocol_interface",
+        "//source/common/api:os_sys_calls_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/stream_info:utility_lib",
     ],
 )

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -6,6 +6,7 @@
 #include "source/common/common/thread.h"
 #include "source/common/common/utility.h"
 #include "source/common/config/metadata.h"
+#include "source/common/formatter/substitution_formatter.h"
 #include "source/common/grpc/common.h"
 #include "source/common/grpc/status.h"
 #include "source/common/http/utility.h"
@@ -307,8 +308,7 @@ HttpBuiltInCommandParser::getKnownFormatters() {
          [](const std::string& format, absl::optional<size_t>& max_length) {
            std::string main_header, alternative_header;
 
-           SubstitutionFormatParser::parseSubcommandHeaders(format, main_header,
-                                                            alternative_header);
+           SubstitutionFormatUtils::parseSubcommandHeaders(format, main_header, alternative_header);
 
            return std::make_unique<RequestHeaderFormatter>(main_header, alternative_header,
                                                            max_length);
@@ -318,8 +318,7 @@ HttpBuiltInCommandParser::getKnownFormatters() {
          [](const std::string& format, absl::optional<size_t>& max_length) {
            std::string main_header, alternative_header;
 
-           SubstitutionFormatParser::parseSubcommandHeaders(format, main_header,
-                                                            alternative_header);
+           SubstitutionFormatUtils::parseSubcommandHeaders(format, main_header, alternative_header);
 
            return std::make_unique<ResponseHeaderFormatter>(main_header, alternative_header,
                                                             max_length);
@@ -329,8 +328,7 @@ HttpBuiltInCommandParser::getKnownFormatters() {
          [](const std::string& format, absl::optional<size_t>& max_length) {
            std::string main_header, alternative_header;
 
-           SubstitutionFormatParser::parseSubcommandHeaders(format, main_header,
-                                                            alternative_header);
+           SubstitutionFormatUtils::parseSubcommandHeaders(format, main_header, alternative_header);
 
            return std::make_unique<ResponseTrailerFormatter>(main_header, alternative_header,
                                                              max_length);
@@ -379,8 +377,7 @@ HttpBuiltInCommandParser::getKnownFormatters() {
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
          [](const std::string& format, absl::optional<size_t>& max_length) {
            std::string main_header, alternative_header;
-           SubstitutionFormatParser::parseSubcommandHeaders(format, main_header,
-                                                            alternative_header);
+           SubstitutionFormatUtils::parseSubcommandHeaders(format, main_header, alternative_header);
 
            return std::make_unique<RequestHeaderFormatter>(main_header, alternative_header,
                                                            max_length);
@@ -404,6 +401,17 @@ FormatterProviderPtr HttpBuiltInCommandParser::parse(const std::string& command,
   // Create a pointer to the formatter by calling a function
   // associated with formatter's name.
   return (*it).second.second(subcommand, max_length);
+}
+
+static const std::string DEFAULT_FORMAT =
+    "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" "
+    "%RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% "
+    "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "
+    "\"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" "
+    "\"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n";
+
+FormatterPtr HttpHttpSubstitutionFormatUtils::defaultSubstitutionFormatter() {
+  return std::make_unique<Envoy::Formatter::FormatterImpl>(DEFAULT_FORMAT, false);
 }
 
 } // namespace Formatter

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -410,7 +410,7 @@ static const std::string DEFAULT_FORMAT =
     "\"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" "
     "\"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n";
 
-FormatterPtr HttpHttpSubstitutionFormatUtils::defaultSubstitutionFormatter() {
+FormatterPtr HttpSubstitutionFormatUtils::defaultSubstitutionFormatter() {
   return std::make_unique<Envoy::Formatter::FormatterImpl>(DEFAULT_FORMAT, false);
 }
 

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -11,7 +11,7 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/utility.h"
-#include "source/common/formatter/stream_info_formatter.h"
+#include "source/common/formatter/substitution_format_utility.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
@@ -221,6 +221,14 @@ private:
       absl::flat_hash_map<absl::string_view, std::pair<CommandSyntaxChecker::CommandSyntaxFlags,
                                                        FormatterProviderCreateFunc>>;
   static const FormatterProviderLookupTbl& getKnownFormatters();
+};
+
+/**
+ * Util class for HTTP access log format.
+ */
+class HttpSubstitutionFormatUtils {
+public:
+  static FormatterPtr defaultSubstitutionFormatter();
 };
 
 } // namespace Formatter

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -137,7 +137,7 @@ FilterStateFormatter::create(const std::string& format, const absl::optional<siz
   static constexpr absl::string_view PLAIN_SERIALIZATION{"PLAIN"};
   static constexpr absl::string_view TYPED_SERIALIZATION{"TYPED"};
 
-  SubstitutionFormatParser::parseSubcommand(format, ':', key, serialize_type);
+  SubstitutionFormatUtils::parseSubcommand(format, ':', key, serialize_type);
   if (key.empty()) {
     throw EnvoyException("Invalid filter state configuration, key cannot be empty.");
   }
@@ -1303,7 +1303,7 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
               std::string filter_namespace;
               std::vector<std::string> path;
 
-              SubstitutionFormatParser::parseSubcommand(format, ':', filter_namespace, path);
+              SubstitutionFormatUtils::parseSubcommand(format, ':', filter_namespace, path);
               return std::make_unique<DynamicMetadataFormatter>(filter_namespace, path, max_length);
             }}},
 
@@ -1313,7 +1313,7 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
               std::string filter_namespace;
               std::vector<std::string> path;
 
-              SubstitutionFormatParser::parseSubcommand(format, ':', filter_namespace, path);
+              SubstitutionFormatUtils::parseSubcommand(format, ':', filter_namespace, path);
               return std::make_unique<ClusterMetadataFormatter>(filter_namespace, path, max_length);
             }}},
           {"UPSTREAM_METADATA",
@@ -1322,7 +1322,7 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
               std::string filter_namespace;
               std::vector<std::string> path;
 
-              SubstitutionFormatParser::parseSubcommand(format, ':', filter_namespace, path);
+              SubstitutionFormatUtils::parseSubcommand(format, ':', filter_namespace, path);
               return std::make_unique<UpstreamHostMetadataFormatter>(filter_namespace, path,
                                                                      max_length);
             }}},

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -11,7 +11,7 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/utility.h"
-#include "source/common/formatter/substitution_formatter.h"
+#include "source/common/formatter/substitution_format_utility.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"

--- a/source/common/formatter/substitution_format_utility.cc
+++ b/source/common/formatter/substitution_format_utility.cc
@@ -1,0 +1,110 @@
+#include "source/common/formatter/substitution_format_utility.h"
+
+#include "envoy/api/os_sys_calls.h"
+
+#include "source/common/api/os_sys_calls_impl.h"
+#include "source/common/http/utility.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/stream_info/utility.h"
+
+namespace Envoy {
+namespace Formatter {
+
+static const std::string DefaultUnspecifiedValueString = "-";
+
+void CommandSyntaxChecker::verifySyntax(CommandSyntaxFlags flags, const std::string& command,
+                                        const std::string& subcommand,
+                                        const absl::optional<size_t>& length) {
+  if ((flags == COMMAND_ONLY) && ((subcommand.length() != 0) || length.has_value())) {
+    throw EnvoyException(fmt::format("{} does not take any parameters or length", command));
+  }
+
+  if ((flags & PARAMS_REQUIRED).any() && (subcommand.length() == 0)) {
+    throw EnvoyException(fmt::format("{} requires parameters", command));
+  }
+
+  if ((flags & LENGTH_ALLOWED).none() && length.has_value()) {
+    throw EnvoyException(fmt::format("{} does not allow length to be specified.", command));
+  }
+}
+
+const absl::optional<std::reference_wrapper<const std::string>>
+SubstitutionFormatUtils::protocolToString(const absl::optional<Http::Protocol>& protocol) {
+  if (protocol) {
+    return Http::Utility::getProtocolString(protocol.value());
+  }
+  return absl::nullopt;
+}
+
+const std::string&
+SubstitutionFormatUtils::protocolToStringOrDefault(const absl::optional<Http::Protocol>& protocol) {
+  if (protocol) {
+    return Http::Utility::getProtocolString(protocol.value());
+  }
+  return DefaultUnspecifiedValueString;
+}
+
+const absl::optional<std::string> SubstitutionFormatUtils::getHostname() {
+#ifdef HOST_NAME_MAX
+  const size_t len = HOST_NAME_MAX;
+#else
+  // This is notably the case in OSX.
+  const size_t len = 255;
+#endif
+  char name[len];
+  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
+  const Api::SysCallIntResult result = os_sys_calls.gethostname(name, len);
+
+  absl::optional<std::string> hostname;
+  if (result.return_value_ == 0) {
+    hostname = name;
+  }
+
+  return hostname;
+}
+
+const std::string SubstitutionFormatUtils::getHostnameOrDefault() {
+  absl::optional<std::string> hostname = getHostname();
+  if (hostname.has_value()) {
+    return hostname.value();
+  }
+  return DefaultUnspecifiedValueString;
+}
+
+const ProtobufWkt::Value& SubstitutionFormatUtils::unspecifiedValue() {
+  return ValueUtil::nullValue();
+}
+
+void SubstitutionFormatUtils::truncate(std::string& str, absl::optional<size_t> max_length) {
+  if (!max_length) {
+    return;
+  }
+
+  if (str.length() > max_length.value()) {
+    str.resize(max_length.value());
+  }
+}
+
+void SubstitutionFormatUtils::parseSubcommandHeaders(const std::string& subcommand,
+                                                     std::string& main_header,
+                                                     std::string& alternative_header) {
+  // subs is used only to check if there are more than 2 headers separated by '?'.
+  std::vector<std::string> subs;
+  alternative_header = "";
+  parseSubcommand(subcommand, '?', main_header, alternative_header, subs);
+  if (!subs.empty()) {
+    throw EnvoyException(
+        // Header format rules support only one alternative header.
+        // docs/root/configuration/observability/access_log/access_log.rst#format-rules
+        absl::StrCat("More than 1 alternative header specified in token: ", subcommand));
+  }
+
+  // The main and alternative header should not contain invalid characters {NUL, LR, CF}.
+  if (!Envoy::Http::validHeaderString(main_header) ||
+      !Envoy::Http::validHeaderString(alternative_header)) {
+    throw EnvoyException("Invalid header configuration. Format string contains null or newline.");
+  }
+}
+
+} // namespace Formatter
+} // namespace Envoy

--- a/source/common/formatter/substitution_format_utility.h
+++ b/source/common/formatter/substitution_format_utility.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "envoy/http/protocol.h"
+#include "envoy/stream_info/stream_info.h"
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
+#include "absl/types/optional.h"
+#include "fmt/format.h"
+
+namespace Envoy {
+namespace Formatter {
+
+class CommandSyntaxChecker {
+public:
+  using CommandSyntaxFlags = std::bitset<4>;
+  static constexpr CommandSyntaxFlags COMMAND_ONLY = 0;
+  static constexpr CommandSyntaxFlags PARAMS_REQUIRED = 1 << 0;
+  static constexpr CommandSyntaxFlags PARAMS_OPTIONAL = 1 << 1;
+  static constexpr CommandSyntaxFlags LENGTH_ALLOWED = 1 << 2;
+
+  static void verifySyntax(CommandSyntaxChecker::CommandSyntaxFlags flags,
+                           const std::string& command, const std::string& subcommand,
+                           const absl::optional<size_t>& length);
+};
+
+/**
+ * Context independent utility class for the formatter.
+ */
+class SubstitutionFormatUtils {
+public:
+  // Optional references are not supported, but this method has large performance
+  // impact, so using reference_wrapper.
+  static const absl::optional<std::reference_wrapper<const std::string>>
+  protocolToString(const absl::optional<Http::Protocol>& protocol);
+  static const std::string&
+  protocolToStringOrDefault(const absl::optional<Http::Protocol>& protocol);
+  static const absl::optional<std::string> getHostname();
+  static const std::string getHostnameOrDefault();
+
+  /**
+   * Unspecified value for protobuf.
+   */
+  static const ProtobufWkt::Value& unspecifiedValue();
+
+  /**
+   * Truncate a string to a maximum length. Do nothing if max_length is not set or
+   * max_length is greater than the length of the string.
+   */
+  static void truncate(std::string& str, absl::optional<size_t> max_length);
+
+  /**
+   * Parse a header subcommand of the form: X?Y .
+   * Will populate a main_header and an optional alternative header if specified.
+   * See doc:
+   * https://envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log#format-rules
+   */
+  static void parseSubcommandHeaders(const std::string& subcommand, std::string& main_header,
+                                     std::string& alternative_header);
+
+  /* Variadic function template to parse the
+     subcommand and assign found tokens to sequence of params.
+     subcommand must be a sequence
+     of tokens separated by the same separator, like: header1:header2 or header1?header2?header3.
+     params must be a sequence of std::string& with optional container storing std::string. Here are
+     examples of params:
+     - std::string& token1
+     - std::string& token1, std::string& token2
+     - std::string& token1, std::string& token2, std::vector<std::string>& remaining
+
+     If command contains more tokens than number of passed params, unassigned tokens will be
+     ignored. If command contains less tokens than number of passed params, some params will be left
+     untouched.
+  */
+  template <typename... Tokens>
+  static void parseSubcommand(const std::string& subcommand, const char separator,
+                              Tokens&&... params) {
+    std::vector<absl::string_view> tokens;
+    tokens = absl::StrSplit(subcommand, separator);
+    std::vector<absl::string_view>::iterator it = tokens.begin();
+    (
+        [&](auto& param) {
+          if (it != tokens.end()) {
+            if constexpr (std::is_same_v<typename std::remove_reference<decltype(param)>::type,
+                                         std::string>) {
+              // Compile time handler for std::string.
+              param = std::string(*it);
+              it++;
+            } else {
+              // Compile time handler for container type. It will catch all remaining tokens and
+              // move iterator to the end.
+              do {
+                param.push_back(std::string(*it));
+                it++;
+              } while (it != tokens.end());
+            }
+          }
+        }(params),
+        ...);
+  }
+};
+
+} // namespace Formatter
+} // namespace Envoy

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -36,90 +36,6 @@ namespace Formatter {
 
 static const std::string DefaultUnspecifiedValueString = "-";
 
-const std::string SubstitutionFormatUtils::DEFAULT_FORMAT =
-    "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" "
-    "%RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% "
-    "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "
-    "\"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" "
-    "\"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n";
-
-void CommandSyntaxChecker::verifySyntax(CommandSyntaxFlags flags, const std::string& command,
-                                        const std::string& subcommand,
-                                        const absl::optional<size_t>& length) {
-  if ((flags == COMMAND_ONLY) && ((subcommand.length() != 0) || length.has_value())) {
-    throw EnvoyException(fmt::format("{} does not take any parameters or length", command));
-  }
-
-  if ((flags & PARAMS_REQUIRED).any() && (subcommand.length() == 0)) {
-    throw EnvoyException(fmt::format("{} requires parameters", command));
-  }
-
-  if ((flags & LENGTH_ALLOWED).none() && length.has_value()) {
-    throw EnvoyException(fmt::format("{} does not allow length to be specified.", command));
-  }
-}
-
-FormatterPtr HttpSubstitutionFormatUtils::defaultSubstitutionFormatter() {
-  return std::make_unique<Envoy::Formatter::FormatterImpl>(DEFAULT_FORMAT, false);
-}
-
-const absl::optional<std::reference_wrapper<const std::string>>
-SubstitutionFormatUtils::protocolToString(const absl::optional<Http::Protocol>& protocol) {
-  if (protocol) {
-    return Http::Utility::getProtocolString(protocol.value());
-  }
-  return absl::nullopt;
-}
-
-const std::string&
-SubstitutionFormatUtils::protocolToStringOrDefault(const absl::optional<Http::Protocol>& protocol) {
-  if (protocol) {
-    return Http::Utility::getProtocolString(protocol.value());
-  }
-  return DefaultUnspecifiedValueString;
-}
-
-const absl::optional<std::string> SubstitutionFormatUtils::getHostname() {
-#ifdef HOST_NAME_MAX
-  const size_t len = HOST_NAME_MAX;
-#else
-  // This is notably the case in OSX.
-  const size_t len = 255;
-#endif
-  char name[len];
-  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
-  const Api::SysCallIntResult result = os_sys_calls.gethostname(name, len);
-
-  absl::optional<std::string> hostname;
-  if (result.return_value_ == 0) {
-    hostname = name;
-  }
-
-  return hostname;
-}
-
-const std::string SubstitutionFormatUtils::getHostnameOrDefault() {
-  absl::optional<std::string> hostname = getHostname();
-  if (hostname.has_value()) {
-    return hostname.value();
-  }
-  return DefaultUnspecifiedValueString;
-}
-
-const ProtobufWkt::Value& SubstitutionFormatUtils::unspecifiedValue() {
-  return ValueUtil::nullValue();
-}
-
-void SubstitutionFormatUtils::truncate(std::string& str, absl::optional<size_t> max_length) {
-  if (!max_length) {
-    return;
-  }
-
-  if (str.length() > max_length.value()) {
-    str.resize(max_length.value());
-  }
-}
-
 FormatterImpl::FormatterImpl(const std::string& format, bool omit_empty_values)
     : empty_value_string_(omit_empty_values ? EMPTY_STRING : DefaultUnspecifiedValueString) {
   providers_ = SubstitutionFormatParser::parse(format);
@@ -337,27 +253,6 @@ ProtobufWkt::Struct StructFormatter::format(const Http::RequestHeaderMap& reques
       },
   };
   return structFormatMapCallback(struct_output_format_, visitor).struct_value();
-}
-
-void SubstitutionFormatUtils::parseSubcommandHeaders(const std::string& subcommand,
-                                                     std::string& main_header,
-                                                     std::string& alternative_header) {
-  // subs is used only to check if there are more than 2 headers separated by '?'.
-  std::vector<std::string> subs;
-  alternative_header = "";
-  parseSubcommand(subcommand, '?', main_header, alternative_header, subs);
-  if (!subs.empty()) {
-    throw EnvoyException(
-        // Header format rules support only one alternative header.
-        // docs/root/configuration/observability/access_log/access_log.rst#format-rules
-        absl::StrCat("More than 1 alternative header specified in token: ", subcommand));
-  }
-
-  // The main and alternative header should not contain invalid characters {NUL, LR, CF}.
-  if (!Envoy::Http::validHeaderString(main_header) ||
-      !Envoy::Http::validHeaderString(alternative_header)) {
-    throw EnvoyException("Invalid header configuration. Format string contains null or newline.");
-  }
 }
 
 std::vector<FormatterProviderPtr> SubstitutionFormatParser::parse(const std::string& format) {

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -59,7 +59,7 @@ void CommandSyntaxChecker::verifySyntax(CommandSyntaxFlags flags, const std::str
   }
 }
 
-FormatterPtr SubstitutionFormatUtils::defaultSubstitutionFormatter() {
+FormatterPtr HttpSubstitutionFormatUtils::defaultSubstitutionFormatter() {
   return std::make_unique<Envoy::Formatter::FormatterImpl>(DEFAULT_FORMAT, false);
 }
 
@@ -339,9 +339,9 @@ ProtobufWkt::Struct StructFormatter::format(const Http::RequestHeaderMap& reques
   return structFormatMapCallback(struct_output_format_, visitor).struct_value();
 }
 
-void SubstitutionFormatParser::parseSubcommandHeaders(const std::string& subcommand,
-                                                      std::string& main_header,
-                                                      std::string& alternative_header) {
+void SubstitutionFormatUtils::parseSubcommandHeaders(const std::string& subcommand,
+                                                     std::string& main_header,
+                                                     std::string& alternative_header) {
   // subs is used only to check if there are more than 2 headers separated by '?'.
   std::vector<std::string> subs;
   alternative_header = "";

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -12,6 +12,8 @@
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/utility.h"
+#include "source/common/formatter/http_specific_formatter.h"
+#include "source/common/formatter/stream_info_formatter.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -19,19 +19,6 @@
 namespace Envoy {
 namespace Formatter {
 
-class CommandSyntaxChecker {
-public:
-  using CommandSyntaxFlags = std::bitset<4>;
-  static constexpr CommandSyntaxFlags COMMAND_ONLY = 0;
-  static constexpr CommandSyntaxFlags PARAMS_REQUIRED = 1 << 0;
-  static constexpr CommandSyntaxFlags PARAMS_OPTIONAL = 1 << 1;
-  static constexpr CommandSyntaxFlags LENGTH_ALLOWED = 1 << 2;
-
-  static void verifySyntax(CommandSyntaxChecker::CommandSyntaxFlags flags,
-                           const std::string& command, const std::string& subcommand,
-                           const absl::optional<size_t>& length);
-};
-
 /**
  * Access log format parser.
  */
@@ -40,86 +27,6 @@ public:
   static std::vector<FormatterProviderPtr> parse(const std::string& format);
   static std::vector<FormatterProviderPtr>
   parse(const std::string& format, const std::vector<CommandParserPtr>& command_parsers);
-
-  /**
-   * Parse a header subcommand of the form: X?Y .
-   * Will populate a main_header and an optional alternative header if specified.
-   * See doc:
-   * https://envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log#format-rules
-   */
-  static void parseSubcommandHeaders(const std::string& subcommand, std::string& main_header,
-                                     std::string& alternative_header);
-
-  /* Variadic function template to parse the
-     subcommand and assign found tokens to sequence of params.
-     subcommand must be a sequence
-     of tokens separated by the same separator, like: header1:header2 or header1?header2?header3.
-     params must be a sequence of std::string& with optional container storing std::string. Here are
-     examples of params:
-     - std::string& token1
-     - std::string& token1, std::string& token2
-     - std::string& token1, std::string& token2, std::vector<std::string>& remaining
-
-     If command contains more tokens than number of passed params, unassigned tokens will be
-     ignored. If command contains less tokens than number of passed params, some params will be left
-     untouched.
-  */
-  template <typename... Tokens>
-  static void parseSubcommand(const std::string& subcommand, const char separator,
-                              Tokens&&... params) {
-    std::vector<absl::string_view> tokens;
-    tokens = absl::StrSplit(subcommand, separator);
-    std::vector<absl::string_view>::iterator it = tokens.begin();
-    (
-        [&](auto& param) {
-          if (it != tokens.end()) {
-            if constexpr (std::is_same_v<typename std::remove_reference<decltype(param)>::type,
-                                         std::string>) {
-              // Compile time handler for std::string.
-              param = std::string(*it);
-              it++;
-            } else {
-              // Compile time handler for container type. It will catch all remaining tokens and
-              // move iterator to the end.
-              do {
-                param.push_back(std::string(*it));
-                it++;
-              } while (it != tokens.end());
-            }
-          }
-        }(params),
-        ...);
-  }
-};
-
-/**
- * Util class for access log format.
- */
-class SubstitutionFormatUtils {
-public:
-  static FormatterPtr defaultSubstitutionFormatter();
-  // Optional references are not supported, but this method has large performance
-  // impact, so using reference_wrapper.
-  static const absl::optional<std::reference_wrapper<const std::string>>
-  protocolToString(const absl::optional<Http::Protocol>& protocol);
-  static const std::string&
-  protocolToStringOrDefault(const absl::optional<Http::Protocol>& protocol);
-  static const absl::optional<std::string> getHostname();
-  static const std::string getHostnameOrDefault();
-
-  /**
-   * Unspecified value for protobuf.
-   */
-  static const ProtobufWkt::Value& unspecifiedValue();
-
-  /**
-   * Truncate a string to a maximum length. Do nothing if max_length is not set or
-   * max_length is greater than the length of the string.
-   */
-  static void truncate(std::string& str, absl::optional<size_t> max_length);
-
-private:
-  static const std::string DEFAULT_FORMAT;
 };
 
 /**

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -22,7 +22,7 @@ createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::Filter
         Formatter::SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format(), context);
   } else if (fal_config.access_log_format_case() ==
              T::AccessLogFormatCase::ACCESS_LOG_FORMAT_NOT_SET) {
-    formatter = Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter();
+    formatter = Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter();
   }
   Filesystem::FilePathAndType file_info{destination_type, ""};
   return std::make_shared<AccessLoggers::File::FileAccessLog>(

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -38,7 +38,7 @@ AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
   switch (fal_config.access_log_format_case()) {
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kFormat:
     if (fal_config.format().empty()) {
-      formatter = Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter();
+      formatter = Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter();
     } else {
       envoy::config::core::v3::SubstitutionFormatString sff_config;
       sff_config.mutable_text_format_source()->set_inline_string(fal_config.format());
@@ -62,7 +62,7 @@ AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
       ACCESS_LOG_FORMAT_NOT_SET:
-    formatter = Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter();
+    formatter = Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter();
     break;
   }
 

--- a/source/extensions/formatter/metadata/metadata.cc
+++ b/source/extensions/formatter/metadata/metadata.cc
@@ -65,8 +65,8 @@ MetadataFormatterCommandParser::parse(const std::string& command, const std::str
     std::string type, filter_namespace;
     std::vector<std::string> path;
 
-    ::Envoy::Formatter::SubstitutionFormatParser::parseSubcommand(subcommand, ':', type,
-                                                                  filter_namespace, path);
+    ::Envoy::Formatter::SubstitutionFormatUtils::parseSubcommand(subcommand, ':', type,
+                                                                 filter_namespace, path);
 
     auto provider = metadata_formatter_providers_.find(type);
     if (provider == metadata_formatter_providers_.end()) {

--- a/source/extensions/formatter/req_without_query/req_without_query.cc
+++ b/source/extensions/formatter/req_without_query/req_without_query.cc
@@ -74,8 +74,8 @@ ReqWithoutQueryCommandParser::parse(const std::string& command, const std::strin
   if (command == "REQ_WITHOUT_QUERY") {
     std::string main_header, alternative_header;
 
-    Envoy::Formatter::SubstitutionFormatParser::parseSubcommandHeaders(subcommand, main_header,
-                                                                       alternative_header);
+    Envoy::Formatter::SubstitutionFormatUtils::parseSubcommandHeaders(subcommand, main_header,
+                                                                      alternative_header);
     return std::make_unique<ReqWithoutQuery>(main_header, alternative_header, max_length);
   }
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -251,7 +251,7 @@ void InitialImpl::initAdminAccessLog(const envoy::config::bootstrap::v3::Bootstr
     Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File,
                                           admin.access_log_path()};
     admin_.access_logs_.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
-        file_info, {}, Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter(),
+        file_info, {}, Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),
         server.accessLogManager()));
   }
 }

--- a/test/common/formatter/substitution_formatter_speed_test.cc
+++ b/test/common/formatter/substitution_formatter_speed_test.cc
@@ -191,7 +191,7 @@ static void BM_FormatterCommandParsing(benchmark::State& state) {
   const std::string token = "Listener:namespace:key";
   std::string listener, names, key;
   for (auto _ : state) { // NOLINT: Silences warning about dead store
-    Formatter::SubstitutionFormatParser::parseSubcommand(token, ':', listener, names, key);
+    Formatter::SubstitutionFormatUtils::parseSubcommand(token, ':', listener, names, key);
   }
 }
 BENCHMARK(BM_FormatterCommandParsing);

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -112,19 +112,19 @@ TEST(SubstitutionFormatParser, commandParser) {
   std::string token1;
 
   std::string command = "item1";
-  SubstitutionFormatParser::parseSubcommand(command, ':', token1);
+  SubstitutionFormatUtils::parseSubcommand(command, ':', token1);
   ASSERT_EQ(token1, "item1");
 
   std::string token2;
   command = "item1:item2";
-  SubstitutionFormatParser::parseSubcommand(command, ':', token1, token2);
+  SubstitutionFormatUtils::parseSubcommand(command, ':', token1, token2);
   ASSERT_EQ(token1, "item1");
   ASSERT_EQ(token2, "item2");
 
   // Three tokens.
   std::string token3;
   command = "item1?item2?item3";
-  SubstitutionFormatParser::parseSubcommand(command, '?', token1, token2, token3);
+  SubstitutionFormatUtils::parseSubcommand(command, '?', token1, token2, token3);
   ASSERT_EQ(token1, "item1");
   ASSERT_EQ(token2, "item2");
   ASSERT_EQ(token3, "item3");
@@ -132,7 +132,7 @@ TEST(SubstitutionFormatParser, commandParser) {
   // Command string has 4 tokens but 3 are expected.
   // The first 3 will be read, the fourth will be ignored.
   command = "item1?item2?item3?item4";
-  SubstitutionFormatParser::parseSubcommand(command, '?', token1, token2, token3);
+  SubstitutionFormatUtils::parseSubcommand(command, '?', token1, token2, token3);
   ASSERT_EQ(token1, "item1");
   ASSERT_EQ(token2, "item2");
   ASSERT_EQ(token3, "item3");
@@ -141,7 +141,7 @@ TEST(SubstitutionFormatParser, commandParser) {
   // The third extracted token should be empty.
   command = "item1?item2";
   token3.erase();
-  SubstitutionFormatParser::parseSubcommand(command, '?', token1, token2, token3);
+  SubstitutionFormatUtils::parseSubcommand(command, '?', token1, token2, token3);
   ASSERT_EQ(token1, "item1");
   ASSERT_EQ(token2, "item2");
   ASSERT_TRUE(token3.empty());
@@ -150,7 +150,7 @@ TEST(SubstitutionFormatParser, commandParser) {
   // and remaining 2 into a vector of strings.
   command = "item1?item2?item3?item4";
   std::vector<std::string> bucket;
-  SubstitutionFormatParser::parseSubcommand(command, '?', token1, token2, bucket);
+  SubstitutionFormatUtils::parseSubcommand(command, '?', token1, token2, bucket);
   ASSERT_EQ(token1, "item1");
   ASSERT_EQ(token2, "item2");
   ASSERT_EQ(bucket.size(), 2);

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -17,7 +17,7 @@ HttpConnectionManagerImplMixin::HttpConnectionManagerImplMixin()
       access_log_path_("dummy_path"),
       access_logs_{AccessLog::InstanceSharedPtr{new Extensions::AccessLoggers::File::FileAccessLog(
           Filesystem::FilePathAndType{Filesystem::DestinationType::File, access_log_path_}, {},
-          Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter(), log_manager_)}},
+          Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(), log_manager_)}},
       codec_(new NiceMock<MockServerConnection>()),
       stats_({ALL_HTTP_CONN_MAN_STATS(POOL_COUNTER(*fake_stats_.rootScope()),
                                       POOL_GAUGE(*fake_stats_.rootScope()),

--- a/test/server/admin/admin_instance.cc
+++ b/test/server/admin/admin_instance.cc
@@ -14,7 +14,7 @@ AdminInstanceTest::AdminInstanceTest()
   std::list<AccessLog::InstanceSharedPtr> access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
-      file_info, {}, Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter(),
+      file_info, {}, Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),
       server_.accessLogManager()));
   admin_.startHttpListener(access_logs, address_out_path_,
                            Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr,

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -72,7 +72,7 @@ TEST_P(AdminInstanceTest, AdminAddress) {
   std::list<AccessLog::InstanceSharedPtr> access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
-      file_info, {}, Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter(),
+      file_info, {}, Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),
       server_.accessLogManager()));
   EXPECT_LOG_CONTAINS("info", "admin address:",
                       admin_address_out_path.startHttpListener(
@@ -88,7 +88,7 @@ TEST_P(AdminInstanceTest, AdminBadAddressOutPath) {
   std::list<AccessLog::InstanceSharedPtr> access_logs;
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, "/dev/null"};
   access_logs.emplace_back(new Extensions::AccessLoggers::File::FileAccessLog(
-      file_info, {}, Formatter::SubstitutionFormatUtils::defaultSubstitutionFormatter(),
+      file_info, {}, Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter(),
       server_.accessLogManager()));
   EXPECT_LOG_CONTAINS(
       "critical", "cannot open admin address output file " + bad_path + " for writing.",

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -119,6 +119,7 @@ paths:
     - source/common/formatter/http_specific_formatter.cc
     - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.cc
+    - source/common/formatter/substitution_format_utility.cc
     - source/common/formatter/substitution_format_string.cc
     - source/common/stats/tag_extractor_impl.cc
     - source/common/stats/tag_producer_impl.cc


### PR DESCRIPTION

Commit Message: formatter: move context independent util function/class to seperated source file
Additional Description:

First sub PR that splited out from #29021 
This PR is simple refactor to move some utility function/class to seperated source file. This is necessary because the templated formatter will change the deps of different libs.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.