### PR TITLE
some optimizations to inline map

### DIFF
--- a/source/common/common/inline_map.h
+++ b/source/common/common/inline_map.h
@@ -374,12 +374,13 @@ public:
 
     const uint64_t inline_keys_num = descriptor_.inlineKeysNum();
     const auto& inline_keys = descriptor_.inlineKeys();
+    const Value* inline_entries = inlineEntries();
     for (uint64_t i = 0; i < inline_keys_num; ++i) {
       if (!inlineEntryValid(i)) {
         continue;
       }
 
-      if (!callback(inline_keys[i], inlineEntries()[i])) {
+      if (!callback(inline_keys[i], inline_entries[i])) {
         return;
       }
     }
@@ -459,7 +460,9 @@ private:
 
   template <class SetValue> void resetInlineMapEntry(uint64_t inline_entry_id, SetValue&& value) {
     ASSERT(inline_entry_id < descriptor_.inlineKeysNum());
-    // Only allocate the memory for inline entries when the first inline entry is added.
+    // Only allocate the memory for inline entries when the first inline entry is added. The avoid
+    // the unnecessary memory allocation and deallocation for the map instances that never add any
+    // inline entries.
     lazyInitializeInlineEntriesMemory();
 
     clearInlineMapEntry(inline_entry_id);

--- a/source/common/common/inline_map.h
+++ b/source/common/common/inline_map.h
@@ -546,7 +546,7 @@ private:
   uint64_t inline_entries_size_{};
 
   // These are flags to indicate if the inline entries are valid. We keep pointer here to
-  // avoid calucating the offset every time.
+  // avoid computing the offset every time.
   bool* inline_entries_valid_{};
 };
 

--- a/source/common/common/inline_map.h
+++ b/source/common/common/inline_map.h
@@ -452,7 +452,7 @@ private:
       const uint64_t memory_size = value_memory_size + valid_memory_size;
 
       inline_entries_.reset(new uint8_t[memory_size]);
-      memset(inline_entries_.get(), 0, memory_size);
+      memset(inline_entries_.get() + value_memory_size, 0, valid_memory_size);
 
       inline_entries_valid_ = reinterpret_cast<bool*>(inline_entries_.get() + value_memory_size);
     }

