### PR TITLE
filter manager: fix 200 on no_healthy_upstream

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -71,6 +71,10 @@ bug_fixes:
 - area: router check tool
   change: |
     Fixed a bug where the route coverage is not correctly calculated when a route has weighted clusters.
+- area: filter manager
+  change: |
+    Fixed a bug where immediate responses for no_healthy_upstream sent responding to a gRPC request contained a 200
+    status code.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -975,7 +975,8 @@ void DownstreamFilterManager::prepareLocalReplyViaFilterChain(
             local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), response_headers,
                                  streamInfo(), code, body, content_type);
           },
-          [this](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
+          [this, code](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
+            headers->setStatus(uint64_t(code));
             filter_manager_callbacks_.setResponseHeaders(std::move(headers));
             encodeHeaders(nullptr, filter_manager_callbacks_.responseHeaders().ref(), end_stream);
           },


### PR DESCRIPTION
Commit Message: A gRPC request which was routed to a cluster with no healthy upstreams would receive a response code of 200. The access logs showed the 200 alongside the response code details of no_healthy_upstream
Additional Description:
Risk Level: low
Testing: 
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue] #29052 
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
