### PR TITLE
Register HotRestartingParent as udp forwarding packet recipient

### DIFF
--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -91,8 +91,10 @@ public:
    * Stop listeners using the listener tag as a key. This will not close any connections and is used
    * for draining.
    * @param listener_tag supplies the tag passed to addListener().
+   * @param options additional options to be passed through to shutdownListener.
    */
-  virtual void stopListeners(uint64_t listener_tag) PURE;
+  virtual void stopListeners(uint64_t listener_tag,
+                             const Network::ExtraShutdownListenerOptions& options) PURE;
 
   /**
    * Stop all listeners. This will not close any connections and is used for draining.

--- a/envoy/server/instance.h
+++ b/envoy/server/instance.h
@@ -84,8 +84,10 @@ public:
 
   /**
    * Close the server's listening sockets and begin draining the listeners.
+   * @param options - if provided, options are passed through to shutdownListener.
    */
-  virtual void drainListeners() PURE;
+  virtual void
+  drainListeners(OptRef<const Network::ExtraShutdownListenerOptions> options = absl::nullopt) PURE;
 
   /**
    * @return DrainManager& singleton for use by the entire server.

--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -221,6 +221,7 @@ public:
    * is used for server draining and /drain_listeners admin endpoint. This method directly stops the
    * listeners on workers. Once a listener is stopped, any listener modifications are not allowed.
    * @param stop_listeners_type indicates listeners to stop.
+   * @param options additional options passed through to shutdownListener.
    */
   virtual void stopListeners(StopListenersType stop_listeners_type,
                              const Network::ExtraShutdownListenerOptions& options) PURE;

--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -222,7 +222,8 @@ public:
    * listeners on workers. Once a listener is stopped, any listener modifications are not allowed.
    * @param stop_listeners_type indicates listeners to stop.
    */
-  virtual void stopListeners(StopListenersType stop_listeners_type) PURE;
+  virtual void stopListeners(StopListenersType stop_listeners_type,
+                             const Network::ExtraShutdownListenerOptions& options) PURE;
 
   /**
    * Stop all threaded workers from running. When this routine returns all worker threads will

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -84,11 +84,13 @@ public:
   /**
    * Stop a listener from accepting new connections. This is used for server draining.
    * @param listener supplies the listener to stop.
+   * @param options additional options to be passed through to shutdownListener.
    * @param completion supplies the completion to be called when the listener has stopped
    * accepting new connections. This completion is called on the worker thread. No locking is
    * performed by the worker.
    */
   virtual void stopListener(Network::ListenerConfig& listener,
+                            const Network::ExtraShutdownListenerOptions& options,
                             std::function<void()> completion) PURE;
 };
 

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
@@ -30,7 +30,7 @@ public:
   uint64_t numConnections() const override { return 0; }
   bool removeListener(const std::string&) override { return true; }
   void startWorkers(GuardDog&, std::function<void()> callback) override { callback(); }
-  void stopListeners(StopListenersType) override {}
+  void stopListeners(StopListenersType, const Network::ExtraShutdownListenerOptions&) override {}
   void stopWorkers() override {}
   void beginListenerUpdate() override {}
   void endListenerUpdate(FailureStates&&) override {}

--- a/source/extensions/listener_managers/listener_manager/connection_handler_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/connection_handler_impl.cc
@@ -241,13 +241,15 @@ void ConnectionHandlerImpl::removeFilterChains(
   Event::DeferredTaskUtil::deferredRun(dispatcher_, std::move(completion));
 }
 
