### PR TITLE
git/hooks: Use `envoy.code.check`

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -85,7 +85,9 @@ do
     # TODO(mattklein123): Optimally we would be able to do this on a per-file basis.
     "$SCRIPT_DIR"/proto_format/proto_format.sh check || exit 1
 
-    "$SCRIPT_DIR"/code_format/format_python_tools.sh check || exit 1
+    bazel run //tools/code:check -- \
+          -s main \
+          -v warn || exit 1
 
     # Check correctness of repositories definitions.
     echo "  Checking repositories definitions"


### PR DESCRIPTION
This is step towards removing any system python from ci - and means the hook is running the same tools that actual CI runs

Follow-ups planned:

- unify local formatting code paths
- route local formatting through do_ci.sh to ensure consistent bazel env

Fix #29597 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
