### PR TITLE
clang/tidy: Fixes (`/source`)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,85 +1,77 @@
-Checks:           '-clang-analyzer-core.NonNullParamChecker,
-                   -clang-analyzer-optin.cplusplus.UninitializedObject,
-                   abseil-duration-*,
-                   abseil-faster-strsplit-delimiter,
-                   abseil-no-namespace,
-                   abseil-redundant-strcat-calls,
-                   abseil-str-cat-append,
-                   abseil-string-find-startswith,
-                   abseil-upgrade-duration-conversions,
-                   bugprone-assert-side-effect,
-                   bugprone-unused-raii,
-                   bugprone-use-after-move,
-                   clang-analyzer-core.DivideZero,
-                   misc-unused-using-decls,
-                   modernize-deprecated-headers,
-                   modernize-loop-convert,
-                   modernize-make-shared,
-                   modernize-make-unique,
-                   modernize-return-braced-init-list,
-                   modernize-use-default-member-init,
-                   modernize-use-equals-default,
-                   modernize-use-nullptr,
-                   modernize-use-override,
-                   modernize-use-using,
-                   performance-faster-string-find,
-                   performance-for-range-copy,
-                   performance-inefficient-algorithm,
-                   performance-inefficient-vector-operation,
-                   performance-noexcept-move-constructor,
-                   performance-move-constructor-init,
-                   performance-type-promotion-in-math-fn,
-                   performance-unnecessary-copy-initialization,
-                   readability-braces-around-statements,
-                   readability-container-size-empty,
-                   readability-identifier-naming,
-                   readability-redundant-control-flow,
-                   readability-redundant-member-init,
-                   readability-redundant-smartptr-get,
-                   readability-redundant-string-cstr'
-
-WarningsAsErrors:  '*'
+Checks: >
+  -clang-analyzer-core.NonNullParamChecker,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  abseil-duration-*,
+  abseil-faster-strsplit-delimiter,
+  abseil-no-namespace,
+  abseil-redundant-strcat-calls,
+  abseil-str-cat-append,
+  abseil-string-find-startswith,
+  abseil-upgrade-duration-conversions,
+  bugprone-assert-side-effect,
+  bugprone-unused-raii,
+  bugprone-use-after-move,
+  clang-analyzer-core.DivideZero,
+  misc-unused-using-decls,
+  modernize-deprecated-headers,
+  modernize-loop-convert,
+  modernize-make-shared,
+  modernize-make-unique,
+  modernize-return-braced-init-list,
+  modernize-use-default-member-init,
+  modernize-use-equals-default,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-faster-string-find,
+  performance-for-range-copy,
+  performance-inefficient-algorithm,
+  performance-inefficient-vector-operation,
+  performance-noexcept-move-constructor,
+  performance-move-constructor-init,
+  performance-type-promotion-in-math-fn,
+  performance-unnecessary-copy-initialization,
+  readability-braces-around-statements,
+  readability-container-size-empty,
+  readability-identifier-naming,
+  readability-redundant-control-flow,
+  readability-redundant-member-init,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr
 
 CheckOptions:
-  - key:             bugprone-assert-side-effect.AssertMacros
-    value:           'ASSERT'
+- key: cppcoreguidelines-unused-variable.IgnorePattern
+  value: "^_$"
+- key: bugprone-assert-side-effect.AssertMacros
+  value: 'ASSERT'
+- key: bugprone-dangling-handle.HandleClasses
+  value: 'std::basic_string_view;std::experimental::basic_string_view;absl::string_view'
+- key: modernize-use-auto.MinTypeNameLength
+  value: '10'
+- key: readability-identifier-naming.ClassCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.EnumCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.EnumConstantCase
+  value: 'CamelCase'
+# Ignore GoogleTest function macros.
+- key: readability-identifier-naming.FunctionIgnoredRegexp
+  value: '(TEST|TEST_F|TEST_P|INSTANTIATE_TEST_SUITE_P|MOCK_METHOD|TYPED_TEST)'
+- key: readability-identifier-naming.ParameterCase
+  value: 'lower_case'
+- key: readability-identifier-naming.PrivateMemberCase
+  value: 'lower_case'
+- key: readability-identifier-naming.PrivateMemberSuffix
+  value: '_'
+- key: readability-identifier-naming.StructCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.TypeAliasCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.UnionCase
+  value: 'CamelCase'
+- key: readability-identifier-naming.FunctionCase
+  value: 'camelBack'
 
