### PR TITLE
repo/tools: Add (sha) replacement tool

### DIFF
--- a/tools/sha/BUILD
+++ b/tools/sha/BUILD
@@ -1,0 +1,12 @@
+load("@envoy_repo//:path.bzl", "PATH")
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+sh_binary(
+    name = "replace",
+    srcs = ["replace.sh"],
+    args = [PATH],
+)

--- a/tools/sha/replace.sh
+++ b/tools/sha/replace.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+# This tool is for replacing shas in the repo, altho it could be
+# used to replace any strings.
+#
+# It does not currently validate that target/replacements are any kind of sha.
+
+REPO_PATH="$1"
+shift
+
+cd "$REPO_PATH" || exit 1
+
+for arg in "$@"; do
+    target="$(echo "$arg" | cut -d: -f1)"
+    replacement="$(echo "$arg" | cut -d: -f2)"
+    echo "Replacing ${target} -> ${replacement}"
+    git grep "$target" \
+        | cut -d: -f1 \
+        | xargs sed -i "s/${target}/${replacement}/g" || {
+        echo "No shas replaced for ${target}" >&2
+    }
+done


### PR DESCRIPTION
This provides a tool for replacing shas in the repo which can be helpful updating dependencies.

The tool is actually a generic string replacer (with many limitations), but as the focus is for shas ive added it to `tool/sha`

It can be run:

```console
$ bazel run //tools/sha:replace 1f2f7ee78f894859de0fa7a415b0bedde1f6c560:56f235b141079013e64912d676fe7da981368402

```

where the string/shas to be replaced are specified `$target:$replacement`

multiple replacements can be specified

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
