### PR TITLE
mobile: Re-enable -Xcheck:jni

### DIFF
--- a/mobile/bazel/kotlin_test.bzl
+++ b/mobile/bazel/kotlin_test.bzl
@@ -36,9 +36,7 @@ def jvm_flags(lib_name):
     return [
         "-Djava.library.path=library/common/jni:test/common/jni",
         "-Denvoy_jni_library_name={}".format(lib_name),
-        # TODO(RyanTheOptimist): Uncomment this when when
-        # https://github.com/envoyproxy/envoy/issues/28981 is fixed.
-        # "-Xcheck:jni",
+        "-Xcheck:jni",
     ] + select({
         "@envoy//bazel:disable_google_grpc": ["-Denvoy_jni_google_grpc_disabled=true"],
         "//conditions:default": [],

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -53,7 +53,7 @@ int unbox_integer(JNIEnv* env, jobject boxedInteger) {
   jclass jcls_Integer = env->FindClass("java/lang/Integer");
   jmethodID jmid_intValue = env->GetMethodID(jcls_Integer, "intValue", "()I");
   env->DeleteLocalRef(jcls_Integer);
-  return env->CallIntMethod(boxedInteger, jmid_intValue);
+  return callIntMethod(env, boxedInteger, jmid_intValue);
 }
 
 envoy_data array_to_native_data(JNIEnv* env, jbyteArray j_data) {
@@ -140,7 +140,7 @@ jobject native_map_to_map(JNIEnv* env, envoy_map map) {
   for (envoy_map_size_t i = 0; i < map.length; i++) {
     auto key = native_data_to_string(env, map.entries[i].key);
     auto value = native_data_to_string(env, map.entries[i].value);
-    env->CallObjectMethod(j_hashMap, jmid_hashMapPut, key, value);
+    callObjectMethod(env, j_hashMap, jmid_hashMapPut, key, value);
     env->DeleteLocalRef(key);
     env->DeleteLocalRef(value);
   }
@@ -158,7 +158,7 @@ envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data) {
     // are supported. We will crash here if this is an invalid buffer, but guards may be
     // implemented in the JVM layer.
     jmethodID jmid_array = env->GetMethodID(jcls_ByteBuffer, "array", "()[B");
-    jbyteArray array = static_cast<jbyteArray>(env->CallObjectMethod(j_data, jmid_array));
+    jbyteArray array = static_cast<jbyteArray>(callObjectMethod(env, j_data, jmid_array));
     env->DeleteLocalRef(jcls_ByteBuffer);
 
     envoy_data native_data = array_to_native_data(env, array);
@@ -179,7 +179,7 @@ envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data, size_t data_length
     // are supported. We will crash here if this is an invalid buffer, but guards may be
     // implemented in the JVM layer.
     jmethodID jmid_array = env->GetMethodID(jcls_ByteBuffer, "array", "()[B");
-    jbyteArray array = static_cast<jbyteArray>(env->CallObjectMethod(j_data, jmid_array));
+    jbyteArray array = static_cast<jbyteArray>(callObjectMethod(env, j_data, jmid_array));
     env->DeleteLocalRef(jcls_ByteBuffer);
 
     envoy_data native_data = array_to_native_data(env, array, data_length);
@@ -384,3 +384,55 @@ std::vector<MatcherData> javaObjectArrayToMatcherData(JNIEnv* env, jobjectArray 
   }
   return ret;
 }
+
+#define DEFINE_CALL_METHOD(JAVA_TYPE, JNI_TYPE)                                                    \
+  JNI_TYPE call##JAVA_TYPE##Method(JNIEnv* env, jobject object, jmethodID method_id, ...) {        \
+    va_list args;                                                                                  \
+    va_start(args, method_id);                                                                     \
+    JNI_TYPE result = env->Call##JAVA_TYPE##MethodV(object, method_id, args);                      \
+    va_end(args);                                                                                  \
+    Envoy::JNI::Exception::checkAndClear();                                                        \
+    return result;                                                                                 \
+  }
+
+void callVoidMethod(JNIEnv* env, jobject object, jmethodID method_id, ...) {
+  va_list args;
+  va_start(args, method_id);
+  env->CallVoidMethodV(object, method_id, args);
+  va_end(args);
+  Envoy::JNI::Exception::checkAndClear();
+}
+
+DEFINE_CALL_METHOD(Char, jchar)
+DEFINE_CALL_METHOD(Short, jshort)
+DEFINE_CALL_METHOD(Int, jint)
+DEFINE_CALL_METHOD(Long, jlong)
+DEFINE_CALL_METHOD(Double, jdouble)
+DEFINE_CALL_METHOD(Boolean, jboolean)
+DEFINE_CALL_METHOD(Object, jobject)
+
+#define DEFINE_CALL_STATIC_METHOD(JAVA_TYPE, JNI_TYPE)                                             \
+  JNI_TYPE callStatic##JAVA_TYPE##Method(JNIEnv* env, jclass clazz, jmethodID method_id, ...) {    \
+    va_list args;                                                                                  \
+    va_start(args, method_id);                                                                     \
+    JNI_TYPE result = env->CallStatic##JAVA_TYPE##MethodV(clazz, method_id, args);                 \
+    va_end(args);                                                                                  \
+    Envoy::JNI::Exception::checkAndClear();                                                        \
+    return result;                                                                                 \
+  }
+
+void callStaticVoidMethod(JNIEnv* env, jclass clazz, jmethodID method_id, ...) {
+  va_list args;
+  va_start(args, method_id);
+  env->CallStaticVoidMethodV(clazz, method_id, args);
+  va_end(args);
+  Envoy::JNI::Exception::checkAndClear();
+}
+
+DEFINE_CALL_STATIC_METHOD(Char, jchar)
+DEFINE_CALL_STATIC_METHOD(Short, jshort)
+DEFINE_CALL_STATIC_METHOD(Int, jint)
+DEFINE_CALL_STATIC_METHOD(Long, jlong)
+DEFINE_CALL_STATIC_METHOD(Double, jdouble)
+DEFINE_CALL_STATIC_METHOD(Boolean, jboolean)
+DEFINE_CALL_STATIC_METHOD(Object, jobject)

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -118,3 +118,37 @@ void JavaArrayOfByteToString(JNIEnv* env, jbyteArray jbytes, std::string* out);
 
 std::vector<MatcherData> javaObjectArrayToMatcherData(JNIEnv* env, jobjectArray array,
                                                       std::string& cluster_out);
+
+// Helper functions for JNI's `Call<Type>Method` with proper exception handling in order to satisfy
+// -Xcheck:jni.
+// See
+// https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#calling-instance-methods
+#define DECLARE_CALL_METHOD(JAVA_TYPE, JNI_TYPE)                                                   \
+  JNI_TYPE call##JAVA_TYPE##Method(JNIEnv* env, jobject object, jmethodID method_id, ...);
+
+void callVoidMethod(JNIEnv* env, jobject object, jmethodID method_id, ...);
+DECLARE_CALL_METHOD(Byte, jbyte)
+DECLARE_CALL_METHOD(Char, jchar)
+DECLARE_CALL_METHOD(Short, jshort)
+DECLARE_CALL_METHOD(Int, jint)
+DECLARE_CALL_METHOD(Long, jlong)
+DECLARE_CALL_METHOD(Double, jdouble)
+DECLARE_CALL_METHOD(Boolean, jboolean)
+DECLARE_CALL_METHOD(Object, jobject)
+
+// Helper functions for JNI's `CallStatic<Type>Method` with proper exception handling in order to
+// satisfy -Xcheck:jni.
+// See
+// https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#calling-static-methods
+#define DECLARE_CALL_STATIC_METHOD(JAVA_TYPE, JNI_TYPE)                                            \
+  JNI_TYPE callStatic##JAVA_TYPE##Method(JNIEnv* env, jclass clazz, jmethodID method_id, ...);
+
+void callStaticVoidMethod(JNIEnv* env, jclass clazz, jmethodID method_id, ...);
+DECLARE_CALL_STATIC_METHOD(Byte, jbyte)
+DECLARE_CALL_STATIC_METHOD(Char, jchar)
+DECLARE_CALL_STATIC_METHOD(Short, jshort)
+DECLARE_CALL_STATIC_METHOD(Int, jint)
+DECLARE_CALL_STATIC_METHOD(Long, jlong)
+DECLARE_CALL_STATIC_METHOD(Double, jdouble)
+DECLARE_CALL_STATIC_METHOD(Boolean, jboolean)
+DECLARE_CALL_STATIC_METHOD(Object, jobject)


### PR DESCRIPTION
This PR fixes #28981 by creating wrappers for JNI's `Call<Type>Method` and `CallStatic<Type>Method` that will check on the exception that might be thrown to satisfy `-Xcheck:jni` and updating the code to use the wrappers.

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
