### PR TITLE
network: fix bug in unix-domain socket peerAddress() on macOS

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -71,6 +71,9 @@ bug_fixes:
 - area: router check tool
   change: |
     Fixed a bug where the route coverage is not correctly calculated when a route has weighted clusters.
+- area: unix domain sockets
+  change: |
+    Fixed a crash on some versions of macOS when using a listener on a unix-domain socket.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: On some versions of macOS, `getpeeraddr` returns a length of 3, which is enough to read the `ss_family` and include a 1-byte `sun_path`, but Envoy was incorrectly treating this as invalid. This resulted in an uncaught exception.
Additional Description:
Risk Level: Low
Testing: Existing tests cover this
Docs Changes:
Release Notes: added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
