### PR TITLE
Add filter config name as streamInfo attibute

### DIFF
--- a/api/envoy/data/accesslog/v3/accesslog.proto
+++ b/api/envoy/data/accesslog/v3/accesslog.proto
@@ -498,7 +498,7 @@ message HTTPRequestProperties {
   uint64 downstream_header_bytes_received = 15;
 }
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message HTTPResponseProperties {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.data.accesslog.v2.HTTPResponseProperties";
@@ -532,4 +532,7 @@ message HTTPResponseProperties {
 
   // Number of header bytes sent to the downstream by the http stream, including protocol overhead.
   uint64 downstream_header_bytes_sent = 8;
+
+  // The HTTP response filter name.
+  string response_filter_name = 9;
 }

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -598,6 +598,12 @@ public:
   virtual void setResponseCodeDetails(absl::string_view rc_details) PURE;
 
   /**
+   * @param rc_filter_name the response filter name string to set for this request. It should not
+   * contain any empty or space characters (' ', '\t', '\f', '\v', '\n', '\r'). See
+   */
+  virtual void setResponseFilterName(absl::string_view rc_filter_name) PURE;
+
+  /**
    * @param connection_termination_details the termination details string to set for this
    * connection.
    */
@@ -676,6 +682,11 @@ public:
    * @return the response code details.
    */
   virtual const absl::optional<std::string>& responseCodeDetails() const PURE;
+
+  /**
+   * @return the response filter name details.
+   */
+  virtual const absl::optional<std::string>& responseFilterName() const PURE;
 
   /**
    * @return the termination details of the connection.

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -797,6 +797,14 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                     return stream_info.responseCodeDetails();
                   });
             }}},
+          {"RESPONSE_FILTER_NAME",
+           {CommandSyntaxChecker::COMMAND_ONLY,
+            [](const std::string&, absl::optional<size_t>) {
+              return std::make_unique<StreamInfoStringFormatterProvider>(
+                  [](const StreamInfo::StreamInfo& stream_info) {
+                    return stream_info.responseFilterName();
+                  });
+            }}},
           {"CONNECTION_TERMINATION_DETAILS",
            {CommandSyntaxChecker::COMMAND_ONLY,
             [](const std::string&, absl::optional<size_t>) {

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -456,6 +456,9 @@ void ActiveStreamDecoderFilter::sendLocalReply(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
+
+  parent_.streamInfo().setResponseFilterName(this->filterConfigName());
+
   parent_.sendLocalReply(code, body, modify_headers, grpc_status, details);
 }
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -210,11 +210,20 @@ struct StreamInfoImpl : public StreamInfo {
     return response_code_details_;
   }
 
+  const absl::optional<std::string>& responseFilterName() const override {
+    return response_filter_name_;
+  }
+
   void setResponseCode(uint32_t code) override { response_code_ = code; }
 
   void setResponseCodeDetails(absl::string_view rc_details) override {
     ASSERT(!StringUtil::hasEmptySpace(rc_details));
     response_code_details_.emplace(rc_details);
+  }
+
+  void setResponseFilterName(absl::string_view rc_filter_name) override {
+    ASSERT(!StringUtil::hasEmptySpace(rc_filter_name));
+    response_filter_name_.emplace(rc_filter_name);
   }
 
   const absl::optional<std::string>& connectionTerminationDetails() const override {
@@ -420,6 +429,7 @@ private:
 
 public:
   absl::optional<std::string> response_code_details_;
+  absl::optional<std::string> response_filter_name_;
   absl::optional<std::string> connection_termination_details_;
   uint64_t response_flags_{};
   bool health_check_request_{};

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -184,6 +184,12 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
       return CelValue::CreateString(&details.value());
     }
     return {};
+  } else if (value == FilterName) {
+    const absl::optional<std::string>& filter_name = info_.responseFilterName();
+    if (filter_name.has_value()) {
+      return CelValue::CreateString(&filter_name.value());
+    }
+    return {};
   }
   return {};
 }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -46,6 +46,7 @@ constexpr absl::string_view CodeDetails = "code_details";
 constexpr absl::string_view Trailers = "trailers";
 constexpr absl::string_view Flags = "flags";
 constexpr absl::string_view GrpcStatus = "grpc_status";
+constexpr absl::string_view FilterName = "filter_name";
 
 // Per-request or per-connection metadata
 constexpr absl::string_view Metadata = "metadata";


### PR DESCRIPTION
Commit Message: Add filter config name as streamInfo attribute Additional Description: This PR is related to #28834 Add filter config name as streamInfo attribute to be consumed by access log or any custom filter.
Risk Level: Low
Testing: WIP
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #28834

