### PR TITLE
Make HotRestart reference available to ActiveQuicListeners

### DIFF
--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
@@ -49,7 +49,7 @@ class ApiListenerManagerFactoryImpl : public ListenerManagerFactory {
 public:
   std::unique_ptr<ListenerManager>
   createListenerManager(Instance& server, std::unique_ptr<ListenerComponentFactory>&&,
-                        WorkerFactory&, bool, Quic::QuicStatNames&) override {
+                        WorkerFactory&, bool, Quic::QuicContext&) override {
     return std::make_unique<ApiListenerManagerImpl>(server);
   }
   std::string name() const override { return "envoy.listener_manager_impl.api"; }

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -68,12 +68,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "quic_context_lib",
+    hdrs = ["quic_context.h"],
+    tags = ["nofips"],
+    deps = [":quic_stat_names_lib"],
+)
+
+envoy_cc_library(
     name = "quic_stat_names_lib",
     srcs = ["quic_stat_names.cc"],
-    hdrs = [
-        "quic_context.h",
-        "quic_stat_names.h",
-    ],
+    hdrs = ["quic_stat_names.h"],
     tags = ["nofips"],
     deps = [
         "//envoy/stats:stats_interface",
@@ -409,6 +413,7 @@ envoy_cc_library(
         ":envoy_quic_proof_source_lib",
         ":envoy_quic_server_preferred_address_config_factory_interface",
         ":envoy_quic_utils_lib",
+        ":quic_context_lib",
         "//envoy/network:listener_interface",
         "//source/common/network:listener_lib",
         "//source/common/protobuf:utility_lib",

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -70,7 +70,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_stat_names_lib",
     srcs = ["quic_stat_names.cc"],
-    hdrs = ["quic_stat_names.h"],
+    hdrs = [
+        "quic_context.h",
+        "quic_stat_names.h",
+    ],
     tags = ["nofips"],
     deps = [
         "//envoy/stats:stats_interface",

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -12,6 +12,7 @@
 #include "source/common/quic/envoy_quic_dispatcher.h"
 #include "source/common/quic/envoy_quic_proof_source_factory_interface.h"
 #include "source/common/quic/envoy_quic_server_preferred_address_config_factory.h"
+#include "source/common/quic/quic_context.h"
 #include "source/common/runtime/runtime_protos.h"
 #include "source/server/active_udp_listener.h"
 

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -34,8 +34,7 @@ public:
                      Network::ListenerConfig& listener_config, const quic::QuicConfig& quic_config,
                      bool kernel_worker_routing,
                      const envoy::config::core::v3::RuntimeFeatureFlag& enabled,
-                     QuicStatNames& quic_stat_names,
-                     uint32_t packets_to_read_to_connection_count_ratio,
+                     QuicContext& quic_context, uint32_t packets_to_read_to_connection_count_ratio,
                      EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory,
                      EnvoyQuicProofSourceFactoryInterface& proof_source_factory,
                      QuicConnectionIdGeneratorPtr&& cid_generator,
@@ -104,7 +103,7 @@ class ActiveQuicListenerFactory : public Network::ActiveUdpListenerFactory,
                                   Logger::Loggable<Logger::Id::quic> {
 public:
   ActiveQuicListenerFactory(const envoy::config::listener::v3::QuicProtocolOptions& config,
-                            uint32_t concurrency, QuicStatNames& quic_stat_names,
+                            uint32_t concurrency, QuicContext& quic_context,
                             ProtobufMessage::ValidationVisitor& validation_visitor,
                             ProcessContextOptRef context);
 
@@ -127,7 +126,7 @@ protected:
       Event::Dispatcher& dispatcher, Network::UdpConnectionHandler& parent,
       Network::SocketSharedPtr&& listen_socket, Network::ListenerConfig& listener_config,
       const quic::QuicConfig& quic_config, bool kernel_worker_routing,
-      const envoy::config::core::v3::RuntimeFeatureFlag& enabled, QuicStatNames& quic_stat_names,
+      const envoy::config::core::v3::RuntimeFeatureFlag& enabled, QuicContext& quic_context,
       uint32_t packets_to_read_to_connection_count_ratio,
       EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory,
       EnvoyQuicProofSourceFactoryInterface& proof_source_factory,
@@ -145,7 +144,7 @@ private:
   quic::QuicConfig quic_config_;
   const uint32_t concurrency_;
   envoy::config::core::v3::RuntimeFeatureFlag enabled_;
-  QuicStatNames& quic_stat_names_;
+  QuicContext& quic_context_;
   const uint32_t packets_to_read_to_connection_count_ratio_;
   const Network::Socket::OptionsSharedPtr options_{std::make_shared<Network::Socket::Options>()};
   QuicConnectionIdWorkerSelector worker_selector_;

--- a/source/common/quic/quic_context.h
+++ b/source/common/quic/quic_context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/common/optref.h"
+
 #include "source/common/quic/quic_stat_names.h"
 
 namespace Envoy {

--- a/source/common/quic/quic_context.h
+++ b/source/common/quic/quic_context.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "source/common/quic/quic_stat_names.h"
+
+namespace Envoy {
+namespace Server {
+class HotRestart;
+} // namespace Server
+namespace Quic {
+
+class QuicContext {
+public:
+  QuicContext(Stats::SymbolTable& stat_names, OptRef<Envoy::Server::HotRestart> hot_restart)
+      : stat_names_(stat_names), hot_restart_(hot_restart) {}
+  QuicStatNames& statNames() { return stat_names_; }
+  OptRef<Envoy::Server::HotRestart> hotRestart() { return hot_restart_; }
+
+private:
+  QuicStatNames stat_names_;
+  OptRef<Envoy::Server::HotRestart> hot_restart_;
+};
+
+} // namespace Quic
+} // namespace Envoy

--- a/source/common/quic/quic_context.h
+++ b/source/common/quic/quic_context.h
@@ -10,6 +10,15 @@ class HotRestart;
 } // namespace Server
 namespace Quic {
 
+// A wrapper around QuicStatNames and a HotRestart reference which may be unset.
+//
+// When HotRestart is available, ActiveQuicListener needs access to it in order to
+// register to receive packets forwarded from the parent to child instance.
+//
+// The parts are wrapped together into this object because the factory that takes
+// a QuicContext reference is instantiated per cluster - taking a reference to
+// StatName and HotRestart separately therefore increases the per-cluster memory
+// usage. Wrapping them into a single reference is more efficient.
 class QuicContext {
 public:
   QuicContext(Stats::SymbolTable& stat_names, OptRef<Envoy::Server::HotRestart> hot_restart)

--- a/source/common/quic/quic_stat_names.h
+++ b/source/common/quic/quic_stat_names.h
@@ -2,6 +2,7 @@
 
 #ifdef ENVOY_ENABLE_QUIC
 
+#include "envoy/common/optref.h"
 #include "envoy/stats/scope.h"
 
 #include "source/common/common/thread.h"
@@ -11,6 +12,11 @@
 #include "quiche/quic/core/quic_types.h"
 
 namespace Envoy {
+
+namespace Server {
+class HotRestart;
+} // namespace Server
+
 namespace Quic {
 
 class QuicStatNames {
@@ -60,6 +66,18 @@ public:
 };
 
 #endif
+
+class QuicContext {
+public:
+  QuicContext(Stats::SymbolTable& stat_names, OptRef<Server::HotRestart> hot_restart)
+      : stat_names_(stat_names), hot_restart_(hot_restart) {}
+  QuicStatNames& statNames() { return stat_names_; }
+  OptRef<Server::HotRestart> hotRestart() { return hot_restart_; }
+
+private:
+  QuicStatNames stat_names_;
+  OptRef<Server::HotRestart> hot_restart_;
+};
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/quic_stat_names.h
+++ b/source/common/quic/quic_stat_names.h
@@ -69,14 +69,14 @@ public:
 
 class QuicContext {
 public:
-  QuicContext(Stats::SymbolTable& stat_names, OptRef<Server::HotRestart> hot_restart)
+  QuicContext(Stats::SymbolTable& stat_names, OptRef<Envoy::Server::HotRestart> hot_restart)
       : stat_names_(stat_names), hot_restart_(hot_restart) {}
   QuicStatNames& statNames() { return stat_names_; }
-  OptRef<Server::HotRestart> hotRestart() { return hot_restart_; }
+  OptRef<Envoy::Server::HotRestart> hotRestart() { return hot_restart_; }
 
 private:
   QuicStatNames stat_names_;
-  OptRef<Server::HotRestart> hot_restart_;
+  OptRef<Envoy::Server::HotRestart> hot_restart_;
 };
 
 } // namespace Quic

--- a/source/common/quic/quic_stat_names.h
+++ b/source/common/quic/quic_stat_names.h
@@ -2,7 +2,6 @@
 
 #ifdef ENVOY_ENABLE_QUIC
 
-#include "envoy/common/optref.h"
 #include "envoy/stats/scope.h"
 
 #include "source/common/common/thread.h"
@@ -12,11 +11,6 @@
 #include "quiche/quic/core/quic_types.h"
 
 namespace Envoy {
-
-namespace Server {
-class HotRestart;
-} // namespace Server
-
 namespace Quic {
 
 class QuicStatNames {
@@ -66,18 +60,6 @@ public:
 };
 
 #endif
-
-class QuicContext {
-public:
-  QuicContext(Stats::SymbolTable& stat_names, OptRef<Envoy::Server::HotRestart> hot_restart)
-      : stat_names_(stat_names), hot_restart_(hot_restart) {}
-  QuicStatNames& statNames() { return stat_names_; }
-  OptRef<Envoy::Server::HotRestart> hotRestart() { return hot_restart_; }
-
-private:
-  QuicStatNames stat_names_;
-  OptRef<Envoy::Server::HotRestart> hot_restart_;
-};
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/extensions/listener_managers/listener_manager/BUILD
+++ b/source/extensions/listener_managers/listener_manager/BUILD
@@ -64,7 +64,7 @@ envoy_cc_extension(
         "//source/common/network:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/stream_info:stream_info_lib",
-        "//source/common/quic:quic_stat_names_lib",
+        "//source/common/quic:quic_context_lib",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/upstreams/http/generic:config",
         "//source/extensions/udp_packet_writer/default:config",

--- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
@@ -358,7 +358,7 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
           std::make_shared<Server::Configuration::TransportSocketFactoryContextImpl>(
               parent_.server_.serverFactoryContext(), parent_.server_.sslContextManager(),
               listenerScope(), parent_.server_.clusterManager(), validation_visitor_)),
-      quic_stat_names_(parent_.quicStatNames()),
+      quic_context_(parent_.quicContext()),
       missing_listener_config_stats_({ALL_MISSING_LISTENER_CONFIG_STATS(
           POOL_COUNTER(listener_factory_context_->listenerScope()))}) {
   std::vector<std::reference_wrapper<
@@ -479,7 +479,7 @@ ListenerImpl::ListenerImpl(ListenerImpl& origin,
                             parent_.inPlaceFilterChainUpdate(*this);
                           }),
       transport_factory_context_(origin.transport_factory_context_),
-      quic_stat_names_(parent_.quicStatNames()),
+      quic_context_(parent_.quicContext()),
       missing_listener_config_stats_({ALL_MISSING_LISTENER_CONFIG_STATS(
           POOL_COUNTER(listener_factory_context_->listenerScope()))}) {
   buildAccessLog();
@@ -620,7 +620,7 @@ void ListenerImpl::buildUdpListenerFactory(uint32_t concurrency) {
                            "doesn't work with connection balancer.");
     }
     udp_listener_config_->listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
-        config_.udp_listener_config().quic_options(), concurrency, quic_stat_names_,
+        config_.udp_listener_config().quic_options(), concurrency, quic_context_,
         validation_visitor_, listener_factory_context_->processContext());
 #if UDP_GSO_BATCH_WRITER_COMPILETIME_SUPPORT
     // TODO(mattklein123): We should be able to use GSO without QUICHE/QUIC. Right now this causes

--- a/source/extensions/listener_managers/listener_manager/listener_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
@@ -532,7 +532,7 @@ private:
   std::shared_ptr<Server::Configuration::TransportSocketFactoryContextImpl>
       transport_factory_context_;
 
-  Quic::QuicStatNames& quic_stat_names_;
+  Quic::QuicContext& quic_context_;
   MissingListenerConfigStats missing_listener_config_stats_;
 
   // to access ListenerManagerImpl::factory_.

--- a/source/extensions/listener_managers/listener_manager/listener_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
@@ -21,7 +21,7 @@
 #include "source/common/config/metadata.h"
 #include "source/common/init/manager_impl.h"
 #include "source/common/init/target_impl.h"
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 #include "source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.h"
 #include "source/server/transport_socket_config_impl.h"
 

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -293,10 +293,10 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
                                          std::unique_ptr<ListenerComponentFactory>&& factory,
                                          WorkerFactory& worker_factory,
                                          bool enable_dispatcher_stats,
-                                         Quic::QuicStatNames& quic_stat_names)
+                                         Quic::QuicContext& quic_context)
     : server_(server), factory_(std::move(factory)),
       scope_(server.stats().createScope("listener_manager.")), stats_(generateStats(*scope_)),
-      enable_dispatcher_stats_(enable_dispatcher_stats), quic_stat_names_(quic_stat_names) {
+      enable_dispatcher_stats_(enable_dispatcher_stats), quic_context_(quic_context) {
   if (!factory_) {
     factory_ = std::make_unique<ProdListenerComponentFactory>(server);
   }

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
@@ -189,7 +189,7 @@ class ListenerManagerImpl : public ListenerManager, Logger::Loggable<Logger::Id:
 public:
   ListenerManagerImpl(Instance& server, std::unique_ptr<ListenerComponentFactory>&& factory,
                       WorkerFactory& worker_factory, bool enable_dispatcher_stats,
-                      Quic::QuicStatNames& quic_stat_names);
+                      Quic::QuicContext& quic_context);
 
   void onListenerWarmed(ListenerImpl& listener);
   void inPlaceFilterChainUpdate(ListenerImpl& listener);
@@ -216,7 +216,7 @@ public:
   Http::Context& httpContext() { return server_.httpContext(); }
   ApiListenerOptRef apiListener() override;
 
-  Quic::QuicStatNames& quicStatNames() { return quic_stat_names_; }
+  Quic::QuicContext& quicContext() { return quic_context_; }
 
   Instance& server_;
   std::unique_ptr<ListenerComponentFactory> factory_;
@@ -336,7 +336,7 @@ private:
   using UpdateFailureState = envoy::admin::v3::UpdateFailureState;
   absl::flat_hash_map<std::string, std::unique_ptr<UpdateFailureState>> error_state_tracker_;
   FailureStates overall_error_state_;
-  Quic::QuicStatNames& quic_stat_names_;
+  Quic::QuicContext& quic_context_;
 };
 
 class ListenerFilterChainFactoryBuilder : public FilterChainFactoryBuilder {
@@ -364,9 +364,9 @@ public:
   std::unique_ptr<ListenerManager>
   createListenerManager(Instance& server, std::unique_ptr<ListenerComponentFactory>&& factory,
                         WorkerFactory& worker_factory, bool enable_dispatcher_stats,
-                        Quic::QuicStatNames& quic_stat_names) override {
+                        Quic::QuicContext& quic_context) override {
     return std::make_unique<ListenerManagerImpl>(server, std::move(factory), worker_factory,
-                                                 enable_dispatcher_stats, quic_stat_names);
+                                                 enable_dispatcher_stats, quic_context);
   }
   std::string name() const override {
     return Config::ServerExtensionValues::get().DEFAULT_LISTENER;

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
@@ -20,7 +20,7 @@
 
 #include "source/common/config/well_known_names.h"
 #include "source/common/filter/config_discovery_impl.h"
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 #include "source/extensions/listener_managers/listener_manager/filter_chain_factory_context_callback.h"
 #include "source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.h"
 #include "source/extensions/listener_managers/listener_manager/lds_api.h"

--- a/source/extensions/listener_managers/validation_listener_manager/validation_listener_manager.h
+++ b/source/extensions/listener_managers/validation_listener_manager/validation_listener_manager.h
@@ -65,11 +65,11 @@ public:
   std::unique_ptr<ListenerManager>
   createListenerManager(Instance& server, std::unique_ptr<ListenerComponentFactory>&& factory,
                         WorkerFactory& worker_factory, bool enable_dispatcher_stats,
-                        Quic::QuicStatNames& quic_stat_names) override {
+                        Quic::QuicContext& quic_context) override {
     ASSERT(!factory);
     return std::make_unique<ListenerManagerImpl>(
         server, std::make_unique<ValidationListenerComponentFactory>(server), worker_factory,
-        enable_dispatcher_stats, quic_stat_names);
+        enable_dispatcher_stats, quic_context);
   }
   std::string name() const override {
     return Config::ServerExtensionValues::get().VALIDATION_LISTENER;

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -370,7 +370,7 @@ envoy_cc_library(
         "//envoy/server:factory_context_interface",
         "//envoy/server:listener_manager_interface",
         "//envoy/server:worker_interface",
-        "//source/common/quic:quic_stat_names_lib",
+        "//source/common/quic:quic_context_lib",
     ],
 )
 
@@ -426,7 +426,7 @@ envoy_cc_library(
         "//source/common/memory:heap_shrinker_lib",
         "//source/common/memory:stats_lib",
         "//source/common/protobuf:utility_lib",
-        "//source/common/quic:quic_stat_names_lib",
+        "//source/common/quic:quic_context_lib",
         "//source/common/router:rds_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/secret:secret_manager_impl_lib",

--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -92,7 +92,7 @@ envoy_cc_library(
         "//source/common/grpc:common_lib",
         "//source/common/local_info:local_info_lib",
         "//source/common/protobuf:utility_lib",
-        "//source/common/quic:quic_stat_names_lib",
+        "//source/common/quic:quic_context_lib",
         "//source/common/router:context_lib",
         "//source/common/router:rds_lib",
         "//source/common/runtime:runtime_lib",

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -59,7 +59,7 @@ ValidationInstance::ValidationInstance(
       mutex_tracer_(nullptr), grpc_context_(stats_store_.symbolTable()),
       http_context_(stats_store_.symbolTable()), router_context_(stats_store_.symbolTable()),
       time_system_(time_system), server_contexts_(*this),
-      quic_context_(stats_store_.symbolTable(), absl::nullopt) {
+      quic_context_(stats_store_.symbolTable(), /* hot_restart = */ absl::nullopt) {
   TRY_ASSERT_MAIN_THREAD { initialize(options, local_address, component_factory); }
   END_TRY
   catch (const EnvoyException& e) {

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -190,7 +190,7 @@ private:
   Router::ContextImpl router_context_;
   Event::TimeSystem& time_system_;
   ServerFactoryContextImpl server_contexts_;
-  Quic::QuicStatNames quic_stat_names_;
+  Quic::QuicContext quic_context_;
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
 };
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -18,7 +18,7 @@
 #include "source/common/grpc/common.h"
 #include "source/common/network/dns_resolver/dns_factory_util.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 #include "source/common/router/context_impl.h"
 #include "source/common/router/rds_impl.h"
 #include "source/common/runtime/runtime_impl.h"

--- a/source/server/listener_manager_factory.h
+++ b/source/server/listener_manager_factory.h
@@ -5,7 +5,7 @@
 #include "envoy/server/listener_manager.h"
 #include "envoy/server/worker.h"
 
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 
 namespace Envoy {
 namespace Server {

--- a/source/server/listener_manager_factory.h
+++ b/source/server/listener_manager_factory.h
@@ -15,7 +15,7 @@ public:
   virtual std::unique_ptr<ListenerManager>
   createListenerManager(Instance& server, std::unique_ptr<ListenerComponentFactory>&& factory,
                         WorkerFactory& worker_factory, bool enable_dispatcher_stats,
-                        Quic::QuicStatNames& quic_stat_names) PURE;
+                        Quic::QuicContext& quic_context) PURE;
 
   std::string category() const override { return "envoy.listener_manager_impl"; }
 };

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -34,7 +34,7 @@
 #include "source/common/init/manager_impl.h"
 #include "source/common/memory/heap_shrinker.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 #include "source/common/router/context_impl.h"
 #include "source/common/runtime/runtime_impl.h"
 #include "source/common/secret/secret_manager_impl.h"

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -296,7 +296,7 @@ public:
   }
   bool enableReusePortDefault() override;
 
-  Quic::QuicStatNames& quicStatNames() { return quic_stat_names_; }
+  Quic::QuicStatNames& quicStatNames() { return quic_context_.statNames(); }
 
   void setSinkPredicates(std::unique_ptr<Envoy::Stats::SinkPredicates>&& sink_predicates) override {
     stats_store_.setSinkPredicates(std::move(sink_predicates));
@@ -398,7 +398,7 @@ private:
   // whenever we have support for histogram merge across hot restarts.
   Stats::TimespanPtr initialization_timer_;
   ListenerHooks& hooks_;
-  Quic::QuicStatNames quic_stat_names_;
+  Quic::QuicContext quic_context_;
   ServerFactoryContextImpl server_contexts_;
   bool enable_reuse_port_default_;
   Regex::EnginePtr regex_engine_;

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -114,7 +114,8 @@ protected:
         transport_socket_factory_(true, *store_.rootScope(),
                                   std::make_unique<NiceMock<Ssl::MockServerContextConfig>>()),
         quic_version_(quic::CurrentSupportedHttp3Versions()[0]),
-        quic_context_(listener_config_.listenerScope().symbolTable(), absl::nullopt) {}
+        quic_context_(listener_config_.listenerScope().symbolTable(),
+                      /* hot_restart = */ absl::nullopt) {}
 
   template <typename A, typename B>
   std::unique_ptr<A> staticUniquePointerCast(std::unique_ptr<B>&& source) {

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -116,7 +116,7 @@ public:
         *server_.server_factory_context_, server_.stats(), server_.threadLocal(),
         server_.httpContext(),
         [this]() -> Network::DnsResolverSharedPtr { return this->server_.dnsResolver(); },
-        ssl_context_manager_, server_.secretManager(), server_.quic_stat_names_, server_);
+        ssl_context_manager_, server_.secretManager(), server_.quic_context_.statNames(), server_);
 
     ON_CALL(server_, clusterManager()).WillByDefault(Invoke([&]() -> Upstream::ClusterManager& {
       return *main_config.clusterManager();
@@ -174,7 +174,7 @@ public:
   NiceMock<Server::MockListenerComponentFactory>& component_factory_{*component_factory_ptr_};
   NiceMock<Server::MockWorkerFactory> worker_factory_;
   Server::ListenerManagerImpl listener_manager_{server_, std::move(component_factory_ptr_),
-                                                worker_factory_, false, server_.quic_stat_names_};
+                                                worker_factory_, false, server_.quic_context_};
   Random::RandomGeneratorImpl random_;
   std::shared_ptr<Runtime::MockSnapshot> snapshot_{
       std::make_shared<NiceMock<Runtime::MockSnapshot>>()};

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.h
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.h
@@ -83,7 +83,7 @@ protected:
         .WillByDefault(ReturnRef(validation_visitor));
     manager_ = std::make_unique<ListenerManagerImpl>(server_, std::move(listener_factory_ptr_),
                                                      worker_factory_, enable_dispatcher_stats_,
-                                                     server_.quic_stat_names_);
+                                                     server_.quic_context_);
 
     // Use real filter loading by default.
     ON_CALL(listener_factory_, createNetworkFilterFactoryList(_, _))

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -42,7 +42,7 @@
 
 #if defined(ENVOY_ENABLE_QUIC)
 #include "source/common/quic/active_quic_listener.h"
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 #endif
 
 #include "source/extensions/listener_managers/listener_manager/active_raw_udp_listener_config.h"

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -836,7 +836,7 @@ private:
       if (is_quic) {
 #if defined(ENVOY_ENABLE_QUIC)
         udp_listener_config_.listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
-            parent_.quic_options_, 1, parent_.quic_stat_names_, parent_.validation_visitor_,
+            parent_.quic_options_, 1, parent_.quic_context_, parent_.validation_visitor_,
             absl::nullopt);
         // Initialize QUICHE flags.
         quiche::FlagRegistry::getInstance();
@@ -943,7 +943,7 @@ private:
   Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
   testing::NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
 #ifdef ENVOY_ENABLE_QUIC
-  Quic::QuicStatNames quic_stat_names_ = Quic::QuicStatNames(stats_store_.symbolTable());
+  Quic::QuicContext quic_context_{stats_store_.symbolTable(), absl::nullopt};
 #endif
   bool initialized_ = false;
 };

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -943,7 +943,7 @@ private:
   Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
   testing::NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
 #ifdef ENVOY_ENABLE_QUIC
-  Quic::QuicContext quic_context_{stats_store_.symbolTable(), absl::nullopt};
+  Quic::QuicContext quic_context_{stats_store_.symbolTable(), /* hot_restart = */ absl::nullopt};
 #endif
   bool initialized_ = false;
 };

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -204,6 +204,7 @@ envoy_cc_mock(
         "//envoy/server:factory_context_interface",
         "//source/common/grpc:context_lib",
         "//source/common/http:context_lib",
+        "//source/common/quic:quic_context_lib",
         "//source/common/quic:quic_stat_names_lib",
         "//source/common/router:context_lib",
         "//source/common/secret:secret_manager_impl_lib",

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -16,7 +16,8 @@ MockInstance::MockInstance()
       cluster_manager_(timeSource()), ssl_context_manager_(timeSource()),
       singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
       grpc_context_(stats_store_.symbolTable()), http_context_(stats_store_.symbolTable()),
-      router_context_(stats_store_.symbolTable()), quic_stat_names_(stats_store_.symbolTable()),
+      router_context_(stats_store_.symbolTable()),
+      quic_context_(stats_store_.symbolTable(), absl::nullopt),
       stats_config_(std::make_shared<NiceMock<Configuration::MockStatsConfig>>()),
       server_factory_context_(
           std::make_shared<NiceMock<Configuration::MockServerFactoryContext>>()),

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -17,7 +17,7 @@ MockInstance::MockInstance()
       singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
       grpc_context_(stats_store_.symbolTable()), http_context_(stats_store_.symbolTable()),
       router_context_(stats_store_.symbolTable()),
-      quic_context_(stats_store_.symbolTable(), absl::nullopt),
+      quic_context_(stats_store_.symbolTable(), /* hot_restart = */ absl::nullopt),
       stats_config_(std::make_shared<NiceMock<Configuration::MockStatsConfig>>()),
       server_factory_context_(
           std::make_shared<NiceMock<Configuration::MockServerFactoryContext>>()),

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -93,7 +93,7 @@ public:
   Http::ContextImpl http_context_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   Router::ContextImpl router_context_;
-  Quic::QuicStatNames quic_stat_names_;
+  Quic::QuicContext quic_context_;
   testing::NiceMock<ProtobufMessage::MockValidationContext> validation_context_;
   std::shared_ptr<testing::NiceMock<Configuration::MockStatsConfig>> stats_config_;
   std::shared_ptr<testing::NiceMock<Configuration::MockServerFactoryContext>>

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -4,7 +4,7 @@
 
 #include "source/common/grpc/context_impl.h"
 #include "source/common/http/context_impl.h"
-#include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_context.h"
 #include "source/common/router/context_impl.h"
 #include "source/common/stats/symbol_table.h"
 #include "source/extensions/transport_sockets/tls/context_manager_impl.h"

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -64,7 +64,7 @@ protected:
         cluster_manager_factory_(
             server_context_, server_.stats(), server_.threadLocal(), server_.httpContext(),
             [this]() -> Network::DnsResolverSharedPtr { return this->server_.dnsResolver(); },
-            server_.sslContextManager(), server_.secretManager(), server_.quic_stat_names_,
+            server_.sslContextManager(), server_.secretManager(), server_.quic_context_.statNames(),
             server_) {
     ON_CALL(server_context_.api_, threadFactory())
         .WillByDefault(


### PR DESCRIPTION
Commit Message: Make HotRestart reference available to ActiveQuicListeners
Additional Description: This is a prerequisite for quic hot restart support; listeners must be registered with the hot restart class so that it can find where to send forwarded packets. Adding the hot restart reference to the factory as a new field causes per-cluster memory tests to fail, so it has to be rolled in with an existing reference to avoid that (the alternative would be piping it through as a new parameter through a much longer chain of function calls, which has a relatively large blast-radius and logically makes less sense than delivering it via a factory.)
Risk Level: None - when it builds it's effectively a no-op for now.
Testing: Existing coverage. The hotRestart() getter is not tested until a subsequent change in which it is used.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
