### PR TITLE
Rename whitelist to allowlist

### DIFF
--- a/bazel/wasm/wasm.bzl
+++ b/bazel/wasm/wasm.bzl
@@ -52,7 +52,7 @@ def _wasm_attrs(transition):
         "precompile": attr.bool(default = False),
         # This is deliberately in target configuration to avoid compiling v8 twice.
         "_compile_tool": attr.label(default = "@envoy//test/tools/wee8_compile:wee8_compile_tool", executable = True, cfg = "target"),
-        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
     }
 
 wasm_rust_binary_rule = rule(


### PR DESCRIPTION
The change has been made in Bazel in 2020, so it should be safe to rename.

Commit Message: Rename whitelist to allowlist
Additional Description: The change has been made in Bazel in 2020, so it should be safe to rename.
Risk Level: Low
Testing: manual testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A