### PR TITLE
mobile: adding a cronvoy logger

### DIFF
--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -95,6 +95,12 @@ static void jvm_on_track(envoy_map events, const void* context) {
   env->DeleteLocalRef(jcls_EnvoyEventTracker);
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_setLogLevel(JNIEnv* env, jclass, jint level) {
+  Envoy::Logger::Context::changeAllLogLevels(static_cast<spdlog::level::level_enum>(level));
+  return 0;
+}
+
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
     JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context,
     jobject j_event_tracker) {

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -90,4 +90,6 @@ public class AndroidEngineImpl implements EnvoyEngine {
   }
 
   public void setProxySettings(String host, int port) { envoyEngine.setProxySettings(host, port); }
+
+  public void setLogLevel(LogLevel log_level) { envoyEngine.setLogLevel(log_level); }
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -99,4 +99,16 @@ public interface EnvoyEngine {
    * @param port The proxy port.
    */
   void setProxySettings(String host, int port);
+
+  /*
+   * These are the available log levels for Envoy Mobile.
+   */
+  public enum LogLevel { TRACE, DEBUG, INFO, WARN, ERR, CRITICAL, OFF }
+
+  /**
+   * Set the log level for Envoy mobile
+   *
+   * @param log_level the verbosity of logging Envoy should use.
+   */
+  public void setLogLevel(LogLevel log_level);
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -182,4 +182,33 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   public void setProxySettings(String host, int port) {
     JniLibrary.setProxySettings(engineHandle, host, port);
   }
+
+  @Override
+  public void setLogLevel(LogLevel log_level) {
+    int level = 0;
+    switch (log_level) {
+    case TRACE:
+      level = 0;
+      break;
+    case DEBUG:
+      level = 1;
+      break;
+    case INFO:
+      level = 2;
+      break;
+    case WARN:
+      level = 3;
+      break;
+    case ERR:
+      level = 4;
+      break;
+    case CRITICAL:
+      level = 5;
+      break;
+    case OFF:
+      level = 6;
+      break;
+    }
+    JniLibrary.setLogLevel(level);
+  }
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -185,30 +185,6 @@ public class EnvoyEngineImpl implements EnvoyEngine {
 
   @Override
   public void setLogLevel(LogLevel log_level) {
-    int level = 0;
-    switch (log_level) {
-    case TRACE:
-      level = 0;
-      break;
-    case DEBUG:
-      level = 1;
-      break;
-    case INFO:
-      level = 2;
-      break;
-    case WARN:
-      level = 3;
-      break;
-    case ERR:
-      level = 4;
-      break;
-    case CRITICAL:
-      level = 5;
-      break;
-    case OFF:
-      level = 6;
-      break;
-    }
-    JniLibrary.setLogLevel(level);
+    JniLibrary.setLogLevel(log_level.ordinal());
   }
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -265,6 +265,13 @@ public class JniLibrary {
   protected static native int setProxySettings(long engine, String host, int port);
 
   /**
+   * Update the log level for all active logs
+   *
+   * @param log_level The Log level to change to. Must be an integer 0-6.
+   */
+  protected static native void setLogLevel(int log_level);
+
+  /**
    * Mimic a call to AndroidNetworkLibrary#verifyServerCertificates from native code.
    * To be used for testing only.
    *

--- a/mobile/library/java/org/chromium/net/impl/BUILD
+++ b/mobile/library/java/org/chromium/net/impl/BUILD
@@ -21,6 +21,7 @@ android_library(
         "CronvoyEngineBuilderImpl.java",
         "CronvoyExceptionImpl.java",
         "CronvoyImplVersion.java",
+        "CronvoyLogger.java",
         "CronvoyMetrics.java",
         "CronvoyNetworkExceptionImpl.java",
         "CronvoyPreconditions.java",

--- a/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
@@ -81,7 +81,6 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
   private String mExperimentalOptions;
   private boolean mNetworkQualityEstimatorEnabled;
   private int mThreadPriority = INVALID_THREAD_PRIORITY;
-  private String mLogLevel = "off";
 
   /**
    * Default config enables SPDY and QUIC, disables SDCH and HTTP cache.
@@ -359,13 +358,6 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
   int threadPriority(int defaultThreadPriority) {
     return mThreadPriority == INVALID_THREAD_PRIORITY ? defaultThreadPriority : mThreadPriority;
   }
-
-  public CronvoyEngineBuilderImpl setLogLevel(String logLevel) {
-    mLogLevel = logLevel;
-    return this;
-  }
-
-  public String getLogLevel() { return mLogLevel; }
 
   /**
    * Returns {@link Context} for builder.

--- a/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
@@ -81,7 +81,7 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
   private String mExperimentalOptions;
   private boolean mNetworkQualityEstimatorEnabled;
   private int mThreadPriority = INVALID_THREAD_PRIORITY;
-  private String mLogLevel = "info";
+  private String mLogLevel = "off";
 
   /**
    * Default config enables SPDY and QUIC, disables SDCH and HTTP cache.

--- a/mobile/library/java/org/chromium/net/impl/CronvoyLogger.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyLogger.java
@@ -1,0 +1,54 @@
+package org.chromium.net.impl;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
+
+final class CronvoyLogger implements EnvoyLogger {
+  private FileWriter mWriter;
+
+  public CronvoyLogger() {}
+
+  public void stopLogging() {
+    try {
+      if (mWriter != null) {
+        mWriter.close();
+        mWriter = null;
+      }
+    } catch (IOException e) {
+      System.err.println("Encountered " + e.toString() + " when trying to stopLogging");
+    }
+  }
+
+  @Override
+  public void log(String str) {
+    if (mWriter != null) {
+      try {
+        mWriter.write(str);
+      } catch (IOException e) {
+        System.err.println("Encountered " + e.toString() + " when trying to log");
+      }
+    }
+  }
+
+  public void setNetLogToFile(String fileName) {
+    try {
+      File file = new File(fileName);
+      mWriter = new FileWriter(file, true);
+    } catch (IOException e) {
+      System.err.println("Encountered " + e.toString() + " when trying to setNetLogToFile");
+    }
+  }
+
+  public void setNetLogToDisk(String dirPath, int maxSize) {
+    try {
+      // TODO(alyssawilk) do we need to create the directory?
+      File file = new File(dirPath);
+      mWriter = new FileWriter(file, true);
+    } catch (IOException e) {
+      System.err.println("Encountered " + e.toString() + " when trying to setNetLogToDisk");
+    }
+    // TODO(alyssawilk) implement size checks.
+  }
+}

--- a/mobile/library/java/org/chromium/net/impl/CronvoyLogger.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyLogger.java
@@ -5,8 +5,22 @@ import java.io.FileWriter;
 import java.io.IOException;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
 
+/*
+ * CronvoyLogger
+ *
+ * This class bridges Envoy and Cronet logging by providing an EnvoyLogger with Envoy's log API
+ * which also has Cronet-style setNetLogToFile and setNetLogToDisk functions.
+ *
+ * The Envoy engine is supplied the logger on start-up but will only log at the configured log
+ * level (Cronvoy defaults logging off). When logging is desired, the CronvoyUrlRequestContext
+ * sets the Envoy log level to TRACE or DEBUG (based on if logAll is set), and passes the desired
+ * log info to the CronvoyLogger. The CronvoyLogger will then in append pass Envoy log messages to
+ * the desired file until CronvoyUrlRequestContext.stopNetLog disables Envoy logging.
+ *
+ */
 final class CronvoyLogger implements EnvoyLogger {
   private FileWriter mWriter;
+  static final String LOG_TAG = CronvoyUrlRequestContext.class.getSimpleName();
 
   public CronvoyLogger() {}
 
@@ -17,7 +31,7 @@ final class CronvoyLogger implements EnvoyLogger {
         mWriter = null;
       }
     } catch (IOException e) {
-      System.err.println("Encountered " + e.toString() + " when trying to stopLogging");
+      android.util.Log.e(LOG_TAG, "Failed to stop logging", e);
     }
   }
 
@@ -27,7 +41,7 @@ final class CronvoyLogger implements EnvoyLogger {
       try {
         mWriter.write(str);
       } catch (IOException e) {
-        System.err.println("Encountered " + e.toString() + " when trying to log");
+        android.util.Log.e(LOG_TAG, "Failed to log message", e);
       }
     }
   }
@@ -37,7 +51,7 @@ final class CronvoyLogger implements EnvoyLogger {
       File file = new File(fileName);
       mWriter = new FileWriter(file, true);
     } catch (IOException e) {
-      System.err.println("Encountered " + e.toString() + " when trying to setNetLogToFile");
+      android.util.Log.e(LOG_TAG, "Failed to start logging", e);
     }
   }
 
@@ -47,7 +61,7 @@ final class CronvoyLogger implements EnvoyLogger {
       File file = new File(dirPath);
       mWriter = new FileWriter(file, true);
     } catch (IOException e) {
-      System.err.println("Encountered " + e.toString() + " when trying to setNetLogToDisk");
+      android.util.Log.e(LOG_TAG, "Failed to start logging", e);
     }
     // TODO(alyssawilk) implement size checks.
   }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
