### PR TITLE
redis proxy : read commands policy for prefix route

### DIFF
--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -118,6 +118,7 @@ message RedisProxy {
   }
 
   message PrefixRoutes {
+    // [#next-free-field: 6]
     message Route {
       // The router is capable of shadowing traffic from one cluster to another. The current
       // implementation is "fire and forget," meaning Envoy will not wait for the shadow cluster to
@@ -140,6 +141,10 @@ message RedisProxy {
         bool exclude_read_commands = 3;
       }
 
+      message ReadCommandPolicy {
+        string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+      }
+
       // String prefix that must match the beginning of the keys. Envoy will always favor the
       // longest match.
       string prefix = 1;
@@ -152,6 +157,8 @@ message RedisProxy {
 
       // Indicates that the route has a request mirroring policy.
       repeated RequestMirrorPolicy request_mirror_policy = 4;
+
+      ReadCommandPolicy read_command_policy = 5;
     }
 
     // List of prefix routes.

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -138,7 +138,7 @@ message RedisProxy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes";
 
-    // [#next-free-field: 6]
+    // [#next-free-field: 7]
     message Route {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.Route";
@@ -168,6 +168,10 @@ message RedisProxy {
         bool exclude_read_commands = 3;
       }
 
+      message ReadCommandPolicy {
+        string cluster = 1 [(validate.rules).string = {min_len: 1}];
+      }
+
       // String prefix that must match the beginning of the keys. Envoy will always favor the
       // longest match.
       string prefix = 1 [(validate.rules).string = {max_bytes: 1000}];
@@ -184,6 +188,8 @@ message RedisProxy {
       // Indicates how redis key should be formatted. To substitute redis key into the formatting
       // expression, use %KEY% as a string replacement command.
       string key_formatter = 5;
+
+      ReadCommandPolicy read_command_policy = 6;
     }
 
     reserved 3;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -32,8 +32,8 @@ Common::Redis::Client::PoolRequest* makeSingleServerRequest(
   // If a transaction is active, clients_[0] is the primary connection to the cluster.
   // The subsequent clients in the array are used for mirroring.
   transaction.current_client_idx_ = 0;
-  auto handler = route->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
-                                                callbacks, transaction);
+  auto handler = route->upstream(command)->makeRequest(key, ConnPool::RespVariant(incoming_request),
+                                                       callbacks, transaction);
   if (handler) {
     for (auto& mirror_policy : route->mirrorPolicies()) {
       transaction.current_client_idx_++;
@@ -62,8 +62,8 @@ makeFragmentedRequest(const RouteSharedPtr& route, const std::string& command,
                       const std::string& key, const Common::Redis::RespValue& incoming_request,
                       ConnPool::PoolCallbacks& callbacks,
                       Common::Redis::Client::Transaction& transaction) {
-  auto handler = route->upstream()->makeRequest(key, ConnPool::RespVariant(incoming_request),
-                                                callbacks, transaction);
+  auto handler = route->upstream(command)->makeRequest(key, ConnPool::RespVariant(incoming_request),
+                                                       callbacks, transaction);
   if (handler) {
     for (auto& mirror_policy : route->mirrorPolicies()) {
       if (mirror_policy->shouldMirror(command)) {

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -27,6 +27,9 @@ inline void addUniqueClusters(
   for (auto& mirror : route.request_mirror_policy()) {
     clusters.emplace(mirror.cluster());
   }
+  if (route.has_read_command_policy()) {
+    clusters.emplace(route.read_command_policy().cluster());
+  }
 }
 } // namespace
 

--- a/source/extensions/filters/network/redis_proxy/router.h
+++ b/source/extensions/filters/network/redis_proxy/router.h
@@ -46,7 +46,7 @@ class Route {
 public:
   virtual ~Route() = default;
 
-  virtual ConnPool::InstanceSharedPtr upstream() const PURE;
+  virtual ConnPool::InstanceSharedPtr upstream(const std::string& command) const PURE;
 
   virtual const MirrorPolicies& mirrorPolicies() const PURE;
 };

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -53,6 +53,21 @@ Prefix::Prefix(
     mirror_policies_.emplace_back(std::make_shared<MirrorPolicyImpl>(
         mirror_policy, upstreams.at(mirror_policy.cluster()), runtime));
   }
+  if (route.has_read_command_policy()) {
+    read_upstream_ = upstreams.at(route.read_command_policy().cluster());
+  }
+}
+
+ConnPool::InstanceSharedPtr Prefix::upstream(const std::string& command) const {
+
+  if (read_upstream_) {
+    std::string to_lower_string = absl::AsciiStrToLower(command);
+    if (Common::Redis::SupportedCommands::isReadCommand(to_lower_string)) {
+      return read_upstream_;
+    }
+  }
+
+  return upstream_;
 }
 
 PrefixRoutes::PrefixRoutes(

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -50,7 +50,7 @@ public:
              route,
          Upstreams& upstreams, Runtime::Loader& runtime);
 
-  ConnPool::InstanceSharedPtr upstream() const override { return upstream_; }
+  ConnPool::InstanceSharedPtr upstream(const std::string& command) const override;
   const MirrorPolicies& mirrorPolicies() const override { return mirror_policies_; };
   const std::string& prefix() const { return prefix_; }
   bool removePrefix() const { return remove_prefix_; }
@@ -62,6 +62,7 @@ private:
   const bool remove_prefix_;
   const ConnPool::InstanceSharedPtr upstream_;
   MirrorPolicies mirror_policies_;
+  ConnPool::InstanceSharedPtr read_upstream_;
 };
 
 using PrefixSharedPtr = std::shared_ptr<Prefix>;

--- a/test/extensions/filters/network/redis_proxy/mocks.cc
+++ b/test/extensions/filters/network/redis_proxy/mocks.cc
@@ -15,7 +15,7 @@ MockRouter::MockRouter(RouteSharedPtr route) : route_(std::move(route)) {
 MockRouter::~MockRouter() = default;
 
 MockRoute::MockRoute(ConnPool::InstanceSharedPtr conn_pool) : conn_pool_(std::move(conn_pool)) {
-  ON_CALL(*this, upstream()).WillByDefault(Return(conn_pool_));
+  ON_CALL(*this, upstream("")).WillByDefault(Return(conn_pool_));
   ON_CALL(*this, mirrorPolicies()).WillByDefault(ReturnRef(policies_));
 }
 MockRoute::~MockRoute() = default;

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -39,7 +39,7 @@ public:
   MockRoute(ConnPool::InstanceSharedPtr);
   ~MockRoute() override;
 
-  MOCK_METHOD(ConnPool::InstanceSharedPtr, upstream, (), (const));
+  MOCK_METHOD(ConnPool::InstanceSharedPtr, upstream, (const std::string&), (const));
   MOCK_METHOD(const MirrorPolicies&, mirrorPolicies, (), (const));
   ConnPool::InstanceSharedPtr conn_pool_;
   MirrorPolicies policies_;

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -67,7 +67,7 @@ TEST(PrefixRoutesTest, RoutedToCatchAll) {
 
   std::string key("c:bar");
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_EQ(upstream_c, router.upstreamPool(key, stream_info)->upstream());
+  EXPECT_EQ(upstream_c, router.upstreamPool(key, stream_info)->upstream(""));
 }
 
 TEST(PrefixRoutesTest, RoutedToLongestPrefix) {
@@ -83,7 +83,7 @@ TEST(PrefixRoutesTest, RoutedToLongestPrefix) {
 
   std::string key("ab:bar");
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_EQ(upstream_a, router.upstreamPool(key, stream_info)->upstream());
+  EXPECT_EQ(upstream_a, router.upstreamPool(key, stream_info)->upstream(""));
 }
 
 TEST(PrefixRoutesTest, TestFormatterWithCatchAllRoute) {
@@ -120,7 +120,7 @@ TEST(PrefixRoutesTest, TestFormatterWithCatchAllRoute) {
   PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_);
   std::string key("removeMe_catchAllKey");
   EXPECT_EQ(upstream_catch_all,
-            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream());
+            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream(""));
   EXPECT_EQ("{catchAllKey}-catchAllEnv-subjectCN-{catchAllKey}", key);
 }
 
@@ -157,7 +157,7 @@ TEST(PrefixRoutesTest, TestFormatterWithPrefixRoute) {
   PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_);
   std::string key("abc:bar");
   EXPECT_EQ(upstream_c,
-            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream());
+            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream(""));
   EXPECT_EQ("{abc:bar}-test-subjectCN-{abc:bar}", key);
 }
 
@@ -194,7 +194,7 @@ TEST(PrefixRoutesTest, TestFormatterWithPercentInKey) {
   PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_);
   std::string key("%abc:bar%");
   EXPECT_EQ(upstream_c,
-            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream());
+            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream(""));
   EXPECT_EQ("{%abc:bar%}-test-subjectCN-{%abc:bar%}", key);
 }
 
@@ -229,7 +229,7 @@ TEST(PrefixRoutesTest, TestKeyPrefixFormatterWithMissingFilterState) {
   PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_);
   std::string key("abc:bar");
   EXPECT_EQ(upstream_c,
-            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream());
+            router.upstreamPool(key, filter_callbacks.connection().streamInfo())->upstream(""));
   EXPECT_EQ("abc:bar", key);
 }
 
@@ -249,7 +249,7 @@ TEST(PrefixRoutesTest, CaseUnsensitivePrefix) {
 
   std::string key("AB:bar");
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_EQ(upstream_a, router.upstreamPool(key, stream_info)->upstream());
+  EXPECT_EQ(upstream_a, router.upstreamPool(key, stream_info)->upstream(""));
 }
 
 TEST(PrefixRoutesTest, RemovePrefix) {
@@ -274,7 +274,7 @@ TEST(PrefixRoutesTest, RemovePrefix) {
 
   std::string key("abc:bar");
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_EQ(upstream_a, router.upstreamPool(key, stream_info)->upstream());
+  EXPECT_EQ(upstream_a, router.upstreamPool(key, stream_info)->upstream(""));
   EXPECT_EQ(":bar", key);
 }
 
@@ -291,7 +291,7 @@ TEST(PrefixRoutesTest, RoutedToShortestPrefix) {
 
   std::string key("a:bar");
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_EQ(upstream_b, router.upstreamPool(key, stream_info)->upstream());
+  EXPECT_EQ(upstream_b, router.upstreamPool(key, stream_info)->upstream(""));
   EXPECT_EQ("a:bar", key);
 }
 
@@ -317,10 +317,10 @@ TEST(PrefixRoutesTest, DifferentPrefixesSameUpstream) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   std::string key1("a:bar");
-  EXPECT_EQ(upstream_b, router.upstreamPool(key1, stream_info)->upstream());
+  EXPECT_EQ(upstream_b, router.upstreamPool(key1, stream_info)->upstream(""));
 
   std::string key2("also_route_to_b:bar");
-  EXPECT_EQ(upstream_b, router.upstreamPool(key2, stream_info)->upstream());
+  EXPECT_EQ(upstream_b, router.upstreamPool(key2, stream_info)->upstream(""));
 }
 
 TEST(PrefixRoutesTest, DuplicatePrefix) {
@@ -341,6 +341,40 @@ TEST(PrefixRoutesTest, DuplicatePrefix) {
 
   EXPECT_THROW_WITH_MESSAGE(PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_),
                             EnvoyException, "prefix `ab` already exists.")
+}
+
+TEST(PrefixRoutesTest, RouteReadWriteToDiffClusters) {
+  auto upstream_a = std::make_shared<ConnPool::MockInstance>();
+  auto upstream_b = std::make_shared<ConnPool::MockInstance>();
+  auto upstream_c = std::make_shared<ConnPool::MockInstance>();
+  auto upstream_cr = std::make_shared<ConnPool::MockInstance>();
+
+  Upstreams upstreams;
+  upstreams.emplace("fake_clusterA", upstream_a);
+  upstreams.emplace("fake_clusterB", upstream_b);
+  upstreams.emplace("fake_clusterC", upstream_c);
+  upstreams.emplace("fake_clusterCR", upstream_cr);
+
+  Runtime::MockLoader runtime_;
+
+  auto prefix_routes = createPrefixRoutes();
+  prefix_routes.mutable_catch_all_route()->set_cluster("fake_clusterC");
+  auto read_policy = prefix_routes.mutable_catch_all_route()->mutable_read_command_policy();
+  read_policy->set_cluster("fake_clusterCR");
+
+  PrefixRoutes router(prefix_routes, std::move(upstreams), runtime_);
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
+  std::string get_command("GET");
+  std::string set_command("SET");
+
+  std::string key1("c:bar");
+  EXPECT_EQ(upstream_cr, router.upstreamPool(key1, stream_info)->upstream(get_command));
+  EXPECT_EQ(upstream_c, router.upstreamPool(key1, stream_info)->upstream(set_command));
+
+  std::string key2("ab:bar");
+  EXPECT_EQ(upstream_a, router.upstreamPool(key2, stream_info)->upstream(get_command));
+  EXPECT_EQ(upstream_a, router.upstreamPool(key2, stream_info)->upstream(set_command));
 }
 
 TEST(MirrorPolicyImplTest, ShouldMirrorDefault) {


### PR DESCRIPTION
There is the ability to route read commands to another cluster in some cases.
e.g.  Mirror writes commands to another Redis cluster in a remote datacenter but reads the Redis cluster in the local datacenter.

Commit Message: read commands policy for prefix route
Additional Description:
Risk Level: Low
Testing: Ut
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