-  - key:             bugprone-dangling-handle.HandleClasses
-    value:           'std::basic_string_view;std::experimental::basic_string_view;absl::string_view'
+UseColor: true
 
-  - key:             modernize-use-auto.MinTypeNameLength
-    value:           '10'
-
-  - key:             readability-identifier-naming.ClassCase
-    value:           'CamelCase'
-
-  - key:             readability-identifier-naming.EnumCase
-    value:           'CamelCase'
-
-  - key:             readability-identifier-naming.EnumConstantCase
-    value:           'CamelCase'
-
-  # Ignore GoogleTest function macros.
-  - key:             readability-identifier-naming.FunctionIgnoredRegexp
-    value:           '(TEST|TEST_F|TEST_P|INSTANTIATE_TEST_SUITE_P|MOCK_METHOD|TYPED_TEST)'
-
-  - key:             readability-identifier-naming.ParameterCase
-    value:           'lower_case'
-
-  - key:             readability-identifier-naming.PrivateMemberCase
-    value:           'lower_case'
-
-  - key:             readability-identifier-naming.PrivateMemberSuffix
-    value:           '_'
-
-  - key:             readability-identifier-naming.StructCase
-    value:           'CamelCase'
-
-  - key:             readability-identifier-naming.TypeAliasCase
-    value:           'CamelCase'
-
-  - key:             readability-identifier-naming.UnionCase
-    value:           'CamelCase'
-
-  - key:             readability-identifier-naming.FunctionCase
-    value:           'camelBack'
+WarningsAsErrors: '*'

--- a/.yamllint
+++ b/.yamllint
@@ -18,3 +18,8 @@ rules:
     - "false"
     # https://github.com/adrienverge/yamllint/issues/430
     - "on"
+
+yaml-files:
+- .clang-format
+- "*.yml"
+- "*.yaml"

--- a/source/common/common/random_generator.cc
+++ b/source/common/common/random_generator.cc
@@ -128,7 +128,7 @@ std::string RandomGeneratorImpl::uuid() {
     uuid[2 * i + 5] = hex[d & 0x0f];
   }
 
-  return std::string(uuid, UUID_LENGTH);
+  return {uuid, UUID_LENGTH};
 }
 
 } // namespace Random

