### PR TITLE
Plumb the flag that UHV is enabled into HTTP codecs

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1257,10 +1257,16 @@ public:
   virtual Http::Http3::CodecStats& http3CodecStats() const PURE;
 
   /**
-   * @return create header validator based on cluster configuration. Returns nullptr if
+   * @return header validator based on cluster configuration. Returns nullptr if
    * ENVOY_ENABLE_UHV is undefined.
    */
   virtual Http::ClientHeaderValidatorPtr makeHeaderValidator(Http::Protocol protocol) const PURE;
+
+  /**
+   * @return true if header validator was enabled in cluster configuration. Always returns false if
+   * ENVOY_ENABLE_UHV is undefined.
+   */
+  virtual bool universalHeaderValidatorEnabled() const PURE;
 
 protected:
   /**

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -285,21 +285,24 @@ NoConnectCodecClientProd::NoConnectCodecClientProd(
     }
     codec_ = std::make_unique<Http1::ClientConnectionImpl>(
         *connection_, host->cluster().http1CodecStats(), *this, host->cluster().http1Settings(),
-        host->cluster().maxResponseHeadersCount(), proxied);
+        host->cluster().maxResponseHeadersCount(), proxied,
+        host->cluster().universalHeaderValidatorEnabled());
     break;
   }
   case CodecType::HTTP2:
     codec_ = std::make_unique<Http2::ClientConnectionImpl>(
         *connection_, *this, host->cluster().http2CodecStats(), random_generator,
         host->cluster().http2Options(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-        host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
+        host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get(),
+        host->cluster().universalHeaderValidatorEnabled());
     break;
   case CodecType::HTTP3: {
 #ifdef ENVOY_ENABLE_QUIC
     auto& quic_session = dynamic_cast<Quic::EnvoyQuicClientSession&>(*connection_);
     codec_ = std::make_unique<Quic::QuicHttpClientConnectionImpl>(
         quic_session, *this, host->cluster().http3CodecStats(), host->cluster().http3Options(),
-        Http::DEFAULT_MAX_REQUEST_HEADERS_KB, host->cluster().maxResponseHeadersCount());
+        Http::DEFAULT_MAX_REQUEST_HEADERS_KB, host->cluster().maxResponseHeadersCount(),
+        host->cluster().universalHeaderValidatorEnabled());
     // Initialize the session after max request header size is changed in above http client
     // connection creation.
     quic_session.Initialize();

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -62,17 +62,17 @@ ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
     uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
     envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
         headers_with_underscores_action,
-    Server::OverloadManager& overload_manager) {
+    Server::OverloadManager& overload_manager, bool uhv_enabled) {
   if (determineNextProtocol(connection, data) == Utility::AlpnNames::get().Http2) {
     Http2::CodecStats& stats = Http2::CodecStats::atomicGet(http2_codec_stats, scope);
     return std::make_unique<Http2::ServerConnectionImpl>(
         connection, callbacks, stats, random, http2_options, max_request_headers_kb,
-        max_request_headers_count, headers_with_underscores_action, overload_manager);
+        max_request_headers_count, headers_with_underscores_action, overload_manager, uhv_enabled);
   } else {
     Http1::CodecStats& stats = Http1::CodecStats::atomicGet(http1_codec_stats, scope);
     return std::make_unique<Http1::ServerConnectionImpl>(
         connection, stats, callbacks, http1_settings, max_request_headers_kb,
-        max_request_headers_count, headers_with_underscores_action, overload_manager);
+        max_request_headers_count, headers_with_underscores_action, overload_manager, uhv_enabled);
   }
 }
 

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -46,7 +46,7 @@ public:
                   uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
                   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
                       headers_with_underscores_action,
-                  Server::OverloadManager& overload_manager);
+                  Server::OverloadManager& overload_manager, bool uhv_enabled);
 
   /* The result after calling mutateRequestHeaders(), containing the final remote address. Note that
    * an extension used for detecting the original IP of the request might decide it should be

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -129,7 +129,7 @@ public:
   ConnectionImpl(Network::Connection& connection, CodecStats& stats,
                  Random::RandomGenerator& random_generator,
                  const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
-                 const uint32_t max_headers_kb, const uint32_t max_headers_count);
+                 const uint32_t max_headers_kb, const uint32_t max_headers_count, bool uhv_enabled);
 
   ~ConnectionImpl() override;
 
@@ -156,6 +156,17 @@ public:
   // ScopeTrackedObject
   void dumpState(std::ostream& os, int indent_level) const override;
 
+  // Indicates that header validation is performed by UHV in HTTP Connection Manager
+  bool uhvEnabled() const {
+#ifdef ENVOY_ENABLE_UHV
+    return uhv_enabled_;
+#else
+    // Workaround for gcc not understanding [[maybe_unused]] for class members.
+    (void)uhv_enabled_;
+    return false;
+#endif
+  }
+
 protected:
   friend class ProdNghttp2SessionFactory;
 
@@ -179,7 +190,7 @@ protected:
   class Http2Options {
   public:
     Http2Options(const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
-                 uint32_t max_headers_kb);
+                 uint32_t max_headers_kb, bool uhv_enabled);
     ~Http2Options();
 
     const nghttp2_option* options() { return options_; }
@@ -193,7 +204,7 @@ protected:
   class ClientHttp2Options : public Http2Options {
   public:
     ClientHttp2Options(const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
-                       uint32_t max_headers_kb);
+                       uint32_t max_headers_kb, bool uhv_enabled);
   };
 
   /**
@@ -724,6 +735,8 @@ private:
   std::map<int32_t, StreamImpl*> pending_deferred_reset_streams_;
   bool dispatching_ : 1;
   bool raised_goaway_ : 1;
+  // Indicates that header validation is performed by UHV in HTTP Connection Manager
+  const bool uhv_enabled_ : 1;
   Event::SchedulableCallbackPtr protocol_constraint_violation_callback_;
   Random::RandomGenerator& random_;
   MonotonicTime last_received_data_time_{};
@@ -745,7 +758,7 @@ public:
                        const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
                        const uint32_t max_response_headers_kb,
                        const uint32_t max_response_headers_count,
-                       SessionFactory& http2_session_factory);
+                       SessionFactory& http2_session_factory, bool uhv_enabled);
 
   // Http::ClientConnection
   RequestEncoder& newStream(ResponseDecoder& response_decoder) override;
@@ -775,7 +788,7 @@ public:
                        const uint32_t max_request_headers_count,
                        envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
                            headers_with_underscores_action,
-                       Server::OverloadManager& overload_manager);
+                       Server::OverloadManager& overload_manager, bool uhv_enabled);
 
 private:
   // ConnectionImpl

--- a/source/common/quic/client_codec_impl.cc
+++ b/source/common/quic/client_codec_impl.cc
@@ -16,13 +16,15 @@ QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
     EnvoyQuicClientSession& session, Http::ConnectionCallbacks& callbacks,
     Http::Http3::CodecStats& stats,
     const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
-    const uint32_t max_request_headers_kb, const uint32_t max_response_headers_count)
+    const uint32_t max_request_headers_kb, const uint32_t max_response_headers_count,
+    bool uhv_enabled)
     : QuicHttpConnectionImplBase(session, stats), quic_client_session_(session) {
   session.setCodecStats(stats);
   session.setHttp3Options(http3_options);
   session.setHttpConnectionCallbacks(callbacks);
   session.setMaxIncomingHeadersCount(max_response_headers_count);
   session.set_max_inbound_header_list_size(max_request_headers_kb * 1024);
+  session.setUhvEnabled(uhv_enabled);
 }
 
 void QuicHttpClientConnectionImpl::goAway() {

--- a/source/common/quic/client_codec_impl.h
+++ b/source/common/quic/client_codec_impl.h
@@ -18,7 +18,7 @@ public:
                                Http::ConnectionCallbacks& callbacks, Http::Http3::CodecStats& stats,
                                const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
                                const uint32_t max_request_headers_kb,
-                               const uint32_t max_response_headers_count);
+                               const uint32_t max_response_headers_count, bool uhv_enabled);
 
   // Http::ClientConnection
   Http::RequestEncoder& newStream(Http::ResponseDecoder& response_decoder) override;

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -147,7 +147,7 @@ std::unique_ptr<quic::QuicSpdyClientStream> EnvoyQuicClientSession::CreateClient
   ASSERT(codec_stats_.has_value() && http3_options_.has_value());
   return std::make_unique<EnvoyQuicClientStream>(GetNextOutgoingBidirectionalStreamId(), this,
                                                  quic::BIDIRECTIONAL, codec_stats_.value(),
-                                                 http3_options_.value());
+                                                 http3_options_.value(), uhv_enabled_);
 }
 
 quic::QuicSpdyStream* EnvoyQuicClientSession::CreateIncomingStream(quic::QuicStreamId /*id*/) {

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -41,6 +41,8 @@ public:
     http_connection_callbacks_ = &callbacks;
   }
 
