### PR TITLE
quic: Use name() instead of DebugString() 

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -403,6 +403,7 @@ envoy_cc_library(
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/upstream_codec/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/raw_buffer/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/http_11_proxy/v3:pkg_cc_proto",
         "//envoy/event:dispatcher_interface",
         "//envoy/event:timer_interface",
         "//envoy/network:dns_interface",

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1390,7 +1390,8 @@ bool validateTransportSocketSupportsQuic(
   if (transport_socket.name() == "envoy.transport_sockets.quic") {
     return true;
   }
-  if (transport_socket.name() != "envoy.transport_sockets.http_11_proxy") {
+  if (transport_socket.name() != "envoy.transport_sockets.http_11_proxy" &&
+      transport_socket.name() != "envoy.transport_sockets.upstream_http_11_proxy") {
     return false;
   }
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -18,8 +18,8 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
 #include "envoy/extensions/filters/http/upstream_codec/v3/upstream_codec.pb.h"
-#include "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.pb.h"
 #include "envoy/extensions/transport_sockets/http_11_proxy/v3/upstream_http_11_connect.pb.h"
+#include "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.pb.h"
 #include "envoy/init/manager.h"
 #include "envoy/network/dns.h"
 #include "envoy/network/transport_socket.h"
@@ -1383,14 +1383,16 @@ ClusterInfoImpl::upstreamHttpProtocol(absl::optional<Http::Protocol> downstream_
                                                                : Http::Protocol::Http11};
 }
 
-bool validateTransportSocketSupportsQuic(const envoy::config::core::v3::TransportSocket& transport_socket) {
+bool validateTransportSocketSupportsQuic(
+    const envoy::config::core::v3::TransportSocket& transport_socket) {
   if (transport_socket.name() == "envoy.transport_sockets.quic") {
     return true;
   }
   if (transport_socket.name() != "envoy.transport_sockets.http_11_proxy") {
     return false;
   }
-  envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport http11_socket;
+  envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
+      http11_socket;
   transport_socket.typed_config().UnpackTo(&http11_socket);
   return (http11_socket.transport_socket().name() == "envoy.transport_sockets.quic");
 }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1440,8 +1440,8 @@ ClusterImplBase::ClusterImplBase(const envoy::config::cluster::v3::Cluster& clus
 #if defined(ENVOY_ENABLE_QUIC)
     if (cluster.transport_socket().name() != "envoy.transport_sockets.quic") {
       throw EnvoyException(
-          fmt::format("HTTP3 requires a QuicUpstreamTransport transport socket: {} {}", cluster.name(),
-                      cluster.DebugString()));
+          fmt::format("HTTP3 requires a QuicUpstreamTransport transport socket: {} {}",
+                      cluster.name(), cluster.DebugString()));
     }
 #else
     throw EnvoyException("HTTP3 configured but not enabled in the build.");

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1395,7 +1395,7 @@ bool validateTransportSocketSupportsQuic(
   }
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
       http11_socket;
-  transport_socket.typed_config().UnpackTo(&http11_socket);
+  MessageUtil::unpackTo(transport_socket.typed_config(), http11_socket);
   return http11_socket.transport_socket().name() == "envoy.transport_sockets.quic";
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1390,8 +1390,7 @@ bool validateTransportSocketSupportsQuic(
   if (transport_socket.name() == "envoy.transport_sockets.quic") {
     return true;
   }
-  if (transport_socket.name() != "envoy.transport_sockets.http_11_proxy" &&
-      transport_socket.name() != "envoy.transport_sockets.upstream_http_11_proxy") {
+  if (transport_socket.name() != "envoy.transport_sockets.http_11_proxy") {
     return false;
   }
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1438,10 +1438,9 @@ ClusterImplBase::ClusterImplBase(const envoy::config::cluster::v3::Cluster& clus
 
   if (info_->features() & ClusterInfoImpl::Features::HTTP3) {
 #if defined(ENVOY_ENABLE_QUIC)
-    if (cluster.transport_socket().DebugString().find("envoy.transport_sockets.quic") ==
-        std::string::npos) {
+    if (cluster.transport_socket().name() != "envoy.transport_sockets.quic") {
       throw EnvoyException(
-          fmt::format("HTTP3 requires a QuicUpstreamTransport transport socket: {}", cluster.name(),
+          fmt::format("HTTP3 requires a QuicUpstreamTransport transport socket: {} {}", cluster.name(),
                       cluster.DebugString()));
     }
 #else

--- a/source/extensions/transport_sockets/http_11_proxy/BUILD
+++ b/source/extensions/transport_sockets/http_11_proxy/BUILD
@@ -13,6 +13,8 @@ envoy_cc_extension(
     name = "upstream_config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    # This is core Envoy config.
+    visibility = ["//visibility:public"],
     deps = [
         ":connect",
         "//envoy/network:transport_socket_interface",

--- a/source/extensions/transport_sockets/http_11_proxy/BUILD
+++ b/source/extensions/transport_sockets/http_11_proxy/BUILD
@@ -13,8 +13,9 @@ envoy_cc_extension(
     name = "upstream_config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
-    # This is core Envoy config.
-    visibility = ["//visibility:public"],
+    extra_visibility = [
+        "//test/common/upstream:__subpackages__",
+    ],
     deps = [
         ":connect",
         "//envoy/network:transport_socket_interface",

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -554,6 +554,7 @@ envoy_cc_test(
         "//source/extensions/clusters/static:static_cluster_lib",
         "//source/extensions/clusters/strict_dns:strict_dns_cluster_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/http_11_proxy:upstream_config",
         "//source/extensions/transport_sockets/tls:config",
         "//source/extensions/upstreams/http:config",
         "//source/extensions/upstreams/tcp:config",

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -4511,6 +4511,88 @@ TEST_F(ClusterInfoImplTest, Http3) {
       downstream_h3->info()->http3Options().quic_protocol_options().has_max_concurrent_streams());
 }
 
+TEST_F(ClusterInfoImplTest, Http3WithHttp11WrappedSocket) {
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: MAGLEV
+    load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: foo.bar.com
+                    port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.http_11_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.http_11_proxy.v3.Http11ProxyUpstreamTransport
+        transport_socket:
+          name: envoy.transport_sockets.quic
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport
+            upstream_tls_context:
+              common_tls_context:
+                tls_certificates:
+                - certificate_chain:
+                    filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_cert.pem"
+                  private_key:
+                    filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_uri_key.pem"
+                validation_context:
+                  trusted_ca:
+                    filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"
+                  match_typed_subject_alt_names:
+                  - matcher:
+                      exact: localhost
+                    san_type: URI
+                  - matcher:
+                      exact: 127.0.0.1
+                    san_type: IP_ADDRESS
+  )EOF",
+                                                       Network::Address::IpVersion::v4);
+
+  auto cluster1 = makeCluster(yaml);
+  ASSERT_TRUE(cluster1->info()->idleTimeout().has_value());
+  EXPECT_EQ(std::chrono::hours(1), cluster1->info()->idleTimeout().value());
+
+  const std::string explicit_http3 = R"EOF(
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http3_protocol_options:
+            quic_protocol_options:
+              max_concurrent_streams: 2
+        common_http_protocol_options:
+          idle_timeout: 1s
+  )EOF";
+
+  const std::string downstream_http3 = R"EOF(
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        use_downstream_protocol_config:
+          http3_protocol_options: {}
+        common_http_protocol_options:
+          idle_timeout: 1s
+  )EOF";
+
+  auto explicit_h3 = makeCluster(yaml + explicit_http3);
+  EXPECT_EQ(Http::Protocol::Http3,
+            explicit_h3->info()->upstreamHttpProtocol({Http::Protocol::Http10})[0]);
+  EXPECT_EQ(
+      explicit_h3->info()->http3Options().quic_protocol_options().max_concurrent_streams().value(),
+      2);
+
+  auto downstream_h3 = makeCluster(yaml + downstream_http3);
+  EXPECT_EQ(Http::Protocol::Http3,
+            downstream_h3->info()->upstreamHttpProtocol({Http::Protocol::Http3})[0]);
+  EXPECT_FALSE(
+      downstream_h3->info()->http3Options().quic_protocol_options().has_max_concurrent_streams());
+}
+
 TEST_F(ClusterInfoImplTest, Http3BadConfig) {
   const std::string yaml = TestEnvironment::substitute(R"EOF(
     name: name

--- a/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_integration_test.cc
@@ -77,7 +77,7 @@ typed_config:
       if (inner_socket.name().empty()) {
         inner_socket.set_name("envoy.transport_sockets.raw_buffer");
       }
-      transport_socket->set_name("envoy.transport_sockets.upstream_http_11_proxy");
+      transport_socket->set_name("envoy.transport_sockets.http_11_proxy");
       envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
           transport;
       transport.mutable_transport_socket()->MergeFrom(inner_socket);


### PR DESCRIPTION
quic: Use name() instead of DebugString() when checking that the QUIC transport socket is configured

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A