### PR TITLE
UHV: add global runtime key for toggling UHV on/off

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -116,6 +116,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_refresh_rtt_after_request);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 // TODO(adisuissa): enable by default once this is tested in prod.
 FALSE_RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
+// TODO(yanavlasov) change to true when UHV is sufficently tested
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_header_validator);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -133,6 +133,10 @@ createHeaderValidatorFactory([[maybe_unused]] const envoy::extensions::filters::
 
   Http::HeaderValidatorFactoryPtr header_validator_factory;
 #ifdef ENVOY_ENABLE_UHV
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_header_validator")) {
+    // This will cause codecs to use legacy header validation and path normalization
+    return nullptr;
+  }
   ::envoy::config::core::v3::TypedExtensionConfig legacy_header_validator_config;
   if (!config.has_typed_header_validation_config()) {
     // If header validator is not configured ensure that the defaults match Envoy's original

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -109,6 +109,10 @@ Envoy::Http::HeaderValidatorFactoryPtr createHeaderValidatorFactory(
 
   Envoy::Http::HeaderValidatorFactoryPtr header_validator_factory;
 #ifdef ENVOY_ENABLE_UHV
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_header_validator")) {
+    // This will cause codecs to use legacy header validation and path normalization
+    return nullptr;
+  }
   ::envoy::config::core::v3::TypedExtensionConfig legacy_header_validator_config;
   if (!options.has_header_validation_config()) {
     // If header validator is not configured ensure that the defaults match Envoy's original

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -3028,6 +3028,9 @@ TEST_F(HttpConnectionManagerConfigTest, HeaderValidatorConfig) {
       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   )EOF";
 
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_header_validator", "true"}});
+
   TestHeaderValidatorFactoryConfig factory;
   Registry::InjectFactory<Http::HeaderValidatorFactoryConfig> registration(factory);
   EXPECT_CALL(context_.runtime_loader_.snapshot_, featureEnabled(_, An<uint64_t>()))
@@ -3064,6 +3067,8 @@ TEST_F(HttpConnectionManagerConfigTest, DefaultHeaderValidatorConfig) {
       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   )EOF";
 
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_header_validator", "true"}});
   ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig
       proto_config;
   DefaultHeaderValidatorFactoryConfigOverride factory(proto_config);
@@ -3108,8 +3113,9 @@ TEST_F(HttpConnectionManagerConfigTest, TranslateLegacyConfigToDefaultHeaderVali
       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   )EOF";
 
-  // Make sure the http_reject_path_with_fragment runtime value is reflected in config
   TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_header_validator", "true"}});
+  // Make sure the http_reject_path_with_fragment runtime value is reflected in config
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.http_reject_path_with_fragment", "false"}});
 

--- a/test/extensions/upstreams/http/BUILD
+++ b/test/extensions/upstreams/http/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test(
         "//test/mocks/http:header_validator_mocks",
         "//test/mocks/server:instance_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -792,7 +792,7 @@ envoy_cc_test(
     ],
     # As this test has many H1/H2/v4/v6 tests it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
-    shard_count = 8,
+    shard_count = 16,
     tags = [
         "cpu:3",
     ],

--- a/test/integration/default_header_validator_integration_test.cc
+++ b/test/integration/default_header_validator_integration_test.cc
@@ -135,25 +135,25 @@ TEST_P(DownstreamUhvIntegrationTest, BackslashInUriPathConversionWithUhvOverride
                                      {":path", "/path\\with%5Cback%5Cslashes"},
                                      {":scheme", "http"},
                                      {":authority", "host"}});
-#ifdef ENVOY_ENABLE_UHV
-  // By default Envoy disconnects connection on protocol errors
-  ASSERT_TRUE(codec_client_->waitForDisconnect());
-  if (downstream_protocol_ != Http::CodecType::HTTP2) {
-    ASSERT_TRUE(response->complete());
-    EXPECT_EQ("400", response->headers().getStatusValue());
+  if (use_header_validator_) {
+    // By default Envoy disconnects connection on protocol errors
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+    if (downstream_protocol_ != Http::CodecType::HTTP2) {
+      ASSERT_TRUE(response->complete());
+      EXPECT_EQ("400", response->headers().getStatusValue());
+    } else {
+      ASSERT_TRUE(response->reset());
+      EXPECT_EQ(Http::StreamResetReason::ConnectionTermination, response->resetReason());
+    }
   } else {
-    ASSERT_TRUE(response->reset());
-    EXPECT_EQ(Http::StreamResetReason::ConnectionTermination, response->resetReason());
+    waitForNextUpstreamRequest();
+
+    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path/with%5Cback%5Cslashes");
+
+    // Send a headers only response.
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+    ASSERT_TRUE(response->waitForEndStream());
   }
-#else
-  waitForNextUpstreamRequest();
-
-  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path/with%5Cback%5Cslashes");
-
-  // Send a headers only response.
-  upstream_request_->encodeHeaders(default_response_headers_, true);
-  ASSERT_TRUE(response->waitForEndStream());
-#endif
 }
 
 // By default the `allow_non_compliant_characters_in_path` == true and UHV behaves just like legacy
@@ -222,11 +222,11 @@ TEST_P(DownstreamUhvIntegrationTest, UrlEncodedTripletsCasePreservedWithUhvOverr
                                      {":authority", "host"}});
   waitForNextUpstreamRequest();
 
