### PR TITLE
ci/cache: Fix cache priming for Docker only

### DIFF
--- a/.azure-pipelines/docker/prime_cache.sh
+++ b/.azure-pipelines/docker/prime_cache.sh
@@ -34,6 +34,18 @@ echo "==================================================="
 echo
 
 echo
+echo "================ Docker fetch ======================"
+if [[ "$DOCKER_RESTORED" != "true" ]]; then
+    echo "Fetching Docker"
+    ./ci/run_envoy_docker.sh uname -a
+    docker images
+else
+    echo "Not fetching Docker as it was restored"
+fi
+echo "==================================================="
+echo
+
+echo
 echo "================ Bazel fetch ======================"
 # Fetch bazel dependencies
 if [[ "$BAZEL_RESTORED" != "true" ]]; then
@@ -45,7 +57,6 @@ fi
 echo "==================================================="
 echo
 
-docker images
 df -h
 
 echo

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -47,7 +47,7 @@ variables:
 - name: cacheKeyName
   value: envoy
 - name: cacheKeyVersion
-  value: v1
+  value: v2
 - name: cacheKeyBazel
   value: '.bazelversion | ./WORKSPACE | **/*.bzl, !mobile/**, !envoy-docs/**'
 - name: cacheKeyDocker


### PR DESCRIPTION
Currently if only docker changed and not bazel its creating an empty cache, this should fix

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