+  void setUhvEnabled(bool uhv_enabled) { uhv_enabled_ = uhv_enabled; }
+
   // Network::Connection
   absl::string_view requestedServerName() const override;
   void dumpState(std::ostream&, int) const override {
@@ -127,6 +129,8 @@ private:
   OptRef<Http::HttpServerPropertiesCache> rtt_cache_;
   Stats::Scope& scope_;
   bool disable_keepalive_{false};
+  // Indicates that header validation is performed by UHV in HTTP Connection Manager
+  bool uhv_enabled_{false};
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
 };
 

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -20,14 +20,15 @@ namespace Quic {
 EnvoyQuicClientStream::EnvoyQuicClientStream(
     quic::QuicStreamId id, quic::QuicSpdyClientSession* client_session, quic::StreamType type,
     Http::Http3::CodecStats& stats,
-    const envoy::config::core::v3::Http3ProtocolOptions& http3_options)
+    const envoy::config::core::v3::Http3ProtocolOptions& http3_options, bool uhv_enabled)
     : quic::QuicSpdyClientStream(id, client_session, type),
       EnvoyQuicStream(
           // Flow control receive window should be larger than 8k so that the send buffer can fully
           // utilize congestion control window before it reaches the high watermark.
           static_cast<uint32_t>(GetReceiveWindow().value()), *filterManagerConnection(),
           [this]() { runLowWatermarkCallbacks(); }, [this]() { runHighWatermarkCallbacks(); },
-          stats, http3_options) {
+          stats, http3_options),
+      uhv_enabled_(uhv_enabled) {
   ASSERT(static_cast<uint32_t>(GetReceiveWindow().value()) > 8 * 1024,
          "Send buffer limit should be larger than 8KB.");
 }