--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -235,7 +235,8 @@ OutputBufferStream::OutputBufferStream(char* data, size_t size)
 int OutputBufferStream::bytesWritten() const { return pptr() - pbase(); }
 
 absl::string_view OutputBufferStream::contents() const {
-  return absl::string_view(pbase(), bytesWritten());
+  const std::string::size_type written = bytesWritten();
+  return {pbase(), written};
 }
 
 ConstMemoryStreamBuffer::ConstMemoryStreamBuffer(const char* data, size_t size) {
@@ -433,7 +434,7 @@ size_t StringUtil::strlcpy(char* dst, const char* src, size_t size) {
 }
 
 std::string StringUtil::subspan(absl::string_view source, size_t start, size_t end) {
-  return std::string(source.data() + start, end - start);
+  return {source.data() + start, end - start};
 }
 
 std::string StringUtil::escape(const absl::string_view source) {

--- a/source/common/event/scaled_range_timer_manager_impl.cc
+++ b/source/common/event/scaled_range_timer_manager_impl.cc
@@ -214,7 +214,7 @@ ScaledRangeTimerManagerImpl::activateTimer(std::chrono::milliseconds duration,
     resetQueueTimer(queue, dispatcher_.approximateMonotonicTime());
   }
 
-  return ScalingTimerHandle(queue, --queue.range_timers_.end());
+  return {queue, --queue.range_timers_.end()};
 }
 
 void ScaledRangeTimerManagerImpl::removeTimer(ScalingTimerHandle handle) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1608,8 +1608,7 @@ void ConnectionManagerImpl::ActiveStream::requestRouteConfigUpdate(
 
 absl::optional<Router::ConfigConstSharedPtr> ConnectionManagerImpl::ActiveStream::routeConfig() {
   if (connection_manager_.config_.routeConfigProvider() != nullptr) {
-    return absl::optional<Router::ConfigConstSharedPtr>(
-        connection_manager_.config_.routeConfigProvider()->configCast());
+    return {connection_manager_.config_.routeConfigProvider()->configCast()};
   }
   return {};
 }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -506,7 +506,7 @@ Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
 Utility::QueryParamsMulti Utility::QueryParamsMulti::parseQueryString(absl::string_view url) {
   size_t start = url.find('?');
   if (start == std::string::npos) {
-    return Utility::QueryParamsMulti();
+    return {};
   }
 
   start++;
@@ -528,7 +528,7 @@ Utility::QueryParamsMulti
 Utility::QueryParamsMulti::parseAndDecodeQueryString(absl::string_view url) {
   size_t start = url.find('?');
   if (start == std::string::npos) {
-    return Utility::QueryParamsMulti();
+    return {};
   }
 
   start++;
@@ -622,8 +622,7 @@ absl::string_view Utility::findQueryStringStart(const HeaderString& path) {
 std::string Utility::stripQueryString(const HeaderString& path) {
   absl::string_view path_str = path.getStringView();
   size_t query_offset = path_str.find('?');
-  return std::string(path_str.data(),
-                     query_offset != path_str.npos ? query_offset : path_str.size());
+  return {path_str.data(), query_offset != path_str.npos ? query_offset : path_str.size()};
 }
 
 std::string Utility::replaceQueryString(const HeaderString& path,

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -208,7 +208,8 @@ std::string Ipv4Instance::sockaddrToString(const sockaddr_in& addr) {
       *--start = '.';
     }
   }
-  return std::string(start, str + BufferSize - start);
+  const std::string::size_type end = str + BufferSize - start;
+  return {start, end};
 }
 
 absl::Status Ipv4Instance::validateProtocolSupported() {

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -62,7 +62,7 @@ Api::IoCallUint64Result IoSocketHandleImpl::close() {
   ASSERT(SOCKET_VALID(fd_));
   const int rc = Api::OsSysCallsSingleton::get().close(fd_).return_value_;
   SET_SOCKET_INVALID(fd_);
-  return Api::IoCallUint64Result(rc, Api::IoErrorPtr(nullptr, IoSocketError::deleteIoError));
+  return {static_cast<unsigned long>(rc), Api::IoErrorPtr(nullptr, IoSocketError::deleteIoError)};
 }
 
 bool IoSocketHandleImpl::isOpen() const { return SOCKET_VALID(fd_); }

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -123,7 +123,7 @@ QuicFilterManagerConnectionImpl::socketOptions() const {
 }
 
 Ssl::ConnectionInfoConstSharedPtr QuicFilterManagerConnectionImpl::ssl() const {
-  return Ssl::ConnectionInfoConstSharedPtr(quic_ssl_info_);
+  return {quic_ssl_info_};
 }
 
 void QuicFilterManagerConnectionImpl::rawWrite(Buffer::Instance& /*data*/, bool /*end_stream*/) {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -942,7 +942,7 @@ std::string ParentHistogramImpl::quantileSummary() const {
     }
     return absl::StrJoin(summary, " ");
   } else {
-    return std::string("No recorded values");
+    return {"No recorded values"};
   }
 }
 
@@ -958,7 +958,7 @@ std::string ParentHistogramImpl::bucketSummary() const {
     }
     return absl::StrJoin(bucket_summary, " ");
   } else {
-    return std::string("No recorded values");
+    return {"No recorded values"};
   }
 }
 

--- a/source/common/upstream/default_local_address_selector.cc
+++ b/source/common/upstream/default_local_address_selector.cc
@@ -10,7 +10,7 @@ DefaultUpstreamLocalAddressSelector::DefaultUpstreamLocalAddressSelector(
     : upstream_local_addresses_(std::move(upstream_local_addresses)) {
   // If bind config is not provided, we insert at least one
   // ``UpstreamLocalAddress`` with null address.
-  ASSERT(upstream_local_addresses_.size() > 0);
+  ASSERT(!upstream_local_addresses_.empty());
 }
 
 UpstreamLocalAddress DefaultUpstreamLocalAddressSelector::getUpstreamLocalAddressImpl(

--- a/source/common/upstream/default_local_address_selector_factory.cc
+++ b/source/common/upstream/default_local_address_selector_factory.cc
@@ -12,7 +12,7 @@ constexpr absl::string_view kDefaultLocalAddressSelectorName =
 void validate(const std::vector<::Envoy::Upstream::UpstreamLocalAddress>& upstream_local_addresses,
               absl::optional<std::string> cluster_name) {
 
-  if (upstream_local_addresses.size() == 0) {
+  if (upstream_local_addresses.empty()) {
     throw EnvoyException(fmt::format("{}'s upstream binding config has no valid source address.",
                                      !(cluster_name.has_value())
                                          ? "Bootstrap"

--- a/source/common/upstream/transport_socket_match_impl.cc
+++ b/source/common/upstream/transport_socket_match_impl.cc
@@ -42,10 +42,10 @@ TransportSocketMatcherImpl::resolve(const envoy::config::core::v3::Metadata* met
     if (Config::Metadata::metadataLabelMatch(
             match.label_set, metadata,
             Envoy::Config::MetadataFilters::get().ENVOY_TRANSPORT_SOCKET_MATCH, false)) {
-      return MatchData(*match.factory, match.stats, match.name);
+      return {*match.factory, match.stats, match.name};
     }
   }
-  return MatchData(*default_match_.factory, default_match_.stats, default_match_.name);
+  return {*default_match_.factory, default_match_.stats, default_match_.name};
 }
 
 } // namespace Upstream

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -848,7 +848,7 @@ ClusterInfoImpl::generateStats(Stats::ScopeSharedPtr scope,
 
 ClusterRequestResponseSizeStats ClusterInfoImpl::generateRequestResponseSizeStats(
     Stats::Scope& scope, const ClusterRequestResponseSizeStatNames& stat_names) {
-  return ClusterRequestResponseSizeStats(stat_names, scope);
+  return {stat_names, scope};
 }
 
 ClusterLoadReportStats

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -282,7 +282,6 @@ void EdsClusterImpl::update(
 
   BatchUpdateHelper helper(*this, *used_load_assignment);
   priority_set_.batchHostUpdate(helper);
-  return;
 }
 
 absl::Status

--- a/source/extensions/clusters/redis/BUILD
+++ b/source/extensions/clusters/redis/BUILD
@@ -11,19 +11,15 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "crc16_lib",
-    srcs = [
-        "crc16.cc",
-        "crc16.h",
-    ],
+    srcs = ["crc16.cc"],
+    hdrs = ["crc16.h"],
     deps = ["@com_google_absl//absl/strings"],
 )
 
 envoy_cc_library(
     name = "redis_cluster_lb",
-    srcs = [
-        "redis_cluster_lb.cc",
-        "redis_cluster_lb.h",
-    ],
+    srcs = ["redis_cluster_lb.cc"],
+    hdrs = ["redis_cluster_lb.h"],
     deps = [
         ":crc16_lib",
         "//envoy/upstream:thread_local_cluster_interface",
@@ -38,10 +34,8 @@ envoy_cc_library(
 
 envoy_cc_extension(
     name = "redis_cluster",
-    srcs = [
-        "redis_cluster.cc",
-        "redis_cluster.h",
-    ],
+    srcs = ["redis_cluster.cc"],
+    hdrs = ["redis_cluster.h"],
     deps = [
         "redis_cluster_lb",
         "//envoy/api:api_interface",

--- a/source/extensions/common/aws/region_provider_impl.cc
+++ b/source/extensions/common/aws/region_provider_impl.cc
@@ -9,9 +9,7 @@ static const char AWS_REGION[] = "AWS_REGION";
 
 StaticRegionProvider::StaticRegionProvider(const std::string& region) : region_(region) {}
 
-absl::optional<std::string> StaticRegionProvider::getRegion() {
-  return absl::optional<std::string>(region_);
-}
+absl::optional<std::string> StaticRegionProvider::getRegion() { return {region_}; }
 
 absl::optional<std::string> EnvironmentRegionProvider::getRegion() {
   const auto region = std::getenv(AWS_REGION);
@@ -19,7 +17,7 @@ absl::optional<std::string> EnvironmentRegionProvider::getRegion() {
     return absl::nullopt;
   }
   ENVOY_LOG(debug, "Found environment region {}={}", AWS_REGION, region);
-  return absl::optional<std::string>(region);
+  return {region};
 }
 
 } // namespace Aws

--- a/source/extensions/compression/zstd/common/BUILD
+++ b/source/extensions/compression/zstd/common/BUILD
@@ -20,7 +20,7 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "zstd_dictionary_manager_lib",
-    srcs = ["dictionary_manager.h"],
+    hdrs = ["dictionary_manager.h"],
     external_deps = ["zstd"],
     deps = [
         "//envoy/event:dispatcher_interface",

--- a/source/extensions/config_subscription/grpc/watch_map.cc
+++ b/source/extensions/config_subscription/grpc/watch_map.cc
@@ -77,7 +77,7 @@ WatchMap::updateWatchInterest(Watch* watch,
       eds_resources_cache_->removeResource(resource_name);
     }
   }
-  return AddedRemoved(std::move(added_resources), std::move(removed_resources));
+  return {std::move(added_resources), std::move(removed_resources)};
 }
 
 absl::flat_hash_set<Watch*> WatchMap::watchesInterestedIn(const std::string& resource_name) {
@@ -287,8 +287,8 @@ void WatchMap::onConfigUpdate(
     for (const auto& resource : decoded_resources) {
       const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment =
           dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
-              resource.get()->resource());
-      eds_resources_cache_->setResource(resource.get()->name(), cluster_load_assignment);
+              resource->resource());
+      eds_resources_cache_->setResource(resource->name(), cluster_load_assignment);
     }
     // No need to remove resources from the cache, as currently only non-collection
     // subscriptions are supported, and these resources are removed in the call

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -288,7 +288,7 @@ VaryHeaderUtils::getVaryValues(const Http::ResponseHeaderMap& headers) {
 
   std::vector<absl::string_view> values =
       CacheHeadersUtils::parseCommaDelimitedHeader(vary_headers);
-  return absl::btree_set<absl::string_view>(values.begin(), values.end());
+  return {values.begin(), values.end()};
 }
 
 namespace {

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -35,7 +35,7 @@ absl::optional<std::string> HeaderValueSelector::extract(Http::HeaderMap& map) c
 absl::optional<std::string> CookieValueSelector::extract(Http::HeaderMap& map) const {
   std::string value = Envoy::Http::Utility::parseCookieValue(map, cookie_);
   if (!value.empty()) {
-    return absl::optional<std::string>(std::move(value));
+    return {std::move(value)};
   }
   return absl::nullopt;
 }

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -9,8 +9,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace RateLimitQuota {
 
-using ::envoy::type::v3::RateLimitStrategy;
-
 Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                               bool end_stream) {
   ENVOY_LOG(trace, "decodeHeaders: end_stream = {}", end_stream);

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
@@ -76,7 +76,7 @@ DubboHessian2SerializerImpl::deserializeRpcInvocation(Buffer::Instance& buffer,
     }
   });
 
-  return std::pair<RpcInvocationSharedPtr, bool>(invo, true);
+  return {invo, true};
 }
 
 std::pair<RpcResultSharedPtr, bool>
@@ -125,7 +125,7 @@ DubboHessian2SerializerImpl::deserializeRpcResult(Buffer::Instance& buffer,
                     (context->bodySize() - total_size)));
   }
 
-  return std::pair<RpcResultSharedPtr, bool>(result, true);
+  return {result, true};
 }
 
 size_t DubboHessian2SerializerImpl::serializeRpcResult(Buffer::Instance& output_buffer,

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -89,7 +89,7 @@ DubboProtocolImpl::decodeHeader(Buffer::Instance& buffer, MessageMetadataSharedP
   }
 
   if (buffer.length() < DubboProtocolImpl::MessageSize) {
-    return std::pair<ContextSharedPtr, bool>(nullptr, false);
+    return {nullptr, false};
   }
 
   uint16_t magic_number = buffer.peekBEInt<uint16_t>();
@@ -130,7 +130,7 @@ DubboProtocolImpl::decodeHeader(Buffer::Instance& buffer, MessageMetadataSharedP
   context->setBodySize(body_size);
   context->setHeartbeat(is_event);
 
-  return std::pair<ContextSharedPtr, bool>(context, true);
+  return {context, true};
 }
 
 bool DubboProtocolImpl::decodeData(Buffer::Instance& buffer, ContextSharedPtr context,

--- a/source/extensions/filters/udp/udp_proxy/config.cc
+++ b/source/extensions/filters/udp/udp_proxy/config.cc
@@ -17,7 +17,7 @@ UdpProxyFilterConfigImpl::UdpProxyFilterConfigImpl(
       // Default prefer_gro to true for upstream client traffic.
       upstream_socket_config_(config.upstream_socket_config(), true),
       random_(context.api().randomGenerator()) {
-  if (use_per_packet_load_balancing_ && config.session_filters().size() > 0) {
+  if (use_per_packet_load_balancing_ && !config.session_filters().empty()) {
     throw EnvoyException(
         "Only one of use_per_packet_load_balancing or session_filters can be used.");
   }

--- a/source/extensions/grpc_credentials/aws_iam/config.cc
+++ b/source/extensions/grpc_credentials/aws_iam/config.cc
@@ -101,9 +101,7 @@ AwsIamHeaderAuthenticator::GetMetadata(grpc::string_ref service_url, grpc::strin
                                     absl::string_view(method_name.data(), method_name.length()));
 
   TRY_NEEDS_AUDIT { signer_->sign(message, false); }
-  END_TRY catch (const EnvoyException& e) {
-    return grpc::Status(grpc::StatusCode::INTERNAL, e.what());
-  }
+  END_TRY catch (const EnvoyException& e) { return {grpc::StatusCode::INTERNAL, e.what()}; }
 
   signedHeadersToMetadata(message.headers(), *metadata);
 

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -18,7 +18,6 @@ namespace EnvoyDefault {
 
 using ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig;
 using ::Envoy::Http::HeaderString;
-using ::Envoy::Http::LowerCaseString;
 using ::Envoy::Http::Protocol;
 using ::Envoy::Http::RequestHeaderMap;
 using ::Envoy::Http::UhvResponseCodeDetail;

--- a/source/extensions/io_socket/user_space/BUILD
+++ b/source/extensions/io_socket/user_space/BUILD
@@ -11,7 +11,7 @@ envoy_extension_package()
 
 envoy_cc_extension(
     name = "config",
-    srcs = ["config.h"],
+    hdrs = ["config.h"],
     # for integration tests and bootstrap.internal_listener
     visibility = ["//visibility:public"],
     deps = [

--- a/source/extensions/listener_managers/listener_manager/connection_handler_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/connection_handler_impl.cc
@@ -357,8 +357,7 @@ ConnectionHandlerImpl::getBalancedHandlerByAddress(const Network::Address::Insta
   if (auto listener_it = tcp_listener_map_by_address_.find(address.asStringView());
       listener_it != tcp_listener_map_by_address_.end() &&
       listener_it->second->listener_->listener() != nullptr) {
-    return Network::BalancedConnectionHandlerOptRef(
-        listener_it->second->tcpListener().value().get());
+    return {listener_it->second->tcpListener().value().get()};
   }
 
   OptRef<ConnectionHandlerImpl::PerAddressActiveListenerDetails> details;

--- a/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_manager_impl.cc
@@ -272,9 +272,8 @@ Network::ListenerFilterMatcherSharedPtr ProdListenerComponentFactory::createList
   if (!listener_filter.has_filter_disabled()) {
     return nullptr;
   }
-  return std::shared_ptr<Network::ListenerFilterMatcher>(
-      Network::ListenerFilterMatcherBuilder::buildListenerFilterMatcher(
-          listener_filter.filter_disabled()));
+  return {Network::ListenerFilterMatcherBuilder::buildListenerFilterMatcher(
+      listener_filter.filter_disabled())};
 }
 
 Network::SocketSharedPtr ProdListenerComponentFactory::createListenSocket(

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
@@ -14,7 +14,7 @@ OtlpOptions::OtlpOptions(const SinkConfig& sink_config)
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, emit_tags_as_attributes, true)),
       use_tag_extracted_name_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, use_tag_extracted_name, true)),
-      stat_prefix_(sink_config.prefix() != "" ? sink_config.prefix() + "." : "") {}
+      stat_prefix_(!sink_config.prefix().empty() ? sink_config.prefix() + "." : "") {}
 
 OpenTelemetryGrpcMetricsExporterImpl::OpenTelemetryGrpcMetricsExporterImpl(
     const OtlpOptionsSharedPtr config, Grpc::RawAsyncClientSharedPtr raw_async_client)

--- a/source/extensions/tracers/xray/localized_sampling.cc
+++ b/source/extensions/tracers/xray/localized_sampling.cc
@@ -31,8 +31,8 @@ void fail(absl::string_view msg) {
   ENVOY_LOG_TO_LOGGER(logger, error, "Failed to parse sampling rules - {}", msg);
 }
 
-bool is_valid_rate(double n) { return n >= 0 && n <= 1.0; }
-bool is_valid_fixed_target(double n) { return n >= 0 && static_cast<uint32_t>(n) == n; }
+bool isValidRate(double n) { return n >= 0 && n <= 1.0; }
+bool isValidFixedTarget(double n) { return n >= 0 && static_cast<uint32_t>(n) == n; }
 
 bool validateRule(const ProtobufWkt::Struct& rule) {
   using ProtobufWkt::Value;
@@ -61,7 +61,7 @@ bool validateRule(const ProtobufWkt::Struct& rule) {
   const auto fixed_target_it = rule.fields().find(FixedTargetJsonKey);
   if (fixed_target_it == rule.fields().end() ||
       fixed_target_it->second.kind_case() != Value::KindCase::kNumberValue ||
-      !is_valid_fixed_target(fixed_target_it->second.number_value())) {
+      !isValidFixedTarget(fixed_target_it->second.number_value())) {
     fail("fixed target is missing or not a valid positive integer");
     return false;
   }
@@ -69,7 +69,7 @@ bool validateRule(const ProtobufWkt::Struct& rule) {
   const auto rate_it = rule.fields().find(RateJsonKey);
   if (rate_it == rule.fields().end() ||
       rate_it->second.kind_case() != Value::KindCase::kNumberValue ||
-      !is_valid_rate(rate_it->second.number_value())) {
+      !isValidRate(rate_it->second.number_value())) {
     fail("rate is missing or not a valid positive floating number");
     return false;
   }

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -135,7 +135,7 @@ SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
 
   if (b3.length() == 1) { // possibly sampling flags
     if (validSamplingFlags(b3[0])) {
-      return std::pair<SpanContext, bool>(SpanContext(), false);
+      return {SpanContext(), false};
     }
     throw ExtractorException(fmt::format("Invalid input: invalid sampling flag {}", b3[0]));
   }

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -21,7 +21,7 @@ namespace Extensions {
 namespace TransportSockets {
 namespace ProxyProtocol {
 
-UpstreamProxyProtocolStats GenerateUpstreamProxyProtocolStats(Stats::Scope& stats_scope) {
+UpstreamProxyProtocolStats generateUpstreamProxyProtocolStats(Stats::Scope& stats_scope) {
   const char prefix[]{"upstream.proxyprotocol."};
   return {ALL_PROXY_PROTOCOL_TRANSPORT_SOCKET_STATS(POOL_COUNTER_PREFIX(stats_scope, prefix))};
 }
@@ -31,7 +31,7 @@ UpstreamProxyProtocolSocket::UpstreamProxyProtocolSocket(
     Network::TransportSocketOptionsConstSharedPtr options, ProxyProtocolConfig config,
     Stats::Scope& scope)
     : PassthroughSocket(std::move(transport_socket)), options_(options), version_(config.version()),
-      stats_(GenerateUpstreamProxyProtocolStats(scope)),
+      stats_(generateUpstreamProxyProtocolStats(scope)),
       pass_all_tlvs_(config.has_pass_through_tlvs() ? config.pass_through_tlvs().match_type() ==
                                                           ProxyProtocolPassThroughTLVs::INCLUDE_ALL
                                                     : false) {

--- a/source/extensions/transport_sockets/tls/ocsp/ocsp.cc
+++ b/source/extensions/transport_sockets/tls/ocsp/ocsp.cc
@@ -278,9 +278,7 @@ ResponseData Asn1OcspUtility::parseResponseData(CBS& cbs) {
   skipResponderId(elem);
   unwrap(Asn1Utility::skip(elem, CBS_ASN1_GENERALIZEDTIME));
   auto responses = unwrap(Asn1Utility::parseSequenceOf<SingleResponse>(
-      elem, [](CBS& cbs) -> ParsingResult<SingleResponse> {
-        return ParsingResult<SingleResponse>(parseSingleResponse(cbs));
-      }));
+      elem, [](CBS& cbs) -> ParsingResult<SingleResponse> { return {parseSingleResponse(cbs)}; }));
   // Extensions currently ignored.
 
   return {std::move(responses)};


### PR DESCRIPTION
This fixes most of the clang-tidy issues in `/source` - where the problem was reasonably obvious

Also updates the `.clang-tidy` file and brings it into yaml linting

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
