### PR TITLE
Optimize AsyncClientManager by moving hashing to control plane

### DIFF
--- a/envoy/grpc/async_client_manager.h
+++ b/envoy/grpc/async_client_manager.h
@@ -43,7 +43,7 @@ public:
   friend bool operator==(const GrpcServiceHashKeyWrapper& lhs,
                          const GrpcServiceHashKeyWrapper& rhs) {
     return lhs.config_.GetTypeName() == rhs.config_.GetTypeName() &&
-           lhs.serialized_config_ == rhs.serialized_config_;
+           lhs.config_as_string_ == rhs.config_as_string_;
   }
 
   const envoy::config::core::v3::GrpcService& config() const { return config_; }
@@ -51,7 +51,7 @@ public:
 private:
   const envoy::config::core::v3::GrpcService config_;
   const std::size_t pre_computed_hash_;
-  const std::string serialized_config_;
+  const std::string config_as_string_;
 };
 
 // Singleton gRPC client manager. Grpc::AsyncClientManager can be used to create per-service

--- a/envoy/grpc/async_client_manager.h
+++ b/envoy/grpc/async_client_manager.h
@@ -63,6 +63,7 @@ class AsyncClientManager {
 public:
   virtual ~AsyncClientManager() = default;
 
+  // TODO(diazalan) deprecate old getOrCreateRawAsyncClient once all filters have been transitioned
   /**
    * Create a Grpc::RawAsyncClient. The async client is cached thread locally and shared across
    * different filter instances.
@@ -78,7 +79,18 @@ public:
   getOrCreateRawAsyncClient(const envoy::config::core::v3::GrpcService& grpc_service,
                             Stats::Scope& scope, bool skip_cluster_check) PURE;
 
-  // TODO(diazalan) deprecate old getOrCreateRawAsyncClient once all filters have been transitioned
+  /**
+   * Create a Grpc::RawAsyncClient. The async client is cached thread locally and shared across
+   * different filter instances.
+   * @param grpc_service Envoy::Grpc::GrpcServiceConfigWithHashKey which contains config and
+   * hashkey.
+   * @param scope stats scope.
+   * @param skip_cluster_check if set to true skips checks for cluster presence and being statically
+   * configured.
+   * @param cache_option always use cache or use cache when runtime is enabled.
+   * @return RawAsyncClientPtr a grpc async client.
+   * @throws EnvoyException when grpc_service validation fails.
+   */
   virtual RawAsyncClientSharedPtr
   getOrCreateRawAsyncClientWithHashKey(const GrpcServiceConfigWithHashKey& grpc_service,
                                        Stats::Scope& scope, bool skip_cluster_check) PURE;

--- a/envoy/grpc/async_client_manager.h
+++ b/envoy/grpc/async_client_manager.h
@@ -34,7 +34,8 @@ using AsyncClientFactoryPtr = std::unique_ptr<AsyncClientFactory>;
 
 class GrpcServiceHashKeyWrapper {
 public:
-  GrpcServiceHashKeyWrapper(const envoy::config::core::v3::GrpcService& config);
+  GrpcServiceHashKeyWrapper(const envoy::config::core::v3::GrpcService& config)
+      : config_(config), pre_computed_hash_(Envoy::MessageUtil::hash(config)){};
 
   template <typename H> friend H AbslHashValue(H h, const GrpcServiceHashKeyWrapper& wrapper) {
     return H::combine(std::move(h), wrapper.pre_computed_hash_);
@@ -42,8 +43,7 @@ public:
 
   friend bool operator==(const GrpcServiceHashKeyWrapper& lhs,
                          const GrpcServiceHashKeyWrapper& rhs) {
-    return lhs.config_.GetTypeName() == rhs.config_.GetTypeName() &&
-           lhs.config_as_string_ == rhs.config_as_string_;
+    return Protobuf::util::MessageDifferencer::Equivalent(lhs.config_, rhs.config_);
   }
 
   const envoy::config::core::v3::GrpcService& config() const { return config_; }
@@ -51,7 +51,6 @@ public:
 private:
   const envoy::config::core::v3::GrpcService config_;
   const std::size_t pre_computed_hash_;
-  const std::string config_as_string_;
 };
 
 // Singleton gRPC client manager. Grpc::AsyncClientManager can be used to create per-service

--- a/envoy/grpc/async_client_manager.h
+++ b/envoy/grpc/async_client_manager.h
@@ -34,12 +34,14 @@ using AsyncClientFactoryPtr = std::unique_ptr<AsyncClientFactory>;
 
 class GrpcServiceConfigWithHashKey {
 public:
-  GrpcServiceConfigWithHashKey(const envoy::config::core::v3::GrpcService& config)
+  explicit GrpcServiceConfigWithHashKey(const envoy::config::core::v3::GrpcService& config)
       : config_(config), pre_computed_hash_(Envoy::MessageUtil::hash(config)){};
 
   template <typename H> friend H AbslHashValue(H h, const GrpcServiceConfigWithHashKey& wrapper) {
     return H::combine(std::move(h), wrapper.pre_computed_hash_);
   }
+
+  std::size_t getPreComputedHash() const { return pre_computed_hash_; }
 
   friend bool operator==(const GrpcServiceConfigWithHashKey& lhs,
                          const GrpcServiceConfigWithHashKey& rhs) {

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -52,7 +52,7 @@ AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
 GrpcServiceHashKeyWrapper::GrpcServiceHashKeyWrapper(
     const envoy::config::core::v3::GrpcService& config)
     : config_(config), pre_computed_hash_(Envoy::MessageUtil::hash(config)),
-      serialized_config_(config.SerializeAsString()) {}
+      config_as_string_(Envoy::MessageUtil::getYamlStringFromMessage(config)) {}
 
 AsyncClientManagerImpl::AsyncClientManagerImpl(Upstream::ClusterManager& cm,
                                                ThreadLocal::Instance& tls, TimeSource& time_source,

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -49,11 +49,6 @@ AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
   cm_.checkActiveStaticCluster(config.envoy_grpc().cluster_name());
 }
 
-GrpcServiceHashKeyWrapper::GrpcServiceHashKeyWrapper(
-    const envoy::config::core::v3::GrpcService& config)
-    : config_(config), pre_computed_hash_(Envoy::MessageUtil::hash(config)),
-      config_as_string_(Envoy::MessageUtil::getYamlStringFromMessage(config)) {}
-
 AsyncClientManagerImpl::AsyncClientManagerImpl(Upstream::ClusterManager& cm,
                                                ThreadLocal::Instance& tls, TimeSource& time_source,
                                                Api::Api& api, const StatNames& stat_names)

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/upstream/cluster_manager.h"
 
 #include "source/common/grpc/stat_names.h"
+#include "source/common/protobuf/utility.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -51,32 +52,34 @@ public:
   getOrCreateRawAsyncClient(const envoy::config::core::v3::GrpcService& config, Stats::Scope& scope,
                             bool skip_cluster_check) override;
 
+  RawAsyncClientSharedPtr
+  getOrCreateRawAsyncClientWithWrapper(const GrpcServiceHashKeyWrapper& key_wrapper,
+                                       Stats::Scope& scope, bool skip_cluster_check) override;
+
   AsyncClientFactoryPtr factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
                                               Stats::Scope& scope,
                                               bool skip_cluster_check) override;
   class RawAsyncClientCache : public ThreadLocal::ThreadLocalObject {
   public:
     explicit RawAsyncClientCache(Event::Dispatcher& dispatcher);
-    void setCache(const envoy::config::core::v3::GrpcService& config,
+    void setCache(const GrpcServiceHashKeyWrapper& key_wrapper,
                   const RawAsyncClientSharedPtr& client);
 
-    RawAsyncClientSharedPtr getCache(const envoy::config::core::v3::GrpcService& config);
+    RawAsyncClientSharedPtr getCache(const GrpcServiceHashKeyWrapper& key_wrapper);
 
   private:
     void evictEntriesAndResetEvictionTimer();
     struct CacheEntry {
       CacheEntry(const envoy::config::core::v3::GrpcService& config,
                  RawAsyncClientSharedPtr const& client, MonotonicTime create_time)
-          : config_(config), client_(client), accessed_time_(create_time) {}
-      envoy::config::core::v3::GrpcService config_;
+          : key_wrapper_(config), client_(client), accessed_time_(create_time) {}
+      GrpcServiceHashKeyWrapper key_wrapper_;
       RawAsyncClientSharedPtr client_;
       MonotonicTime accessed_time_;
     };
     using LruList = std::list<CacheEntry>;
-    absl::flat_hash_map<envoy::config::core::v3::GrpcService, LruList::iterator, MessageUtil,
-                        MessageUtil>
-        lru_map_;
     LruList lru_list_;
+    absl::flat_hash_map<GrpcServiceHashKeyWrapper, LruList::iterator> lru_map_wrapper_;
     Event::Dispatcher& dispatcher_;
     Envoy::Event::TimerPtr cache_eviction_timer_;
     static constexpr std::chrono::seconds EntryTimeoutInterval{50};

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -49,13 +49,13 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
 
     Config::Utility::checkTransportVersion(proto_config);
-    Envoy::Grpc::GrpcServiceHashKeyWrapper wrapper =
-        Envoy::Grpc::GrpcServiceHashKeyWrapper(proto_config.grpc_service());
+    Envoy::Grpc::GrpcServiceConfigWithHashKey config_with_hash_key =
+        Envoy::Grpc::GrpcServiceConfigWithHashKey(proto_config.grpc_service());
     callback = [&context, filter_config, timeout_ms,
-                wrapper](Http::FilterChainFactoryCallbacks& callbacks) {
+                config_with_hash_key](Http::FilterChainFactoryCallbacks& callbacks) {
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
-          context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClientWithWrapper(
-              wrapper, context.scope(), true),
+          context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClientWithHashKey(
+              config_with_hash_key, context.scope(), true),
           std::chrono::milliseconds(timeout_ms));
       callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, std::move(client)));
     };

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -6,6 +6,7 @@
 #include "envoy/config/core/v3/grpc_service.pb.h"
 #include "envoy/extensions/filters/http/ext_authz/v3/ext_authz.pb.h"
 #include "envoy/extensions/filters/http/ext_authz/v3/ext_authz.pb.validate.h"
+#include "envoy/grpc/async_client_manager.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/config/utility.h"
@@ -42,32 +43,20 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
           context.clusterManager(), client_config);
       callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, std::move(client)));
     };
