### PR TITLE
golang extension: optimization: added noescape and nocallback directives for C functions.

### DIFF
--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -58,6 +58,15 @@ const (
 	ValueUpstreamRemoteAddress   = 10
 	ValueUpstreamClusterName     = 11
 	ValueVirtualClusterName      = 12
+
+	// NOTE: this is a trade-off value.
+	// When the number of header is less this value, we could use the slice on the stack,
+	// otherwise, we have to allocate a new slice on the heap,
+	// and the slice on the stack will be wasted.
+	// So, we choose a value that many requests' number of header is less than this value.
+	// But also, it should not be too large, otherwise it might be waste stack memory.
+	maxStackAllocedHeaderSize = 16
+	maxStackAllocedSliceLen   = maxStackAllocedHeaderSize * 2
 )
 
 type httpCApiImpl struct{}
@@ -124,9 +133,9 @@ func (c *httpCApiImpl) HttpGetHeader(r unsafe.Pointer, key *string, value *strin
 
 func (c *httpCApiImpl) HttpCopyHeaders(r unsafe.Pointer, num uint64, bytes uint64) map[string][]string {
 	var strs []string
-	if num <= 16 {
+	if num <= maxStackAllocedHeaderSize {
 		// NOTE: only const length slice may be allocated on stack.
-		strs = make([]string, 32)
+		strs = make([]string, maxStackAllocedSliceLen)
 	} else {
 		// TODO: maybe we could use a memory pool for better performance,
 		// since these go strings in strs, will be copied into the following map.
@@ -201,9 +210,9 @@ func (c *httpCApiImpl) HttpSetBufferHelper(r unsafe.Pointer, bufferPtr uint64, v
 
 func (c *httpCApiImpl) HttpCopyTrailers(r unsafe.Pointer, num uint64, bytes uint64) map[string][]string {
 	var strs []string
-	if num <= 16 {
+	if num <= maxStackAllocedHeaderSize {
 		// NOTE: only const length slice may be allocated on stack.
-		strs = make([]string, 32)
+		strs = make([]string, maxStackAllocedSliceLen)
 	} else {
 		// TODO: maybe we could use a memory pool for better performance,
 		// since these go strings in strs, will be copied into the following map.

--- a/contrib/golang/filters/http/source/go/pkg/http/cgo_go122.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/cgo_go122.go
@@ -1,0 +1,54 @@
+//go:build go1.22
+
+package http
+
+/*
+// This is a performance optimization.
+// The following noescape and nocallback directives are used to
+// prevent the Go compiler from allocating function parameters on the heap.
+
+#cgo noescape envoyGoFilterHttpCopyHeaders
+#cgo nocallback envoyGoFilterHttpCopyHeaders
+#cgo noescape envoyGoFilterHttpSendPanicReply
+#cgo nocallback envoyGoFilterHttpSendPanicReply
+#cgo noescape envoyGoFilterHttpGetHeader
+#cgo nocallback envoyGoFilterHttpGetHeader
+#cgo noescape envoyGoFilterHttpSetHeaderHelper
+#cgo nocallback envoyGoFilterHttpSetHeaderHelper
+#cgo noescape envoyGoFilterHttpRemoveHeader
+#cgo nocallback envoyGoFilterHttpRemoveHeader
+#cgo noescape envoyGoFilterHttpGetBuffer
+#cgo nocallback envoyGoFilterHttpGetBuffer
+#cgo noescape envoyGoFilterHttpSetBufferHelper
+#cgo nocallback envoyGoFilterHttpSetBufferHelper
+#cgo noescape envoyGoFilterHttpCopyTrailers
+#cgo nocallback envoyGoFilterHttpCopyTrailers
+#cgo noescape envoyGoFilterHttpSetTrailer
+#cgo nocallback envoyGoFilterHttpSetTrailer
+#cgo noescape envoyGoFilterHttpRemoveTrailer
+#cgo nocallback envoyGoFilterHttpRemoveTrailer
+#cgo noescape envoyGoFilterHttpGetStringValue
+#cgo nocallback envoyGoFilterHttpGetStringValue
+#cgo noescape envoyGoFilterHttpGetIntegerValue
+#cgo nocallback envoyGoFilterHttpGetIntegerValue
+#cgo noescape envoyGoFilterHttpGetDynamicMetadata
+#cgo nocallback envoyGoFilterHttpGetDynamicMetadata
+#cgo noescape envoyGoFilterHttpSetDynamicMetadata
+#cgo nocallback envoyGoFilterHttpSetDynamicMetadata
+#cgo noescape envoyGoFilterLog
+#cgo nocallback envoyGoFilterLog
+#cgo noescape envoyGoFilterHttpSetStringFilterState
+#cgo nocallback envoyGoFilterHttpSetStringFilterState
+#cgo noescape envoyGoFilterHttpGetStringFilterState
+#cgo nocallback envoyGoFilterHttpGetStringFilterState
+#cgo noescape envoyGoFilterHttpGetStringProperty
+#cgo nocallback envoyGoFilterHttpGetStringProperty
+#cgo noescape envoyGoFilterHttpDefineMetric
+#cgo nocallback envoyGoFilterHttpDefineMetric
+#cgo noescape envoyGoFilterHttpIncrementMetric
+#cgo nocallback envoyGoFilterHttpIncrementMetric
+#cgo noescape envoyGoFilterHttpGetMetric
+#cgo nocallback envoyGoFilterHttpGetMetric
+
+*/
+import "C"

--- a/contrib/golang/filters/network/source/go/pkg/network/cgo_go122.go
+++ b/contrib/golang/filters/network/source/go/pkg/network/cgo_go122.go
@@ -1,0 +1,26 @@
+//go:build go1.22
+
+package network
+
+/*
+// This is a performance optimization.
+// The following noescape and nocallback directives are used to
+// prevent the Go compiler from allocating function parameters on the heap.
+
+#cgo noescape envoyGoFilterDownstreamWrite
+#cgo nocallback envoyGoFilterDownstreamWrite
+#cgo noescape envoyGoFilterDownstreamInfo
+#cgo nocallback envoyGoFilterDownstreamInfo
+#cgo noescape envoyGoFilterUpstreamConnect
+#cgo nocallback envoyGoFilterUpstreamConnect
+#cgo noescape envoyGoFilterUpstreamWrite
+#cgo nocallback envoyGoFilterUpstreamWrite
+#cgo noescape envoyGoFilterUpstreamInfo
+#cgo nocallback envoyGoFilterUpstreamInfo
+#cgo noescape envoyGoFilterSetFilterState
+#cgo nocallback envoyGoFilterSetFilterState
+#cgo noescape envoyGoFilterGetFilterState
+#cgo nocallback envoyGoFilterGetFilterState
+
+*/
+import "C"


### PR DESCRIPTION
they could prevent the Go compiler from allocating function parameters on the heap.

`noescape` and `nocallback` are new go1.22 cgo directives that help the Go compiler make better decisions. See https://github.com/golang/go/issues/56378 for more context.