### PR TITLE
code cleanup 2: update all format to formatWithContext in the source and remove unnecessary specialization

### DIFF
--- a/envoy/formatter/substitution_formatter.h
+++ b/envoy/formatter/substitution_formatter.h
@@ -107,42 +107,6 @@ private:
   AccessLog::AccessLogType log_type_{AccessLog::AccessLogType::NotSet};
 };
 
-/**
- * Interface for substitution formatter.
- * Formatters provide a complete substitution output line for the given headers/trailers/stream.
- * This is specilization of FormatterBase for HTTP and backwards compatibliity.
- */
-template <> class FormatterBase<HttpFormatterContext> {
-public:
-  virtual ~FormatterBase() = default;
-
-  /**
-   * Return a formatted substitution line.
-   * @param context supplies the formatter context.
-   * @param stream_info supplies the stream info.
-   * @param local_reply_body supplies the local reply body.
-   * @return std::string string containing the complete formatted substitution line.
-   */
-  virtual std::string format(const Http::RequestHeaderMap& request_headers,
-                             const Http::ResponseHeaderMap& response_headers,
-                             const Http::ResponseTrailerMap& response_trailers,
-                             const StreamInfo::StreamInfo& stream_info,
-                             absl::string_view local_reply_body,
-                             AccessLog::AccessLogType access_log_type) const PURE;
-
-  /**
-   * Return a formatted substitution line.
-   * @param context supplies the formatter context.
-   * @param stream_info supplies the stream info.
-   * @return std::string string containing the complete formatted substitution line.
-   */
-  virtual std::string formatWithContext(const HttpFormatterContext& context,
-                                        const StreamInfo::StreamInfo& stream_info) const {
-    return format(context.requestHeaders(), context.responseHeaders(), context.responseTrailers(),
-                  stream_info, context.localReplyBody(), context.accessLogType());
-  }
-};
-
 using Formatter = FormatterBase<HttpFormatterContext>;
 using FormatterPtr = std::unique_ptr<Formatter>;
 using FormatterConstSharedPtr = std::shared_ptr<const Formatter>;

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -37,8 +37,9 @@ public:
               const Http::ResponseTrailerMap& response_trailers,
               const StreamInfo::StreamInfo& stream_info, std::string& body,
               absl::string_view& content_type) const {
-    body = formatter_->format(request_headers, response_headers, response_trailers, stream_info,
-                              body, AccessLog::AccessLogType::NotSet);
+    body = formatter_->formatWithContext({&request_headers, &response_headers, &response_trailers,
+                                          body, AccessLog::AccessLogType::NotSet},
+                                         stream_info);
     content_type = content_type_;
   }
 

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -37,9 +37,8 @@ public:
               const Http::ResponseTrailerMap& response_trailers,
               const StreamInfo::StreamInfo& stream_info, std::string& body,
               absl::string_view& content_type) const {
-    body = formatter_->formatWithContext({&request_headers, &response_headers, &response_trailers,
-                                          body, AccessLog::AccessLogType::NotSet},
-                                         stream_info);
+    body = formatter_->formatWithContext(
+        {&request_headers, &response_headers, &response_trailers, body}, stream_info);
     content_type = content_type_;
   }
 

--- a/source/common/router/header_formatter.h
+++ b/source/common/router/header_formatter.h
@@ -42,9 +42,7 @@ public:
                            const Http::ResponseHeaderMap& response_headers,
                            const Envoy::StreamInfo::StreamInfo& stream_info) const override {
     std::string buf;
-    buf = formatter_->format(request_headers, response_headers,
-                             *Http::StaticEmptyHeaders::get().response_trailers, stream_info, "",
-                             AccessLog::AccessLogType::NotSet);
+    buf = formatter_->formatWithContext({&request_headers, &response_headers}, stream_info);
     return buf;
   };
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -643,10 +643,7 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
 }
 
 std::string TunnelingConfigHelperImpl::host(const StreamInfo::StreamInfo& stream_info) const {
-  return hostname_fmt_->format(*Http::StaticEmptyHeaders::get().request_headers,
-                               *Http::StaticEmptyHeaders::get().response_headers,
-                               *Http::StaticEmptyHeaders::get().response_trailers, stream_info,
-                               absl::string_view(), AccessLog::AccessLogType::NotSet);
+  return hostname_fmt_->formatWithContext({}, stream_info);
 }
 
 void TunnelingConfigHelperImpl::propagateResponseHeaders(

--- a/source/extensions/access_loggers/common/file_access_log_impl.cc
+++ b/source/extensions/access_loggers/common/file_access_log_impl.cc
@@ -17,8 +17,10 @@ void FileAccessLog::emitLog(const Http::RequestHeaderMap& request_headers,
                             const Http::ResponseTrailerMap& response_trailers,
                             const StreamInfo::StreamInfo& stream_info,
                             AccessLog::AccessLogType access_log_type) {
-  log_file_->write(formatter_->format(request_headers, response_headers, response_trailers,
-                                      stream_info, absl::string_view(), access_log_type));
+  log_file_->write(
+      formatter_->formatWithContext({&request_headers, &response_headers, &response_trailers,
+                                     absl::string_view(), access_log_type},
+                                    stream_info));
 }
 
 } // namespace File