-void ConnectionHandlerImpl::stopListeners(uint64_t listener_tag) {
+void ConnectionHandlerImpl::stopListeners(uint64_t listener_tag,
+                                          const Network::ExtraShutdownListenerOptions& options) {
   if (auto iter = listener_map_by_tag_.find(listener_tag); iter != listener_map_by_tag_.end()) {
-    iter->second->invokeListenerMethod([](Network::ConnectionHandler::ActiveListener& listener) {
-      if (listener.listener() != nullptr) {
-        listener.shutdownListener({});
-      }
-    });
+    iter->second->invokeListenerMethod(
+        [options](Network::ConnectionHandler::ActiveListener& listener) {
+          if (listener.listener() != nullptr) {
+            listener.shutdownListener(options);
+          }
+        });
   }
 }
 

--- a/source/extensions/listener_managers/listener_manager/connection_handler_impl.h
+++ b/source/extensions/listener_managers/listener_manager/connection_handler_impl.h
@@ -50,7 +50,8 @@ public:
   void removeFilterChains(uint64_t listener_tag,
                           const std::list<const Network::FilterChain*>& filter_chains,
                           std::function<void()> completion) override;
-  void stopListeners(uint64_t listener_tag) override;
+  void stopListeners(uint64_t listener_tag,
+                     const Network::ExtraShutdownListenerOptions& options) override;
   void stopListeners() override;
   void disableListeners() override;
   void enableListeners() override;

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -593,7 +593,8 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
   // Tell all workers to stop accepting new connections on this listener.
   draining_it->listener_->debugLog("draining listener");
   const uint64_t listener_tag = draining_it->listener_->listenerTag();
-  stopListener(*draining_it->listener_, [this, listener_tag]() {
+  Network::ExtraShutdownListenerOptions empty_options;
+  stopListener(*draining_it->listener_, empty_options, [this, listener_tag]() {
     for (auto& listener : draining_listeners_) {
       if (listener.listener_->listenerTag() == listener_tag) {
         maybeCloseSocketsForListener(*listener.listener_);
@@ -922,10 +923,11 @@ void ListenerManagerImpl::startWorkers(GuardDog& guard_dog, std::function<void()
 }
 
 void ListenerManagerImpl::stopListener(Network::ListenerConfig& listener,
+                                       const Network::ExtraShutdownListenerOptions& options,
                                        std::function<void()> callback) {
   const auto workers_pending_stop = std::make_shared<std::atomic<uint64_t>>(workers_.size());
   for (const auto& worker : workers_) {
-    worker->stopListener(listener, [this, callback, workers_pending_stop]() {
+    worker->stopListener(listener, options, [this, callback, workers_pending_stop]() {
       if (--(*workers_pending_stop) == 0) {
         server_.dispatcher().post(callback);
       }
@@ -933,7 +935,8 @@ void ListenerManagerImpl::stopListener(Network::ListenerConfig& listener,
   }
 }
 
-void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type) {
+void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
+                                        const Network::ExtraShutdownListenerOptions& options) {
   stop_listeners_type_ = stop_listeners_type;
   for (Network::ListenerConfig& listener : listeners()) {
     if (stop_listeners_type != StopListenersType::InboundOnly ||
@@ -948,7 +951,7 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type) {
       // Close the socket once all workers stopped accepting its connections.
       // This allows clients to fast fail instead of waiting in the accept queue.
       const uint64_t listener_tag = listener.listenerTag();
-      stopListener(listener, [this, listener_tag]() {
+      stopListener(listener, options, [this, listener_tag]() {
         stats_.listener_stopped_.inc();
         for (auto& listener : active_listeners_) {
           if (listener->listenerTag() == listener_tag) {

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -593,8 +593,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
   // Tell all workers to stop accepting new connections on this listener.
   draining_it->listener_->debugLog("draining listener");
   const uint64_t listener_tag = draining_it->listener_->listenerTag();
-  Network::ExtraShutdownListenerOptions empty_options;
-  stopListener(*draining_it->listener_, empty_options, [this, listener_tag]() {
+  stopListener(*draining_it->listener_, {}, [this, listener_tag]() {
     for (auto& listener : draining_listeners_) {
       if (listener.listener_->listenerTag() == listener_tag) {
         maybeCloseSocketsForListener(*listener.listener_);

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.h
@@ -208,7 +208,8 @@ public:
   uint64_t numConnections() const override;
   bool removeListener(const std::string& listener_name) override;
   void startWorkers(GuardDog& guard_dog, std::function<void()> callback) override;
-  void stopListeners(StopListenersType stop_listeners_type) override;
+  void stopListeners(StopListenersType stop_listeners_type,
+                     const Network::ExtraShutdownListenerOptions& options) override;
   void stopWorkers() override;
   void beginListenerUpdate() override { error_state_tracker_.clear(); }
   void endListenerUpdate(FailureStates&& failure_state) override;
@@ -291,10 +292,13 @@ private:
    * Stop a listener. The listener will stop accepting new connections and its socket will be
    * closed.
    * @param listener supplies the listener to stop.
+   * @param options additional options to be passed through to shutdownListener.
    * @param completion supplies the completion to be called when all workers are stopped accepting
    * new connections. This completion is called on the main thread.
    */
-  void stopListener(Network::ListenerConfig& listener, std::function<void()> completion);
+  void stopListener(Network::ListenerConfig& listener,
+                    const Network::ExtraShutdownListenerOptions& options,
+                    std::function<void()> completion);
 
   /**
    * Get a listener by name. This routine is used because listeners have inherent order in static

--- a/source/server/admin/listeners_handler.cc
+++ b/source/server/admin/listeners_handler.cc
@@ -27,11 +27,13 @@ Http::Code ListenersHandler::handlerDrainListeners(Http::ResponseHeaderMap&,
     // already started.
     if (!server_.drainManager().draining()) {
       server_.drainManager().startDrainSequence([this, stop_listeners_type]() {
-        server_.listenerManager().stopListeners(stop_listeners_type);
+        Network::ExtraShutdownListenerOptions empty_options;
+        server_.listenerManager().stopListeners(stop_listeners_type, empty_options);
       });
     }
   } else {
-    server_.listenerManager().stopListeners(stop_listeners_type);
+    Network::ExtraShutdownListenerOptions empty_options;
+    server_.listenerManager().stopListeners(stop_listeners_type, empty_options);
   }
 
   response.add("OK\n");

--- a/source/server/admin/listeners_handler.cc
+++ b/source/server/admin/listeners_handler.cc
@@ -27,13 +27,11 @@ Http::Code ListenersHandler::handlerDrainListeners(Http::ResponseHeaderMap&,
     // already started.
     if (!server_.drainManager().draining()) {
       server_.drainManager().startDrainSequence([this, stop_listeners_type]() {
-        Network::ExtraShutdownListenerOptions empty_options;
-        server_.listenerManager().stopListeners(stop_listeners_type, empty_options);
+        server_.listenerManager().stopListeners(stop_listeners_type, {});
       });
     }
   } else {
-    Network::ExtraShutdownListenerOptions empty_options;
-    server_.listenerManager().stopListeners(stop_listeners_type, empty_options);
+    server_.listenerManager().stopListeners(stop_listeners_type, {});
   }
 
   response.add("OK\n");

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -84,7 +84,7 @@ public:
         Network::createDefaultDnsResolverFactory(typed_dns_resolver_config);
     return dns_resolver_factory.createDnsResolver(dispatcher(), api(), typed_dns_resolver_config);
   }
-  void drainListeners() override {}
+  void drainListeners(OptRef<const Network::ExtraShutdownListenerOptions>) override {}
   DrainManager& drainManager() override { PANIC("not implemented"); }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
   void failHealthcheck(bool) override {}

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -184,7 +184,11 @@ void HotRestartingParent::Internal::recordDynamics(HotRestartMessage::Reply::Sta
   }
 }
 
-void HotRestartingParent::Internal::drainListeners() { server_->drainListeners(); }
+void HotRestartingParent::Internal::drainListeners() {
+  Network::ExtraShutdownListenerOptions options;
+  options.non_dispatched_udp_packet_handler_ = *this;
+  server_->drainListeners(options);
+}
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -20,6 +20,12 @@ HotRestartingParent::HotRestartingParent(int base_id, int restart_epoch,
   bindDomainSocket(restart_epoch_, "parent", socket_path, socket_mode);
 }
 
+// Network::NonDispatchedUdpPacketHandler
+void HotRestartingParent::Internal::handle(uint32_t /*worker_index*/,
+                                           const Network::UdpRecvData& /*packet*/) {
+  // TODO(ravenblack): forward the packet over a domain socket to HotRestartingChild.
+}
+
 void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {
   socket_event_ = dispatcher.createFileEvent(
       myDomainSocket(),

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -23,9 +23,11 @@ HotRestartingParent::HotRestartingParent(int base_id, int restart_epoch,
 // Network::NonDispatchedUdpPacketHandler
 void HotRestartingParent::Internal::handle(uint32_t /*worker_index*/,
                                            const Network::UdpRecvData& /*packet*/) {
-  // TODO(ravenblack): encapsulate the packet, dispatch it to the hot restarter thread, and
-  // forward the message over a domain socket to HotRestartingChild.
-  // (Pending PR #29328)
+  dispatcher_.post([]() {
+    // TODO(ravenblack): encapsulate the packet, dispatch it to the hot restarter thread, and
+    // forward the message over a domain socket to HotRestartingChild.
+    // (Pending PR #29328)
+  });
 }
 
 void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {

--- a/source/server/hot_restarting_parent.h
+++ b/source/server/hot_restarting_parent.h
@@ -22,7 +22,7 @@ public:
   // request from the child for that action.
   class Internal : public Network::NonDispatchedUdpPacketHandler {
   public:
-    explicit Internal(Server::Instance* server);
+    explicit Internal(Server::Instance* server, Event::Dispatcher& dispatcher);
     // Return value is the response to return to the child.
     envoy::HotRestartMessage shutdownAdmin();
     // Return value is the response to return to the child.
@@ -39,6 +39,7 @@ public:
 
   private:
     Server::Instance* const server_{};
+    Event::Dispatcher& dispatcher_;
   };
 
 private:

--- a/source/server/hot_restarting_parent.h
+++ b/source/server/hot_restarting_parent.h
@@ -20,7 +20,7 @@ public:
 
   // The hot restarting parent's hot restart logic. Each function is meant to be called to fulfill a
   // request from the child for that action.
-  class Internal {
+  class Internal : public Network::NonDispatchedUdpPacketHandler {
   public:
     explicit Internal(Server::Instance* server);
     // Return value is the response to return to the child.
@@ -33,6 +33,9 @@ public:
     void recordDynamics(envoy::HotRestartMessage::Reply::Stats* stats, const std::string& name,
                         Stats::StatName stat_name);
     void drainListeners();
+
+    // Network::NonDispatchedUdpPacketHandler
+    void handle(uint32_t worker_index, const Network::UdpRecvData& packet) override;
 
   private:
     Server::Instance* const server_{};

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -186,9 +186,9 @@ const Upstream::ClusterManager& InstanceImpl::clusterManager() const {
 
 void InstanceImpl::drainListeners(OptRef<const Network::ExtraShutdownListenerOptions> options) {
   ENVOY_LOG(info, "closing and draining listeners");
-  Network::ExtraShutdownListenerOptions empty_options;
   listener_manager_->stopListeners(ListenerManager::StopListenersType::All,
-                                   options.has_value() ? *options : empty_options);
+                                   options.has_value() ? *options
+                                                       : Network::ExtraShutdownListenerOptions{});
   drain_manager_->startDrainSequence([] {});
 }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -184,9 +184,11 @@ const Upstream::ClusterManager& InstanceImpl::clusterManager() const {
   return *config_.clusterManager();
 }
 
-void InstanceImpl::drainListeners() {
+void InstanceImpl::drainListeners(OptRef<const Network::ExtraShutdownListenerOptions> options) {
   ENVOY_LOG(info, "closing and draining listeners");
-  listener_manager_->stopListeners(ListenerManager::StopListenersType::All);
+  Network::ExtraShutdownListenerOptions empty_options;
+  listener_manager_->stopListeners(ListenerManager::StopListenersType::All,
+                                   options.has_value() ? *options : empty_options);
   drain_manager_->startDrainSequence([] {});
 }
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -253,7 +253,7 @@ public:
   Ssl::ContextManager& sslContextManager() override { return *ssl_context_manager_; }
   Event::Dispatcher& dispatcher() override { return *dispatcher_; }
   Network::DnsResolverSharedPtr dnsResolver() override { return dns_resolver_; }
-  void drainListeners() override;
+  void drainListeners(OptRef<const Network::ExtraShutdownListenerOptions> options) override;
   DrainManager& drainManager() override { return *drain_manager_; }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
   void failHealthcheck(bool fail) override;

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -126,10 +126,12 @@ void WorkerImpl::stop() {
   }
 }
 
-void WorkerImpl::stopListener(Network::ListenerConfig& listener, std::function<void()> completion) {
+void WorkerImpl::stopListener(Network::ListenerConfig& listener,
+                              const Network::ExtraShutdownListenerOptions& options,
+                              std::function<void()> completion) {
   const uint64_t listener_tag = listener.listenerTag();
-  dispatcher_->post([this, listener_tag, completion]() -> void {
-    handler_->stopListeners(listener_tag);
+  dispatcher_->post([this, listener_tag, options, completion]() -> void {
+    handler_->stopListeners(listener_tag, options);
     if (completion != nullptr) {
       completion();
     }

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -63,7 +63,9 @@ public:
   void start(GuardDog& guard_dog, const std::function<void()>& cb) override;
   void initializeStats(Stats::Scope& scope) override;
   void stop() override;
-  void stopListener(Network::ListenerConfig& listener, std::function<void()> completion) override;
+  void stopListener(Network::ListenerConfig& listener,
+                    const Network::ExtraShutdownListenerOptions& options,
+                    std::function<void()> completion) override;
 
 private:
   void threadRoutine(GuardDog& guard_dog, const std::function<void()>& cb);

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_quic_only_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_quic_only_test.cc
@@ -169,10 +169,11 @@ filter_chain_matcher:
 
   // Stop listening shouldn't close the socket.
   EXPECT_CALL(server_.dispatcher_, post(_)).WillOnce([](Event::PostCb callback) { callback(); });
-  EXPECT_CALL(*worker_, stopListener(_, _))
-      .WillOnce(
-          Invoke([](Network::ListenerConfig&, std::function<void()> completion) { completion(); }));
-  manager_->stopListeners(ListenerManager::StopListenersType::All);
+  EXPECT_CALL(*worker_, stopListener(_, _, _))
+      .WillOnce(Invoke([](Network::ListenerConfig&, const Network::ExtraShutdownListenerOptions&,
+                          std::function<void()> completion) { completion(); }));
+  Network::ExtraShutdownListenerOptions empty_options;
+  manager_->stopListeners(ListenerManager::StopListenersType::All, empty_options);
   EXPECT_CALL(*listener_factory_.socket_, close()).Times(0u);
   EXPECT_TRUE(listener_factory_.socket_->socket_is_open_);
 }

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_quic_only_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_quic_only_test.cc
@@ -172,8 +172,7 @@ filter_chain_matcher:
   EXPECT_CALL(*worker_, stopListener(_, _, _))
       .WillOnce(Invoke([](Network::ListenerConfig&, const Network::ExtraShutdownListenerOptions&,
                           std::function<void()> completion) { completion(); }));
-  Network::ExtraShutdownListenerOptions empty_options;
-  manager_->stopListeners(ListenerManager::StopListenersType::All, empty_options);
+  manager_->stopListeners(ListenerManager::StopListenersType::All, {});
   EXPECT_CALL(*listener_factory_.socket_, close()).Times(0u);
   EXPECT_TRUE(listener_factory_.socket_->socket_is_open_);
 }

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
@@ -153,7 +153,7 @@ public:
       EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, bind_type, _, 0));
     }
     EXPECT_CALL(*worker_, addListener(_, _, _, _));
-    EXPECT_CALL(*worker_, stopListener(_, _));
+    EXPECT_CALL(*worker_, stopListener(_, _, _));
     EXPECT_CALL(*old_listener_handle->drain_manager_, startDrainSequence(_));
 
     EXPECT_TRUE(addOrUpdateListener(new_listener_proto));
@@ -169,7 +169,7 @@ public:
   void expectRemove(const envoy::config::listener::v3::Listener& listener_proto,
                     ListenerHandle* listener_handle, Network::MockListenSocket& socket) {
 
-    EXPECT_CALL(*worker_, stopListener(_, _));
+    EXPECT_CALL(*worker_, stopListener(_, _, _));
     EXPECT_CALL(socket, close());
     EXPECT_CALL(*listener_handle->drain_manager_, startDrainSequence(_));
     EXPECT_TRUE(manager_->removeListener(listener_proto.name()));
@@ -1733,7 +1733,7 @@ dynamic_listeners:
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
   EXPECT_CALL(*duplicated_socket, duplicate());
   EXPECT_CALL(*worker_, addListener(_, _, _, _));
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "version3", true));
   worker_->callAddCompletion();
@@ -2554,12 +2554,13 @@ filter_chains:
 
   // Remove foo into draining.
   std::function<void()> stop_completion;
-  EXPECT_CALL(*worker_, stopListener(_, _))
-      .WillOnce(Invoke(
-          [&stop_completion](Network::ListenerConfig&, std::function<void()> completion) -> void {
-            ASSERT_TRUE(completion != nullptr);
-            stop_completion = std::move(completion);
-          }));
+  EXPECT_CALL(*worker_, stopListener(_, _, _))
+      .WillOnce(Invoke([&stop_completion](Network::ListenerConfig&,
+                                          const Network::ExtraShutdownListenerOptions&,
+                                          std::function<void()> completion) -> void {
+        ASSERT_TRUE(completion != nullptr);
+        stop_completion = std::move(completion);
+      }));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
@@ -2615,12 +2616,13 @@ filter_chains:
 
   // Remove foo into draining.
   std::function<void()> stop_completion;
-  EXPECT_CALL(*worker_, stopListener(_, _))
-      .WillOnce(Invoke(
-          [&stop_completion](Network::ListenerConfig&, std::function<void()> completion) -> void {
-            ASSERT_TRUE(completion != nullptr);
-            stop_completion = std::move(completion);
-          }));
+  EXPECT_CALL(*worker_, stopListener(_, _, _))
+      .WillOnce(Invoke([&stop_completion](Network::ListenerConfig&,
+                                          const Network::ExtraShutdownListenerOptions&,
+                                          std::function<void()> completion) -> void {
+        ASSERT_TRUE(completion != nullptr);
+        stop_completion = std::move(completion);
+      }));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
@@ -2674,7 +2676,7 @@ filter_chains:
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
   // Remove foo into draining.
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
@@ -2728,7 +2730,7 @@ filter_chains:
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
   // Remove foo into draining.
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close()).Times(2);
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
@@ -2835,7 +2837,7 @@ filter_chains:
   EXPECT_CALL(server_.drain_manager_, drainClose()).WillOnce(Return(false));
   EXPECT_FALSE(listener_foo->context_->drainDecision().drainClose());
 
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
 
   EXPECT_TRUE(manager_->removeListener("foo"));
@@ -3097,7 +3099,7 @@ filter_chains:
   EXPECT_CALL(server_.drain_manager_, drainClose()).WillOnce(Return(false));
   EXPECT_FALSE(listener_foo->context_->drainDecision().drainClose());
 
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
   checkStats(__LINE__, 1, 0, 1, 0, 0, 1, 0);
@@ -3186,7 +3188,7 @@ filter_chains:
 
   // Remove foo which should remove both warming and active.
   EXPECT_CALL(*listener_foo_update1, onDestroy());
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
@@ -3254,9 +3256,10 @@ filter_chains:
   EXPECT_EQ(2UL, manager_->listeners().size());
 
   // Validate that stop listener is only called once - for inbound listeners.
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
-  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly);
+  Network::ExtraShutdownListenerOptions empty_options;
+  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly, empty_options);
   EXPECT_EQ(1, server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
 
   // Validate that listener creation in outbound direction is allowed.
@@ -3333,10 +3336,11 @@ filter_chains:
   EXPECT_EQ(1UL, manager_->listeners().size());
   checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo, onDestroy());
-  manager_->stopListeners(ListenerManager::StopListenersType::All);
+  Network::ExtraShutdownListenerOptions empty_options;
+  manager_->stopListeners(ListenerManager::StopListenersType::All, empty_options);
   EXPECT_EQ(1, server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
 
   // Validate that adding a listener is not allowed after all listeners are stopped.
@@ -3403,10 +3407,11 @@ filter_chains:
 
   // Stop foo which should remove warming listener.
   EXPECT_CALL(*listener_foo_update1, onDestroy());
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo, onDestroy());
-  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly);
+  Network::ExtraShutdownListenerOptions empty_options;
+  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly, empty_options);
   EXPECT_EQ(1, server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
 }
 
@@ -7118,7 +7123,7 @@ per_connection_buffer_limit_bytes: 10
   // removal.
   ListenerHandle* listener_foo_update2 = expectListenerCreate(false, true);
   EXPECT_CALL(*worker_, addListener(_, _, _, _));
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml), "version3", true));
   worker_->callAddCompletion();
@@ -7334,10 +7339,11 @@ filter_chains:
 
   // Stop foo which should remove warming listener.
   EXPECT_CALL(*listener_foo_update1, onDestroy());
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo, onDestroy());
-  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly);
+  Network::ExtraShutdownListenerOptions empty_options;
+  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly, empty_options);
   EXPECT_EQ(1, server_.stats_store_.counter("listener_manager.listener_stopped").value());
 }
 
@@ -7396,7 +7402,7 @@ filter_chains:
 
   // Remove foo which should remove both warming and active.
   EXPECT_CALL(*listener_foo_update1, onDestroy());
-  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
@@ -7691,12 +7697,13 @@ filter_chains:
 
   // Stop the active listener listener_foo_update1.
   std::function<void()> stop_completion;
-  EXPECT_CALL(*worker_, stopListener(_, _))
-      .WillOnce(Invoke(
-          [&stop_completion](Network::ListenerConfig&, std::function<void()> completion) -> void {
-            ASSERT_TRUE(completion != nullptr);
-            stop_completion = std::move(completion);
-          }));
+  EXPECT_CALL(*worker_, stopListener(_, _, _))
+      .WillOnce(Invoke([&stop_completion](Network::ListenerConfig&,
+                                          const Network::ExtraShutdownListenerOptions&,
+                                          std::function<void()> completion) -> void {
+        ASSERT_TRUE(completion != nullptr);
+        stop_completion = std::move(completion);
+      }));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
 
@@ -7795,12 +7802,13 @@ filter_chains:
 
   // Stop the active listener listener_foo_update1.
   std::function<void()> stop_completion;
-  EXPECT_CALL(*worker_, stopListener(_, _))
-      .WillOnce(Invoke(
-          [&stop_completion](Network::ListenerConfig&, std::function<void()> completion) -> void {
-            ASSERT_TRUE(completion != nullptr);
-            stop_completion = std::move(completion);
-          }));
+  EXPECT_CALL(*worker_, stopListener(_, _, _))
+      .WillOnce(Invoke([&stop_completion](Network::ListenerConfig&,
+                                          const Network::ExtraShutdownListenerOptions&,
+                                          std::function<void()> completion) -> void {
+        ASSERT_TRUE(completion != nullptr);
+        stop_completion = std::move(completion);
+      }));
   EXPECT_CALL(*listener_foo_update1->drain_manager_, startDrainSequence(_));
   EXPECT_TRUE(manager_->removeListener("foo"));
 

--- a/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
+++ b/test/extensions/listener_managers/listener_manager/listener_manager_impl_test.cc
@@ -3338,12 +3338,11 @@ filter_chains:
   EXPECT_CALL(*worker_, stopListener(_, _, _));
   EXPECT_CALL(*listener_factory_.socket_, close());
   EXPECT_CALL(*listener_foo, onDestroy());
-  manager_->stopListeners(ListenerManager::StopListenersType::All, {);
-    EXPECT_EQ(1,
-              server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
+  manager_->stopListeners(ListenerManager::StopListenersType::All, {});
+  EXPECT_EQ(1, server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
 
-    // Validate that adding a listener is not allowed after all listeners are stopped.
-    const std::string listener_bar_yaml = R"EOF(
+  // Validate that adding a listener is not allowed after all listeners are stopped.
+  const std::string listener_bar_yaml = R"EOF(
 name: bar
 address:
   socket_address:
@@ -3352,18 +3351,18 @@ address:
 filter_chains:
 - filters: []
   )EOF";
-    EXPECT_FALSE(addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)));
+  EXPECT_FALSE(addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)));
 }
 
 // Validate that stopping a warming listener, removes directly from warming listener list.
 TEST_P(ListenerManagerImplTest, StopWarmingListener) {
-    InSequence s;
+  InSequence s;
 
-    EXPECT_CALL(*worker_, start(_, _));
-    manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
+  EXPECT_CALL(*worker_, start(_, _));
+  manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
 
-    // Add foo listener into warming.
-    const std::string listener_foo_yaml = R"EOF(
+  // Add foo listener into warming.
+  const std::string listener_foo_yaml = R"EOF(
 name: foo
 traffic_direction: INBOUND
 address:
@@ -3374,19 +3373,19 @@ filter_chains:
 - filters: []
   )EOF";
 
-    ListenerHandle* listener_foo = expectListenerCreate(true, true);
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    EXPECT_CALL(listener_foo->target_, initialize());
-    EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
-    checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
-    EXPECT_CALL(*worker_, addListener(_, _, _, _));
-    listener_foo->target_.ready();
-    worker_->callAddCompletion();
-    EXPECT_EQ(1UL, manager_->listeners().size());
-    checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
+  ListenerHandle* listener_foo = expectListenerCreate(true, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(listener_foo->target_, initialize());
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
+  checkStats(__LINE__, 1, 0, 0, 1, 0, 0, 0);
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  listener_foo->target_.ready();
+  worker_->callAddCompletion();
+  EXPECT_EQ(1UL, manager_->listeners().size());
+  checkStats(__LINE__, 1, 0, 0, 0, 1, 0, 0);
 
-    // Update foo into warming.
-    const std::string listener_foo_update1_yaml = R"EOF(
+  // Update foo into warming.
+  const std::string listener_foo_update1_yaml = R"EOF(
 name: foo
 traffic_direction: INBOUND
 address:
@@ -3398,24 +3397,23 @@ filter_chains:
 - filters: []
   )EOF";
 
-    ListenerHandle* listener_foo_update1 = expectListenerCreate(true, true);
-    EXPECT_CALL(*listener_factory_.socket_, duplicate());
-    EXPECT_CALL(listener_foo_update1->target_, initialize());
-    EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_update1_yaml)));
-    EXPECT_EQ(1UL, manager_->listeners().size());
+  ListenerHandle* listener_foo_update1 = expectListenerCreate(true, true);
+  EXPECT_CALL(*listener_factory_.socket_, duplicate());
+  EXPECT_CALL(listener_foo_update1->target_, initialize());
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_update1_yaml)));
+  EXPECT_EQ(1UL, manager_->listeners().size());
 
-    // Stop foo which should remove warming listener.
-    EXPECT_CALL(*listener_foo_update1, onDestroy());
-    EXPECT_CALL(*worker_, stopListener(_, _, _));
-    EXPECT_CALL(*listener_factory_.socket_, close());
-    EXPECT_CALL(*listener_foo, onDestroy());
-    manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly, {});
-    EXPECT_EQ(1,
-              server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
+  // Stop foo which should remove warming listener.
+  EXPECT_CALL(*listener_foo_update1, onDestroy());
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
+  EXPECT_CALL(*listener_factory_.socket_, close());
+  EXPECT_CALL(*listener_foo, onDestroy());
+  manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly, {});
+  EXPECT_EQ(1, server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
 }
 
 TEST_P(ListenerManagerImplTest, StatsNameValidCharacterTest) {
-    const std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
 address:
   socket_address:
     address: "::1"
@@ -3424,14 +3422,14 @@ filter_chains:
 - filters: []
   )EOF";
 
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    manager_->listeners().front().get().listenerScope().counterFromString("foo").inc();
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  manager_->listeners().front().get().listenerScope().counterFromString("foo").inc();
 
-    EXPECT_EQ(1UL, server_.stats_store_.counterFromString("listener.[__1]_10000.foo").value());
+  EXPECT_EQ(1UL, server_.stats_store_.counterFromString("listener.[__1]_10000.foo").value());
 }
 
 TEST_P(ListenerManagerImplTest, ListenerStatPrefix) {
-    const std::string yaml = R"EOF(
+  const std::string yaml = R"EOF(
 stat_prefix: test_prefix
 address:
   socket_address:
@@ -3441,20 +3439,20 @@ filter_chains:
 - filters: []
   )EOF";
 
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    manager_->listeners().front().get().listenerScope().counterFromString("foo").inc();
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  manager_->listeners().front().get().listenerScope().counterFromString("foo").inc();
 
-    EXPECT_EQ(1UL, server_.stats_store_.counterFromString("listener.test_prefix.foo").value());
+  EXPECT_EQ(1UL, server_.stats_store_.counterFromString("listener.test_prefix.foo").value());
 }
 
 TEST_P(ListenerManagerImplTest, DuplicateAddressDontBind) {
-    InSequence s;
+  InSequence s;
 
-    EXPECT_CALL(*worker_, start(_, _));
-    manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
+  EXPECT_CALL(*worker_, start(_, _));
+  manager_->startWorkers(guard_dog_, callback_.AsStdFunction());
 
-    // Add foo listener into warming.
-    const std::string listener_foo_yaml = R"EOF(
+  // Add foo listener into warming.
+  const std::string listener_foo_yaml = R"EOF(
 name: foo
 address:
   socket_address:
@@ -3465,14 +3463,14 @@ filter_chains:
 - filters: []
   )EOF";
 
-    ListenerHandle* listener_foo = expectListenerCreate(true, true);
-    EXPECT_CALL(listener_factory_,
-                createListenSocket(_, _, _, ListenerComponentFactory::BindType::NoBind, _, 0));
-    EXPECT_CALL(listener_foo->target_, initialize());
-    EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
+  ListenerHandle* listener_foo = expectListenerCreate(true, true);
+  EXPECT_CALL(listener_factory_,
+              createListenSocket(_, _, _, ListenerComponentFactory::BindType::NoBind, _, 0));
+  EXPECT_CALL(listener_foo->target_, initialize());
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
 
-    // Add bar with same non-binding address. Should fail.
-    const std::string listener_bar_yaml = R"EOF(
+  // Add bar with same non-binding address. Should fail.
+  const std::string listener_bar_yaml = R"EOF(
 name: bar
 address:
   socket_address:
@@ -3483,36 +3481,36 @@ filter_chains:
 - filters: []
   )EOF";
 
-    ListenerHandle* listener_bar = expectListenerCreate(true, true);
-    EXPECT_CALL(*listener_bar, onDestroy());
-    EXPECT_THROW_WITH_MESSAGE(
-        addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)), EnvoyException,
-        "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
+  ListenerHandle* listener_bar = expectListenerCreate(true, true);
+  EXPECT_CALL(*listener_bar, onDestroy());
+  EXPECT_THROW_WITH_MESSAGE(
+      addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)), EnvoyException,
+      "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
-    // Move foo to active and then try to add again. This should still fail.
-    EXPECT_CALL(*worker_, addListener(_, _, _, _));
-    listener_foo->target_.ready();
-    worker_->callAddCompletion();
+  // Move foo to active and then try to add again. This should still fail.
+  EXPECT_CALL(*worker_, addListener(_, _, _, _));
+  listener_foo->target_.ready();
+  worker_->callAddCompletion();
 
-    listener_bar = expectListenerCreate(true, true);
-    EXPECT_CALL(*listener_bar, onDestroy());
-    EXPECT_THROW_WITH_MESSAGE(
-        addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)), EnvoyException,
-        "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
+  listener_bar = expectListenerCreate(true, true);
+  EXPECT_CALL(*listener_bar, onDestroy());
+  EXPECT_THROW_WITH_MESSAGE(
+      addOrUpdateListener(parseListenerFromV3Yaml(listener_bar_yaml)), EnvoyException,
+      "error adding listener: 'bar' has duplicate address '0.0.0.0:1234' as existing listener");
 
-    EXPECT_CALL(*listener_foo, onDestroy());
+  EXPECT_CALL(*listener_foo, onDestroy());
 }
 
 TEST_P(ListenerManagerImplTest, EarlyShutdown) {
-    // If stopWorkers is called before the workers are started, it should be a no-op: they should be
-    // neither started nor stopped.
-    EXPECT_CALL(*worker_, start(_, _)).Times(0);
-    EXPECT_CALL(*worker_, stop()).Times(0);
-    manager_->stopWorkers();
+  // If stopWorkers is called before the workers are started, it should be a no-op: they should be
+  // neither started nor stopped.
+  EXPECT_CALL(*worker_, start(_, _)).Times(0);
+  EXPECT_CALL(*worker_, stop()).Times(0);
+  manager_->stopWorkers();
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDestinationPortMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3532,9 +3530,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDestinationP
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -3550,36 +3548,35 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDestinationP
                   "@type": type.googleapis.com/google.protobuf.StringValue
                   value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv4 client connects to unknown port - no match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv4 client connects to unknown port - no match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // IPv4 client connects to valid port - using 1st filter chain.
-    filter_chain = findFilterChain(8080, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client connects to valid port - using 1st filter chain.
+  filter_chain = findFilterChain(8080, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // UDS client - no match.
-    filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // UDS client - no match.
+  filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDirectSourceIPMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3599,9 +3596,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDirectSource
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -3623,36 +3620,35 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDirectSource
                     "@type": type.googleapis.com/google.protobuf.StringValue
                     value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv4 client connects to unknown IP - no match.
-    auto filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111, "1.2.3.4");
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv4 client connects to unknown IP - no match.
+  auto filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111, "1.2.3.4");
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // IPv4 client connects to valid IP - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111, "127.0.0.1");
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client connects to valid IP - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111, "127.0.0.1");
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // UDS client - no match.
-    filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // UDS client - no match.
+  filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDestinationIPMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3672,9 +3668,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDestinationI
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -3696,37 +3692,36 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithDestinationI
                     "@type": type.googleapis.com/google.protobuf.StringValue
                     value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv4 client connects to unknown IP - no match.
-    auto filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv4 client connects to unknown IP - no match.
+  auto filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // IPv4 client connects to valid IP - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client connects to valid IP - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // UDS client - no match.
-    filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // UDS client - no match.
+  filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        SingleFilterChainWithDestinationIPMatchWithIPSanCerts) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3746,9 +3741,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_ip_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_ip_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -3770,41 +3765,40 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
                     "@type": type.googleapis.com/google.protobuf.StringValue
                     value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv4 client connects to unknown IP - no match.
-    auto filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv4 client connects to unknown IP - no match.
+  auto filter_chain = findFilterChain(1234, "1.2.3.4", "", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // IPv4 client connects to valid IP - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto local_ip_sans = ssl_socket->ssl()->ipSansLocalCertificate();
-    EXPECT_EQ(local_ip_sans.size(), 1);
-    EXPECT_EQ(local_ip_sans.front(), "1.1.1.1");
+  // IPv4 client connects to valid IP - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto local_ip_sans = ssl_socket->ssl()->ipSansLocalCertificate();
+  EXPECT_EQ(local_ip_sans.size(), 1);
+  EXPECT_EQ(local_ip_sans.front(), "1.1.1.1");
 
-    // Assert twice to ensure a cached value is returned and still valid.
-    local_ip_sans = ssl_socket->ssl()->ipSansLocalCertificate();
-    EXPECT_EQ(local_ip_sans.size(), 1);
-    EXPECT_EQ(local_ip_sans.front(), "1.1.1.1");
+  // Assert twice to ensure a cached value is returned and still valid.
+  local_ip_sans = ssl_socket->ssl()->ipSansLocalCertificate();
+  EXPECT_EQ(local_ip_sans.size(), 1);
+  EXPECT_EQ(local_ip_sans.front(), "1.1.1.1");
 
-    // UDS client - no match.
-    filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // UDS client - no match.
+  filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithServerNamesMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3824,9 +3818,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithServerNamesM
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -3842,42 +3836,41 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithServerNamesM
                   "@type": type.googleapis.com/google.protobuf.StringValue
                   value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TLS client without SNI - no match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // TLS client without SNI - no match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // TLS client without matching SNI - no match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "www.example.com", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // TLS client without matching SNI - no match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "www.example.com", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // TLS client with matching SNI - using 1st filter chain.
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "server1.example.com", "tls", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client with matching SNI - using 1st filter chain.
+  filter_chain =
+      findFilterChain(1234, "127.0.0.1", "server1.example.com", "tls", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // Assert twice to ensure a cached value is returned and still valid.
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // Assert twice to ensure a cached value is returned and still valid.
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithTransportProtocolMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3897,9 +3890,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithTransportPro
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -3915,36 +3908,35 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithTransportPro
                   "@type": type.googleapis.com/google.protobuf.StringValue
                   value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TCP client - no match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "raw_buffer", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // TCP client - no match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "raw_buffer", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // TLS client - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithFilterStateMatch) {
-    if (!use_matcher_) {
-      return;
-    }
+  if (!use_matcher_) {
+    return;
+  }
 
-    std::string yaml = R"EOF(
+  std::string yaml = R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -3970,43 +3962,43 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithFilterStateM
                   value: foo
     )EOF";
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // No filter state value set - no match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // No filter state value set - no match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    stream_info_.filterState()->setData(
-        "unknown_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData(
+      "unknown_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
-    // Filter state set to a non-matching key - no match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // Filter state set to a non-matching key - no match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    stream_info_.filterState()->setData(
-        "filter_state_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData(
+      "filter_state_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
-    // Filter state set to a matching key but unknown value - no match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // Filter state set to a matching key but unknown value - no match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    stream_info_.filterState()->setData(
-        "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData(
+      "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
-    // Known filter state key and matching value - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_EQ(filter_chain->name(), "foo");
+  // Known filter state key and matching value - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_EQ(filter_chain->name(), "foo");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithApplicationProtocolMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4027,10 +4019,10 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithApplicationP
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      // TODO(kyessenov) Switch to using prefix/suffix/containment matching for ALPN.
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    // TODO(kyessenov) Switch to using prefix/suffix/containment matching for ALPN.
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4046,36 +4038,35 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithApplicationP
                   "@type": type.googleapis.com/google.protobuf.StringValue
                   value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TLS client without ALPN - no match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // TLS client without ALPN - no match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // TLS client with "http/1.1" ALPN - using 1st filter chain.
-    filter_chain = findFilterChain(
-        1234, "127.0.0.1", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "8.8.8.8",
-        111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client with "http/1.1" ALPN - using 1st filter chain.
+  filter_chain = findFilterChain(
+      1234, "127.0.0.1", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "8.8.8.8",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 // Define a source_type filter chain match and test against it.
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceTypeMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4095,9 +4086,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceTypeMa
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4113,50 +4104,48 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceTypeMa
                   "@type": type.googleapis.com/google.protobuf.StringValue
                   value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // EXTERNAL IPv4 client without "http/1.1" ALPN - no match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // EXTERNAL IPv4 client without "http/1.1" ALPN - no match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "8.8.8.8", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // LOCAL IPv4 client with "http/1.1" ALPN - using 1st filter chain.
-    filter_chain = findFilterChain(
-        1234, "127.0.0.1", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // LOCAL IPv4 client with "http/1.1" ALPN - using 1st filter chain.
+  filter_chain = findFilterChain(
+      1234, "127.0.0.1", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "127.0.0.1",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // LOCAL UDS client with "http/1.1" ALPN - using 1st filter chain.
-    filter_chain = findFilterChain(
-        0, "/tmp/test.sock", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "/tmp/test.sock", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // LOCAL UDS client with "http/1.1" ALPN - using 1st filter chain.
+  filter_chain = findFilterChain(
+      0, "/tmp/test.sock", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
+      "/tmp/test.sock", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 // Verify source IP matches.
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceIpMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4178,9 +4167,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceIpMatc
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4202,48 +4191,47 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceIpMatc
                     "@type": type.googleapis.com/google.protobuf.StringValue
                     value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv4 client with source 10.0.1.1. No match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "10.0.1.1", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv4 client with source 10.0.1.1. No match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "10.0.1.1", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // IPv4 client with source 10.0.0.10, Match.
-    filter_chain = findFilterChain(
-        1234, "127.0.0.1", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "10.0.0.10", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client with source 10.0.0.10, Match.
+  filter_chain = findFilterChain(
+      1234, "127.0.0.1", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "10.0.0.10",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // IPv6 client. No match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {},
-                                   "2001:0db8:85a3:0000:0000:8a2e:0370:7334", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv6 client. No match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {},
+                                 "2001:0db8:85a3:0000:0000:8a2e:0370:7334", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // UDS client. No match.
-    filter_chain = findFilterChain(
-        0, "/tmp/test.sock", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "/tmp/test.sock", 0);
-    ASSERT_EQ(filter_chain, nullptr);
+  // UDS client. No match.
+  filter_chain = findFilterChain(
+      0, "/tmp/test.sock", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
+      "/tmp/test.sock", 0);
+  ASSERT_EQ(filter_chain, nullptr);
 }
 
 // Verify source IPv6 matches.
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceIpv6Match) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4265,9 +4253,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceIpv6Ma
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4289,27 +4277,27 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourceIpv6Ma
                     "@type": type.googleapis.com/google.protobuf.StringValue
                     value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv6 client with matching subnet. Match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {},
-                                        "2001:0db8:85a3:0000:0000:8a2e:0370:7334", 111);
-    EXPECT_NE(filter_chain, nullptr);
+  // IPv6 client with matching subnet. Match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {},
+                                      "2001:0db8:85a3:0000:0000:8a2e:0370:7334", 111);
+  EXPECT_NE(filter_chain, nullptr);
 
-    // IPv6 client with non-matching subnet. No match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {},
-                                   "2001:0db8:85a3:0001:0000:8a2e:0370:7334", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // IPv6 client with non-matching subnet. No match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {},
+                                 "2001:0db8:85a3:0001:0000:8a2e:0370:7334", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 }
 
 // Verify source port matches.
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourcePortMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4330,9 +4318,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourcePortMa
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4348,36 +4336,35 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithSourcePortMa
                   "@type": type.googleapis.com/google.protobuf.StringValue
                   value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // Client with source port 100. Match.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 100);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // Client with source port 100. Match.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 100);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // Client with source port 101. No match.
-    filter_chain = findFilterChain(
-        1234, "8.8.8.8", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "4.4.4.4",
-        101);
-    ASSERT_EQ(filter_chain, nullptr);
+  // Client with source port 101. No match.
+  filter_chain = findFilterChain(
+      1234, "8.8.8.8", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "4.4.4.4",
+      101);
+  ASSERT_EQ(filter_chain, nullptr);
 }
 
 // Define multiple source_type filter chain matches and test against them.
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithSourceTypeMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4420,10 +4407,10 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithSourceTyp
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      // TODO(kyessenov) Switch to using prefix/suffix/containment matching for ALPN.
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    // TODO(kyessenov) Switch to using prefix/suffix/containment matching for ALPN.
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4475,59 +4462,56 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithSourceTyp
                 "@type": type.googleapis.com/google.protobuf.StringValue
                 value: baz
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // LOCAL TLS client with "http/1.1" ALPN - no match.
-    auto filter_chain = findFilterChain(
-        1234, "127.0.0.1", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "127.0.0.1", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // LOCAL TLS client with "http/1.1" ALPN - no match.
+  auto filter_chain = findFilterChain(
+      1234, "127.0.0.1", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "127.0.0.1",
+      111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // LOCAL TLS client without "http/1.1" ALPN - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // LOCAL TLS client without "http/1.1" ALPN - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // EXTERNAL TLS client with "http/1.1" ALPN - using 2nd filter chain.
-    filter_chain = findFilterChain(
-        1234, "8.8.8.8", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "4.4.4.4",
-        111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // EXTERNAL TLS client with "http/1.1" ALPN - using 2nd filter chain.
+  filter_chain = findFilterChain(
+      1234, "8.8.8.8", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "4.4.4.4",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // EXTERNAL TLS client without "http/1.1" ALPN - using 3rd filter chain.
-    filter_chain = findFilterChain(1234, "8.8.8.8", "", "tls", {}, "4.4.4.4", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 2);
-    EXPECT_EQ(server_names.front(), "*.example.com");
+  // EXTERNAL TLS client without "http/1.1" ALPN - using 3rd filter chain.
+  filter_chain = findFilterChain(1234, "8.8.8.8", "", "tls", {}, "4.4.4.4", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 2);
+  EXPECT_EQ(server_names.front(), "*.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDestinationPortMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4569,9 +4553,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDestinati
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4599,59 +4583,55 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDestinati
             "@type": type.googleapis.com/google.protobuf.StringValue
             value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // IPv4 client connects to default port - using 1st filter chain.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // IPv4 client connects to default port - using 1st filter chain.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // IPv4 client connects to port 8080 - using 2nd filter chain.
-    filter_chain = findFilterChain(8080, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client connects to port 8080 - using 2nd filter chain.
+  filter_chain = findFilterChain(8080, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // IPv4 client connects to port 8081 - using 3rd filter chain.
-    filter_chain = findFilterChain(8081, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 2);
-    EXPECT_EQ(server_names.front(), "*.example.com");
+  // IPv4 client connects to port 8081 - using 3rd filter chain.
+  filter_chain = findFilterChain(8081, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 2);
+  EXPECT_EQ(server_names.front(), "*.example.com");
 
-    // UDS client - using 1st filter chain.
-    filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // UDS client - using 1st filter chain.
+  filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDestinationIPMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4693,9 +4673,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDestinati
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4732,69 +4712,64 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDestinati
             "@type": type.googleapis.com/google.protobuf.StringValue
             value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // UDS client connects - using 1st filter chain with no IP match
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // UDS client connects - using 1st filter chain with no IP match
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // IPv4 client connects to default IP - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // IPv4 client connects to default IP - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // IPv4 client connects to exact IP match - using 2nd filter chain.
-    filter_chain = findFilterChain(1234, "192.168.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client connects to exact IP match - using 2nd filter chain.
+  filter_chain = findFilterChain(1234, "192.168.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // IPv4 client connects to wildcard IP match - using 3rd filter chain.
-    filter_chain = findFilterChain(1234, "192.168.1.1", "", "tls", {}, "192.168.1.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 2);
-    EXPECT_EQ(server_names.front(), "*.example.com");
+  // IPv4 client connects to wildcard IP match - using 3rd filter chain.
+  filter_chain = findFilterChain(1234, "192.168.1.1", "", "tls", {}, "192.168.1.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 2);
+  EXPECT_EQ(server_names.front(), "*.example.com");
 
-    // UDS client - using 1st filter chain.
-    filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // UDS client - using 1st filter chain.
+  filter_chain = findFilterChain(0, "/tmp/test.sock", "", "tls", {}, "/tmp/test.sock", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDirectSourceIPMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4836,9 +4811,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDirectSou
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_multiple_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -4875,64 +4850,58 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDirectSou
             "@type": type.googleapis.com/google.protobuf.StringValue
             value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // UDS client connects - using 1st filter chain with no IP match
-    auto filter_chain = findFilterChain(1234, "/uds_1", "", "tls", {}, "/uds_2", 111, "/uds_3");
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // UDS client connects - using 1st filter chain with no IP match
+  auto filter_chain = findFilterChain(1234, "/uds_1", "", "tls", {}, "/uds_2", 111, "/uds_3");
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // IPv4 client connects to default IP - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111, "127.0.0.1");
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // IPv4 client connects to default IP - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111, "127.0.0.1");
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // IPv4 client connects to exact IP match - using 2nd filter chain.
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111, "192.168.0.1");
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // IPv4 client connects to exact IP match - using 2nd filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111, "192.168.0.1");
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // IPv4 client connects to wildcard IP match - using 3rd filter chain.
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111, "192.168.1.1");
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 2);
-    EXPECT_EQ(server_names.front(), "*.example.com");
+  // IPv4 client connects to wildcard IP match - using 3rd filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111, "192.168.1.1");
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 2);
+  EXPECT_EQ(server_names.front(), "*.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithServerNamesMatch) {
-    if (use_matcher_) {
-      GTEST_SKIP() << "Server name matching not implemented for unified matcher";
-    }
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  if (use_matcher_) {
+    GTEST_SKIP() << "Server name matching not implemented for unified matcher";
+  }
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -4980,63 +4949,59 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithServerNam
             keys:
             - filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ticket_key_a"
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TLS client without SNI - using 1st filter chain.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
-    EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
+  // TLS client without SNI - using 1st filter chain.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto uri = ssl_socket->ssl()->uriSanLocalCertificate();
+  EXPECT_EQ(uri[0], "spiffe://lyft.com/test-team");
 
-    // TLS client with exact SNI match - using 2nd filter chain.
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "server1.example.com", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client with exact SNI match - using 2nd filter chain.
+  filter_chain =
+      findFilterChain(1234, "127.0.0.1", "server1.example.com", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 
-    // TLS client with wildcard SNI match - using 3rd filter chain.
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "server2.example.com", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 2);
-    EXPECT_EQ(server_names.front(), "*.example.com");
+  // TLS client with wildcard SNI match - using 3rd filter chain.
+  filter_chain =
+      findFilterChain(1234, "127.0.0.1", "server2.example.com", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 2);
+  EXPECT_EQ(server_names.front(), "*.example.com");
 
-    // TLS client with wildcard SNI match - using 3rd filter chain.
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "www.wildcard.com", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 2);
-    EXPECT_EQ(server_names.front(), "*.example.com");
+  // TLS client with wildcard SNI match - using 3rd filter chain.
+  filter_chain =
+      findFilterChain(1234, "127.0.0.1", "www.wildcard.com", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  ssl_socket = dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 2);
+  EXPECT_EQ(server_names.front(), "*.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithTransportProtocolMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5059,9 +5024,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithTransport
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -5083,37 +5048,36 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithTransport
             "@type": type.googleapis.com/google.protobuf.StringValue
             value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TCP client - using 1st filter chain.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "raw_buffer", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  // TCP client - using 1st filter chain.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "raw_buffer", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
 
-    // TLS client - using 2nd filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client - using 2nd filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithFilterStateMatch) {
-    if (!use_matcher_) {
-      return;
-    }
+  if (!use_matcher_) {
+    return;
+  }
 
-    std::string yaml = R"EOF(
+  std::string yaml = R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5146,46 +5110,46 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithFilterSta
             value: foo
     )EOF";
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // No filter state value set - match foo.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_EQ(filter_chain->name(), "foo");
+  // No filter state value set - match foo.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_EQ(filter_chain->name(), "foo");
 
-    stream_info_.filterState()->setData(
-        "unknown_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData(
+      "unknown_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
-    // Filter state set to a non-matching key - no match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_EQ(filter_chain->name(), "foo");
+  // Filter state set to a non-matching key - no match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_EQ(filter_chain->name(), "foo");
 
-    stream_info_.filterState()->setData(
-        "filter_state_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData(
+      "filter_state_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
-    // Filter state set to a matching key but unknown value - no match.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_EQ(filter_chain->name(), "foo");
+  // Filter state set to a matching key but unknown value - no match.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_EQ(filter_chain->name(), "foo");
 
-    stream_info_.filterState()->setData(
-        "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData(
+      "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
+      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
 
-    // Known filter state key and matching value - using 1st filter chain.
-    filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_EQ(filter_chain->name(), "bar");
+  // Known filter state key and matching value - using 1st filter chain.
+  filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_EQ(filter_chain->name(), "bar");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithApplicationProtocolMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5208,9 +5172,9 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithApplicati
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                   Network::Address::IpVersion::v4);
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+                                                 Network::Address::IpVersion::v4);
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -5232,39 +5196,38 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithApplicati
             "@type": type.googleapis.com/google.protobuf.StringValue
             value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TLS client without ALPN - using 1st filter chain.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  // TLS client without ALPN - using 1st filter chain.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
 
-    // TLS client with "h2,http/1.1" ALPN - using 2nd filter chain.
-    filter_chain = findFilterChain(
-        1234, "127.0.0.1", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client with "h2,http/1.1" ALPN - using 2nd filter chain.
+  filter_chain = findFilterChain(
+      1234, "127.0.0.1", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "127.0.0.1",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithMultipleRequirementsMatch) {
-    if (use_matcher_) {
-      GTEST_SKIP() << "ALPN list and server name matching not implemented for unified matcher";
-    }
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  if (use_matcher_) {
+    GTEST_SKIP() << "ALPN list and server name matching not implemented for unified matcher";
+  }
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5287,50 +5250,49 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithMultipleR
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 
-    // TLS client without SNI and ALPN - using 1st filter chain.
-    auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  // TLS client without SNI and ALPN - using 1st filter chain.
+  auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "tls", {}, "127.0.0.1", 111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
 
-    // TLS client with exact SNI match but without ALPN - no match (SNI blackholed by
-    // configuration).
-    filter_chain =
-        findFilterChain(1234, "127.0.0.1", "server1.example.com", "tls", {}, "127.0.0.1", 111);
-    EXPECT_EQ(filter_chain, nullptr);
+  // TLS client with exact SNI match but without ALPN - no match (SNI blackholed by
+  // configuration).
+  filter_chain =
+      findFilterChain(1234, "127.0.0.1", "server1.example.com", "tls", {}, "127.0.0.1", 111);
+  EXPECT_EQ(filter_chain, nullptr);
 
-    // TLS client with ALPN match but without SNI - using 1st filter chain.
-    filter_chain = findFilterChain(
-        1234, "127.0.0.1", "", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  // TLS client with ALPN match but without SNI - using 1st filter chain.
+  filter_chain = findFilterChain(
+      1234, "127.0.0.1", "", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "127.0.0.1",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_FALSE(filter_chain->transportSocketFactory().implementsSecureTransport());
 
-    // TLS client with exact SNI match and ALPN match - using 2nd filter chain.
-    filter_chain = findFilterChain(
-        1234, "127.0.0.1", "server1.example.com", "tls",
-        {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11},
-        "127.0.0.1", 111);
-    ASSERT_NE(filter_chain, nullptr);
-    EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
-    auto transport_socket =
-        filter_chain->transportSocketFactory().createDownstreamTransportSocket();
-    auto ssl_socket =
-        dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
-    auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
-    EXPECT_EQ(server_names.size(), 1);
-    EXPECT_EQ(server_names.front(), "server1.example.com");
+  // TLS client with exact SNI match and ALPN match - using 2nd filter chain.
+  filter_chain = findFilterChain(
+      1234, "127.0.0.1", "server1.example.com", "tls",
+      {Http::Utility::AlpnNames::get().Http2, Http::Utility::AlpnNames::get().Http11}, "127.0.0.1",
+      111);
+  ASSERT_NE(filter_chain, nullptr);
+  EXPECT_TRUE(filter_chain->transportSocketFactory().implementsSecureTransport());
+  auto transport_socket = filter_chain->transportSocketFactory().createDownstreamTransportSocket();
+  auto ssl_socket =
+      dynamic_cast<Extensions::TransportSockets::Tls::SslSocket*>(transport_socket.get());
+  auto server_names = ssl_socket->ssl()->dnsSansLocalCertificate();
+  EXPECT_EQ(server_names.size(), 1);
+  EXPECT_EQ(server_names.front(), "server1.example.com");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDifferentSessionTicketKeys) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5367,17 +5329,17 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithDifferent
             keys:
             - filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ticket_key_b"
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        MultipleFilterChainsWithMixedUseOfSessionTicketKeys) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5411,16 +5373,16 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_key.pem" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithInvalidDestinationIPMatch) {
-    std::string yaml = TestEnvironment::substitute(R"EOF(
+  std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5432,10 +5394,10 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithInvalidDesti
         prefix_ranges: { address_prefix: a.b.c.d, prefix_len: 32 }
       name: foo
   )EOF",
-                                                   Network::Address::IpVersion::v4);
+                                                 Network::Address::IpVersion::v4);
 
-    if (use_matcher_) {
-      yaml = yaml + R"EOF(
+  if (use_matcher_) {
+    yaml = yaml + R"EOF(
     filter_chain_matcher:
       matcher_tree:
         input:
@@ -5457,17 +5419,17 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithInvalidDesti
                     "@type": type.googleapis.com/google.protobuf.StringValue
                     value: foo
     )EOF";
-    }
+  }
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "malformed IP address: a.b.c.d");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "malformed IP address: a.b.c.d");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithInvalidServerNamesMatch) {
-    if (use_matcher_) {
-      GTEST_SKIP() << "Server name matching not implemented for unified matcher";
-    }
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  if (use_matcher_) {
+    GTEST_SKIP() << "Server name matching not implemented for unified matcher";
+  }
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5478,15 +5440,15 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithInvalidServe
     - filter_chain_match:
         server_names: "*w.example.com"
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "error adding listener '127.0.0.1:1234': partial wildcards are not "
-                              "supported in \"server_names\"");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "error adding listener '127.0.0.1:1234': partial wildcards are not "
+                            "supported in \"server_names\"");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithSameMatch) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5501,20 +5463,20 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithSameMatch
       filter_chain_match:
         transport_protocol: "tls"
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    if (use_matcher_) {
-      EXPECT_NO_THROW(addOrUpdateListener(parseListenerFromV3Yaml(yaml)));
-      return;
-    }
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "error adding listener '127.0.0.1:1234': filter chain 'bar' has "
-                              "the same matching rules defined as 'foo'");
+  if (use_matcher_) {
+    EXPECT_NO_THROW(addOrUpdateListener(parseListenerFromV3Yaml(yaml)));
+    return;
+  }
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "error adding listener '127.0.0.1:1234': filter chain 'bar' has "
+                            "the same matching rules defined as 'foo'");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest,
        MultipleFilterChainsWithSameMatchPlusUnimplementedFields) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5530,15 +5492,15 @@ TEST_P(ListenerManagerImplWithRealFiltersTest,
         transport_protocol: "tls"
         address_suffix: 127.0.0.0
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(
-        addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-        "error adding listener '127.0.0.1:1234': filter chain 'bar' contains unimplemented fields");
+  EXPECT_THROW_WITH_MESSAGE(
+      addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+      "error adding listener '127.0.0.1:1234': filter chain 'bar' contains unimplemented fields");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithOverlappingRules) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5553,19 +5515,19 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithOverlappi
       filter_chain_match:
         server_names: ["example.com", "www.example.com"]
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    if (use_matcher_) {
-      EXPECT_NO_THROW(addOrUpdateListener(parseListenerFromV3Yaml(yaml)));
-      return;
-    }
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "error adding listener '127.0.0.1:1234': multiple filter chains with "
-                              "overlapping matching rules are defined");
+  if (use_matcher_) {
+    EXPECT_NO_THROW(addOrUpdateListener(parseListenerFromV3Yaml(yaml)));
+    return;
+  }
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "error adding listener '127.0.0.1:1234': multiple filter chains with "
+                            "overlapping matching rules are defined");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MatcherFilterChainWithoutName) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5589,15 +5551,15 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MatcherFilterChainWithoutName) {
     filter_chains:
     - filters: []
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "error adding listener '127.0.0.1:1234': \"name\" field is required "
-                              "when using a listener matcher");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "error adding listener '127.0.0.1:1234': \"name\" field is required "
+                            "when using a listener matcher");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, MatcherFilterChainWithDuplicateName) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     listener_filters:
@@ -5624,22 +5586,21 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MatcherFilterChainWithDuplicateNa
     - name: foo
       filters: []
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(
-        addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-        "error adding listener '127.0.0.1:1234': \"name\" field is duplicated "
-        "with value 'foo'");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "error adding listener '127.0.0.1:1234': \"name\" field is duplicated "
+                            "with value 'foo'");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInline) {
-    const std::string cert = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
-        "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem"));
-    const std::string pkey = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
-        "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_key.pem"));
-    const std::string ca = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
-        "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"));
-    const std::string yaml = absl::StrCat(R"EOF(
+  const std::string cert = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem"));
+  const std::string pkey = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_key.pem"));
+  const std::string ca = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem"));
+  const std::string yaml = absl::StrCat(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5651,24 +5612,24 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInline) {
           common_tls_context:
             tls_certificates:
               - certificate_chain: { inline_string: ")EOF",
-                                          absl::CEscape(cert), R"EOF(" }
+                                        absl::CEscape(cert), R"EOF(" }
                 private_key: { inline_string: ")EOF",
-                                          absl::CEscape(pkey), R"EOF(" }
+                                        absl::CEscape(pkey), R"EOF(" }
             validation_context:
               trusted_ca: { inline_string: ")EOF",
-                                          absl::CEscape(ca), R"EOF(" }
+                                        absl::CEscape(ca), R"EOF(" }
   )EOF");
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateChainInlinePrivateKeyFilename) {
-    const std::string cert = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
-        "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem"));
-    const std::string yaml = TestEnvironment::substitute(absl::StrCat(R"EOF(
+  const std::string cert = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem"));
+  const std::string yaml = TestEnvironment::substitute(absl::StrCat(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5681,18 +5642,18 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateChainInlinePrivateK
             tls_certificates:
               - private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_key.pem" }
                 certificate_chain: { inline_string: ")EOF",
-                                                                      absl::CEscape(cert), R"EOF(" }
+                                                                    absl::CEscape(cert), R"EOF(" }
   )EOF"),
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateIncomplete) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5705,14 +5666,14 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateIncomplete) {
             tls_certificates:
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "Failed to load incomplete private key from path: ");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "Failed to load incomplete private key from path: ");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidCertificateChain) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5726,18 +5687,18 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidCertificateC
               - certificate_chain: { inline_string: "invalid" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_key.pem" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "Failed to load certificate chain from <inline>");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "Failed to load certificate chain from <inline>");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidIntermediateCA) {
-    const std::string leaf = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
-        "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_cert.pem"));
-    const std::string yaml = TestEnvironment::substitute(
-        absl::StrCat(
-            R"EOF(
+  const std::string leaf = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_cert.pem"));
+  const std::string yaml = TestEnvironment::substitute(
+      absl::StrCat(
+          R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5749,18 +5710,18 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidIntermediate
           common_tls_context:
             tls_certificates:
               - certificate_chain: { inline_string: ")EOF",
-            absl::CEscape(leaf),
-            R"EOF(\n-----BEGIN CERTIFICATE-----\nDEFINITELY_INVALID_CERTIFICATE\n-----END CERTIFICATE-----" }
+          absl::CEscape(leaf),
+          R"EOF(\n-----BEGIN CERTIFICATE-----\nDEFINITELY_INVALID_CERTIFICATE\n-----END CERTIFICATE-----" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_key.pem" }
   )EOF"),
-        Network::Address::IpVersion::v4);
+      Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "Failed to load certificate chain from <inline>");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "Failed to load certificate chain from <inline>");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidPrivateKey) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5774,15 +5735,15 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidPrivateKey) 
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem" }
                 private_key: { inline_string: "invalid" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "Failed to load private key from <inline>, "
-                              "Cause: error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "Failed to load private key from <inline>, "
+                            "Cause: error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidTrustedCA) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5798,14 +5759,14 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateInvalidTrustedCA) {
             validation_context:
               trusted_ca: { inline_string: "invalid" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-                              "Failed to load trusted CA certificates from <inline>");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+                            "Failed to load trusted CA certificates from <inline>");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateCertPrivateKeyMismatch) {
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     filter_chains:
@@ -5819,17 +5780,17 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, TlsCertificateCertPrivateKeyMisma
               - certificate_chain: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_chain.pem" }
                 private_key: { filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns2_key.pem" }
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_REGEX(
-        addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
-        "Failed to load private key from .*, "
-        "Cause: error:0b000074:X.509 certificate routines:OPENSSL_internal:KEY_VALUES_MISMATCH");
+  EXPECT_THROW_WITH_REGEX(
+      addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
+      "Failed to load private key from .*, "
+      "Cause: error:0b000074:X.509 certificate routines:OPENSSL_internal:KEY_VALUES_MISMATCH");
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, Metadata) {
 #ifdef SOL_IP
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1234 }
     metadata: { filter_metadata: { com.bar.foo: { baz: test_value } } }
@@ -5854,33 +5815,33 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, Metadata) {
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
   )EOF",
