### PR TITLE
mobile: HTTP/2 and "HTTP/3" tests

### DIFF
--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -94,6 +94,7 @@ BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion
   use_lds_ = false;
   autonomous_upstream_ = true;
   defer_listener_finalization_ = true;
+  memset(&last_stream_final_intel_, 0, sizeof(envoy_final_stream_intel));
 
   builder_.addLogLevel(getPlatformLogLevelFromOptions());
   // The admin interface gets added by default in the ConfigHelper's constructor. Since the admin
@@ -119,6 +120,7 @@ void BaseClientIntegrationTest::initialize() {
   });
   stream_prototype_->setOnComplete(
       [this](envoy_stream_intel, envoy_final_stream_intel final_intel) {
+        memcpy(&last_stream_final_intel_, &final_intel, sizeof(envoy_final_stream_intel));
         if (expect_data_streams_) {
           validateStreamIntel(final_intel, expect_dns_, upstream_tls_, cc_.on_complete_calls == 0);
         }

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -81,6 +81,7 @@ protected:
   // True if data plane requests are expected in the test; false otherwise.
   bool expect_data_streams_ = true;
   TestEngineBuilder builder_;
+  envoy_final_stream_intel last_stream_final_intel_;
 };
 
 } // namespace Envoy


### PR DESCRIPTION
Adding an E-M C++ HTTP/2 test and a commented-out HTTP/3-with-hints test.