### PR TITLE
terminate_handler: using try macros

### DIFF
--- a/test/exe/terminate_handler_test.cc
+++ b/test/exe/terminate_handler_test.cc
@@ -24,20 +24,6 @@ TEST_F(TerminateHandlerTest, LogsEnvoyException) {
                       logException(std::make_exception_ptr(EnvoyException("boom"))));
 }
 
-#ifdef WIN32
-TEST_F(TerminateHandlerTest, LogsStdException) {
-  EXPECT_LOG_CONTAINS("critical",
-                      "std::terminate called! Uncaught exception 'Unknown exception', see trace.",
-                      logException(std::make_exception_ptr(std::exception())));
-}
-#else
-TEST_F(TerminateHandlerTest, LogsStdException) {
-  EXPECT_LOG_CONTAINS("critical",
-                      "std::terminate called! Uncaught exception 'std::exception', see trace.",
-                      logException(std::make_exception_ptr(std::exception())));
-}
-#endif
-
 TEST_F(TerminateHandlerTest, LogsUnknownException) {
   EXPECT_LOG_CONTAINS("critical", "std::terminate called! Uncaught unknown exception, see trace.",
                       logException(std::make_exception_ptr("Boom")));


### PR DESCRIPTION
This does lose us a bit of granularity but non-Envoy throws are few and far between so I think consistency outweighs?

Risk Level: low
Testing: updated test
Docs Changes: n/a
Release Notes: n/a