### PR TITLE
test: fix contention in HttpIntegrationTest::testLargeRequestHeaders

### DIFF
--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -99,9 +99,11 @@ void AutonomousStream::sendResponse() {
 AutonomousHttpConnection::AutonomousHttpConnection(AutonomousUpstream& autonomous_upstream,
                                                    SharedConnectionWrapper& shared_connection,
                                                    Http::CodecType type,
+                                                   uint32_t max_request_headers_kb,
+                                                   uint32_t max_request_headers_count,
                                                    AutonomousUpstream& upstream)
     : FakeHttpConnection(autonomous_upstream, shared_connection, type, upstream.timeSystem(),
-                         Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,
+                         max_request_headers_kb, max_request_headers_count,
                          envoy::config::core::v3::HttpProtocolOptions::ALLOW),
       upstream_(upstream) {}
 
@@ -122,8 +124,9 @@ AutonomousUpstream::~AutonomousUpstream() {
 bool AutonomousUpstream::createNetworkFilterChain(Network::Connection& connection,
                                                   const Filter::NetworkFilterFactoriesList&) {
   shared_connections_.emplace_back(new SharedConnectionWrapper(connection));
-  AutonomousHttpConnectionPtr http_connection(
-      new AutonomousHttpConnection(*this, *shared_connections_.back(), http_type_, *this));
+  AutonomousHttpConnectionPtr http_connection(new AutonomousHttpConnection(
+      *this, *shared_connections_.back(), http_type_, config().max_request_headers_kb_,
+      config().max_request_headers_count_, *this));
   http_connection->initialize();
   http_connections_.push_back(std::move(http_connection));
   return true;

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -46,6 +46,7 @@ class AutonomousHttpConnection : public FakeHttpConnection {
 public:
   AutonomousHttpConnection(AutonomousUpstream& autonomous_upstream,
                            SharedConnectionWrapper& shared_connection, Http::CodecType type,
+                           uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
                            AutonomousUpstream& upstream);
 
   Http::RequestDecoder& newStream(Http::ResponseEncoder& response_encoder, bool) override;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -766,6 +766,8 @@ public:
   absl::Mutex& lock() { return lock_; }
 
 protected:
+  const FakeUpstreamConfig& config() const { return config_; }
+
   Stats::IsolatedStoreImpl stats_store_;
   const Http::CodecType http_type_;
 


### PR DESCRIPTION
Commit Message: it's a potential fix to https://github.com/envoyproxy/envoy/issues/29191#issuecomment-1702384740. No matter whether it fixes the issue or not, it should improve test speed under TSAN.

Risk Level: low, test only
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #29191