-  } else if (proto_config.grpc_service().has_google_grpc()) {
-    // Google gRPC client.
+  } else {
+    // gRPC client.
     const uint32_t timeout_ms =
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
 
     Config::Utility::checkTransportVersion(proto_config);
+    Envoy::Grpc::GrpcServiceHashKeyWrapper wrapper =
+        Envoy::Grpc::GrpcServiceHashKeyWrapper(proto_config.grpc_service());
     callback = [&context, filter_config, timeout_ms,
-                proto_config](Http::FilterChainFactoryCallbacks& callbacks) {
+                wrapper](Http::FilterChainFactoryCallbacks& callbacks) {
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
-          context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
-              proto_config.grpc_service(), context.scope(), true),
+          context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClientWithWrapper(
+              wrapper, context.scope(), true),
           std::chrono::milliseconds(timeout_ms));
-      callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, std::move(client)));
-    };
-  } else {
-    // Envoy gRPC client.
-    const uint32_t timeout_ms =
-        PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
-    Config::Utility::checkTransportVersion(proto_config);
-    callback = [grpc_service = proto_config.grpc_service(), &context, filter_config,
-                timeout_ms](Http::FilterChainFactoryCallbacks& callbacks) {
-      Grpc::RawAsyncClientSharedPtr raw_client =
-          context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
-              grpc_service, context.scope(), true);
-      auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
-          raw_client, std::chrono::milliseconds(timeout_ms));
       callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, std::move(client)));
     };
   }

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -217,13 +217,13 @@ envoy_cc_test(
 )
 
 envoy_cc_benchmark_binary(
-  name = "async_client_manager_benchmark",
-  srcs = ["async_client_manager_benchmark.cc"],
-  external_deps = [
-      "benchmark",
-  ],
-  deps = [
-    "//source/common/api:api_lib",
+    name = "async_client_manager_benchmark",
+    srcs = ["async_client_manager_benchmark.cc"],
+    external_deps = [
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/api:api_lib",
         "//source/common/grpc:async_client_manager_lib",
         "//test/mocks/stats:stats_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
@@ -232,11 +232,11 @@ envoy_cc_benchmark_binary(
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-  ]
+    ],
 )
 
 envoy_benchmark_test(
-  name = "async_client_manager_benchmark_test",
-  timeout = "long",
-  benchmark_binary = "async_client_manager_benchmark",
+    name = "async_client_manager_benchmark_test",
+    timeout = "long",
+    benchmark_binary = "async_client_manager_benchmark",
 )

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -1,5 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
@@ -212,4 +214,29 @@ envoy_cc_test(
         "//source/common/grpc:buffered_message_ttl_manager_lib",
         "//test/test_common:utility_lib",
     ],
+)
+
+envoy_cc_benchmark_binary(
+  name = "async_client_manager_benchmark",
+  srcs = ["async_client_manager_benchmark.cc"],
+  external_deps = [
+      "benchmark",
+  ],
+  deps = [
+    "//source/common/api:api_lib",
+        "//source/common/grpc:async_client_manager_lib",
+        "//test/mocks/stats:stats_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
+        "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/mocks/upstream:cluster_priority_set_mocks",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+  ]
+)
+
+envoy_benchmark_test(
+  name = "async_client_manager_benchmark_test",
+  timeout = "long",
+  benchmark_binary = "async_client_manager_benchmark",
 )

