### PR TITLE
fix push hook to use the new bazel-y check format call

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -72,7 +72,7 @@ do
     # either of these things aren't true, the check fails.
     for i in $(git diff --name-only "$RANGE" --diff-filter=ACMR --ignore-submodules=all 2>&1); do
       echo -ne "  Checking format for $i - "
-      "$SCRIPT_DIR"/code_format/check_format.py check "$i" || exit 1
+      bazel run //tools/code_format:check_format -- check "$i"
 
       # TODO(phlax): It seems this is not running in CI anymore and is now finding issues
       # in merged PRs. Unify this hook and format checks in CI when the new format tool is rolled

--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -72,7 +72,7 @@ do
     # either of these things aren't true, the check fails.
     for i in $(git diff --name-only "$RANGE" --diff-filter=ACMR --ignore-submodules=all 2>&1); do
       echo -ne "  Checking format for $i - "
-      bazel run //tools/code_format:check_format -- check "$i"
+      bazel run //tools/code_format:check_format -- check "$i" || exit 1
 
       # TODO(phlax): It seems this is not running in CI anymore and is now finding issues
       # in merged PRs. Unify this hook and format checks in CI when the new format tool is rolled


### PR DESCRIPTION
Commit Message:
Additional Description: The changes in https://github.com/envoyproxy/envoy/pull/29397 broke the pre-push hook. This changes that hook to use the new bazel target
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