-                                                         Network::Address::IpVersion::v4);
-    Configuration::ListenerFactoryContext* listener_factory_context = nullptr;
-    // Extract listener_factory_context avoid accessing private member.
-    ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
-        .WillByDefault(Invoke(
-            [&listener_factory_context,
-             this](const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
-                       filters,
-                   Configuration::ListenerFactoryContext& context)
-                -> Filter::ListenerFilterFactoriesList {
-              listener_factory_context = &context;
-              return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
-                  filters, context, *listener_factory_.getTcpListenerConfigProviderManager());
-            }));
-    server_.server_factory_context_->cluster_manager_.initializeClusters({"service_foo"}, {});
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    ASSERT_NE(nullptr, listener_factory_context);
-    EXPECT_EQ("test_value", Config::Metadata::metadataValue(
-                                &listener_factory_context->listenerMetadata(), "com.bar.foo", "baz")
-                                .string_value());
-    EXPECT_EQ(envoy::config::core::v3::INBOUND, listener_factory_context->direction());
+                                                       Network::Address::IpVersion::v4);
+  Configuration::ListenerFactoryContext* listener_factory_context = nullptr;
+  // Extract listener_factory_context avoid accessing private member.
+  ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
+      .WillByDefault(
+          Invoke([&listener_factory_context, this](
+                     const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
+                         filters,
+                     Configuration::ListenerFactoryContext& context)
+                     -> Filter::ListenerFilterFactoriesList {
+            listener_factory_context = &context;
+            return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
+                filters, context, *listener_factory_.getTcpListenerConfigProviderManager());
+          }));
+  server_.server_factory_context_->cluster_manager_.initializeClusters({"service_foo"}, {});
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  ASSERT_NE(nullptr, listener_factory_context);
+  EXPECT_EQ("test_value", Config::Metadata::metadataValue(
+                              &listener_factory_context->listenerMetadata(), "com.bar.foo", "baz")
+                              .string_value());
+  EXPECT_EQ(envoy::config::core::v3::INBOUND, listener_factory_context->direction());
 #endif
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilterWin32NoTrafficDirection) {
 #ifdef WIN32
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     filter_chains: {}
@@ -5889,19 +5850,19 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilterWin32NoTrafficDi
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
   )EOF",
