### PR TITLE
Add set_envoy_filter_state proxy wasm foreign function

### DIFF
--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -92,6 +92,7 @@ envoy_cc_extension(
         "//source/common/network/dns_resolver:dns_factory_util_lib",
         "//source/extensions/common/wasm/ext:declare_property_cc_proto",
         "//source/extensions/common/wasm/ext:envoy_null_vm_wasm_api",
+        "//source/extensions/common/wasm/ext:set_envoy_filter_state_cc_proto",
         "//source/extensions/filters/common/expr:context_lib",
         "@com_google_cel_cpp//eval/public/containers:field_access",
         "@com_google_cel_cpp//eval/public/containers:field_backed_list_impl",

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1142,8 +1142,8 @@ WasmResult Context::setEnvoyFilterState(std::string_view path, std::string_view 
     return WasmResult::NotFound;
   }
 
-  stream_info->filterState()->setData(path, object, StreamInfo::FilterState::StateType::Mutable,
-                                      prototype.life_span_);
+  stream_info->filterState()->setData(path, std::move(object),
+                                      StreamInfo::FilterState::StateType::Mutable);
   return WasmResult::Ok;
 }
 

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1125,7 +1125,8 @@ WasmResult Context::setProperty(std::string_view path, std::string_view value) {
   return WasmResult::Ok;
 }
 
-WasmResult Context::setEnvoyFilterState(std::string_view path, std::string_view value) {
+WasmResult Context::setEnvoyFilterState(std::string_view path, std::string_view value,
+                                        StreamInfo::FilterState::LifeSpan life_span) {
   auto* factory =
       Registry::FactoryRegistry<StreamInfo::FilterState::ObjectFactory>::getFactory(path);
   if (!factory) {
@@ -1143,7 +1144,7 @@ WasmResult Context::setEnvoyFilterState(std::string_view path, std::string_view 
   }
 
   stream_info->filterState()->setData(path, std::move(object),
-                                      StreamInfo::FilterState::StateType::Mutable);
+                                      StreamInfo::FilterState::StateType::Mutable, life_span);
   return WasmResult::Ok;
 }
 

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1125,6 +1125,28 @@ WasmResult Context::setProperty(std::string_view path, std::string_view value) {
   return WasmResult::Ok;
 }
 
+WasmResult Context::setEnvoyFilterState(std::string_view path, std::string_view value) {
+  auto* factory =
+      Registry::FactoryRegistry<StreamInfo::FilterState::ObjectFactory>::getFactory(path);
+  if (!factory) {
+    return WasmResult::NotFound;
+  }
+
+  auto object = factory->createFromBytes(value);
+  if (!object) {
+    return WasmResult::BadArgument;
+  }
+
+  auto* stream_info = getRequestStreamInfo();
+  if (!stream_info) {
+    return WasmResult::NotFound;
+  }
+
+  stream_info->filterState()->setData(path, object, StreamInfo::FilterState::StateType::Mutable,
+                                      prototype.life_span_);
+  return WasmResult::Ok;
+}
+
 WasmResult
 Context::declareProperty(std::string_view path,
                          Filters::Common::Expr::CelStatePrototypeConstPtr state_prototype) {

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -207,7 +207,8 @@ public:
   // State accessors
   WasmResult getProperty(std::string_view path, std::string* result) override;
   WasmResult setProperty(std::string_view path, std::string_view value) override;
-  WasmResult setEnvoyFilterState(std::string_view path, std::string_view value);
+  WasmResult setEnvoyFilterState(std::string_view path, std::string_view value,
+                                 StreamInfo::FilterState::LifeSpan life_span);
   WasmResult declareProperty(std::string_view path,
                              Filters::Common::Expr::CelStatePrototypeConstPtr state_prototype);
 

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -207,6 +207,7 @@ public:
   // State accessors
   WasmResult getProperty(std::string_view path, std::string* result) override;
   WasmResult setProperty(std::string_view path, std::string_view value) override;
+  WasmResult setEnvoyFilterState(std::string_view path, std::string_view value);
   WasmResult declareProperty(std::string_view path,
                              Filters::Common::Expr::CelStatePrototypeConstPtr state_prototype);
 

--- a/source/extensions/common/wasm/ext/BUILD
+++ b/source/extensions/common/wasm/ext/BUILD
@@ -96,6 +96,9 @@ cc_proto_library(
 proto_library(
     name = "set_envoy_filter_state_proto",
     srcs = ["set_envoy_filter_state.proto"],
+    deps = [
+        "declare_property_proto",
+    ],
 )
 
 # NB: this target is compiled both to native code and to Wasm. Hence the generic rule.

--- a/source/extensions/common/wasm/ext/BUILD
+++ b/source/extensions/common/wasm/ext/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
     ],
     deps = [
         ":declare_property_cc_proto",
+        ":set_envoy_filter_state_cc_proto",
         "//source/common/grpc:async_client_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
@@ -49,6 +50,7 @@ cc_library(
     tags = ["manual"],
     deps = [
         ":declare_property_cc_proto",
+        ":set_envoy_filter_state_cc_proto",
         ":node_subset_cc_proto",
         "@proxy_wasm_cpp_sdk//:proxy_wasm_intrinsics",
     ],
@@ -88,4 +90,16 @@ cc_proto_library(
         ":node_subset_proto",
         # "//external:protobuf_clib",
     ],
+)
+
+# NB: this target is compiled both to native code and to Wasm. Hence the generic rule.
+proto_library(
+    name = "set_envoy_filter_state_proto",
+    srcs = ["set_envoy_filter_state.proto"],
+)
+
+# NB: this target is compiled both to native code and to Wasm. Hence the generic rule.
+cc_proto_library(
+    name = "set_envoy_filter_state_cc_proto",
+    deps = [":set_envoy_filter_state_proto"],
 )

--- a/source/extensions/common/wasm/ext/set_envoy_filter_state.proto
+++ b/source/extensions/common/wasm/ext/set_envoy_filter_state.proto
@@ -2,9 +2,13 @@ syntax = "proto3";
 
 package envoy.source.extensions.common.wasm;
 
+import "source/extensions/common/wasm/ext/declare_property.proto";
+
 message SetEnvoyFilterStateArguments {
   // path is the filter state key
   string path = 1;
   // value is the filter state object factory input
   string value = 2;
+  // span is the life span of the filter state object
+  LifeSpan span = 3;
 };

--- a/source/extensions/common/wasm/ext/set_envoy_filter_state.proto
+++ b/source/extensions/common/wasm/ext/set_envoy_filter_state.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package envoy.source.extensions.common.wasm;
 
 message SetEnvoyFilterStateArguments {
+  // path is the filter state key
   string path = 1;
+  // value is the filter state object factory input
   string value = 2;
 };

--- a/source/extensions/common/wasm/ext/set_envoy_filter_state.proto
+++ b/source/extensions/common/wasm/ext/set_envoy_filter_state.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package envoy.source.extensions.common.wasm;
+
+message SetEnvoyFilterStateArguments {
+  string path = 1;
+  string value = 2;
+};

--- a/source/extensions/common/wasm/foreign.cc
+++ b/source/extensions/common/wasm/foreign.cc
@@ -1,5 +1,6 @@
 #include "source/common/common/logger.h"
 #include "source/extensions/common/wasm/ext/declare_property.pb.h"
+#include "source/extensions/common/wasm/ext/set_envoy_filter_state.pb.h"
 #include "source/extensions/common/wasm/wasm.h"
 
 #if defined(WASM_USE_CEL_PARSER)
@@ -59,6 +60,18 @@ RegisterForeignFunction registerUncompressForeignFunction(
         }
         dest_len = dest_len * 2;
       }
+    });
+
+RegisterForeignFunction registerSetEnvoyFilterStateForeignFunction(
+    "set_envoy_filter_state",
+    [](WasmBase&, std::string_view arguments,
+       const std::function<void*(size_t size)>&) -> WasmResult {
+      envoy::source::extensions::common::wasm::SetEnvoyFilterStateArguments args;
+      if (args.ParseFromArray(arguments.data(), arguments.size())) {
+        auto context = static_cast<Context*>(proxy_wasm::current_context_);
+        return context->setEnvoyFilterState(args.path(), args.value());
+      }
+      return WasmResult::BadArgument;
     });
 
 #if defined(WASM_USE_CEL_PARSER)

