### PR TITLE
golang filer: support Drain & Reset

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -239,6 +239,12 @@ updates:
     time: "06:00"
 
 - package-ecosystem: "gomod"
+  directory: "/contrib/golang/filters/http/test/test_data/buffer"
+  schedule:
+    interval: daily
+    time: "06:00"
+
+- package-ecosystem: "gomod"
   directory: "/contrib/golang/filters/http/test/test_data/routeconfig"
   schedule:
     interval: daily

--- a/contrib/golang/common/go/api/api.h
+++ b/contrib/golang/common/go/api/api.h
@@ -62,6 +62,7 @@ CAPIStatus envoyGoFilterHttpSetHeaderHelper(void* r, void* key, void* value, hea
 CAPIStatus envoyGoFilterHttpRemoveHeader(void* r, void* key);
 
 CAPIStatus envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer, void* value);
+CAPIStatus envoyGoFilterHttpDrainBuffer(void* r, unsigned long long int buffer, uint64_t length);
 CAPIStatus envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer, void* data,
                                             int length, bufferAction action);
 

--- a/contrib/golang/common/go/api/capi.go
+++ b/contrib/golang/common/go/api/capi.go
@@ -33,6 +33,7 @@ type HttpCAPI interface {
 	HttpRemoveHeader(r unsafe.Pointer, key *string)
 
 	HttpGetBuffer(r unsafe.Pointer, bufferPtr uint64, value *string, length uint64)
+	HttpDrainBuffer(r unsafe.Pointer, bufferPtr uint64, length uint64)
 	HttpSetBufferHelper(r unsafe.Pointer, bufferPtr uint64, value string, action BufferAction)
 
 	HttpCopyTrailers(r unsafe.Pointer, num uint64, bytes uint64) map[string][]string

--- a/contrib/golang/common/go/api/type.go
+++ b/contrib/golang/common/go/api/type.go
@@ -200,12 +200,6 @@ type DataBufferBase interface {
 	// buffer becomes too large, Write will panic with ErrTooLarge.
 	WriteUint64(p uint64) error
 
-	// Peek returns n bytes from buffer, without draining any buffered data.
-	// If n > readable buffer, nil will be returned.
-	// It can be used in codec to check first-n-bytes magic bytes
-	// Note: do not change content in return bytes, use write instead
-	Peek(n int) []byte
-
 	// Bytes returns all bytes from buffer, without draining any buffered data.
 	// It can be used to get fixed-length content, such as headers, body.
 	// Note: do not change content in return bytes, use write instead

--- a/contrib/golang/filters/http/source/cgo.cc
+++ b/contrib/golang/filters/http/source/cgo.cc
@@ -158,6 +158,15 @@ CAPIStatus envoyGoFilterHttpGetBuffer(void* r, unsigned long long int buffer_ptr
       });
 }
 