-                                                         Network::Address::IpVersion::v4);
+                                                       Network::Address::IpVersion::v4);
 
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-                              , EnvoyException,
-                              "[Windows] Setting original destination filter on a listener without "
-                              "specifying the traffic_direction."
-                              "Configure the traffic_direction listener option");
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+                            , EnvoyException,
+                            "[Windows] Setting original destination filter on a listener without "
+                            "specifying the traffic_direction."
+                            "Configure the traffic_direction listener option");
 #endif
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilterWin32NoFeatureSupport) {
 #if defined(WIN32) && !defined(SOL_IP)
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     filter_chains: {}
@@ -5911,17 +5872,17 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilterWin32NoFeatureSu
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
   )EOF",
-                                                         Network::Address::IpVersion::v4);
-    EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-                              , EnvoyException,
-                              "[Windows] Envoy was compiled without support for `SO_ORIGINAL_DST`, "
-                              "the original destination filter cannot be used");
+                                                       Network::Address::IpVersion::v4);
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+                            , EnvoyException,
+                            "[Windows] Envoy was compiled without support for `SO_ORIGINAL_DST`, "
+                            "the original destination filter cannot be used");
 #endif
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilter) {
 #ifdef SOL_IP
-    const std::string yaml = TestEnvironment::substitute(R"EOF(
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
     address:
       socket_address: { address: 127.0.0.1, port_value: 1111 }
     filter_chains:
@@ -5933,85 +5894,83 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, OriginalDstFilter) {
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.listener.original_dst.v3.OriginalDst
   )EOF",
-                                                         Network::Address::IpVersion::v4);
-    EXPECT_CALL(server_.api_.random_, uuid());
-    EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+                                                       Network::Address::IpVersion::v4);
+  EXPECT_CALL(server_.api_.random_, uuid());
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
 
