### PR TITLE
tools/clang: Remove remaining host clang-format usage (+docs update)

### DIFF
--- a/.github/workflows/mobile-format.yml
+++ b/.github/workflows/mobile-format.yml
@@ -32,8 +32,6 @@ jobs:
     timeout-minutes: 45
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu }}
-      env:
-        CLANG_FORMAT: /opt/llvm/bin/clang-format
     steps:
     - uses: actions/checkout@v4
     - name: Add safe directory

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -932,7 +932,7 @@ TEST_TMPDIR=/tmp tools/gen_compilation_database.py
 
 Note that if you run the `check_spelling.py` script you will need to have `aspell` installed.
 
-Once this is set up, you can run clang-format without docker:
+You can run clang-format directly, without docker:
 
 ```shell
 bazel run //tools/code_format:check_format -- check

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -930,59 +930,7 @@ TEST_TMPDIR=/tmp tools/gen_compilation_database.py
 
 # Running format linting without docker
 
-The easiest way to run the clang-format check/fix commands is to run them via
-docker, which helps ensure the right toolchain is set up. However you may prefer
-to run clang-format scripts on your workstation directly:
- * It's possible there is a speed advantage
- * Docker itself can sometimes go awry and you then have to deal with that
- * Type-ahead doesn't always work when waiting running a command through docker
-
-To run the tools directly, you must install the correct version of clang. This
-may change over time, check the version of clang in the docker image. You must
-also have 'buildifier' installed from the bazel distribution.
-
 Note that if you run the `check_spelling.py` script you will need to have `aspell` installed.
-
-Edit the paths shown here to reflect the installation locations on your system:
-
-```shell
-export CLANG_FORMAT="$HOME/ext/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang-format"
-export BUILDIFIER_BIN="/usr/bin/buildifier"
-```
-
-A relatively easy way to use the correct `clang-format` in your host system is to copy the `clang-format` from the ci docker image.
-
-* Run the ci docker image
-
-```shell
-ci/run_envoy_docker.sh bash
-```
-
-* Get the docker container ID
-
-```shell
-dockerContainerID=$(docker ps | grep envoy-build-ubuntu | awk '{print $1}')
-```
-
-* Copy the `clang-format` to host machine
-
-```shell
-docker cp $dockerContainerID:/opt/llvm/bin/clang-format clang-format-ci
-```
-
-* Ensure that the copied `clang-format` is the default one, by ensuring it is in `$PATH`:
-
-```shell
-cp clang-format-ci /usr/local/bin/clang-format
-```
-
-Alternatively, if you are a non-root user, you can use a bin dir and add that to `$PATH`
-
-```shell
-mkdir bin
-mv clang-format-ci bin/clang-format
-export PATH=$PATH:$PWD/bin/
-```
 
 Once this is set up, you can run clang-format without docker:
 

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -87,7 +87,6 @@ fi
 export ENVOY_TEST_TMPDIR="${ENVOY_TEST_TMPDIR:-$BUILD_DIR/tmp}"
 export LLVM_ROOT="${LLVM_ROOT:-/opt/llvm}"
 export PATH=${LLVM_ROOT}/bin:${PATH}
-export CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
 
 if [[ -f "/etc/redhat-release" ]]; then
   BAZEL_BUILD_EXTRA_OPTIONS+=("--copt=-DENVOY_IGNORE_GLIBCXX_USE_CXX11_ABI_ERROR=1")
@@ -138,7 +137,6 @@ BAZEL_BUILD_OPTIONS=(
   "${BAZEL_GLOBAL_OPTIONS[@]}"
   "--verbose_failures"
   "--experimental_generate_json_trace_profile"
-  "--action_env=CLANG_FORMAT"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 

--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -65,12 +65,6 @@ do
     # our `relpath` helper.
     SCRIPT_DIR="$(dirname "$(realpath "$0")")/../../tools"
 
-    # TODO(hausdorff): We should have a more graceful failure story when the
-    # user does not have all the tools set up correctly. This script assumes
-    # `$CLANG_FORMAT` and `$BUILDIFY` are defined, or that the default values it
-    # assumes for these variables correspond to real binaries on the system. If
-    # either of these things aren't true, the check fails.
-
     _CHANGES=$(git diff --name-only "$RANGE" --diff-filter=ACMR --ignore-submodules=all 2>&1 | tr '\n' ' ')
     IFS=' ' read -ra CHANGES <<< "$_CHANGES"
 

--- a/tools/protoprint/BUILD
+++ b/tools/protoprint/BUILD
@@ -15,6 +15,7 @@ py_binary(
     srcs = ["protoprint.py"],
     data = [
         "//:.clang-format",
+        "//tools/clang-format",
         "//tools/type_whisperer:api_type_db.pb_text",
     ],
     visibility = ["//visibility:public"],

--- a/tools/protoprint/protoprint.bzl
+++ b/tools/protoprint/protoprint.bzl
@@ -20,7 +20,7 @@ protoprint_aspect = api_proto_plugin_aspect(
     "//tools/protoprint",
     _protoprint_impl,
     use_type_db = True,
-    extra_inputs = ["//:.clang-format"],
+    extra_inputs = ["//:.clang-format", "//tools/clang-format"],
 )
 
 def _protoprint_rule_impl(ctx):


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
