### PR TITLE
fix test failure because the sync of multiple commits

### DIFF
--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -930,7 +930,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {
 
     StreamInfoFormatter upstream_format("FILTER_CHAIN_NAME");
 
-    EXPECT_EQ("mock_filter_chain_name", upstream_format.formatValueWithContext({}, stream_info));
+    EXPECT_EQ("mock_filter_chain_name", upstream_format.formatWithContext({}, stream_info));
   }
 
   {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -930,9 +930,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {
 
     StreamInfoFormatter upstream_format("FILTER_CHAIN_NAME");
 
-    EXPECT_EQ("mock_filter_chain_name",
-              upstream_format.format(request_headers, response_headers, response_trailers,
-                                     stream_info, body, AccessLog::AccessLogType::NotSet));
+    EXPECT_EQ("mock_filter_chain_name", upstream_format.formatValueWithContext({}, stream_info));
   }
 
   {


### PR DESCRIPTION

Commit Message: fix test failure because the sync of multiple commits
Additional Description:

#28804 and #29314 introduced a test fature because they update same file and don't result in conflict.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.