### PR TITLE
[1.27 backport] tls: Remove additional tracking on SSL_ERROR_SYSCALL

### DIFF
--- a/envoy/ssl/handshaker.h
+++ b/envoy/ssl/handshaker.h
@@ -31,7 +31,7 @@ public:
   /**
    * A callback which will be executed at most once upon handshake failure.
    */
-  virtual void onFailure(bool syscall_error_occurred = false) PURE;
+  virtual void onFailure() PURE;
 
   /**
    * Returns a pointer to the transportSocketCallbacks struct, or nullptr if

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -99,12 +99,6 @@ Network::PostIoAction SslHandshakerImpl::doHandshake() {
     case SSL_ERROR_WANT_CERTIFICATE_VERIFY:
       state_ = Ssl::SocketState::HandshakeInProgress;
       return PostIoAction::KeepOpen;
-    case SSL_ERROR_SYSCALL:
-      // By default, when SSL_ERROR_SYSCALL occurred, the underlying transport does not participate
-      // in the error queue. Therefore, setting `syscall_error_occurred` to true to report the error
-      // in `drainErrorQueue`.
-      handshake_callbacks_->onFailure(/*syscall_error_occurred=*/true);
-      return PostIoAction::Close;
     default:
       handshake_callbacks_->onFailure();
       return PostIoAction::Close;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -197,11 +197,11 @@ void SslSocket::onSuccess(SSL* ssl) {
   callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
 }
 
-void SslSocket::onFailure(bool syscall_error_occurred) { drainErrorQueue(syscall_error_occurred); }
+void SslSocket::onFailure() { drainErrorQueue(); }
 
 PostIoAction SslSocket::doHandshake() { return info_->doHandshake(); }
 
-void SslSocket::drainErrorQueue(bool syscall_error_occurred) {
+void SslSocket::drainErrorQueue() {
   bool saw_error = false;
   bool saw_counted_error = false;
   while (uint64_t err = ERR_get_error()) {
@@ -227,18 +227,6 @@ void SslSocket::drainErrorQueue(bool syscall_error_occurred) {
                                         absl::NullSafeStringView(ERR_lib_error_string(err)), ":",
                                         absl::NullSafeStringView(ERR_func_error_string(err)), ":",
                                         absl::NullSafeStringView(ERR_reason_error_string(err))));
-  }
-
-  if (syscall_error_occurred) {
-    if (failure_reason_.empty()) {
-      failure_reason_ = "TLS error:";
-    }
-    failure_reason_.append(
-        "SSL_ERROR_SYSCALL error has occured, which indicates the operation failed externally to "
-        "the library. This is typically |errno| but may be something custom if using a custom "
-        "|BIO|. It may also be signaled if the transport returned EOF, in which case the "
-        "operation's return value will be zero.");
-    saw_error = true;
   }
 
   if (!failure_reason_.empty()) {

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -69,7 +69,7 @@ public:
   // Ssl::HandshakeCallbacks
   Network::Connection& connection() const override;
   void onSuccess(SSL* ssl) override;
-  void onFailure(bool syscall_error_occurred = false) override;
+  void onFailure() override;
   Network::TransportSocketCallbacks* transportSocketCallbacks() override { return callbacks_; }
   void onAsynchronousCertValidationComplete() override;
 
@@ -86,7 +86,7 @@ private:
   ReadResult sslReadIntoSlice(Buffer::RawSlice& slice);
 
   Network::PostIoAction doHandshake();
-  void drainErrorQueue(bool syscall_error_occurred = false);
+  void drainErrorQueue();
   void shutdownSsl();
   void shutdownBasic();
   void resumeHandshake();

--- a/test/extensions/transport_sockets/tls/handshaker_test.cc
+++ b/test/extensions/transport_sockets/tls/handshaker_test.cc
@@ -43,7 +43,7 @@ public:
   ~MockHandshakeCallbacks() override = default;
   MOCK_METHOD(Network::Connection&, connection, (), (const, override));
   MOCK_METHOD(void, onSuccess, (SSL*), (override));
-  MOCK_METHOD(void, onFailure, (bool syscall_error_occurred), (override));
+  MOCK_METHOD(void, onFailure, (), (override));
   MOCK_METHOD(Network::TransportSocketCallbacks*, transportSocketCallbacks, (), (override));
   MOCK_METHOD(void, onAsynchronousCertValidationComplete, (), (override));
 };


### PR DESCRIPTION
Backport of #29263

Fixes #28415

This reverts part of #24923

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