--- a/test/common/grpc/async_client_manager_benchmark.cc
+++ b/test/common/grpc/async_client_manager_benchmark.cc
@@ -7,6 +7,7 @@
 #include "source/common/event/dispatcher_impl.h"
 #include "source/common/grpc/async_client_manager_impl.h"
 
+#include "test/benchmark/main.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
@@ -15,12 +16,9 @@
 #include "test/test_common/test_time.h"
 #include "test/test_common/utility.h"
 
+#include "benchmark/benchmark.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include "test/benchmark/main.h"
-
-#include "benchmark/benchmark.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -48,10 +46,11 @@ void testGetOrCreateAsyncClientWithConfig(::benchmark::State& state) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
-  for(auto _ : state) {
-    for(int i = 0; i < 1000; i++){
+  for (auto _ : state) {
+    for (int i = 0; i < 1000; i++) {
       RawAsyncClientSharedPtr foo_client0 =
-          async_client_man_test.async_client_manager_.getOrCreateRawAsyncClient(grpc_service, async_client_man_test.scope_, true);
+          async_client_man_test.async_client_manager_.getOrCreateRawAsyncClient(
+              grpc_service, async_client_man_test.scope_, true);
     }
   }
 }
@@ -63,19 +62,18 @@ void testGetOrCreateAsyncClientWithHashConfig(::benchmark::State& state) {
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
   GrpcServiceConfigWithHashKey config_with_hash_key_a = GrpcServiceConfigWithHashKey(grpc_service);
 
-  for(auto _ : state) {
-      for(int i = 0; i < 1000; i++){
+  for (auto _ : state) {
+    for (int i = 0; i < 1000; i++) {
       RawAsyncClientSharedPtr foo_client0 =
-          async_client_man_test.async_client_manager_.getOrCreateRawAsyncClientWithHashKey(config_with_hash_key_a, async_client_man_test.scope_, true);
+          async_client_man_test.async_client_manager_.getOrCreateRawAsyncClientWithHashKey(
+              config_with_hash_key_a, async_client_man_test.scope_, true);
     }
   }
-
 }
 
 BENCHMARK(testGetOrCreateAsyncClientWithConfig)->Unit(::benchmark::kMicrosecond);
 BENCHMARK(testGetOrCreateAsyncClientWithHashConfig)->Unit(::benchmark::kMicrosecond);
 
-
-}
-}
-}
+} // namespace
+} // namespace Grpc
+} // namespace Envoy

