### PR TITLE
matchers: removing switch default

### DIFF
--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -31,9 +31,10 @@ ValueMatcherConstSharedPtr ValueMatcher::create(const envoy::type::matcher::v3::
     return std::make_shared<const PresentMatcher>(v.present_match());
   case envoy::type::matcher::v3::ValueMatcher::MatchPatternCase::kListMatch:
     return std::make_shared<const ListMatcher>(v.list_match());
-  default:
-    throw EnvoyException("Uncaught default");
+  case envoy::type::matcher::v3::ValueMatcher::MatchPatternCase::MATCH_PATTERN_NOT_SET:
+    break; // Fall through to PANIC.
   }
+  PANIC("unexpected");
 }
 
 bool NullMatcher::match(const ProtobufWkt::Value& value) const {

--- a/source/extensions/stat_sinks/graphite_statsd/config.cc
+++ b/source/extensions/stat_sinks/graphite_statsd/config.cc
@@ -40,7 +40,7 @@ GraphiteStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
       STATSD_SPECIFIER_NOT_SET:
     break;
   }
-  throw EnvoyException("unexpected statsd specifier enum");
+  PANIC("unexpected statsd specifier enum");
 }
 
 ProtobufTypes::MessagePtr GraphiteStatsdSinkFactory::createEmptyConfigProto() {

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -37,7 +37,7 @@ StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
   case envoy::config::metrics::v3::StatsdSink::StatsdSpecifierCase::STATSD_SPECIFIER_NOT_SET:
     break; // Fall through to PANIC
   }
-  throw EnvoyException("unexpected statsd specifier case num");
+  PANIC("unexpected statsd specifier case num");
 }
 
 ProtobufTypes::MessagePtr StatsdSinkFactory::createEmptyConfigProto() {

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -45,8 +45,8 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/http/cache/simple_http_cache:95.9"
 "source/extensions/rate_limit_descriptors:95.0"
 "source/extensions/rate_limit_descriptors/expr:95.0"
-"source/extensions/stat_sinks/graphite_statsd:82.1"
-"source/extensions/stat_sinks/statsd:84.6"
+"source/extensions/stat_sinks/graphite_statsd:78.6" # Death tests don't report LCOV
+"source/extensions/stat_sinks/statsd:80.8" # Death tests don't report LCOV
 "source/extensions/tracers:95.8"
 "source/extensions/tracers/common:73.8"
 "source/extensions/tracers/common/ot:71.8"


### PR DESCRIPTION
In general Envoy config enums we don't allow default: (which makes it easy to add new variables and not implement handling) and we PANIC on completely invalid values.  Bringing 2 files in line with this.

Risk Level: low
Testing: n/a (can't test panic)
Docs Changes: n/a
Release Notes: n/a
https://github.com/envoyproxy/envoy-mobile/issues/176