### PR TITLE
mobile: Rewrite SdsIntegrationTest

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -23,7 +23,6 @@
 #include "envoy/extensions/common/matching/v3/extension_matcher.pb.validate.h"
 #endif
 
-#include "source/common/common/assert.h"
 #include "source/common/http/matching/inputs.h"
 #include "source/extensions/clusters/dynamic_forward_proxy/cluster.h"
 
@@ -149,6 +148,9 @@ void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap* bootstrap) const
         bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
     list->add_patterns()->set_exact("cluster_manager.active_clusters");
     list->add_patterns()->set_exact("cluster_manager.cluster_added");
+    // Allow SDS related stats.
+    list->add_patterns()->mutable_safe_regex()->set_regex("sds\\..*");
+    list->add_patterns()->mutable_safe_regex()->set_regex(".*\\.ssl_context_update_by_sds");
   }
 }
 #endif

--- a/mobile/test/common/integration/sds_integration_test.cc
+++ b/mobile/test/common/integration/sds_integration_test.cc
@@ -1,11 +1,9 @@
-#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/config_source.pb.h"
 #include "envoy/extensions/transport_sockets/tls/v3/cert.pb.h"
 #include "envoy/service/secret/v3/sds.pb.h"
 
 #include "test/common/integration/xds_integration_test.h"
-#include "test/config/integration/certs/clientcert_hash.h"
 #include "test/integration/ssl_utility.h"
 
 #include "extension_registry.h"
@@ -16,77 +14,80 @@ namespace {
 
 // Hack to force linking of the service: https://github.com/google/protobuf/issues/4221.
 const envoy::service::secret::v3::SdsDummy _sds_dummy;
+constexpr absl::string_view XDS_CLUSTER_NAME = "test_cluster";
+constexpr absl::string_view SECRET_NAME = "client_cert";
 
 class SdsIntegrationTest : public XdsIntegrationTest {
 public:
-  SdsIntegrationTest() {
-    override_builder_config_ = true;
-    ExtensionRegistry::registerFactories();
+  void initialize() override {
+    create_xds_upstream_ = false;
+    use_lds_ = false;
     skip_tag_extraction_rule_check_ = true;
-    upstream_tls_ = true;
+    ExtensionRegistry::registerFactories();
 
-    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // The default stats config has overenthusiastic filters.
-      bootstrap.clear_stats_config();
-
-      // Add two clusters by default:
-      //  - base: An HTTP2 cluster with one fake upstream endpoint, for accepting requests from
-      //  EM.
-      //  - xds_cluster.lyft.com: An xDS management server cluster, with one fake upstream endpoint.
-      bootstrap.mutable_static_resources()->clear_clusters();
-      bootstrap.mutable_static_resources()->add_clusters()->MergeFrom(
-          createSingleEndpointClusterConfig("base"));
-      bootstrap.mutable_static_resources()->add_clusters()->MergeFrom(
-          createSingleEndpointClusterConfig(std::string(XDS_CLUSTER)));
-    });
-
-    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // Change the base cluster to use SSL and SDS.
-      auto* transport_socket =
-          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
-      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
-      tls_context.set_sni("lyft.com");
-      auto* secret_config =
-          tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
-      setUpSdsConfig(secret_config, "client_cert");
-
-      transport_socket->set_name("envoy.transport_sockets.tls");
-      transport_socket->mutable_typed_config()->PackFrom(tls_context);
-    });
+    XdsIntegrationTest::initialize();
+    initializeXdsStream();
   }
 
