### PR TITLE
mobile/ci: Set the mobile-release workflow to use agent_ubuntu

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
       packages: read
     name: android_release_artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
     timeout-minutes: 120
     container:
       image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}


### PR DESCRIPTION
Instead of hard-coding the Ubuntu version number, it will get it from the env.yml macro.