@@ -35,16 +36,16 @@ EnvoyQuicClientStream::EnvoyQuicClientStream(
 Http::Status EnvoyQuicClientStream::encodeHeaders(const Http::RequestHeaderMap& headers,
                                                   bool end_stream) {
   ENVOY_STREAM_LOG(debug, "encodeHeaders: (end_stream={}) {}.", *this, end_stream, headers);
-#ifndef ENVOY_ENABLE_UHV
-  // Headers are now validated by UHV before encoding by the codec. Two checks below are not needed
-  // when UHV is enabled.
-  //
-  // Required headers must be present. This can only happen by some erroneous processing after the
-  // downstream codecs decode.
-  RETURN_IF_ERROR(Http::HeaderUtility::checkRequiredRequestHeaders(headers));
-  // Verify that a filter hasn't added an invalid header key or value.
-  RETURN_IF_ERROR(Http::HeaderUtility::checkValidRequestHeaders(headers));
-#endif
+  if (!uhvEnabled()) {
+    // Headers are now validated by UHV before encoding by the codec. Two checks below are not
+    // needed when UHV is enabled.
+    //
+    // Required headers must be present. This can only happen by some erroneous processing after the
+    // downstream codecs decode.
+    RETURN_IF_ERROR(Http::HeaderUtility::checkRequiredRequestHeaders(headers));
+    // Verify that a filter hasn't added an invalid header key or value.
+    RETURN_IF_ERROR(Http::HeaderUtility::checkValidRequestHeaders(headers));
+  }
 
   if (write_side_closed()) {
     return absl::CancelledError("encodeHeaders is called on write-closed stream.");
@@ -53,41 +54,43 @@ Http::Status EnvoyQuicClientStream::encodeHeaders(const Http::RequestHeaderMap& 
   local_end_stream_ = end_stream;
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);
   spdy::Http2HeaderBlock spdy_headers;
-#ifndef ENVOY_ENABLE_UHV
-  // Extended CONNECT to H/1 upgrade transformation has moved to UHV
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_http3_header_normalisation") &&
-      Http::Utility::isUpgrade(headers)) {
-    // In Envoy, both upgrade requests and extended CONNECT requests are
-    // represented as their HTTP/1 forms, regardless of the HTTP version used.
-    // Therefore, these need to be transformed into their HTTP/3 form, before
-    // sending them.
-    upgrade_protocol_ = std::string(headers.getUpgradeValue());
-    Http::RequestHeaderMapPtr modified_headers =
-        Http::createHeaderMap<Http::RequestHeaderMapImpl>(headers);
-    Http::Utility::transformUpgradeRequestFromH1toH3(*modified_headers);
-    spdy_headers = envoyHeadersToHttp2HeaderBlock(*modified_headers);
-  } else if (headers.Method()) {
-    spdy_headers = envoyHeadersToHttp2HeaderBlock(headers);
-    if (headers.Method()->value() == "CONNECT") {
+  if (!uhvEnabled()) {
+    // Extended CONNECT to H/1 upgrade transformation has moved to UHV
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.use_http3_header_normalisation") &&
+        Http::Utility::isUpgrade(headers)) {
+      // In Envoy, both upgrade requests and extended CONNECT requests are
+      // represented as their HTTP/1 forms, regardless of the HTTP version used.
+      // Therefore, these need to be transformed into their HTTP/3 form, before
+      // sending them.
+      upgrade_protocol_ = std::string(headers.getUpgradeValue());
       Http::RequestHeaderMapPtr modified_headers =
           Http::createHeaderMap<Http::RequestHeaderMapImpl>(headers);
-      modified_headers->remove(Http::Headers::get().Scheme);
-      modified_headers->remove(Http::Headers::get().Path);
-      modified_headers->remove(Http::Headers::get().Protocol);
+      Http::Utility::transformUpgradeRequestFromH1toH3(*modified_headers);
       spdy_headers = envoyHeadersToHttp2HeaderBlock(*modified_headers);
-    } else if (headers.Method()->value() == "HEAD") {
+    } else if (headers.Method()) {
+      spdy_headers = envoyHeadersToHttp2HeaderBlock(headers);
+      if (headers.Method()->value() == "CONNECT") {
+        Http::RequestHeaderMapPtr modified_headers =
+            Http::createHeaderMap<Http::RequestHeaderMapImpl>(headers);
+        modified_headers->remove(Http::Headers::get().Scheme);
+        modified_headers->remove(Http::Headers::get().Path);
+        modified_headers->remove(Http::Headers::get().Protocol);
+        spdy_headers = envoyHeadersToHttp2HeaderBlock(*modified_headers);
+      } else if (headers.Method()->value() == "HEAD") {
+        sent_head_request_ = true;
+      }
+    }
+    if (spdy_headers.empty()) {
+      spdy_headers = envoyHeadersToHttp2HeaderBlock(headers);
+    }
+  } else {
+    spdy_headers = envoyHeadersToHttp2HeaderBlock(headers);
+    if (headers.Method()->value() == "HEAD") {
       sent_head_request_ = true;
     }
   }
-  if (spdy_headers.empty()) {
-    spdy_headers = envoyHeadersToHttp2HeaderBlock(headers);
-  }
-#else
-  spdy_headers = envoyHeadersToHttp2HeaderBlock(headers);
-  if (headers.Method()->value() == "HEAD") {
-    sent_head_request_ = true;
-  }
-#endif
+
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_connect_udp_support") &&
       (Http::HeaderUtility::isCapsuleProtocol(headers) ||
@@ -255,35 +258,36 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
 
   const absl::optional<uint64_t> optional_status =
       Http::Utility::getResponseStatusOrNullopt(*headers);
-#ifndef ENVOY_ENABLE_UHV
-  if (!optional_status.has_value()) {
-    details_ = Http3ResponseCodeDetailValues::invalid_http_header;
-    onStreamError(!http3_options_.override_stream_error_on_invalid_http_message().value(),
-                  quic::QUIC_BAD_APPLICATION_PAYLOAD);
-    return;
-  }
+  if (!uhvEnabled()) {
+    if (!optional_status.has_value()) {
+      details_ = Http3ResponseCodeDetailValues::invalid_http_header;
+      onStreamError(!http3_options_.override_stream_error_on_invalid_http_message().value(),
+                    quic::QUIC_BAD_APPLICATION_PAYLOAD);
+      return;
+    }
 
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_http3_header_normalisation") &&
-      !upgrade_protocol_.empty()) {
-    Http::Utility::transformUpgradeResponseFromH3toH1(*headers, upgrade_protocol_);
-  }
-#else
-  // Extended CONNECT to H/1 upgrade transformation has moved to UHV
-  // In Envoy, both upgrade requests and extended CONNECT requests are
-  // represented as their HTTP/1 forms, regardless of the HTTP version used.
-  // Therefore, these need to be transformed into their HTTP/1 form.
+    if (Runtime::runtimeFeatureEnabled(
+            "envoy.reloadable_features.use_http3_header_normalisation") &&
+        !upgrade_protocol_.empty()) {
+      Http::Utility::transformUpgradeResponseFromH3toH1(*headers, upgrade_protocol_);
+    }
+  } else {
+    // Extended CONNECT to H/1 upgrade transformation has moved to UHV
+    // In Envoy, both upgrade requests and extended CONNECT requests are
+    // represented as their HTTP/1 forms, regardless of the HTTP version used.
+    // Therefore, these need to be transformed into their HTTP/1 form.
 
-  // In UHV mode the :status header at this point can be malformed, as it is validated
-  // later on in the response_decoder_.decodeHeaders() call.
-  // Account for this here.
-  if (!optional_status.has_value()) {
-    // In case the status is invalid or missing, the response_decoder_.decodeHeaders() will fail the
-    // request
-    response_decoder_->decodeHeaders(std::move(headers), fin);
-    ConsumeHeaderList();
-    return;
+    // In UHV mode the :status header at this point can be malformed, as it is validated
+    // later on in the response_decoder_.decodeHeaders() call.
+    // Account for this here.
+    if (!optional_status.has_value()) {
+      // In case the status is invalid or missing, the response_decoder_.decodeHeaders() will fail
+      // the request
+      response_decoder_->decodeHeaders(std::move(headers), fin);
+      ConsumeHeaderList();
+      return;
+    }
   }
-#endif
 
   const uint64_t status = optional_status.value();
   // TODO(#29071) determine how to handle 101, since it is not supported by HTTP/2

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -61,7 +61,8 @@ quic::QuicSpdyStream* EnvoyQuicServerSession::CreateIncomingStream(quic::QuicStr
     return nullptr;
   }
   auto stream = new EnvoyQuicServerStream(id, this, quic::BIDIRECTIONAL, codec_stats_.value(),
-                                          http3_options_.value(), headers_with_underscores_action_);
+                                          http3_options_.value(), headers_with_underscores_action_,
+                                          uhv_enabled_);
   ActivateStream(absl::WrapUnique(stream));
   if (aboveHighWatermark()) {
     stream->runHighWatermarkCallbacks();

--- a/source/common/quic/envoy_quic_server_session.h
+++ b/source/common/quic/envoy_quic_server_session.h
@@ -97,6 +97,8 @@ public:
                                   const Network::FilterChain& filter_chain,
                                   ConnectionMapIter position);
 
+  void setUhvEnabled(bool uhv_enabled) { uhv_enabled_ = uhv_enabled; }
+
   void setHttp3Options(const envoy::config::core::v3::Http3ProtocolOptions& http3_options) override;
   using quic::QuicSession::PerformActionOnActiveStreams;
 
@@ -145,6 +147,8 @@ private:
   EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory_;
   absl::optional<ConnectionMapPosition> position_;
   QuicConnectionStats& connection_stats_;
+  // Indicates that header validation is performed by UHV in HTTP Connection Manager
+  bool uhv_enabled_{false};
 };
 
 } // namespace Quic

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -19,7 +19,8 @@ public:
                         quic::StreamType type, Http::Http3::CodecStats& stats,
                         const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
                         envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-                            headers_with_underscores_action);
