### PR TITLE
Refactor hot restart rpc stream

### DIFF
--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -16,22 +16,23 @@ static constexpr uint64_t MaxSendmsgSize = 4096;
 static constexpr absl::Duration CONNECTION_REFUSED_RETRY_DELAY = absl::Seconds(1);
 static constexpr int SENDMSG_MAX_RETRIES = 10;
 
-HotRestartingBase::~HotRestartingBase() {
-  if (my_domain_socket_ != -1) {
+HotRestartingBase::RpcStream::~RpcStream() {
+  if (domain_socket_ != -1) {
     Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
-    Api::SysCallIntResult result = os_sys_calls.close(my_domain_socket_);
+    Api::SysCallIntResult result = os_sys_calls.close(domain_socket_);
     ASSERT(result.return_value_ == 0);
   }
 }
 
-void HotRestartingBase::initDomainSocketAddress(sockaddr_un* address) {
+void HotRestartingBase::RpcStream::initDomainSocketAddress(sockaddr_un* address) {
   memset(address, 0, sizeof(*address));
   address->sun_family = AF_UNIX;
 }
 
-sockaddr_un HotRestartingBase::createDomainSocketAddress(uint64_t id, const std::string& role,
-                                                         const std::string& socket_path,
-                                                         mode_t socket_mode) {
+sockaddr_un HotRestartingBase::RpcStream::createDomainSocketAddress(uint64_t id,
+                                                                    const std::string& role,
+                                                                    const std::string& socket_path,
+                                                                    mode_t socket_mode) {
   // Right now we only allow a maximum of 3 concurrent envoy processes to be running. When the third
   // starts up it will kill the oldest parent.
   static constexpr uint64_t MaxConcurrentProcesses = 3;
@@ -41,21 +42,22 @@ sockaddr_un HotRestartingBase::createDomainSocketAddress(uint64_t id, const std:
   Network::Address::PipeInstance addr(
       fmt::format(fmt::runtime(socket_path + "_{}_{}"), role, base_id_ + id), socket_mode, nullptr);
   safeMemcpy(&address, &(addr.getSockAddr()));
-  fchmod(my_domain_socket_, socket_mode);
+  fchmod(domain_socket_, socket_mode);
 
   return address;
 }
 
-void HotRestartingBase::bindDomainSocket(uint64_t id, const std::string& role,
-                                         const std::string& socket_path, mode_t socket_mode) {
+void HotRestartingBase::RpcStream::bindDomainSocket(uint64_t id, const std::string& role,
+                                                    const std::string& socket_path,
+                                                    mode_t socket_mode) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   // This actually creates the socket and binds it. We use the socket in datagram mode so we can
   // easily read single messages.
-  my_domain_socket_ = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+  domain_socket_ = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0);
   sockaddr_un address = createDomainSocketAddress(id, role, socket_path, socket_mode);
   unlink(address.sun_path);
   Api::SysCallIntResult result =
-      os_sys_calls.bind(my_domain_socket_, reinterpret_cast<sockaddr*>(&address), sizeof(address));
+      os_sys_calls.bind(domain_socket_, reinterpret_cast<sockaddr*>(&address), sizeof(address));
   if (result.return_value_ != 0) {
     const auto msg = fmt::format(
         "unable to bind domain socket with base_id={}, id={}, errno={} (see --base-id option)",
@@ -67,8 +69,8 @@ void HotRestartingBase::bindDomainSocket(uint64_t id, const std::string& role,
   }
 }
 
-void HotRestartingBase::sendHotRestartMessage(sockaddr_un& address,
-                                              const HotRestartMessage& proto) {
+void HotRestartingBase::RpcStream::sendHotRestartMessage(sockaddr_un& address,
+                                                         const HotRestartMessage& proto) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   const uint64_t serialized_size = proto.ByteSizeLong();
   const uint64_t total_size = sizeof(uint64_t) + serialized_size;
@@ -79,7 +81,7 @@ void HotRestartingBase::sendHotRestartMessage(sockaddr_un& address,
   RELEASE_ASSERT(proto.SerializeWithCachedSizesToArray(send_buf.data() + sizeof(uint64_t)),
                  "failed to serialize a HotRestartMessage");
 
-  RELEASE_ASSERT(fcntl(my_domain_socket_, F_SETFL, 0) != -1,
+  RELEASE_ASSERT(fcntl(domain_socket_, F_SETFL, 0) != -1,
                  fmt::format("Set domain socket blocking failed, errno = {}", errno));
 
   uint8_t* next_byte_to_send = send_buf.data();
@@ -118,7 +120,7 @@ void HotRestartingBase::sendHotRestartMessage(sockaddr_un& address,
     int rc = 0;
     bool sent = false;
     for (int i = 0; i < SENDMSG_MAX_RETRIES; i++) {
-      auto result = os_sys_calls.sendmsg(my_domain_socket_, &message, 0);
+      auto result = os_sys_calls.sendmsg(domain_socket_, &message, 0);
       rc = result.return_value_;
       saved_errno = result.errno_;
 
@@ -143,12 +145,12 @@ void HotRestartingBase::sendHotRestartMessage(sockaddr_un& address,
     }
   }
 
-  RELEASE_ASSERT(fcntl(my_domain_socket_, F_SETFL, O_NONBLOCK) != -1,
+  RELEASE_ASSERT(fcntl(domain_socket_, F_SETFL, O_NONBLOCK) != -1,
                  fmt::format("Set domain socket nonblocking failed, errno = {}", errno));
 }
 
-bool HotRestartingBase::replyIsExpectedType(const HotRestartMessage* proto,
-                                            HotRestartMessage::Reply::ReplyCase oneof_type) const {
+bool HotRestartingBase::RpcStream::replyIsExpectedType(
+    const HotRestartMessage* proto, HotRestartMessage::Reply::ReplyCase oneof_type) const {
   return proto != nullptr && proto->requestreply_case() == HotRestartMessage::kReply &&
          proto->reply().reply_case() == oneof_type;
 }
@@ -157,7 +159,7 @@ bool HotRestartingBase::replyIsExpectedType(const HotRestartMessage* proto,
 // PassListenSocketReply proto; the higher level code will see a listening fd that Just Works. We
 // should only get control data in a PassListenSocketReply, it should only be the fd passing type,
 // and there should only be one at a time. Crash on any other control data.
-void HotRestartingBase::getPassedFdIfPresent(HotRestartMessage* out, msghdr* message) {
+void HotRestartingBase::RpcStream::getPassedFdIfPresent(HotRestartMessage* out, msghdr* message) {
   cmsghdr* cmsg = CMSG_FIRSTHDR(message);
   if (cmsg != nullptr) {
     RELEASE_ASSERT(cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS &&
@@ -175,7 +177,7 @@ void HotRestartingBase::getPassedFdIfPresent(HotRestartMessage* out, msghdr* mes
 
 // While in use, recv_buf_ is always >= MaxSendmsgSize. In between messages, it is kept empty,
 // to be grown back to MaxSendmsgSize at the start of the next message.
-void HotRestartingBase::initRecvBufIfNewMessage() {
+void HotRestartingBase::RpcStream::initRecvBufIfNewMessage() {
   if (recv_buf_.empty()) {
     ASSERT(cur_msg_recvd_bytes_ == 0);
     ASSERT(!expected_proto_length_.has_value());
@@ -185,7 +187,7 @@ void HotRestartingBase::initRecvBufIfNewMessage() {
 
 // Must only be called when recv_buf_ contains a full proto. Returns that proto, and resets all of
 // our receive-buffering state back to empty, to await a new message.
-std::unique_ptr<HotRestartMessage> HotRestartingBase::parseProtoAndResetState() {
+std::unique_ptr<HotRestartMessage> HotRestartingBase::RpcStream::parseProtoAndResetState() {
   auto ret = std::make_unique<HotRestartMessage>();
   RELEASE_ASSERT(
       ret->ParseFromArray(recv_buf_.data() + sizeof(uint64_t), expected_proto_length_.value()),
@@ -196,10 +198,11 @@ std::unique_ptr<HotRestartMessage> HotRestartingBase::parseProtoAndResetState() 
   return ret;
 }
 
-std::unique_ptr<HotRestartMessage> HotRestartingBase::receiveHotRestartMessage(Blocking block) {
+std::unique_ptr<HotRestartMessage>
+HotRestartingBase::RpcStream::receiveHotRestartMessage(Blocking block) {
   // By default the domain socket is non blocking. If we need to block, make it blocking first.
   if (block == Blocking::Yes) {
-    RELEASE_ASSERT(fcntl(my_domain_socket_, F_SETFL, 0) != -1,
+    RELEASE_ASSERT(fcntl(domain_socket_, F_SETFL, 0) != -1,
                    fmt::format("Set domain socket blocking failed, errno = {}", errno));
   }
 
@@ -221,7 +224,7 @@ std::unique_ptr<HotRestartMessage> HotRestartingBase::receiveHotRestartMessage(B
     message.msg_control = control_buffer;
     message.msg_controllen = CMSG_SPACE(sizeof(int));
 
-    const int recvmsg_rc = recvmsg(my_domain_socket_, &message, 0);
+    const int recvmsg_rc = recvmsg(domain_socket_, &message, 0);
     if (block == Blocking::No && recvmsg_rc == -1 && errno == SOCKET_ERROR_AGAIN) {
       return nullptr;
     }
@@ -253,7 +256,7 @@ std::unique_ptr<HotRestartMessage> HotRestartingBase::receiveHotRestartMessage(B
 
   // Turn non-blocking back on if we made it blocking.
   if (block == Blocking::Yes) {
-    RELEASE_ASSERT(fcntl(my_domain_socket_, F_SETFL, O_NONBLOCK) != -1,
+    RELEASE_ASSERT(fcntl(domain_socket_, F_SETFL, O_NONBLOCK) != -1,
                    fmt::format("Set domain socket nonblocking failed, errno = {}", errno));
   }
   getPassedFdIfPresent(ret.get(), &message);

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -21,6 +21,70 @@
 namespace Envoy {
 namespace Server {
 
+class RpcStream : public Logger::Loggable<Logger::Id::main> {
+public:
+  enum class Blocking { Yes, No };
+
+  explicit RpcStream(uint64_t base_id) : base_id_(base_id) {}
+  ~RpcStream();
+  void initDomainSocketAddress(sockaddr_un* address);
+  sockaddr_un createDomainSocketAddress(uint64_t id, const std::string& role,
+                                        const std::string& socket_path, mode_t socket_mode);
+  void bindDomainSocket(uint64_t id, const std::string& role, const std::string& socket_path,
+                        mode_t socket_mode);
+
+  // Protocol description:
+  //
+  // In each direction between parent<-->child, a series of pairs of:
+  //   A uint64 'length' (bytes in network order),
+  //   followed by 'length' bytes of a serialized HotRestartMessage.
+  // Each new message must start in a new sendmsg datagram, i.e. 'length' must always start at
+  // byte 0. Each sendmsg datagram can be up to 4096 bytes (including 'length' if present). When
+  // the serialized protobuf is longer than 4096-8 bytes, and so cannot fit in just one datagram,
+  // it is delivered by a series of datagrams. In each of these continuation datagrams, the
+  // protobuf data starts at byte 0.
+  //
+  // There is no mechanism to explicitly pair responses to requests. However, the child initiates
+  // all exchanges, and blocks until a reply is received, so there is implicit pairing.
+  void sendHotRestartMessage(sockaddr_un& address, const envoy::HotRestartMessage& proto);
+
+  // Receive data, possibly enough to build one of our protocol messages.
+  // If block is true, blocks until a full protocol message is available.
+  // If block is false, returns nullptr if we run out of data to receive before a full protocol
+  // message is available. In either case, the HotRestartingBase may end up buffering some data
+  // for the next protocol message, even if the function returns a protobuf.
+  std::unique_ptr<envoy::HotRestartMessage> receiveHotRestartMessage(Blocking block);
+  bool replyIsExpectedType(const envoy::HotRestartMessage* proto,
+                           envoy::HotRestartMessage::Reply::ReplyCase oneof_type) const;
+
+  int domain_socket_{-1};
+
+private:
+  void getPassedFdIfPresent(envoy::HotRestartMessage* out, msghdr* message);
+  std::unique_ptr<envoy::HotRestartMessage> parseProtoAndResetState();
+  void initRecvBufIfNewMessage();
+  // State for the receiving half of the protocol.
+  //
+  // When filled, the size in bytes that the in-flight HotRestartMessage should be.
+  // When empty, we're ready to start receiving a new message (starting with a uint64 'length').
+  absl::optional<uint64_t> expected_proto_length_;
+  // How much of the current in-flight message (including both the uint64 'length', plus the proto
+  // itself) we have received. Once this equals expected_proto_length_ + sizeof(uint64_t), we're
+  // ready to parse the HotRestartMessage. Should be set to 0 in between messages, to indicate
+  // readiness for a new message.
+  uint64_t cur_msg_recvd_bytes_{};
+  // The first 8 bytes will always be the raw net-order bytes of the current value of
+  // expected_proto_length_. The protobuf partial data starts at byte 8.
+  // Should be resized to 0 in between messages, to indicate readiness for a new message.
+  std::vector<uint8_t> recv_buf_;
+  // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
+  // next of 0,1,2,0,1,...
+  // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
+  // this value to determine which domain socket name to treat as our parent, and which to treat
+  // as our child. (E.g. if we are 2, 1 is parent and 0 is child).
+  const uint64_t base_id_;
+};
+
 /**
  * Logic shared by the implementations of both sides of the child<-->parent hot restart protocol:
  * domain socket communication, and our ad hoc RPC protocol.
@@ -29,73 +93,10 @@ class HotRestartingBase : public Logger::Loggable<Logger::Id::main> {
 protected:
   HotRestartingBase(uint64_t base_id) : main_rpc_stream_(base_id) {}
 
-  enum class Blocking { Yes, No };
-
   // Returns a Gauge that tracks hot-restart generation, where every successive
   // child increments this number.
   static Stats::Gauge& hotRestartGeneration(Stats::Scope& scope);
 
-  class RpcStream {
-  public:
-    explicit RpcStream(uint64_t base_id) : base_id_(base_id) {}
-    ~RpcStream();
-    void initDomainSocketAddress(sockaddr_un* address);
-    sockaddr_un createDomainSocketAddress(uint64_t id, const std::string& role,
-                                          const std::string& socket_path, mode_t socket_mode);
-    void bindDomainSocket(uint64_t id, const std::string& role, const std::string& socket_path,
-                          mode_t socket_mode);
-
-    // Protocol description:
-    //
-    // In each direction between parent<-->child, a series of pairs of:
-    //   A uint64 'length' (bytes in network order),
-    //   followed by 'length' bytes of a serialized HotRestartMessage.
-    // Each new message must start in a new sendmsg datagram, i.e. 'length' must always start at
-    // byte 0. Each sendmsg datagram can be up to 4096 bytes (including 'length' if present). When
-    // the serialized protobuf is longer than 4096-8 bytes, and so cannot fit in just one datagram,
-    // it is delivered by a series of datagrams. In each of these continuation datagrams, the
-    // protobuf data starts at byte 0.
-    //
-    // There is no mechanism to explicitly pair responses to requests. However, the child initiates
-    // all exchanges, and blocks until a reply is received, so there is implicit pairing.
-    void sendHotRestartMessage(sockaddr_un& address, const envoy::HotRestartMessage& proto);
-
-    // Receive data, possibly enough to build one of our protocol messages.
-    // If block is true, blocks until a full protocol message is available.
-    // If block is false, returns nullptr if we run out of data to receive before a full protocol
-    // message is available. In either case, the HotRestartingBase may end up buffering some data
-    // for the next protocol message, even if the function returns a protobuf.
-    std::unique_ptr<envoy::HotRestartMessage> receiveHotRestartMessage(Blocking block);
-    bool replyIsExpectedType(const envoy::HotRestartMessage* proto,
-                             envoy::HotRestartMessage::Reply::ReplyCase oneof_type) const;
-
-    int domain_socket_{-1};
-
-  private:
-    void getPassedFdIfPresent(envoy::HotRestartMessage* out, msghdr* message);
-    std::unique_ptr<envoy::HotRestartMessage> parseProtoAndResetState();
-    void initRecvBufIfNewMessage();
-    // State for the receiving half of the protocol.
-    //
-    // When filled, the size in bytes that the in-flight HotRestartMessage should be.
-    // When empty, we're ready to start receiving a new message (starting with a uint64 'length').
-    absl::optional<uint64_t> expected_proto_length_;
-    // How much of the current in-flight message (including both the uint64 'length', plus the proto
-    // itself) we have received. Once this equals expected_proto_length_ + sizeof(uint64_t), we're
-    // ready to parse the HotRestartMessage. Should be set to 0 in between messages, to indicate
-    // readiness for a new message.
-    uint64_t cur_msg_recvd_bytes_{};
-    // The first 8 bytes will always be the raw net-order bytes of the current value of
-    // expected_proto_length_. The protobuf partial data starts at byte 8.
-    // Should be resized to 0 in between messages, to indicate readiness for a new message.
-    std::vector<uint8_t> recv_buf_;
-    // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
-    // next of 0,1,2,0,1,...
-    // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
-    // this value to determine which domain socket name to treat as our parent, and which to treat
-    // as our child. (E.g. if we are 2, 1 is parent and 0 is child).
-    const uint64_t base_id_;
-  };
   RpcStream main_rpc_stream_;
 };
 

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -63,6 +63,12 @@ private:
   void getPassedFdIfPresent(envoy::HotRestartMessage* out, msghdr* message);
   std::unique_ptr<envoy::HotRestartMessage> parseProtoAndResetState();
   void initRecvBufIfNewMessage();
+  // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
+  // next of 0,1,2,0,1,...
+  // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
+  // this value to determine which domain socket name to treat as our parent, and which to treat
+  // as our child. (E.g. if we are 2, 1 is parent and 0 is child).
+  const uint64_t base_id_;
   // State for the receiving half of the protocol.
   //
   // When filled, the size in bytes that the in-flight HotRestartMessage should be.
@@ -77,12 +83,6 @@ private:
   // expected_proto_length_. The protobuf partial data starts at byte 8.
   // Should be resized to 0 in between messages, to indicate readiness for a new message.
   std::vector<uint8_t> recv_buf_;
-  // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
-  // next of 0,1,2,0,1,...
-  // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
-  // this value to determine which domain socket name to treat as our parent, and which to treat
-  // as our child. (E.g. if we are 2, 1 is parent and 0 is child).
-  const uint64_t base_id_;
 };
 
 /**

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -27,73 +27,76 @@ namespace Server {
  */
 class HotRestartingBase : public Logger::Loggable<Logger::Id::main> {
 protected:
-  HotRestartingBase(uint64_t base_id) : base_id_(base_id) {}
-  ~HotRestartingBase();
-
-  void initDomainSocketAddress(sockaddr_un* address);
-  sockaddr_un createDomainSocketAddress(uint64_t id, const std::string& role,
-                                        const std::string& socket_path, mode_t socket_mode);
-  void bindDomainSocket(uint64_t id, const std::string& role, const std::string& socket_path,
-                        mode_t socket_mode);
-  int myDomainSocket() const { return my_domain_socket_; }
-
-  // Protocol description:
-  //
-  // In each direction between parent<-->child, a series of pairs of:
-  //   A uint64 'length' (bytes in network order),
-  //   followed by 'length' bytes of a serialized HotRestartMessage.
-  // Each new message must start in a new sendmsg datagram, i.e. 'length' must always start at byte
-  // 0. Each sendmsg datagram can be up to 4096 bytes (including 'length' if present). When the
-  // serialized protobuf is longer than 4096-8 bytes, and so cannot fit in just one datagram, it is
-  // delivered by a series of datagrams. In each of these continuation datagrams, the protobuf data
-  // starts at byte 0.
-  //
-  // There is no mechanism to explicitly pair responses to requests. However, the child initiates
-  // all exchanges, and blocks until a reply is received, so there is implicit pairing.
-  void sendHotRestartMessage(sockaddr_un& address, const envoy::HotRestartMessage& proto);
+  HotRestartingBase(uint64_t base_id) : my_rpc_stream_(base_id) {}
 
   enum class Blocking { Yes, No };
-  // Receive data, possibly enough to build one of our protocol messages.
-  // If block is true, blocks until a full protocol message is available.
-  // If block is false, returns nullptr if we run out of data to receive before a full protocol
-  // message is available. In either case, the HotRestartingBase may end up buffering some data for
-  // the next protocol message, even if the function returns a protobuf.
-  std::unique_ptr<envoy::HotRestartMessage> receiveHotRestartMessage(Blocking block);
-
-  bool replyIsExpectedType(const envoy::HotRestartMessage* proto,
-                           envoy::HotRestartMessage::Reply::ReplyCase oneof_type) const;
 
   // Returns a Gauge that tracks hot-restart generation, where every successive
   // child increments this number.
   static Stats::Gauge& hotRestartGeneration(Stats::Scope& scope);
 
-private:
-  void getPassedFdIfPresent(envoy::HotRestartMessage* out, msghdr* message);
-  std::unique_ptr<envoy::HotRestartMessage> parseProtoAndResetState();
-  void initRecvBufIfNewMessage();
+  class RpcStream {
+  public:
+    explicit RpcStream(uint64_t base_id) : base_id_(base_id) {}
+    ~RpcStream();
+    void initDomainSocketAddress(sockaddr_un* address);
+    sockaddr_un createDomainSocketAddress(uint64_t id, const std::string& role,
+                                          const std::string& socket_path, mode_t socket_mode);
+    void bindDomainSocket(uint64_t id, const std::string& role, const std::string& socket_path,
+                          mode_t socket_mode);
 
-  // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
-  // next of 0,1,2,0,1,...
-  // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
-  // this value to determine which domain socket name to treat as our parent, and which to treat as
-  // our child. (E.g. if we are 2, 1 is parent and 0 is child).
-  const uint64_t base_id_;
-  int my_domain_socket_{-1};
+    // Protocol description:
+    //
+    // In each direction between parent<-->child, a series of pairs of:
+    //   A uint64 'length' (bytes in network order),
+    //   followed by 'length' bytes of a serialized HotRestartMessage.
+    // Each new message must start in a new sendmsg datagram, i.e. 'length' must always start at
+    // byte 0. Each sendmsg datagram can be up to 4096 bytes (including 'length' if present). When
+    // the serialized protobuf is longer than 4096-8 bytes, and so cannot fit in just one datagram,
+    // it is delivered by a series of datagrams. In each of these continuation datagrams, the
+    // protobuf data starts at byte 0.
+    //
+    // There is no mechanism to explicitly pair responses to requests. However, the child initiates
+    // all exchanges, and blocks until a reply is received, so there is implicit pairing.
+    void sendHotRestartMessage(sockaddr_un& address, const envoy::HotRestartMessage& proto);
 
-  // State for the receiving half of the protocol.
-  //
-  // When filled, the size in bytes that the in-flight HotRestartMessage should be.
-  // When empty, we're ready to start receiving a new message (starting with a uint64 'length').
-  absl::optional<uint64_t> expected_proto_length_;
-  // How much of the current in-flight message (including both the uint64 'length', plus the proto
-  // itself) we have received. Once this equals expected_proto_length_ + sizeof(uint64_t), we're
-  // ready to parse the HotRestartMessage. Should be set to 0 in between messages, to indicate
-  // readiness for a new message.
-  uint64_t cur_msg_recvd_bytes_{};
-  // The first 8 bytes will always be the raw net-order bytes of the current value of
-  // expected_proto_length_. The protobuf partial data starts at byte 8.
-  // Should be resized to 0 in between messages, to indicate readiness for a new message.
-  std::vector<uint8_t> recv_buf_;
+    // Receive data, possibly enough to build one of our protocol messages.
+    // If block is true, blocks until a full protocol message is available.
+    // If block is false, returns nullptr if we run out of data to receive before a full protocol
+    // message is available. In either case, the HotRestartingBase may end up buffering some data
+    // for the next protocol message, even if the function returns a protobuf.
+    std::unique_ptr<envoy::HotRestartMessage> receiveHotRestartMessage(Blocking block);
+    bool replyIsExpectedType(const envoy::HotRestartMessage* proto,
+                             envoy::HotRestartMessage::Reply::ReplyCase oneof_type) const;
+
+    int domain_socket_{-1};
+
+  private:
+    void getPassedFdIfPresent(envoy::HotRestartMessage* out, msghdr* message);
+    std::unique_ptr<envoy::HotRestartMessage> parseProtoAndResetState();
+    void initRecvBufIfNewMessage();
+    // State for the receiving half of the protocol.
+    //
+    // When filled, the size in bytes that the in-flight HotRestartMessage should be.
+    // When empty, we're ready to start receiving a new message (starting with a uint64 'length').
+    absl::optional<uint64_t> expected_proto_length_;
+    // How much of the current in-flight message (including both the uint64 'length', plus the proto
+    // itself) we have received. Once this equals expected_proto_length_ + sizeof(uint64_t), we're
+    // ready to parse the HotRestartMessage. Should be set to 0 in between messages, to indicate
+    // readiness for a new message.
+    uint64_t cur_msg_recvd_bytes_{};
+    // The first 8 bytes will always be the raw net-order bytes of the current value of
+    // expected_proto_length_. The protobuf partial data starts at byte 8.
+    // Should be resized to 0 in between messages, to indicate readiness for a new message.
+    std::vector<uint8_t> recv_buf_;
+    // An int in [0, MaxConcurrentProcesses). As hot restarts happen, each next process gets the
+    // next of 0,1,2,0,1,...
+    // A HotRestartingBase's domain socket's name contains its base_id_ value, and so we can use
+    // this value to determine which domain socket name to treat as our parent, and which to treat
+    // as our child. (E.g. if we are 2, 1 is parent and 0 is child).
+    const uint64_t base_id_;
+  };
+  RpcStream my_rpc_stream_;
 };
 
 } // namespace Server

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -27,7 +27,7 @@ namespace Server {
  */
 class HotRestartingBase : public Logger::Loggable<Logger::Id::main> {
 protected:
-  HotRestartingBase(uint64_t base_id) : my_rpc_stream_(base_id) {}
+  HotRestartingBase(uint64_t base_id) : main_rpc_stream_(base_id) {}
 
   enum class Blocking { Yes, No };
 
@@ -96,7 +96,7 @@ protected:
     // as our child. (E.g. if we are 2, 1 is parent and 0 is child).
     const uint64_t base_id_;
   };
-  RpcStream my_rpc_stream_;
+  RpcStream main_rpc_stream_;
 };
 
 } // namespace Server

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -30,7 +30,7 @@ int HotRestartingChild::duplicateParentListenSocket(const std::string& address,
   main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 
   std::unique_ptr<HotRestartMessage> wrapped_reply =
-      main_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
+      main_rpc_stream_.receiveHotRestartMessage(RpcStream::Blocking::Yes);
   if (!main_rpc_stream_.replyIsExpectedType(wrapped_reply.get(),
                                             HotRestartMessage::Reply::kPassListenSocket)) {
     return -1;
@@ -48,7 +48,7 @@ std::unique_ptr<HotRestartMessage> HotRestartingChild::getParentStats() {
   main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 
   std::unique_ptr<HotRestartMessage> wrapped_reply =
-      main_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
+      main_rpc_stream_.receiveHotRestartMessage(RpcStream::Blocking::Yes);
   RELEASE_ASSERT(
       main_rpc_stream_.replyIsExpectedType(wrapped_reply.get(), HotRestartMessage::Reply::kStats),
       "Hot restart parent did not respond as expected to get stats request.");
@@ -76,7 +76,7 @@ HotRestartingChild::sendParentAdminShutdownRequest() {
   main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 
   std::unique_ptr<HotRestartMessage> wrapped_reply =
-      main_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
+      main_rpc_stream_.receiveHotRestartMessage(RpcStream::Blocking::Yes);
   RELEASE_ASSERT(main_rpc_stream_.replyIsExpectedType(wrapped_reply.get(),
                                                       HotRestartMessage::Reply::kShutdownAdmin),
                  "Hot restart parent did not respond as expected to ShutdownParentAdmin.");

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -10,12 +10,12 @@ using HotRestartMessage = envoy::HotRestartMessage;
 HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
                                        const std::string& socket_path, mode_t socket_mode)
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch) {
-  my_rpc_stream_.initDomainSocketAddress(&parent_address_);
+  main_rpc_stream_.initDomainSocketAddress(&parent_address_);
   if (restart_epoch_ != 0) {
-    parent_address_ = my_rpc_stream_.createDomainSocketAddress(restart_epoch_ + -1, "parent",
-                                                               socket_path, socket_mode);
+    parent_address_ = main_rpc_stream_.createDomainSocketAddress(restart_epoch_ + -1, "parent",
+                                                                 socket_path, socket_mode);
   }
-  my_rpc_stream_.bindDomainSocket(restart_epoch_, "child", socket_path, socket_mode);
+  main_rpc_stream_.bindDomainSocket(restart_epoch_, "child", socket_path, socket_mode);
 }
 
 int HotRestartingChild::duplicateParentListenSocket(const std::string& address,
@@ -27,12 +27,12 @@ int HotRestartingChild::duplicateParentListenSocket(const std::string& address,
   HotRestartMessage wrapped_request;
   wrapped_request.mutable_request()->mutable_pass_listen_socket()->set_address(address);
   wrapped_request.mutable_request()->mutable_pass_listen_socket()->set_worker_index(worker_index);
-  my_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
+  main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 
   std::unique_ptr<HotRestartMessage> wrapped_reply =
-      my_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
-  if (!my_rpc_stream_.replyIsExpectedType(wrapped_reply.get(),
-                                          HotRestartMessage::Reply::kPassListenSocket)) {
+      main_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
+  if (!main_rpc_stream_.replyIsExpectedType(wrapped_reply.get(),
+                                            HotRestartMessage::Reply::kPassListenSocket)) {
     return -1;
   }
   return wrapped_reply->reply().pass_listen_socket().fd();
@@ -45,12 +45,12 @@ std::unique_ptr<HotRestartMessage> HotRestartingChild::getParentStats() {
 
   HotRestartMessage wrapped_request;
   wrapped_request.mutable_request()->mutable_stats();
-  my_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
+  main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 
   std::unique_ptr<HotRestartMessage> wrapped_reply =
-      my_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
+      main_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
   RELEASE_ASSERT(
-      my_rpc_stream_.replyIsExpectedType(wrapped_reply.get(), HotRestartMessage::Reply::kStats),
+      main_rpc_stream_.replyIsExpectedType(wrapped_reply.get(), HotRestartMessage::Reply::kStats),
       "Hot restart parent did not respond as expected to get stats request.");
   return wrapped_reply;
 }
@@ -62,7 +62,7 @@ void HotRestartingChild::drainParentListeners() {
   // No reply expected.
   HotRestartMessage wrapped_request;
   wrapped_request.mutable_request()->mutable_drain_listeners();
-  my_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
+  main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 }
 
 absl::optional<HotRestart::AdminShutdownResponse>
@@ -73,12 +73,12 @@ HotRestartingChild::sendParentAdminShutdownRequest() {
 
   HotRestartMessage wrapped_request;
   wrapped_request.mutable_request()->mutable_shutdown_admin();
-  my_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
+  main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
 
   std::unique_ptr<HotRestartMessage> wrapped_reply =
-      my_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
-  RELEASE_ASSERT(my_rpc_stream_.replyIsExpectedType(wrapped_reply.get(),
-                                                    HotRestartMessage::Reply::kShutdownAdmin),
+      main_rpc_stream_.receiveHotRestartMessage(Blocking::Yes);
+  RELEASE_ASSERT(main_rpc_stream_.replyIsExpectedType(wrapped_reply.get(),
+                                                      HotRestartMessage::Reply::kShutdownAdmin),
                  "Hot restart parent did not respond as expected to ShutdownParentAdmin.");
   return HotRestart::AdminShutdownResponse{
       static_cast<time_t>(
@@ -92,7 +92,7 @@ void HotRestartingChild::sendParentTerminateRequest() {
   }
   HotRestartMessage wrapped_request;
   wrapped_request.mutable_request()->mutable_terminate();
-  my_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
+  main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
   parent_terminated_ = true;
 
   // Note that the 'generation' counter needs to retain the contribution from

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -16,14 +16,14 @@ using HotRestartMessage = envoy::HotRestartMessage;
 HotRestartingParent::HotRestartingParent(int base_id, int restart_epoch,
                                          const std::string& socket_path, mode_t socket_mode)
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch) {
-  child_address_ = my_rpc_stream_.createDomainSocketAddress(restart_epoch_ + 1, "child",
-                                                            socket_path, socket_mode);
-  my_rpc_stream_.bindDomainSocket(restart_epoch_, "parent", socket_path, socket_mode);
+  child_address_ = main_rpc_stream_.createDomainSocketAddress(restart_epoch_ + 1, "child",
+                                                              socket_path, socket_mode);
+  main_rpc_stream_.bindDomainSocket(restart_epoch_, "parent", socket_path, socket_mode);
 }
 
 void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {
   socket_event_ = dispatcher.createFileEvent(
-      my_rpc_stream_.domain_socket_,
+      main_rpc_stream_.domain_socket_,
       [this](uint32_t events) -> void {
         ASSERT(events == Event::FileReadyType::Read);
         onSocketEvent();
@@ -34,22 +34,22 @@ void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Inst
 
 void HotRestartingParent::onSocketEvent() {
   std::unique_ptr<HotRestartMessage> wrapped_request;
-  while ((wrapped_request = my_rpc_stream_.receiveHotRestartMessage(Blocking::No))) {
+  while ((wrapped_request = main_rpc_stream_.receiveHotRestartMessage(Blocking::No))) {
     if (wrapped_request->requestreply_case() == HotRestartMessage::kReply) {
       ENVOY_LOG(error, "child sent us a HotRestartMessage reply (we want requests); ignoring.");
       HotRestartMessage wrapped_reply;
       wrapped_reply.set_didnt_recognize_your_last_message(true);
-      my_rpc_stream_.sendHotRestartMessage(child_address_, wrapped_reply);
+      main_rpc_stream_.sendHotRestartMessage(child_address_, wrapped_reply);
       continue;
     }
     switch (wrapped_request->request().request_case()) {
     case HotRestartMessage::Request::kShutdownAdmin: {
-      my_rpc_stream_.sendHotRestartMessage(child_address_, internal_->shutdownAdmin());
+      main_rpc_stream_.sendHotRestartMessage(child_address_, internal_->shutdownAdmin());
       break;
     }
 
     case HotRestartMessage::Request::kPassListenSocket: {
-      my_rpc_stream_.sendHotRestartMessage(
+      main_rpc_stream_.sendHotRestartMessage(
           child_address_, internal_->getListenSocketsForChild(wrapped_request->request()));
       break;
     }
@@ -57,7 +57,7 @@ void HotRestartingParent::onSocketEvent() {
     case HotRestartMessage::Request::kStats: {
       HotRestartMessage wrapped_reply;
       internal_->exportStatsToChild(wrapped_reply.mutable_reply()->mutable_stats());
-      my_rpc_stream_.sendHotRestartMessage(child_address_, wrapped_reply);
+      main_rpc_stream_.sendHotRestartMessage(child_address_, wrapped_reply);
       break;
     }
 
@@ -76,7 +76,7 @@ void HotRestartingParent::onSocketEvent() {
       ENVOY_LOG(error, "child sent us an unfamiliar type of HotRestartMessage; ignoring.");
       HotRestartMessage wrapped_reply;
       wrapped_reply.set_didnt_recognize_your_last_message(true);
-      my_rpc_stream_.sendHotRestartMessage(child_address_, wrapped_reply);
+      main_rpc_stream_.sendHotRestartMessage(child_address_, wrapped_reply);
       break;
     }
     }

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -34,7 +34,7 @@ void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Inst
 
 void HotRestartingParent::onSocketEvent() {
   std::unique_ptr<HotRestartMessage> wrapped_request;
-  while ((wrapped_request = main_rpc_stream_.receiveHotRestartMessage(Blocking::No))) {
+  while ((wrapped_request = main_rpc_stream_.receiveHotRestartMessage(RpcStream::Blocking::No))) {
     if (wrapped_request->requestreply_case() == HotRestartMessage::kReply) {
       ENVOY_LOG(error, "child sent us a HotRestartMessage reply (we want requests); ignoring.");
       HotRestartMessage wrapped_reply;

--- a/test/server/hot_restarting_base_test.cc
+++ b/test/server/hot_restarting_base_test.cc
@@ -15,10 +15,10 @@ using HotRestartMessage = envoy::HotRestartMessage;
 class MockHotRestartingBase : public HotRestartingBase {
 public:
   MockHotRestartingBase(const std::string& socket_path) : HotRestartingBase(0) {
-    bindDomainSocket(1, "parent", socket_path, 0644);
+    main_rpc_stream_.bindDomainSocket(1, "parent", socket_path, 0644);
   }
   void sendMessage(sockaddr_un& address, const envoy::HotRestartMessage& message) {
-    sendHotRestartMessage(address, message);
+    main_rpc_stream_.sendHotRestartMessage(address, message);
   }
 };
 


### PR DESCRIPTION
Commit Message: Refactor hot restart RPC stream
Additional Description: Before this PR, the RPC stream behavior is hardcoded into HotRestartingBase. This change breaks it out into a member class, as a precursor to udp forwarding during hot restart, which will require an additional channel for forwarded UDP. By unifying the RPC behavior into a separate class, we can have two instances of the class rather than duplicating a lot of code.
Risk Level: Very low, as this is essentially a no-op.
Testing: As covered as it was before. Coverage should be improved with the change that comes after this (#29328).
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
