### PR TITLE
Config: preserve the load balancer factory when merging CIOs if there's no new

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1288,7 +1288,9 @@ ClusterManagerImpl::addOrUpdateClusterInitializationObjectIfSupported(
     // We need to copy from an existing Cluster Initialization Object. In
     // particular, only update the params with changed priority.
     auto new_initialization_object = std::make_shared<ClusterInitializationObject>(
-        entry->second->per_priority_state_, params, std::move(cluster_info), load_balancer_factory,
+        entry->second->per_priority_state_, params, std::move(cluster_info),
+        load_balancer_factory == nullptr ? entry->second->load_balancer_factory_
+                                         : load_balancer_factory,
         map);
     cluster_initialization_map_[cluster_name] = new_initialization_object;
     return new_initialization_object;

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -851,7 +851,11 @@ TEST_P(EdsIntegrationTest, DataplaneTrafficAfterEdsUpdateOfInitializedCluster) {
   }
   autonomous_upstream_ = true;
 
-  initializeTest(false);
+  initializeTest(false, [](envoy::config::cluster::v3::Cluster& cluster) {
+    // Make the cluster a maglev cluster which relies on the load balancer
+    // factory that is created when the cluster is first added.
+    cluster.set_lb_policy(::envoy::config::cluster::v3::Cluster::MAGLEV);
+  });
   EndpointSettingOptions options;
   options.total_endpoints = 1;
   options.healthy_endpoints = 1;


### PR DESCRIPTION
load balancer factory provided.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Config: preserve the load balancer factory when merging CIOs if there's no new load balancer factory provided.
Additional Description: 
Risk Level: low / med 
Testing: modified test include testing this behavior
Docs Changes: na
Release Notes: na
Platform Specific Features: na
[Optional Runtime guard:] Config guarded feature
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
