### PR TITLE
mobile: Fix compiler warnings.

### DIFF
--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -148,6 +148,8 @@ envoy_cert_validation_result verify_x509_cert_chain(const std::vector<std::strin
   case CERT_VERIFY_STATUS_NOT_YET_VALID:
     return {ENVOY_FAILURE, SSL_AD_CERTIFICATE_UNKNOWN,
             "AndroidNetworkLibrary_verifyServerCertificates failed: not yet valid."};
+  default:
+    PANIC_DUE_TO_CORRUPT_ENUM
   }
 }
 

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -370,7 +370,7 @@ std::vector<MatcherData> javaObjectArrayToMatcherData(JNIEnv* env, jobjectArray 
 
   JavaArrayOfByteToString(env, static_cast<jbyteArray>(env->GetObjectArrayElement(array, 0)),
                           &cluster_name_out);
-  for (int i = 1; i < len; i += 3) {
+  for (size_t i = 1; i < len; i += 3) {
     std::string name;
     std::string type_as_string;
     std::string value;


### PR DESCRIPTION
This fixes the following compiler warnings:
- `-Wsign-compare`
- `-Wreturn-type`

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