--- a/source/extensions/access_loggers/open_telemetry/substitution_formatter.cc
+++ b/source/extensions/access_loggers/open_telemetry/substitution_formatter.cc
@@ -88,11 +88,13 @@ OpenTelemetryFormatter::FormatBuilder::toFormatStringValue(const std::string& st
   ASSERT(!providers.empty());
   ::opentelemetry::proto::common::v1::AnyValue output;
   std::vector<std::string> bits(providers.size());
+
+  const Formatter::HttpFormatterContext formatter_context{
+      &request_headers, &response_headers, &response_trailers, local_reply_body, access_log_type};
+
   std::transform(providers.begin(), providers.end(), bits.begin(),
                  [&](const Formatter::FormatterProviderPtr& provider) {
-                   return provider
-                       ->format(request_headers, response_headers, response_trailers, stream_info,
-                                local_reply_body, access_log_type)
+                   return provider->formatWithContext(formatter_context, stream_info)
                        .value_or(DefaultUnspecifiedValueString);
                  });
   output.set_string_value(absl::StrJoin(bits, ""));

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -362,9 +362,8 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
   }
 
   Formatter::FormatterImpl formatter(config_->redirectUri());
-  const auto redirect_uri = formatter.format(
-      headers, *Http::ResponseHeaderMapImpl::create(), *Http::ResponseTrailerMapImpl::create(),
-      decoder_callbacks_->streamInfo(), "", AccessLog::AccessLogType::NotSet);
+  const auto redirect_uri =
+      formatter.formatWithContext({&headers}, decoder_callbacks_->streamInfo());
   oauth_client_->asyncGetAccessToken(auth_code_, config_->clientId(), config_->clientSecret(),
                                      redirect_uri, config_->authType());
 
@@ -419,9 +418,8 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) const 
           : Http::Utility::PercentEncoding::encode(state_path, ":/=&?");
 
   Formatter::FormatterImpl formatter(config_->redirectUri());
-  const auto redirect_uri = formatter.format(
-      headers, *Http::ResponseHeaderMapImpl::create(), *Http::ResponseTrailerMapImpl::create(),
-      decoder_callbacks_->streamInfo(), "", AccessLog::AccessLogType::NotSet);
+  const auto redirect_uri =
+      formatter.formatWithContext({&headers}, decoder_callbacks_->streamInfo());
   const std::string escaped_redirect_uri =
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.oauth_use_url_encoding")
           ? Http::Utility::PercentEncoding::urlEncodeQueryParameter(redirect_uri)

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -49,9 +49,9 @@ Config::applySubstitutionFormatter(StreamInfo::StreamInfo& stream_info) {
     for (const RateLimit::DescriptorEntry& descriptor_entry : descriptor.entries_) {
 
       std::string value = descriptor_entry.value_;
-      value = formatter_it->get()->format(*request_headers_.get(), *response_headers_.get(),
-                                          *response_trailers_.get(), stream_info, value,
-                                          AccessLog::AccessLogType::NotSet);
+      value = formatter_it->get()->formatWithContext(
+          {request_headers_.get(), response_headers_.get(), response_trailers_.get(), value},
+          stream_info);
       formatter_it++;
       new_descriptor.entries_.push_back({descriptor_entry.key_, value});
     }

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -44,9 +44,8 @@ void LocalResponsePolicy::formatBody(const Envoy::Http::RequestHeaderMap& reques
   }
 
   if (formatter_) {
-    formatter_->format(request_headers, response_headers,
-                       *Envoy::Http::StaticEmptyHeaders::get().response_trailers, stream_info, body,
-                       AccessLog::AccessLogType::NotSet);
+    formatter_->formatWithContext({&request_headers, &response_headers, nullptr, body},
+                                  stream_info);
   }
 }
 

