### PR TITLE
access_log: use FILTER_STATE field formatter for proxy protocol TLVs

### DIFF
--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -555,7 +555,9 @@ envoy_cc_library(
     hdrs = ["proxy_protocol_filter_state.h"],
     deps = [
         "//envoy/network:proxy_protocol_options_lib",
+        "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",
+        "//source/common/common:base64_lib",
         "//source/common/common:macros",
     ],
 )

--- a/source/common/network/proxy_protocol_filter_state.cc
+++ b/source/common/network/proxy_protocol_filter_state.cc
@@ -21,16 +21,12 @@ public:
     ASSERT(!tlv_type_str.empty());
     int tlv_type;
     if (!absl::SimpleAtoi(tlv_type_str, &tlv_type)) {
-    throw EnvoyException(fmt::format(
-        "Invalid parameter provided for FIELD value: {}. The proxy protocol TLV type must be parsable as int.",
-        tlv_type_str));
+      return absl::monostate();
     }
 
     // Check if a valid TLV type was passed in.
     if (tlv_type >= 256 || tlv_type <= 0) {
-      throw EnvoyException(fmt::format("Invalid parameter provided for FIELD value: "
-                                      "{}. The proxy protocol TLV type must be a positive integer less than 256.",
-                                      tlv_type_str));
+      return absl::monostate();
     }
 
     // Parse the TLVs with the given type from the filter state object.
@@ -58,7 +54,8 @@ public:
   std::unique_ptr<StreamInfo::FilterState::Object>
   createFromBytes(absl::string_view) const override {
     // Note: we do not parse the proxy protocol data from the given string because this
-    // isn't relevant to the functionality of this factory. 
+    // isn't relevant to the functionality of this factory.
+    PANIC("not implemented");
     return nullptr;
   }
 

--- a/source/common/network/proxy_protocol_filter_state.cc
+++ b/source/common/network/proxy_protocol_filter_state.cc
@@ -29,18 +29,15 @@ public:
       return absl::monostate();
     }
 
-    // Parse the TLVs with the given type from the filter state object.
-    std::ostringstream oss;
-    int match_count = 0;
+    // Parse a TLV with the given type from the filter state.
+    // (only returns first one found with given type)
     for (auto& tlv : object_->value().tlv_vector_) {
       if (tlv.type == tlv_type) {
-        if (match_count > 0)
-          oss << ", ";
-        oss << Base64::encode(reinterpret_cast<const char*>(tlv.value.data()), tlv.value.size());
-        match_count++;
+        return Base64::encode(reinterpret_cast<const char*>(tlv.value.data()), tlv.value.size());
       }
     }
-    return oss.str();
+    // TLV with given type was not found.
+    return absl::monostate();
   }
 
 private:

--- a/source/common/network/proxy_protocol_filter_state.cc
+++ b/source/common/network/proxy_protocol_filter_state.cc
@@ -5,8 +5,6 @@
 #include "source/common/common/base64.h"
 #include "source/common/common/macros.h"
 
-// #include "fmt/format.h"
-
 namespace Envoy {
 namespace Network {
 
@@ -49,8 +47,6 @@ public:
       }
     }
     return oss.str();
-
-    // Always return something 
   }
 
 private:

--- a/source/common/network/proxy_protocol_filter_state.cc
+++ b/source/common/network/proxy_protocol_filter_state.cc
@@ -16,9 +16,7 @@ class ProxyProtocolFilterStateReflection : public StreamInfo::FilterState::Objec
 public:
   ProxyProtocolFilterStateReflection(const ProxyProtocolFilterState* object) : object_(object) {}
 
-  FieldType getField(absl::string_view tlv_type_str) const override {
-    // Returns field type and serialized string value
-    
+  FieldType getField(absl::string_view tlv_type_str) const override {    
     // Specified tlv_type must be parsable as an int.
     ASSERT(!tlv_type_str.empty());
     int tlv_type;
@@ -35,7 +33,7 @@ public:
                                       tlv_type_str));
     }
 