+                            headers_with_underscores_action,
+                        bool uhv_enabled);
 
   void setRequestDecoder(Http::RequestDecoder& decoder) override {
     request_decoder_ = &decoder;
@@ -107,6 +108,17 @@ private:
   // Deliver awaiting trailers if body has been delivered.
   void maybeDecodeTrailers();
 
+  // Indicates that header validation is performed by UHV in HTTP Connection Manager
+  bool uhvEnabled() const {
+#ifdef ENVOY_ENABLE_UHV
+    return uhv_enabled_;
+#else
+    // Workaround for gcc not understanding [[maybe_unused]] for class members.
+    (void)uhv_enabled_;
+    return false;
+#endif
+  }
+
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
   // Makes the QUIC stream use Capsule Protocol. Once this method is called, any calls to encodeData
   // are expected to contain capsules which will be sent along as HTTP Datagrams. Also, the stream
@@ -125,6 +137,8 @@ private:
 #endif
   // True if a :path header has been seen before.
   bool saw_path_{false};
+  // Indicates that header validation is performed by UHV in HTTP Connection Manager
+  const bool uhv_enabled_{false};
 };
 
 } // namespace Quic

--- a/source/common/quic/server_codec_impl.cc
+++ b/source/common/quic/server_codec_impl.cc
@@ -18,7 +18,8 @@ QuicHttpServerConnectionImpl::QuicHttpServerConnectionImpl(
     const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
     const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
     envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-        headers_with_underscores_action)
+        headers_with_underscores_action,
+    bool uhv_enabled)
     : QuicHttpConnectionImplBase(quic_session, stats), quic_server_session_(quic_session) {
   quic_session.setCodecStats(stats);
   quic_session.setHttp3Options(http3_options);
@@ -26,6 +27,7 @@ QuicHttpServerConnectionImpl::QuicHttpServerConnectionImpl(
   quic_session.setHttpConnectionCallbacks(callbacks);
   quic_session.setMaxIncomingHeadersCount(max_request_headers_count);
   quic_session.set_max_inbound_header_list_size(max_request_headers_kb * 1024u);
+  quic_session.setUhvEnabled(uhv_enabled);
 }
 
 void QuicHttpServerConnectionImpl::onUnderlyingConnectionAboveWriteBufferHighWatermark() {

--- a/source/common/quic/server_codec_impl.h
+++ b/source/common/quic/server_codec_impl.h
@@ -21,7 +21,8 @@ public:
       const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
       const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
       envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-          headers_with_underscores_action);
+          headers_with_underscores_action,
+      bool uhv_enabled);
 
   // Http::Connection
   void goAway() override;
@@ -43,10 +44,12 @@ public:
       const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
       const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
       envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-          headers_with_underscores_action) override {
+          headers_with_underscores_action,
+      bool uhv_enabled) override {
     return std::make_unique<QuicHttpServerConnectionImpl>(
         dynamic_cast<Quic::EnvoyQuicServerSession&>(connection), callbacks, stats, http3_options,
-        max_request_headers_kb, max_request_headers_count, headers_with_underscores_action);
+        max_request_headers_kb, max_request_headers_count, headers_with_underscores_action,
+        uhv_enabled);
   }
   std::string name() const override { return "quic.http_server_connection.default"; }
 };

--- a/source/common/quic/server_connection_factory.h
+++ b/source/common/quic/server_connection_factory.h
@@ -15,7 +15,8 @@ public:
       const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
       const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
       envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-          headers_with_underscores_action) PURE;
+          headers_with_underscores_action,
+      bool uhv_enabled) PURE;
 
   std::string category() const override { return "quic.http_server_connection"; }
 };

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1761,6 +1761,14 @@ ClusterInfoImpl::makeHeaderValidator([[maybe_unused]] Http::Protocol protocol) c
 #endif
 }
 
