### PR TITLE
doc: fix golang-http example path in the doc

### DIFF
--- a/docs/root/start/sandboxes/golang-http.rst
+++ b/docs/root/start/sandboxes/golang-http.rst
@@ -20,12 +20,12 @@ It also shows how Go plugins can be independently configured at runtime.
 Step 1: Compile the go plugin library
 *************************************
 
-Change to the ``examples/golang`` directory and build the go plugin library.
+Change to the ``examples/golang-http`` directory and build the go plugin library.
 
 .. code-block:: console
 
    $ pwd
-   envoy/examples/golang
+   envoy/examples/golang-http
    $ docker compose -f docker-compose-go.yaml run --rm go_plugin_compile
 
 The compiled library should now be in the ``lib`` folder.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: "doc: fix golang-http example path in the doc"
Additional Description: After adding adding golang-network plugin and sandboxes, this directory and sandbox path didn't change in the docs
Risk Level:
Testing: 
Docs Changes: docs/root/start/sandboxes/golang-http
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
