### PR TITLE
Use #if defined(ENVOY_ENABLE_FULL_PROTOS instead of #ifdef ENVOY_ENABLE_FULL_PROTOS to be more readable

### DIFF
--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -201,7 +201,7 @@ FilterStateFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
     return absl::nullopt;
   }
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   std::string value;
   const auto status = Protobuf::util::MessageToJsonString(*proto, &value);
   if (!status.ok()) {

--- a/source/common/protobuf/create_reflectable_message.cc
+++ b/source/common/protobuf/create_reflectable_message.cc
@@ -1,6 +1,6 @@
 #include "source/common/protobuf/utility.h"
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
 
 namespace Envoy {
 Protobuf::ReflectableMessage createReflectableMessage(const Protobuf::Message& message) {

--- a/source/common/protobuf/protobuf.h
+++ b/source/common/protobuf/protobuf.h
@@ -29,7 +29,7 @@
 #include "google/protobuf/util/type_resolver_util.h"
 #include "google/protobuf/wrappers.pb.h"
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
 
 namespace google::protobuf {
 using ReflectableMessage = ::google::protobuf::Message*;

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -139,7 +139,7 @@ void ProtoExceptionUtil::throwProtoValidationException(const std::string& valida
 size_t MessageUtil::hash(const Protobuf::Message& message) {
   std::string text_format;
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   {
     Protobuf::TextFormat::Printer printer;
     printer.SetExpandAny(true);
@@ -155,7 +155,7 @@ size_t MessageUtil::hash(const Protobuf::Message& message) {
   return HashUtil::xxHash64(text_format);
 }
 
-#ifndef ENVOY_ENABLE_FULL_PROTOS
+#if !defined(ENVOY_ENABLE_FULL_PROTOS)
 // NOLINTNEXTLINE(readability-identifier-naming)
 bool MessageLiteDifferencer::Equals(const Protobuf::Message& message1,
                                     const Protobuf::Message& message2) {
@@ -339,7 +339,7 @@ void MessageUtil::recursivePgvCheck(const Protobuf::Message& message) {
 }
 
 void MessageUtil::packFrom(ProtobufWkt::Any& any_message, const Protobuf::Message& message) {
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   any_message.PackFrom(message);
 #else
   any_message.set_type_url(message.GetTypeName());
@@ -348,7 +348,7 @@ void MessageUtil::packFrom(ProtobufWkt::Any& any_message, const Protobuf::Messag
 }
 
 void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Message& message) {
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   if (!any_message.UnpackTo(&message)) {
     throw EnvoyException(fmt::format("Unable to unpack as {}: {}",
                                      message.GetDescriptor()->full_name(),
@@ -363,7 +363,7 @@ void MessageUtil::unpackTo(const ProtobufWkt::Any& any_message, Protobuf::Messag
 
 absl::Status MessageUtil::unpackToNoThrow(const ProtobufWkt::Any& any_message,
                                           Protobuf::Message& message) {
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   if (!any_message.UnpackTo(&message)) {
     return absl::InternalError(absl::StrCat("Unable to unpack as ",
                                             message.GetDescriptor()->full_name(), ": ",

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -170,7 +170,7 @@ public:
   template <class ProtoType>
   static std::size_t hash(const Protobuf::RepeatedPtrField<ProtoType>& source) {
     std::string text;
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
     {
       Protobuf::TextFormat::Printer printer;
       printer.SetExpandAny(true);

--- a/source/exe/process_wide.cc
+++ b/source/exe/process_wide.cc
@@ -31,7 +31,7 @@ ProcessWide::ProcessWide(bool validate_proto_descriptors) {
     // TODO(mattklein123): Audit the following as not all of these have to be re-initialized in the
     // edge case where something does init/destroy/init/destroy.
     Event::Libevent::Global::initialize();
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
     if (validate_proto_descriptors) {
       Envoy::Server::validateProtoDescriptors();
     }

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -118,7 +118,7 @@ public:
                bool skip_cluster_check));
 };
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
 MATCHER_P(ProtoBufferEq, expected, "") {
   typename std::remove_const<decltype(expected)>::type proto;
   if (!proto.ParseFromString(arg->toString())) {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -369,7 +369,7 @@ public:
    */
   static std::string uniqueFilename(absl::string_view prefix = "");
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   /**
    * Compare two protos of the same type for equality.
    *
@@ -440,7 +440,7 @@ public:
   static std::vector<std::string> split(const std::string& source, const std::string& split,
                                         bool keep_empty_string = false);
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   /**
    * Compare two RepeatedPtrFields of the same type for equality.
    *
@@ -1231,7 +1231,7 @@ MATCHER_P(HeaderMapEqualIgnoreOrder, expected, "") {
   return equal;
 }
 
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
 MATCHER_P(ProtoEq, expected, "") {
   const bool equal =
       TestUtility::protoEqual(arg, expected, /*ignore_repeated_field_ordering=*/false);


### PR DESCRIPTION
Change `#ifdef ENVOY_ENABLE_FULL_PROTOS` to `#if defined(ENVOY_ENABLE_FULL_PROTOS)`, 
and `#ifndef ENVOY_ENABLE_FULL_PROTOS` to `#if !defined(ENVOY_ENABLE_FULL_PROTOS)`
in order to improve readability.

Risk Level: N/A - No behavior change
Testing: N/A
Docs Changes: N/A
Release Notes: N/A