### PR TITLE
Clean up: Remove http_filter_avoid_reentrant_local_reply runtime guard.

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -44,6 +44,9 @@ bug_fixes:
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+- area: http filters
+  change: |
+    Removed ``envoy_reloadable_features_http_filter_avoid_reentrant_local_reply`` runtime flag and legacy code paths.
 
 new_features:
 - area: access_log

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -917,8 +917,7 @@ void DownstreamFilterManager::sendLocalReply(
 
     // We only prepare a local reply to execute later if we're actively
     // invoking filters to avoid re-entrant in filters.
-    if (avoid_reentrant_filter_invocation_during_local_reply_ &&
-        (state_.filter_call_state_ & FilterCallState::IsDecodingMask)) {
+    if (state_.filter_call_state_ & FilterCallState::IsDecodingMask) {
       prepareLocalReplyViaFilterChain(is_grpc_request, code, body, modify_headers, is_head_request,
                                       grpc_status, details);
     } else {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -1062,9 +1062,7 @@ public:
                       proxy_100_continue, buffer_limit, filter_chain_factory),
         stream_info_(protocol, time_source, connection.connectionInfoProviderSharedPtr(),
                      parent_filter_state, filter_state_life_span),
-        local_reply_(local_reply),
-        avoid_reentrant_filter_invocation_during_local_reply_(Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.http_filter_avoid_reentrant_local_reply")) {}
+        local_reply_(local_reply) {}
   ~DownstreamFilterManager() override {
     ASSERT(prepared_local_reply_ == nullptr,
            "Filter Manager destroyed without executing prepared local reply");
@@ -1137,7 +1135,6 @@ private:
 private:
   OverridableRemoteConnectionInfoSetterStreamInfo stream_info_;
   const LocalReply::LocalReply& local_reply_;
-  const bool avoid_reentrant_filter_invocation_during_local_reply_;
   Utility::PreparedLocalReplyPtr prepared_local_reply_{nullptr};
 };
 

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -676,13 +676,9 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedRequestBodyTooBig) {
         ProcessingRequest header_resp;
         bool seen_response_headers = false;
 
-        // Reading from the stream, we might receive the response headers
-        // later if we execute the local reply after the filter executes.
-        const int num_reads_for_response_headers =
-            Runtime::runtimeFeatureEnabled(
-                "envoy.reloadable_features.http_filter_avoid_reentrant_local_reply")
-                ? 2
-                : 1;
+        // Reading from the stream, we receive the response headers
+        // later due to executing the local reply after the filter executes.
+        const int num_reads_for_response_headers = 2;
         for (int i = 0; i < num_reads_for_response_headers; ++i) {
           if (stream->Read(&header_resp) && header_resp.has_response_headers()) {
             seen_response_headers = true;

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -1249,10 +1249,6 @@ TEST_P(FilterIntegrationTest, ResetFilter) {
 }
 
 TEST_P(FilterIntegrationTest, LocalReplyViaFilterChainDoesNotConcurrentlyInvokeFilter) {
-  if (!Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.http_filter_avoid_reentrant_local_reply")) {
-    return;
-  }
   prependFilter(R"EOF(
   name: assert-non-reentrant-filter
   )EOF");

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -88,7 +88,7 @@ public:
 };
 
 class UpstreamDownstreamIntegrationTest
-    : public testing::TestWithParam<std::tuple<HttpProtocolTestParams, bool, bool>>,
+    : public testing::TestWithParam<std::tuple<HttpProtocolTestParams, bool>>,
       public HttpIntegrationTest {
 public:
   UpstreamDownstreamIntegrationTest()
@@ -101,23 +101,17 @@ public:
     config_helper_.addRuntimeOverride(
         Runtime::defer_processing_backedup_streams,
         std::get<0>(GetParam()).defer_processing_backedup_streams ? "true" : "false");
-    const bool avoid_reentrant_filter_local_reply = std::get<2>(GetParam());
-    config_helper_.addRuntimeOverride(
-        "envoy_reloadable_features_http_filter_avoid_reentrant_local_reply",
-        avoid_reentrant_filter_local_reply ? "true" : "false");
   }
   static std::string testParamsToString(
-      const ::testing::TestParamInfo<std::tuple<HttpProtocolTestParams, bool, bool>>& params) {
+      const ::testing::TestParamInfo<std::tuple<HttpProtocolTestParams, bool>>& params) {
     return fmt::format(
-        "{}_{}_{}",
+        "{}_{}",
         HttpProtocolIntegrationTest::protocolTestParamsToString(
             ::testing::TestParamInfo<HttpProtocolTestParams>(std::get<0>(params.param), 0)),
-        std::get<1>(params.param) ? "DownstreamFilter" : "UpstreamFilter",
-        std::get<2>(params.param) ? "AvoidReentrantFilterLocalReply"
-                                  : "AllowReentrantFilterLocalReply");
+        std::get<1>(params.param) ? "DownstreamFilter" : "UpstreamFilter");
   }
 
-  static std::vector<std::tuple<HttpProtocolTestParams, bool, bool>>
+  static std::vector<std::tuple<HttpProtocolTestParams, bool>>
   getDefaultTestParams(const std::vector<Http::CodecType>& downstream_protocols =
                            {
                                Http::CodecType::HTTP1,
@@ -129,19 +123,15 @@ public:
                            Http::CodecType::HTTP2,
                            Http::CodecType::HTTP3,
                        }) {
-    std::vector<std::tuple<HttpProtocolTestParams, bool, bool>> ret;
+    std::vector<std::tuple<HttpProtocolTestParams, bool>> ret;
     std::vector<HttpProtocolTestParams> protocol_defaults =
         HttpProtocolIntegrationTest::getProtocolTestParams(downstream_protocols,
                                                            upstream_protocols);
     const std::vector<bool> testing_downstream_filter_values{true, false};
-    const std::vector<bool> avoid_reentrant_filter_local_reply_values{true, false};
 
     for (auto& param : protocol_defaults) {
       for (bool testing_downstream_filter : testing_downstream_filter_values) {
-        for (bool avoid_reentrant_filter_local_reply : avoid_reentrant_filter_local_reply_values) {
-          ret.push_back(std::make_tuple(param, testing_downstream_filter,
-                                        avoid_reentrant_filter_local_reply));
-        }
+        ret.push_back(std::make_tuple(param, testing_downstream_filter));
       }
     }
     return ret;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Clean up: Remove http_filter_avoid_reentrant_local_reply runtime guard.
Additional Description: na
Risk Level: low
Testing: ran tests
Docs Changes: na
Release Notes: inc
Platform Specific Features: na
 Fixes #29095

