### PR TITLE
build(deps): fix v8 missing include for numeric_t types

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -988,7 +988,10 @@ cc_library(name = "curl", visibility = ["//visibility:public"], deps = ["@envoy/
 def _v8():
     external_http_archive(
         name = "v8",
-        patches = ["@envoy//bazel:v8.patch"],
+        patches = [
+            "@envoy//bazel:v8.patch",
+            "@envoy//bazel:v8_include.patch",
+        ],
         patch_args = ["-p1"],
     )
     native.bind(

--- a/bazel/v8_include.patch
+++ b/bazel/v8_include.patch
@@ -1,0 +1,41 @@
+# fix include types for late clang (15.0.7) / gcc (13.2.1)
+# for Arch linux / Fedora, like in
+#     In file included from external/v8/src/torque/torque.cc:5:
+#     In file included from external/v8/src/torque/source-positions.h:10:
+#     In file included from external/v8/src/torque/contextual.h:10:
+#     In file included from external/v8/src/base/macros.h:12:
+#     external/v8/src/base/logging.h:154:26: error: use of undeclared identifier 'uint16_t'
+
+diff --git a/src/base/logging.h b/src/base/logging.h
+--- a/src/base/logging.h
++++ b/src/base/logging.h
+@@ -5,6 +5,7 @@
+ #ifndef V8_BASE_LOGGING_H_
+ #define V8_BASE_LOGGING_H_
+ 
++#include <cstdint>
+ #include <cstring>
+ #include <sstream>
+ #include <string>
+diff --git a/src/base/macros.h b/src/base/macros.h
+--- a/src/base/macros.h
++++ b/src/base/macros.h
+@@ -5,6 +5,7 @@
+ #ifndef V8_BASE_MACROS_H_
+ #define V8_BASE_MACROS_H_
+
++#include <cstdint>
+ #include <limits>
+ #include <type_traits>
+
+diff --git a/src/inspector/v8-string-conversions.h b/src/inspector/v8-string-conversions.h
+--- a/src/inspector/v8-string-conversions.h
++++ b/src/inspector/v8-string-conversions.h
+@@ -5,6 +5,7 @@
+ #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+ #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+ 
++#include <cstdint>
+ #include <string>
+ 
+ // Conversion routines between UT8 and UTF16, used by string-16.{h,cc}. You may


### PR DESCRIPTION
See https://github.com/envoyproxy/envoy/issues/29311.

The patch fixes include types for late clang (15.0.7) / gcc (13.2.1) for Arch linux / Fedora, like in

    In file included from external/v8/src/torque/torque.cc:5:
    In file included from external/v8/src/torque/source-positions.h:10:
    In file included from external/v8/src/torque/contextual.h:10:
    In file included from external/v8/src/base/macros.h:12:
    external/v8/src/base/logging.h:154:26: error: use of undeclared identifier 'uint16_t'
    ...

Commit Message: build(deps): fix v8 missing include for numeric_t types
Risk Level: Low
Testing: Compiles

---

in main it's fixed by https://chromium.googlesource.com/v8/v8.git/+/c2792e58035fcbaa16d0cb70998852fbeb5df4cc%5E%21/#F1 since `10.8.136`.

See https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes.

Also see Gentoo Linux bug report: https://bugs.gentoo.org/865981