-    Configuration::ListenerFactoryContext* listener_factory_context = nullptr;
-    // Extract listener_factory_context to unit test functions.
-    ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
-        .WillByDefault(Invoke(
-            [&listener_factory_context,
-             this](const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
-                       filters,
-                   Configuration::ListenerFactoryContext& context)
-                -> Filter::ListenerFilterFactoriesList {
-              listener_factory_context = &context;
-              return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
-                  filters, context, *listener_factory_.getTcpListenerConfigProviderManager());
-            }));
+  Configuration::ListenerFactoryContext* listener_factory_context = nullptr;
+  // Extract listener_factory_context to unit test functions.
+  ON_CALL(listener_factory_, createListenerFilterFactoryList(_, _))
+      .WillByDefault(
+          Invoke([&listener_factory_context, this](
+                     const Protobuf::RepeatedPtrField<envoy::config::listener::v3::ListenerFilter>&
+                         filters,
+                     Configuration::ListenerFactoryContext& context)
+                     -> Filter::ListenerFilterFactoriesList {
+            listener_factory_context = &context;
+            return ProdListenerComponentFactory::createListenerFilterFactoryListImpl(
+                filters, context, *listener_factory_.getTcpListenerConfigProviderManager());
+          }));
 
-    addOrUpdateListener(parseListenerFromV3Yaml(yaml));
-    EXPECT_EQ(1U, manager_->listeners().size());
-    Network::ListenerConfig& listener = manager_->listeners().back().get();
+  addOrUpdateListener(parseListenerFromV3Yaml(yaml));
+  EXPECT_EQ(1U, manager_->listeners().size());
+  Network::ListenerConfig& listener = manager_->listeners().back().get();
 