+bool ClusterInfoImpl::universalHeaderValidatorEnabled() const {
+#ifdef ENVOY_ENABLE_UHV
+  return http_protocol_options_->header_validator_factory_ != nullptr;
+#else
+  return false;
+#endif
+}
+
 std::pair<absl::optional<double>, absl::optional<uint32_t>> ClusterInfoImpl::getRetryBudgetParams(
     const envoy::config::cluster::v3::CircuitBreakers::Thresholds& thresholds) {
   constexpr double default_budget_percent = 20.0;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1012,6 +1012,7 @@ public:
   Http::Http2::CodecStats& http2CodecStats() const override;
   Http::Http3::CodecStats& http3CodecStats() const override;
   Http::ClientHeaderValidatorPtr makeHeaderValidator(Http::Protocol protocol) const override;
+  bool universalHeaderValidatorEnabled() const override;
 
 protected:
   // Gets the retry budget percent/concurrency from the circuit breaker thresholds. If the retry

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -678,13 +678,13 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
     return std::make_unique<Http::Http1::ServerConnectionImpl>(
         connection, Http::Http1::CodecStats::atomicGet(http1_codec_stats_, context_.scope()),
         callbacks, http1_settings_, maxRequestHeadersKb(), maxRequestHeadersCount(),
-        headersWithUnderscoresAction(), overload_manager);
+        headersWithUnderscoresAction(), overload_manager, uhvEnabled());
   case CodecType::HTTP2:
     return std::make_unique<Http::Http2::ServerConnectionImpl>(
         connection, callbacks,
         Http::Http2::CodecStats::atomicGet(http2_codec_stats_, context_.scope()),
         context_.api().randomGenerator(), http2_options_, maxRequestHeadersKb(),
-        maxRequestHeadersCount(), headersWithUnderscoresAction(), overload_manager);
+        maxRequestHeadersCount(), headersWithUnderscoresAction(), overload_manager, uhvEnabled());
   case CodecType::HTTP3:
     return Config::Utility::getAndCheckFactoryByName<QuicHttpServerConnectionFactory>(
                "quic.http_server_connection.default")
@@ -692,13 +692,13 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
             connection, callbacks,
             Http::Http3::CodecStats::atomicGet(http3_codec_stats_, context_.scope()),
             http3_options_, maxRequestHeadersKb(), maxRequestHeadersCount(),
-            headersWithUnderscoresAction());
+            headersWithUnderscoresAction(), uhvEnabled());
   case CodecType::AUTO:
     return Http::ConnectionManagerUtility::autoCreateCodec(
         connection, data, callbacks, context_.scope(), context_.api().randomGenerator(),
         http1_codec_stats_, http2_codec_stats_, http1_settings_, http2_options_,
         maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction(),
-        overload_manager);
+        overload_manager, uhvEnabled());
   }
   PANIC_DUE_TO_CORRUPT_ENUM;
 }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -281,6 +281,14 @@ private:
       const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
           filter_config);
 
+  bool uhvEnabled() const {
+#ifdef ENVOY_ENABLE_UHV
+    return header_validator_factory_ != nullptr;
+#else
+    return false;
+#endif
+  }
+
   Http::RequestIDExtensionSharedPtr request_id_extension_;
   Server::Configuration::FactoryContext& context_;
   FilterFactoriesList filter_factories_;

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -242,13 +242,14 @@ Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection
                                                  const Buffer::Instance& data,
                                                  Http::ServerConnectionCallbacks& callbacks,
                                                  Server::OverloadManager& overload_manager) {
+  // TODO(#29503): figure out how admin will interact with UHV. For now UHV is not used in admin
   return Http::ConnectionManagerUtility::autoCreateCodec(
       connection, data, callbacks, *server_.stats().rootScope(), server_.api().randomGenerator(),
       http1_codec_stats_, http2_codec_stats_, Http::Http1Settings(),
       ::Envoy::Http2::Utility::initializeAndValidateOptions(
           envoy::config::core::v3::Http2ProtocolOptions()),
       maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction(),
-      overload_manager);
+      overload_manager, false);
 }
 
 bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -601,11 +601,11 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
     client = std::make_unique<Http2::ClientConnectionImpl>(
         client_connection, client_callbacks, Http2::CodecStats::atomicGet(http2_stats, scope),
         random, client_http2_options, max_request_headers_kb, max_response_headers_count,
-        Http2::ProdNghttp2SessionFactory::get());
+        Http2::ProdNghttp2SessionFactory::get(), false);
   } else {
     client = std::make_unique<Http1::ClientConnectionImpl>(
         client_connection, Http1::CodecStats::atomicGet(http1_stats, scope), client_callbacks,
-        client_http1settings, max_response_headers_count);
+        client_http1settings, max_response_headers_count, false, false);
   }
 
   if (http2) {
@@ -614,13 +614,13 @@ void codecFuzz(const test::common::http::CodecImplFuzzTestCase& input, HttpVersi
     server = std::make_unique<Http2::ServerConnectionImpl>(
         server_connection, server_callbacks, Http2::CodecStats::atomicGet(http2_stats, scope),
         random, server_http2_options, max_request_headers_kb, max_request_headers_count,
-        headers_with_underscores_action, overload_manager_);
+        headers_with_underscores_action, overload_manager_, false);
   } else {
     const Http1Settings server_http1settings{fromHttp1Settings(input.h1_settings().server())};
     server = std::make_unique<Http1::ServerConnectionImpl>(
         server_connection, Http1::CodecStats::atomicGet(http1_stats, scope), server_callbacks,
         server_http1settings, max_request_headers_kb, max_request_headers_count,
-        headers_with_underscores_action, overload_manager_);
+        headers_with_underscores_action, overload_manager_, false);
   }
 
   // We track whether the connection should be closed for HTTP/1, since stream resets imply
@@ -806,6 +806,7 @@ void codecFuzzHttp2Oghttp2(const test::common::http::CodecImplFuzzTestCase& inpu
 } // namespace
 
 // Fuzz the H1/H2 codec implementations.
+// TODO(#28841) parameterize test suite to run with and without UHV
 DEFINE_PROTO_FUZZER(const test::common::http::CodecImplFuzzTestCase& input) {
   try {
     // Validate input early.

--- a/test/common/http/http1/http1_connection_fuzz_test.cc
+++ b/test/common/http/http1/http1_connection_fuzz_test.cc
@@ -45,7 +45,7 @@ public:
     client_ = std::make_unique<Http1::ClientConnectionImpl>(
         mock_client_connection_,
         Http1::CodecStats::atomicGet(http1_stats_, *stats_store_.rootScope()),
-        mock_client_callbacks_, client_settings_, Http::DEFAULT_MAX_HEADERS_COUNT);
+        mock_client_callbacks_, client_settings_, Http::DEFAULT_MAX_HEADERS_COUNT, false, false);
     Status status = client_->dispatch(payload);
   }
 
@@ -56,7 +56,7 @@ public:
         Http1::CodecStats::atomicGet(http1_stats_, *stats_store_.rootScope()),
         mock_server_callbacks_, server_settings_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
         Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW,
