### PR TITLE
config_validation: extend ssl manager lifetime beyond the dispatcher

### DIFF
--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -166,12 +166,14 @@ private:
   ThreadLocal::InstanceImpl thread_local_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   Api::ApiPtr api_;
+  // ssl_context_manager_ must come before dispatcher_, since ClusterInfo
+  // references SslSocketFactory and is deleted on the main thread via the dispatcher.
+  std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   Event::DispatcherPtr dispatcher_;
   std::unique_ptr<Server::ValidationAdmin> admin_;
   Singleton::ManagerPtr singleton_manager_;
   std::unique_ptr<Runtime::Loader> runtime_;
   Random::RandomGeneratorImpl random_generator_;
-  std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   Configuration::MainImpl config_;
   LocalInfo::LocalInfoPtr local_info_;
   AccessLog::AccessLogManagerImpl access_log_manager_;


### PR DESCRIPTION
Commit Message: config_validation: extend ssl manager lifetime beyond the dispatcher
Additional Description:
This is similar to the fix of #23452 which fixed the same issue for the Envoy server, but applied to the config-validator mode.
Risk Level: low - config-validator only,
