### PR TITLE
upstream: fix bug of unexpected cluster initialization object merge

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1275,13 +1275,13 @@ ClusterManagerImpl::addOrUpdateClusterInitializationObjectIfSupported(
   // TODO(kbaichoo): if EDS can be configured via cluster_type() then modify the
   // merging logic below.
   //
-  // This method may be called multiple times to create mutiple ClusterInitializationObject
-  // instances for the same cluster. And before the thread local clusters are acutally initialized,
+  // This method may be called multiple times to create multiple ClusterInitializationObject
+  // instances for the same cluster. And before the thread local clusters are actually initialized,
   // the new instances will override the old instances in the work threads. But part of data is only
   // be created only once, such as the load balancer factory. So we need to merge the new instance
   // with the old one to keep the latest instance always have all necessary data.
   //
-  // More specifically, this will happend in the following scenarios for now:
+  // More specifically, this will happen in the following scenarios for now:
   // 1. EDS clusters: the ClusterLoadAssignment of EDS cluster may be updated multiples before
   //   the thread local cluster is initialized.
   // 2. Clusters in the unit tests: the cluster in the unit test may be updated multiples before

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1278,8 +1278,8 @@ ClusterManagerImpl::addOrUpdateClusterInitializationObjectIfSupported(
   // This method may be called multiple times to create mutiple ClusterInitializationObject
   // instances for the same cluster. And before the thread local clusters are acutally initialized,
   // the new instances will override the old instances in the work threads. But part of data is only
-  // be created once in the first time, such as the load balancer factory. So we need to merge
-  // the new instance with the old one to keep the data.
+  // be created only once, such as the load balancer factory. So we need to merge the new instance
+  // with the old one to keep the latest instance always have all necessary data.
   //
   // More specifically, this will happend in the following scenarios for now:
   // 1. EDS clusters: the ClusterLoadAssignment of EDS cluster may be updated multiples before
@@ -1360,9 +1360,6 @@ ClusterManagerImpl::ClusterInitializationObject::ClusterInitializationObject(
     : per_priority_state_(per_priority_state), cluster_info_(std::move(cluster_info)),
       load_balancer_factory_(load_balancer_factory), cross_priority_host_map_(map) {
 
-  ASSERT(cluster_info_->type() == envoy::config::cluster::v3::Cluster::EDS,
-         fmt::format("Using merge constructor on possible non-mergable cluster of type {}",
-                     cluster_info_->type()));
   // Because EDS Clusters receive the entire ClusterLoadAssignment but only
   // provides the delta we must process the hosts_added and hosts_removed and
   // not simply overwrite with hosts added.

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1277,15 +1277,15 @@ ClusterManagerImpl::addOrUpdateClusterInitializationObjectIfSupported(
   //
   // This method may be called multiple times to create multiple ClusterInitializationObject
   // instances for the same cluster. And before the thread local clusters are actually initialized,
-  // the new instances will override the old instances in the work threads. But part of data is only
-  // be created only once, such as the load balancer factory. So we need to merge the new instance
-  // with the old one to keep the latest instance always have all necessary data.
+  // the new instances will override the old instances in the work threads. But part of data is be
+  // created only once, such as load balancer factory. So we should always to merge the new instance
+  // with the old one to keep the latest instance have all necessary data.
   //
   // More specifically, this will happen in the following scenarios for now:
   // 1. EDS clusters: the ClusterLoadAssignment of EDS cluster may be updated multiples before
   //   the thread local cluster is initialized.
   // 2. Clusters in the unit tests: the cluster in the unit test may be updated multiples before
-  //   the thread local cluster is initialized by calling `updateHosts` directly.
+  //   the thread local cluster is initialized by calling 'updateHosts' manually.
   const bool should_merge_with_prior_cluster =
       entry != cluster_initialization_map_.end() && entry->second->cluster_info_ == cluster_info;
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -867,11 +867,11 @@ private:
 
 protected:
   ClusterMap active_clusters_;
+  ClusterInitializationMap cluster_initialization_map_;
 
 private:
   ClusterMap warming_clusters_;
   const bool deferred_cluster_creation_;
-  ClusterInitializationMap cluster_initialization_map_;
   absl::optional<envoy::config::core::v3::BindConfig> bind_config_;
   Outlier::EventLoggerSharedPtr outlier_event_logger_;
   const LocalInfo::LocalInfo& local_info_;

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -69,6 +69,7 @@ envoy_cc_test(
         "//envoy/upstream:cluster_manager_interface",
         "//source/extensions/clusters/eds:eds_lib",
         "//source/extensions/clusters/static:static_cluster_lib",
+        "//source/extensions/load_balancing_policies/ring_hash:config",
         "//test/mocks/config:config_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",

--- a/test/common/upstream/deferred_cluster_initialization_test.cc
+++ b/test/common/upstream/deferred_cluster_initialization_test.cc
@@ -537,6 +537,14 @@ TEST_P(EdsTest, ShouldNotMergeAddingHostsForDifferentClustersWithSameName) {
   auto bootstrap = parseBootstrapFromV3YamlEnableDeferredCluster(bootstrap_yaml);
   create(bootstrap);
 
+  EXPECT_CALL(factory_, create(_))
+      .Times(2)
+      .WillRepeatedly(
+          testing::Invoke([this](Config::ConfigSubscriptionFactory::SubscriptionData& data) {
+            callbacks_ = &data.callbacks_;
+            return std::make_unique<NiceMock<Envoy::Config::MockSubscription>>();
+          }));
+
   const std::string eds_cluster_yaml = R"EOF(
       name: cluster_1
       connect_timeout: 0.25s
@@ -551,18 +559,8 @@ TEST_P(EdsTest, ShouldNotMergeAddingHostsForDifferentClustersWithSameName) {
             - eds
             refresh_delay: 1s
     )EOF";
-
-  EXPECT_CALL(factory_, create(_))
-      .Times(2)
-      .WillRepeatedly(
-          testing::Invoke([this](Config::ConfigSubscriptionFactory::SubscriptionData& data) {
-            callbacks_ = &data.callbacks_;
-            return std::make_unique<NiceMock<Envoy::Config::MockSubscription>>();
-          }));
-
-  EXPECT_EQ(readGauge("thread_local_cluster_manager.test_thread.clusters_inflated"), 0);
-  EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(
-      parseClusterFromV3Yaml(eds_cluster_yaml, getEdsClusterType()), "version1"));
+  auto cluster = parseClusterFromV3Yaml(eds_cluster_yaml, getEdsClusterType());
+  EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(cluster, "version1"));
 
   envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
   cluster_load_assignment.set_cluster_name("fare");
@@ -575,36 +573,26 @@ TEST_P(EdsTest, ShouldNotMergeAddingHostsForDifferentClustersWithSameName) {
   // RING_HASH lb policy requires Envoy re-create the load balancer when the cluster is updated.
   EXPECT_TRUE(initiailization_instance->load_balancer_factory_->recreateOnHostChange());
 
-  const std::string new_eds_cluster_yaml = R"EOF(
-      name: cluster_1
-      connect_timeout: 0.25s
-      lb_policy: ROUND_ROBIN
-      eds_cluster_config:
-        service_name: new_fare
-        eds_config:
-          api_config_source:
-            api_type: REST
-            transport_api_version: V3
-            cluster_names:
-            - eds
-            refresh_delay: 1s
-    )EOF";
+  // Update the cluster with a different lb policy. Now it's a different cluster and should
+  // not be merged.
+  cluster.set_lb_policy(::envoy::config::cluster::v3::Cluster::ROUND_ROBIN);
+  EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(cluster, "version2"));
 
-  EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(
-      parseClusterFromV3Yaml(new_eds_cluster_yaml, getEdsClusterType()), "version2"));
-  envoy::config::endpoint::v3::ClusterLoadAssignment new_cluster_load_assignment;
-  new_cluster_load_assignment.set_cluster_name("new_fare");
-  addEndpoint(new_cluster_load_assignment, 100);
-  doOnConfigUpdateVerifyNoThrow(new_cluster_load_assignment);
+  // Because the eds_service_name is the same, we can reuse the same load assignment here.
+  cluster_load_assignment.clear_endpoints();
+  // Note we only add one endpoint to the priority 1 to the new cluster.
+  addEndpoint(cluster_load_assignment, 100, 1);
+  doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 
   auto new_initialization_instance =
       cluster_manager_->clusterInitializationMap().find("cluster_1")->second;
   EXPECT_NE(initiailization_instance.get(), new_initialization_instance.get());
-  // If no merge happened, the ROUND_ROBIN lb policy should be used and the load balancer factory
-  // should be null.
-  // TODO(wbpcode): if we remove the legacy LB policy and configure all LB policies via new
-  // TypedLoadBalancerFactory, we need a new way to check the LB policy.
-  EXPECT_EQ(nullptr, new_initialization_instance->load_balancer_factory_);
+
+  EXPECT_EQ(1, new_initialization_instance->per_priority_state_.at(1).hosts_added_.size());
+  // Ensure the hosts_added_ is empty for priority 0. Because if unexpected merge happens,
+  // the hosts_added_ will be non-empty.
+  EXPECT_TRUE(!new_initialization_instance->per_priority_state_.contains(0) ||
+              new_initialization_instance->per_priority_state_.at(0).hosts_added_.empty());
 }
 
 // Test that removed hosts do not appear when initializing a deferred eds cluster.

--- a/test/common/upstream/deferred_cluster_initialization_test.cc
+++ b/test/common/upstream/deferred_cluster_initialization_test.cc
@@ -574,6 +574,8 @@ TEST_P(EdsTest, ShouldNotMergeAddingHostsForDifferentClustersWithSameName) {
   auto initiailization_instance =
       cluster_manager_->clusterInitializationMap().find("cluster_1")->second;
   EXPECT_NE(nullptr, initiailization_instance->load_balancer_factory_);
+  // RING_HASH lb policy requires Envoy re-create the load balancer when the cluster is updated.
+  EXPECT_TRUE(initiailization_instance->load_balancer_factory_->recreateOnHostChange());
 
   const std::string new_eds_cluster_yaml = R"EOF(
       name: cluster_1

--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -199,6 +199,10 @@ public:
     return clusters;
   }
 
+  const ClusterInitializationMap& clusterInitializationMap() const {
+    return cluster_initialization_map_;
+  }
+
   OdCdsApiHandlePtr createOdCdsApiHandle(OdCdsApiSharedPtr odcds) {
     return ClusterManagerImpl::OdCdsApiHandleImpl::create(*this, std::move(odcds));
   }


### PR DESCRIPTION
Commit Message: upstream: minor optimization to the cluster initialization object merge
Additional Description:

Defering cluster creation is a interesting/great feature. But in the current implementation, there may be unexpected merge of cluster initialization objects.

Now, previous cluster initialization objects will be merged to the new one when the cluster name, cluster type are same and the type is EDS.
However, if an EDS cluster is updated by the CDS API, they have same cluster name, same cluster type, but they may have complete different eds service name or lb config. They are complete different two cluster and merge shouldn't happen.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