-#ifdef ENVOY_ENABLE_UHV
-  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path/with%3Bmixed%5Ccase%FEsequences");
-#else
-  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path/with%3bmixed%5Ccase%Fesequences");
-#endif
+  if (use_header_validator_) {
+    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path/with%3Bmixed%5Ccase%FEsequences");
+  } else {
+    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path/with%3bmixed%5Ccase%Fesequences");
+  }
   // Send a headers only response.
   upstream_request_->encodeHeaders(default_response_headers_, true);
   ASSERT_TRUE(response->waitForEndStream());
@@ -375,25 +375,25 @@ TEST_P(DownstreamUhvIntegrationTest, MalformedUrlEncodedTripletsRejectedWithUhvO
                                      {":path", "/path%Z%30with%XYbad%7Jencoding%A"},
                                      {":scheme", "http"},
                                      {":authority", "host"}});
-#ifdef ENVOY_ENABLE_UHV
-  // By default Envoy disconnects connection on protocol errors
-  ASSERT_TRUE(codec_client_->waitForDisconnect());
-  if (downstream_protocol_ != Http::CodecType::HTTP2) {
-    ASSERT_TRUE(response->complete());
-    EXPECT_EQ("400", response->headers().getStatusValue());
+  if (use_header_validator_) {
+    // By default Envoy disconnects connection on protocol errors
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+    if (downstream_protocol_ != Http::CodecType::HTTP2) {
+      ASSERT_TRUE(response->complete());
+      EXPECT_EQ("400", response->headers().getStatusValue());
+    } else {
+      ASSERT_TRUE(response->reset());
+      EXPECT_EQ(Http::StreamResetReason::ConnectionTermination, response->resetReason());
+    }
   } else {
-    ASSERT_TRUE(response->reset());
-    EXPECT_EQ(Http::StreamResetReason::ConnectionTermination, response->resetReason());
+    waitForNextUpstreamRequest();
+
+    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%Z0with%XYbad%7Jencoding%A");
+
+    // Send a headers only response.
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+    ASSERT_TRUE(response->waitForEndStream());
   }
-#else
-  waitForNextUpstreamRequest();
-
-  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%Z0with%XYbad%7Jencoding%A");
-
-  // Send a headers only response.
-  upstream_request_->encodeHeaders(default_response_headers_, true);
-  ASSERT_TRUE(response->waitForEndStream());
-#endif
 }
 
 // By default the `uhv_allow_malformed_url_encoding` == true and UHV behaves just like legacy path