--- a/test/common/grpc/async_client_manager_benchmark.cc
+++ b/test/common/grpc/async_client_manager_benchmark.cc
@@ -1,0 +1,81 @@
+#include <memory>
+
+#include "envoy/config/core/v3/grpc_service.pb.h"
+#include "envoy/grpc/async_client.h"
+
+#include "source/common/api/api_impl.h"
+#include "source/common/event/dispatcher_impl.h"
+#include "source/common/grpc/async_client_manager_impl.h"
+
+#include "test/mocks/stats/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/upstream/cluster_manager.h"
+#include "test/mocks/upstream/cluster_priority_set.h"
+#include "test/test_common/test_runtime.h"
+#include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "test/benchmark/main.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Grpc {
+namespace {
+
+class AsyncClientManagerImplTest {
+public:
+  AsyncClientManagerImplTest()
+      : api_(Api::createApiForTest()), stat_names_(scope_.symbolTable()),
+        async_client_manager_(cm_, tls_, test_time_.timeSystem(), *api_, stat_names_) {}
+
+  Upstream::MockClusterManager cm_;
+  NiceMock<ThreadLocal::MockInstance> tls_;
+  Stats::MockStore store_;
+  Stats::MockScope& scope_{store_.mockScope()};
+  DangerousDeprecatedTestTime test_time_;
+  Api::ApiPtr api_;
+  StatNames stat_names_;
+  AsyncClientManagerImpl async_client_manager_;
+};
+
+void testGetOrCreateAsyncClientWithConfig(::benchmark::State& state) {
+  AsyncClientManagerImplTest async_client_man_test;
+
+  envoy::config::core::v3::GrpcService grpc_service;
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
+
+  for(auto _ : state) {
+    for(int i = 0; i < 1000; i++){
+      RawAsyncClientSharedPtr foo_client0 =
+          async_client_man_test.async_client_manager_.getOrCreateRawAsyncClient(grpc_service, async_client_man_test.scope_, true);
+    }
+  }
+}
+
+void testGetOrCreateAsyncClientWithHashConfig(::benchmark::State& state) {
+  AsyncClientManagerImplTest async_client_man_test;
+
+  envoy::config::core::v3::GrpcService grpc_service;
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
+  GrpcServiceConfigWithHashKey config_with_hash_key_a = GrpcServiceConfigWithHashKey(grpc_service);
+
+  for(auto _ : state) {
+      for(int i = 0; i < 1000; i++){
+      RawAsyncClientSharedPtr foo_client0 =
+          async_client_man_test.async_client_manager_.getOrCreateRawAsyncClientWithHashKey(config_with_hash_key_a, async_client_man_test.scope_, true);
+    }
+  }
+
+}
+
+BENCHMARK(testGetOrCreateAsyncClientWithConfig)->Unit(::benchmark::kMicrosecond);
+BENCHMARK(testGetOrCreateAsyncClientWithHashConfig)->Unit(::benchmark::kMicrosecond);
+
+
+}
+}
+}

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -52,16 +52,17 @@ protected:
 TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   envoy::config::core::v3::GrpcService foo_service;
   foo_service.mutable_envoy_grpc()->set_cluster_name("foo");
