### PR TITLE
mobile: Fix StreamIdleTimeoutTest

### DIFF
--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -101,6 +101,20 @@ envoy_mobile_jni_kt_test(
 )
 
 envoy_mobile_jni_kt_test(
+    name = "stream_idle_timeout_test",
+    srcs = [
+        "StreamIdleTimeoutTest.kt",
+    ],
+    native_deps = [
+        "//test/common/jni:libenvoy_jni_with_test_extensions.so",
+        "//test/common/jni:libenvoy_jni_with_test_extensions_jnilib",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
+)
+
+envoy_mobile_jni_kt_test(
     name = "cancel_grpc_stream_test",
     srcs = [
         "CancelGRPCStreamTest.kt",


### PR DESCRIPTION
Prior to this PR, `StreamIdleTimeoutTest` did not have a build target, which means the test was never executed. This PR fixes the issue by adding a build target for `StreamIdleTimeoutTest` as well as updating it, so that it compiles and passes the test.

Risk Level: low (fixing test only)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
