### PR TITLE
[backport/1.26] tls: fix handshake failure when both private key provider and cert validation are set

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: tls
+  change: |
+    fixed a bug where handshake may fail when both private key provider and cert validation are set.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/envoy/ssl/ssl_socket_extended_info.h
+++ b/envoy/ssl/ssl_socket_extended_info.h
@@ -60,7 +60,6 @@ public:
   virtual ClientValidationStatus certificateValidationStatus() const PURE;
 
   /**
-   * Only called when doing asynchronous cert validation.
    * @return ValidateResultCallbackPtr a callback used to return the validation result.
    */
   virtual ValidateResultCallbackPtr createValidateResultCallback() PURE;
@@ -68,8 +67,9 @@ public:
   /**
    * Called after the cert validation completes either synchronously or asynchronously.
    * @param succeeded true if the validation succeeded.
+   * @param async true if the validation is completed asynchronously.
    */
-  virtual void onCertificateValidationCompleted(bool succeeded) PURE;
+  virtual void onCertificateValidationCompleted(bool succeeded, bool async) PURE;
 
   /**
    * @return ValidateStatus the validation status.

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -524,7 +524,7 @@ ValidationResults ContextImpl::customVerifyCertChain(
   if (result.status != ValidationResults::ValidationStatus::Pending) {
     extended_socket_info->setCertificateValidationStatus(result.detailed_status);
     extended_socket_info->onCertificateValidationCompleted(
-        result.status == ValidationResults::ValidationStatus::Successful);
+        result.status == ValidationResults::ValidationStatus::Successful, false);
   }
   return result;
 }

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -26,7 +26,7 @@ void ValidateResultCallbackImpl::onCertValidationResult(bool succeeded,
   }
   extended_socket_info_->setCertificateValidationStatus(detailed_status);
   extended_socket_info_->setCertificateValidationAlert(tls_alert);
-  extended_socket_info_->onCertificateValidationCompleted(succeeded);
+  extended_socket_info_->onCertificateValidationCompleted(succeeded, true);
 }
 
 SslExtendedSocketInfoImpl::~SslExtendedSocketInfoImpl() {
@@ -44,15 +44,16 @@ Envoy::Ssl::ClientValidationStatus SslExtendedSocketInfoImpl::certificateValidat
   return certificate_validation_status_;
 }
 
-void SslExtendedSocketInfoImpl::onCertificateValidationCompleted(bool succeeded) {
+void SslExtendedSocketInfoImpl::onCertificateValidationCompleted(bool succeeded, bool async) {
   cert_validation_result_ =
       succeeded ? Ssl::ValidateStatus::Successful : Ssl::ValidateStatus::Failed;
   if (cert_validate_result_callback_.has_value()) {
     ASSERT(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.tls_async_cert_validation"));
-    // This is an async cert validation.
     cert_validate_result_callback_.reset();
     // Resume handshake.
-    ssl_handshaker_.handshakeCallbacks()->onAsynchronousCertValidationComplete();
+    if (async) {
+      ssl_handshaker_.handshakeCallbacks()->onAsynchronousCertValidationComplete();
+    }
   }
 }
 

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.h
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.h
@@ -59,7 +59,7 @@ public:
   void setCertificateValidationStatus(Envoy::Ssl::ClientValidationStatus validated) override;
   Envoy::Ssl::ClientValidationStatus certificateValidationStatus() const override;
   Ssl::ValidateResultCallbackPtr createValidateResultCallback() override;
-  void onCertificateValidationCompleted(bool succeeded) override;
+  void onCertificateValidationCompleted(bool succeeded, bool async) override;
   Ssl::ValidateStatus certificateValidationResult() const override {
     return cert_validation_result_;
   }

--- a/test/extensions/transport_sockets/tls/cert_validator/test_common.h
+++ b/test/extensions/transport_sockets/tls/cert_validator/test_common.h
@@ -26,7 +26,7 @@ public:
 
   Ssl::ValidateResultCallbackPtr createValidateResultCallback() override { return nullptr; };
 
-  void onCertificateValidationCompleted(bool succeeded) override {
+  void onCertificateValidationCompleted(bool succeeded, bool) override {
     validate_result_ = succeeded ? Ssl::ValidateStatus::Successful : Ssl::ValidateStatus::Failed;
   }
   Ssl::ValidateStatus certificateValidationResult() const override { return validate_result_; }

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -6667,6 +6667,46 @@ TEST_P(SslSocketTest, RsaAndEcdsaPrivateKeyProviderMultiCertFail) {
                .setExpectedServerStats("ssl.connection_error"));
 }
 
+// Test private key provider and cert validation can work together.
+TEST_P(SslSocketTest, PrivateKeyProviderWithCertValidation) {
+  const std::string client_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
+)EOF";
+
+  const std::string server_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem"
+      private_key_provider:
+        provider_name: test
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+          value:
+            private_key_file: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_key.pem"
+            expected_operation: sign
+            sync_mode: false
+            mode: rsa
+    validation_context:
+      trusted_ca:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
+)EOF";
+
+  TestUtilOptions test_options(client_ctx_yaml, server_ctx_yaml, true, version_);
+  testUtil(test_options.setPrivateKeyMethodExpected(true)
+               .setExpectedSha256Digest(TEST_NO_SAN_CERT_256_HASH)
+               .setExpectedSha1Digest(TEST_NO_SAN_CERT_1_HASH)
+               .setExpectedSerialNumber(TEST_NO_SAN_CERT_SERIAL));
+}
+
 TEST_P(SslSocketTest, TestStaplesOcspResponseSuccess) {
   const std::string server_ctx_yaml = R"EOF(
   common_tls_context:

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -18,7 +18,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/network:94.4" # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
 "source/common/network/dns_resolver:91.6"  # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
 "source/common/protobuf:96.3"
-"source/common/quic:93.4"
+"source/common/quic:93.3"
 "source/common/router:96.1"
 "source/common/secret:95.0"
 "source/common/signal:87.2" # Death tests don't report LCOV


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: tls: fix handshake failure when both private key provider and cert validation are set
Additional Description: See #29002
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