+  GrpcServiceConfigWithHashKey config_with_hash_key(foo_service);
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
-  client_cache_.setCache(foo_service, foo_client);
+  client_cache_.setCache(config_with_hash_key, foo_client);
   waitForSeconds(49);
   // Cache entry hasn't been evicted because it was created 49s ago.
-  EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
+  EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), foo_client.get());
   waitForSeconds(49);
   // Cache entry hasn't been evicted because it was accessed 49s ago.
-  EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
+  EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), foo_client.get());
   waitForSeconds(51);
-  EXPECT_EQ(client_cache_.getCache(foo_service).get(), nullptr);
+  EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), nullptr);
 }
 
 TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
@@ -69,23 +70,27 @@ TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
   for (int i = 1; i <= 50; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    client_cache_.setCache(grpc_service, foo_client);
+    GrpcServiceConfigWithHashKey config_with_hash_key(grpc_service);
+    client_cache_.setCache(config_with_hash_key, foo_client);
   }
   waitForSeconds(20);
   for (int i = 51; i <= 100; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    client_cache_.setCache(grpc_service, foo_client);
+    GrpcServiceConfigWithHashKey config_with_hash_key(grpc_service);
+    client_cache_.setCache(config_with_hash_key, foo_client);
   }
   waitForSeconds(30);
   // Cache entries created 50s before have expired.
   for (int i = 1; i <= 50; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    EXPECT_EQ(client_cache_.getCache(grpc_service).get(), nullptr);
+    GrpcServiceConfigWithHashKey config_with_hash_key(grpc_service);
+    EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), nullptr);
   }
   // Cache entries 30s before haven't expired.
   for (int i = 51; i <= 100; i++) {
     grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    EXPECT_EQ(client_cache_.getCache(grpc_service).get(), foo_client.get());
+    GrpcServiceConfigWithHashKey config_with_hash_key(grpc_service);
+    EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), foo_client.get());
   }
 }
 
