### PR TITLE
Add hot restart handoff integration test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -363,8 +363,12 @@ envoy_py_test(
         "//conditions:default": ["hotrestart_handoff_test.py"],
     }),
     data = [":hotrestart_main"],
-    # Hot restart does not apply on Windows, skipping
-    tags = ["skip_on_windows"],
+    # Hot restart does not apply on Windows.
+    # py_test doesn't do coverage.
+    tags = [
+        "nocoverage",
+        "skip_on_windows",
+    ],
     deps = [
         requirement("aiohttp"),
     ],

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -359,7 +359,7 @@ envoy_py_test(
     name = "hotrestart_handoff_test",
     size = "medium",
     srcs = select({
-        "//bazel:disable_hot_restart_or_admin": [],
+        "//bazel:disable_hot_restart_or_admin": ["null_test.py"],
         "//conditions:default": ["hotrestart_handoff_test.py"],
     }),
     data = [":hotrestart_main"],

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -363,6 +363,10 @@ envoy_py_test(
         "//conditions:default": ["hotrestart_handoff_test.py"],
     }),
     data = [":hotrestart_main"],
+    main = select({
+        "//bazel:disable_hot_restart_or_admin": "null_test.py",
+        "//conditions:default": "hotrestart_handoff_test.py",
+    }),
     # Hot restart does not apply on Windows.
     # py_test doesn't do coverage.
     tags = [

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1,3 +1,4 @@
+load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 load(
     "//bazel:envoy_build_system.bzl",
@@ -7,6 +8,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_py_test",
     "envoy_select_admin_functionality",
     "envoy_select_enable_http3",
     "envoy_select_enable_yaml",
@@ -350,6 +352,21 @@ envoy_cc_test_binary(
         "//source/extensions/clusters/static:static_cluster_lib",
         "//source/extensions/clusters/strict_dns:strict_dns_cluster_lib",
         "//source/extensions/load_balancing_policies/ring_hash:config",
+    ],
+)
+
+envoy_py_test(
+    name = "hotrestart_handoff_test",
+    size = "medium",
+    srcs = select({
+        "//bazel:disable_hot_restart_or_admin": [],
+        "//conditions:default": ["hotrestart_handoff_test.py"],
+    }),
+    data = [":hotrestart_main"],
+    # Hot restart does not apply on Windows, skipping
+    tags = ["skip_on_windows"],
+    deps = [
+        requirement("aiohttp"),
     ],
 )
 

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -86,8 +86,8 @@ class Upstream:
 
 async def _http_request(url):
     # Separate session per request is against aiohttp idioms, but is
-    # intentional here because we're testing where connections go - we
-    # definitely don't want to accidentally reuse a connection!
+    # intentional here because the point of the test is verifying
+    # where connections go - reusing a connection would do the wrong thing.
     async with ClientSession() as session:
         retries = 5
         while retries:
@@ -107,8 +107,8 @@ async def _http_request(url):
 
 async def _full_http_request(url: str) -> str:
     # Separate session per request is against aiohttp idioms, but is
-    # intentional here because we're testing where connections go - we
-    # definitely don't want to accidentally reuse a connection!
+    # intentional here because the point of the test is verifying
+    # where connections go - reusing a connection would do the wrong thing.
     async with ClientSession() as session:
         async with session.get(url) as response:
             return await response.text()

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -109,13 +109,17 @@ def make_envoy_config_yaml(upstream_port, file_path):
             f"""
 admin:
   address:
-    socket_address: {{ address: {ENVOY_HOST}, port_value: {ENVOY_ADMIN_PORT} }}
+    socket_address:
+      address: {ENVOY_HOST}
+      port_value: {ENVOY_ADMIN_PORT}
 
 static_resources:
   listeners:
   - name: listener_0
     address:
-      socket_address: {{ address: {ENVOY_HOST}, port_value: {ENVOY_PORT} }}
+      socket_address:
+        address: {ENVOY_HOST}
+        port_value: {ENVOY_PORT}
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -129,8 +133,10 @@ static_resources:
             - name: local_service
               domains: ["*"]
               routes:
-              - match: {{ prefix: "/" }}
-                route: {{ cluster: some_service }}
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: some_service
           http_filters:
           - name: envoy.filters.http.router
             typed_config:

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -95,7 +95,6 @@ async def _http_request(url) -> AsyncIterator[str]:
         async with session.get(url) as response:
             async for line in response.content:
                 yield line
-            return
 
 
 async def _full_http_request(url: str) -> str:

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -1,0 +1,255 @@
+"""Tests the behavior of connection handoff between instances during hot restart.
+
+Specifically, tests that:
+1. A tcp connection opened before hot restart begins continues to function during drain.
+2. A tcp connection opened after hot restart begins while the old instance is still running
+   goes to the new instance.
+TODO(ravenblack): perform the same tests for quic connections once they will work as expected.
+"""
+
+from datetime import datetime
+import json
+import os
+import random
+import unittest
+from aiohttp import client_exceptions, web, web_runner, ClientSession
+import asyncio
+import logging
+import subprocess
+import sys
+import threading
+
+def random_loopback_host():
+    """Returns a randomized loopback IP.
+    This can be used to reduce the chance of port conflicts when tests are
+    running in parallel."""
+    return f"127.{random.randrange(0,256)}.{random.randrange(0,256)}.{random.randrange(1, 255)}"
+
+UPSTREAM_SLOW_PORT = 54321
+UPSTREAM_FAST_PORT = 54322
+UPSTREAM_HOST = random_loopback_host()
+ENVOY_HOST = UPSTREAM_HOST
+ENVOY_PORT = 54323
+ENVOY_ADMIN_PORT = 54324
+SOCKET_PATH = "@envoy_domain_socket"
+SOCKET_MODE = 0
+ENVOY_BINARY = "./test/integration/hotrestart_main"
+
+# This log config makes logs interleave with other test output, which
+# is useful since with all the async operations it can be hard to figure
+# out what's happening.
+log = logging.getLogger()
+log.level = logging.INFO
+_stream_handler = logging.StreamHandler(sys.stdout)
+log.addHandler(_stream_handler)
+
+class Upstream:
+    # This class runs a server on a thread which takes an http request to
+    # path=/ and responds with "start\n" [three second pause] "end\n".
+    # This allows us to test that during hot restart an already-opened
+    # connection will persist.
+    # If initialized with True it will instead respond with
+    # "fast instance" immediately.
+    def __init__(self, fast_version = False):
+        self.port = UPSTREAM_FAST_PORT if fast_version else UPSTREAM_SLOW_PORT
+        self.app = web.Application()
+        self.app.add_routes([
+            web.get('/', self.fast_response) if fast_version else web.get('/', self.slow_response),
+            web.get('/shutdown', self.handle_shutdown),
+        ])
+
+    def start(self):
+        def run():
+            event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
+            log.debug("running test upstream service")
+            try:
+                web.run_app(self.app, host=UPSTREAM_HOST, port=self.port, handle_signals=False)
+            except web_runner.GracefulExit:
+                pass
+            event_loop.close()
+
+        self.thread = threading.Thread(target=run)
+        self.thread.start()
+
+    async def stop(self):
+        log.debug("requesting upstream shutdown")
+        try:
+            async for _ in http_request(f"http://{UPSTREAM_HOST}:{self.port}/shutdown"):
+                pass
+        except client_exceptions.ServerDisconnectedError:
+            # ServerDisconnected is the expectation since we requested it to shut down!
+            pass
+        self.thread.join()
+        log.debug("upstream thread joined")
+
+    async def fast_response(self, request):
+        return web.Response(status=200, reason='OK', headers={'content-type': 'text/plain'}, body='fast instance')
+
+    async def slow_response(self, request):
+        log.debug("slow request received")
+        response = web.StreamResponse(status=200, reason='OK', headers={'content-type': 'text/plain'})
+        await response.prepare(request)
+        await response.write(b"start\n")
+        await asyncio.sleep(3)
+        await response.write(b"end\n")
+        await response.write_eof()
+        return response
+    
+    async def handle_shutdown(self, request):
+        log.debug("shutdown request received")
+        raise web_runner.GracefulExit()
+
+async def http_request(url):
+    async with ClientSession() as session:
+        retries = 5
+        while retries:
+            try:
+                retries -= 1
+                async with session.get(url) as response:
+                    async for line in response.content:
+                        yield line
+                    return
+            except client_exceptions.ClientConnectorError as e:
+                if not retries:
+                    raise e
+                await asyncio.sleep(0.2)
+                if retries <= 3:
+                    log.debug(f"retrying request ({retries} remain)\n")
+
+def make_envoy_config_yaml(upstream_port, file_path):
+    with open(file_path, "w") as file:
+        file.write(f"""
+admin:
+  address:
+    socket_address: {{ address: {ENVOY_HOST}, port_value: {ENVOY_ADMIN_PORT} }}
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: {{ address: {ENVOY_HOST}, port_value: {ENVOY_PORT} }}
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: {{ prefix: "/" }}
+                route: {{ cluster: some_service }}
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: some_service
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: some_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: {UPSTREAM_HOST}
+                port_value: {upstream_port}
+""")
+
+async def full_http_request(path):
+    response_lines = []
+    async for line in http_request(path):
+        response_lines.append(line.decode())
+    return "".join(response_lines)
+
+async def wait_for_envoy_epoch(i):
+    """Load the admin/server_info page until restart_epoch is i, or timeout"""
+    tries = 5
+    response_json = {}
+    while tries:
+        tries -= 1
+        response = await full_http_request(f"http://{ENVOY_HOST}:{ENVOY_ADMIN_PORT}/server_info")
+        try:
+            response_json = json.loads(response)
+            if response_json["command_line_options"]["restart_epoch"] == i:
+                return
+        except json.decoder.JSONDecodeError:
+            pass
+        await asyncio.sleep(0.2)
+    # Envoy instance with expected restart_epoch should have started up
+    assert response_json and response_json["command_line_options"] and response_json["command_line_options"]["restart_epoch"] == i, f"server_info={response}"
+
+
+class IntegrationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_connection_handoffs(self):
+        tmpdir = os.environ["TEST_TMPDIR"]
+        slow_config_path = os.path.join(tmpdir, "slow_config.yaml")
+        fast_config_path = os.path.join(tmpdir, "fast_config.yaml")
+        base_id_path = os.path.join(tmpdir, "base_id.txt")
+        make_envoy_config_yaml(upstream_port=UPSTREAM_SLOW_PORT, file_path=slow_config_path)
+        make_envoy_config_yaml(upstream_port=UPSTREAM_FAST_PORT, file_path=fast_config_path)
+        log.info("starting upstreams")
+        slow_upstream = Upstream()
+        slow_upstream.start()
+        fast_upstream = Upstream(True)
+        fast_upstream.start()
+        envoy_args = [
+            ENVOY_BINARY,
+            "--socket-path", SOCKET_PATH,
+            "--socket-mode", str(SOCKET_MODE),
+        ]
+        log.info("starting envoy")
+        envoy_process_1 = subprocess.Popen(envoy_args + [
+            "--restart-epoch", "0",
+            "--use-dynamic-base-id",
+            "--base-id-path", base_id_path,
+            "-c", slow_config_path,
+        ])
+        log.info("waiting for envoy ready")
+        await wait_for_envoy_epoch(0)
+        log.info("making request")
+        slow_response = http_request(f"http://{ENVOY_HOST}:{ENVOY_PORT}/")
+        log.info("waiting for response to begin")
+        self.assertEqual(await anext(slow_response, None), b"start\n")
+        with open(base_id_path, "r") as base_id_file:
+            base_id=int(base_id_file.read())
+        log.info(f"starting envoy hot restart for base id {base_id}")
+        envoy_process_2 = subprocess.Popen(envoy_args + [
+            "--restart-epoch", "1",
+            "--parent-shutdown-time-s", "3",
+            "--base-id", str(base_id),
+            "-c", fast_config_path,
+        ])
+        log.info("waiting for new envoy instance to begin")
+        await wait_for_envoy_epoch(1)
+        log.info("sending request to fast upstream")
+        fast_response = await full_http_request(f"http://{ENVOY_HOST}:{ENVOY_PORT}/")
+        self.assertEqual(fast_response, "fast instance", "new requests after hot restart begins should go to new cluster")
+        # Now we can wait for the slow request to complete, and make sure it still gets the
+        # response from the old instance.
+        log.info("waiting for completion of original slow request")
+        t1 = datetime.now()
+        self.assertEqual(await anext(slow_response, None), b"end\n")
+        t2 = datetime.now()
+        self.assertGreater((t2 - t1).total_seconds(), 0.5, "slow request should be incomplete when we wait for it, otherwise the test is not necessarily validating during-drain behavior")
+        self.assertIsNone(await anext(slow_response, None))
+        log.info("shutting everything down")
+        envoy_process_1.terminate()
+        envoy_process_2.terminate()
+        await slow_upstream.stop()
+        await fast_upstream.stop()
+        envoy_process_1.wait()
+        envoy_process_2.wait()
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -176,7 +176,8 @@ async def _wait_for_envoy_epoch(i: int):
     while tries:
         tries -= 1
         try:
-            response = await _full_http_request(f"http://{ENVOY_HOST}:{ENVOY_ADMIN_PORT}/server_info")
+            response = await _full_http_request(
+                f"http://{ENVOY_HOST}:{ENVOY_ADMIN_PORT}/server_info")
             if expected_substring in response:
                 return
         except client_exceptions.ClientConnectorError:
@@ -208,7 +209,7 @@ class IntegrationTest(unittest.IsolatedAsyncioTestCase):
         await self.slow_upstream.start()
         self.fast_upstream = Upstream(True)
         await self.fast_upstream.start()
-    
+
     async def asyncTearDown(self) -> None:
         await self.slow_upstream.stop()
         await self.fast_upstream.stop()
@@ -253,7 +254,7 @@ class IntegrationTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             fast_response, "fast instance",
             "new requests after hot restart begins should go to new cluster")
-        # Now we can wait for the slow request to complete, and make sure it still gets the
+        # Now wait for the slow request to complete, and make sure it still gets the
         # response from the old instance.
         log.info("waiting for completion of original slow request")
         t1 = datetime.now()
@@ -261,7 +262,7 @@ class IntegrationTest(unittest.IsolatedAsyncioTestCase):
         t2 = datetime.now()
         self.assertGreater(
             (t2 - t1).total_seconds(), 0.5,
-            "slow request should be incomplete when we wait for it, otherwise the test is not necessarily validating during-drain behavior"
+            "slow request should be incomplete when the test waits for it, otherwise the test is not necessarily validating during-drain behavior"
         )
         self.assertIsNone(await anext(slow_response, None))
         log.info("shutting everything down")

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -13,7 +13,7 @@ import os
 import pathlib
 import random
 import sys
-from typing import Iterator
+from typing import AsyncIterator
 import unittest
 from datetime import datetime, timedelta
 from aiohttp import client_exceptions, web, ClientSession
@@ -87,7 +87,7 @@ class Upstream:
         return response
 
 
-async def _http_request(url) -> Iterator[str]:
+async def _http_request(url) -> AsyncIterator[str]:
     # Separate session per request is against aiohttp idioms, but is
     # intentional here because the point of the test is verifying
     # where connections go - reusing a connection would do the wrong thing.

--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -109,7 +109,7 @@ async def _full_http_request(url: str) -> str:
 
 def _make_envoy_config_yaml(upstream_port, file_path):
     file_path.write_text(
-            f"""
+        f"""
 admin:
   address:
     socket_address:

--- a/test/integration/null_test.py
+++ b/test/integration/null_test.py
@@ -1,4 +1,4 @@
-# py_test targets with empty srcs provoke a build error, so this file is 
+# py_test targets with empty srcs provoke a build error, so this file is
 # necessary for hotrestart_handoff_test to be possible to disable based on config.
 
 if __name__ == '__main__':

--- a/test/integration/null_test.py
+++ b/test/integration/null_test.py
@@ -1,0 +1,5 @@
+# py_test targets with empty srcs provoke a build error, so this file is 
+# necessary for hotrestart_handoff_test to be possible to disable based on config.
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
Commit Message: Add hot restart handoff integration test
Additional Description:
> Tests the behavior of connection handoff between instances during hot restart.
> 
> Specifically, tests that:
> 1. A tcp connection opened before hot restart begins continues to function during drain.
> 2. A tcp connection opened after hot restart begins while the old instance is still running
>    goes to the new instance.
>
> The intent is to add the same test for QUIC connections, when the work to make that
> supported is complete.

Risk Level: Very low, test only. Minor risk of making CI flakier, as the test has timing aspects.
Testing: Passed 100% with runs_per_test=100
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Disabled on Windows where there is no hot restart support.