--- a/source/common/common/inline_map.h
+++ b/source/common/common/inline_map.h
@@ -46,12 +46,11 @@ namespace Envoy {
  *   descriptor.finalize();
  *
  *   // Create the inline map.
- *   InlineMapPtr<std::string, std::string> inline_map = InlineMap<std::string,
- *     std::string>::create(descriptor);
+ *   InlineMap<std::string, std::string> inline_map(descriptor)
  *
  *   // Set value by handle.
- *   inline_map->set(handle, "value");
- *   EXPECT_EQ(*inline_map->lookup(handle), "value");
+ *   inline_map.set(handle, "value");
+ *   EXPECT_EQ(*inline_map.get(handle), "value");
  */
 
 /**
@@ -219,9 +218,7 @@ public:
     rhs.inline_entries_valid_ = nullptr;
   }
 
-  ~InlineMap() { /*clear()*/
-    ;
-  }
+  ~InlineMap() { clear(); }
 
   /**
    * Get the entry by the given key. Heterogeneous lookup is supported here.

--- a/test/common/common/inline_map_speed_test.cc
+++ b/test/common/common/inline_map_speed_test.cc
@@ -24,6 +24,56 @@ static void BM_InlineMapConstructAndDestruct(benchmark::State& state) {
 
   const auto create_normal_map = []() {
     absl::flat_hash_map<std::string, std::string> normal_map;
+    return normal_map.size();
+  };
+
+  const auto create_inline_map_200 = [&descriptor_200]() {
+    InlineMap<std::string, std::string> inline_map(descriptor_200);
+    return inline_map.size();
+  };
+
+  const auto create_inline_map_0 = [&descriptor_0]() {
+    InlineMap<std::string, std::string> inline_map(descriptor_0);
+    return inline_map.size();
+  };
+
+  if (map_type == 0) {
+    // Normal map.
+    for (auto _ : state) { // NOLINT
+      benchmark::DoNotOptimize(create_normal_map());
+    }
+  } else if (map_type == 1) {
+    // Inline map without any inline keys.
+    for (auto _ : state) { // NOLINT
+      benchmark::DoNotOptimize(create_inline_map_0());
+    }
+  } else {
+    // Inline map with 200 inline keys.
+    for (auto _ : state) { // NOLINT
+      benchmark::DoNotOptimize(create_inline_map_200());
+    }
+  }
+}
+
+BENCHMARK(BM_InlineMapConstructAndDestruct)->Args({0})->Args({1})->Args({2});
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_InlineMapConstructAndDestructWithSingleEntry(benchmark::State& state) {
+  const size_t map_type = state.range(0);
+
+  InlineMapDescriptor<std::string> descriptor_200;
+  // Create 200 inline keys.
+  for (size_t i = 0; i < 200; ++i) {
+    const std::string key = "key_" + std::to_string(i);
+    descriptor_200.addInlineKey(key);
+  }
+  InlineMapDescriptor<std::string> descriptor_0;
+
+  descriptor_200.finalize();
+  descriptor_0.finalize();
+
+  const auto create_normal_map = []() {
+    absl::flat_hash_map<std::string, std::string> normal_map;
     normal_map.insert({"key_1", "value_1"});
     return normal_map.size();
   };
@@ -58,7 +108,7 @@ static void BM_InlineMapConstructAndDestruct(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_InlineMapConstructAndDestruct)->Args({0})->Args({1})->Args({2});
+BENCHMARK(BM_InlineMapConstructAndDestructWithSingleEntry)->Args({0})->Args({1})->Args({2});
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_InlineMapSet(benchmark::State& state) {

--- a/test/common/common/inline_map_speed_test.cc
+++ b/test/common/common/inline_map_speed_test.cc
@@ -14,8 +14,7 @@ static void BM_InlineMapConstructAndDestruct(benchmark::State& state) {
   InlineMapDescriptor<std::string> descriptor_200;
   // Create 200 inline keys.
   for (size_t i = 0; i < 200; ++i) {
-    const std::string key = "key_" + std::to_string(i);
-    descriptor_200.addInlineKey(key);
+    descriptor_200.addInlineKey(absl::StrCat("key_", i));
   }
   InlineMapDescriptor<std::string> descriptor_0;
 
@@ -64,8 +63,7 @@ static void BM_InlineMapConstructAndDestructWithSingleEntry(benchmark::State& st
   InlineMapDescriptor<std::string> descriptor_200;
   // Create 200 inline keys.
   for (size_t i = 0; i < 200; ++i) {
-    const std::string key = "key_" + std::to_string(i);
-    descriptor_200.addInlineKey(key);
+    descriptor_200.addInlineKey(absl::StrCat("key_", i));
   }
   InlineMapDescriptor<std::string> descriptor_0;
 
@@ -122,10 +120,10 @@ static void BM_InlineMapSet(benchmark::State& state) {
   // Create 200 inline keys.
   std::vector<InlineMapDescriptor<std::string>::Handle> inline_handles_200;
   for (size_t i = 0; i < 200; ++i) {
-    const std::string key = "key_" + std::to_string(i);
+    const std::string key = absl::StrCat("key_", i);
     inline_handles_200.push_back(descriptor_200.addInlineKey(key));
     normal_keys.push_back(key);
-    normal_values.push_back("value_" + std::to_string(i));
+    normal_values.push_back(absl::StrCat("value_", i));
   }
   InlineMapDescriptor<std::string> descriptor_0;
 
@@ -185,7 +183,7 @@ static void BM_InlineMapGet(benchmark::State& state) {
   // Create 200 inline keys.
   std::vector<InlineMapDescriptor<std::string>::Handle> inline_handles_200;
   for (size_t i = 0; i < 200; ++i) {
-    const std::string key = "key_" + std::to_string(i);
+    const std::string key = absl::StrCat("key_", i);
     inline_handles_200.push_back(descriptor_200.addInlineKey(key));
     normal_keys.push_back(key);
   }
@@ -199,9 +197,10 @@ static void BM_InlineMapGet(benchmark::State& state) {
   InlineMap<std::string, std::string> inline_map_0(descriptor_0);
 
   for (size_t i = 0; i < 200; ++i) {
-    normal_map[normal_keys[i]] = "value_" + std::to_string(i);
-    inline_map_200.set(normal_keys[i], "value_" + std::to_string(i));
-    inline_map_0.set(normal_keys[i], "value_" + std::to_string(i));
+    const std::string value = absl::StrCat("value_", i);
+    normal_map[normal_keys[i]] = value;
+    inline_map_200.set(normal_keys[i], value);
+    inline_map_0.set(normal_keys[i], value);
   }
 
   if (map_type == 0) {

--- a/test/common/common/inline_map_speed_test.cc
+++ b/test/common/common/inline_map_speed_test.cc
@@ -28,13 +28,13 @@ static void BM_InlineMapFind(benchmark::State& state) {
   descriptor_0.finalize();
 
   absl::flat_hash_map<std::string, std::string> normal_map;
-  auto inline_map_200 = InlineMap<std::string, std::string>::create(descriptor_200);
-  auto inline_map_0 = InlineMap<std::string, std::string>::create(descriptor_0);
+  InlineMap<std::string, std::string> inline_map_200(descriptor_200);
+  InlineMap<std::string, std::string> inline_map_0(descriptor_0);
 
   for (size_t i = 0; i < 200; ++i) {
     normal_map[normal_keys[i]] = "value_" + std::to_string(i);
-    inline_map_200->set(normal_keys[i], "value_" + std::to_string(i));
-    inline_map_0->set(normal_keys[i], "value_" + std::to_string(i));
+    inline_map_200.set(normal_keys[i], "value_" + std::to_string(i));
+    inline_map_0.set(normal_keys[i], "value_" + std::to_string(i));
   }
 
   if (map_type == 0) {
@@ -48,7 +48,7 @@ static void BM_InlineMapFind(benchmark::State& state) {
     // Inline map without any inline keys.
     for (auto _ : state) { // NOLINT
       for (size_t i = 0; i < 200; ++i) {
-        inline_map_0->get(normal_keys[i]);
+        inline_map_0.get(normal_keys[i]);
       }
     }
   } else {
@@ -56,13 +56,13 @@ static void BM_InlineMapFind(benchmark::State& state) {
     if (used_inline_handles == 0) {
       for (auto _ : state) { // NOLINT
         for (size_t i = 0; i < 200; ++i) {
-          inline_map_200->get(normal_keys[i]);
+          inline_map_200.get(normal_keys[i]);
         }
       }
     } else {
       for (auto _ : state) { // NOLINT
         for (size_t i = 0; i < 200; ++i) {
-          inline_map_200->get(inline_handles_200[i]);
+          inline_map_200.get(inline_handles_200[i]);
         }
       }
     }

--- a/test/common/common/inline_map_speed_test.cc
+++ b/test/common/common/inline_map_speed_test.cc
@@ -21,36 +21,30 @@ static void BM_InlineMapConstructAndDestruct(benchmark::State& state) {
   descriptor_200.finalize();
   descriptor_0.finalize();
 
-  const auto create_normal_map = []() {
-    absl::flat_hash_map<std::string, std::string> normal_map;
-    return normal_map.size();
-  };
-
-  const auto create_inline_map_200 = [&descriptor_200]() {
-    InlineMap<std::string, std::string> inline_map(descriptor_200);
-    return inline_map.size();
-  };
-
-  const auto create_inline_map_0 = [&descriptor_0]() {
-    InlineMap<std::string, std::string> inline_map(descriptor_0);
-    return inline_map.size();
-  };
-
   if (map_type == 0) {
     // Normal map.
+    size_t total_size = 0;
     for (auto _ : state) { // NOLINT
-      benchmark::DoNotOptimize(create_normal_map());
+      absl::flat_hash_map<std::string, std::string> normal_map;
+      total_size += normal_map.size();
     }
+    benchmark::DoNotOptimize(total_size);
   } else if (map_type == 1) {
     // Inline map without any inline keys.
+    size_t total_size = 0;
     for (auto _ : state) { // NOLINT
-      benchmark::DoNotOptimize(create_inline_map_0());
+      InlineMap<std::string, std::string> inline_map(descriptor_0);
+      total_size += inline_map.size();
     }
+    benchmark::DoNotOptimize(total_size);
   } else {
     // Inline map with 200 inline keys.
+    size_t total_size = 0;
     for (auto _ : state) { // NOLINT
-      benchmark::DoNotOptimize(create_inline_map_200());
+      InlineMap<std::string, std::string> inline_map(descriptor_200);
+      total_size += inline_map.size();
     }
+    benchmark::DoNotOptimize(total_size);
   }
 }
 
@@ -70,39 +64,33 @@ static void BM_InlineMapConstructAndDestructWithSingleEntry(benchmark::State& st
   descriptor_200.finalize();
   descriptor_0.finalize();
 
-  const auto create_normal_map = []() {
-    absl::flat_hash_map<std::string, std::string> normal_map;
-    normal_map.insert({"key_1", "value_1"});
-    return normal_map.size();
-  };
-
-  const auto create_inline_map_200 = [&descriptor_200]() {
-    InlineMap<std::string, std::string> inline_map(descriptor_200);
-    inline_map.set("key_1", "value_1");
-    return inline_map.size();
-  };
-
-  const auto create_inline_map_0 = [&descriptor_0]() {
-    InlineMap<std::string, std::string> inline_map(descriptor_0);
-    inline_map.set("key_1", "value_1");
-    return inline_map.size();
-  };
-
   if (map_type == 0) {
     // Normal map.
+    size_t total_size = 0;
     for (auto _ : state) { // NOLINT
-      benchmark::DoNotOptimize(create_normal_map());
+      absl::flat_hash_map<std::string, std::string> normal_map;
+      normal_map.insert({"key_1", "value_1"});
+      total_size += normal_map.size();
     }
+    benchmark::DoNotOptimize(total_size);
   } else if (map_type == 1) {
     // Inline map without any inline keys.
+    size_t total_size = 0;
     for (auto _ : state) { // NOLINT
-      benchmark::DoNotOptimize(create_inline_map_0());
+      InlineMap<std::string, std::string> inline_map(descriptor_0);
+      inline_map.set("key_1", "value_1");
+      total_size += inline_map.size();
     }
+    benchmark::DoNotOptimize(total_size);
   } else {
     // Inline map with 200 inline keys.
+    size_t total_size = 0;
     for (auto _ : state) { // NOLINT
-      benchmark::DoNotOptimize(create_inline_map_200());
+      InlineMap<std::string, std::string> inline_map(descriptor_200);
+      inline_map.set("key_1", "value_1");
+      total_size += inline_map.size();
     }
+    benchmark::DoNotOptimize(total_size);
   }
 }
 

--- a/test/common/common/inline_map_speed_test.cc
+++ b/test/common/common/inline_map_speed_test.cc
@@ -22,29 +22,38 @@ static void BM_InlineMapConstructAndDestruct(benchmark::State& state) {
   descriptor_200.finalize();
   descriptor_0.finalize();
 
+  const auto create_normal_map = []() {
+    absl::flat_hash_map<std::string, std::string> normal_map;
+    normal_map.insert({"key_1", "value_1"});
+    return normal_map.size();
+  };
+
+  const auto create_inline_map_200 = [&descriptor_200]() {
+    InlineMap<std::string, std::string> inline_map(descriptor_200);
+    inline_map.set("key_1", "value_1");
+    return inline_map.size();
+  };
+
+  const auto create_inline_map_0 = [&descriptor_0]() {
+    InlineMap<std::string, std::string> inline_map(descriptor_0);
+    inline_map.set("key_1", "value_1");
+    return inline_map.size();
+  };
+
   if (map_type == 0) {
     // Normal map.
     for (auto _ : state) { // NOLINT
-      for (size_t i = 0; i < 200; ++i) {
-        absl::flat_hash_map<std::string, std::string> normal_map;
-        benchmark::DoNotOptimize(normal_map.size());
-      }
+      benchmark::DoNotOptimize(create_normal_map());
     }
   } else if (map_type == 1) {
     // Inline map without any inline keys.
     for (auto _ : state) { // NOLINT
-      for (size_t i = 0; i < 200; ++i) {
-        InlineMap<std::string, std::string> inline_map(descriptor_0);
-        benchmark::DoNotOptimize(inline_map.size());
-      }
+      benchmark::DoNotOptimize(create_inline_map_0());
     }
   } else {
     // Inline map with 200 inline keys.
     for (auto _ : state) { // NOLINT
-      for (size_t i = 0; i < 200; ++i) {
-        InlineMap<std::string, std::string> inline_map(descriptor_200);
-        benchmark::DoNotOptimize(inline_map.size());
-      }
+      benchmark::DoNotOptimize(create_inline_map_200());
     }
   }
 }

--- a/test/common/common/inline_map_test.cc
+++ b/test/common/common/inline_map_test.cc
@@ -295,5 +295,37 @@ TEST(InlineMapWith3InlineKey, TestInlineKeysAsString) {
   EXPECT_EQ(descriptor.inlineKeysAsString("-"), "key_0-key_1-key_2");
 }
 
+TEST(InlineMapWith3InlineKey, TestInlineMapMoveConstructor) {
+  InlineMapDescriptor<std::string> descriptor;
+  // Create 3 inline keys.
+  for (size_t i = 0; i < 3; ++i) {
+    descriptor.addInlineKey("key_" + std::to_string(i));
+  }
+
+  descriptor.finalize();
+
+  InlineMap<std::string, std::unique_ptr<std::string>> map(descriptor);
+  for (size_t i = 0; i < 10; ++i) {
+    map.set("key_" + std::to_string(i),
+            std::make_unique<std::string>("value_" + std::to_string(i)));
+  }
+
+  // Check values by the keys.
+  for (size_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(*map.get("key_" + std::to_string(i)).ref(), "value_" + std::to_string(i));
+  }
+
+  InlineMap<std::string, std::unique_ptr<std::string>> map2(std::move(map));
+
+  // Check original map is empty.
+  EXPECT_EQ(map.size(), 0);
+  EXPECT_EQ(map2.size(), 10);
+
+  // Check values by the keys.
+  for (size_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(*map2.get("key_" + std::to_string(i)).ref(), "value_" + std::to_string(i));
+  }
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/common/common/inline_map_test.cc
+++ b/test/common/common/inline_map_test.cc
@@ -15,22 +15,22 @@ TEST(InlineMapWithZeroInlineKey, InlineMapWithZeroInlineKeyTest) {
 
   // Set entries.
   for (size_t i = 0; i < 100; ++i) {
-    map.set("key_" + std::to_string(i), "value_" + std::to_string(i));
+    map.set(absl::StrCat("key_", i), absl::StrCat("value_", i));
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_FALSE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_FALSE(map.set(absl::StrCat("key_", i), absl::StrCat("value_", i)).second);
   }
 
   // Use operator[] to set entries could overwrite existing entries.
   for (size_t i = 0; i < 100; ++i) {
-    map["key_" + std::to_string(i)] = "value_" + std::to_string(i) + "_new";
+    map[absl::StrCat("key_", i)] = absl::StrCat("value_", i, "_new");
   }
 
   // Get entries.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(*map.get("key_" + std::to_string(i)), "value_" + std::to_string(i) + "_new");
+    EXPECT_EQ(*map.get(absl::StrCat("key_", i)), absl::StrCat("value_", i, "_new"));
   }
 
   // Get entries by non-existing keys.
@@ -38,7 +38,7 @@ TEST(InlineMapWithZeroInlineKey, InlineMapWithZeroInlineKeyTest) {
 
   // Erase entries.
   for (size_t i = 0; i < 100; ++i) {
-    map.erase("key_" + std::to_string(i));
+    map.erase(absl::StrCat("key_", i));
   }
 }
 
@@ -49,12 +49,12 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Create 20 inline keys.
   for (size_t i = 0; i < 20; ++i) {
-    handles.push_back(descriptor.addInlineKey("key_" + std::to_string(i)));
+    handles.push_back(descriptor.addInlineKey(absl::StrCat("key_", i)));
   }
 
   // Add repeated inline keys will make no effect and return the same handle.
   for (size_t i = 0; i < 20; ++i) {
-    EXPECT_EQ(handles[i], descriptor.addInlineKey("key_" + std::to_string(i)));
+    EXPECT_EQ(handles[i], descriptor.addInlineKey(absl::StrCat("key_", i)));
   }
 
   descriptor.finalize();
@@ -63,27 +63,27 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Set entries by normal keys. But these keys are registered as inline keys.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_TRUE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_TRUE(map.set(absl::StrCat("key_", i), absl::StrCat("value_", i)).second);
     EXPECT_EQ(map.size(), i + 1);
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_FALSE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_FALSE(map.set(absl::StrCat("key_", i), absl::StrCat("value_", i)).second);
     EXPECT_EQ(map.size(), 10);
   }
 
   // Set entries by typed inline handle.
   for (size_t i = 10; i < 20; ++i) {
     auto handle = handles[i];
-    EXPECT_TRUE(map.set(handle, "value_" + std::to_string(i)).second);
+    EXPECT_TRUE(map.set(handle, absl::StrCat("value_", i)).second);
     EXPECT_EQ(map.size(), i + 1);
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 0; i < 20; ++i) {
     auto handle = handles[i];
-    EXPECT_FALSE(map.set(handle, "value_" + std::to_string(i)).second);
+    EXPECT_FALSE(map.set(handle, absl::StrCat("value_", i)).second);
 
     // The size will not change.
     EXPECT_EQ(map.size(), 20);
@@ -91,19 +91,19 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Set entries by normal keys.
   for (size_t i = 20; i < 100; ++i) {
-    EXPECT_TRUE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_TRUE(map.set(absl::StrCat("key_", i), absl::StrCat("value_", i)).second);
     EXPECT_EQ(map.size(), i + 1);
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 20; i < 100; ++i) {
-    EXPECT_FALSE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_FALSE(map.set(absl::StrCat("key_", i), absl::StrCat("value_", i)).second);
     EXPECT_EQ(map.size(), 100);
   }
 
   // Use operator[] to set entries with typed inline handle could overwrite existing keys.
   for (size_t i = 0; i < 10; ++i) {
-    map[handles[i]] = "value_" + std::to_string(i) + "_new";
+    map[handles[i]] = absl::StrCat("value_", i, "_new");
 
     // The size will not change.
     EXPECT_EQ(map.size(), 100);
@@ -112,7 +112,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
   // Use operator[] to set entries could overwrite existing keys (10-20 will be the keys that
   // registered as inline keys).
   for (size_t i = 10; i < 100; ++i) {
-    map["key_" + std::to_string(i)] = "value_" + std::to_string(i) + "_new";
+    map[absl::StrCat("key_", i)] = absl::StrCat("value_", i, "_new");
 
     // The size will not change.
     EXPECT_EQ(map.size(), 100);
@@ -120,7 +120,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Get entries.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(*map.get("key_" + std::to_string(i)), "value_" + std::to_string(i) + "_new");
+    EXPECT_EQ(*map.get(absl::StrCat("key_", i)), absl::StrCat("value_", i, "_new"));
 
     // The size will not change.
     EXPECT_EQ(map.size(), 100);
@@ -128,9 +128,9 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Get entries by typed inline handle.
   for (size_t i = 0; i < handles.size(); ++i) {
-    const std::string key = "key_" + std::to_string(i);
+    const std::string key = absl::StrCat("key_", i);
     auto handle = handles[i];
-    EXPECT_EQ(*map.get(handle), "value_" + std::to_string(i) + "_new");
+    EXPECT_EQ(*map.get(handle), absl::StrCat("value_", i, "_new"));
 
     // The size will not change.
     EXPECT_EQ(map.size(), 100);
@@ -141,7 +141,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Erase entries by typed inline handle.
   for (size_t i = 0; i < 10; ++i) {
-    const std::string key = "key_" + std::to_string(i);
+    const std::string key = absl::StrCat("key_", i);
     auto handle = handles[i];
     map.erase(handle);
 
@@ -150,7 +150,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Erase entries.
   for (size_t i = 10; i < 100; ++i) {
-    map.erase("key_" + std::to_string(i));
+    map.erase(absl::StrCat("key_", i));
 
     EXPECT_EQ(map.size(), 100 - i - 1);
   }
@@ -159,7 +159,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   // Get entries from empty map by normal key will return nothing.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(map.get("key_" + std::to_string(i)), OptRef<std::string>{});
+    EXPECT_EQ(map.get(absl::StrCat("key_", i)), OptRef<std::string>{});
   }
 
   // Get entries from empty map by typed inline handle will return nothing.
@@ -175,7 +175,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
   }
 
   for (size_t i = 10; i < 100; ++i) {
-    EXPECT_EQ(map["key_" + std::to_string(i)], "");
+    EXPECT_EQ(map[absl::StrCat("key_", i)], "");
 
     EXPECT_EQ(map.size(), i + 1);
   }
@@ -190,12 +190,12 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestDestructWithEntries) 
 
   // Create 20 inline keys.
   for (size_t i = 0; i < 20; ++i) {
-    handles.push_back(descriptor.addInlineKey("key_" + std::to_string(i)));
+    handles.push_back(descriptor.addInlineKey(absl::StrCat("key_", i)));
   }
 
   // Add repeated inline keys will make no effect and return the same handle.
   for (size_t i = 0; i < 20; ++i) {
-    EXPECT_EQ(handles[i], descriptor.addInlineKey("key_" + std::to_string(i)));
+    EXPECT_EQ(handles[i], descriptor.addInlineKey(absl::StrCat("key_", i)));
   }
 
   descriptor.finalize();
@@ -205,12 +205,12 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestDestructWithEntries) 
 
     // Set inline entries.
     for (size_t i = 0; i < 20; ++i) {
-      map.set(handles[i], "value_" + std::to_string(i));
+      map.set(handles[i], absl::StrCat("value_", i));
     }
 
     // Set dynamic entries.
     for (size_t i = 20; i < 100; ++i) {
-      map.set("key_" + std::to_string(i), "value_" + std::to_string(i));
+      map.set(absl::StrCat("key_", i), absl::StrCat("value_", i));
     }
   }
 }
@@ -222,12 +222,12 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestWithUniquePtrAsValue)
 
   // Create 20 inline keys.
   for (size_t i = 0; i < 20; ++i) {
-    handles.push_back(descriptor.addInlineKey("key_" + std::to_string(i)));
+    handles.push_back(descriptor.addInlineKey(absl::StrCat("key_", i)));
   }
 
   // Add repeated inline keys will make no effect and return the same handle.
   for (size_t i = 0; i < 20; ++i) {
-    EXPECT_EQ(handles[i], descriptor.addInlineKey("key_" + std::to_string(i)));
+    EXPECT_EQ(handles[i], descriptor.addInlineKey(absl::StrCat("key_", i)));
   }
 
   descriptor.finalize();
@@ -236,13 +236,12 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestWithUniquePtrAsValue)
 
   // Set inline entries.
   for (size_t i = 0; i < 20; ++i) {
-    map.set(handles[i], std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set(handles[i], std::make_unique<std::string>(absl::StrCat("value_", i)));
   }
 
   // Set dynamic entries.
   for (size_t i = 20; i < 100; ++i) {
-    map.set("key_" + std::to_string(i),
-            std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set(absl::StrCat("key_", i), std::make_unique<std::string>(absl::StrCat("value_", i)));
   }
 
   // Erase entries by typed inline handle.
@@ -252,18 +251,17 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestWithUniquePtrAsValue)
 
   // Overwrite entries by typed inline handle.
   for (size_t i = 5; i < 10; ++i) {
-    map[handles[i]] = std::make_unique<std::string>("value_" + std::to_string(i) + "_new");
+    map[handles[i]] = std::make_unique<std::string>(absl::StrCat("value_", i, "_new"));
   }
 
   // Erase entries by dynamic key.
   for (size_t i = 20; i < 25; ++i) {
-    map.erase("key_" + std::to_string(i));
+    map.erase(absl::StrCat("key_", i));
   }
 
   // Overwrite entries by dynamic key.
   for (size_t i = 25; i < 30; ++i) {
-    map["key_" + std::to_string(i)] =
-        std::make_unique<std::string>("value_" + std::to_string(i) + "_new");
+    map[absl::StrCat("key_", i)] = std::make_unique<std::string>(absl::StrCat("value_", i, "_new"));
   }
 
   // Clear the map.
@@ -273,8 +271,7 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestWithUniquePtrAsValue)
 
   // Reset the entries.
   for (size_t i = 0; i < 100; ++i) {
-    map.set("key_" + std::to_string(i),
-            std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set(absl::StrCat("key_", i), std::make_unique<std::string>(absl::StrCat("value_", i)));
   }
 
   EXPECT_EQ(map.size(), 100);
@@ -284,7 +281,7 @@ TEST(InlineMapWith3InlineKey, TestInlineKeysAsString) {
   InlineMapDescriptor<std::string> descriptor;
   // Create 3 inline keys.
   for (size_t i = 0; i < 3; ++i) {
-    descriptor.addInlineKey("key_" + std::to_string(i));
+    descriptor.addInlineKey(absl::StrCat("key_", i));
   }
 
   descriptor.finalize();
@@ -299,20 +296,19 @@ TEST(InlineMapWith3InlineKey, TestInlineMapMoveConstructor) {
   InlineMapDescriptor<std::string> descriptor;
   // Create 3 inline keys.
   for (size_t i = 0; i < 3; ++i) {
-    descriptor.addInlineKey("key_" + std::to_string(i));
+    descriptor.addInlineKey(absl::StrCat("key_", i));
   }
 
   descriptor.finalize();
 
   InlineMap<std::string, std::unique_ptr<std::string>> map(descriptor);
   for (size_t i = 0; i < 10; ++i) {
-    map.set("key_" + std::to_string(i),
-            std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set(absl::StrCat("key_", i), std::make_unique<std::string>(absl::StrCat("value_", i)));
   }
 
   // Check values by the keys.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_EQ(*map.get("key_" + std::to_string(i)).ref(), "value_" + std::to_string(i));
+    EXPECT_EQ(*map.get(absl::StrCat("key_", i)).ref(), absl::StrCat("value_", i));
   }
 
   InlineMap<std::string, std::unique_ptr<std::string>> map2(std::move(map));
@@ -323,7 +319,7 @@ TEST(InlineMapWith3InlineKey, TestInlineMapMoveConstructor) {
 
   // Check values by the keys.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_EQ(*map2.get("key_" + std::to_string(i)).ref(), "value_" + std::to_string(i));
+    EXPECT_EQ(*map2.get(absl::StrCat("key_", i)).ref(), absl::StrCat("value_", i));
   }
 }
 

--- a/test/common/common/inline_map_test.cc
+++ b/test/common/common/inline_map_test.cc
@@ -11,36 +11,35 @@ TEST(InlineMapWithZeroInlineKey, InlineMapWithZeroInlineKeyTest) {
   InlineMapDescriptor<std::string> descriptor;
   descriptor.finalize();
 
-  auto map = InlineMap<std::string, std::string>::create(descriptor);
+  InlineMap<std::string, std::string> map(descriptor);
 
   // Set entries.
   for (size_t i = 0; i < 100; ++i) {
-    map->set("key_" + std::to_string(i), "value_" + std::to_string(i));
+    map.set("key_" + std::to_string(i), "value_" + std::to_string(i));
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_FALSE(map->set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_FALSE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
   }
 
   // Use operator[] to set entries could overwrite existing entries.
   for (size_t i = 0; i < 100; ++i) {
-    (*map)["key_" + std::to_string(i)] = "value_" + std::to_string(i) + "_new";
+    map["key_" + std::to_string(i)] = "value_" + std::to_string(i) + "_new";
   }
 
   // Get entries.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(*map->get("key_" + std::to_string(i)), "value_" + std::to_string(i) + "_new");
+    EXPECT_EQ(*map.get("key_" + std::to_string(i)), "value_" + std::to_string(i) + "_new");
   }
 
   // Get entries by non-existing keys.
-  EXPECT_FALSE(map->get("non_existing_key"));
+  EXPECT_FALSE(map.get("non_existing_key"));
 
   // Erase entries.
   for (size_t i = 0; i < 100; ++i) {
-    map->erase("key_" + std::to_string(i));
+    map.erase("key_" + std::to_string(i));
   }
-  map.reset();
 }
 
 TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
@@ -60,130 +59,128 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTest) {
 
   descriptor.finalize();
 
-  auto map = InlineMap<std::string, std::string>::create(descriptor);
+  InlineMap<std::string, std::string> map(descriptor);
 
   // Set entries by normal keys. But these keys are registered as inline keys.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_TRUE(map->set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
-    EXPECT_EQ(map->size(), i + 1);
+    EXPECT_TRUE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_EQ(map.size(), i + 1);
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_FALSE(map->set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
-    EXPECT_EQ(map->size(), 10);
+    EXPECT_FALSE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_EQ(map.size(), 10);
   }
 
   // Set entries by typed inline handle.
   for (size_t i = 10; i < 20; ++i) {
     auto handle = handles[i];
-    EXPECT_TRUE(map->set(handle, "value_" + std::to_string(i)).second);
-    EXPECT_EQ(map->size(), i + 1);
+    EXPECT_TRUE(map.set(handle, "value_" + std::to_string(i)).second);
+    EXPECT_EQ(map.size(), i + 1);
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 0; i < 20; ++i) {
     auto handle = handles[i];
-    EXPECT_FALSE(map->set(handle, "value_" + std::to_string(i)).second);
+    EXPECT_FALSE(map.set(handle, "value_" + std::to_string(i)).second);
 
     // The size will not change.
-    EXPECT_EQ(map->size(), 20);
+    EXPECT_EQ(map.size(), 20);
   }
 
   // Set entries by normal keys.
   for (size_t i = 20; i < 100; ++i) {
-    EXPECT_TRUE(map->set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
-    EXPECT_EQ(map->size(), i + 1);
+    EXPECT_TRUE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_EQ(map.size(), i + 1);
   }
 
   // Set entries by duplicate keys will fail.
   for (size_t i = 20; i < 100; ++i) {
-    EXPECT_FALSE(map->set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
-    EXPECT_EQ(map->size(), 100);
+    EXPECT_FALSE(map.set("key_" + std::to_string(i), "value_" + std::to_string(i)).second);
+    EXPECT_EQ(map.size(), 100);
   }
 
   // Use operator[] to set entries with typed inline handle could overwrite existing keys.
   for (size_t i = 0; i < 10; ++i) {
-    (*map)[handles[i]] = "value_" + std::to_string(i) + "_new";
+    map[handles[i]] = "value_" + std::to_string(i) + "_new";
 
     // The size will not change.
-    EXPECT_EQ(map->size(), 100);
+    EXPECT_EQ(map.size(), 100);
   }
 
   // Use operator[] to set entries could overwrite existing keys (10-20 will be the keys that
   // registered as inline keys).
   for (size_t i = 10; i < 100; ++i) {
-    (*map)["key_" + std::to_string(i)] = "value_" + std::to_string(i) + "_new";
+    map["key_" + std::to_string(i)] = "value_" + std::to_string(i) + "_new";
 
     // The size will not change.
-    EXPECT_EQ(map->size(), 100);
+    EXPECT_EQ(map.size(), 100);
   }
 
   // Get entries.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(*map->get("key_" + std::to_string(i)), "value_" + std::to_string(i) + "_new");
+    EXPECT_EQ(*map.get("key_" + std::to_string(i)), "value_" + std::to_string(i) + "_new");
 
     // The size will not change.
-    EXPECT_EQ(map->size(), 100);
+    EXPECT_EQ(map.size(), 100);
   }
 
   // Get entries by typed inline handle.
   for (size_t i = 0; i < handles.size(); ++i) {
     const std::string key = "key_" + std::to_string(i);
     auto handle = handles[i];
-    EXPECT_EQ(*map->get(handle), "value_" + std::to_string(i) + "_new");
+    EXPECT_EQ(*map.get(handle), "value_" + std::to_string(i) + "_new");
 
     // The size will not change.
-    EXPECT_EQ(map->size(), 100);
+    EXPECT_EQ(map.size(), 100);
   }
 
   // Get entries by non-existing keys.
-  EXPECT_FALSE(map->get("non_existing_key"));
+  EXPECT_FALSE(map.get("non_existing_key"));
 
   // Erase entries by typed inline handle.
   for (size_t i = 0; i < 10; ++i) {
     const std::string key = "key_" + std::to_string(i);
     auto handle = handles[i];
-    map->erase(handle);
+    map.erase(handle);
 
-    EXPECT_EQ(map->size(), 100 - i - 1);
+    EXPECT_EQ(map.size(), 100 - i - 1);
   }
 
   // Erase entries.
   for (size_t i = 10; i < 100; ++i) {
-    map->erase("key_" + std::to_string(i));
+    map.erase("key_" + std::to_string(i));
 
-    EXPECT_EQ(map->size(), 100 - i - 1);
+    EXPECT_EQ(map.size(), 100 - i - 1);
   }
 
-  EXPECT_EQ(map->size(), 0);
+  EXPECT_EQ(map.size(), 0);
 
   // Get entries from empty map by normal key will return nothing.
   for (size_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(map->get("key_" + std::to_string(i)), OptRef<std::string>{});
+    EXPECT_EQ(map.get("key_" + std::to_string(i)), OptRef<std::string>{});
   }
 
   // Get entries from empty map by typed inline handle will return nothing.
   for (auto handle : handles) {
-    EXPECT_EQ(map->get(handle), OptRef<std::string>{});
+    EXPECT_EQ(map.get(handle), OptRef<std::string>{});
   }
 
   // Operator[] will insert new entry if the key does not exist.
   for (size_t i = 0; i < 10; ++i) {
-    EXPECT_EQ((*map)[handles[i]], "");
+    EXPECT_EQ(map[handles[i]], "");
 
-    EXPECT_EQ(map->size(), i + 1);
+    EXPECT_EQ(map.size(), i + 1);
   }
 
   for (size_t i = 10; i < 100; ++i) {
-    EXPECT_EQ((*map)["key_" + std::to_string(i)], "");
+    EXPECT_EQ(map["key_" + std::to_string(i)], "");
 
-    EXPECT_EQ(map->size(), i + 1);
+    EXPECT_EQ(map.size(), i + 1);
   }
 
-  EXPECT_EQ(map->size(), 100);
-
-  map.reset();
+  EXPECT_EQ(map.size(), 100);
 }
 
 TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestDestructWithEntries) {
@@ -203,20 +200,19 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestDestructWithEntries) 
 
   descriptor.finalize();
 
-  auto map = InlineMap<std::string, std::string>::create(descriptor);
+  {
+    InlineMap<std::string, std::string> map(descriptor);
 
-  // Set inline entries.
-  for (size_t i = 0; i < 20; ++i) {
-    map->set(handles[i], "value_" + std::to_string(i));
+    // Set inline entries.
+    for (size_t i = 0; i < 20; ++i) {
+      map.set(handles[i], "value_" + std::to_string(i));
+    }
+
+    // Set dynamic entries.
+    for (size_t i = 20; i < 100; ++i) {
+      map.set("key_" + std::to_string(i), "value_" + std::to_string(i));
+    }
   }
-
-  // Set dynamic entries.
-  for (size_t i = 20; i < 100; ++i) {
-    map->set("key_" + std::to_string(i), "value_" + std::to_string(i));
-  }
-
-  // Destruct the map.
-  map.reset();
 }
 
 TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestWithUniquePtrAsValue) {
@@ -236,75 +232,52 @@ TEST(InlineMapWith20InlineKey, InlineMapWith20InlineKeyTestWithUniquePtrAsValue)
 
   descriptor.finalize();
 
-  auto map = InlineMap<std::string, std::unique_ptr<std::string>>::create(descriptor);
+  InlineMap<std::string, std::unique_ptr<std::string>> map(descriptor);
 
   // Set inline entries.
   for (size_t i = 0; i < 20; ++i) {
-    map->set(handles[i], std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set(handles[i], std::make_unique<std::string>("value_" + std::to_string(i)));
   }
 
   // Set dynamic entries.
   for (size_t i = 20; i < 100; ++i) {
-    map->set("key_" + std::to_string(i),
-             std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set("key_" + std::to_string(i),
+            std::make_unique<std::string>("value_" + std::to_string(i)));
   }
 
   // Erase entries by typed inline handle.
   for (size_t i = 0; i < 5; ++i) {
-    map->erase(handles[i]);
+    map.erase(handles[i]);
   }
 
   // Overwrite entries by typed inline handle.
   for (size_t i = 5; i < 10; ++i) {
-    (*map)[handles[i]] = std::make_unique<std::string>("value_" + std::to_string(i) + "_new");
+    map[handles[i]] = std::make_unique<std::string>("value_" + std::to_string(i) + "_new");
   }
 
   // Erase entries by dynamic key.
   for (size_t i = 20; i < 25; ++i) {
-    map->erase("key_" + std::to_string(i));
+    map.erase("key_" + std::to_string(i));
   }
 
   // Overwrite entries by dynamic key.
   for (size_t i = 25; i < 30; ++i) {
-    (*map)["key_" + std::to_string(i)] =
+    map["key_" + std::to_string(i)] =
         std::make_unique<std::string>("value_" + std::to_string(i) + "_new");
   }
 
   // Clear the map.
-  map->clear();
+  map.clear();
 
-  EXPECT_EQ(map->size(), 0);
+  EXPECT_EQ(map.size(), 0);
 
   // Reset the entries.
   for (size_t i = 0; i < 100; ++i) {
-    map->set("key_" + std::to_string(i),
-             std::make_unique<std::string>("value_" + std::to_string(i)));
+    map.set("key_" + std::to_string(i),
+            std::make_unique<std::string>("value_" + std::to_string(i)));
   }
 
-  EXPECT_EQ(map->size(), 100);
-
-  // Destruct the map.
-  map.reset();
-}
-
-TEST(InlineMapWith20InlineKey, MapCreationWillFinalizeTheDescriptor) {
-  InlineMapDescriptor<std::string> descriptor;
-
-  std::vector<InlineMapDescriptor<std::string>::Handle> handles;
-
-  // Create 20 inline keys.
-  for (size_t i = 0; i < 20; ++i) {
-    handles.push_back(descriptor.addInlineKey("key_" + std::to_string(i)));
-  }
-
-  // Add repeated inline keys will make no effect and return the same handle.
-  for (size_t i = 0; i < 20; ++i) {
-    EXPECT_EQ(handles[i], descriptor.addInlineKey("key_" + std::to_string(i)));
-  }
-
-  auto map = InlineMap<std::string, std::unique_ptr<std::string>>::create(descriptor);
-
-  EXPECT_TRUE(descriptor.finalized());
+  EXPECT_EQ(map.size(), 100);
 }
 
 TEST(InlineMapWith3InlineKey, TestInlineKeysAsString) {


### PR DESCRIPTION

Commit Message: optimization to inline map
Additional Description:

This PR contains some useful improvements to inline map lib from recent practices. This patch contains following changes:
1. Update instantiation of inline map. Now the inline map could be created at stack.
2. Lazy memory allocation. Memory will be only allocated when first inline entry is added.
3. Continuous memory for inline entry values and flags.
4. More benchmark tests.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
