### PR TITLE
clear route cache in json_to_metadata filter

### DIFF
--- a/source/extensions/filters/http/json_to_metadata/filter.cc
+++ b/source/extensions/filters/http/json_to_metadata/filter.cc
@@ -184,6 +184,8 @@ void Filter::finalizeDynamicMetadata(Http::StreamFilterCallbacks& filter_callbac
     for (auto const& entry : struct_map) {
       filter_callback.streamInfo().setDynamicMetadata(entry.first, entry.second);
     }
+
+    decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
   }
 }
 

--- a/test/extensions/filters/http/json_to_metadata/filter_test.cc
+++ b/test/extensions/filters/http/json_to_metadata/filter_test.cc
@@ -133,6 +133,7 @@ TEST_F(FilterTest, BasicStringMatch) {
             filter_->decodeHeaders(incoming_headers_, false));
 
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
   EXPECT_CALL(stream_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
   testRequestWithBody(request_body);
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: the metadata can be used in the RouteMatch configuration, so need to call clearRouteCache() if some metadata is added
Additional Description:
Risk Level: low
Testing: unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