-    // Parse the TLVs with the given type from the filter state object
+    // Parse the TLVs with the given type from the filter state object.
     std::ostringstream oss;
     int match_count = 0;
     for (auto& tlv : object_->value().tlv_vector_) {

--- a/source/common/network/proxy_protocol_filter_state.cc
+++ b/source/common/network/proxy_protocol_filter_state.cc
@@ -1,6 +1,11 @@
 #include "source/common/network/proxy_protocol_filter_state.h"
 
+#include "envoy/registry/registry.h"
+
+#include "source/common/common/base64.h"
 #include "source/common/common/macros.h"
+
+// #include "fmt/format.h"
 
 namespace Envoy {
 namespace Network {
@@ -8,6 +13,71 @@ namespace Network {
 const std::string& ProxyProtocolFilterState::key() {
   CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.proxy_protocol_options");
 }
+
+class ProxyProtocolFilterStateReflection : public StreamInfo::FilterState::ObjectReflection {
+public:
+  ProxyProtocolFilterStateReflection(const ProxyProtocolFilterState* object) : object_(object) {}
+
+  FieldType getField(absl::string_view tlv_type_str) const override {
+    // Returns field type and serialized string value
+    
+    // Specified tlv_type must be parsable as an int.
+    ASSERT(!tlv_type_str.empty());
+    int tlv_type;
+    if (!absl::SimpleAtoi(tlv_type_str, &tlv_type)) {
+    throw EnvoyException(fmt::format(
+        "Invalid parameter provided for FIELD value: {}. The proxy protocol TLV type must be parsable as int.",
+        tlv_type_str));
+    }
+
+    // Check if a valid TLV type was passed in.
+    if (tlv_type >= 256 || tlv_type <= 0) {
+      throw EnvoyException(fmt::format("Invalid parameter provided for FIELD value: "
+                                      "{}. The proxy protocol TLV type must be a positive integer less than 256.",
+                                      tlv_type_str));
+    }
+
+    // Parse the TLVs with the given type from the filter state object
+    std::ostringstream oss;
+    int match_count = 0;
+    for (auto& tlv : object_->value().tlv_vector_) {
+      if (tlv.type == tlv_type) {
+        if (match_count > 0)
+          oss << ", ";
+        oss << Base64::encode(reinterpret_cast<const char*>(tlv.value.data()), tlv.value.size());
+        match_count++;
+      }
+    }
+    return oss.str();
+
+    // Always return something 
+  }
+
+private:
+  const ProxyProtocolFilterState* object_;
+};
+
+class ProxyProtocolFilterStateFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return ProxyProtocolFilterState::key(); }
+
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view) const override {
+    // Note: we do not parse the proxy protocol data from the given string because this
+    // isn't relevant to the functionality of this factory. 
+    return nullptr;
+  }
+
+  std::unique_ptr<StreamInfo::FilterState::ObjectReflection> reflect(const StreamInfo::FilterState::Object* data) const override {
+    const auto* object = dynamic_cast<const ProxyProtocolFilterState*>(data);
+    if (object) {
+      return std::make_unique<ProxyProtocolFilterStateReflection>(object);
+    }
+    return nullptr;
+  }
+};
+
+REGISTER_FACTORY(ProxyProtocolFilterStateFactory, StreamInfo::FilterState::ObjectFactory);
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/proxy_protocol_filter_state.h
+++ b/source/common/network/proxy_protocol_filter_state.h
@@ -11,12 +11,15 @@ namespace Network {
  */
 class ProxyProtocolFilterState : public StreamInfo::FilterState::Object {
 public:
+  // Returns the key for looking up in the FilterState.
+  static const std::string& key();
+
   ProxyProtocolFilterState(Network::ProxyProtocolData options) : options_(options) {}
   const Network::ProxyProtocolData& value() const { return options_; }
-  static const std::string& key();
 
 private:
   const Network::ProxyProtocolData options_;
+  friend class ProxyProtocolDataReflection;
 };
 
 } // namespace Network

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -2154,6 +2154,14 @@ TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
   EXPECT_NE(dynamic_cast<ProxyProtocol::Filter*>(added_filter.get()), nullptr);
 }
 
+TEST(ProxyProtocolTest, ObjectFactory) {
+  const std::string name = "envoy.network.proxy_protocol_options";
+  auto* factory =
+      Registry::FactoryRegistry<StreamInfo::FilterState::ObjectFactory>::getFactory(name);
+  ASSERT_NE(nullptr, factory);
+  EXPECT_EQ(name, factory->name());
+}
+
 } // namespace
 } // namespace ProxyProtocol
 } // namespace ListenerFilters

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1018,6 +1018,7 @@ paren
 parens
 parentid
 parentspanid
+parsable
 parseable
 parsers
 passphrase


### PR DESCRIPTION
Commit Message: use FILTER_STATE field formatter for proxy protocol TLVs
Additional Description: uses https://github.com/envoyproxy/envoy/pull/29223 to enable formatting proxy protocol TLV field data given the TLV type as
Risk Level: low
Testing: manually tested
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

**Manual testing notes**

This can be invoked through the following example inclusion in the envoy config, where <tlv_type> is a valid TLV type according to the [proxy protocol spec](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt):
```
            request_headers_to_add:
            - header:
                key: proxy-protocol-tlv
                value: "%FILTER_STATE(envoy.network.proxy_protocol_options:FIELD:<tlv_type>)%"
```