### PR TITLE
docs: Update instructions for running the code format tool

### DIFF
--- a/envoy/stats/primitive_stats_macros.h
+++ b/envoy/stats/primitive_stats_macros.h
@@ -17,8 +17,8 @@ namespace Envoy {
  *
  * By convention, starting with #7083, we sort the lines of this macro block, so
  * all the counters are grouped together, then all the gauges, etc. We do not
- * use clang-format-on/off etc. "./tools/code_format/check_format.py fix" will take care of
- * lining up the backslashes.
+ * use clang-format-on/off etc. "bazel run //tools/code_format:check_format -- fix" will take
+ * care of lining up the backslashes.
  *
  * Now actually put these stats somewhere, usually as a member of a struct:
  *   struct MyCoolStats {

--- a/envoy/stats/stats_macros.h
+++ b/envoy/stats/stats_macros.h
@@ -25,8 +25,8 @@ namespace Envoy {
  *
  * By convention, starting with #7083, we sort the lines of this macro block, so
  * all the counters are grouped together, then all the gauges, etc. We do not
- * use clang-format-on/off etc. "./tools/code_format/check_format.py fix" will take care of
- * lining up the backslashes.
+ * use clang-format-on/off etc. "bazel run //tools/code_format:check_format -- fix" will take
+ * care of lining up the backslashes.
  *
  * Now actually put these stats somewhere, usually as a member of a struct:
  *   struct MyCoolStats {

--- a/support/README.md
+++ b/support/README.md
@@ -55,19 +55,19 @@ affected files manually or run the provided formatting script.
 
 To run the format fix script directly:
 
-```shell
+```console
 bazel run //tools/code_format:check_format -- fix && ./tools/code_format/format_python_tools.sh fix
 ```
 
 To run the format fix script under Docker:
 
-```shell
+```console
 ./ci/run_envoy_docker.sh './ci/do_ci.sh format'
 ```
 
 To run clang-tidy under Docker, run the following (this creates a full
 compilation db and takes a long time):
 
-```shell
+```console
 ./ci/run_envoy_docker.sh ci/do_ci.sh bazel.clang_tidy
 ```

--- a/support/README.md
+++ b/support/README.md
@@ -55,19 +55,19 @@ affected files manually or run the provided formatting script.
 
 To run the format fix script directly:
 
-```
-./tools/code_format/check_format.py fix && ./tools/code_format/format_python_tools.sh fix
+```shell
+bazel run //tools/code_format:check_format -- fix && ./tools/code_format/format_python_tools.sh fix
 ```
 
 To run the format fix script under Docker:
 
-```
+```shell
 ./ci/run_envoy_docker.sh './ci/do_ci.sh format'
 ```
 
 To run clang-tidy under Docker, run the following (this creates a full
 compilation db and takes a long time):
 
-```
+```shell
 ./ci/run_envoy_docker.sh ci/do_ci.sh bazel.clang_tidy
 ```

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1048,7 +1048,9 @@ class FormatChecker:
 
         if self.check_error_messages():
             if self.args.operation_type == "check":
-                print("ERROR: check format failed. run 'bazel run //tools/code_format:check_format -- fix'")
+                print(
+                    "ERROR: check format failed. run 'bazel run //tools/code_format:check_format -- fix'"
+                )
             else:
                 print("ERROR: check format failed. diff has been applied'")
             sys.exit(1)

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1048,7 +1048,7 @@ class FormatChecker:
 
         if self.check_error_messages():
             if self.args.operation_type == "check":
-                print("ERROR: check format failed. run '//tools/code_format:check_format -- fix'")
+                print("ERROR: check format failed. run 'bazel run //tools/code_format:check_format -- fix'")
             else:
                 print("ERROR: check format failed. diff has been applied'")
             sys.exit(1)


### PR DESCRIPTION
Commit Message: Update instructions for running the code format tool
Additional Description: #29397 changed the way to run the `check_format` python script but the some of the docs are still referring to the "old" way of running it, which does not work anymore.
Risk Level: 
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
