### PR TITLE
build: exclude liburing from non-Linux builds

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -1,5 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
-load("//bazel:envoy_build_system.bzl", "envoy_cmake", "envoy_package")
+load("//bazel:envoy_build_system.bzl", "envoy_cmake", "envoy_package", "envoy_cc_library")
 
 licenses(["notice"])  # Apache 2
 
@@ -15,6 +15,15 @@ configure_make(
         "nocompdb",
         "skip_on_windows",
     ],
+)
+
+envoy_cc_library(
+    name = "liburing_linux",
+    srcs = [],
+    deps = select({
+        "//bazel:linux": [":liburing"],
+        "//conditions:default": [],
+    }),
 )
 
 # autotools packages are unusable on Windows as-is

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -1,5 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
-load("//bazel:envoy_build_system.bzl", "envoy_cmake", "envoy_package", "envoy_cc_library")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_cmake", "envoy_package")
 
 licenses(["notice"])  # Apache 2
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -388,7 +388,7 @@ def _com_github_axboe_liburing():
     )
     native.bind(
         name = "uring",
-        actual = "@envoy//bazel/foreign_cc:liburing",
+        actual = "@envoy//bazel/foreign_cc:liburing_linux",
     )
 
 def _com_github_bazel_buildtools():

--- a/source/common/io/BUILD
+++ b/source/common/io/BUILD
@@ -10,9 +10,10 @@ envoy_package()
 
 envoy_cc_library(
     name = "io_uring_impl_lib",
-    srcs = [
-        "io_uring_impl.cc",
-    ],
+    srcs = select({
+        "@envoy//bazel:linux": ["io_uring_impl.cc"],
+        "//conditions:default": [],
+    }),
     hdrs = [
         "io_uring_impl.h",
     ],
@@ -26,7 +27,10 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "io_uring_worker_lib",
-    srcs = ["io_uring_worker_impl.cc"],
+    srcs = select({
+        "@envoy//bazel:linux": ["io_uring_worker_impl.cc"],
+        "//conditions:default": [],
+    }),
     hdrs = ["io_uring_worker_impl.h"],
     deps = [
         ":io_uring_impl_lib",

--- a/source/common/io/BUILD
+++ b/source/common/io/BUILD
@@ -11,7 +11,7 @@ envoy_package()
 envoy_cc_library(
     name = "io_uring_impl_lib",
     srcs = select({
-        "@envoy//bazel:linux": ["io_uring_impl.cc"],
+        "//bazel:linux": ["io_uring_impl.cc"],
         "//conditions:default": [],
     }),
     hdrs = [
@@ -28,7 +28,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "io_uring_worker_lib",
     srcs = select({
-        "@envoy//bazel:linux": ["io_uring_worker_impl.cc"],
+        "//bazel:linux": ["io_uring_worker_impl.cc"],
         "//conditions:default": [],
     }),
     hdrs = ["io_uring_worker_impl.h"],


### PR DESCRIPTION
This fixes some uncommon bazel invocations such as `bazel build //source/...` and `tools/gen_compilation_database.py` on non-Linux.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
