### PR TITLE
udp_session_filters: add callback to inject read/write datagrams to filter chain

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -201,6 +201,11 @@ new_features:
   change: |
     added :ref:`session_filters <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.session_filters>` config to
     support optional filters that will run for each upstream UDP session. More information can be found in the UDP proxy documentation.
+- area: udp_proxy
+  change: |
+    added ``injectDatagramToFilterChain()`` callback to UDP session filters that allows session filters to inject datagrams downstream
+    or upstream the filter chain during a filter chain iteration. This can be used, for example, by session filters that are required
+    to buffer datagrams due to an asynchronous call.
 - area: otlp_stats_sink
   change: |
     added :ref:` stats prefix option<envoy_v3_api_field_extensions.stat_sinks.open_telemetry.v3.SinkConfig.stats_prefix>`

--- a/source/extensions/filters/udp/udp_proxy/session_filters/filter.h
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/filter.h
@@ -26,6 +26,14 @@ public:
    * @return StreamInfo for logging purposes.
    */
   virtual StreamInfo::StreamInfo& streamInfo() PURE;
+
+  /**
+   * Allows a filter to inject a datagram to successive filters in the session filter chain.
+   * The injected datagram will be iterated as a regular received datagram, and may also be
+   * stopped by further filters. This can be used, for example, to continue processing previously
+   * buffered datagrams by a filter after an asynchronous operation ended.
+   */
+  virtual void injectDatagramToFilterChain(Network::UdpRecvData& data) PURE;
 };
 
 class ReadFilterCallbacks : public FilterCallbacks {

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -139,6 +139,9 @@ private:
     uint64_t sessionId() const override { return parent_.sessionId(); };
     StreamInfo::StreamInfo& streamInfo() override { return parent_.streamInfo(); };
     void continueFilterChain() override { parent_.onContinueFilterChain(this); }
+    void injectDatagramToFilterChain(Network::UdpRecvData& data) override {
+      parent_.onInjectReadDatagramToFilterChain(this, data);
+    }
 
     ActiveSession& parent_;
     ReadFilterSharedPtr read_filter_;
@@ -154,6 +157,9 @@ private:
     // SessionFilters::WriteFilterCallbacks
     uint64_t sessionId() const override { return parent_.sessionId(); };
     StreamInfo::StreamInfo& streamInfo() override { return parent_.streamInfo(); };
+    void injectDatagramToFilterChain(Network::UdpRecvData& data) override {
+      parent_.onInjectWriteDatagramToFilterChain(this, data);
+    }
 
     ActiveSession& parent_;
     WriteFilterSharedPtr write_filter_;
@@ -179,6 +185,7 @@ private:
     void onNewSession();
     void onData(Network::UdpRecvData& data);
     void writeUpstream(Network::UdpRecvData& data);
+    void writeDownstream(Network::UdpRecvData& data);
 
     void createFilterChain() {
       cluster_.filter_.config_->sessionFilterFactory().createFilterChain(*this);
@@ -187,6 +194,8 @@ private:
     uint64_t sessionId() const { return session_id_; };
     StreamInfo::StreamInfo& streamInfo() { return udp_session_info_; };
     void onContinueFilterChain(ActiveReadFilter* filter);
+    void onInjectReadDatagramToFilterChain(ActiveReadFilter* filter, Network::UdpRecvData& data);
+    void onInjectWriteDatagramToFilterChain(ActiveWriteFilter* filter, Network::UdpRecvData& data);
 
     // SessionFilters::FilterChainFactoryCallbacks
     void addReadFilter(ReadFilterSharedPtr filter) override {

--- a/test/extensions/filters/udp/udp_proxy/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/BUILD
@@ -89,6 +89,8 @@ envoy_extension_cc_test(
         "//source/extensions/filters/udp/udp_proxy:config",
         "//source/extensions/filters/udp/udp_proxy/session_filters:filter_config_interface",
         "//source/extensions/filters/udp/udp_proxy/session_filters:filter_interface",
+        "//test/extensions/filters/udp/udp_proxy/session_filters:buffer_filter_config_lib",
+        "//test/extensions/filters/udp/udp_proxy/session_filters:buffer_filter_proto_cc_proto",
         "//test/extensions/filters/udp/udp_proxy/session_filters:drainer_filter_config_lib",
         "//test/extensions/filters/udp/udp_proxy/session_filters:drainer_filter_proto_cc_proto",
         "//test/integration:integration_lib",

--- a/test/extensions/filters/udp/udp_proxy/mocks.h
+++ b/test/extensions/filters/udp/udp_proxy/mocks.h
@@ -22,6 +22,7 @@ public:
   MOCK_METHOD(uint64_t, sessionId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
   MOCK_METHOD(void, continueFilterChain, ());
+  MOCK_METHOD(void, injectDatagramToFilterChain, (Network::UdpRecvData & data));
 
   uint64_t session_id_{1};
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
@@ -34,6 +35,7 @@ public:
 
   MOCK_METHOD(uint64_t, sessionId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
+  MOCK_METHOD(void, injectDatagramToFilterChain, (Network::UdpRecvData & data));
 
   uint64_t session_id_{1};
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;

--- a/test/extensions/filters/udp/udp_proxy/session_filters/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/BUILD
@@ -40,3 +40,21 @@ envoy_cc_test_library(
     ],
     alwayslink = 1,
 )
+
+envoy_proto_library(
+    name = "buffer_filter_proto",
+    srcs = ["buffer_filter.proto"],
+)
+
+envoy_cc_test_library(
+    name = "buffer_filter_config_lib",
+    srcs = ["buffer_filter.h"],
+    deps = [
+        ":buffer_filter_proto_cc_proto",
+        "//envoy/registry",
+        "//source/extensions/filters/udp/udp_proxy/session_filters:factory_base_lib",
+        "//source/extensions/filters/udp/udp_proxy/session_filters:filter_interface",
+        "//test/test_common:utility_lib",
+    ],
+    alwayslink = 1,
+)

--- a/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
@@ -39,9 +39,7 @@ public:
     write_callbacks_ = &callbacks;
   }
 
-  ReadFilterStatus onNewSession() override {
-    return ReadFilterStatus::Continue;
-  }
+  ReadFilterStatus onNewSession() override { return ReadFilterStatus::Continue; }
 
   ReadFilterStatus onData(Network::UdpRecvData& data) override {
     if (downstream_buffer_.size() < downstream_datagrams_to_buffer_) {
@@ -89,7 +87,7 @@ private:
   void bufferRead(Network::UdpRecvData& data) {
     auto buffered_datagram = std::make_unique<Network::UdpRecvData>();
     buffered_datagram->addresses_ = {std::move(data.addresses_.local_),
-                                      std::move(data.addresses_.peer_)};
+                                     std::move(data.addresses_.peer_)};
     buffered_datagram->buffer_ = std::move(data.buffer_);
     buffered_datagram->receive_time_ = data.receive_time_;
     downstream_buffer_.push(std::move(buffered_datagram));
@@ -98,7 +96,7 @@ private:
   void bufferWrite(Network::UdpRecvData& data) {
     auto buffered_datagram = std::make_unique<Network::UdpRecvData>();
     buffered_datagram->addresses_ = {std::move(data.addresses_.local_),
-                                      std::move(data.addresses_.peer_)};
+                                     std::move(data.addresses_.peer_)};
     buffered_datagram->buffer_ = std::move(data.buffer_);
     buffered_datagram->receive_time_ = data.receive_time_;
     upstream_buffer_.push(std::move(buffered_datagram));

--- a/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
@@ -23,7 +23,7 @@ using BufferingFilterConfig =
 
 using BufferedDatagramPtr = std::unique_ptr<Network::UdpRecvData>;
 
-class BufferingSessionFilter : public Filter  {
+class BufferingSessionFilter : public Filter {
 public:
   BufferingSessionFilter(int downstream_datagrams_to_buffer, int upstream_datagrams_to_buffer,
                          bool continue_after_inject)

--- a/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <queue>
+
+#include "envoy/registry/registry.h"
+
+#include "source/common/config/utility.h"
+#include "source/extensions/filters/udp/udp_proxy/session_filters/factory_base.h"
+#include "source/extensions/filters/udp/udp_proxy/session_filters/filter.h"
+
+#include "test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.pb.h"
+#include "test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.pb.validate.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace UdpFilters {
+namespace UdpProxy {
+namespace SessionFilters {
+
+using BufferingFilterConfig =
+    test::extensions::filters::udp::udp_proxy::session_filters::BufferingFilterConfig;
+
+using BufferedDatagramPtr = std::unique_ptr<Network::UdpRecvData>;
+
+class BufferingSessionFilter : public Filter  {
+public:
+  BufferingSessionFilter(int downstream_datagrams_to_buffer, int upstream_datagrams_to_buffer,
+                         bool continue_after_inject)
+      : downstream_datagrams_to_buffer_(downstream_datagrams_to_buffer),
+        upstream_datagrams_to_buffer_(upstream_datagrams_to_buffer),
+        continue_after_inject_(continue_after_inject) {}
+
+  void initializeReadFilterCallbacks(ReadFilterCallbacks& callbacks) override {
+    read_callbacks_ = &callbacks;
+  }
+
+  void initializeWriteFilterCallbacks(WriteFilterCallbacks& callbacks) override {
+    write_callbacks_ = &callbacks;
+  }
+
+  ReadFilterStatus onNewSession() override {
+    return ReadFilterStatus::Continue;
+  }
+
+  ReadFilterStatus onData(Network::UdpRecvData& data) override {
+    if (downstream_buffer_.size() < downstream_datagrams_to_buffer_) {
+      bufferRead(data);
+      return ReadFilterStatus::StopIteration;
+    }
+
+    // There's no async callback, so we use the next datagram as a trigger to flush the buffer.
+    while (!downstream_buffer_.empty()) {
+      BufferedDatagramPtr buffered_datagram = std::move(downstream_buffer_.front());
+      downstream_buffer_.pop();
+      read_callbacks_->injectDatagramToFilterChain(*buffered_datagram);
+    }
+
+    if (continue_after_inject_) {
+      return ReadFilterStatus::Continue;
+    }
+
+    bufferRead(data);
+    return ReadFilterStatus::StopIteration;
+  }
+
+  WriteFilterStatus onWrite(Network::UdpRecvData& data) override {
+    if (upstream_buffer_.size() < upstream_datagrams_to_buffer_) {
+      bufferWrite(data);
+      return WriteFilterStatus::StopIteration;
+    }
+
+    // There's no async callback, so we use the next datagram as a trigger to flush the buffer.
+    while (!upstream_buffer_.empty()) {
+      BufferedDatagramPtr buffered_datagram = std::move(upstream_buffer_.front());
+      upstream_buffer_.pop();
+      write_callbacks_->injectDatagramToFilterChain(*buffered_datagram);
+    }
+
+    if (continue_after_inject_) {
+      return WriteFilterStatus::Continue;
+    }
+
+    bufferWrite(data);
+    return WriteFilterStatus::StopIteration;
+  }
+
+private:
+  void bufferRead(Network::UdpRecvData& data) {
+    auto buffered_datagram = std::make_unique<Network::UdpRecvData>();
+    buffered_datagram->addresses_ = {std::move(data.addresses_.local_),
+                                      std::move(data.addresses_.peer_)};
+    buffered_datagram->buffer_ = std::move(data.buffer_);
+    buffered_datagram->receive_time_ = data.receive_time_;
+    downstream_buffer_.push(std::move(buffered_datagram));
+  }
+
+  void bufferWrite(Network::UdpRecvData& data) {
+    auto buffered_datagram = std::make_unique<Network::UdpRecvData>();
+    buffered_datagram->addresses_ = {std::move(data.addresses_.local_),
+                                      std::move(data.addresses_.peer_)};
+    buffered_datagram->buffer_ = std::move(data.buffer_);
+    buffered_datagram->receive_time_ = data.receive_time_;
+    upstream_buffer_.push(std::move(buffered_datagram));
+  }
+
+  ReadFilterCallbacks* read_callbacks_;
+  WriteFilterCallbacks* write_callbacks_;
+  uint32_t downstream_datagrams_to_buffer_;
+  uint32_t upstream_datagrams_to_buffer_;
+  bool continue_after_inject_{false};
+  std::queue<BufferedDatagramPtr> downstream_buffer_;
+  std::queue<BufferedDatagramPtr> upstream_buffer_;
+};
+
+class BufferingSessionFilterConfigFactory : public FactoryBase<BufferingFilterConfig> {
+public:
+  BufferingSessionFilterConfigFactory() : FactoryBase("test.udp_session.buffer") {}
+
+private:
+  FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const BufferingFilterConfig& config,
+                                    Server::Configuration::FactoryContext&) override {
+    return [config](FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addFilter(std::make_shared<BufferingSessionFilter>(
+          config.downstream_datagrams_to_buffer(), config.upstream_datagrams_to_buffer(),
+          config.continue_after_inject()));
+    };
+  }
+};
+
+static Registry::RegisterFactory<BufferingSessionFilterConfigFactory,
+                                 NamedUdpSessionFilterConfigFactory>
+    register_buffer_udp_session_filter_;
+
+} // namespace SessionFilters
+} // namespace UdpProxy
+} // namespace UdpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.proto
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package test.extensions.filters.udp.udp_proxy.session_filters;
+
+message BufferingFilterConfig {
+  uint32 downstream_datagrams_to_buffer = 1;
+  uint32 upstream_datagrams_to_buffer = 2;
+  bool continue_after_inject = 3;
+}

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
@@ -194,8 +194,8 @@ typed_config:
 )EOF";
 
     for (auto config : session_filters_configs) {
-        session_filters += fmt::format(
-            R"EOF(
+      session_filters += fmt::format(
+          R"EOF(
   - name: foo
     typed_config:
       '@type': type.googleapis.com/test.extensions.filters.udp.udp_proxy.session_filters.BufferingFilterConfig
@@ -203,8 +203,8 @@ typed_config:
       upstream_datagrams_to_buffer: {}
       continue_after_inject: {}
 )EOF",
-            config.downstream_datagrams_to_buffer_, config.upstream_datagrams_to_buffer_,
-            config.continue_after_inject_);
+          config.downstream_datagrams_to_buffer_, config.upstream_datagrams_to_buffer_,
+          config.continue_after_inject_);
     }
 
     return session_filters;

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
@@ -4,6 +4,8 @@
 #include "envoy/network/filter.h"
 #include "envoy/server/filter_config.h"
 
+#include "test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h"
+#include "test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.pb.h"
 #include "test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h"
 #include "test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.pb.h"
 #include "test/integration/integration.h"
@@ -175,6 +177,34 @@ typed_config:
             config.stop_iteration_on_new_session_, config.stop_iteration_on_first_read_,
             config.continue_filter_chain_, config.stop_iteration_on_first_write_);
       }
+    }
+
+    return session_filters;
+  }
+
+  struct BufferFilterConfig {
+    int downstream_datagrams_to_buffer_;
+    int upstream_datagrams_to_buffer_;
+    bool continue_after_inject_;
+  };
+
+  std::string getBufferSessionFilterConfig(std::list<BufferFilterConfig> session_filters_configs) {
+    std::string session_filters = R"EOF(
+  session_filters:
+)EOF";
+
+    for (auto config : session_filters_configs) {
+        session_filters += fmt::format(
+            R"EOF(
+  - name: foo
+    typed_config:
+      '@type': type.googleapis.com/test.extensions.filters.udp.udp_proxy.session_filters.BufferingFilterConfig
+      downstream_datagrams_to_buffer: {}
+      upstream_datagrams_to_buffer: {}
+      continue_after_inject: {}
+)EOF",
+            config.downstream_datagrams_to_buffer_, config.upstream_datagrams_to_buffer_,
+            config.continue_after_inject_);
     }
 
     return session_filters;