-    // Unit test PerListenerFactoryContextImpl for coverage.
-    ASSERT_TRUE(listener_factory_context != nullptr);
-    ListenerFactoryContextBaseImpl& parent_context =
-        static_cast<PerListenerFactoryContextImpl*>(listener_factory_context)
-            ->parentFactoryContext();
-    EXPECT_EQ(&listener_factory_context->timeSource(),
-              &listener_factory_context->api().timeSource());
-    EXPECT_EQ(&listener_factory_context->initManager(), &listener.initManager());
-    EXPECT_EQ(&listener_factory_context->lifecycleNotifier(), &server_.lifecycleNotifier());
-    EXPECT_EQ(&listener_factory_context->messageValidationContext(),
-              &listener_factory_context->getServerFactoryContext().messageValidationContext());
-    EXPECT_EQ(&listener_factory_context->mainThreadDispatcher(),
-              &parent_context.mainThreadDispatcher());
-    EXPECT_EQ(&listener_factory_context->options(), &parent_context.options());
-    EXPECT_EQ(&listener_factory_context->grpcContext(), &parent_context.grpcContext());
-    EXPECT_EQ(listener_factory_context->healthCheckFailed(), parent_context.healthCheckFailed());
-    EXPECT_EQ(&listener_factory_context->httpContext(), &parent_context.httpContext());
-    EXPECT_EQ(&listener_factory_context->routerContext(), &parent_context.routerContext());
-    EXPECT_EQ(&listener_factory_context->overloadManager(), &parent_context.overloadManager());
-    EXPECT_EQ(listener_factory_context->admin().has_value(), parent_context.admin().has_value());
-    EXPECT_EQ(&listener_factory_context->listenerTypedMetadata(),
-              &parent_context.listenerTypedMetadata());
-    EXPECT_EQ(listener_factory_context->processContext().has_value(),
-              parent_context.processContext().has_value());
-    EXPECT_EQ(&listener_factory_context->getTransportSocketFactoryContext(),
-              &parent_context.getTransportSocketFactoryContext());
-    EXPECT_EQ(listener_factory_context->isQuicListener(), parent_context.isQuicListener());
+  // Unit test PerListenerFactoryContextImpl for coverage.
+  ASSERT_TRUE(listener_factory_context != nullptr);
+  ListenerFactoryContextBaseImpl& parent_context =
+      static_cast<PerListenerFactoryContextImpl*>(listener_factory_context)->parentFactoryContext();
+  EXPECT_EQ(&listener_factory_context->timeSource(), &listener_factory_context->api().timeSource());
+  EXPECT_EQ(&listener_factory_context->initManager(), &listener.initManager());
+  EXPECT_EQ(&listener_factory_context->lifecycleNotifier(), &server_.lifecycleNotifier());
+  EXPECT_EQ(&listener_factory_context->messageValidationContext(),
+            &listener_factory_context->getServerFactoryContext().messageValidationContext());
+  EXPECT_EQ(&listener_factory_context->mainThreadDispatcher(),
+            &parent_context.mainThreadDispatcher());
+  EXPECT_EQ(&listener_factory_context->options(), &parent_context.options());
+  EXPECT_EQ(&listener_factory_context->grpcContext(), &parent_context.grpcContext());
+  EXPECT_EQ(listener_factory_context->healthCheckFailed(), parent_context.healthCheckFailed());
+  EXPECT_EQ(&listener_factory_context->httpContext(), &parent_context.httpContext());
+  EXPECT_EQ(&listener_factory_context->routerContext(), &parent_context.routerContext());
+  EXPECT_EQ(&listener_factory_context->overloadManager(), &parent_context.overloadManager());
+  EXPECT_EQ(listener_factory_context->admin().has_value(), parent_context.admin().has_value());
+  EXPECT_EQ(&listener_factory_context->listenerTypedMetadata(),
+            &parent_context.listenerTypedMetadata());
+  EXPECT_EQ(listener_factory_context->processContext().has_value(),
+            parent_context.processContext().has_value());
+  EXPECT_EQ(&listener_factory_context->getTransportSocketFactoryContext(),
+            &parent_context.getTransportSocketFactoryContext());
+  EXPECT_EQ(listener_factory_context->isQuicListener(), parent_context.isQuicListener());
 
