### PR TITLE
mobile: Remove the use of TestEngineBuilder from the lifetimes_test and send_headers_test.

### DIFF
--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -1,60 +1,15 @@
-#include "test/common/integration/test_engine_builder.h"
 #include "test/test_common/utility.h"
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine.h"
+#include "library/cc/engine_builder.h"
 #include "library/cc/envoy_error.h"
 #include "library/cc/log_level.h"
 #include "library/cc/request_headers_builder.h"
 #include "library/cc/request_method.h"
-#include "library/cc/response_headers.h"
 
 namespace Envoy {
 namespace {
-
-const static std::string CONFIG = R"(
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion
-                match_config:
-                  http_request_headers_match:
-                    headers:
-                      - name: ":authority"
-                        exact_match: example.com
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-)";
 
 struct Status {
   int status_code;
@@ -64,20 +19,18 @@ struct Status {
 void sendRequest(Platform::EngineSharedPtr engine, Status& status,
                  absl::Notification& stream_complete) {
   auto stream_prototype = engine->streamClient()->newStreamPrototype();
-  auto stream = (*stream_prototype)
-                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
-                                      envoy_stream_intel) {
+  auto stream = stream_prototype
+                    ->setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
+                                       envoy_stream_intel) {
                       status.status_code = headers->httpStatus();
                       status.end_stream = end_stream;
                     })
+                    .setOnData([&](envoy_data, bool end_stream) { status.end_stream = end_stream; })
                     .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
                       stream_complete.Notify();
                     })
-                    .setOnError([&](Platform::EnvoyErrorSharedPtr envoy_error, envoy_stream_intel,
-                                    envoy_final_stream_intel) {
-                      (void)envoy_error;
-                      stream_complete.Notify();
-                    })
+                    .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                                    envoy_final_stream_intel) { stream_complete.Notify(); })
                     .setOnCancel([&](envoy_stream_intel, envoy_final_stream_intel) {
                       stream_complete.Notify();
                     })
@@ -90,10 +43,17 @@ void sendRequest(Platform::EngineSharedPtr engine, Status& status,
 }
 
 void sendRequestEndToEnd() {
-  TestEngineBuilder engine_builder;
-  auto bootstrap = std::make_unique<envoy::config::bootstrap::v3::Bootstrap>();
-  TestUtility::loadFromYaml(CONFIG, *bootstrap);
-  Platform::EngineSharedPtr engine = engine_builder.createEngine(std::move(bootstrap));
+  Platform::EngineBuilder engine_builder;
+  engine_builder.addNativeFilter(
+      "test_remote_response",
+      "{'@type': "
+      "type.googleapis.com/"
+      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
+  absl::Notification engine_running;
+  Platform::EngineSharedPtr engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
+                                         .setOnEngineRunning([&]() { engine_running.Notify(); })
+                                         .build();
+  engine_running.WaitForNotification();
 
   Status status;
   absl::Notification stream_complete;

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -19,9 +19,9 @@ struct Status {
 void sendRequest(Platform::EngineSharedPtr engine, Status& status,
                  absl::Notification& stream_complete) {
   auto stream_prototype = engine->streamClient()->newStreamPrototype();
-  auto stream = stream_prototype
-                    ->setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
-                                       envoy_stream_intel) {
+  auto stream = (*stream_prototype)
+                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
+                                      envoy_stream_intel) {
                       status.status_code = headers->httpStatus();
                       status.end_stream = end_stream;
                     })

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -32,8 +32,8 @@ TEST(SendHeadersTest, CanSendHeaders) {
   absl::Notification stream_complete;
   auto stream_prototype = engine->streamClient()->newStreamPrototype();
   Platform::StreamSharedPtr stream =
-      stream_prototype
-          ->setOnHeaders(
+      (*stream_prototype)
+          .setOnHeaders(
               [&](Platform::ResponseHeadersSharedPtr headers, bool end_stream, envoy_stream_intel) {
                 status.status_code = headers->httpStatus();
                 status.end_stream = end_stream;

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -1,60 +1,14 @@
-#include "test/common/integration/test_engine_builder.h"
 #include "test/test_common/utility.h"
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine.h"
+#include "library/cc/engine_builder.h"
 #include "library/cc/envoy_error.h"
-#include "library/cc/log_level.h"
 #include "library/cc/request_headers_builder.h"
 #include "library/cc/request_method.h"
-#include "library/cc/response_headers.h"
 
 namespace Envoy {
 namespace {
-
-const static std::string CONFIG = R"(
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion
-                match_config:
-                  http_request_headers_match:
-                    headers:
-                      - name: ":authority"
-                        exact_match: example.com
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-)";
 
 struct Status {
   int status_code;
@@ -62,32 +16,36 @@ struct Status {
 };
 
 TEST(SendHeadersTest, CanSendHeaders) {
-  TestEngineBuilder engine_builder;
-  auto bootstrap = std::make_unique<envoy::config::bootstrap::v3::Bootstrap>();
-  TestUtility::loadFromYaml(CONFIG, *bootstrap);
-  Platform::EngineSharedPtr engine = engine_builder.createEngine(std::move(bootstrap));
+  Platform::EngineBuilder engine_builder;
+  engine_builder.addNativeFilter(
+      "test_remote_response",
+      "{'@type': "
+      "type.googleapis.com/"
+      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
+  absl::Notification engine_running;
+  Platform::EngineSharedPtr engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
+                                         .setOnEngineRunning([&]() { engine_running.Notify(); })
+                                         .build();
+  engine_running.WaitForNotification();
 
   Status status;
   absl::Notification stream_complete;
-  Platform::StreamSharedPtr stream;
   auto stream_prototype = engine->streamClient()->newStreamPrototype();
-
-  stream_prototype->setOnHeaders(
-      [&](Platform::ResponseHeadersSharedPtr headers, bool end_stream, envoy_stream_intel) {
-        status.status_code = headers->httpStatus();
-        status.end_stream = end_stream;
-      });
-  stream_prototype->setOnComplete(
-      [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); });
-  stream_prototype->setOnError(
-      [&](Platform::EnvoyErrorSharedPtr envoy_error, envoy_stream_intel, envoy_final_stream_intel) {
-        (void)envoy_error;
-        stream_complete.Notify();
-      });
-  stream_prototype->setOnCancel(
-      [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); });
-
-  stream = stream_prototype->start();
+  Platform::StreamSharedPtr stream =
+      stream_prototype
+          ->setOnHeaders(
+              [&](Platform::ResponseHeadersSharedPtr headers, bool end_stream, envoy_stream_intel) {
+                status.status_code = headers->httpStatus();
+                status.end_stream = end_stream;
+              })
+          .setOnData([&](envoy_data, bool end_stream) { status.end_stream = end_stream; })
+          .setOnComplete(
+              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
+          .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                          envoy_final_stream_intel) { stream_complete.Notify(); })
+          .setOnCancel(
+              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
+          .start();
 
   Platform::RequestHeadersBuilder request_headers_builder(Platform::RequestMethod::GET, "https",
                                                           "example.com", "/");


### PR DESCRIPTION
This updates the `lifetimes_test` and `send_headers_test` to use `EngineBuilder` directly instead of `TestEngineBuilder`. `TestEngineBuilder` will soon be removed.

Risk Level: low (clean up)
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
