### PR TITLE
buffer: use std::to_chars for serializing doubles

### DIFF
--- a/source/common/buffer/BUILD
+++ b/source/common/buffer/BUILD
@@ -42,3 +42,13 @@ envoy_cc_library(
         "//source/common/protobuf",
     ],
 )
+
+envoy_cc_library(
+    name = "buffer_util_lib",
+    srcs = ["buffer_util.cc"],
+    hdrs = ["buffer_util.h"],
+    deps = [
+        "//envoy/buffer:buffer_interface",
+        "//source/common/common:assert_lib",
+    ],
+)

--- a/source/common/buffer/buffer_util.cc
+++ b/source/common/buffer/buffer_util.cc
@@ -30,7 +30,7 @@ void Util::serializeDouble(double number, Buffer::Instance& buffer) {
   // it is the fastest correct option on other platforms.
   char buf[100];
   std::to_chars_result result = std::to_chars(buf, buf + sizeof(buf), number);
-  ASSERT(result.ec == std::errc{}, std::make_error_code(result.ec).message());
+  ENVOY_BUG(result.ec == std::errc{}, std::make_error_code(result.ec).message());
   buffer.addFragments({absl::string_view(buf, result.ptr - buf)});
 
   // Note: there is room to speed this up further by serializing the number directly

--- a/source/common/buffer/buffer_util.cc
+++ b/source/common/buffer/buffer_util.cc
@@ -1,0 +1,43 @@
+#include "source/common/buffer/buffer_util.h"
+
+#include <charconv>
+
+#include "source/common/common/macros.h"
+
+namespace Envoy {
+namespace Buffer {
+
+void Util::serializeDouble(double number, Buffer::Instance& buffer) {
+  // Converting a double to a string: who would think it would be so complex?
+  // It's easy if you don't care about speed or accuracy :). Here we are measuring
+  // the speed with test/server/admin/stats_handler_speed_test --benchmark_filter=BM_HistogramsJson
+  // Here are some options:
+  //   * absl::StrCat(number) -- fast (19ms on speed test) but loses precision (drops decimals).
+  //   * absl::StrFormat("%.15g") -- works great but a bit slow (24ms on speed test)
+  //   * `snprintf`(buf, sizeof(buf), "%.15g", ...) -- works but slow as molasses: 30ms.
+  //   * fmt::format("{}") -- works great and is a little faster than absl::StrFormat: 21ms.
+  //   * fmt::to_string -- works great and is a little faster than fmt::format: 19ms.
+  //   * std::to_chars -- fast (16ms) and precise, but requires a few lines to
+  //     generate the string_view, and does not work on all platforms yet.
+  //
+  // The accuracy is checked in buffer_util_test.
+#if defined(__APPLE__) || defined(GCC_COMPILER)
+  // On Apple and gcc, std::to_chars does not work with 'double', so we revert
+  // to the next fastest correct implementation.
+  buffer.addFragments({fmt::to_string(number)});
+#else
+  // This version is awkward, and doesn't work on Apple as of August 2023, but
+  // it is the fastest correct option on other platforms.
+  char buf[100];
+  std::to_chars_result result = std::to_chars(buf, buf + sizeof(buf), number);
+  ASSERT(result.ec == std::errc{}, std::make_error_code(result.ec).message());
+  buffer.addFragments({absl::string_view(buf, result.ptr - buf)});
+
+  // Note: there is room to speed this up further by serializing the number directly
+  // into the buffer. However, buffer does not currently make it easy and fast
+  // to get (say) 100 characters of raw buffer to serialize into.
+#endif
+}
+
+} // namespace Buffer
+} // namespace Envoy

--- a/source/common/buffer/buffer_util.h
+++ b/source/common/buffer/buffer_util.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+
+namespace Envoy {
+namespace Buffer {
+
+class Util {
+public:
+  /**
+   * Serializes double to a buffer with high precision and high performance.
+   *
+   * This helper function is defined on Buffer rather than working with
+   * intermediate string constructs because, depending on the platform, a
+   * different sort of intermediate char buffer is chosen for maximum
+   * performance. It's fastest to then directly append the serialized
+   * char-buffer into the Buffer::Instance, without defining the intermediate
+   * char-buffer as part of the API.
+   *
+   * @param number the number to convert.
+   * @param buffer the buffer in which to write the double.
+   */
+  static void serializeDouble(double number, Buffer::Instance& buffer);
+};
+
+} // namespace Buffer
+} // namespace Envoy

--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -53,6 +53,7 @@ envoy_cc_library(
     deps = [
         ":json_sanitizer_lib",
         "//envoy/buffer:buffer_interface",
+        "//source/common/buffer:buffer_util_lib",
         "//source/common/common:assert_lib",
     ],
 )

--- a/source/common/json/json_streamer.cc
+++ b/source/common/json/json_streamer.cc
@@ -1,8 +1,7 @@
 #include "source/common/json/json_streamer.h"
 
+#include "source/common/buffer/buffer_util.h"
 #include "source/common/json/json_sanitizer.h"
-
-#include "absl/strings/str_format.h"
 
 namespace Envoy {
 namespace Json {
@@ -154,7 +153,7 @@ void Streamer::addNumber(double number) {
   if (std::isnan(number)) {
     response_.addFragments({"null"});
   } else {
-    response_.addFragments({absl::StrFormat("%.15g", number)});
+    Buffer::Util::serializeDouble(number, response_);
   }
 }
 

--- a/source/server/admin/stats_render.cc
+++ b/source/server/admin/stats_render.cc
@@ -53,8 +53,8 @@ void StatsTextRender::addDetail(const std::vector<Stats::ParentHistogram::Bucket
                                 Buffer::Instance& response) {
   absl::string_view delim = "";
   for (const Stats::ParentHistogram::Bucket& bucket : buckets) {
-    response.addFragments(
-        {delim, absl::StrCat(bucket.lower_bound_, ",", bucket.width_, ":", bucket.count_)});
+    response.addFragments({delim, absl::StrFormat("%.15g,%.15g:%lu", bucket.lower_bound_,
+                                                  bucket.width_, bucket.count_)});
     delim = ", ";
   }
 }

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -72,6 +72,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "buffer_util_test",
+    srcs = ["buffer_util_test.cc"],
+    deps = [
+        ":utility_lib",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/buffer:buffer_util_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "watermark_buffer_test",
     srcs = ["watermark_buffer_test.cc"],
     deps = [

--- a/test/common/buffer/buffer_util_test.cc
+++ b/test/common/buffer/buffer_util_test.cc
@@ -1,0 +1,29 @@
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/buffer/buffer_util.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Buffer {
+namespace {
+
+class UtilTest : public testing::Test {
+protected:
+  std::string serialize(double number) {
+    OwnedImpl buf;
+    Util::serializeDouble(number, buf);
+    return buf.toString();
+  }
+};
+
+TEST_F(UtilTest, SerializeDouble) {
+  EXPECT_EQ("0", serialize(0));
+  EXPECT_EQ("0.5", serialize(0.5));
+  EXPECT_EQ("3.141592654", serialize(3.141592654));
+  EXPECT_EQ("-989282.1087", serialize(-989282.1087));
+  EXPECT_EQ("1.23456789012345e+67", serialize(1.23456789012345e+67));
+}
+
+} // namespace
+} // namespace Buffer
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: A performance regression was found in a late commit as part of #28988 where we switched from a low-precision fast serialization of doubles (absl::StrCat) to a high-precision slow serialization of doubles (absl::StrFormat("%.15g", ...). This resolves that issue using std::to_chars which is faster than absl::StrCat and is also high precision. The downside is it doesn't work on all platforms, so an intermediate high-precision medium-speed solution was found for Apple and GCC. The serialize-double-to-buffer functionality is moved out of Json::Streamer and into a new Buffer::Util namespace.

Latest Json histogram serialization performance:
```
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
BM_HistogramsJson                   17.3 ms         17.3 ms           41
```
Additional Description:
Risk Level: low
Testing: /test/common/json/... test/common/buffer //test/server/admin/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