--- a/test/extensions/common/wasm/BUILD
+++ b/test/extensions/common/wasm/BUILD
@@ -131,6 +131,8 @@ envoy_cc_test(
         ],
     }),
     deps = [
+        "//source/common/network:filter_state_dst_address_lib",
+        "//source/common/tcp_proxy",
         "//source/extensions/common/wasm:wasm_hdr",
         "//source/extensions/common/wasm:wasm_lib",
         "//test/mocks/http:http_mocks",

--- a/test/extensions/common/wasm/BUILD
+++ b/test/extensions/common/wasm/BUILD
@@ -132,7 +132,7 @@ envoy_cc_test(
     }),
     deps = [
         "//source/common/network:filter_state_dst_address_lib",
-        "//source/common/tcp_proxy",
+        "//source/common/tcp_proxy:tcp_proxy",
         "//source/extensions/common/wasm:wasm_hdr",
         "//source/extensions/common/wasm:wasm_lib",
         "//test/mocks/http:http_mocks",

--- a/test/extensions/common/wasm/BUILD
+++ b/test/extensions/common/wasm/BUILD
@@ -132,7 +132,7 @@ envoy_cc_test(
     }),
     deps = [
         "//source/common/network:filter_state_dst_address_lib",
-        "//source/common/tcp_proxy:tcp_proxy",
+        "//source/common/tcp_proxy",
         "//source/extensions/common/wasm:wasm_hdr",
         "//source/extensions/common/wasm:wasm_lib",
         "//test/mocks/http:http_mocks",


### PR DESCRIPTION
Proxy wasm supports setProperty method. However that method always prefixes all property keys with `wasm.`. So currently there's no way to set envoy filter state from wasm which prevents from using it for some scenarios (like chaining a custom network wasm filter with tcp proxy filter and setting `envoy.tcp_proxy.cluster` filter state to select upstream cluster).

This change adds a new wasm foreign function `set_envoy_filter_state` and uses the [object factory to create filter state objects](https://github.com/envoyproxy/envoy/pull/29030).

Related Issue: https://github.com/envoyproxy/envoy/issues/28673

Commit Message: Add set_envoy_filter_state proxy wasm foreign function
Additional Description: Adds a proxy wasm foreign function to set envoy filter state
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
