### PR TITLE
front-proxy sandbox adds service envoy healthcheck

### DIFF
--- a/examples/front-proxy/docker-compose.yaml
+++ b/examples/front-proxy/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
       dockerfile: ../shared/envoy/Dockerfile
     depends_on:
       service-envoy-1:
-        condition: service_started
+        condition: service_healthy
       service-envoy-2:
-        condition: service_started
+        condition: service_healthy
     ports:
     - "${PORT_PROXY:-8080}:8080"
     - "${PORT_HTTPS:-8443}:8443"

--- a/examples/shared/envoy/Dockerfile
+++ b/examples/shared/envoy/Dockerfile
@@ -13,6 +13,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get -qq update -y \
     && apt-get -qq install --no-install-recommends -y curl
 COPY --chmod=777 "$ENVOY_CONFIG" /etc/envoy.yaml
+HEALTHCHECK \
+    --interval=1s \
+    --timeout=1s \
+    --start-period=1s \
+    --retries=3 \
+    CMD /bin/bash -c "test $(curl -s localhost:8001/stats?filter=server.state | cut -d ':' -f2 | sed 's/ //') == 0 && test $(curl -s localhost:8001/stats?filter=listener_manager.workers_started | cut -d ':' -f2 | sed -s 's/ //') == 1"
 CMD ["/usr/local/bin/envoy", "-c", "/etc/envoy.yaml"]
 
 

--- a/examples/shared/envoy/Dockerfile
+++ b/examples/shared/envoy/Dockerfile
@@ -18,7 +18,8 @@ HEALTHCHECK \
     --timeout=1s \
     --start-period=1s \
     --retries=3 \
-    CMD /bin/bash -c "test $(curl -s localhost:8001/stats?filter=server.state | cut -d ':' -f2 | sed 's/ //') == 0 && test $(curl -s localhost:8001/stats?filter=listener_manager.workers_started | cut -d ':' -f2 | sed -s 's/ //') == 1"
+    CMD curl -s localhost:8001/stats?filter=server.state | grep 0 \
+             && curl -s localhost:8001/stats?filter=listener_manager.workers_started | grep 1
 CMD ["/usr/local/bin/envoy", "-c", "/etc/envoy.yaml"]
 
 


### PR DESCRIPTION
Commit Message: front-proxy sandbox adds service envoy healthcheck
Additional Description: main purpose to pass this idea by phlax
Risk Level: LOW
Testing: the front-proxy sandbox's verify.sh script
Docs Changes: none
Release Notes: revise front-proxy sandbox front-envoy to depend on service envoy healthy
Platform Specific Features: none
