### PR TITLE
http: new runtime flag to disable name downgrading in per filter config searching

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,12 @@ behavior_changes:
     :ref:`initial_fetch_timeout <envoy_v3_api_field_config.core.v3.ConfigSource.initial_fetch_timeout>` times out, and will then apply
     the cached assignment and finish updating the warmed cluster. This change is disabled by default, and can be enabled by setting
     the runtime flag ``envoy.restart_features.use_eds_cache_for_ads`` to true.
+- area: http
+  change: |
+    Introduced a new runtime flag ``envoy.reloadable_features.no_downgrade_to_canonical_name`` to disable the name downgrading in the
+    per filter config searching. By default, the filter config name will be used to search the per filter config. If the filter config
+    name is not found, we will downgrade to use canonical name and try again.
+    This downgrading can be disabled by setting the ``envoy.reloadable_features.no_downgrade_to_canonical_name`` to true.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -284,9 +284,24 @@ ActiveStreamFilterBase::mostSpecificPerFilterConfig() const {
 
   auto* result = current_route->mostSpecificPerFilterConfig(filter_context_.config_name);
 
-  if (result == nullptr && filter_context_.filter_name != filter_context_.config_name) {
-    // Fallback to use filter name.
+  /**
+   * If:
+   * 1. no per filter config is found for the filter config name.
+   * 2. filter config name is different from the filter canonical name.
+   * 3. downgrade feature is not disabled.
+   * we fallback to use the filter canonical name.
+   */
+  if (result == nullptr && !parent_.no_downgrade_to_canonical_name_ &&
+      filter_context_.filter_name != filter_context_.config_name) {
+    // Fallback to use filter canonical name.
     result = current_route->mostSpecificPerFilterConfig(filter_context_.filter_name);
+
+    if (result != nullptr) {
+      ENVOY_LOG_FIRST_N(warn, 10,
+                        "No per filter config is found by filter config name and fallback to use "
+                        "filter canonical name. This is deprecated and will be forbidden very "
+                        "soon. Please use the filter config name to index per filter config.");
+    }
   }
   return result;
 }
@@ -306,11 +321,19 @@ void ActiveStreamFilterBase::traversePerFilterConfig(
         cb(config);
       });
 
-  if (handled || filter_context_.filter_name == filter_context_.config_name) {
+  if (handled || parent_.no_downgrade_to_canonical_name_ ||
+      filter_context_.filter_name == filter_context_.config_name) {
     return;
   }
 
-  current_route->traversePerFilterConfig(filter_context_.filter_name, cb);
+  current_route->traversePerFilterConfig(
+      filter_context_.filter_name, [&cb](const Router::RouteSpecificFilterConfig& config) {
+        ENVOY_LOG_FIRST_N(warn, 10,
+                          "No per filter config is found by filter config name and fallback to use "
+                          "filter canonical name. This is deprecated and will be forbidden very "
+                          "soon. Please use the filter config name to index per filter config.");
+        cb(config);
+      });
 }
 
 Http1StreamEncoderOptionsOptRef ActiveStreamFilterBase::http1StreamEncoderOptions() {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -25,6 +25,7 @@
 #include "source/common/local_reply/local_reply.h"
 #include "source/common/matcher/matcher.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/common/stream_info/stream_info_impl.h"
 
 namespace Envoy {
@@ -610,7 +611,9 @@ public:
       : filter_manager_callbacks_(filter_manager_callbacks), dispatcher_(dispatcher),
         connection_(connection), stream_id_(stream_id), account_(std::move(account)),
         proxy_100_continue_(proxy_100_continue), buffer_limit_(buffer_limit),
-        filter_chain_factory_(filter_chain_factory) {}
+        filter_chain_factory_(filter_chain_factory),
+        no_downgrade_to_canonical_name_(Runtime::runtimeFeatureEnabled(
+            "envoy.restart_features.no_downgrade_to_canonical_name")) {}
   ~FilterManager() override {
     ASSERT(state_.destroyed_);
     ASSERT(state_.filter_call_state_ == 0);
@@ -1045,6 +1048,8 @@ private:
   // clang-format on
 
   State state_;
+
+  const bool no_downgrade_to_canonical_name_{};
 };
 
 // The DownstreamFilterManager has explicit handling to send local replies.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -116,6 +116,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_refresh_rtt_after_request);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 // TODO(adisuissa): enable by default once this is tested in prod.
 FALSE_RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
+// TODO(wbpcode): enable by default after a complete deprecation period.
+FALSE_RUNTIME_GUARD(envoy_restart_features_no_downgrade_to_canonical_name);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -131,6 +131,7 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/local_reply:local_reply_mocks",
         "//test/mocks/network:network_mocks",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 


### PR DESCRIPTION
Commit Message: http: new runtime flag to disable name downgrading in per filter config searching
Additional Description:

In current implementation, the http filter config name is used in priority to search per filter config. And if there is no releated entry with the filter config name, we will downgrade to use filter canonical name. This downgrading is for backward compatibility. But it's not perfect solution and may bring other problems.

For example, if two lua filters are enabled in the http filter chain, one use `envoy.filters.http.lua` as config name, one use `custom_http_lua_filter_0` as config name, then the route level per filter config of first one may also be refered by the second one because downgrading. This maybe an unexpected behavior.

This PR introduced a new runtime flag to disable this downgrading.

By default, this new runtime flag is set to false. And after a complete deprecation period, we will update default value of flag to true. And finally, we will remove this downgrading completely.

Risk Level: mid.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
[Optional Runtime guard:] envoy.reloadable_features.no_downgrade_to_canonical_name, default to false.