@@ -626,6 +656,120 @@ TEST_P(UdpProxyIntegrationTest, WriteSessionFilterStopOnWrite) {
   Network::UdpRecvData response_datagram;
   client.recv(response_datagram);
   EXPECT_EQ(expected_response, response_datagram.buffer_->toString());
+}
+
+TEST_P(UdpProxyIntegrationTest, BufferingFilterBasicFlow) {
+  setup(1, absl::nullopt, getBufferSessionFilterConfig({{2, 2, true}}));
+  const uint32_t port = lookupPort("listener_0");
+  const auto listener_address = Network::Utility::resolveUrl(
+      fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
+
+  Network::Test::UdpSyncPeer client(version_, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
+  client.write("hello1", *listener_address);
+  client.write("hello2", *listener_address);
+
+  // Two downstream datagrams should be received, but none sent upstream due to filter buffering.
+  test_server_->waitForCounterEq("udp.foo.downstream_sess_rx_datagrams", 2);
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.udp.sess_tx_datagrams")->value());
+
+  // Third downstream datagram should flush the previously buffered datagrams, due to
+  // injectDatagramToFilterChain() call.
+  client.write("hello3", *listener_address);
+
+  // Wait for the upstream datagram.
+  Network::UdpRecvData request_datagram;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForUdpDatagram(request_datagram));
+  EXPECT_EQ("hello1", request_datagram.buffer_->toString());
+  ASSERT_TRUE(fake_upstreams_[0]->waitForUdpDatagram(request_datagram));
+  EXPECT_EQ("hello2", request_datagram.buffer_->toString());
+  ASSERT_TRUE(fake_upstreams_[0]->waitForUdpDatagram(request_datagram));
+  EXPECT_EQ("hello3", request_datagram.buffer_->toString());
+  EXPECT_EQ(3, test_server_->counter("udp.foo.downstream_sess_rx_datagrams")->value());
+  EXPECT_EQ(3, test_server_->counter("cluster.cluster_0.udp.sess_tx_datagrams")->value());
+
+  // Two upstream datagrams should be received, but none sent downstream due to filter buffering.
+  fake_upstreams_[0]->sendUdpDatagram("response1", request_datagram.addresses_.peer_);
+  fake_upstreams_[0]->sendUdpDatagram("response2", request_datagram.addresses_.peer_);
+  test_server_->waitForCounterEq("cluster.cluster_0.udp.sess_rx_datagrams", 2);
+  EXPECT_EQ(0, test_server_->counter("udp.foo.downstream_sess_tx_datagrams")->value());
+
+  // Third upstream datagram should flush the previously buffered datagrams, due to
+  // injectDatagramToFilterChain() call.
+  fake_upstreams_[0]->sendUdpDatagram("response3", request_datagram.addresses_.peer_);
+
+  Network::UdpRecvData response_datagram;
+  client.recv(response_datagram);
+  EXPECT_EQ("response1", response_datagram.buffer_->toString());
+  client.recv(response_datagram);
+  EXPECT_EQ("response2", response_datagram.buffer_->toString());
+  client.recv(response_datagram);
+  EXPECT_EQ("response3", response_datagram.buffer_->toString());
+  EXPECT_EQ(3, test_server_->counter("cluster.cluster_0.udp.sess_rx_datagrams")->value());
+  EXPECT_EQ(3, test_server_->counter("udp.foo.downstream_sess_rx_datagrams")->value());
+}
+
+TEST_P(UdpProxyIntegrationTest, TwoBufferingFilters) {
+  setup(1, absl::nullopt, getBufferSessionFilterConfig({{1, 1, false}, {1, 1, false}}));
+  const uint32_t port = lookupPort("listener_0");
+  const auto listener_address = Network::Utility::resolveUrl(
+      fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
+
+  Network::Test::UdpSyncPeer client(version_, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
+  client.write("hello1", *listener_address); // Buffered in the first filter.
+  // 'hello1' will proceed to second filter. 'hello2' will buffer in first filter.
+  client.write("hello2", *listener_address);
+
+  // Two downstream datagrams should be received, but none sent upstream due to filter buffering.
+  test_server_->waitForCounterEq("udp.foo.downstream_sess_rx_datagrams", 2);
+  EXPECT_EQ(0, test_server_->counter("cluster.cluster_0.udp.sess_tx_datagrams")->value());
+
+  // 'hello1' will flush upstream, 'hello2' will proceed to second filter. 'hello3' will
+  // buffer in the first filter.
+  client.write("hello3", *listener_address);
+
+  // Wait for the upstream datagram.
+  Network::UdpRecvData request_datagram;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForUdpDatagram(request_datagram));
+  EXPECT_EQ("hello1", request_datagram.buffer_->toString());
+  EXPECT_EQ(3, test_server_->counter("udp.foo.downstream_sess_rx_datagrams")->value());
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.udp.sess_tx_datagrams")->value());
+
+  // 'hello2' will flush upstream, 'hello3' will proceed to second filter. 'hello4' will
+  // buffer in the first filter.
+  client.write("hello4", *listener_address);
+
+  // Wait for the upstream datagram.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForUdpDatagram(request_datagram));
+  EXPECT_EQ("hello2", request_datagram.buffer_->toString());
+  EXPECT_EQ(4, test_server_->counter("udp.foo.downstream_sess_rx_datagrams")->value());
+  EXPECT_EQ(2, test_server_->counter("cluster.cluster_0.udp.sess_tx_datagrams")->value());
+
+  // Testing the upstream to downstream direction.
+  // Two upstream datagrams should be received, but none sent downstream due to filter buffering.
+  fake_upstreams_[0]->sendUdpDatagram("response1", request_datagram.addresses_.peer_);
+  // 'response1' will proceed to second filter. 'response2' will buffer in first filter.
+  fake_upstreams_[0]->sendUdpDatagram("response2", request_datagram.addresses_.peer_);
+  test_server_->waitForCounterEq("cluster.cluster_0.udp.sess_rx_datagrams", 2);
+  EXPECT_EQ(0, test_server_->counter("udp.foo.downstream_sess_tx_datagrams")->value());
+
+  // 'response1' will flush downstream, 'response2' will proceed to second filter. 'response3' will
+  // buffer in the first filter.
+  fake_upstreams_[0]->sendUdpDatagram("response3", request_datagram.addresses_.peer_);
+
+  // Wait for the downstream datagram.
+  Network::UdpRecvData response_datagram;
+  client.recv(response_datagram);
+  EXPECT_EQ("response1", response_datagram.buffer_->toString());
+  EXPECT_EQ(3, test_server_->counter("cluster.cluster_0.udp.sess_rx_datagrams")->value());
+  EXPECT_EQ(1, test_server_->counter("udp.foo.downstream_sess_tx_datagrams")->value());
+
+  // 'response2' will flush downstream, 'response3' will proceed to second filter. 'response4' will
+  // buffer in the first filter.
+  fake_upstreams_[0]->sendUdpDatagram("response4", request_datagram.addresses_.peer_);
+  client.recv(response_datagram);
+  EXPECT_EQ("response2", response_datagram.buffer_->toString());
+  EXPECT_EQ(4, test_server_->counter("cluster.cluster_0.udp.sess_rx_datagrams")->value());
+  EXPECT_EQ(2, test_server_->counter("udp.foo.downstream_sess_tx_datagrams")->value());
 }
 
 } // namespace


### PR DESCRIPTION
Additional Description: Part of the UDP tunneling effort (#29277). This PR adds the option to inject datagrams downstream/upstream from a UDP session filter. This allows UDP session filters to buffer datagrams for arbitrary purposes while returning ``StopIteration`` and then flushing the buffered datagrams when the filter is ready to continue, for example, due to async callback. An example use case would be a dynamic forward proxy filter that will create a DNS request, waiting for a DNS response, allowing datagrams received meanwhile to be buffered until the response is ready.
Risk Level: low
Testing: Integration tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none