### PR TITLE
grpc_http1_bridge: support for upgrading json to grpc+json

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
@@ -26,4 +26,11 @@ message Config {
   // For the requests that went through this upgrade the filter will also strip the frame before forwarding the
   // response to the client.
   bool upgrade_protobuf_to_grpc = 1;
+
+  // If true then requests with content type set to ``application/json`` will be automatically converted to gRPC+JSON.
+  // This works by prepending the payload data with the gRPC header frame, as defined by the wiring format, and
+  // Content-Type will be updated accordingly before sending the request.
+  // For the requests that went through this upgrade the filter will also strip the frame before forwarding the
+  // response to the client.
+  bool upgrade_json_to_grpc_json = 2;
 }

--- a/docs/root/configuration/http/http_filters/grpc_http1_bridge_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_http1_bridge_filter.rst
@@ -46,15 +46,22 @@ Protobuf upgrade support
 ------------------------
 
 The filter will automatically frame requests with content-type ``application/x-protobuf`` as gRPC requests if
-:ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` is set.
-In this case the filter will prepend the body with the gRPC frame described above, and update the content-type header to
-``application/grpc`` before sending the request to the gRPC server.
+:ref:`upgrade_protobuf_to_grpc <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_protobuf_to_grpc>` is set. In this case the filter will prepend the body with the gRPC frame header described above, and update the content-type header to ``application/grpc`` before sending the request to the gRPC server.
+
+The response body returned to the client will not contain the gRPC frame header for requests that are upgraded in this
+fashion, i.e. the body will contain only the encoded Protobuf.
+
+JSON upgrade support
+--------------------
+
+Likewise, the filter will frame requests with content-type ``application/json`` as gRPC+JSON requests if
+:ref:`upgrade_json_to_grpc_json <envoy_v3_api_field_extensions.filters.http.grpc_http1_bridge.v3.Config.upgrade_json_to_grpc_json>` is set. In this case the filter will prepend the body with the gRPC frame header described above, and update the content-type header to ``application/grpc+json`` before sending the request to the gRPC server.
 
 In case the client sends a ``content-length`` header it will be removed before proceeding, as the value may conflict with
 the size specified in the gRPC frame.
 
-The response body returned to the client will not contain the gRPC header frame for requests that are upgraded in this
-fashion, i.e. the body will contain only the encoded Protobuf.
+The response body returned to the client will not contain the gRPC frame header for requests that are upgraded in this
+fashion, i.e. the body will contain only the encoded JSON.
 
 Statistics
 ----------

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -51,6 +51,10 @@ bool Common::hasProtobufContentType(const Http::RequestOrResponseHeaderMap& head
   return headers.getContentTypeValue() == Http::Headers::get().ContentTypeValues.Protobuf;
 }
 
+bool Common::hasJsonContentType(const Http::RequestOrResponseHeaderMap& headers) {
+  return headers.getContentTypeValue() == Http::Headers::get().ContentTypeValues.Json;
+}
+
 bool Common::isGrpcRequestHeaders(const Http::RequestHeaderMap& headers) {
   if (!headers.Path()) {
     return false;
@@ -77,6 +81,13 @@ bool Common::isProtobufRequestHeaders(const Http::RequestHeaderMap& headers) {
     return false;
   }
   return hasProtobufContentType(headers);
+}
+
+bool Common::isJsonRequestHeaders(const Http::RequestHeaderMap& headers) {
+  if (!headers.Path()) {
+    return false;
+  }
+  return hasJsonContentType(headers);
 }
 
 bool Common::isGrpcResponseHeaders(const Http::ResponseHeaderMap& headers, bool end_stream) {

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -56,6 +56,12 @@ public:
 
   /**
    * @param headers the headers to parse.
+   * @return bool indicating whether content-type is Json.
+   */
+  static bool hasJsonContentType(const Http::RequestOrResponseHeaderMap& headers);
+
+  /**
+   * @param headers the headers to parse.
    * @return bool indicating whether the header is a gRPC request header.
    * Currently headers are considered gRPC request headers if they have the gRPC
    * content type, and have a path header.
@@ -79,10 +85,18 @@ public:
   /**
    * @param headers the headers to parse.
    * @return bool indicating whether the header is a protobuf request header.
-   * Currently headers are considered gRPC request headers if they have the protobuf
+   * Currently headers are considered protobuf request headers if they have the protobuf
    * content type, and have a path header.
    */
   static bool isProtobufRequestHeaders(const Http::RequestHeaderMap& headers);
+
+  /**
+   * @param headers the headers to parse.
+   * @return bool indicating whether the header is a json request header.
+   * Currently headers are considered json request headers if they have the json
+   * content type, and have a path header.
+   */
+  static bool isJsonRequestHeaders(const Http::RequestHeaderMap& headers);
 
   /**
    * @param headers the headers to parse.

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -258,6 +258,7 @@ public:
     const std::string Connect{"application/connect"};
     const std::string ConnectProto{"application/connect+proto"};
     const std::string Grpc{"application/grpc"};
+    const std::string GrpcJson{"application/grpc+json"};
     const std::string GrpcWeb{"application/grpc-web"};
     const std::string GrpcWebProto{"application/grpc-web+proto"};
     const std::string GrpcWebText{"application/grpc-web-text"};

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -22,7 +22,8 @@ public:
   explicit Http1BridgeFilter(
       Grpc::Context& context,
       const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config)
-      : context_(context), upgrade_protobuf_(proto_config.upgrade_protobuf_to_grpc()) {}
+      : context_(context), upgrade_protobuf_(proto_config.upgrade_protobuf_to_grpc()),
+        upgrade_json_(proto_config.upgrade_json_to_grpc_json()) {}
 
   // Http::StreamFilterBase
   void onDestroy() override {}
@@ -64,6 +65,7 @@ private:
   bool do_framing_{};
   Grpc::Context& context_;
   bool upgrade_protobuf_{};
+  bool upgrade_json_{};
 };
 
 } // namespace GrpcHttp1Bridge

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -337,6 +337,16 @@ TEST(GrpcContextTest, IsProtobufRequestHeader) {
   EXPECT_FALSE(Common::isProtobufRequestHeaders(is_not));
 }
 
+TEST(GrpcContextTest, IsJsonRequestHeader) {
+  Http::TestRequestHeaderMapImpl is{
+      {":method", "GET"}, {":path", "/"}, {"content-type", "application/json"}};
+  EXPECT_TRUE(Common::isJsonRequestHeaders(is));
+
+  Http::TestRequestHeaderMapImpl is_not{{":method", "CONNECT"},
+                                        {"content-type", "application/json"}};
+  EXPECT_FALSE(Common::isJsonRequestHeaders(is_not));
+}
+
 TEST(GrpcContextTest, ValidateResponse) {
   {
     Http::ResponseMessageImpl response(


### PR DESCRIPTION
This PR is correlated with #19331 .

When filter config <upgrade_json_to_grpc_json> is enabled and downstream request has a content-type value <application/json>, the filter will prepend the request json body with the 5 bytes gRPC frame header. Before returning upstream response to client, the filter will trim the gRPC frame header.

This functionality is useful when some clients can only send http/1.1+json requests rather than http/1.1+PB. 
It can be turn on/off by config <upgrade_json_to_grpc_json>. 


Risk Level: Medium
Testing: Unit tests
Docs Changes: Done