@@ -172,6 +172,9 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
   @Override
   public void shutdown() {
     synchronized (mLock) {
+      if (mEngine == null) {
+        return; // Already shut down.
+      }
       checkHaveAdapter();
       if (mActiveRequestCount.get() != 0) {
         throw new IllegalStateException("Cannot shutdown with active requests.");
@@ -200,34 +203,37 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
   }
 
   @Override
-  public void startNetLogToFile(String fileName, boolean logAll) {
-    mCronvoyLogger.setNetLogToFile(fileName);
+  public void startNetLogToFile(String fileName, boolean logAll) throws IllegalStateException {
     synchronized (mLock) {
+      if (mEngine == null) {
+        throw new IllegalStateException("Engine is shut down.");
+      }
+      mCronvoyLogger.setNetLogToFile(fileName);
       // Turn up logging
       if (logAll) {
         mLogLevel = EnvoyEngine.LogLevel.TRACE;
       } else {
         mLogLevel = EnvoyEngine.LogLevel.DEBUG;
       }
-      if (mEngine != null) {
-        mEngine.setLogLevel(mLogLevel);
-      }
+      mEngine.setLogLevel(mLogLevel);
     }
   }
 
   @Override
-  public void startNetLogToDisk(String dirPath, boolean logAll, int maxSize) {
-    mCronvoyLogger.setNetLogToDisk(dirPath, maxSize);
+  public void startNetLogToDisk(String dirPath, boolean logAll, int maxSize)
+      throws IllegalStateException {
     synchronized (mLock) {
+      if (mEngine == null) {
+        throw new IllegalStateException("Engine is shut down.");
+      }
+      mCronvoyLogger.setNetLogToDisk(dirPath, maxSize);
       // Turn up logging
       if (logAll) {
         mLogLevel = EnvoyEngine.LogLevel.TRACE;
       } else {
         mLogLevel = EnvoyEngine.LogLevel.DEBUG;
       }
-      if (mEngine != null) {
-        mEngine.setLogLevel(mLogLevel);
-      }
+      mEngine.setLogLevel(mLogLevel);
     }
   }
 

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -31,7 +31,6 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
 
   // TODO(refactor) move unshared variables into their specific methods.
   private final List<EnvoyNativeFilterConfig> nativeFilterChain = new ArrayList<>();
-  private final EnvoyLogger mEnvoyLogger = null;
   private final EnvoyEventTracker mEnvoyEventTracker = null;
   private String mGrpcStatsDomain = null;
   private int mConnectTimeoutSeconds = 30;
@@ -105,8 +104,8 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
     return new CronvoyUrlRequestContext(this);
   }
 
-  EnvoyEngine createEngine(EnvoyOnEngineRunning onEngineRunning) {
-    AndroidEngineImpl engine = new AndroidEngineImpl(getContext(), onEngineRunning, mEnvoyLogger,
+  EnvoyEngine createEngine(EnvoyOnEngineRunning onEngineRunning, EnvoyLogger envoyLogger) {
+    AndroidEngineImpl engine = new AndroidEngineImpl(getContext(), onEngineRunning, envoyLogger,
                                                      mEnvoyEventTracker, mEnableProxying);
     AndroidJniLibrary.load(getContext());
     AndroidNetworkMonitor.load(getContext(), engine);

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -104,12 +104,13 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
     return new CronvoyUrlRequestContext(this);
   }
 
-  EnvoyEngine createEngine(EnvoyOnEngineRunning onEngineRunning, EnvoyLogger envoyLogger) {
+  EnvoyEngine createEngine(EnvoyOnEngineRunning onEngineRunning, EnvoyLogger envoyLogger,
+                           String logLevel) {
     AndroidEngineImpl engine = new AndroidEngineImpl(getContext(), onEngineRunning, envoyLogger,
                                                      mEnvoyEventTracker, mEnableProxying);
     AndroidJniLibrary.load(getContext());
     AndroidNetworkMonitor.load(getContext(), engine);
-    engine.runWithConfig(createEnvoyConfiguration(), getLogLevel());
+    engine.runWithConfig(createEnvoyConfiguration(), logLevel);
     return engine;
   }
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -44,4 +44,6 @@ internal class MockEnvoyEngine : EnvoyEngine {
   override fun setPreferredNetwork(network: EnvoyNetworkType) = Unit
 
   override fun setProxySettings(host: String, port: Int) = Unit
+
+  override fun setLogLevel(level: EnvoyEngine.LogLevel) = Unit
 }

--- a/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
+++ b/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
@@ -310,6 +310,45 @@ public class BidirectionalStreamTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
+  public void testSimpleGetWithLogging() throws Exception {
+    File file = File.createTempFile("some-prefix", "some-ext");
+    file.deleteOnExit();
+    System.out.println("Starting logging");
+    mCronetEngine.startNetLogToFile(file.getAbsolutePath(), true);
+    System.out.println("Started logging");
+
+    String url = Http2TestServer.getCombinedHeadersUrl();
+    TestBidirectionalStreamCallback callback = new TestBidirectionalStreamCallback();
+    TestRequestFinishedListener requestFinishedListener = new TestRequestFinishedListener();
+    mCronetEngine.addRequestFinishedListener(requestFinishedListener);
+    // Create stream.
+    BidirectionalStream stream =
+        mCronetEngine.newBidirectionalStreamBuilder(url, callback, callback.getExecutor())
+            .setHttpMethod("GET")
+            .build();
+    stream.start();
+    callback.blockForDone();
+    assertTrue(stream.isDone());
+    requestFinishedListener.blockUntilDone();
+    assertEquals(200, callback.mResponseInfo.getHttpStatusCode());
+    // Default method is 'GET'.
+    assertEquals("GET", callback.mResponseAsString);
+    assertEquals("bar", callback.mResponseInfo.getAllHeaders().get("foo").get(0));
+    assertEquals("bar2", callback.mResponseInfo.getAllHeaders().get("foo").get(1));
+    RequestFinishedInfo finishedInfo = requestFinishedListener.getRequestInfo();
+    assertTrue(finishedInfo.getAnnotations().isEmpty());
+
+    System.out.println("Stopping logging");
+    mCronetEngine.stopNetLog();
+    char[] buffer = new char[5000];
+    byte[] bytes = Files.readAllBytes(Paths.get(file.getAbsolutePath()));
+    String fileContent = new String(bytes);
+    assertTrue(fileContent.contains("request headers for stream"));
+  }
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
   public void testSimplePostWithFlush() throws Exception {
     String url = Http2TestServer.getEchoStreamUrl();
     TestBidirectionalStreamCallback callback = new TestBidirectionalStreamCallback();

--- a/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
+++ b/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
@@ -52,6 +52,10 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 /**
  * Test functionality of BidirectionalStream interface.
  */

--- a/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
@@ -328,7 +328,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testNetLog() throws Exception {
     Context context = getContext();
     File directory = new File(PathUtils.getDataDirectory());
@@ -348,7 +347,8 @@ public class CronetUrlRequestContextTest {
     cronetEngine.stopNetLog();
     assertTrue(file.exists());
     assertTrue(file.length() != 0);
-    assertFalse(hasBytesInNetLog(file));
+    assertTrue(hasDebugInNetLog(file));
+    assertFalse(hasTraceInNetLog(file));
     assertTrue(file.delete());
     assertTrue(!file.exists());
   }
@@ -356,7 +356,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testBoundedFileNetLog() throws Exception {
     Context context = getContext();
     File directory = new File(PathUtils.getDataDirectory());
@@ -379,7 +378,7 @@ public class CronetUrlRequestContextTest {
     cronetEngine.stopNetLog();
     assertTrue(logFile.exists());
     assertTrue(logFile.length() != 0);
-    assertFalse(hasBytesInNetLog(logFile));
+    assertFalse(hasTraceInNetLog(logFile));
     FileUtils.recursivelyDeleteFile(netLogDir, FileUtils.DELETE_ALL);
     assertFalse(netLogDir.exists());
   }
@@ -387,7 +386,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   // Tests that if stopNetLog is not explicitly called, CronetEngine.shutdown()
   // will take care of it. crbug.com/623701.
   public void testNoStopNetLog() throws Exception {
@@ -406,8 +404,8 @@ public class CronetUrlRequestContextTest {
     // Shut down the engine without calling stopNetLog.
     cronetEngine.shutdown();
     assertTrue(file.exists());
-    assertTrue(file.length() != 0);
-    assertFalse(hasBytesInNetLog(file));
+    assertTrue(hasDebugInNetLog(file));
+    assertFalse(hasTraceInNetLog(file));
     assertTrue(file.delete());
     assertTrue(!file.exists());
   }
@@ -415,7 +413,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   // Tests that if stopNetLog is not explicitly called, CronetEngine.shutdown()
   // will take care of it. crbug.com/623701.
   public void testNoStopBoundedFileNetLog() throws Exception {
@@ -446,6 +443,7 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
+  // TODO(alyssawilk) debug this and all other disabled Netlog tests
   @Ignore("Netlog not implemented")
   // Tests that NetLog contains events emitted by all live CronetEngines.
   public void testNetLogContainEventsFromAllLiveEngines() throws Exception {
@@ -678,7 +676,7 @@ public class CronetUrlRequestContextTest {
     } catch (Exception e) {
       assertEquals("Engine is shut down.", e.getMessage());
     }
-    assertFalse(hasBytesInNetLog(file));
+    assertFalse(hasTraceInNetLog(file));
     assertTrue(file.delete());
     assertFalse(file.exists());
   }
@@ -715,7 +713,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testNetLogStartMultipleTimes() throws Exception {
     final CronetTestFramework testFramework = mTestRule.startCronetTestFramework();
     File directory = new File(PathUtils.getDataDirectory());
@@ -733,8 +730,8 @@ public class CronetUrlRequestContextTest {
     callback.blockForDone();
     testFramework.mCronetEngine.stopNetLog();
     assertTrue(file.exists());
-    assertTrue(file.length() != 0);
-    assertFalse(hasBytesInNetLog(file));
+    assertTrue(hasDebugInNetLog(file));
+    assertFalse(hasTraceInNetLog(file));
     assertTrue(file.delete());
     assertFalse(file.exists());
   }
@@ -742,7 +739,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testBoundedFileNetLogStartMultipleTimes() throws Exception {
     final CronetTestFramework testFramework = mTestRule.startCronetTestFramework();
     File directory = new File(PathUtils.getDataDirectory());
@@ -765,7 +761,7 @@ public class CronetUrlRequestContextTest {
     testFramework.mCronetEngine.stopNetLog();
     assertTrue(logFile.exists());
     assertTrue(logFile.length() != 0);
-    assertFalse(hasBytesInNetLog(logFile));
+    assertFalse(hasTraceInNetLog(logFile));
     FileUtils.recursivelyDeleteFile(netLogDir, FileUtils.DELETE_ALL);
     assertFalse(netLogDir.exists());
   }
@@ -773,7 +769,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testNetLogStopMultipleTimes() throws Exception {
     final CronetTestFramework testFramework = mTestRule.startCronetTestFramework();
     File directory = new File(PathUtils.getDataDirectory());
@@ -792,8 +787,8 @@ public class CronetUrlRequestContextTest {
     testFramework.mCronetEngine.stopNetLog();
     testFramework.mCronetEngine.stopNetLog();
     assertTrue(file.exists());
-    assertTrue(file.length() != 0);
-    assertFalse(hasBytesInNetLog(file));
+    assertTrue(hasDebugInNetLog(file));
+    assertFalse(hasTraceInNetLog(file));
     assertTrue(file.delete());
     assertFalse(file.exists());
   }
@@ -801,7 +796,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testBoundedFileNetLogStopMultipleTimes() throws Exception {
     final CronetTestFramework testFramework = mTestRule.startCronetTestFramework();
     File directory = new File(PathUtils.getDataDirectory());
@@ -825,7 +819,7 @@ public class CronetUrlRequestContextTest {
     testFramework.mCronetEngine.stopNetLog();
     assertTrue(logFile.exists());
     assertTrue(logFile.length() != 0);
-    assertFalse(hasBytesInNetLog(logFile));
+    assertFalse(hasTraceInNetLog(logFile));
     FileUtils.recursivelyDeleteFile(netLogDir, FileUtils.DELETE_ALL);
     assertFalse(netLogDir.exists());
   }
@@ -833,7 +827,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testNetLogWithBytes() throws Exception {
     Context context = getContext();
     File directory = new File(PathUtils.getDataDirectory());
@@ -849,8 +842,8 @@ public class CronetUrlRequestContextTest {
     callback.blockForDone();
     cronetEngine.stopNetLog();
     assertTrue(file.exists());
-    assertTrue(file.length() != 0);
-    assertTrue(hasBytesInNetLog(file));
+    assertTrue(hasDebugInNetLog(file));
+    assertTrue(hasTraceInNetLog(file));
     assertTrue(file.delete());
     assertFalse(file.exists());
   }
@@ -858,7 +851,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testBoundedFileNetLogWithBytes() throws Exception {
     Context context = getContext();
     File directory = new File(PathUtils.getDataDirectory());
@@ -879,13 +871,17 @@ public class CronetUrlRequestContextTest {
 
     assertTrue(logFile.exists());
     assertTrue(logFile.length() != 0);
-    assertTrue(hasBytesInNetLog(logFile));
+    assertTrue(hasTraceInNetLog(logFile));
     FileUtils.recursivelyDeleteFile(netLogDir, FileUtils.DELETE_ALL);
     assertFalse(netLogDir.exists());
   }
 
-  private boolean hasBytesInNetLog(File logFile) throws Exception {
-    return containsStringInNetLog(logFile, "\"bytes\"");
+  private boolean hasTraceInNetLog(File logFile) throws Exception {
+    return containsStringInNetLog(logFile, "trace");
+  }
+
+  private boolean hasDebugInNetLog(File logFile) throws Exception {
+    return containsStringInNetLog(logFile, "debug");
   }
 
   private boolean containsStringInNetLog(File logFile, String content) throws Exception {

--- a/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
@@ -443,9 +443,7 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  // TODO(alyssawilk) debug this and all other disabled Netlog tests
-  @Ignore("Netlog not implemented")
-  // Tests that NetLog contains events emitted by all live CronetEngines.
+  // Unlike Cronet, Cronvoy will log all events emitted to the last log file requested.
   public void testNetLogContainEventsFromAllLiveEngines() throws Exception {
     Context context = getContext();
     File directory = new File(PathUtils.getDataDirectory());
@@ -472,12 +470,8 @@ public class CronetUrlRequestContextTest {
     cronetEngine2.stopNetLog();
     assertTrue(file1.exists());
     assertTrue(file2.exists());
-    // Make sure both files contain the two requests made separately using
-    // different engines.
-    assertTrue(containsStringInNetLog(file1, mUrl404));
-    assertTrue(containsStringInNetLog(file1, mUrl500));
-    assertTrue(containsStringInNetLog(file2, mUrl404));
-    assertTrue(containsStringInNetLog(file2, mUrl500));
+    assertTrue(containsStringInNetLog(file2, NativeTestServer.getNotFoundPath()));
+    assertTrue(containsStringInNetLog(file2, NativeTestServer.getInternalErrorPath()));
     assertTrue(file1.delete());
     assertTrue(file2.delete());
   }
@@ -485,8 +479,7 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
-  // Tests that NetLog contains events emitted by all live CronetEngines.
+  // Unlike Cronet, Cronvoy will log all events emitted to the last log file requested.
   public void testBoundedFileNetLogContainEventsFromAllLiveEngines() throws Exception {
     Context context = getContext();
     File directory = new File(PathUtils.getDataDirectory());
@@ -521,15 +514,15 @@ public class CronetUrlRequestContextTest {
 
     assertTrue(logFile1.exists());
     assertTrue(logFile2.exists());
-    assertTrue(logFile1.length() != 0);
+
+    BufferedReader logReader = new BufferedReader(new FileReader(logFile2));
+    String logLine;
+    logReader.close();
+
     assertTrue(logFile2.length() != 0);
 
-    // Make sure both files contain the two requests made separately using
-    // different engines.
-    assertTrue(containsStringInNetLog(logFile1, mUrl404));
-    assertTrue(containsStringInNetLog(logFile1, mUrl500));
-    assertTrue(containsStringInNetLog(logFile2, mUrl404));
-    assertTrue(containsStringInNetLog(logFile2, mUrl500));
+    assertTrue(containsStringInNetLog(logFile2, NativeTestServer.getNotFoundPath()));
+    assertTrue(containsStringInNetLog(logFile2, NativeTestServer.getInternalErrorPath()));
 
     FileUtils.recursivelyDeleteFile(netLogDir1, FileUtils.DELETE_ALL);
     assertFalse(netLogDir1.exists());
@@ -658,7 +651,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testNetLogAfterShutdown() throws Exception {
     final CronetTestFramework testFramework = mTestRule.startCronetTestFramework();
     TestUrlRequestCallback callback = new TestUrlRequestCallback();
@@ -684,7 +676,6 @@ public class CronetUrlRequestContextTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("Netlog not implemented")
   public void testBoundedFileNetLogAfterShutdown() throws Exception {
     final CronetTestFramework testFramework = mTestRule.startCronetTestFramework();
     TestUrlRequestCallback callback = new TestUrlRequestCallback();

--- a/mobile/test/java/org/chromium/net/impl/BUILD
+++ b/mobile/test/java/org/chromium/net/impl/BUILD
@@ -12,6 +12,7 @@ envoy_mobile_android_test(
         "CancelProofEnvoyStreamTest.java",
         "CronetBidirectionalStateTest.java",
         "CronvoyEngineTest.java",
+        "CronvoyLoggerTest.java",
         "UrlRequestCallbackTester.java",
     ],
     exec_properties = {

--- a/mobile/test/java/org/chromium/net/impl/CronvoyLoggerTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CronvoyLoggerTest.java
@@ -1,0 +1,92 @@
+package org.chromium.net.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import org.junit.rules.ExpectedException;
+import org.chromium.net.testing.Feature;
+import org.junit.runner.RunWith;
+import org.junit.Rule;
+import org.junit.Test;
+import org.chromium.net.impl.CronvoyLogger;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Tests that ConvoyLogger works as expected.
+ */
+@RunWith(AndroidJUnit4.class)
+public class CronvoyLoggerTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
+  public void logWithLoggerUnconfigured() throws Exception {
+    CronvoyLogger logger = new CronvoyLogger();
+    // Should be a no-op.
+    logger.log("hello");
+  }
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
+  public void testBasicLogToFile() throws Exception {
+    File file = File.createTempFile("some-prefix", "some-ext");
+    file.deleteOnExit();
+    String filename = file.getAbsolutePath() + "foo"; // Pick a path that doesn't exist.
+    CronvoyLogger logger = new CronvoyLogger();
+    System.out.println(file.getAbsolutePath());
+    logger.setNetLogToFile(filename);
+    logger.log("hello");
+    logger.stopLogging();
+    char[] buffer = new char[5000];
+    byte[] bytes = Files.readAllBytes(Paths.get(filename));
+    String fileContent = new String(bytes);
+    assertEquals(fileContent, "hello");
+  }
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
+  public void testBasicLogToDisk() throws Exception {
+    File file = File.createTempFile("some-prefix", "some-ext");
+    file.deleteOnExit();
+    String filename = file.getAbsolutePath() + "bar/foo"; // Pick a directory that doesn't exist.
+    CronvoyLogger logger = new CronvoyLogger();
+    System.out.println(file.getAbsolutePath());
+    logger.setNetLogToDisk(filename, 5000);
+    logger.log("hello");
+    logger.stopLogging();
+    char[] buffer = new char[5000];
+    byte[] bytes = Files.readAllBytes(Paths.get(filename));
+    String fileContent = new String(bytes);
+    assertEquals(fileContent, "hello");
+  }
+
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
+  public void testLogToDiskWithLimits() throws Exception {
+    File file = File.createTempFile("some-prefix", "some-ext");
+    file.deleteOnExit();
+    String filename = file.getAbsolutePath();
+    CronvoyLogger logger = new CronvoyLogger();
+    System.out.println(file.getAbsolutePath());
+    logger.setNetLogToDisk(filename, 5);
+    logger.log("hello");
+    logger.log("goodbye");
+    logger.stopLogging();
+    char[] buffer = new char[5000];
+    byte[] bytes = Files.readAllBytes(Paths.get(filename));
+    String fileContent = new String(bytes);
+    assertEquals("goodbye", fileContent);
+  }
+}

--- a/mobile/test/java/org/chromium/net/impl/CronvoyLoggerTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CronvoyLoggerTest.java
@@ -39,11 +39,10 @@ public class CronvoyLoggerTest {
   @SmallTest
   @Feature({"Cronet"})
   public void testBasicLogToFile() throws Exception {
-    File file = File.createTempFile("some-prefix", "some-ext");
+    File file = File.createTempFile("some-prefix", "file-ext");
     file.deleteOnExit();
     String filename = file.getAbsolutePath() + "foo"; // Pick a path that doesn't exist.
     CronvoyLogger logger = new CronvoyLogger();
-    System.out.println(file.getAbsolutePath());
     logger.setNetLogToFile(filename);
     logger.log("hello");
     logger.stopLogging();
@@ -57,16 +56,15 @@ public class CronvoyLoggerTest {
   @SmallTest
   @Feature({"Cronet"})
   public void testBasicLogToDisk() throws Exception {
-    File file = File.createTempFile("some-prefix", "some-ext");
+    File file = File.createTempFile("some-prefix", "basic-ext");
     file.deleteOnExit();
     String filename = file.getAbsolutePath() + "bar/foo"; // Pick a directory that doesn't exist.
     CronvoyLogger logger = new CronvoyLogger();
-    System.out.println(file.getAbsolutePath());
     logger.setNetLogToDisk(filename, 5000);
     logger.log("hello");
     logger.stopLogging();
     char[] buffer = new char[5000];
-    byte[] bytes = Files.readAllBytes(Paths.get(filename));
+    byte[] bytes = Files.readAllBytes(Paths.get(filename + "/netlog.json"));
     String fileContent = new String(bytes);
     assertEquals(fileContent, "hello");
   }
@@ -75,17 +73,16 @@ public class CronvoyLoggerTest {
   @SmallTest
   @Feature({"Cronet"})
   public void testLogToDiskWithLimits() throws Exception {
-    File file = File.createTempFile("some-prefix", "some-ext");
+    File file = File.createTempFile("some-prefix", "limits-ext");
     file.deleteOnExit();
-    String filename = file.getAbsolutePath();
+    String filename = file.getAbsolutePath() + "bar";
     CronvoyLogger logger = new CronvoyLogger();
-    System.out.println(file.getAbsolutePath());
     logger.setNetLogToDisk(filename, 5);
-    logger.log("hello");
+    logger.log("hello!");
     logger.log("goodbye");
     logger.stopLogging();
     char[] buffer = new char[5000];
-    byte[] bytes = Files.readAllBytes(Paths.get(filename));
+    byte[] bytes = Files.readAllBytes(Paths.get(filename + "/netlog.json"));
     String fileContent = new String(bytes);
     assertEquals("goodbye", fileContent);
   }

--- a/mobile/test/java/org/chromium/net/testing/NativeTestServer.java
+++ b/mobile/test/java/org/chromium/net/testing/NativeTestServer.java
@@ -82,13 +82,17 @@ public final class NativeTestServer {
 
   public static String getSuccessURL() { return getUrl("/success.txt"); }
 
-  public static String getInternalErrorURL() { return getUrl("/internalerror.txt"); }
+  public static String getInternalErrorPath() { return "/internalerror.txt"; }
+
+  public static String getInternalErrorURL() { return getUrl(getInternalErrorPath()); }
 
   public static String getRedirectURL() { return getUrl("/redirect.html"); }
 
   public static String getMultiRedirectURL() { return getUrl("/multiredirect.html"); }
 
-  public static String getNotFoundURL() { return getUrl("/notfound.html"); }
+  public static String getNotFoundPath() { return "/notfound.html"; }
+
+  public static String getNotFoundURL() { return getUrl(getNotFoundPath()); }
 
   public static int getPort() { return mockWebServerRef.get().getPort(); }
 


### PR DESCRIPTION
This has 2 major changes for Cronvoy.
1) turn logs off by default (theoretically no-op for optimized build, but avoids context switching for non-opt)
2) wait for engine creation before allowing further down-calls. This avoids a race condition where logging is changed before the engine is created but also will slow app start-up.  We can revisit and do per-downcall waits if necessary

Risk Level: low (off by default)
Testing: basic tests
Docs Changes: n/a
Release Notes: n/a