### PR TITLE
router: switch to use new QueryParametersMulti type

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -632,7 +632,8 @@ message RouteMatch {
   // match. The router will check the query string from the ``path`` header
   // against all the specified query parameters. If the number of specified
   // query parameters is nonzero, they all must match the ``path`` header's
-  // query string for a match to occur.
+  // query string for a match to occur.  In the event query parameters are
+  // repeated, only the first value for each key will be considered.
   //
   // .. note::
   //

--- a/envoy/http/query_params.h
+++ b/envoy/http/query_params.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <map>
-#include <optional>
 #include <string>
 #include <vector>
 
 #include "absl/container/btree_map.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include "header_map.h"
 
 namespace Envoy {
@@ -30,7 +30,7 @@ public:
   void overwrite(absl::string_view key, absl::string_view value);
   std::string toString();
   std::string replaceQueryString(const HeaderString& path);
-  std::optional<std::string> get_first_value(absl::string_view key) const;
+  absl::optional<std::string> get_first_value(absl::string_view key) const;
 
   const absl::btree_map<std::string, std::vector<std::string>>& data() { return data_; }
 

--- a/envoy/http/query_params.h
+++ b/envoy/http/query_params.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,7 @@ public:
   void overwrite(absl::string_view key, absl::string_view value);
   std::string toString();
   std::string replaceQueryString(const HeaderString& path);
+  std::optional<std::string> get_first_value(absl::string_view key) const;
 
   const absl::btree_map<std::string, std::vector<std::string>>& data() { return data_; }
 

--- a/envoy/http/query_params.h
+++ b/envoy/http/query_params.h
@@ -30,7 +30,7 @@ public:
   void overwrite(absl::string_view key, absl::string_view value);
   std::string toString();
   std::string replaceQueryString(const HeaderString& path);
-  absl::optional<std::string> get_first_value(absl::string_view key) const;
+  absl::optional<std::string> getFirstValue(absl::string_view key) const;
 
   const absl::btree_map<std::string, std::vector<std::string>>& data() { return data_; }
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -610,8 +610,7 @@ void Utility::QueryParamsMulti::overwrite(absl::string_view key, absl::string_vi
   this->data_[key] = std::vector<std::string>{std::string(value)};
 }
 
-absl::optional<std::string>
-Utility::QueryParamsMulti::get_first_value(absl::string_view key) const {
+absl::optional<std::string> Utility::QueryParamsMulti::getFirstValue(absl::string_view key) const {
   auto it = this->data_.find(key);
   if (it == this->data_.end()) {
     return std::nullopt;

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -3,6 +3,7 @@
 #include <http_parser.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -607,6 +608,15 @@ void Utility::QueryParamsMulti::add(absl::string_view key, absl::string_view val
 
 void Utility::QueryParamsMulti::overwrite(absl::string_view key, absl::string_view value) {
   this->data_[key] = std::vector<std::string>{std::string(value)};
+}
+
+std::optional<std::string> Utility::QueryParamsMulti::get_first_value(absl::string_view key) const {
+  auto it = this->data_.find(key);
+  if (it == this->data_.end()) {
+    return std::nullopt;
+  }
+
+  return std::optional<std::string>{it->second.at(0)};
 }
 
 absl::string_view Utility::findQueryStringStart(const HeaderString& path) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -3,7 +3,6 @@
 #include <http_parser.h>
 
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -33,6 +32,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include "quiche/http2/adapter/http2_protocol.h"
 
 namespace Envoy {
@@ -610,13 +610,14 @@ void Utility::QueryParamsMulti::overwrite(absl::string_view key, absl::string_vi
   this->data_[key] = std::vector<std::string>{std::string(value)};
 }
 
-std::optional<std::string> Utility::QueryParamsMulti::get_first_value(absl::string_view key) const {
+absl::optional<std::string>
+Utility::QueryParamsMulti::get_first_value(absl::string_view key) const {
   auto it = this->data_.find(key);
   if (it == this->data_.end()) {
     return std::nullopt;
   }
 
-  return std::optional<std::string>{it->second.at(0)};
+  return absl::optional<std::string>{it->second.at(0)};
 }
 
 absl::string_view Utility::findQueryStringStart(const HeaderString& path) {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -791,8 +791,8 @@ bool RouteEntryImplBase::matchRoute(const Http::RequestHeaderMap& headers,
     return false;
   }
   if (!config_query_parameters_.empty()) {
-    Http::Utility::QueryParams query_parameters =
-        Http::Utility::parseQueryString(headers.getPathValue());
+    auto query_parameters =
+        Http::Utility::QueryParamsMulti::parseQueryString(headers.getPathValue());
     matches &= ConfigUtility::matchQueryParams(query_parameters, config_query_parameters_);
     if (!matches) {
       return false;

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -38,16 +38,19 @@ ConfigUtility::QueryParameterMatcher::QueryParameterMatcher(
     : name_(config.name()), matcher_(maybeCreateStringMatcher(config)) {}
 
 bool ConfigUtility::QueryParameterMatcher::matches(
-    const Http::Utility::QueryParams& request_query_params) const {
-  auto query_param = request_query_params.find(name_);
-  if (query_param == request_query_params.end()) {
+    const Http::Utility::QueryParamsMulti& request_query_params) const {
+  // The docs specify that only the first instance of the query parameter should be matched
+  auto data = request_query_params.get_first_value(name_);
+  if (!data.has_value()) {
     return false;
-  } else if (!matcher_.has_value()) {
-    // Present match.
-    return true;
-  } else {
-    return matcher_.value().match(query_param->second);
   }
+
+  if (!matcher_.has_value()) {
+    // Present check
+    return true;
+  }
+
+  return matcher_.value().match(data.value());
 }
 
 Upstream::ResourcePriority
@@ -63,7 +66,7 @@ ConfigUtility::parsePriority(const envoy::config::core::v3::RoutingPriority& pri
 }
 
 bool ConfigUtility::matchQueryParams(
-    const Http::Utility::QueryParams& query_params,
+    const Http::Utility::QueryParamsMulti& query_params,
     const std::vector<QueryParameterMatcherPtr>& config_query_params) {
   for (const auto& config_query_param : config_query_params) {
     if (!config_query_param->matches(query_params)) {

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -40,7 +40,7 @@ ConfigUtility::QueryParameterMatcher::QueryParameterMatcher(
 bool ConfigUtility::QueryParameterMatcher::matches(
     const Http::Utility::QueryParamsMulti& request_query_params) const {
   // The docs specify that only the first instance of the query parameter should be matched
-  auto data = request_query_params.get_first_value(name_);
+  auto data = request_query_params.getFirstValue(name_);
   if (!data.has_value()) {
     return false;
   }

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -39,7 +39,7 @@ ConfigUtility::QueryParameterMatcher::QueryParameterMatcher(
 
 bool ConfigUtility::QueryParameterMatcher::matches(
     const Http::Utility::QueryParamsMulti& request_query_params) const {
-  // The docs specify that only the first instance of the query parameter should be matched
+  // This preserves the legacy behavior of ignoring all but the first value for a given key
   auto data = request_query_params.getFirstValue(name_);
   if (!data.has_value()) {
     return false;

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -39,7 +39,7 @@ public:
      * @param request_query_params supplies the parsed query parameters from a request.
      * @return bool true if a match for this QueryParameterMatcher exists in request_query_params.
      */
-    bool matches(const Http::Utility::QueryParams& request_query_params) const;
+    bool matches(const Http::Utility::QueryParamsMulti& request_query_params) const;
 
   private:
     const std::string name_;
@@ -62,7 +62,7 @@ public:
    * @return bool true if all the query params (and values) in the config_params are found in the
    *         query_params
    */
-  static bool matchQueryParams(const Http::Utility::QueryParams& query_params,
+  static bool matchQueryParams(const Http::Utility::QueryParamsMulti& query_params,
                                const std::vector<QueryParameterMatcherPtr>& config_query_params);
 
   /**

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -257,8 +257,8 @@ QueryParameterValueMatchAction::QueryParameterValueMatchAction(
 bool QueryParameterValueMatchAction::populateDescriptor(
     RateLimit::DescriptorEntry& descriptor_entry, const std::string&,
     const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo&) const {
-  Http::Utility::QueryParams query_parameters =
-      Http::Utility::parseAndDecodeQueryString(headers.getPathValue());
+  Http::Utility::QueryParamsMulti query_parameters =
+      Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(headers.getPathValue());
   if (expect_match_ ==
       ConfigUtility::matchQueryParams(query_parameters, action_query_parameters_)) {
     descriptor_entry = {descriptor_key_, descriptor_value_};

--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -42,8 +42,8 @@ public:
 
     matches &= Http::HeaderUtility::matchHeaders(headers, config_headers_);
     if (!config_query_parameters_.empty()) {
-      Http::Utility::QueryParams query_parameters =
-          Http::Utility::parseQueryString(headers.getPathValue());
+      Http::Utility::QueryParamsMulti query_parameters =
+          Http::Utility::QueryParamsMulti::parseQueryString(headers.getPathValue());
       matches &= ConfigUtility::matchQueryParams(query_parameters, config_query_parameters_);
     }
     return matches;

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -298,9 +298,9 @@ TEST(HttpUtility, testQueryParamModification) {
   EXPECT_EQ(params.toString(), "?a=1&a=2&b=3&c=4");
   params.overwrite("b", "foo");
   EXPECT_EQ(params.toString(), "?a=1&a=2&b=foo&c=4");
-  EXPECT_EQ(params.get_first_value("a").value(), "1");
-  EXPECT_EQ(params.get_first_value("b").value(), "foo");
-  EXPECT_FALSE(params.get_first_value("d").has_value());
+  EXPECT_EQ(params.getFirstValue("a").value(), "1");
+  EXPECT_EQ(params.getFirstValue("b").value(), "foo");
+  EXPECT_FALSE(params.getFirstValue("d").has_value());
   params.remove("b");
   EXPECT_EQ(params.toString(), "?a=1&a=2&c=4");
   params.overwrite("a", "bar");

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -298,6 +298,9 @@ TEST(HttpUtility, testQueryParamModification) {
   EXPECT_EQ(params.toString(), "?a=1&a=2&b=3&c=4");
   params.overwrite("b", "foo");
   EXPECT_EQ(params.toString(), "?a=1&a=2&b=foo&c=4");
+  EXPECT_EQ(params.get_first_value("a").value(), "1");
+  EXPECT_EQ(params.get_first_value("b").value(), "foo");
+  EXPECT_FALSE(params.get_first_value("d").has_value());
   params.remove("b");
   EXPECT_EQ(params.toString(), "?a=1&a=2&c=4");
   params.overwrite("a", "bar");

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2716,6 +2716,20 @@ virtual_hosts:
               config.route(headers, 0)->routeEntry()->clusterName());
   }
 
+  { // Repeated parameter - match should only track the first, and match
+    Http::TestRequestHeaderMapImpl headers =
+        genHeaders("example.com", "/?debug3=foo&debug3=bar", "GET");
+    EXPECT_EQ("local_service_with_string_match_query_parameter",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+
+  { // Repeated parameter - match should only track the first, and not match
+    Http::TestRequestHeaderMapImpl headers =
+        genHeaders("example.com", "/?debug3=bar&debug3=foo", "GET");
+    EXPECT_EQ("local_service_without_query_parameters",
+              config.route(headers, 0)->routeEntry()->clusterName());
+  }
+
   {
     Http::TestRequestHeaderMapImpl headers = genHeaders("example.com", "/?debug=2", "GET");
     EXPECT_EQ("local_service_with_valueless_query_parameter",


### PR DESCRIPTION
Commit Message:

router: switch from old QueryParams type to new QueryParamsMulti type

Additional Description:

This PR is follow-up work I promised @ggreenway as part of #28788 in [this comment chain](https://github.com/envoyproxy/envoy/pull/28788#issuecomment-1664328670).

It switches the router from the old `QueryParams` type to the replacement `QueryParamsMulti` type.

How the router handles repeating query parameters is actually specified [in the docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/matcher/v3/http_inputs.proto#type-matcher-v3-httprequestqueryparammatchinput):

> The resulting input string will be the first query parameter for the value ‘query_param’.

I preserved this functionality in the cutover.  At some point in the future I might file a PR to add an matcher option to allow matching any instance of the query parameter, but one thing at a time. 

To make this easier, and to set myself up for further cutovers, I added a `get_first_value` method to the `QueryParamsMulti` type.  It returns an `optional<string>`.

Risk Level: Low

Testing: 

* Added unit tests around the new class method
* Old router tests still work
* Added new router tests to ensure that the behavior specified in the docs is preserved

Docs Changes: N/A (user-visible behavior doesn't change)
Release Notes: N/A
Platform Specific Features: N/A