### PR TITLE
mobile: Clean up Kotlin integration tests

### DIFF
--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -9,7 +9,6 @@ import io.envoyproxy.envoymobile.FilterTrailersStatus
 import io.envoyproxy.envoymobile.FinalStreamIntel
 import io.envoyproxy.envoymobile.GRPCClient
 import io.envoyproxy.envoymobile.GRPCRequestHeadersBuilder
-import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
@@ -22,9 +21,9 @@ import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-private val filterName = "cancel_validation_filter"
-private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
-private const val localErrorFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+private const val FILTER_NAME = "cancel_validation_filter"
+private const val PBF_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+private const val LOCAL_ERROR_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
 
 class CancelGRPCStreamTest {
 
@@ -73,12 +72,11 @@ class CancelGRPCStreamTest {
   fun `cancel grpc stream calls onCancel callback`() {
     val engine = EngineBuilder(Standard())
       .addPlatformFilter(
-        name = filterName,
+        name = FILTER_NAME,
         factory = { CancelValidationFilter(filterExpectation) }
       )
-      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $pbfType, platform_filter_name: $filterName}")
-      .addNativeFilter("envoy.filters.http.local_error", "{'@type': $localErrorFilterType}")
-      .setOnEngineRunning {}
+      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $PBF_TYPE, platform_filter_name: $FILTER_NAME}")
+      .addNativeFilter("envoy.filters.http.local_error", "{'@type': $LOCAL_ERROR_FILTER_TYPE}")
       .build()
 
     val client = GRPCClient(engine.streamClient())

--- a/mobile/test/kotlin/integration/CancelStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelStreamTest.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 
 class CancelStreamTest {
 
@@ -73,8 +73,7 @@ class CancelStreamTest {
         name = "cancel_validation_filter",
         factory = { CancelValidationFilter(filterExpectation) }
       )
-      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
-      .setOnEngineRunning {}
+      .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .build()
 
     val client = engine.streamClient()

--- a/mobile/test/kotlin/integration/EngineApiTest.kt
+++ b/mobile/test/kotlin/integration/EngineApiTest.kt
@@ -1,7 +1,6 @@
 package test.kotlin.integration
 
 import io.envoyproxy.envoymobile.Element
-import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.engine.JniLibrary

--- a/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
+++ b/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
-import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.FilterDataStatus
 import io.envoyproxy.envoymobile.FilterHeadersStatus
@@ -28,7 +27,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -21,12 +21,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val hcmType =
-  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
-private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
-private const val localErrorFilterType =
-  "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
-private const val filterName = "error_validation_filter"
+private const val PBF_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+private const val FILTER_NAME = "error_validation_filter"
 
 class GRPCReceiveErrorTest {
   init {
@@ -84,17 +80,14 @@ class GRPCReceiveErrorTest {
 
     val engine = EngineBuilder(Standard())
       .addPlatformFilter(
-        name = filterName,
+        name = FILTER_NAME,
         factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }
       )
-      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $pbfType, platform_filter_name: $filterName}")
-      .setOnEngineRunning {}
+      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $PBF_TYPE, platform_filter_name: $FILTER_NAME}")
       .build()
 
     GRPCClient(engine.streamClient())
       .newGRPCStreamPrototype()
-      .setOnResponseHeaders { _, _, _ -> }
-      .setOnResponseMessage { _, _ -> }
       .setOnError { _, _ ->
         callbackReceivedError.countDown()
       }

--- a/mobile/test/kotlin/integration/KeyValueStoreTest.kt
+++ b/mobile/test/kotlin/integration/KeyValueStoreTest.kt
@@ -6,17 +6,15 @@ import io.envoyproxy.envoymobile.KeyValueStore
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
-private const val testKey = "foo"
-private const val testValue = "bar"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val TEST_KEY = "foo"
+private const val TEST_VALUE = "bar"
 
 class KeyValueStoreTest {
 
@@ -37,8 +35,8 @@ class KeyValueStoreTest {
 
     val engine = EngineBuilder(Standard())
         .addKeyValueStore("envoy.key_value.platform_test", testKeyValueStore)
-        .addNativeFilter("envoy.filters.http.test_kv_store", "{'@type': type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore, kv_store_name: envoy.key_value.platform_test, test_key: $testKey, test_value: $testValue}")
-        .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+        .addNativeFilter("envoy.filters.http.test_kv_store", "{'@type': type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore, kv_store_name: envoy.key_value.platform_test, test_key: $TEST_KEY, test_value: $TEST_VALUE}")
+        .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
         .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/ReceiveDataTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveDataTest.kt
@@ -12,7 +12,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 
 class ReceiveDataTest {
 
@@ -24,7 +24,7 @@ class ReceiveDataTest {
   fun `response headers and response data call onResponseHeaders and onResponseData`() {
 
     val engine = EngineBuilder(Standard())
-      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+      .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/ReceiveDataWithDeliveryLimitsTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveDataWithDeliveryLimitsTest.kt
@@ -12,9 +12,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 
-class ReceiveDataTest {
+class ReceiveDataWithDeliveryLimitsTest {
 
   init {
     JniLibrary.loadTestLibrary()
@@ -24,7 +24,7 @@ class ReceiveDataTest {
   fun `data is received with min delivery size set`() {
 
     val engine = EngineBuilder(Standard())
-      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+      .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/ReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveErrorTest.kt
@@ -20,9 +20,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
-private const val localErrorFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
-private const val filterName = "error_validation_filter"
+private const val PBF_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+private const val LOCAL_ERROR_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+private const val FILTER_NAME = "error_validation_filter"
 
 class ReceiveErrorTest {
   init {
@@ -80,12 +80,11 @@ class ReceiveErrorTest {
 
     val engine = EngineBuilder(Standard())
       .addPlatformFilter(
-        name = filterName,
+        name = FILTER_NAME,
         factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }
       )
-      .setOnEngineRunning {}
-      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $pbfType, platform_filter_name: $filterName}")
-      .addNativeFilter("envoy.filters.http.local_error", "{'@type': $localErrorFilterType}")
+      .addNativeFilter("envoy.filters.http.platform_bridge", "{'@type': $PBF_TYPE, platform_filter_name: $FILTER_NAME}")
+      .addNativeFilter("envoy.filters.http.local_error", "{'@type': $LOCAL_ERROR_FILTER_TYPE}")
       .build()
 
     var errorCode: Int? = null

--- a/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
@@ -22,13 +22,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
-private const val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-private const val matcherTrailerName = "test-trailer"
-private const val matcherTrailerValue = "test.code"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val MATCHER_TRAILER_NAME = "test-trailer"
+private const val MATCHER_TRAILER_VALUE = "test.code"
 
-class SendTrailersTest {
+class ReceiveTrailersTest {
 
   init {
     JniLibrary.loadTestLibrary()
@@ -79,8 +77,7 @@ class SendTrailersTest {
         name = "test_platform_filter",
         factory = { ErrorValidationFilter(trailersReceived) }
     )
-      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
-      .setOnEngineRunning { }
+      .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .build()
 
     val client = engine.streamClient()
@@ -96,7 +93,7 @@ class SendTrailersTest {
 
     val body = ByteBuffer.wrap("match_me".toByteArray(Charsets.UTF_8))
     val requestTrailers = RequestTrailersBuilder()
-      .add(matcherTrailerName, matcherTrailerValue)
+      .add(MATCHER_TRAILER_NAME, MATCHER_TRAILER_VALUE)
       .build()
 
     var responseStatus: Int? = null

--- a/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
+++ b/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
@@ -12,9 +12,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
-private val apiListenerType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
-private val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 
 // This test doesn't do what it advertises (https://github.com/envoyproxy/envoy/issues/25180)
 class ResetConnectivityStateTest {
@@ -28,7 +26,7 @@ class ResetConnectivityStateTest {
     val headersExpectation = CountDownLatch(2)
 
     val engine = EngineBuilder(Standard())
-      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+      .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -15,26 +15,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
-private const val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-private const val requestStringMatch = "match_me"
+private const val ASSERTION_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+private const val REQUEST_STRING_MATCH = "match_me"
 
 class SendDataTest {
   init {
-    AndroidJniLibrary.loadTestLibrary();
+    AndroidJniLibrary.loadTestLibrary()
     JniLibrary.load()
   }
 
   @Test
   fun `successful sending data`() {
-    TestJni.startHttp2TestServer();
-    val port = TestJni.getServerPort();
+    TestJni.startHttp2TestServer()
+    val port = TestJni.getServerPort()
 
     val expectation = CountDownLatch(1)
     val engine = EngineBuilder(Standard())
-      .addNativeFilter("envoy.filters.http.assertion", "{'@type': $assertionFilterType, match_config: {http_request_generic_body_match: {patterns: [{string_match: $requestStringMatch}]}}}")
+      .addNativeFilter("envoy.filters.http.assertion", "{'@type': $ASSERTION_FILTER_TYPE, match_config: {http_request_generic_body_match: {patterns: [{string_match: $REQUEST_STRING_MATCH}]}}}")
       .setTrustChainVerification(TrustChainVerification.ACCEPT_UNTRUSTED)
-      .setOnEngineRunning { }
       .build()
 
     val client = engine.streamClient()
@@ -42,12 +40,12 @@ class SendDataTest {
     val requestHeaders = RequestHeadersBuilder(
       method = RequestMethod.GET,
       scheme = "https",
-      authority = "localhost:" + port,
+      authority = "localhost:$port",
       path = "/simple.txt"
     )
       .build()
 
-    val body = ByteBuffer.wrap(requestStringMatch.toByteArray(Charsets.UTF_8))
+    val body = ByteBuffer.wrap(REQUEST_STRING_MATCH.toByteArray(Charsets.UTF_8))
 
     var responseStatus: Int? = null
     var responseEndStream = false

--- a/mobile/test/kotlin/integration/SendHeadersTest.kt
+++ b/mobile/test/kotlin/integration/SendHeadersTest.kt
@@ -12,7 +12,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 
 class SendHeadersTest {
 
@@ -25,7 +25,7 @@ class SendHeadersTest {
     val headersExpectation = CountDownLatch(1)
 
     val engine = EngineBuilder(Standard())
-    .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
+    .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
     .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/SendTrailersTest.kt
+++ b/mobile/test/kotlin/integration/SendTrailersTest.kt
@@ -13,10 +13,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
-private const val testResponseFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
-private const val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-private const val matcherTrailerName = "test-trailer"
-private const val matcherTrailerValue = "test.code"
+private const val TEST_RESPONSE_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
+private const val ASSERTION_FILTER_TYPE = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+private const val MATCHER_TRAILER_NAME = "test-trailer"
+private const val MATCHER_TRAILER_VALUE = "test.code"
 
 class SendTrailersTest {
 
@@ -29,10 +29,9 @@ class SendTrailersTest {
 
     val expectation = CountDownLatch(1)
     val engine = EngineBuilder(Standard())
-      .addNativeFilter("envoy.filters.http.assertion", "{'@type': $assertionFilterType, match_config: {http_request_trailers_match: {headers: [{name: 'test-trailer', exact_match: 'test.code'}]}}}")
+      .addNativeFilter("envoy.filters.http.assertion", "{'@type': $ASSERTION_FILTER_TYPE, match_config: {http_request_trailers_match: {headers: [{name: 'test-trailer', exact_match: 'test.code'}]}}}")
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":65000}")
-      .addNativeFilter("test_remote_response", "{'@type': $testResponseFilterType}")
-      .setOnEngineRunning { }
+      .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .build()
 
     val client = engine.streamClient()
@@ -47,7 +46,7 @@ class SendTrailersTest {
 
     val body = ByteBuffer.wrap("match_me".toByteArray(Charsets.UTF_8))
     val requestTrailers = RequestTrailersBuilder()
-      .add(matcherTrailerName, matcherTrailerValue)
+      .add(MATCHER_TRAILER_NAME, MATCHER_TRAILER_VALUE)
       .build()
 
     var responseStatus: Int? = null

--- a/mobile/test/kotlin/integration/SetLoggerTest.kt
+++ b/mobile/test/kotlin/integration/SetLoggerTest.kt
@@ -35,7 +35,6 @@ class SetLoggerTest {
           logEventLatch.countDown()
         }
       }
-      .setOnEngineRunning {}
       .build()
 
     countDownLatch.await(30, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/mobile/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -9,7 +9,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Test
 
 class StatFlushIntegrationTest {

--- a/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
+++ b/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
@@ -80,7 +80,6 @@ class StreamIdleTimeoutTest {
       )
       .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
       .addStreamIdleTimeoutSeconds(1)
-      .setOnEngineRunning {}
       .build()
 
     val client = engine.streamClient()


### PR DESCRIPTION
This PR cleans up Kotlin integrations to make it more idiomatic Kotlin. The changes are as follows:
- Removed useless `setOnEngineRunning {}`
- Removed other methods that take empty lambda
- Renamed the constants to use UPPER_SNAKE_CASE
- Removed unused imports
- Renamed the class name to match the file name prevent class redeclaration

Risk Level: low (clean up)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