@@ -95,14 +100,15 @@ TEST_F(RawAsyncClientCacheTest, GetExpiredButNotEvictedCacheEntry) {
   envoy::config::core::v3::GrpcService foo_service;
   foo_service.mutable_envoy_grpc()->set_cluster_name("foo");
   RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
-  client_cache_.setCache(foo_service, foo_client);
+  GrpcServiceConfigWithHashKey config_with_hash_key(foo_service);
+  client_cache_.setCache(config_with_hash_key, foo_client);
   time_system_.advanceTimeAsyncImpl(std::chrono::seconds(50));
   // Cache entry hasn't been evicted because it is accessed before timer fire.
-  EXPECT_EQ(client_cache_.getCache(foo_service).get(), foo_client.get());
+  EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), foo_client.get());
   time_system_.advanceTimeAndRun(std::chrono::seconds(50), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
   // Cache entry has been evicted because it is accessed after timer fire.
-  EXPECT_EQ(client_cache_.getCache(foo_service).get(), nullptr);
+  EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), nullptr);
 }
 
 class AsyncClientManagerImplTest : public testing::Test {
@@ -126,6 +132,22 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcOk) {
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
   EXPECT_CALL(cm_, checkActiveStaticCluster("foo")).WillOnce(Return());
   async_client_manager_.factoryForGrpcService(grpc_service, scope_, false);
+}
+
+TEST_F(AsyncClientManagerImplTest, GrpcServiceConfigWithHashKeyTest) {
+  envoy::config::core::v3::GrpcService grpc_service;
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
+  envoy::config::core::v3::GrpcService grpc_service_c;
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("bar");
+
+  GrpcServiceConfigWithHashKey config_with_hash_key_a = GrpcServiceConfigWithHashKey(grpc_service);
+  GrpcServiceConfigWithHashKey config_with_hash_key_b = GrpcServiceConfigWithHashKey(grpc_service);
+  GrpcServiceConfigWithHashKey config_with_hash_key_c = GrpcServiceConfigWithHashKey(grpc_service_c);
+  EXPECT_TRUE(config_with_hash_key_a == config_with_hash_key_b);
+  EXPECT_FALSE(config_with_hash_key_a == config_with_hash_key_c);
+
+  EXPECT_EQ(config_with_hash_key_a.getPreComputedHash(), config_with_hash_key_b.getPreComputedHash());
+  EXPECT_NE(config_with_hash_key_a.getPreComputedHash(), config_with_hash_key_c.getPreComputedHash());
 }
 
 TEST_F(AsyncClientManagerImplTest, RawAsyncClientCache) {

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -142,12 +142,15 @@ TEST_F(AsyncClientManagerImplTest, GrpcServiceConfigWithHashKeyTest) {
 
   GrpcServiceConfigWithHashKey config_with_hash_key_a = GrpcServiceConfigWithHashKey(grpc_service);
   GrpcServiceConfigWithHashKey config_with_hash_key_b = GrpcServiceConfigWithHashKey(grpc_service);
-  GrpcServiceConfigWithHashKey config_with_hash_key_c = GrpcServiceConfigWithHashKey(grpc_service_c);
+  GrpcServiceConfigWithHashKey config_with_hash_key_c =
+      GrpcServiceConfigWithHashKey(grpc_service_c);
   EXPECT_TRUE(config_with_hash_key_a == config_with_hash_key_b);
   EXPECT_FALSE(config_with_hash_key_a == config_with_hash_key_c);
 
-  EXPECT_EQ(config_with_hash_key_a.getPreComputedHash(), config_with_hash_key_b.getPreComputedHash());
-  EXPECT_NE(config_with_hash_key_a.getPreComputedHash(), config_with_hash_key_c.getPreComputedHash());
+  EXPECT_EQ(config_with_hash_key_a.getPreComputedHash(),
+            config_with_hash_key_b.getPreComputedHash());
+  EXPECT_NE(config_with_hash_key_a.getPreComputedHash(),
+            config_with_hash_key_c.getPreComputedHash());
 }
 
 TEST_F(AsyncClientManagerImplTest, RawAsyncClientCache) {

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -64,12 +64,13 @@ public:
     // Delegate call to mock async client manager to real async client manager.
     ON_CALL(context_, getServerFactoryContext()).WillByDefault(testing::ReturnRef(server_context_));
     ON_CALL(context_.cluster_manager_.async_client_manager_,
-            getOrCreateRawAsyncClientWithWrapper(_, _, _))
-        .WillByDefault(Invoke([&](const Envoy::Grpc::GrpcServiceHashKeyWrapper& config,
-                                  Stats::Scope& scope, bool skip_cluster_check) {
-          return async_client_manager_->getOrCreateRawAsyncClientWithWrapper(config, scope,
-                                                                             skip_cluster_check);
-        }));
+            getOrCreateRawAsyncClientWithHashKey(_, _, _))
+        .WillByDefault(
+            Invoke([&](const Envoy::Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
+                       Stats::Scope& scope, bool skip_cluster_check) {
+              return async_client_manager_->getOrCreateRawAsyncClientWithHashKey(
+                  config_with_hash_key, scope, skip_cluster_check);
+            }));
     ExtAuthzFilterConfig factory;
     return factory.createFilterFactoryFromProto(ext_authz_config, "stats", context_);
   }
