### PR TITLE
docs: fix grammar errors in cli help texts

### DIFF
--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -47,7 +47,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       fmt::format("\nDefault is [{}]", spdlog::level::level_string_views[default_log_level]);
 
   const std::string component_log_level_string =
-      "Comma separated list of component log levels. For example upstream:debug,config:trace";
+      "Comma-separated list of component log levels. For example upstream:debug,config:trace";
   const std::string log_format_string =
       fmt::format("Log message format in spdlog syntax "
                   "(see https://github.com/gabime/spdlog/wiki/3.-Custom-formatting)"
@@ -56,15 +56,15 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
 
   TCLAP::CmdLine cmd("envoy", ' ', VersionInfo::version());
   TCLAP::ValueArg<uint32_t> base_id(
-      "", "base-id", "base ID so that multiple envoys can run on the same host if needed", false, 0,
+      "", "base-id", "Base ID so that multiple envoys can run on the same host if needed", false, 0,
       "uint32_t", cmd);
   TCLAP::SwitchArg use_dynamic_base_id(
       "", "use-dynamic-base-id",
-      "the server chooses a base ID dynamically. Supersedes a static base ID. May not be used "
+      "The server chooses a base ID dynamically. Supersedes a static base ID. May not be used "
       "when the restart epoch is non-zero.",
       cmd, false);
   TCLAP::ValueArg<std::string> base_id_path(
-      "", "base-id-path", "path to which the base ID is written", false, "", "string", cmd);
+      "", "base-id-path", "Path to which the base ID is written", false, "", "string", cmd);
   TCLAP::ValueArg<uint32_t> concurrency("", "concurrency", "# of worker threads to run", false,
                                         std::thread::hardware_concurrency(), "uint32_t", cmd);
   TCLAP::ValueArg<std::string> config_path("c", "config-path", "Path to configuration file", false,
@@ -74,16 +74,16 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       false, "", "string", cmd);
 
   TCLAP::SwitchArg allow_unknown_fields("", "allow-unknown-fields",
-                                        "allow unknown fields in static configuration (DEPRECATED)",
+                                        "Allow unknown fields in static configuration (DEPRECATED)",
                                         cmd, false);
   TCLAP::SwitchArg allow_unknown_static_fields("", "allow-unknown-static-fields",
-                                               "allow unknown fields in static configuration", cmd,
+                                               "Allow unknown fields in static configuration", cmd,
                                                false);
   TCLAP::SwitchArg reject_unknown_dynamic_fields("", "reject-unknown-dynamic-fields",
-                                                 "reject unknown fields in dynamic configuration",
+                                                 "Reject unknown fields in dynamic configuration",
                                                  cmd, false);
   TCLAP::SwitchArg ignore_unknown_dynamic_fields("", "ignore-unknown-dynamic-fields",
-                                                 "ignore unknown fields in dynamic configuration",
+                                                 "Ignore unknown fields in dynamic configuration",
                                                  cmd, false);
 
   TCLAP::ValueArg<std::string> admin_address_path("", "admin-address-path", "Admin address path",
@@ -107,10 +107,10 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       "Logger mode: enable file level log control (Fine-Grain Logger) or not", cmd, false);
   TCLAP::ValueArg<std::string> log_path("", "log-path", "Path to logfile", false, "", "string",
                                         cmd);
-  TCLAP::ValueArg<uint32_t> restart_epoch("", "restart-epoch", "hot restart epoch #", false, 0,
+  TCLAP::ValueArg<uint32_t> restart_epoch("", "restart-epoch", "Hot restart epoch #", false, 0,
                                           "uint32_t", cmd);
   TCLAP::SwitchArg hot_restart_version_option("", "hot-restart-version",
-                                              "hot restart compatibility version", cmd);
+                                              "Hot restart compatibility version", cmd);
   TCLAP::ValueArg<std::string> service_cluster("", "service-cluster", "Cluster name", false, "",
                                                "string", cmd);
   TCLAP::ValueArg<std::string> service_node("", "service-node", "Node name", false, "", "string",


### PR DESCRIPTION
Previously, envoy flag help texts started with a mix of upper- and lower-case letters. Now, all help
texts start with upper-case.

This PR also adds a hyphen to one instance of "comma-separated".

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Previously, envoy flag help texts started with a mix of upper- and lower-case letters. Now, all help
texts start with upper-case. This PR also adds a hyphen to one instance of "comma-separated".
Additional Description: N/A
Risk Level: Low
Testing: None
Docs Changes: Docs-only change. See commit message.
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
