### PR TITLE
Revert "redis_proxy: fix crash if catch_all_route is not defined (#29138)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -41,9 +41,6 @@ bug_fixes:
 - area: extension_discovery_service
   change: |
     Fixed a bug causing crash if ECDS is used with upstream HTTP filters.
-- area: redis_proxy
-  change: |
-    Fixed a bug causing crash if incoming redis key does not match against a prefix_route and catch_all_route is not defined.
 - area: tls
   change: |
     fixed a bug where handshake may fail when both private key provider and cert validation are set.

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -87,14 +87,10 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key,
   } else {
     value = prefix_lookup_table_.findLongestPrefix(key.c_str());
   }
+
   if (value == nullptr) {
-    // prefix route not found, check if catch_all_route is defined to fallback to.
-    if (catch_all_route_ != nullptr) {
-      value = catch_all_route_;
-    } else {
-      // no route found.
-      return value;
-    }
+    // prefix route not found, default to catch all route.
+    value = catch_all_route_;
   }
 
   if (value->removePrefix()) {

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -50,19 +50,6 @@ createPrefixRoutes() {
   return prefix_routes;
 }
 
-TEST(PrefixRoutesTest, MissingCatchAll) {
-  Upstreams upstreams;
-  upstreams.emplace("fake_clusterA", std::make_shared<ConnPool::MockInstance>());
-  upstreams.emplace("fake_clusterB", std::make_shared<ConnPool::MockInstance>());
-
-  Runtime::MockLoader runtime_;
-
-  PrefixRoutes router(createPrefixRoutes(), std::move(upstreams), runtime_);
-
-  std::string key("c:bar");
-  EXPECT_EQ(nullptr, router.upstreamPool(key));
-}
-
 TEST(PrefixRoutesTest, RoutedToCatchAll) {
   auto upstream_c = std::make_shared<ConnPool::MockInstance>();
 


### PR DESCRIPTION
Revert "redis_proxy: fix crash if catch_all_route is not defined (#29138)"

This reverts commit 1438a10da220f32b3c29219c2afda42287e162cf.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