-        overload_manager_);
+        overload_manager_, false);
 
     Status status = server_->dispatch(payload);
   }

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -240,12 +240,12 @@ public:
     client_ = std::make_unique<TestClientConnectionImpl>(
         client_connection_, client_callbacks_, *client_stats_store_.rootScope(),
         client_http2_options_, random_, max_request_headers_kb_, max_response_headers_count_,
-        ProdNghttp2SessionFactory::get());
+        ProdNghttp2SessionFactory::get(), uhvEnabled());
     client_wrapper_ = std::make_unique<ConnectionWrapper>(client_.get());
     server_ = std::make_unique<TestServerConnectionImpl>(
         server_connection_, server_callbacks_, *server_stats_store_.rootScope(),
         server_http2_options_, random_, max_request_headers_kb_, max_request_headers_count_,
-        headers_with_underscores_action_);
+        headers_with_underscores_action_, uhvEnabled());
     server_wrapper_ = std::make_unique<ConnectionWrapper>(server_.get());
     createHeaderValidator();
     request_encoder_ = &client_->newStream(response_decoder_);
@@ -400,16 +400,25 @@ public:
   }
 
   void createHeaderValidator() {
+    if (uhvEnabled()) {
+      header_validator_config_.set_headers_with_underscores_action(
+          static_cast<::envoy::extensions::http::header_validators::envoy_default::v3::
+                          HeaderValidatorConfig::HeadersWithUnderscoresAction>(
+              headers_with_underscores_action_));
+      header_validator_ = std::make_unique<
+          Extensions::Http::HeaderValidators::EnvoyDefault::ServerHttp2HeaderValidator>(
+          header_validator_config_, Protocol::Http2, server_->http2CodecStats(),
+          header_validator_config_overrides_);
+      request_decoder_.setHeaderValidator(header_validator_.get());
+    }
+  }
+
+  bool uhvEnabled() const {
 #ifdef ENVOY_ENABLE_UHV
-    header_validator_config_.set_headers_with_underscores_action(
-        static_cast<::envoy::extensions::http::header_validators::envoy_default::v3::
-                        HeaderValidatorConfig::HeadersWithUnderscoresAction>(
-            headers_with_underscores_action_));
-    header_validator_ = std::make_unique<
-        Extensions::Http::HeaderValidators::EnvoyDefault::ServerHttp2HeaderValidator>(
-        header_validator_config_, Protocol::Http2, server_->http2CodecStats(),
-        header_validator_config_overrides_);
-    request_decoder_.setHeaderValidator(header_validator_.get());
+    // TODO(#28841) parameterize test suite to run with and without UHV
+    return true;
+#else
+    return false;
 #endif
   }
 
@@ -2499,12 +2508,12 @@ TEST_P(Http2CodecImplStreamLimitTest, MaxClientStreams) {
   client_ = std::make_unique<TestClientConnectionImpl>(
       client_connection_, client_callbacks_, *client_stats_store_.rootScope(),
       client_http2_options_, random_, max_request_headers_kb_, max_response_headers_count_,
-      ProdNghttp2SessionFactory::get());
+      ProdNghttp2SessionFactory::get(), uhvEnabled());
   client_wrapper_ = std::make_unique<ConnectionWrapper>(client_.get());
   server_ = std::make_unique<TestServerConnectionImpl>(
       server_connection_, server_callbacks_, *server_stats_store_.rootScope(),
       server_http2_options_, random_, max_request_headers_kb_, max_request_headers_count_,
-      headers_with_underscores_action_);
+      headers_with_underscores_action_, uhvEnabled());
   server_wrapper_ = std::make_unique<ConnectionWrapper>(server_.get());
   setupDefaultConnectionMocks();
   driveToCompletion();
@@ -4570,7 +4579,7 @@ public:
       uint32_t max_request_headers_count, Http2SessionFactory& http2_session_factory)
       : TestClientConnectionImpl(connection, callbacks, scope, http2_options, random,
                                  max_request_headers_kb, max_request_headers_count,
-                                 http2_session_factory) {}
+                                 http2_session_factory, false) {}
 
   // Overrides TestClientConnectionImpl::submitMetadata().
   bool submitMetadata(const MetadataMapVector& metadata_map_vector, int32_t stream_id) override {
@@ -4670,7 +4679,7 @@ protected:
     server_ = std::make_unique<TestServerConnectionImpl>(
         server_connection_, server_callbacks_, *server_stats_store_.rootScope(),
         server_http2_options_, random_, max_request_headers_kb_, max_request_headers_count_,
-        headers_with_underscores_action_);
+        headers_with_underscores_action_, false);
     server_wrapper_ = std::make_unique<ConnectionWrapper>(server_.get());
     setupDefaultConnectionMocks();
     driveToCompletion();
@@ -4720,7 +4729,7 @@ TEST(CodecChoiceTest, ProtocolOptionExplicitlySet) {
 
   auto client = std::make_unique<TestClientConnectionImpl>(
       client_connection, client_callbacks, *client_stats_store.rootScope(), http2_options, random,
-      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get());
+      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get(), false);
 
   // The protocol option takes precedence over the runtime feature.
   EXPECT_TRUE(client->useOghttp2Library());
@@ -4729,7 +4738,7 @@ TEST(CodecChoiceTest, ProtocolOptionExplicitlySet) {
 
   auto client2 = std::make_unique<TestClientConnectionImpl>(
       client_connection, client_callbacks, *client_stats_store.rootScope(), http2_options, random,
-      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get());
+      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get(), false);
 
   EXPECT_FALSE(client2->useOghttp2Library());
 }
@@ -4757,7 +4766,7 @@ TEST(CodecChoiceTest, ProtocolOptionNotSpecified) {
 
   auto client = std::make_unique<TestClientConnectionImpl>(
       client_connection, client_callbacks, *client_stats_store.rootScope(), http2_options, random,
-      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get());
+      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get(), false);
 
   // Since no protocol option is specified, the runtime feature is used.
   EXPECT_TRUE(client->useOghttp2Library());
@@ -4766,7 +4775,7 @@ TEST(CodecChoiceTest, ProtocolOptionNotSpecified) {
 
   auto client2 = std::make_unique<TestClientConnectionImpl>(
       client_connection, client_callbacks, *client_stats_store.rootScope(), http2_options, random,
-      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get());
+      max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get(), false);
 
   EXPECT_FALSE(client2->useOghttp2Library());
 }

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -84,11 +84,12 @@ public:
       Random::RandomGenerator& random, uint32_t max_request_headers_kb,
       uint32_t max_request_headers_count,
       envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-          headers_with_underscores_action)
