### PR TITLE
mobile: Use envoy_select_enable_yaml to disable various test when YAML is disabled

### DIFF
--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -1,3 +1,4 @@
+load("//third_party/envoy/src/bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
 
 licenses(["notice"])  # Apache 2
@@ -6,7 +7,7 @@ envoy_package()
 
 envoy_cc_test(
     name = "send_headers_test",
-    srcs = ["send_headers_test.cc"],
+    srcs = envoy_select_enable_yaml(["send_headers_test.cc"]),
     repository = "@envoy",
     deps = [
         "//library/cc:envoy_engine_cc_lib_no_stamp",
@@ -17,7 +18,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "lifetimes_test",
-    srcs = ["lifetimes_test.cc"],
+    srcs = envoy_select_enable_yaml(["lifetimes_test.cc"]),
     repository = "@envoy",
     deps = [
         "//library/cc:envoy_engine_cc_lib_no_stamp",

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -6,7 +6,7 @@ envoy_package()
 
 envoy_cc_test(
     name = "envoy_config_test",
-    srcs = ["envoy_config_test.cc"],
+    srcs = envoy_select_enable_yaml(["envoy_config_test.cc"]),
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",

--- a/mobile/test/common/BUILD
+++ b/mobile/test/common/BUILD
@@ -1,3 +1,4 @@
+load("//third_party/envoy/src/bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
 
 licenses(["notice"])  # Apache 2
@@ -17,7 +18,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "engine_test",
-    srcs = ["engine_test.cc"],
+    srcs = envoy_select_enable_yaml(["engine_test.cc"]),
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
@@ -29,7 +30,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "main_interface_test",
-    srcs = ["main_interface_test.cc"],
+    srcs = envoy_select_enable_yaml(["main_interface_test.cc"]),
     repository = "@envoy",
     deps = [
         "//library/common:envoy_main_interface_lib_no_stamp",


### PR DESCRIPTION
mobile: Use envoy_select_enable_yaml to disable various test when YAML is disabled

Risk Level: N/A
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A