### PR TITLE
proto: Use GetTypeName() instead of GetDescriptor to be compatible with lite protos

### DIFF
--- a/source/common/http/match_delegate/config.cc
+++ b/source/common/http/match_delegate/config.cc
@@ -331,9 +331,9 @@ FilterConfigPerRoute::createFilterMatchTree(
   auto requirements =
       std::make_unique<envoy::extensions::filters::common::dependency::v3::MatchingRequirements>();
   requirements->mutable_data_input_allow_list()->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
-      envoy::type::matcher::v3::HttpRequestHeaderMatchInput::descriptor()->full_name()));
+      envoy::type::matcher::v3::HttpRequestHeaderMatchInput::default_instance().GetTypeName()));
   requirements->mutable_data_input_allow_list()->add_type_url(TypeUtil::descriptorFullNameToTypeUrl(
-      xds::type::matcher::v3::HttpAttributesCelMatchInput::descriptor()->full_name()));
+      xds::type::matcher::v3::HttpAttributesCelMatchInput::default_instance().GetTypeName()));
   Envoy::Http::Matching::HttpFilterActionContext action_context{
       fmt::format("http.{}.",
                   server_context.scope().symbolTable().toString(server_context.scope().prefix())),

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2174,8 +2174,8 @@ PerFilterConfigs::PerFilterConfigs(
   const bool ignore_optional_option_from_hcm_for_route_config(Runtime::runtimeFeatureEnabled(
       "envoy.reloadable_features.ignore_optional_option_from_hcm_for_route_config"));
 
-  absl::string_view filter_config_type =
-      envoy::config::route::v3::FilterConfig::default_instance().GetDescriptor()->full_name();
+  std::string filter_config_type =
+      envoy::config::route::v3::FilterConfig::default_instance().GetTypeName();
 
   for (const auto& per_filter_config : typed_configs) {
     const std::string& name = per_filter_config.first;


### PR DESCRIPTION
proto: Use GetTypeName() instead of GetDescriptor to be compatible with lite protos

Risk Level: N/A
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A