-    // Unit test ListenerFactoryContextBaseImpl for coverage.
-    EXPECT_EQ(&parent_context.timeSource(), &listener_factory_context->api().timeSource());
-    EXPECT_EQ(&parent_context.messageValidationContext(), &server_.messageValidationContext());
-    EXPECT_EQ(&parent_context.lifecycleNotifier(), &server_.lifecycleNotifier());
+  // Unit test ListenerFactoryContextBaseImpl for coverage.
+  EXPECT_EQ(&parent_context.timeSource(), &listener_factory_context->api().timeSource());
+  EXPECT_EQ(&parent_context.messageValidationContext(), &server_.messageValidationContext());
+  EXPECT_EQ(&parent_context.lifecycleNotifier(), &server_.lifecycleNotifier());
 
-    Network::FilterChainFactory& filterChainFactory = listener.filterChainFactory();
-    Network::MockListenerFilterManager manager;
+  Network::FilterChainFactory& filterChainFactory = listener.filterChainFactory();
+  Network::MockListenerFilterManager manager;
 
-    // Return error when trying to retrieve the original dst on the invalid handle
-    EXPECT_CALL(os_sys_calls_, getsockopt_(_, _, _, _, _)).WillRepeatedly(Return(-1));
+  // Return error when trying to retrieve the original dst on the invalid handle
+  EXPECT_CALL(os_sys_calls_, getsockopt_(_, _, _, _, _)).WillRepeatedly(Return(-1));
 
-    NiceMock<Network::MockListenerFilterCallbacks> callbacks;
-    Network::AcceptedSocketImpl socket(std::make_unique<Network::IoSocketHandleImpl>(),
-                                       Network::Address::InstanceConstSharedPtr{
-                                           new Network::Address::Ipv4Instance("127.0.0.1", 1234)},
-                                       Network::Address::InstanceConstSharedPtr{
-                                           new Network::Address::Ipv4Instance("127.0.0.1", 5678)});
+  NiceMock<Network::MockListenerFilterCallbacks> callbacks;
+  Network::AcceptedSocketImpl socket(std::make_unique<Network::IoSocketHandleImpl>(),
+                                     Network::Address::InstanceConstSharedPtr{
+                                         new Network::Address::Ipv4Instance("127.0.0.1", 1234)},
+                                     Network::Address::InstanceConstSharedPtr{
+                                         new Network::Address::Ipv4Instance("127.0.0.1", 5678)});
 
-    EXPECT_CALL(callbacks, socket()).WillOnce(Invoke([&]() -> Network::ConnectionSocket& {
-      return socket;
-    }));
+  EXPECT_CALL(callbacks, socket()).WillOnce(Invoke([&]() -> Network::ConnectionSocket& {
+    return socket;
+  }));
 
-    EXPECT_CALL(manager, addAcceptFilter_(_, _))
-        .WillOnce(Invoke([&](const Network::ListenerFilterMatcherSharedPtr&,
-                             Network::ListenerFilterPtr& filter) -> void {
-          EXPECT_EQ(Network::FilterStatus::Continue, filter->onAccept(callbacks));
-        }));
+  EXPECT_CALL(manager, addAcceptFilter_(_, _))
+      .WillOnce(Invoke([&](const Network::ListenerFilterMatcherSharedPtr&,
+                           Network::ListenerFilterPtr& filter) -> void {
+        EXPECT_EQ(Network::FilterStatus::Continue, filter->onAccept(callbacks));
+      }));
 
-    EXPECT_TRUE(filterChainFactory.createListenerFilterChain(manager));
+  EXPECT_TRUE(filterChainFactory.createListenerFilterChain(manager));
 #endif
 }
 
@@ -6024,7 +5983,7 @@ private:
   Network::Address::InstanceConstSharedPtr getOriginalDst(Network::Socket&) override {
     return Network::Address::InstanceConstSharedPtr{
         new Network::Address::Ipv4Instance("127.0.0.2", 2345)};
-}
+  }
 };
 
 class OriginalDstTestConfigFactory : public Configuration::NamedListenerFilterConfigFactory {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -492,7 +492,8 @@ public:
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));
-  MOCK_METHOD(void, stopListeners, (uint64_t listener_tag));
+  MOCK_METHOD(void, stopListeners,
+              (uint64_t listener_tag, const Network::ExtraShutdownListenerOptions& options));
   MOCK_METHOD(void, stopListeners, ());
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -24,7 +24,7 @@ public:
   MOCK_METHOD(Ssl::ContextManager&, sslContextManager, ());
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(Network::DnsResolverSharedPtr, dnsResolver, ());
-  MOCK_METHOD(void, drainListeners, ());
+  MOCK_METHOD(void, drainListeners, (OptRef<const Network::ExtraShutdownListenerOptions> options));
   MOCK_METHOD(DrainManager&, drainManager, ());
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, ());
   MOCK_METHOD(void, failHealthcheck, (bool fail));

--- a/test/mocks/server/listener_manager.h
+++ b/test/mocks/server/listener_manager.h
@@ -22,7 +22,9 @@ public:
   MOCK_METHOD(uint64_t, numConnections, (), (const));
   MOCK_METHOD(bool, removeListener, (const std::string& listener_name));
   MOCK_METHOD(void, startWorkers, (GuardDog & guard_dog, std::function<void()> callback));
-  MOCK_METHOD(void, stopListeners, (StopListenersType listeners_type));
+  MOCK_METHOD(void, stopListeners,
+              (StopListenersType listeners_type,
+               const Network::ExtraShutdownListenerOptions& options));
   MOCK_METHOD(void, stopWorkers, ());
   MOCK_METHOD(void, beginListenerUpdate, ());
   MOCK_METHOD(void, endListenerUpdate, (ListenerManager::FailureStates &&));

--- a/test/mocks/server/worker.cc
+++ b/test/mocks/server/worker.cc
@@ -29,7 +29,7 @@ MockWorker::MockWorker() {
             remove_listener_completion_ = completion;
           }));
 