+CAPIStatus envoyGoFilterHttpDrainBuffer(void* r, unsigned long long int buffer_ptr,
+                                        uint64_t length) {
+  return envoyGoFilterHandlerWrapper(
+      r, [buffer_ptr, length](std::shared_ptr<Filter>& filter) -> CAPIStatus {
+        auto buffer = reinterpret_cast<Buffer::Instance*>(buffer_ptr);
+        return filter->drainBuffer(buffer, length);
+      });
+}
+
 CAPIStatus envoyGoFilterHttpSetBufferHelper(void* r, unsigned long long int buffer_ptr, void* data,
                                             int length, bufferAction action) {
   return envoyGoFilterHandlerWrapper(

--- a/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/capi_impl.go
@@ -193,6 +193,11 @@ func (c *httpCApiImpl) HttpGetBuffer(r unsafe.Pointer, bufferPtr uint64, value *
 	handleCApiStatus(res)
 }
 
+func (c *httpCApiImpl) HttpDrainBuffer(r unsafe.Pointer, bufferPtr uint64, length uint64) {
+	res := C.envoyGoFilterHttpDrainBuffer(r, C.ulonglong(bufferPtr), C.uint64_t(length))
+	handleCApiStatus(res)
+}
+
 func (c *httpCApiImpl) HttpSetBufferHelper(r unsafe.Pointer, bufferPtr uint64, value string, action api.BufferAction) {
 	sHeader := (*reflect.StringHeader)(unsafe.Pointer(&value))
 	var act C.bufferAction

--- a/contrib/golang/filters/http/source/go/pkg/http/type.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/type.go
@@ -369,10 +369,6 @@ func (b *httpBuffer) WriteUint64(p uint64) error {
 	return err
 }
 
-func (b *httpBuffer) Peek(n int) []byte {
-	panic("implement me")
-}
-
 func (b *httpBuffer) Bytes() []byte {
 	if b.length == 0 {
 		return nil
@@ -382,7 +378,18 @@ func (b *httpBuffer) Bytes() []byte {
 }
 
 func (b *httpBuffer) Drain(offset int) {
-	panic("implement me")
+	if offset <= 0 || b.length == 0 {
+		return
+	}
+
+	size := uint64(offset)
+	if size > b.length {
+		size = b.length
+	}
+
+	cAPI.HttpDrainBuffer(unsafe.Pointer(b.request.req), b.envoyBufferInstance, size)
+
+	b.length -= size
 }
 
 func (b *httpBuffer) Len() int {
@@ -390,7 +397,7 @@ func (b *httpBuffer) Len() int {
 }
 
 func (b *httpBuffer) Reset() {
-	panic("implement me")
+	b.Drain(b.Len())
 }
 
 func (b *httpBuffer) String() string {

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -225,6 +225,7 @@ public:
   CAPIStatus setHeader(absl::string_view key, absl::string_view value, headerAction act);
   CAPIStatus removeHeader(absl::string_view key);
   CAPIStatus copyBuffer(Buffer::Instance* buffer, char* data);
+  CAPIStatus drainBuffer(Buffer::Instance* buffer, uint64_t length);
   CAPIStatus setBufferHelper(Buffer::Instance* buffer, absl::string_view& value,
                              bufferAction action);
   CAPIStatus copyTrailers(GoString* go_strs, char* go_buf);

--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -54,6 +54,7 @@ envoy_cc_test(
     data = [
         "//contrib/golang/filters/http/test/test_data/access_log:filter.so",
         "//contrib/golang/filters/http/test/test_data/basic:filter.so",
+        "//contrib/golang/filters/http/test/test_data/buffer:filter.so",
         "//contrib/golang/filters/http/test/test_data/echo:filter.so",
         "//contrib/golang/filters/http/test/test_data/metric:filter.so",
         "//contrib/golang/filters/http/test/test_data/passthrough:filter.so",

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -662,9 +662,43 @@ typed_config:
     cleanup();
   }
 
+  void testBufferApi(std::string query) {
+    initializeBasicFilter(BUFFER, "test.com");
+
+    auto path = std::string("/test?") + query;
+    codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+    Http::TestRequestHeaderMapImpl request_headers{
+        {":method", "POST"},
+        {":path", path},
+        {":scheme", "http"},
+        {":authority", "test.com"},
+    };
+
+    auto encoder_decoder = codec_client_->startRequest(request_headers);
+    Http::RequestEncoder& request_encoder = encoder_decoder.first;
+    auto response = std::move(encoder_decoder.second);
+    std::string data = "";
+    for (int i = 0; i < 10; i++) {
+      data += "12345";
+    }
+    codec_client_->sendData(request_encoder, data, true);
+
+    waitForNextUpstreamRequest();
+
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+    upstream_request_->encodeHeaders(response_headers, false);
+    Buffer::OwnedImpl response_data("goodbye");
+    upstream_request_->encodeData(response_data, true);
+
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+    cleanup();
+  }
+
   const std::string ECHO{"echo"};
   const std::string BASIC{"basic"};
   const std::string PASSTHROUGH{"passthrough"};
+  const std::string BUFFER{"buffer"};
   const std::string ROUTECONFIG{"routeconfig"};
   const std::string PROPERTY{"property"};
   const std::string ACCESSLOG{"access_log"};
@@ -753,6 +787,12 @@ TEST_P(GolangIntegrationTest, PluginNotFound) {
   EXPECT_EQ("200", response->headers().getStatusValue());
   cleanup();
 }
+
+TEST_P(GolangIntegrationTest, BufferDrain) { testBufferApi("Drain"); }
+
+TEST_P(GolangIntegrationTest, BufferReset) { testBufferApi("Reset"); }
+
+TEST_P(GolangIntegrationTest, BufferResetAfterDrain) { testBufferApi("ResetAfterDrain"); }
 
 TEST_P(GolangIntegrationTest, Property) {
   initializePropertyConfig(PROPERTY, genSoPath(PROPERTY), PROPERTY);

--- a/contrib/golang/filters/http/test/test_data/buffer/BUILD
+++ b/contrib/golang/filters/http/test/test_data/buffer/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+licenses(["notice"])  # Apache 2
+
+go_binary(
+    name = "filter.so",
+    srcs = [
+        "config.go",
+        "filter.go",
+    ],
+    out = "filter.so",
+    cgo = True,
+    importpath = "github.com/envoyproxy/envoy/contrib/golang/filters/http/test/test_data/buffer",
+    linkmode = "c-shared",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//contrib/golang/common/go/api",
+        "//contrib/golang/filters/http/source/go/pkg/http",
+        "@com_github_cncf_xds_go//xds/type/v3:type",
+        "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/contrib/golang/filters/http/test/test_data/buffer/config.go
+++ b/contrib/golang/filters/http/test/test_data/buffer/config.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http"
+)
+
+const Name = "buffer"
+
+func init() {
+	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+}
+
+type config struct {
+}
+
+type parser struct {
+}
+
+func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
+	conf := &config{}
+	return conf, nil
+}
+
+func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
+	return child
+}
+
+func ConfigFactory(c interface{}) api.StreamFilterFactory {
+	conf, ok := c.(*config)
+	if !ok {
+		panic("unexpected config type")
+	}
+	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
+		return &filter{
+			callbacks: callbacks,
+			config:    conf,
+		}
+	}
+}
+
+func main() {}

--- a/contrib/golang/filters/http/test/test_data/buffer/filter.go
+++ b/contrib/golang/filters/http/test/test_data/buffer/filter.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+)
+
+type filter struct {
+	api.PassThroughStreamFilter
+
+	callbacks api.FilterCallbackHandler
+	path      string
+	config    *config
+
+	failed bool
+}
+
+func testReset(b api.BufferInstance) {
+	b.Reset()
+
+	bs := b.Bytes()
+	if len(bs) > 0 {
+		panic(fmt.Sprintf("unexpected data: %s", string(bs)))
+	}
+}
+
+func testDrain(b api.BufferInstance) {
+	b.Drain(40)
+	bs := b.Bytes()
+	if string(bs) != "1234512345" {
+		panic(fmt.Sprintf("unexpected data: %s", string(bs)))
+	}
+
+	b.Drain(5)
+	bs = b.Bytes()
+	if string(bs) != "12345" {
+		panic(fmt.Sprintf("unexpected data: %s", string(bs)))
+	}
+
+	b.Drain(10)
+	bs = b.Bytes()
+	if string(bs) != "" {
+		panic(fmt.Sprintf("unexpected data: %s", string(bs)))
+	}
+
+	// drain when all data are drained
+	b.Drain(10)
+	bs = b.Bytes()
+	if string(bs) != "" {
+		panic(fmt.Sprintf("unexpected data: %s", string(bs)))
+	}
+
+	// bad offset
+	for _, n := range []int{-1, 0} {
+		b.Drain(n)
+	}
+}
+
+func testResetAfterDrain(b api.BufferInstance) {
+	b.Drain(40)
+	b.Reset()
+	bs := b.Bytes()
+	if string(bs) != "" {
+		panic(fmt.Sprintf("unexpected data: %s", string(bs)))
+	}
+}
+
+func (f *filter) DecodeData(buffer api.BufferInstance, endStream bool) api.StatusType {
+	if endStream {
+		return api.Continue
+	}
+	// run once
+
+	query, _ := f.callbacks.GetProperty("request.query")
+	switch query {
+	case "Reset":
+		testReset(buffer)
+	case "ResetAfterDrain":
+		testResetAfterDrain(buffer)
+	case "Drain":
+		testDrain(buffer)
+	default:
+		panic(fmt.Sprintf("unknown case %s", query))
+	}
+	return api.Continue
+}

--- a/contrib/golang/filters/http/test/test_data/buffer/go.mod
+++ b/contrib/golang/filters/http/test/test_data/buffer/go.mod
@@ -1,0 +1,10 @@
+module example.com/buffer
+
+go 1.18
+
+require (
+    github.com/envoyproxy/envoy v1.24.0
+    google.golang.org/protobuf v1.31.0
+)
+
+replace github.com/envoyproxy/envoy => ../../../../../../../

--- a/examples/golang-http/simple/filter.go
+++ b/examples/golang-http/simple/filter.go
@@ -60,8 +60,7 @@ func (f *filter) EncodeData(buffer api.BufferInstance, endStream bool) api.Statu
 		if endStream {
 			buffer.SetString(UpdateUpstreamBody)
 		} else {
-			// TODO implement buffer->Drain, buffer.SetString means buffer->Drain(buffer.Len())
-			buffer.SetString("")
+			buffer.Reset()
 		}
 	}
 	return api.Continue


### PR DESCRIPTION
Since we can't provide Peek feature in the callback (the body data is already read and we can't peek unread data), here I remove the Peek method. It's fine as this method is not implemented and can be replaced with Bytes.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level: Low
Testing: Integration
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