@@ -455,20 +455,20 @@ TEST_P(DownstreamUhvIntegrationTest, UhvAllowsPercent00WithOverride) {
                                      {":path", "/path%00/to/something"},
                                      {":scheme", "http"},
                                      {":authority", "host"}});
-#ifdef ENVOY_ENABLE_UHV
-  waitForNextUpstreamRequest();
+  if (use_header_validator_) {
+    waitForNextUpstreamRequest();
 
-  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%00/to/something");
+    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%00/to/something");
 
-  // Send a headers only response.
-  upstream_request_->encodeHeaders(default_response_headers_, true);
-  ASSERT_TRUE(response->waitForEndStream());
-#else
-  // In legacy mode %00 in URL path always causes request to be rejected
-  ASSERT_TRUE(response->waitForEndStream());
-  ASSERT_TRUE(response->complete());
-  EXPECT_EQ("400", response->headers().getStatusValue());
-#endif
+    // Send a headers only response.
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+    ASSERT_TRUE(response->waitForEndStream());
+  } else {
+    // In legacy mode %00 in URL path always causes request to be rejected
+    ASSERT_TRUE(response->waitForEndStream());
+    ASSERT_TRUE(response->complete());
+    EXPECT_EQ("400", response->headers().getStatusValue());
+  }
 }
 
 } // namespace Envoy

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -24,12 +24,13 @@ namespace Envoy {
 namespace {
 
 std::string ipSuppressEnvoyHeadersTestParamsToString(
-    const ::testing::TestParamInfo<std::tuple<Network::Address::IpVersion, bool>>& params) {
+    const ::testing::TestParamInfo<std::tuple<Network::Address::IpVersion, bool, bool>>& params) {
   return fmt::format(
-      "{}_{}",
+      "{}_{}_{}",
       TestUtility::ipTestParamsToString(
           ::testing::TestParamInfo<Network::Address::IpVersion>(std::get<0>(params.param), 0)),
-      std::get<1>(params.param) ? "with_x_envoy_from_router" : "without_x_envoy_from_router");
+      std::get<1>(params.param) ? "with_x_envoy_from_router" : "without_x_envoy_from_router",
+      std::get<2>(params.param) ? "with_UHV" : "without_UHV");
 }
 
 void disableHeaderValueOptionAppend(
@@ -178,7 +179,7 @@ route_config:
 } // namespace
 
 class HeaderIntegrationTest
-    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, bool>>,
+    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, bool, bool>>,
       public HttpIntegrationTest {
 public:
   HeaderIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, std::get<0>(GetParam())) {}
@@ -422,6 +423,9 @@ public:
       };
     }
 
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator",
+                                      std::get<2>(GetParam()) ? "true" : "false");
+
     HttpIntegrationTest::initialize();
   }
 
@@ -464,10 +468,19 @@ protected:
   FakeStreamPtr eds_stream_;
 };
 
+#ifdef ENVOY_ENABLE_UHV
 INSTANTIATE_TEST_SUITE_P(
     IpVersionsSuppressEnvoyHeaders, HeaderIntegrationTest,
-    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool()),
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool(),
+                     testing::Bool(true)),
     ipSuppressEnvoyHeadersTestParamsToString);