--- a/source/extensions/matching/actions/format_string/config.cc
+++ b/source/extensions/matching/actions/format_string/config.cc
@@ -15,10 +15,7 @@ namespace FormatString {
 const Network::FilterChain*
 ActionImpl::get(const Server::Configuration::FilterChainsByName& filter_chains_by_name,
                 const StreamInfo::StreamInfo& info) const {
-  const std::string name = formatter_->format(*Http::StaticEmptyHeaders::get().request_headers,
-                                              *Http::StaticEmptyHeaders::get().response_headers,
-                                              *Http::StaticEmptyHeaders::get().response_trailers,
-                                              info, "", AccessLog::AccessLogType::NotSet);
+  const std::string name = formatter_->formatWithContext({}, info);
   const auto chain_match = filter_chains_by_name.find(name);
   if (chain_match != filter_chains_by_name.end()) {
     return chain_match->second.get();

--- a/test/extensions/formatter/cel/cel_test.cc
+++ b/test/extensions/formatter/cel/cel_test.cc
@@ -86,8 +86,7 @@ TEST_F(CELFormatterTest, TestMissingRequestHeader) {
 
   auto formatter =
       Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
-  EXPECT_EQ("-", formatter->format(request_headers_, response_headers_, response_trailers_,
-                                   stream_info_, body_, AccessLog::AccessLogType::NotSet));
+  EXPECT_EQ("-", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
 TEST_F(CELFormatterTest, TestWithoutMaxLength) {
@@ -104,8 +103,7 @@ TEST_F(CELFormatterTest, TestWithoutMaxLength) {
   auto formatter =
       Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
   EXPECT_EQ("/original/path?secret=parameter",
-            formatter->format(request_headers_, response_headers_, response_trailers_, stream_info_,
-                              body_, AccessLog::AccessLogType::NotSet));
+            formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
 TEST_F(CELFormatterTest, TestMaxLength) {
@@ -121,8 +119,7 @@ TEST_F(CELFormatterTest, TestMaxLength) {
 
   auto formatter =
       Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
-  EXPECT_EQ("/original", formatter->format(request_headers_, response_headers_, response_trailers_,
-                                           stream_info_, body_, AccessLog::AccessLogType::NotSet));
+  EXPECT_EQ("/original", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
 TEST_F(CELFormatterTest, TestInvalidExpression) {

--- a/test/extensions/formatter/req_without_query/req_without_query_test.cc
+++ b/test/extensions/formatter/req_without_query/req_without_query_test.cc
@@ -140,9 +140,7 @@ TEST_F(ReqWithoutQueryTest, TestFormatJson) {
   TestUtility::loadFromYaml(yaml, config_);
   auto formatter =
       Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
-  const std::string actual =
-      formatter->format(request_headers_, response_headers_, response_trailers_, stream_info_,
-                        body_, AccessLog::AccessLogType::NotSet);
+  const std::string actual = formatter->formatWithContext(formatter_context_, stream_info_);
   EXPECT_TRUE(TestUtility::jsonStringEqual(actual, expected));
 }
 


### PR DESCRIPTION
Commit Message: code cleanup 2: update all format to formatWithContext in the source and remove unnecessary specialization
Additional Description:

Related PR: #29314.

After adding templated formatter support, a new `HttpFormatterContext` is introduced to suppies necessary data like request headers, response headers to the formatter.
In the previous PR (#29201), to simplify the review, HTTP template specialization is introduced. All HTTP formatter could still use the old interfaces.
**But I still want to cleanup all the old interface usages and finally remove the HTTP template specialization. This PR cleaned up all these code in the tests first.**

**Note, this is tests only change and in current implementation, the new `formatWithContext` is implemented as to call `format` method directly. So, this change will note reduce the code test coverage.**

```
  // Old interface usage example.
  formatter->format(request_headers, response_headers, response_trailers, stream_info, body,
                    log_type);
  formatter->format(request_headers, response_headers,
                    *Http::StaticEmptyHeaders::get().response_trailers, stream_info,
                    absl::string_view(), AccessLog::AccessLogType::NotSet);
  formatter->format(*Http::StaticEmptyHeaders::get().request_headers,
                    *Http::StaticEmptyHeaders::get().response_headers,
                    *Http::StaticEmptyHeaders::get().response_trailers, stream_info,
                    absl::string_view(), AccessLog::AccessLogType::NotSet);

  // New interface usage example.
  formatter->formatWithContext(
      {&request_headers, &response_headers, &response_trailers, body, log_type}, stream_info);
  formatter->formatWithContext({&request_headers, &response_headers}, stream_info);
  formatter->formatWithContext({}, stream_info);

```

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
