### PR TITLE
tcp: fix socket read data with rst flake

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -684,9 +684,7 @@ void ConnectionImpl::onReadReady() {
   // The socket is closed immediately when receiving RST.
   if (enable_rst_detect_send_ && result.err_code_.has_value() &&
       result.err_code_ == Api::IoError::IoErrorCode::ConnectionReset) {
-    ENVOY_CONN_LOG(trace, "boteng: read: rst close from peer", *this);
-    ENVOY_CONN_LOG(trace, "boteng: read: rst close processed data {}", *this,
-                   result.bytes_processed_);
+    ENVOY_CONN_LOG(trace, "read: rst close from peer", *this);
     if (result.bytes_processed_ != 0) {
       onRead(new_buffer_size);
     }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -684,7 +684,12 @@ void ConnectionImpl::onReadReady() {
   // The socket is closed immediately when receiving RST.
   if (enable_rst_detect_send_ && result.err_code_.has_value() &&
       result.err_code_ == Api::IoError::IoErrorCode::ConnectionReset) {
-    ENVOY_CONN_LOG(trace, "read: rst close from peer", *this);
+    ENVOY_CONN_LOG(trace, "boteng: read: rst close from peer", *this);
+    ENVOY_CONN_LOG(trace, "boteng: read: rst close processed data {}", *this,
+                   result.bytes_processed_);
+    if (result.bytes_processed_ != 0) {
+      onRead(new_buffer_size);
+    }
     setDetectedCloseType(DetectedCloseType::RemoteReset);
     closeSocket(ConnectionEvent::RemoteClose);
     return;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Fix #29595 

It is possible that we will get data + rst from the wrapped transport socket since there is a `do {} while` loop. We should trigger the `onRead` if there is any processed data.

Do not flake anymore.
```
bazel test test/integration:protocol_integration_test --test_filter="*LargeRequestMethod*" --test_arg="-l trace" -c opt --runs_per_test=1000
```

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