-  void createUpstreams() override {
-    // This is the fake upstream configured with SSL for the base cluster.
-    addFakeUpstream(Ssl::createUpstreamSslContext(context_manager_, *api_), upstreamProtocol(),
-                    /*autonomous_upstream=*/true);
+  void createEnvoy() override {
+    const std::string target_uri = Network::Test::getLoopbackAddressUrlString(ipVersion());
+    Platform::XdsBuilder xds_builder(target_uri,
+                                     fake_upstreams_.back()->localAddress()->ip()->port());
+    xds_builder.addClusterDiscoveryService();
+    builder_.setXds(std::move(xds_builder));
+    XdsIntegrationTest::createEnvoy();
   }
+
+  void createUpstreams() override { addFakeUpstream(Http::CodecType::HTTP2); }
 
 protected:
+  void sendCdsResponse() {
+    auto cds_cluster = createSingleEndpointClusterConfig(std::string(XDS_CLUSTER_NAME));
+    // Update the cluster to use SSL.
+    auto* transport_socket = cds_cluster.mutable_transport_socket();
+    envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+    tls_context.set_sni("lyft.com");
+    auto* secret_config =
+        tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
+    setUpSdsConfig(secret_config, SECRET_NAME);
+    transport_socket->set_name("envoy.transport_sockets.tls");
+    transport_socket->mutable_typed_config()->PackFrom(tls_context);
+    sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
+        Config::TypeUrl::get().Cluster, {cds_cluster}, {cds_cluster}, {}, "55");
+  }
+
+  void initializeXdsStream() override {
+    AssertionResult result = fake_upstreams_.back()->waitForHttpConnection(
+        *BaseIntegrationTest::dispatcher_, BaseIntegrationTest::xds_connection_);
+    RELEASE_ASSERT(result, result.message());
+
+    result = BaseIntegrationTest::xds_connection_->waitForNewStream(
+        *BaseIntegrationTest::dispatcher_, xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    xds_stream_->startGrpcStream();
+  }
+
   void sendSdsResponse(const envoy::extensions::transport_sockets::tls::v3::Secret& secret) {
     envoy::service::discovery::v3::DiscoveryResponse discovery_response;
     discovery_response.set_version_info("1");
     discovery_response.set_type_url(Config::TypeUrl::get().Secret);
     discovery_response.add_resources()->PackFrom(secret);
-
     xds_stream_->sendGrpcMessage(discovery_response);
   }
 
   void setUpSdsConfig(envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig* secret_config,
-                      const std::string& secret_name) {
+                      const absl::string_view secret_name) {
     secret_config->set_name(secret_name);
     auto* config_source = secret_config->mutable_sds_config();
     config_source->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-    auto* api_config_source = config_source->mutable_api_config_source();
-    api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
-    api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
-    auto* grpc_service = api_config_source->add_grpc_services();
-    setGrpcService(*grpc_service, std::string(XDS_CLUSTER), fake_upstreams_.back()->localAddress());
-    config_source->mutable_initial_fetch_timeout()->set_seconds(1);
+    // Envoy Mobile only supports SDS with ADS.
+    config_source->mutable_ads();
+    config_source->mutable_initial_fetch_timeout()->set_seconds(5);
   }
 
-  envoy::extensions::transport_sockets::tls::v3::Secret getClientSecret() {
+  static envoy::extensions::transport_sockets::tls::v3::Secret getClientSecret() {
     envoy::extensions::transport_sockets::tls::v3::Secret secret;
-    secret.set_name("client_cert");
+    secret.set_name(SECRET_NAME);
     auto* tls_certificate = secret.mutable_tls_certificate();
     tls_certificate->mutable_certificate_chain()->set_filename(
         TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
@@ -96,33 +97,30 @@ protected:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersionsClientTypeDelta, SdsIntegrationTest,
-                         DELTA_SOTW_GRPC_CLIENT_INTEGRATION_PARAMS);
+INSTANTIATE_TEST_SUITE_P(
+    IpVersionsClientTypeSotw, SdsIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::ValuesIn(TestEnvironment::getsGrpcVersionsForTest()),
+                     // Envoy Mobile's xDS APIs only support state-of-the-world, not delta.
+                     testing::Values(Grpc::SotwOrDelta::Sotw, Grpc::SotwOrDelta::UnifiedSotw)));
 
 // Note: Envoy Mobile does not have listener sockets, so we aren't including a downstream test.
 TEST_P(SdsIntegrationTest, SdsForUpstreamCluster) {
-  on_server_init_function_ = [this]() {
-    initializeXdsStream();
-    sendSdsResponse(getClientSecret());
-  };
   initialize();
+
+  // Wait until the new cluster from CDS is added before sending the SDS response.
+  sendCdsResponse();
+  ASSERT_TRUE(waitForCounterGe("cluster_manager.cluster_added", 1));
 
   // Wait until the Envoy instance has obtained an updated secret from the SDS cluster. This
   // verifies that the SDS API is working from the Envoy client and allows us to know we can start
   // sending HTTP requests to the upstream cluster using the secret.
-  ASSERT_TRUE(waitForCounterGe("sds.client_cert.update_success", 1));
+  sendSdsResponse(getClientSecret());
+  ASSERT_TRUE(waitForCounterGe(fmt::format("sds.{}.update_success", SECRET_NAME), 1));
   ASSERT_TRUE(
-      waitForCounterGe("cluster.base.client_ssl_socket_factory.ssl_context_update_by_sds", 1));
-
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
-  terminal_callback_.waitReady();
-
-  EXPECT_EQ(cc_.on_headers_calls, 1);
-  EXPECT_EQ(cc_.status, "200");
-  EXPECT_EQ(cc_.on_complete_calls, 1);
-  EXPECT_EQ(cc_.on_cancel_calls, 0);
-  EXPECT_EQ(cc_.on_error_calls, 0);
-  EXPECT_EQ(cc_.on_header_consumed_bytes_from_response, 13);
+      waitForCounterGe(fmt::format("cluster.{}.client_ssl_socket_factory.ssl_context_update_by_sds",
+                                   XDS_CLUSTER_NAME),
+                       1));
 }
 
 } // namespace

--- a/mobile/test/common/integration/xds_integration_test.h
+++ b/mobile/test/common/integration/xds_integration_test.h
@@ -30,7 +30,7 @@ protected:
 
   // Initializes the xDS connection and creates a gRPC bi-directional stream for receiving
   // DiscoveryRequests and sending DiscoveryResponses.
-  virtual void initializeXdsStream();
+  void initializeXdsStream();
 
   // Returns the IP version that the test is running with (IPv4 or IPv6).
   Network::Address::IpVersion ipVersion() const override;

--- a/mobile/test/common/integration/xds_integration_test.h
+++ b/mobile/test/common/integration/xds_integration_test.h
@@ -30,7 +30,7 @@ protected:
 
   // Initializes the xDS connection and creates a gRPC bi-directional stream for receiving
   // DiscoveryRequests and sending DiscoveryResponses.
-  void initializeXdsStream();
+  virtual void initializeXdsStream();
 
   // Returns the IP version that the test is running with (IPv4 or IPv6).
   Network::Address::IpVersion ipVersion() const override;


### PR DESCRIPTION
This PR rewrites `SdsIntegrationTest` to be more realistic. especially for the Envoy Mobile use cases.

The changes are the following:
- Uses CDS + SDS with ADS to create a dynamic cluster instead of overriding the Bootstrap config to create static clusters since Envoy Mobile does not support adding static clusters.
- Exports SDS related stats.
- Updates the test parameters to only use state-of-the-world since Envoy Mobile does not support delta.

Risk Level: low (rewriting test)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
