### PR TITLE
Update the doc and status for composite_filter and matching API

### DIFF
--- a/api/envoy/extensions/common/matching/v3/BUILD
+++ b/api/envoy/extensions/common/matching/v3/BUILD
@@ -10,7 +10,6 @@ api_proto_package(
         "//envoy/config/common/matcher/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@com_github_cncf_udpa//xds/annotations/v3:pkg",
         "@com_github_cncf_udpa//xds/type/matcher/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/common/matching/v3/extension_matcher.proto
+++ b/api/envoy/extensions/common/matching/v3/extension_matcher.proto
@@ -24,8 +24,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // decorating an existing extension with a matcher, which can be used to match against
 // relevant protocol data.
 message ExtensionWithMatcher {
-  option (xds.annotations.v3.message_status).work_in_progress = true;
-
   // The associated matcher. This is deprecated in favor of xds_matcher.
   config.common.matcher.v3.Matcher matcher = 1
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];

--- a/api/envoy/extensions/common/matching/v3/extension_matcher.proto
+++ b/api/envoy/extensions/common/matching/v3/extension_matcher.proto
@@ -5,7 +5,6 @@ package envoy.extensions.common.matching.v3;
 import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "xds/annotations/v3/status.proto";
 import "xds/type/matcher/v3/matcher.proto";
 
 import "envoy/annotations/deprecation.proto";

--- a/api/envoy/extensions/filters/http/composite/v3/BUILD
+++ b/api/envoy/extensions/filters/http/composite/v3/BUILD
@@ -8,6 +8,5 @@ api_proto_package(
     deps = [
         "//envoy/config/core/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@com_github_cncf_udpa//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/composite/v3/composite.proto
+++ b/api/envoy/extensions/filters/http/composite/v3/composite.proto
@@ -4,8 +4,6 @@ package envoy.extensions.filters.http.composite.v3;
 
 import "envoy/config/core/v3/extension.proto";
 
-import "xds/annotations/v3/status.proto";
-
 import "udpa/annotations/status.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.composite.v3";

--- a/api/envoy/extensions/filters/http/composite/v3/composite.proto
+++ b/api/envoy/extensions/filters/http/composite/v3/composite.proto
@@ -29,7 +29,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // :ref:`ExecuteFilterAction <envoy_v3_api_msg_extensions.filters.http.composite.v3.ExecuteFilterAction>`)
 // which filter configuration to create and delegate to.
 message Composite {
-  option (xds.annotations.v3.message_status).work_in_progress = true;
 }
 
 // Composite match action (see :ref:`matching docs <arch_overview_matching_api>` for more info on match actions).

--- a/docs/root/configuration/http/http_filters/composite_filter.rst
+++ b/docs/root/configuration/http/http_filters/composite_filter.rst
@@ -5,8 +5,7 @@ Composite Filter
 
 .. attention::
 
-   The composite filter is in alpha and is currently under active development.
-   Capabilities will be expanded over time and the configuration structures are likely to change.
+   The composite filter is in stable status. Breaking API changes are not allowed.
 
 The composite filter allows delegating filter actions to a filter specified by a
 :ref:`match result <arch_overview_matching_api>`. The purpose of this is to allow different filters

--- a/docs/root/configuration/http/http_filters/composite_filter.rst
+++ b/docs/root/configuration/http/http_filters/composite_filter.rst
@@ -3,10 +3,6 @@
 Composite Filter
 ================
 
-.. attention::
-
-   The composite filter is in stable status. Breaking API changes are not allowed.
-
 The composite filter allows delegating filter actions to a filter specified by a
 :ref:`match result <arch_overview_matching_api>`. The purpose of this is to allow different filters
 or filter configurations to be selected based on the incoming request, allowing for more dynamic

--- a/docs/root/intro/arch_overview/advanced/matching/matching_api.rst
+++ b/docs/root/intro/arch_overview/advanced/matching/matching_api.rst
@@ -3,11 +3,6 @@
 Matching API
 ============
 
-.. attention::
-
-   The matching API is alpha and is currently under active development.
-   Capabilities will be expanded over time and the configuration structures are likely to change.
-
 Envoy makes use of a :ref:`matching API <envoy_v3_api_msg_config.common.matcher.v3.Matcher>`
 to allow the various subsystems to express actions that should be performed based on incoming data.
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1355,42 +1355,42 @@ envoy.matching.inputs.request_headers:
   categories:
   - envoy.matching.http.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.type.matcher.v3.HttpRequestHeaderMatchInput
 envoy.matching.inputs.request_trailers:
   categories:
   - envoy.matching.http.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.type.matcher.v3.HttpRequestTrailerMatchInput
 envoy.matching.inputs.response_headers:
   categories:
   - envoy.matching.http.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.type.matcher.v3.HttpResponseHeaderMatchInput
 envoy.matching.inputs.response_trailers:
   categories:
   - envoy.matching.http.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.type.matcher.v3.HttpResponseTrailerMatchInput
 envoy.matching.inputs.query_params:
   categories:
   - envoy.matching.http.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.type.matcher.v3.HttpRequestQueryParamMatchInput
 envoy.matching.inputs.cel_data_input:
   categories:
   - envoy.matching.http.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - xds.type.matcher.v3.HttpAttributesCelMatchInput
 envoy.matching.inputs.destination_ip:
@@ -1398,7 +1398,7 @@ envoy.matching.inputs.destination_ip:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.DestinationIPInput
 envoy.matching.inputs.destination_port:
@@ -1406,7 +1406,7 @@ envoy.matching.inputs.destination_port:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.DestinationPortInput
 envoy.matching.inputs.source_ip:
@@ -1414,7 +1414,7 @@ envoy.matching.inputs.source_ip:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.SourceIPInput
 envoy.matching.inputs.source_port:
@@ -1422,7 +1422,7 @@ envoy.matching.inputs.source_port:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.SourcePortInput
 envoy.matching.inputs.direct_source_ip:
@@ -1430,7 +1430,7 @@ envoy.matching.inputs.direct_source_ip:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.DirectSourceIPInput
 envoy.matching.inputs.source_type:
@@ -1438,7 +1438,7 @@ envoy.matching.inputs.source_type:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.SourceTypeInput
 envoy.matching.inputs.server_name:
@@ -1446,28 +1446,28 @@ envoy.matching.inputs.server_name:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.ServerNameInput
 envoy.matching.inputs.transport_protocol:
   categories:
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.TransportProtocolInput
 envoy.matching.inputs.application_protocol:
   categories:
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.ApplicationProtocolInput
 envoy.matching.inputs.filter_state:
   categories:
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.network.v3.FilterStateInput
 envoy.matching.inputs.uri_san:
@@ -1475,7 +1475,7 @@ envoy.matching.inputs.uri_san:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.ssl.v3.UriSanInput
 envoy.matching.inputs.dns_san:
@@ -1483,7 +1483,7 @@ envoy.matching.inputs.dns_san:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.ssl.v3.DnsSanInput
 envoy.matching.inputs.subject:
@@ -1491,7 +1491,7 @@ envoy.matching.inputs.subject:
   - envoy.matching.http.input
   - envoy.matching.network.input
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.matching.common_inputs.ssl.v3.SubjectInput
 envoy.matching.custom_matchers.trie_matcher:
@@ -1499,7 +1499,7 @@ envoy.matching.custom_matchers.trie_matcher:
   - envoy.matching.http.custom_matchers
   - envoy.matching.network.custom_matchers
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - xds.type.matcher.v3.IPMatcher
 envoy.load_balancing_policies.least_request:
@@ -1569,7 +1569,7 @@ envoy.matching.actions.format_string:
   categories:
   - envoy.matching.action
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.config.core.v3.SubstitutionFormatString
 envoy.http.custom_response.redirect_policy:


### PR DESCRIPTION
- Composite filter has already been declared as stable in extensions_metadata.yaml
- matching API and its extensions have been used for a while. So I think breaking API changes are not allowed.