### PR TITLE
http: make connect-udp upgrade case-insensitive

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -240,8 +240,8 @@ bool HeaderUtility::isConnect(const RequestHeaderMap& headers) {
 }
 
 bool HeaderUtility::isConnectUdp(const RequestHeaderMap& headers) {
-  return headers.Upgrade() &&
-         headers.Upgrade()->value() == Http::Headers::get().UpgradeValues.ConnectUdp;
+  return headers.Upgrade() && absl::EqualsIgnoreCase(headers.Upgrade()->value(),
+                                                     Http::Headers::get().UpgradeValues.ConnectUdp);
 }
 
 bool HeaderUtility::isConnectResponse(const RequestHeaderMap* request_headers,

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -240,7 +240,7 @@ bool HeaderUtility::isConnect(const RequestHeaderMap& headers) {
 }
 
 bool HeaderUtility::isConnectUdp(const RequestHeaderMap& headers) {
-  return headers.Upgrade() && absl::EqualsIgnoreCase(headers.Upgrade()->value(),
+  return headers.Upgrade() && absl::EqualsIgnoreCase(headers.getUpgradeValue(),
                                                      Http::Headers::get().UpgradeValues.ConnectUdp);
 }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -647,9 +647,11 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
     if (!success) {
       throw EnvoyException(absl::StrCat("Duplicate upgrade ", upgrade_config.upgrade_type()));
     }
-    if (upgrade_config.upgrade_type() == Http::Headers::get().MethodValues.Connect ||
+    if (absl::EqualsIgnoreCase(upgrade_config.upgrade_type(),
+                               Http::Headers::get().MethodValues.Connect) ||
         (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_connect_udp_support") &&
-         upgrade_config.upgrade_type() == Http::Headers::get().UpgradeValues.ConnectUdp)) {
+         absl::EqualsIgnoreCase(upgrade_config.upgrade_type(),
+                                Http::Headers::get().UpgradeValues.ConnectUdp))) {
       connect_config_ = std::make_unique<ConnectConfig>(upgrade_config.connect_config());
     } else if (upgrade_config.has_connect_config()) {
       throw EnvoyException(absl::StrCat("Non-CONNECT upgrade type ", upgrade_config.upgrade_type(),

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -1151,6 +1151,9 @@ TEST(HeaderIsValidTest, IsConnect) {
 TEST(HeaderIsValidTest, IsConnectUdp) {
   EXPECT_TRUE(
       HeaderUtility::isConnectUdp(Http::TestRequestHeaderMapImpl{{"upgrade", "connect-udp"}}));
+  // Should use case-insensitive comparison for the upgrade values.
+  EXPECT_TRUE(
+      HeaderUtility::isConnectUdp(Http::TestRequestHeaderMapImpl{{"upgrade", "CONNECT-UDP"}}));
   // Extended CONNECT requests should be normalized to HTTP/1.1.
   EXPECT_FALSE(HeaderUtility::isConnectUdp(
       Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}, {":protocol", "connect-udp"}}));


### PR DESCRIPTION
Commit Message:
Per RFC 9110, the Upgrade value comparison should be case-insensitive. The existing implementation used case-sensitive comparison for CONNECT-UDP, so I fixed the bug. Also, I made the upgrade_type config check use case-insensitive comparison for both CONNECT and CONNECT-UDP.
Additional Description:
See  RFC 9110 (https://www.rfc-editor.org/rfc/rfc9110#section-7.8) for the Upgrade value comparison semantics, and https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-upgradeconfig-upgrade-type for the correct upgrade_type config check semantics.
Risk Level: Low, this is a bug fix.
Testing: Added a unit test to enforce the correct comparison.
Docs Changes: N/A (Existing documentation is correct)
Release Notes: N/A
Platform Specific Features: N/A