+          headers_with_underscores_action,
+      bool uhv_enabled)
       : TestCodecStatsProvider(scope),
         ServerConnectionImpl(connection, callbacks, http2CodecStats(), random, http2_options,
                              max_request_headers_kb, max_request_headers_count,
-                             headers_with_underscores_action, overload_manager_) {}
+                             headers_with_underscores_action, overload_manager_, uhv_enabled) {}
 
   http2::adapter::Http2Adapter* adapter() { return adapter_.get(); }
   using ServerConnectionImpl::getStream;
@@ -110,11 +111,11 @@ public:
                            const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
                            Random::RandomGenerator& random, uint32_t max_request_headers_kb,
                            uint32_t max_request_headers_count,
-                           Http2SessionFactory& http2_session_factory)
+                           Http2SessionFactory& http2_session_factory, bool uhv_enabled)
       : TestCodecStatsProvider(scope),
         ClientConnectionImpl(connection, callbacks, http2CodecStats(), random, http2_options,
                              max_request_headers_kb, max_request_headers_count,
-                             http2_session_factory) {}
+                             http2_session_factory, uhv_enabled) {}
 
   http2::adapter::Http2Adapter* adapter() { return adapter_.get(); }
   // Submits an H/2 METADATA frame to the peer.

--- a/test/common/http/http2/frame_replay_test.cc
+++ b/test/common/http/http2/frame_replay_test.cc
@@ -22,6 +22,7 @@ namespace Http {
 namespace Http2 {
 namespace {
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 // For organizational purposes only.
 class RequestFrameCommentTest : public ::testing::Test {};
 class ResponseFrameCommentTest : public ::testing::Test {};
@@ -60,7 +61,7 @@ TEST_F(RequestFrameCommentTest, SimpleExampleHuffman) {
   TestServerConnectionImpl connection(
       codec.server_connection_, codec.server_callbacks_, *codec.stats_store_.rootScope(),
       codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-      Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+      Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW, false);
   EXPECT_TRUE(codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection).ok());
   EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
   EXPECT_TRUE(codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection).ok());
@@ -93,7 +94,7 @@ TEST_F(ResponseFrameCommentTest, SimpleExampleHuffman) {
   TestClientConnectionImpl connection(
       codec.client_connection_, codec.client_callbacks_, *codec.stats_store_.rootScope(),
       codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-      Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get());
+      Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get(), false);
   setupStream(codec, connection);
 
   EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
@@ -138,7 +139,7 @@ TEST_F(RequestFrameCommentTest, SimpleExamplePlain) {
   TestServerConnectionImpl connection(
       codec.server_connection_, codec.server_callbacks_, *codec.stats_store_.rootScope(),
       codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-      Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+      Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW, false);
   EXPECT_TRUE(codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection).ok());
   EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
   EXPECT_TRUE(codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection).ok());
@@ -173,7 +174,7 @@ TEST_F(ResponseFrameCommentTest, SimpleExamplePlain) {
   TestClientConnectionImpl connection(
       codec.client_connection_, codec.client_callbacks_, *codec.stats_store_.rootScope(),
       codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-      Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get());
+      Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get(), false);
   setupStream(codec, connection);
 
   EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
@@ -203,7 +204,8 @@ TEST_F(RequestFrameCommentTest, SingleByteNulCrLfInHeaderFrame) {
       TestServerConnectionImpl connection(
           codec.server_connection_, codec.server_callbacks_, *codec.stats_store_.rootScope(),
           codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-          Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+          Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW,
+          false);
       EXPECT_TRUE(codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection).ok());
       EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
       EXPECT_TRUE(codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection).ok());
@@ -236,7 +238,7 @@ TEST_F(ResponseFrameCommentTest, SingleByteNulCrLfInHeaderFrame) {
       TestClientConnectionImpl connection(
           codec.client_connection_, codec.client_callbacks_, *codec.stats_store_.rootScope(),
           codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-          Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get());
+          Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get(), false);
       setupStream(codec, connection);
 
       EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
@@ -271,7 +273,8 @@ TEST_F(RequestFrameCommentTest, SingleByteNulCrLfInHeaderField) {
       TestServerConnectionImpl connection(
           codec.server_connection_, codec.server_callbacks_, *codec.stats_store_.rootScope(),
           codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-          Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+          Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW,
+          false);
       EXPECT_TRUE(codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection).ok());
       EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
       EXPECT_TRUE(codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection).ok());
@@ -309,7 +312,7 @@ TEST_F(ResponseFrameCommentTest, SingleByteNulCrLfInHeaderField) {
       TestClientConnectionImpl connection(
           codec.client_connection_, codec.client_callbacks_, *codec.stats_store_.rootScope(),
           codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-          Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get());
+          Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get(), false);
       setupStream(codec, connection);
 
       EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());

--- a/test/common/http/http2/http2_connection_fuzz_test.cc
+++ b/test/common/http/http2/http2_connection_fuzz_test.cc
@@ -192,7 +192,7 @@ public:
         mock_server_connection_, mock_server_callbacks_,
         Http2::CodecStats::atomicGet(http2_stats_, scope), random_, server_settings_,
         Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,
-        envoy::config::core::v3::HttpProtocolOptions::ALLOW, overload_manager_);
+        envoy::config::core::v3::HttpProtocolOptions::ALLOW, overload_manager_, false);
 
     Buffer::OwnedImpl payload;
     payload.add(Http2Frame::Preamble, 24);
@@ -224,6 +224,7 @@ static void resetHarness() { harness = nullptr; }
 // HTTP/2 fuzzer
 //
 // Uses a mix of structured HTTP/2 frames and junk frames for coverage
