### PR TITLE
test: deflake a HTTP/3 test with SocketInterfaceSwap

### DIFF
--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -4341,6 +4341,7 @@ TEST_P(ProtocolIntegrationTest, HandleUpstreamSocketFail) {
   // Shut down the server before os_calls goes out of scope to avoid syscalls
   // during its removal.
   test_server_.reset();
+  cleanupUpstreamAndDownstream();
 }
 
 TEST_P(ProtocolIntegrationTest, NoLocalInterfaceNameForUpstreamConnection) {


### PR DESCRIPTION
Commit Message: fix a data race between the SocketInterfaceSwap object destruction race and the fake upstream QUIC connection sending. So explicitly clean up the upstream connection before exiting the test body.

Risk Level: low, test only
Testing: passed with 1000 runs
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A 
Fixes #29191