### PR TITLE
buffer: use compiler version rather than other platform ifdefs to determine library call to use to serialize doubles

### DIFF
--- a/source/common/buffer/buffer_util.cc
+++ b/source/common/buffer/buffer_util.cc
@@ -21,7 +21,7 @@ void Util::serializeDouble(double number, Buffer::Instance& buffer) {
   //     generate the string_view, and does not work on all platforms yet.
   //
   // The accuracy is checked in buffer_util_test.
-#if __cplusplus < 201703L // C++16 and below
+#if !defined(__clang_major__) || (__clang_major__ < 14)
   // On older compilers, such as those found on Apple, and gcc, std::to_chars
   // does not work with 'double', so we revert to the next fastest correct
   // implementation.

--- a/source/common/buffer/buffer_util.cc
+++ b/source/common/buffer/buffer_util.cc
@@ -21,13 +21,14 @@ void Util::serializeDouble(double number, Buffer::Instance& buffer) {
   //     generate the string_view, and does not work on all platforms yet.
   //
   // The accuracy is checked in buffer_util_test.
-#if defined(__APPLE__) || defined(GCC_COMPILER)
-  // On Apple and gcc, std::to_chars does not work with 'double', so we revert
-  // to the next fastest correct implementation.
+#if __cplusplus < 201703L // C++16 and below
+  // On older compilers, such as those found on Apple, and gcc, std::to_chars
+  // does not work with 'double', so we revert to the next fastest correct
+  // implementation.
   buffer.addFragments({fmt::to_string(number)});
 #else
-  // This version is awkward, and doesn't work on Apple as of August 2023, but
-  // it is the fastest correct option on other platforms.
+  // This version is awkward, and doesn't work on all platforms used in Envoy CI
+  // as of August 2023, but it is the fastest correct option on modern compilers.
   char buf[100];
   std::to_chars_result result = std::to_chars(buf, buf + sizeof(buf), number);
   ENVOY_BUG(result.ec == std::errc{}, std::make_error_code(result.ec).message());

--- a/source/common/buffer/buffer_util.cc
+++ b/source/common/buffer/buffer_util.cc
@@ -1,7 +1,7 @@
 #include "source/common/buffer/buffer_util.h"
 
 #include <charconv>
-#include <version>
+#include <cstddef>
 
 #include "source/common/common/macros.h"
 


### PR DESCRIPTION
Commit Message: In #29500 I introduced a conditional-compilation for using the best available library API to serialize doubles. This is because clang library v14, the primary development platform, has a better API available than older compilers.

The conditional compilation structure I used focused on excluding GCC and Apple, and that passed on CI.

However, the ifdefing didn't quite work for people that develop with older version of clang, or hybrid library environments. I did not think people would be doing that, but they are :) So this changes the conditional compilation strategy to look specifically for clang library versions >= 14.
Additional Description: n/a
Risk Level: low
Testing: just CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