+// TODO(#28841) parameterize test suite to run with and without UHV
 
 DEFINE_PROTO_FUZZER(const test::common::http::http2::Http2ConnectionFuzzCase& input) {
   if (harness == nullptr) {

--- a/test/common/http/http2/request_header_fuzz_test.cc
+++ b/test/common/http/http2/request_header_fuzz_test.cc
@@ -13,12 +13,13 @@ namespace Http {
 namespace Http2 {
 namespace {
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 void replay(const Frame& frame, ServerCodecFrameInjector& codec) {
   // Create the server connection containing the nghttp2 session.
   TestServerConnectionImpl connection(
       codec.server_connection_, codec.server_callbacks_, *codec.stats_store_.rootScope(),
       codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-      Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+      Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW, false);
   Http::Status status = Http::okStatus();
   status = codec.write(WellKnownFrames::clientConnectionPrefaceFrame(), connection);
   status = codec.write(WellKnownFrames::defaultSettingsFrame(), connection);

--- a/test/common/http/http2/response_header_fuzz_test.cc
+++ b/test/common/http/http2/response_header_fuzz_test.cc
@@ -14,12 +14,13 @@ namespace Http {
 namespace Http2 {
 namespace {
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 void replay(const Frame& frame, ClientCodecFrameInjector& codec) {
   // Create the client connection containing the nghttp2 session.
   TestClientConnectionImpl connection(
       codec.client_connection_, codec.client_callbacks_, *codec.stats_store_.rootScope(),
       codec.options_, codec.random_, Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-      Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get());
+      Http::DEFAULT_MAX_HEADERS_COUNT, ProdNghttp2SessionFactory::get(), false);
   // Create a new stream.
   Http::Status status = Http::okStatus();
   codec.request_encoder_ = &connection.newStream(codec.response_decoder_);

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -32,6 +32,7 @@ using testing::Invoke;
 namespace Envoy {
 namespace Quic {
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 class TestEnvoyQuicClientConnection : public EnvoyQuicClientConnection {
 public:
   TestEnvoyQuicClientConnection(const quic::QuicConnectionId& server_connection_id,
@@ -85,7 +86,7 @@ public:
         stats_({ALL_HTTP3_CODEC_STATS(POOL_COUNTER_PREFIX(store_, "http3."),
                                       POOL_GAUGE_PREFIX(store_, "http3."))}),
         http_connection_(envoy_quic_session_, http_connection_callbacks_, stats_, http3_options_,
-                         64 * 1024, 100) {
+                         64 * 1024, 100, false) {
     EXPECT_EQ(time_system_.systemTime(), envoy_quic_session_.streamInfo().startTime());
     EXPECT_EQ(EMPTY_STRING, envoy_quic_session_.nextProtocol());
     EXPECT_EQ(Http::Protocol::Http3, http_connection_.protocol());

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -32,6 +32,7 @@ public:
   MOCK_METHOD(size_t, numPacketsExpectedPerEventLoop, (), (const));
 };
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 class EnvoyQuicClientStreamTest : public testing::Test {
 public:
   EnvoyQuicClientStreamTest()
@@ -54,7 +55,7 @@ public:
         stats_({ALL_HTTP3_CODEC_STATS(POOL_COUNTER_PREFIX(scope_, "http3."),
                                       POOL_GAUGE_PREFIX(scope_, "http3."))}),
         quic_stream_(new EnvoyQuicClientStream(stream_id_, &quic_session_, quic::BIDIRECTIONAL,
-                                               stats_, http3_options_)),
+                                               stats_, http3_options_, false)),
         request_headers_{{":authority", host_}, {":method", "POST"}, {":path", "/"}},
         request_trailers_{{"trailer-key", "trailer-value"}} {
     quic_stream_->setResponseDecoder(stream_decoder_);

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -65,6 +65,7 @@ public:
   virtual void setProofSourceDetails(std::unique_ptr<EnvoyQuicProofSourceDetails> details) = 0;
 };
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 class TestQuicCryptoServerStream : public quic::QuicCryptoServerStream,
                                    public ProofSourceDetailsSetter {
 public:
@@ -214,7 +215,7 @@ public:
       // Create ServerConnection instance and setup callbacks for it.
       http_connection_ = std::make_unique<QuicHttpServerConnectionImpl>(
           envoy_quic_session_, http_connection_callbacks_, stats_, http3_options_, 64 * 1024, 100,
-          envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+          envoy::config::core::v3::HttpProtocolOptions::ALLOW, false);
       EXPECT_EQ(Http::Protocol::Http3, http_connection_->protocol());
       // Stop iteration to avoid calling getRead/WriteBuffer().
       return Network::FilterStatus::StopIteration;

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -37,6 +37,7 @@ constexpr unsigned int kStreamId = 4u;
 
 } // namespace
 
+// TODO(#28841) parameterize test suite to run with and without UHV
 class EnvoyQuicServerStreamTest : public testing::Test {
 public:
   EnvoyQuicServerStreamTest()
@@ -57,7 +58,7 @@ public:
                                    POOL_GAUGE_PREFIX(listener_config_.listenerScope(), "http3."))}),
         quic_stream_(new EnvoyQuicServerStream(
             stream_id_, &quic_session_, quic::BIDIRECTIONAL, stats_, http3_options_,
-            envoy::config::core::v3::HttpProtocolOptions::ALLOW)),
+            envoy::config::core::v3::HttpProtocolOptions::ALLOW, false)),
         response_headers_{{":status", "200"}, {"response-key", "response-value"}},
         response_trailers_{{"trailer-key", "trailer-value"}} {
     EXPECT_CALL(stream_decoder_, accessLogHandlers());

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -204,6 +204,10 @@ MockClusterInfo::MockClusterInfo()
                                            protocol, codecStats(protocol))
                                      : nullptr;
   }));
+
+  ON_CALL(*this, universalHeaderValidatorEnabled()).WillByDefault(Invoke([&]() {
+    return header_validator_factory_ != nullptr;
+  }));
 }
 
 MockClusterInfo::~MockClusterInfo() = default;

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -201,6 +201,7 @@ public:
                Http::FilterChainManager& manager),
               (const));
   MOCK_METHOD(Http::ClientHeaderValidatorPtr, makeHeaderValidator, (Http::Protocol), (const));
+  MOCK_METHOD(bool, universalHeaderValidatorEnabled, (), (const));
 
   ::Envoy::Http::HeaderValidatorStats& codecStats(Http::Protocol protocol) const;
   Http::Http1::CodecStats& http1CodecStats() const override;


### PR DESCRIPTION
Commit Message:
This change allows the runtime toggle for UHV to be implemented, such that some connections are running with UHV and some are without. 

Envoy's production build without the ENVOY_ENABLE_UHV defined is not affected.

Additional Description:
This PR is large mostly due to changes in codec constructor that affected a lot of test files. The change is NOOP for Envoy's production builds (without the ENVOY_ENABLE_UHV defined). And for builds with ENVOY_ENABLE_UHV defined it allows future toggling between UHV and legacy modes on per connection level.

Risk Level: Low (Build flag protected)
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Part of #29388