@@ -205,11 +206,11 @@ private:
   void expectGrpcClientSentRequest(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& ext_authz_config,
       int requests_sent_per_thread) {
-    Envoy::Grpc::GrpcServiceHashKeyWrapper wrapper =
-        Envoy::Grpc::GrpcServiceHashKeyWrapper(ext_authz_config.grpc_service());
+    Envoy::Grpc::GrpcServiceConfigWithHashKey config_with_hash_key =
+        Envoy::Grpc::GrpcServiceConfigWithHashKey(ext_authz_config.grpc_service());
     Grpc::RawAsyncClientSharedPtr async_client =
-        async_client_manager_->getOrCreateRawAsyncClientWithWrapper(wrapper, context_.scope(),
-                                                                    false);
+        async_client_manager_->getOrCreateRawAsyncClientWithHashKey(config_with_hash_key,
+                                                                    context_.scope(), false);
     Grpc::MockAsyncClient* mock_async_client =
         dynamic_cast<Grpc::MockAsyncClient*>(async_client.get());
     EXPECT_NE(mock_async_client, nullptr);

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -116,6 +116,10 @@ public:
   MOCK_METHOD(RawAsyncClientSharedPtr, getOrCreateRawAsyncClient,
               (const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope,
                bool skip_cluster_check));
+
+  MOCK_METHOD(RawAsyncClientSharedPtr, getOrCreateRawAsyncClientWithWrapper,
+              (const GrpcServiceHashKeyWrapper& grpc_service, Stats::Scope& scope,
+               bool skip_cluster_check));
 };
 
 MATCHER_P(ProtoBufferEq, expected, "") {

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -117,8 +117,8 @@ public:
               (const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope,
                bool skip_cluster_check));
 
-  MOCK_METHOD(RawAsyncClientSharedPtr, getOrCreateRawAsyncClientWithWrapper,
-              (const GrpcServiceHashKeyWrapper& grpc_service, Stats::Scope& scope,
+  MOCK_METHOD(RawAsyncClientSharedPtr, getOrCreateRawAsyncClientWithHashKey,
+              (const GrpcServiceConfigWithHashKey& config_with_hash_key, Stats::Scope& scope,
                bool skip_cluster_check));
 };
 


### PR DESCRIPTION
Commit Message: Optimize AsyncClientManager by moving hashing to control plane
Additional Description: This change removes the hashing of the config away from the data plane on every request to the control plane when the filter callback is created. This is accomplished by creating a wrapper object for the config which precomputes the hash and also serializes it to string ahead of time so that calls to the AsyncClientManager with that wrapper can avoid unnecessary overhead.
Risk Level: Low
Testing: Changed some ext_authz tests to account for changes
Added a benchmark test that observed the following improvement
Benchmark                                         Time             CPU   Iterations
testGetOrCreateAsyncClientWithConfig          27199 us        27182 us            1
testGetOrCreateAsyncClientWithHashConfig      15943 us        15943 us            1
