### PR TITLE
encapsulate and forward udp packets from parent instance to child

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -41,6 +41,14 @@ Address::InstanceConstSharedPtr instanceOrNull(StatusOr<Address::InstanceConstSh
   return nullptr;
 }
 
+std::string Utility::urlFromDatagramAddress(const Address::Instance& addr) {
+  if (addr.ip() != nullptr) {
+    return absl::StrCat(UDP_SCHEME, addr.asStringView());
+  } else {
+    return absl::StrCat(UNIX_SCHEME, addr.asStringView());
+  }
+}
+
 Address::InstanceConstSharedPtr Utility::resolveUrl(const std::string& url) {
   if (urlIsTcpScheme(url)) {
     return parseInternetAddressAndPort(url.substr(TCP_SCHEME.size()));

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -95,6 +95,16 @@ public:
   static constexpr absl::string_view UNIX_SCHEME{"unix://"};
 
   /**
+   * Make a URL from a datagram Address::Instance; will be udp:// prefix for
+   * an IP address, and unix:// prefix otherwise. Giving a tcp address to this
+   * function will result in incorrect behavior (addresses don't know if they
+   * are datagram or stream).
+   * @param addr supplies the address to convert to string.
+   * @return The appropriate url string compatible with resolveUrl.
+   */
+  static std::string urlFromDatagramAddress(const Address::Instance& addr);
+
+  /**
    * Resolve a URL.
    * @param url supplies the url to resolve.
    * @return Address::InstanceConstSharedPtr the resolved address.

--- a/source/server/hot_restart.proto
+++ b/source/server/hot_restart.proto
@@ -17,12 +17,22 @@ message HotRestartMessage {
     }
     message Terminate {
     }
+    // A separate socket is established for forwarding undeliverable quic udp packets
+    // from the parent instance to the child instance.
+    message ForwardedUdpPacket {
+      string local_addr = 1;
+      string peer_addr = 2;
+      uint64 receive_time_epoch_microseconds = 3;
+      bytes packet = 4;
+      uint32 worker_index = 5;
+    }
     oneof request {
       PassListenSocket pass_listen_socket = 1;
       ShutdownAdmin shutdown_admin = 2;
       Stats stats = 3;
       DrainListeners drain_listeners = 4;
       Terminate terminate = 5;
+      ForwardedUdpPacket forwarded_udp_packet = 6;
     }
   }
 

--- a/source/server/hot_restart.proto
+++ b/source/server/hot_restart.proto
@@ -23,7 +23,7 @@ message HotRestartMessage {
       string local_addr = 1;
       string peer_addr = 2;
       uint64 receive_time_epoch_microseconds = 3;
-      bytes packet = 4;
+      bytes payload = 4;
       uint32 worker_index = 5;
     }
     oneof request {

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -126,6 +126,7 @@ void HotRestartImpl::registerUdpForwardingListener(
 
 void HotRestartImpl::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {
   as_parent_.initialize(dispatcher, server);
+  as_child_.initialize(dispatcher);
 }
 
 absl::optional<HotRestart::AdminShutdownResponse> HotRestartImpl::sendParentAdminShutdownRequest() {
@@ -147,7 +148,10 @@ HotRestartImpl::mergeParentStatsIfAny(Stats::StoreRoot& stats_store) {
   return response;
 }
 
-void HotRestartImpl::shutdown() { as_parent_.shutdown(); }
+void HotRestartImpl::shutdown() {
+  as_parent_.shutdown();
+  as_child_.shutdown();
+}
 
 uint32_t HotRestartImpl::baseId() { return base_id_; }
 std::string HotRestartImpl::version() { return hotRestartVersion(); }

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -208,6 +208,7 @@ std::unique_ptr<HotRestartMessage> RpcStream::receiveHotRestartMessage(Blocking 
   msghdr message;
   uint8_t control_buffer[CMSG_SPACE(sizeof(int))];
   std::unique_ptr<HotRestartMessage> ret = nullptr;
+  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   while (!ret) {
     iov[0].iov_base = recv_buf_.data() + cur_msg_recvd_bytes_;
     iov[0].iov_len = MaxSendmsgSize;
@@ -220,25 +221,27 @@ std::unique_ptr<HotRestartMessage> RpcStream::receiveHotRestartMessage(Blocking 
     message.msg_control = control_buffer;
     message.msg_controllen = CMSG_SPACE(sizeof(int));
 
-    const int recvmsg_rc = recvmsg(domain_socket_, &message, 0);
-    if (block == Blocking::No && recvmsg_rc == -1 && errno == SOCKET_ERROR_AGAIN) {
+    const Api::SysCallSizeResult recv_result = os_sys_calls.recvmsg(domain_socket_, &message, 0);
+    if (block == Blocking::No && recv_result.return_value_ == -1 &&
+        recv_result.errno_ == SOCKET_ERROR_AGAIN) {
       return nullptr;
     }
-    RELEASE_ASSERT(recvmsg_rc != -1, fmt::format("recvmsg() returned -1, errno = {}", errno));
+    RELEASE_ASSERT(recv_result.return_value_ != -1,
+                   fmt::format("recvmsg() returned -1, errno = {}", recv_result.errno_));
     RELEASE_ASSERT(message.msg_flags == 0,
                    fmt::format("recvmsg() left msg_flags = {}", message.msg_flags));
-    cur_msg_recvd_bytes_ += recvmsg_rc;
+    cur_msg_recvd_bytes_ += recv_result.return_value_;
 
     // If we don't already know 'length', we're at the start of a new length+protobuf message!
     if (!expected_proto_length_.has_value()) {
       // We are not ok with messages so fragmented that the length doesn't even come in one piece.
-      RELEASE_ASSERT(recvmsg_rc >= 8, "received a brokenly tiny message fragment.");
+      RELEASE_ASSERT(recv_result.return_value_ >= 8, "received a brokenly tiny message fragment.");
 
       expected_proto_length_ = be64toh(*reinterpret_cast<uint64_t*>(recv_buf_.data()));
       // Expand the buffer from its default 4096 if this message is going to be longer.
       if (expected_proto_length_.value() > MaxSendmsgSize - sizeof(uint64_t)) {
         recv_buf_.resize(expected_proto_length_.value() + sizeof(uint64_t));
-        cur_msg_recvd_bytes_ = recvmsg_rc;
+        cur_msg_recvd_bytes_ = recv_result.return_value_;
       }
     }
     // If we have received beyond the end of the current in-flight proto, then next is misaligned.

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -99,6 +99,15 @@ protected:
   static Stats::Gauge& hotRestartGeneration(Stats::Scope& scope);
 
   RpcStream main_rpc_stream_;
+  // A separate channel is used for udp forwarding because udp forwarding can
+  // begin while communication on the main channel is still occurring. The hot
+  // restarter is single-threaded, so we don't have to worry about packets coming
+  // in a jumbled order, but there are two instances of the hot restarter, the
+  // parent and the child; it is possible for the child to send a udp packet
+  // while the parent is sending a request on the main channel, for which it will
+  // expect to receive a response (and not an unrelated udp packet). Therefore, a
+  // separate channel is used to deliver udp packets, ensuring no interference
+  // between the two data sources.
   RpcStream udp_forwarding_rpc_stream_;
 };
 

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -91,13 +91,15 @@ private:
  */
 class HotRestartingBase : public Logger::Loggable<Logger::Id::main> {
 protected:
-  HotRestartingBase(uint64_t base_id) : main_rpc_stream_(base_id) {}
+  HotRestartingBase(uint64_t base_id)
+      : main_rpc_stream_(base_id), udp_forwarding_rpc_stream_(base_id) {}
 
   // Returns a Gauge that tracks hot-restart generation, where every successive
   // child increments this number.
   static Stats::Gauge& hotRestartGeneration(Stats::Scope& scope);
 
   RpcStream main_rpc_stream_;
+  RpcStream udp_forwarding_rpc_stream_;
 };
 
 } // namespace Server

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -98,7 +98,11 @@ protected:
   // child increments this number.
   static Stats::Gauge& hotRestartGeneration(Stats::Scope& scope);
 
+  // A stream over a unix socket between the parent and child instances, used
+  // for the child instance to request socket information and control draining
+  // and shutdown of the parent.
   RpcStream main_rpc_stream_;
+
   // A separate channel is used for udp forwarding because udp forwarding can
   // begin while communication on the main channel is still occurring. The hot
   // restarter is single-threaded, so we don't have to worry about packets coming

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -63,10 +63,6 @@ HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
                                               socket_mode);
 }
 
