### PR TITLE
ci/cache: Use `.bazelrc` for docker cache key

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -11,7 +11,7 @@ parameters:
 # caching
 - name: cacheKeyDocker
   type: string
-  default: ".devcontainer/Dockerfile"
+  default: ".bazelrc"
 - name: cacheKeyVersion
   type: string
   default: $(cacheKeyVersion)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -51,7 +51,7 @@ variables:
 - name: cacheKeyBazel
   value: '.bazelversion | ./WORKSPACE | **/*.bzl, !mobile/**, !envoy-docs/**'
 - name: cacheKeyDocker
-  value: ".devcontainer/Dockerfile"
+  value: ".bazelrc"
 # Docker build uses separate docker cache
 - name: cacheKeyDockerBuild
   # VERSION.txt is included to refresh Docker images for release


### PR DESCRIPTION
Currently ci uses `.devcontainer/Dockerfile` for the docker cache key, but `.bazelrc` is actually more reliable

The cache is currently broken as `.devcontainer/Dockerfile` changed and it confused ci

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