+#else
+INSTANTIATE_TEST_SUITE_P(
+    IpVersionsSuppressEnvoyHeaders, HeaderIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool(),
+                     testing::Values(false)),
+    ipSuppressEnvoyHeadersTestParamsToString);
+#endif
 
 TEST_P(HeaderIntegrationTest, WeightedClusterWithClusterHeader) {
   config_helper_.addConfigModifier(

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -51,6 +51,7 @@ std::string testParamsToString(
 // destructor stops Envoy the SocketInterfaceSwap destructor needs to run after it. This order of
 // multiple inheritance ensures that SocketInterfaceSwap destructor runs after
 // Http2FrameIntegrationTest destructor completes.
+// TODO(#28841) parameterise to run with and without UHV
 class Http2FloodMitigationTest
     : public SocketInterfaceSwap,
       public testing::TestWithParam<std::tuple<Network::Address::IpVersion, Http2Impl, bool>>,
@@ -1113,6 +1114,9 @@ TEST_P(Http2FloodMitigationTest, WindowUpdate) {
 
 // Verify that the HTTP/2 connection is terminated upon receiving invalid HEADERS frame.
 TEST_P(Http2FloodMitigationTest, ZerolenHeader) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   beginSession();
 
@@ -1232,6 +1236,9 @@ TEST_P(Http2FloodMitigationTest, UpstreamEmptyHeaders) {
 
 // Verify that the HTTP/2 connection is terminated upon receiving invalid HEADERS frame.
 TEST_P(Http2FloodMitigationTest, UpstreamZerolenHeader) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   initializeUpstreamFloodTest();
   // Send client request which will send an upstream request.
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1254,6 +1261,9 @@ TEST_P(Http2FloodMitigationTest, UpstreamZerolenHeader) {
 
 // Verify that the HTTP/2 connection is terminated upon receiving invalid HEADERS frame.
 TEST_P(Http2FloodMitigationTest, UpstreamZerolenHeaderAllowed) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() >= 1, "");

--- a/test/integration/http_protocol_integration.cc
+++ b/test/integration/http_protocol_integration.cc
@@ -33,12 +33,20 @@ std::vector<HttpProtocolTestParams> HttpProtocolIntegrationTest::getProtocolTest
           defer_processing_values.push_back(true);
         }
 
+        std::vector<bool> use_header_validator_values;
+#ifdef ENVOY_ENABLE_UHV
+        use_header_validator_values.push_back(true);
+#else
+        use_header_validator_values.push_back(false);
+#endif
         for (Http1ParserImpl http1_implementation : http1_implementations) {
           for (Http2Impl http2_implementation : http2_implementations) {
             for (bool defer_processing : defer_processing_values) {
-              ret.push_back(HttpProtocolTestParams{ip_version, downstream_protocol,
-                                                   upstream_protocol, http1_implementation,
-                                                   http2_implementation, defer_processing});
+              for (bool use_header_validator : use_header_validator_values) {
+                ret.push_back(HttpProtocolTestParams{
+                    ip_version, downstream_protocol, upstream_protocol, http1_implementation,
+                    http2_implementation, defer_processing, use_header_validator});
+              }
             }
           }
         }
@@ -90,7 +98,8 @@ std::string HttpProtocolIntegrationTest::protocolTestParamsToString(
                       TestUtility::http1ParserImplToString(params.param.http1_implementation),
                       http2ImplementationToString(params.param.http2_implementation),
                       params.param.defer_processing_backedup_streams ? "WithDeferredProcessing"
-                                                                     : "NoDeferredProcessing");
+                                                                     : "NoDeferredProcessing",
+                      params.param.use_header_validator ? "Uhv" : "Legacy");
 }
 
 void HttpProtocolIntegrationTest::setUpstreamOverrideStreamErrorOnInvalidHttpMessage() {

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -14,6 +14,7 @@ struct HttpProtocolTestParams {
   Http1ParserImpl http1_implementation;
   Http2Impl http2_implementation;
   bool defer_processing_backedup_streams;
+  bool use_header_validator;
 };
 
 // Allows easy testing of Envoy code for HTTP/HTTP2 upstream/downstream.
@@ -70,12 +71,15 @@ public:
       : HttpIntegrationTest(
             GetParam().downstream_protocol, GetParam().version,
             ConfigHelper::httpProxyConfig(/*downstream_is_quic=*/GetParam().downstream_protocol ==
-                                          Http::CodecType::HTTP3)) {
+                                          Http::CodecType::HTTP3)),
+        use_header_validator_(GetParam().use_header_validator) {
     setupHttp1ImplOverrides(GetParam().http1_implementation);
     setupHttp2ImplOverrides(GetParam().http2_implementation);
     config_helper_.addRuntimeOverride(Runtime::defer_processing_backedup_streams,
                                       GetParam().defer_processing_backedup_streams ? "true"
                                                                                    : "false");
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator",
+                                      GetParam().use_header_validator ? "true" : "false");
   }
 
   void SetUp() override {
@@ -85,6 +89,9 @@ public:
 
   void setDownstreamOverrideStreamErrorOnInvalidHttpMessage();
   void setUpstreamOverrideStreamErrorOnInvalidHttpMessage();
+
+protected:
+  const bool use_header_validator_{false};
 };
 
 class UpstreamDownstreamIntegrationTest
@@ -101,6 +108,9 @@ public:
     config_helper_.addRuntimeOverride(
         Runtime::defer_processing_backedup_streams,
         std::get<0>(GetParam()).defer_processing_backedup_streams ? "true" : "false");
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator",
+                                      std::get<0>(GetParam()).use_header_validator ? "true"
+                                                                                   : "false");
   }
   static std::string testParamsToString(
       const ::testing::TestParamInfo<std::tuple<HttpProtocolTestParams, bool>>& params) {

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -854,6 +854,9 @@ TEST_P(IntegrationTest, UpstreamDisconnectWithTwoRequests) {
 }
 
 TEST_P(IntegrationTest, TestSmuggling) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   config_helper_.disableDelayClose();
   initialize();
 
@@ -915,6 +918,9 @@ TEST_P(IntegrationTest, TestSmuggling) {
 }
 
 TEST_P(IntegrationTest, TestInvalidTransferEncoding) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   config_helper_.disableDelayClose();
   initialize();
 
@@ -960,6 +966,9 @@ TEST_P(IntegrationTest, TestPipelinedResponses) {
 }
 
 TEST_P(IntegrationTest, TestServerAllowChunkedLength) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void {
@@ -994,6 +1003,9 @@ TEST_P(IntegrationTest, TestServerAllowChunkedLength) {
 }
 
 TEST_P(IntegrationTest, TestClientAllowChunkedLength) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
     if (fake_upstreams_[0]->httpType() == Http::CodecType::HTTP1) {
@@ -2170,6 +2182,9 @@ TEST_P(IntegrationTest, ConnectWithChunkedBody) {
 }
 
 TEST_P(IntegrationTest, ConnectWithTEChunked) {
+#ifdef ENVOY_ENABLE_UHV
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_header_validator", "true");
+#endif
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void { ConfigHelper::setConnectConfig(hcm, false, false); });

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -7,6 +7,7 @@
 
 // A test class for testing HTTP/1.1 upstream and downstreams
 namespace Envoy {
+// TODO(#28841) parameterise to run with and without UHV
 class IntegrationTest
     : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, Http1ParserImpl>>,
       public HttpIntegrationTest {
@@ -21,6 +22,7 @@ protected:
   const Http1ParserImpl http1_implementation_;
 };
 
+// TODO(#28841) parameterise to run with and without UHV
 class UpstreamEndpointIntegrationTest
     : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, Http1ParserImpl>>,
       public HttpIntegrationTest {

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -71,10 +71,10 @@ TEST_P(ProtocolIntegrationTest, ShutdownWithActiveConnPoolConnections) {
 }
 
 TEST_P(ProtocolIntegrationTest, LogicalDns) {
-#ifdef ENVOY_ENABLE_UHV
-  // TODO(#27132): auto_host_rewrite is broken for IPv6 and is failing UHV validation
-  return;
-#endif
+  if (use_header_validator_) {
+    // TODO(#27132): auto_host_rewrite is broken for IPv6 and is failing UHV validation
+    return;
+  }
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
     auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
@@ -3947,10 +3947,10 @@ TEST_P(ProtocolIntegrationTest, UpstreamDisconnectBeforeResponseCompleteWireByte
 TEST_P(DownstreamProtocolIntegrationTest, BadRequest) {
   config_helper_.disableDelayClose();
   // we only care about upstream protocol.
-#ifdef ENVOY_ENABLE_UHV
-  // permissive parsing is enabled
-  return;
-#endif
+  if (use_header_validator_) {
+    // permissive parsing is enabled
+    return;
+  }
 
   if (downstreamProtocol() != Http::CodecType::HTTP1) {
     return;
@@ -4032,10 +4032,10 @@ TEST_P(DownstreamProtocolIntegrationTest, ValidateUpstreamHeaders) {
 }
 
 TEST_P(ProtocolIntegrationTest, ValidateUpstreamMixedCaseHeaders) {
-#ifdef ENVOY_ENABLE_UHV
-  // UHV does not support this case so far.
-  return;
-#endif
+  if (use_header_validator_) {
+    // UHV does not support this case so far.
+    return;
+  }
   if (upstreamProtocol() != Http::CodecType::HTTP1) {
     autonomous_allow_incomplete_streams_ = true;
     autonomous_upstream_ = true;
@@ -4081,11 +4081,11 @@ TEST_P(ProtocolIntegrationTest, ValidateUpstreamMixedCaseHeaders) {
 }
 
 TEST_P(ProtocolIntegrationTest, ValidateUpstreamHeadersWithOverride) {
-#ifdef ENVOY_ENABLE_UHV
-  // UHV always validated headers before sending them upstream. This test is not applicable
-  // when UHV is enabled.
-  return;
-#endif
+  if (use_header_validator_) {
+    // UHV always validated headers before sending them upstream. This test is not applicable
+    // when UHV is enabled.
+    return;
+  }
   if (upstreamProtocol() == Http::CodecType::HTTP3) {
     testing_upstream_intentionally_ = true;
   }
@@ -4201,10 +4201,10 @@ TEST_P(ProtocolIntegrationTest, BufferContinue) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ContentLengthSmallerThanPayload) {
-#ifdef ENVOY_ENABLE_UHV
-  // UHV does not track consistency of content-length and amount of DATA in HTTP/2
-  return;
-#endif
+  if (use_header_validator_) {
+    // UHV does not track consistency of content-length and amount of DATA in HTTP/2
+    return;
+  }
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -4233,10 +4233,10 @@ TEST_P(DownstreamProtocolIntegrationTest, ContentLengthSmallerThanPayload) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ContentLengthLargerThanPayload) {
-#ifdef ENVOY_ENABLE_UHV
-  // UHV does not track consistency of content-length and amount of DATA in HTTP/2
-  return;
-#endif
+  if (use_header_validator_) {
+    // UHV does not track consistency of content-length and amount of DATA in HTTP/2
+    return;
+  }
 
   if (downstreamProtocol() == Http::CodecType::HTTP1) {
     // HTTP/1.x request rely on Content-Length header to determine payload length. So there is no
@@ -4613,20 +4613,20 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidSchemeHeaderWithWhitespace) {
                                      {":scheme", "/admin http"},
                                      {":authority", "sni.lyft.com"}});
 
-#ifdef ENVOY_ENABLE_UHV
-  if (downstreamProtocol() != Http::CodecType::HTTP1) {
-    ASSERT_TRUE(response->waitForReset());
-    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
-    return;
+  if (use_header_validator_) {
+    if (downstreamProtocol() != Http::CodecType::HTTP1) {
+      ASSERT_TRUE(response->waitForReset());
+      EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
+      return;
+    }
+  } else {
+    if (downstreamProtocol() == Http::CodecType::HTTP2 &&
+        GetParam().http2_implementation == Http2Impl::Nghttp2) {
+      ASSERT_TRUE(response->waitForReset());
+      EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
+      return;
+    }
   }
-#else
-  if (downstreamProtocol() == Http::CodecType::HTTP2 &&
-      GetParam().http2_implementation == Http2Impl::Nghttp2) {
-    ASSERT_TRUE(response->waitForReset());
-    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
-    return;
-  }
-#endif
   // Other HTTP codecs accept the bad scheme but the Envoy should replace it with a valid one.
   waitForNextUpstreamRequest();
   if (upstreamProtocol() == Http::CodecType::HTTP1) {
@@ -4674,14 +4674,15 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidTrailer) {
     ASSERT_TRUE(response->reset());
     EXPECT_EQ(Http::StreamResetReason::ConnectionTermination, response->resetReason());
   }
-#ifndef ENVOY_ENABLE_UHV
-  // TODO(#24620) UHV does not include the DPE prefix in the downstream protocol error reasons
-  if (downstreamProtocol() != Http::CodecType::HTTP3) {
-    // TODO(#24630) QUIC also does not include the DPE prefix in the downstream protocol error
-    // reasons
-    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
+
+  if (!use_header_validator_) {
+    // TODO(#24620) UHV does not include the DPE prefix in the downstream protocol error reasons
+    if (downstreamProtocol() != Http::CodecType::HTTP3) {
+      // TODO(#24630) QUIC also does not include the DPE prefix in the downstream protocol error
+      // reasons
+      EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
+    }
   }
-#endif
 }
 
 // Verify that stream is reset with invalid trailers, when configured.
@@ -4728,14 +4729,14 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidTrailerStreamError) {
   codec_client_->close();
   ASSERT_TRUE(response->reset());
   EXPECT_EQ(Http::StreamResetReason::RemoteReset, response->resetReason());
-#ifndef ENVOY_ENABLE_UHV
-  // TODO(#24620) UHV does not include the DPE prefix in the downstream protocol error reasons
-  if (downstreamProtocol() != Http::CodecType::HTTP3) {
-    // TODO(#24630) QUIC also does not include the DPE prefix in the downstream protocol error
-    // reasons
-    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
+  if (!use_header_validator_) {
+    // TODO(#24620) UHV does not include the DPE prefix in the downstream protocol error reasons
+    if (downstreamProtocol() != Http::CodecType::HTTP3) {
+      // TODO(#24630) QUIC also does not include the DPE prefix in the downstream protocol error
+      // reasons
+      EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
+    }
   }
-#endif
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, UnknownPseudoHeader) {
@@ -4756,15 +4757,15 @@ TEST_P(DownstreamProtocolIntegrationTest, UnknownPseudoHeader) {
                                      {":scheme", "http"},
                                      {":authority", "host"}});
   ASSERT_TRUE(response->waitForReset());
-#ifdef ENVOY_ENABLE_UHV
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
-#else
-  EXPECT_THAT(waitForAccessLog(access_log_name_),
-              HasSubstr((downstreamProtocol() == Http::CodecType::HTTP2 &&
-                         GetParam().http2_implementation == Http2Impl::Oghttp2)
-                            ? "violation"
-                            : "invalid"));
-#endif
+  if (use_header_validator_) {
+    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("invalid"));
+  } else {
+    EXPECT_THAT(waitForAccessLog(access_log_name_),
+                HasSubstr((downstreamProtocol() == Http::CodecType::HTTP2 &&
+                           GetParam().http2_implementation == Http2Impl::Oghttp2)
+                              ? "violation"
+                              : "invalid"));
+  }
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
Add parameter to HttpProtocolIntegrationTest based suites to run with UHV

The option to run tests with UHV is still behind the ENVOY_ENABLE_UHV flag

No impact on the production build.

Additional Description:
Not all tests that rely on UHV are parameterized in this PR to reduce its size. Followup PRs will be created.

Risk Level: Low, build flag protected
Testing: Unit tests
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: N/A
Runtime guard: envoy.reloadable_features.enable_header_validator