-// Destructor must be specified in the cc file because UdpForwardingContext must be defined first
-// so that the destructor knows how to destroy it.
-HotRestartingChild::~HotRestartingChild() = default;
-
 void HotRestartingChild::initialize(Event::Dispatcher& dispatcher) {
   socket_event_udp_forwarding_ = dispatcher.createFileEvent(
       udp_forwarding_rpc_stream_.domain_socket_,

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -1,6 +1,8 @@
 #include "source/server/hot_restarting_child.h"
 
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/utility.h"
+#include "source/common/network/utility.h"
 
 namespace Envoy {
 namespace Server {
@@ -48,11 +50,42 @@ HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
                                        const std::string& socket_path, mode_t socket_mode)
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch) {
   main_rpc_stream_.initDomainSocketAddress(&parent_address_);
+  std::string socket_path_udp = socket_path + "_udp";
+  udp_forwarding_rpc_stream_.initDomainSocketAddress(&parent_address_udp_forwarding_);
   if (restart_epoch_ != 0) {
     parent_address_ = main_rpc_stream_.createDomainSocketAddress(restart_epoch_ + -1, "parent",
                                                                  socket_path, socket_mode);
+    parent_address_udp_forwarding_ = udp_forwarding_rpc_stream_.createDomainSocketAddress(
+        restart_epoch_ + -1, "parent", socket_path_udp, socket_mode);
   }
   main_rpc_stream_.bindDomainSocket(restart_epoch_, "child", socket_path, socket_mode);
+  udp_forwarding_rpc_stream_.bindDomainSocket(restart_epoch_, "child", socket_path_udp,
+                                              socket_mode);
+}
+
+// Destructor must be specified in the cc file because UdpForwardingContext must be defined first
+// so that the destructor knows how to destroy it.
+HotRestartingChild::~HotRestartingChild() = default;
+
+void HotRestartingChild::initialize(Event::Dispatcher& dispatcher) {
+  socket_event_udp_forwarding_ = dispatcher.createFileEvent(
+      udp_forwarding_rpc_stream_.domain_socket_,
+      [this](uint32_t events) -> void {
+        ASSERT(events == Event::FileReadyType::Read);
+        onSocketEventUdpForwarding();
+      },
+      Event::FileTriggerType::Edge, Event::FileReadyType::Read);
+}
+
+void HotRestartingChild::shutdown() { socket_event_udp_forwarding_.reset(); }
+
+void HotRestartingChild::onForwardedUdpPacket(uint32_t worker_index, Network::UdpRecvData&& data) {
+  auto addr_and_listener =
+      udp_forwarding_context_.getListenerForDestination(*data.addresses_.local_);
+  if (addr_and_listener.has_value()) {
+    auto [addr, listener_config] = *addr_and_listener;
+    listener_config->listenerWorkerRouter(*addr).deliver(worker_index, std::move(data));
+  }
 }
 
 int HotRestartingChild::duplicateParentListenSocket(const std::string& address,
@@ -170,6 +203,38 @@ void HotRestartingChild::mergeParentStats(Stats::Store& stats_store,
     }
   }
   stat_merger_->mergeStats(stats_proto.counter_deltas(), stats_proto.gauges(), dynamics);
+}
+
+void HotRestartingChild::onSocketEventUdpForwarding() {
+  std::unique_ptr<HotRestartMessage> wrapped_request;
+  while ((wrapped_request =
+              udp_forwarding_rpc_stream_.receiveHotRestartMessage(RpcStream::Blocking::No))) {
+    if (wrapped_request->requestreply_case() == HotRestartMessage::kReply) {
+      ENVOY_LOG(
+          error,
+          "HotRestartMessage reply received on UdpForwarding (we want only requests); ignoring.");
+      continue;
+    }
+    switch (wrapped_request->request().request_case()) {
+    case HotRestartMessage::Request::kForwardedUdpPacket: {
+      const auto& req = wrapped_request->request().forwarded_udp_packet();
+      Network::UdpRecvData data;
+      data.addresses_.local_ = Network::Utility::parseInternetAddressAndPort(req.local_addr());
+      data.addresses_.peer_ = Network::Utility::parseInternetAddressAndPort(req.peer_addr());
+      data.receive_time_ =
+          MonotonicTime(std::chrono::microseconds{req.receive_time_epoch_microseconds()});
+      data.buffer_ = std::make_unique<Buffer::OwnedImpl>(req.packet());
+      onForwardedUdpPacket(req.worker_index(), std::move(data));
+      break;
+    }
+    default: {
+      ENVOY_LOG(
+          error,
+          "child sent a request other than ForwardedUdpPacket on udp forwarding socket; ignoring.");
+      break;
+    }
+    }
+  }
 }
 
 } // namespace Server

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -83,7 +83,7 @@ void HotRestartingChild::onForwardedUdpPacket(uint32_t worker_index, Network::Ud
     // We send to the worker index from the parent instance.
     // In the case that the number of workers changes between instances,
     // or the quic connection id generator changes how it selects worker
-    // ids, the hot restart packet handoff will fail.
+    // ids, the hot restart packet transfer will fail.
     //
     // One option would be to dispatch an onData call to have the receiving
     // worker forward the packet if the calculated destination differs from

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -230,13 +230,13 @@ void HotRestartingChild::onSocketEventUdpForwarding() {
     switch (wrapped_request->request().request_case()) {
     case HotRestartMessage::Request::kForwardedUdpPacket: {
       const auto& req = wrapped_request->request().forwarded_udp_packet();
-      Network::UdpRecvData data;
-      data.addresses_.local_ = Network::Utility::parseInternetAddressAndPort(req.local_addr());
-      data.addresses_.peer_ = Network::Utility::parseInternetAddressAndPort(req.peer_addr());
-      data.receive_time_ =
+      Network::UdpRecvData packet;
+      packet.addresses_.local_ = Network::Utility::parseInternetAddressAndPort(req.local_addr());
+      packet.addresses_.peer_ = Network::Utility::parseInternetAddressAndPort(req.peer_addr());
+      packet.receive_time_ =
           MonotonicTime(std::chrono::microseconds{req.receive_time_epoch_microseconds()});
-      data.buffer_ = std::make_unique<Buffer::OwnedImpl>(req.packet());
-      onForwardedUdpPacket(req.worker_index(), std::move(data));
+      packet.buffer_ = std::make_unique<Buffer::OwnedImpl>(req.payload());
+      onForwardedUdpPacket(req.worker_index(), std::move(packet));
       break;
     }
     default: {

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -231,10 +231,8 @@ void HotRestartingChild::onSocketEventUdpForwarding() {
     case HotRestartMessage::Request::kForwardedUdpPacket: {
       const auto& req = wrapped_request->request().forwarded_udp_packet();
       Network::UdpRecvData packet;
-      packet.addresses_.local_ =
-          Network::Utility::parseInternetAddressAndPortNoThrow(req.local_addr());
-      packet.addresses_.peer_ =
-          Network::Utility::parseInternetAddressAndPortNoThrow(req.peer_addr());
+      packet.addresses_.local_ = Network::Utility::resolveUrl(req.local_addr());
+      packet.addresses_.peer_ = Network::Utility::resolveUrl(req.peer_addr());
       if (!packet.addresses_.local_ || !packet.addresses_.peer_) {
         break;
       }

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -222,8 +222,8 @@ void HotRestartingChild::onSocketEventUdpForwarding() {
   while ((wrapped_request =
               udp_forwarding_rpc_stream_.receiveHotRestartMessage(RpcStream::Blocking::No))) {
     if (wrapped_request->requestreply_case() == HotRestartMessage::kReply) {
-      ENVOY_LOG(
-          error,
+      ENVOY_LOG_PERIODIC(
+          error, std::chrono::seconds(5),
           "HotRestartMessage reply received on UdpForwarding (we want only requests); ignoring.");
       continue;
     }

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -231,8 +231,13 @@ void HotRestartingChild::onSocketEventUdpForwarding() {
     case HotRestartMessage::Request::kForwardedUdpPacket: {
       const auto& req = wrapped_request->request().forwarded_udp_packet();
       Network::UdpRecvData packet;
-      packet.addresses_.local_ = Network::Utility::parseInternetAddressAndPort(req.local_addr());
-      packet.addresses_.peer_ = Network::Utility::parseInternetAddressAndPort(req.peer_addr());
+      packet.addresses_.local_ =
+          Network::Utility::parseInternetAddressAndPortNoThrow(req.local_addr());
+      packet.addresses_.peer_ =
+          Network::Utility::parseInternetAddressAndPortNoThrow(req.peer_addr());
+      if (!packet.addresses_.local_ || !packet.addresses_.peer_) {
+        break;
+      }
       packet.receive_time_ =
           MonotonicTime(std::chrono::microseconds{req.receive_time_epoch_microseconds()});
       packet.buffer_ = std::make_unique<Buffer::OwnedImpl>(req.payload());

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -13,12 +13,6 @@ namespace Server {
  */
 class HotRestartingChild : public HotRestartingBase {
 public:
-  HotRestartingChild(int base_id, int restart_epoch, const std::string& socket_path,
-                     mode_t socket_mode);
-  ~HotRestartingChild();
-
-  void initialize(Event::Dispatcher& dispatcher);
-  void shutdown();
   // A structure to record the set of registered UDP listeners keyed on their addresses,
   // to support QUIC packet forwarding.
   class UdpForwardingContext {
@@ -45,6 +39,13 @@ public:
     // Map keyed on address as a string, because Network::Address::Instance isn't hashable.
     absl::flat_hash_map<std::string, ForwardEntry> listener_map_;
   };
+
+  HotRestartingChild(int base_id, int restart_epoch, const std::string& socket_path,
+                     mode_t socket_mode);
+  ~HotRestartingChild() = default;
+
+  void initialize(Event::Dispatcher& dispatcher);
+  void shutdown();
 
   int duplicateParentListenSocket(const std::string& address, uint32_t worker_index);
   void registerUdpForwardingListener(Network::Address::InstanceConstSharedPtr address,

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/server/instance.h"
+
 #include "source/common/stats/stat_merger.h"
 #include "source/server/hot_restarting_base.h"
 
@@ -9,11 +11,14 @@ namespace Server {
 /**
  * The child half of hot restarting. Issues requests and commands to the parent.
  */
-class HotRestartingChild : HotRestartingBase {
+class HotRestartingChild : public HotRestartingBase {
 public:
   HotRestartingChild(int base_id, int restart_epoch, const std::string& socket_path,
                      mode_t socket_mode);
+  ~HotRestartingChild();
 
+  void initialize(Event::Dispatcher& dispatcher);
+  void shutdown();
   // A structure to record the set of registered UDP listeners keyed on their addresses,
   // to support QUIC packet forwarding.
   class UdpForwardingContext {
@@ -51,14 +56,20 @@ public:
   void mergeParentStats(Stats::Store& stats_store,
                         const envoy::HotRestartMessage::Reply::Stats& stats_proto);
 
+protected:
+  void onSocketEventUdpForwarding();
+  void onForwardedUdpPacket(uint32_t worker_index, Network::UdpRecvData&& data);
+
 private:
+  friend class HotRestartUdpForwardingTestHelper;
   const int restart_epoch_;
   bool parent_terminated_{};
   sockaddr_un parent_address_;
+  sockaddr_un parent_address_udp_forwarding_;
   std::unique_ptr<Stats::StatMerger> stat_merger_{};
   Stats::StatName hot_restart_generation_stat_name_;
+  Event::FileEventPtr socket_event_udp_forwarding_;
   UdpForwardingContext udp_forwarding_context_;
-  friend class HotRestartUdpForwardingTestHelper;
 };
 
 } // namespace Server

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -38,8 +38,8 @@ void HotRestartingParent::Internal::handle(uint32_t worker_index,
                                            const Network::UdpRecvData& packet) {
   envoy::HotRestartMessage msg;
   auto* packet_msg = msg.mutable_request()->mutable_forwarded_udp_packet();
-  packet_msg->set_local_addr(packet.addresses_.local_->asStringView());
-  packet_msg->set_peer_addr(packet.addresses_.peer_->asStringView());
+  packet_msg->set_local_addr(Network::Utility::urlFromDatagramAddress(*packet.addresses_.local_));
+  packet_msg->set_peer_addr(Network::Utility::urlFromDatagramAddress(*packet.addresses_.peer_));
   packet_msg->set_receive_time_epoch_microseconds(
       std::chrono::duration_cast<std::chrono::microseconds>(packet.receive_time_.time_since_epoch())
           .count());

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -43,7 +43,7 @@ void HotRestartingParent::Internal::handle(uint32_t worker_index,
   packet_msg->set_receive_time_epoch_microseconds(
       std::chrono::duration_cast<std::chrono::microseconds>(packet.receive_time_.time_since_epoch())
           .count());
-  *packet_msg->mutable_packet() = packet.buffer_->toString();
+  *packet_msg->mutable_payload() = packet.buffer_->toString();
   packet_msg->set_worker_index(worker_index);
   udp_sender_.sendHotRestartMessage(std::move(msg));
 }

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -16,19 +16,36 @@ using HotRestartMessage = envoy::HotRestartMessage;
 HotRestartingParent::HotRestartingParent(int base_id, int restart_epoch,
                                          const std::string& socket_path, mode_t socket_mode)
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch) {
+  std::string socket_path_udp = socket_path + "_udp";
   child_address_ = main_rpc_stream_.createDomainSocketAddress(restart_epoch_ + 1, "child",
                                                               socket_path, socket_mode);
+  child_address_udp_forwarding_ = udp_forwarding_rpc_stream_.createDomainSocketAddress(
+      restart_epoch_ + 1, "child", socket_path_udp, socket_mode);
   main_rpc_stream_.bindDomainSocket(restart_epoch_, "parent", socket_path, socket_mode);
+  udp_forwarding_rpc_stream_.bindDomainSocket(restart_epoch_, "parent", socket_path_udp,
+                                              socket_mode);
+}
+
+void HotRestartingParent::sendHotRestartMessage(envoy::HotRestartMessage&& msg) {
+  ASSERT(dispatcher_.has_value());
+  dispatcher_->post([this, msg = std::move(msg)]() {
+    udp_forwarding_rpc_stream_.sendHotRestartMessage(child_address_udp_forwarding_, std::move(msg));
+  });
 }
 
 // Network::NonDispatchedUdpPacketHandler
-void HotRestartingParent::Internal::handle(uint32_t /*worker_index*/,
-                                           const Network::UdpRecvData& /*packet*/) {
-  dispatcher_.post([]() {
-    // TODO(ravenblack): encapsulate the packet, dispatch it to the hot restarter thread, and
-    // forward the message over a domain socket to HotRestartingChild.
-    // (Pending PR #29328)
-  });
+void HotRestartingParent::Internal::handle(uint32_t worker_index,
+                                           const Network::UdpRecvData& packet) {
+  envoy::HotRestartMessage msg;
+  auto* packet_msg = msg.mutable_request()->mutable_forwarded_udp_packet();
+  packet_msg->set_local_addr(packet.addresses_.local_->asStringView());
+  packet_msg->set_peer_addr(packet.addresses_.peer_->asStringView());
+  packet_msg->set_receive_time_epoch_microseconds(
+      std::chrono::duration_cast<std::chrono::microseconds>(packet.receive_time_.time_since_epoch())
+          .count());
+  *packet_msg->mutable_packet() = packet.buffer_->toString();
+  packet_msg->set_worker_index(worker_index);
+  udp_sender_.sendHotRestartMessage(std::move(msg));
 }
 
 void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Instance& server) {
@@ -39,7 +56,8 @@ void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Inst
         onSocketEvent();
       },
       Event::FileTriggerType::Edge, Event::FileReadyType::Read);
-  internal_ = std::make_unique<Internal>(&server, dispatcher);
+  dispatcher_ = dispatcher;
+  internal_ = std::make_unique<Internal>(&server, *this);
 }
 
 void HotRestartingParent::onSocketEvent() {
@@ -95,8 +113,9 @@ void HotRestartingParent::onSocketEvent() {
 
 void HotRestartingParent::shutdown() { socket_event_.reset(); }
 
-HotRestartingParent::Internal::Internal(Server::Instance* server, Event::Dispatcher& dispatcher)
-    : server_(server), dispatcher_(dispatcher) {
+HotRestartingParent::Internal::Internal(Server::Instance* server,
+                                        HotRestartMessageSender& udp_sender)
+    : server_(server), udp_sender_(udp_sender) {
   Stats::Gauge& hot_restart_generation = hotRestartGeneration(*server->stats().rootScope());
   hot_restart_generation.inc();
 }

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -113,6 +113,16 @@ TEST(NetworkUtility, resolveUrl) {
   EXPECT_EQ("[a:b:c:d::]:0", Utility::resolveUrl("udp://[a:b:c:d::]:0")->asString());
 }
 
+TEST(NetworkUtility, urlFromDatagramAddress) {
+  // UDP and unix URLs should be reversible with resolveUrl and urlFromDatagramAddress.
+  std::vector<std::string> urls{
+      "udp://[::1]:1", "udp://[a:b:c:d::]:0", "udp://1.2.3.4:1234", "unix://foo", "unix://",
+  };
+  for (const std::string& url : urls) {
+    EXPECT_EQ(url, Utility::urlFromDatagramAddress(*Utility::resolveUrl(url)));
+  }
+}
+
 TEST(NetworkUtility, socketTypeFromUrl) {
   EXPECT_FALSE(Utility::socketTypeFromUrl("foo").ok());
   EXPECT_FALSE(Utility::socketTypeFromUrl("abc://foo").ok());

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -147,15 +147,39 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test_library(
+    name = "hot_restart_udp_forwarding_test_helper",
+    hdrs = ["hot_restart_udp_forwarding_test_helper.h"],
+    deps = [
+        "//source/server:hot_restart_lib",
+    ],
+)
+
 envoy_cc_test(
     name = "hot_restart_impl_test",
     srcs = envoy_select_hot_restart(["hot_restart_impl_test.cc"]),
     deps = [
+        ":hot_restart_udp_forwarding_test_helper",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
         "//test/mocks/server:server_mocks",
         "//test/test_common:logging_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "hot_restarting_child_test",
+    srcs = envoy_select_hot_restart(["hot_restarting_child_test.cc"]),
+    deps = [
+        ":hot_restart_udp_forwarding_test_helper",
+        "//source/common/api:os_sys_calls_lib",
+        "//source/common/stats:stats_lib",
+        "//source/server:hot_restart_lib",
+        "//source/server:hot_restarting_child",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",
     ],
 )

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -10,6 +10,7 @@
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/hot_restart.h"
+#include "test/server/hot_restart_udp_forwarding_test_helper.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -21,7 +22,6 @@ using testing::_;
 using testing::AnyNumber;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
-using testing::Return;
 using testing::WithArg;
 
 namespace Envoy {
@@ -60,15 +60,17 @@ public:
     EXPECT_CALL(os_sys_calls_, mmap(_, _, _, _, _, _)).WillOnce(InvokeWithoutArgs([this]() {
       return Api::SysCallPtrResult{buffer_.data(), 0};
     }));
-    // We bind two sockets: one to talk to parent, one to talk to our (hypothetical eventual) child
-    EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(2);
+    // We bind two sockets, from both ends (parent and child), totaling four sockets to be bound.
+    // The socket for child->parent RPCs, and the socket for parent->child UDP forwarding
+    // in support of QUIC during hot restart.
+    EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(4);
 
     // Test we match the correct stat with empty-slots before, after, or both.
     hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0);
     hot_restart_->drainParentListeners();
 
-    // We close both sockets.
-    EXPECT_CALL(os_sys_calls_, close(_)).Times(2);
+    // We close both sockets, both ends, totaling 4.
+    EXPECT_CALL(os_sys_calls_, close(_)).Times(4);
   }
 
   // test_addresses_ must be initialized before os_sys_calls_ sets us mocking, as
@@ -104,43 +106,41 @@ TEST_F(HotRestartImplTest, VersionString) {
   }
 }
 
-// Test that HotRestartDomainSocketInUseException is thrown when the domain socket is already
-// in use,
-TEST_F(HotRestartImplTest, DomainSocketAlreadyInUse) {
-  EXPECT_CALL(os_sys_calls_, bind(_, _, _))
-      .WillOnce(Return(Api::SysCallIntResult{-1, SOCKET_ERROR_ADDR_IN_USE}));
-  EXPECT_CALL(os_sys_calls_, close(_));
+class DomainSocketErrorTest : public HotRestartImplTest, public testing::WithParamInterface<int> {};
+
+// The parameter is the number of sockets that bind including the one that errors.
+INSTANTIATE_TEST_CASE_P(SocketIndex, DomainSocketErrorTest, ::testing::Values(1, 2, 3, 4));
+
+// Test that HotRestartDomainSocketInUseException is thrown when any of the domain sockets is
+// already in use.
+TEST_P(DomainSocketErrorTest, DomainSocketAlreadyInUse) {
+  int i = 0;
+  EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(GetParam()).WillRepeatedly([&i]() {
+    if (++i == GetParam()) {
+      return Api::SysCallIntResult{-1, SOCKET_ERROR_ADDR_IN_USE};
+    }
+    return Api::SysCallIntResult{0, 0};
+  });
+  EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
   EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0),
                Server::HotRestartDomainSocketInUseException);
 }
 
-// Test that EnvoyException is thrown when the domain socket bind fails for reasons other than
-// being in use.
-TEST_F(HotRestartImplTest, DomainSocketError) {
-  EXPECT_CALL(os_sys_calls_, bind(_, _, _))
-      .WillOnce(Return(Api::SysCallIntResult{-1, SOCKET_ERROR_ACCESS}));
-  EXPECT_CALL(os_sys_calls_, close(_));
+// Test that EnvoyException is thrown when any of the the domain socket bind fails
+// for reasons other than being in use.
+TEST_P(DomainSocketErrorTest, DomainSocketError) {
+  int i = 0;
+  EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(GetParam()).WillRepeatedly([&i]() {
+    if (++i == GetParam()) {
+      return Api::SysCallIntResult{-1, SOCKET_ERROR_ACCESS};
+    }
+    return Api::SysCallIntResult{0, 0};
+  });
+  EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
   EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0), EnvoyException);
 }
-
-class HotRestartUdpForwardingTestHelper {
-public:
-  explicit HotRestartUdpForwardingTestHelper(HotRestartImpl& hot_restart)
-      : hot_restart_(hot_restart) {}
-  void registerUdpForwardingListener(Network::Address::InstanceConstSharedPtr address,
-                                     std::shared_ptr<Network::UdpListenerConfig> listener_config) {
-    hot_restart_.as_child_.registerUdpForwardingListener(address, listener_config);
-  }
-  absl::optional<HotRestartingChild::UdpForwardingContext::ForwardEntry>
-  getListenerForDestination(const Network::Address::Instance& address) {
-    return hot_restart_.as_child_.udp_forwarding_context_.getListenerForDestination(address);
-  }
-
-private:
-  HotRestartImpl& hot_restart_;
-};
 
 class HotRestartUdpForwardingContextTest : public HotRestartImplTest {
 public:

--- a/test/server/hot_restart_udp_forwarding_test_helper.h
+++ b/test/server/hot_restart_udp_forwarding_test_helper.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "source/server/hot_restart_impl.h"
+
+namespace Envoy {
+namespace Server {
+
+class HotRestartUdpForwardingTestHelper {
+public:
+  explicit HotRestartUdpForwardingTestHelper(HotRestartImpl& hot_restart)
+      : child_(hot_restart.as_child_) {}
+  explicit HotRestartUdpForwardingTestHelper(HotRestartingChild& child) : child_(child) {}
+  void registerUdpForwardingListener(Network::Address::InstanceConstSharedPtr address,
+                                     std::shared_ptr<Network::UdpListenerConfig> listener_config) {
+    child_.registerUdpForwardingListener(address, listener_config);
+  }
+  absl::optional<HotRestartingChild::UdpForwardingContext::ForwardEntry>
+  getListenerForDestination(const Network::Address::Instance& address) {
+    return child_.udp_forwarding_context_.getListenerForDestination(address);
+  }
+
+private:
+  HotRestartingChild& child_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -1,0 +1,191 @@
+#include <memory>
+
+#include "source/common/api/os_sys_calls_impl.h"
+#include "source/common/network/address_impl.h"
+#include "source/server/hot_restarting_child.h"
+#include "source/server/hot_restarting_parent.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/server/instance.h"
+#include "test/mocks/server/listener_manager.h"
+#include "test/server/hot_restart_udp_forwarding_test_helper.h"
+#include "test/test_common/logging.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
+
+#include "gtest/gtest.h"
+
+using testing::AllOf;
+using testing::DoAll;
+using testing::Eq;
+using testing::InSequence;
+using testing::Return;
+using testing::ReturnRef;
+using testing::SaveArg;
+using testing::WhenDynamicCastTo;
+
+namespace Envoy {
+namespace Server {
+namespace {
+
+using HotRestartMessage = envoy::HotRestartMessage;
+
+class FakeHotRestartingParent : public HotRestartingBase {
+public:
+  FakeHotRestartingParent(Api::MockOsSysCalls& os_sys_calls, int base_id, int restart_epoch,
+                          const std::string& socket_path)
+      : HotRestartingBase(base_id), os_sys_calls_(os_sys_calls) {
+    std::string socket_path_udp = socket_path + "_udp";
+    main_rpc_stream_.bindDomainSocket(restart_epoch, "parent", socket_path, 0);
+    udp_forwarding_rpc_stream_.bindDomainSocket(restart_epoch, "parent", socket_path_udp, 0);
+    child_address_udp_forwarding_ = udp_forwarding_rpc_stream_.createDomainSocketAddress(
+        restart_epoch + 1, "child", socket_path_udp, 0);
+  }
+  // Mocks the syscall for both send and receive, performs the send, and
+  // triggers the child's callback to perform the receive.
+  void sendUdpForwardingMessage(const envoy::HotRestartMessage& message) {
+    auto buffer = std::make_shared<std::string>();
+    EXPECT_CALL(os_sys_calls_, sendmsg(_, _, _))
+        .WillOnce([this, buffer](int, const msghdr* msg, int) {
+          *buffer =
+              std::string{static_cast<char*>(msg->msg_iov[0].iov_base), msg->msg_iov[0].iov_len};
+          udp_file_ready_callback_(Event::FileReadyType::Read);
+          return Api::SysCallSizeResult{static_cast<ssize_t>(msg->msg_iov[0].iov_len), 0};
+        });
+    EXPECT_CALL(os_sys_calls_, recvmsg(_, _, _)).WillRepeatedly([buffer](int, msghdr* msg, int) {
+      if (buffer->empty()) {
+        return Api::SysCallSizeResult{-1, SOCKET_ERROR_AGAIN};
+      }
+      msg->msg_control = nullptr;
+      msg->msg_controllen = 0;
+      msg->msg_flags = 0;
+      RELEASE_ASSERT(msg->msg_iovlen == 1,
+                     fmt::format("recv buffer iovlen={}, expected 1", msg->msg_iovlen));
+      size_t sz = std::min(buffer->size(), msg->msg_iov[0].iov_len);
+      buffer->copy(static_cast<char*>(msg->msg_iov[0].iov_base), sz);
+      *buffer = buffer->substr(sz);
+      msg->msg_iov[0].iov_len = sz;
+      return Api::SysCallSizeResult{static_cast<ssize_t>(sz), 0};
+    });
+    udp_forwarding_rpc_stream_.sendHotRestartMessage(child_address_udp_forwarding_, message);
+  }
+  Api::MockOsSysCalls& os_sys_calls_;
+  Event::FileReadyCb udp_file_ready_callback_;
+  sockaddr_un child_address_udp_forwarding_;
+};
+
+class HotRestartingChildTest : public testing::Test {
+public:
+  void SetUp() override {
+    // Address-to-string conversion performs a socket call which we unfortunately
+    // can't have bypass os_sys_calls_.
+    EXPECT_CALL(os_sys_calls_, socket(_, _, _)).WillRepeatedly([this]() {
+      static const int address_stringing_socket = 999;
+      EXPECT_CALL(os_sys_calls_, close(address_stringing_socket))
+          .WillOnce(Return(Api::SysCallIntResult{0, 0}));
+      return Api::SysCallIntResult{address_stringing_socket, 0};
+    });
+    EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(4);
+    EXPECT_CALL(os_sys_calls_, close(_)).Times(4);
+    fake_parent_ = std::make_unique<FakeHotRestartingParent>(os_sys_calls_, 0, 0, socket_path_);
+    hot_restarting_child_ = std::make_unique<HotRestartingChild>(0, 1, socket_path_, 0);
+    EXPECT_CALL(dispatcher_, createFileEvent_(_, _, _, Event::FileReadyType::Read))
+        .WillOnce(DoAll(SaveArg<1>(&fake_parent_->udp_file_ready_callback_), Return(nullptr)));
+    hot_restarting_child_->initialize(dispatcher_);
+  }
+  void TearDown() override { hot_restarting_child_.reset(); }
+  std::string socket_path_{"@envoy_domain_socket"};
+  Api::MockOsSysCalls os_sys_calls_;
+  Event::MockDispatcher dispatcher_;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls_};
+  std::unique_ptr<FakeHotRestartingParent> fake_parent_;
+  std::unique_ptr<HotRestartingChild> hot_restarting_child_;
+};
+
+TEST_F(HotRestartingChildTest, LogsErrorOnReplyMessageInUdpStream) {
+  envoy::HotRestartMessage msg;
+  msg.mutable_reply();
+  EXPECT_LOG_CONTAINS(
+      "error",
+      "HotRestartMessage reply received on UdpForwarding (we want only requests); ignoring.",
+      fake_parent_->sendUdpForwardingMessage(msg));
+}
+
+TEST_F(HotRestartingChildTest, LogsErrorOnNonUdpRelatedMessageInUdpStream) {
+  envoy::HotRestartMessage msg;
+  msg.mutable_request()->mutable_drain_listeners();
+  EXPECT_LOG_CONTAINS(
+      "error",
+      "child sent a request other than ForwardedUdpPacket on udp forwarding socket; ignoring.",
+      fake_parent_->sendUdpForwardingMessage(msg));
+}
+
+TEST_F(HotRestartingChildTest, DoesNothingOnForwardedUdpMessageWithNoMatchingListener) {
+  envoy::HotRestartMessage msg;
+  auto* packet = msg.mutable_request()->mutable_forwarded_udp_packet();
+  packet->set_local_addr("127.0.0.1:1234");
+  packet->set_peer_addr("127.0.0.1:4321");
+  packet->set_packet("hello");
+  EXPECT_LOG_NOT_CONTAINS("error", "", fake_parent_->sendUdpForwardingMessage(msg));
+}
+
+MATCHER_P4(IsUdpWith, local_addr, peer_addr, buffer, timestamp, "") {
+  bool local_matched = *arg.addresses_.local_ == *local_addr;
+  if (!local_matched) {
+    *result_listener << "\nUdpRecvData::addresses_.local_ == "
+                     << arg.addresses_.local_->asStringView()
+                     << "\nexpected == " << local_addr->asStringView();
+  }
+  bool peer_matched = *arg.addresses_.peer_ == *peer_addr;
+  if (!peer_matched) {
+    *result_listener << "\nUdpRecvData::addresses_.local_ == "
+                     << arg.addresses_.peer_->asStringView()
+                     << "\nexpected == " << peer_addr->asStringView();
+  }
+  std::string buffer_contents = arg.buffer_->toString();
+  bool buffer_matched = buffer_contents == buffer;
+  if (!buffer_matched) {
+    *result_listener << "\nUdpRecvData::buffer_ contains " << buffer_contents << "\nexpected "
+                     << buffer;
+  }
+  uint64_t ts =
+      std::chrono::duration_cast<std::chrono::microseconds>(arg.receive_time_.time_since_epoch())
+          .count();
+  bool timestamp_matched = ts == timestamp;
+  if (!timestamp_matched) {
+    *result_listener << "\nUdpRecvData::received_time_ == " << ts << "\nexpected: " << timestamp;
+  }
+  return local_matched && peer_matched && buffer_matched && timestamp_matched;
+}
+
+TEST_F(HotRestartingChildTest, ForwardsPacketToRegisteredListenerOnMatch) {
+  uint32_t worker_index = 12;
+  uint64_t packet_timestamp = 987654321;
+  std::string udp_contents = "beep boop";
+  envoy::HotRestartMessage msg;
+  auto* packet = msg.mutable_request()->mutable_forwarded_udp_packet();
+  auto mock_udp_listener_config = std::make_shared<Network::MockUdpListenerConfig>();
+  auto test_listener_addr = Network::Utility::parseInternetAddressAndPort("127.0.0.1:1234");
+  auto test_remote_addr = Network::Utility::parseInternetAddressAndPort("127.0.0.1:4321");
+  HotRestartUdpForwardingTestHelper(*hot_restarting_child_)
+      .registerUdpForwardingListener(
+          test_listener_addr,
+          std::dynamic_pointer_cast<Network::UdpListenerConfig>(mock_udp_listener_config));
+  packet->set_local_addr(test_listener_addr->asStringView());
+  packet->set_peer_addr(test_remote_addr->asStringView());
+  packet->set_worker_index(worker_index);
+  packet->set_packet(udp_contents);
+  packet->set_receive_time_epoch_microseconds(packet_timestamp);
+  Network::MockUdpListenerWorkerRouter mock_worker_router;
+  EXPECT_CALL(*mock_udp_listener_config,
+              listenerWorkerRouter(WhenDynamicCastTo<const Network::Address::Ipv4Instance&>(
+                  Eq(dynamic_cast<const Network::Address::Ipv4Instance&>(*test_listener_addr)))))
+      .WillOnce(ReturnRef(mock_worker_router));
+  EXPECT_CALL(mock_worker_router,
+              deliver(worker_index, IsUdpWith(test_listener_addr, test_remote_addr, udp_contents,
+                                              packet_timestamp)));
+  EXPECT_LOG_NOT_CONTAINS("error", "", fake_parent_->sendUdpForwardingMessage(msg));
+}
+
+} // namespace
+} // namespace Server
+} // namespace Envoy

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -128,6 +128,24 @@ TEST_F(HotRestartingChildTest, DoesNothingOnForwardedUdpMessageWithNoMatchingLis
   EXPECT_LOG_NOT_CONTAINS("error", "", fake_parent_->sendUdpForwardingMessage(msg));
 }
 
+TEST_F(HotRestartingChildTest, DoesNothingOnUnparseablePeerAddress) {
+  envoy::HotRestartMessage msg;
+  auto* packet = msg.mutable_request()->mutable_forwarded_udp_packet();
+  packet->set_local_addr("127.0.0.1:1234");
+  packet->set_peer_addr("/tmp/domainsocket");
+  packet->set_payload("hello");
+  EXPECT_LOG_NOT_CONTAINS("error", "", fake_parent_->sendUdpForwardingMessage(msg));
+}
+
+TEST_F(HotRestartingChildTest, DoesNothingOnUnparseableLocalAddress) {
+  envoy::HotRestartMessage msg;
+  auto* packet = msg.mutable_request()->mutable_forwarded_udp_packet();
+  packet->set_local_addr("/tmp/domainsocket");
+  packet->set_peer_addr("127.0.0.1:4321");
+  packet->set_payload("hello");
+  EXPECT_LOG_NOT_CONTAINS("error", "", fake_parent_->sendUdpForwardingMessage(msg));
+}
+
 MATCHER_P4(IsUdpWith, local_addr, peer_addr, buffer, timestamp, "") {
   bool local_matched = *arg.addresses_.local_ == *local_addr;
   if (!local_matched) {

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -124,7 +124,7 @@ TEST_F(HotRestartingChildTest, DoesNothingOnForwardedUdpMessageWithNoMatchingLis
   auto* packet = msg.mutable_request()->mutable_forwarded_udp_packet();
   packet->set_local_addr("127.0.0.1:1234");
   packet->set_peer_addr("127.0.0.1:4321");
-  packet->set_packet("hello");
+  packet->set_payload("hello");
   EXPECT_LOG_NOT_CONTAINS("error", "", fake_parent_->sendUdpForwardingMessage(msg));
 }
 
@@ -173,7 +173,7 @@ TEST_F(HotRestartingChildTest, ForwardsPacketToRegisteredListenerOnMatch) {
   packet->set_local_addr(test_listener_addr->asStringView());
   packet->set_peer_addr(test_remote_addr->asStringView());
   packet->set_worker_index(worker_index);
-  packet->set_packet(udp_contents);
+  packet->set_payload(udp_contents);
   packet->set_receive_time_epoch_microseconds(packet_timestamp);
   Network::MockUdpListenerWorkerRouter mock_worker_router;
   EXPECT_CALL(*mock_udp_listener_config,

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -334,7 +334,7 @@ TEST_F(HotRestartingParentTest, UdpPacketIsForwarded) {
   auto* expected_packet = expected_msg.mutable_request()->mutable_forwarded_udp_packet();
   expected_packet->set_local_addr("127.0.0.1:12345");
   expected_packet->set_peer_addr("127.0.0.1:54321");
-  expected_packet->set_packet(msg);
+  expected_packet->set_payload(msg);
   expected_packet->set_receive_time_epoch_microseconds(1234567890);
   expected_packet->set_worker_index(worker_index);
   EXPECT_CALL(message_sender_, sendHotRestartMessage(ProtoEq(expected_msg)));

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -27,6 +27,10 @@ public:
 
 class HotRestartingParentTest : public testing::Test {
 public:
+  Network::Address::InstanceConstSharedPtr ipv4_test_addr_1_ =
+      Network::Utility::parseInternetAddressAndPort("127.0.0.1:12345");
+  Network::Address::InstanceConstSharedPtr ipv4_test_addr_2_ =
+      Network::Utility::parseInternetAddressAndPort("127.0.0.1:54321");
   NiceMock<MockInstance> server_;
   MockHotRestartMessageSender message_sender_;
   HotRestartingParent::Internal hot_restarting_parent_{&server_, message_sender_};
@@ -320,8 +324,20 @@ TEST_F(HotRestartingParentTest, DrainListeners) {
 
 TEST_F(HotRestartingParentTest, UdpPacketIsForwarded) {
   uint32_t worker_index = 12; // arbitrary index
-
-  EXPECT_CALL(message_sender_, sendHotRestartMessage(_));
+  Network::UdpRecvData packet;
+  std::string msg = "hello";
+  packet.addresses_.local_ = ipv4_test_addr_1_;
+  packet.addresses_.peer_ = ipv4_test_addr_2_;
+  packet.buffer_ = std::make_unique<Buffer::OwnedImpl>(msg);
+  packet.receive_time_ = MonotonicTime(std::chrono::microseconds(1234567890));
+  envoy::HotRestartMessage expected_msg;
+  auto* expected_packet = expected_msg.mutable_request()->mutable_forwarded_udp_packet();
+  expected_packet->set_local_addr("127.0.0.1:12345");
+  expected_packet->set_peer_addr("127.0.0.1:54321");
+  expected_packet->set_packet(msg);
+  expected_packet->set_receive_time_epoch_microseconds(1234567890);
+  expected_packet->set_worker_index(worker_index);
+  EXPECT_CALL(message_sender_, sendHotRestartMessage(ProtoEq(expected_msg)));
   hot_restarting_parent_.handle(worker_index, packet);
 }
 

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -332,8 +332,8 @@ TEST_F(HotRestartingParentTest, UdpPacketIsForwarded) {
   packet.receive_time_ = MonotonicTime(std::chrono::microseconds(1234567890));
   envoy::HotRestartMessage expected_msg;
   auto* expected_packet = expected_msg.mutable_request()->mutable_forwarded_udp_packet();
-  expected_packet->set_local_addr("127.0.0.1:12345");
-  expected_packet->set_peer_addr("127.0.0.1:54321");
+  expected_packet->set_local_addr("udp://127.0.0.1:12345");
+  expected_packet->set_peer_addr("udp://127.0.0.1:54321");
   expected_packet->set_payload(msg);
   expected_packet->set_receive_time_epoch_microseconds(1234567890);
   expected_packet->set_worker_index(worker_index);


### PR DESCRIPTION
Commit Message: encapsulate and forward udp packets from parent instance to child
Additional Description: During hot restart, forward UDP packets as delivered to HotRestartingParent (from ActiveQuicListeners) to HotRestartingChild, for delivery to the appropriate listener in the new instance.
Risk Level: Some risk as hot restart behavior is changed by this.
Testing: Unit tests validate the packet delivery.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a