### PR TITLE
network: Fix incorrect int comparison with -Werror,-Wsign-compare

### DIFF
--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -560,7 +560,8 @@ Address::InstanceConstSharedPtr IoSocketHandleImpl::peerAddress() {
         fmt::format("getpeername failed for '{}': {}", fd_, errorDetails(result.errno_)));
   }
 
-  if (ss_len >= (offsetof(sockaddr_storage, ss_family) + sizeof(ss.ss_family)) &&
+  if (static_cast<unsigned int>(ss_len) >=
+          (offsetof(sockaddr_storage, ss_family) + sizeof(ss.ss_family)) &&
       ss.ss_family == AF_UNIX) {
     // For Unix domain sockets, can't find out the peer name, but it should match our own
     // name for the socket (i.e. the path should match, barring any namespace or other


### PR DESCRIPTION
The `mobile-release` workflow has been failing:
https://github.com/envoyproxy/envoy/actions/runs/6162864940/job/16725227974#step:5:53. This is due to a compiler error when the `-Werror` and `-Wsign-compare` compilation options are turned on on certain platforms.

On certain platforms, socklen_t is an int instead of unsigned int, making the comparison with an integer of size_t (unsigned int) cause a compilation failure.

Instead of changing the `mobile-release` workflow to figure out the right compiler options to make the error go away, we fix the problem in the code to ensure we are comparing integers of the same type (both are now compared as unsigned ints).