-  ON_CALL(*this, stopListener(_, _))
+  ON_CALL(*this, stopListener(_, _, _))
       .WillByDefault(
           Invoke([](Network::ListenerConfig&, const Network::ExtraShutdownListenerOptions&,
                     std::function<void()> completion) -> void {

--- a/test/mocks/server/worker.cc
+++ b/test/mocks/server/worker.cc
@@ -31,7 +31,7 @@ MockWorker::MockWorker() {
 
   ON_CALL(*this, stopListener(_, _))
       .WillByDefault(
-          Invoke([](Network::ListenerConfig&, const Network::ExtraShutdownListenerOptions& options,
+          Invoke([](Network::ListenerConfig&, const Network::ExtraShutdownListenerOptions&,
                     std::function<void()> completion) -> void {
             if (completion != nullptr) {
               completion();

--- a/test/mocks/server/worker.cc
+++ b/test/mocks/server/worker.cc
@@ -30,11 +30,13 @@ MockWorker::MockWorker() {
           }));
 
   ON_CALL(*this, stopListener(_, _))
-      .WillByDefault(Invoke([](Network::ListenerConfig&, std::function<void()> completion) -> void {
-        if (completion != nullptr) {
-          completion();
-        }
-      }));
+      .WillByDefault(
+          Invoke([](Network::ListenerConfig&, const Network::ExtraShutdownListenerOptions& options,
+                    std::function<void()> completion) -> void {
+            if (completion != nullptr) {
+              completion();
+            }
+          }));
 
   ON_CALL(*this, removeFilterChains(_, _, _))
       .WillByDefault(Invoke([this](uint64_t, const std::list<const Network::FilterChain*>&,

--- a/test/mocks/server/worker.h
+++ b/test/mocks/server/worker.h
@@ -41,7 +41,9 @@ public:
   MOCK_METHOD(void, initializeStats, (Stats::Scope & scope));
   MOCK_METHOD(void, stop, ());
   MOCK_METHOD(void, stopListener,
-              (Network::ListenerConfig & listener, std::function<void()> completion));
+              (Network::ListenerConfig & listener,
+               const Network::ExtraShutdownListenerOptions& options,
+               std::function<void()> completion));
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -179,7 +179,7 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
                             Filesystem::fileSystemForTest());
 
   // Execute dummy methods.
-  server.drainListeners();
+  server.drainListeners(absl::nullopt);
   server.failHealthcheck(true);
   server.lifecycleNotifier();
   server.secretManager();

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -481,6 +481,7 @@ public:
   std::shared_ptr<AccessLog::MockInstance> access_log_;
   TestScopedRuntime scoped_runtime_;
   Runtime::Loader& runtime_{scoped_runtime_.loader()};
+  Network::ExtraShutdownListenerOptions empty_options_{};
 };
 
 // Verify that if a listener is removed while a rebalanced connection is in flight, we correctly
@@ -630,17 +631,17 @@ TEST_F(ConnectionHandlerTest, RemoveListener) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0);
+  handler_->stopListeners(0, empty_options_);
   handler_->removeListeners(0);
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0);
+  handler_->stopListeners(0, empty_options_);
   handler_->removeListeners(0);
 }
 
@@ -676,18 +677,18 @@ TEST_F(ConnectionHandlerTest, RemoveListenerWithMultiAddrs) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0);
+  handler_->stopListeners(0, empty_options_);
   handler_->removeListeners(0);
 
   EXPECT_CALL(*listener1, onDestroy());
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList()).Times(2);
   handler_->removeListeners(1);
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0);
+  handler_->stopListeners(0, empty_options_);
   handler_->removeListeners(0);
 }
 
@@ -814,10 +815,10 @@ TEST_F(ConnectionHandlerTest, StopAndDisableStoppedListener) {
   handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
 
   // Test stop a stopped listener.
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
 
   // Test disable a stopped listener.
   handler_->disableListeners();
@@ -1156,7 +1157,7 @@ TEST_F(ConnectionHandlerTest, MatchLatestListener) {
   // This emulated the case of update listener in-place. Stop the old listener and
   // add the new listener.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2);
+  handler_->stopListeners(2, empty_options_);
   handler_->addListener(absl::nullopt, *test_listener3, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
@@ -1220,7 +1221,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedListener) {
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2);
+  handler_->stopListeners(2, empty_options_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1280,7 +1281,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListener) {
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2);
+  handler_->stopListeners(2, empty_options_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -2403,7 +2404,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveFilterChainCalledAfterListenerIsR
   EXPECT_EQ(1UL, TestUtility::findGauge(stats_store_, "test.downstream_cx_active")->value());
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(listener_tag);
+  handler_->stopListeners(listener_tag, empty_options_);
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   EXPECT_CALL(*access_log_, log(_, _, _, _, _));
@@ -2455,18 +2456,18 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveListener) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0);
+  handler_->stopListeners(0, empty_options_);
   handler_->removeListeners(0);
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0);
+  handler_->stopListeners(0, empty_options_);
   handler_->removeListeners(0);
 }
 
@@ -2487,7 +2488,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveIpv6AnyAddressWithIpv4CompatListe
   EXPECT_EQ(0UL, handler_->numConnections());
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
@@ -2516,7 +2517,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveIpv4CompatAddressListener) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
@@ -2559,7 +2560,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveWithBothIpv4AnyAndIpv6Any) {
 
   // Remove Listener1 first.
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1);
+  handler_->stopListeners(1, empty_options_);
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
@@ -2570,7 +2571,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveWithBothIpv4AnyAndIpv6Any) {
 
   // Now remove Listener2.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2);
+  handler_->stopListeners(2, empty_options_);
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(2);

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -481,7 +481,6 @@ public:
   std::shared_ptr<AccessLog::MockInstance> access_log_;
   TestScopedRuntime scoped_runtime_;
   Runtime::Loader& runtime_{scoped_runtime_.loader()};
-  Network::ExtraShutdownListenerOptions empty_options_{};
 };
 
 // Verify that if a listener is removed while a rebalanced connection is in flight, we correctly
@@ -631,17 +630,17 @@ TEST_F(ConnectionHandlerTest, RemoveListener) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0, empty_options_);
+  handler_->stopListeners(0, {});
   handler_->removeListeners(0);
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0, empty_options_);
+  handler_->stopListeners(0, {});
   handler_->removeListeners(0);
 }
 
@@ -677,18 +676,18 @@ TEST_F(ConnectionHandlerTest, RemoveListenerWithMultiAddrs) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0, empty_options_);
+  handler_->stopListeners(0, {});
   handler_->removeListeners(0);
 
   EXPECT_CALL(*listener1, onDestroy());
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList()).Times(2);
   handler_->removeListeners(1);
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0, empty_options_);
+  handler_->stopListeners(0, {});
   handler_->removeListeners(0);
 }
 
@@ -815,10 +814,10 @@ TEST_F(ConnectionHandlerTest, StopAndDisableStoppedListener) {
   handler_->addListener(absl::nullopt, *test_listener, runtime_);
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
 
   // Test stop a stopped listener.
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
 
   // Test disable a stopped listener.
   handler_->disableListeners();
@@ -1157,7 +1156,7 @@ TEST_F(ConnectionHandlerTest, MatchLatestListener) {
   // This emulated the case of update listener in-place. Stop the old listener and
   // add the new listener.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2, empty_options_);
+  handler_->stopListeners(2, {});
   handler_->addListener(absl::nullopt, *test_listener3, runtime_);
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
@@ -1221,7 +1220,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedListener) {
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2, empty_options_);
+  handler_->stopListeners(2, {});
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -1281,7 +1280,7 @@ TEST_F(ConnectionHandlerTest, EnsureNotMatchStoppedAnyAddressListener) {
 
   // Stop the listener2.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2, empty_options_);
+  handler_->stopListeners(2, {});
 
   Network::MockListenerFilter* test_filter = new Network::MockListenerFilter();
   EXPECT_CALL(*test_filter, destroy_());
@@ -2404,7 +2403,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveFilterChainCalledAfterListenerIsR
   EXPECT_EQ(1UL, TestUtility::findGauge(stats_store_, "test.downstream_cx_active")->value());
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(listener_tag, empty_options_);
+  handler_->stopListeners(listener_tag, {});
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   EXPECT_CALL(*access_log_, log(_, _, _, _, _));
@@ -2456,18 +2455,18 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveListener) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0, empty_options_);
+  handler_->stopListeners(0, {});
   handler_->removeListeners(0);
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
   EXPECT_EQ(0UL, handler_->numConnections());
 
   // Test stop/remove of not existent listener.
-  handler_->stopListeners(0, empty_options_);
+  handler_->stopListeners(0, {});
   handler_->removeListeners(0);
 }
 
@@ -2488,7 +2487,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveIpv6AnyAddressWithIpv4CompatListe
   EXPECT_EQ(0UL, handler_->numConnections());
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
@@ -2517,7 +2516,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveIpv4CompatAddressListener) {
   EXPECT_EQ(0UL, handler_->numConnections());
 
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
@@ -2560,7 +2559,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveWithBothIpv4AnyAndIpv6Any) {
 
   // Remove Listener1 first.
   EXPECT_CALL(*listener, onDestroy());
-  handler_->stopListeners(1, empty_options_);
+  handler_->stopListeners(1, {});
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(1);
@@ -2571,7 +2570,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveWithBothIpv4AnyAndIpv6Any) {
 
   // Now remove Listener2.
   EXPECT_CALL(*listener2, onDestroy());
-  handler_->stopListeners(2, empty_options_);
+  handler_->stopListeners(2, {});
 
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   handler_->removeListeners(2);

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -23,7 +23,8 @@ using HotRestartMessage = envoy::HotRestartMessage;
 class HotRestartingParentTest : public testing::Test {
 public:
   NiceMock<MockInstance> server_;
-  HotRestartingParent::Internal hot_restarting_parent_{&server_};
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  HotRestartingParent::Internal hot_restarting_parent_{&server_, dispatcher_};
 };
 
 TEST_F(HotRestartingParentTest, ShutdownAdmin) {

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -298,8 +298,18 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
   }
 }
 
+MATCHER_P(UdpPacketHandlerPtrIs, expected_handler, "") {
+  bool matched = arg->non_dispatched_udp_packet_handler_.ptr() == expected_handler;
+  if (!matched) {
+    *result_listener << "\n&non_dispatched_udp_packet_handler_ == "
+                     << arg->non_dispatched_udp_packet_handler_.ptr()
+                     << "\nexpected_handler == " << expected_handler;
+  }
+  return matched;
+}
+
 TEST_F(HotRestartingParentTest, DrainListeners) {
-  EXPECT_CALL(server_, drainListeners(_));
+  EXPECT_CALL(server_, drainListeners(UdpPacketHandlerPtrIs(&hot_restarting_parent_)));
   hot_restarting_parent_.drainListeners();
 }
 

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -298,7 +298,7 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
 }
 
 TEST_F(HotRestartingParentTest, DrainListeners) {
-  EXPECT_CALL(server_, drainListeners());
+  EXPECT_CALL(server_, drainListeners(_));
   hot_restarting_parent_.drainListeners();
 }
 

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -99,15 +99,16 @@ TEST_F(WorkerImplTest, BasicFlow) {
       absl::nullopt, listener2, [&ci]() -> void { ci.setReady(); }, runtime_);
   ci.waitReady();
 
-  EXPECT_CALL(*handler_, stopListeners(2))
+  EXPECT_CALL(*handler_, stopListeners(2, _))
       .WillOnce(InvokeWithoutArgs([current_thread_id, &ci]() -> void {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
         ci.setReady();
       }));
 
   ConditionalInitializer ci2;
+  Network::ExtraShutdownListenerOptions empty_options;
   // Verify that callback is called from the other thread.
-  worker_.stopListener(listener2, [current_thread_id, &ci2]() {
+  worker_.stopListener(listener2, empty_options, [current_thread_id, &ci2]() {
     EXPECT_NE(current_thread_id, std::this_thread::get_id());
     ci2.setReady();
   });

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -106,9 +106,8 @@ TEST_F(WorkerImplTest, BasicFlow) {
       }));
 
   ConditionalInitializer ci2;
-  Network::ExtraShutdownListenerOptions empty_options;
   // Verify that callback is called from the other thread.
-  worker_.stopListener(listener2, empty_options, [current_thread_id, &ci2]() {
+  worker_.stopListener(listener2, {}, [current_thread_id, &ci2]() {
     EXPECT_NE(current_thread_id, std::this_thread::get_id());
     ci2.setReady();
   });


### PR DESCRIPTION
Commit Message: Register HotRestartingParent as udp forwarding packet recipient
Additional Description: When listeners start draining during hot restart, pass them a reference to HotRestartingParent so that ActiveQuicListeners can forward non-routable UDP packets to the child instance.
Risk Level: Low, no behaviors are actually changed yet.
Testing: Existing coverage should cover all touched paths (except the TODO one).
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
