### PR TITLE
UHV: enable for admin interface

### DIFF
--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -157,6 +157,12 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    visibility = [
+        "//source/exe:__subpackages__",
+        "//source/extensions/filters/network/http_connection_manager:__subpackages__",
+        "//source/server/admin:__subpackages__",
+        "//test:__subpackages__",
+    ],
     deps = [
         ":header_validator_factory",
         "//envoy/http:header_validator_factory_interface",

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -75,6 +75,7 @@ envoy_cc_library(
         "//source/common/router:scoped_config_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/access_loggers/common:file_access_log_lib",
+        "//source/extensions/http/header_validators/envoy_default:config",
         "//source/extensions/listener_managers/listener_manager:listener_manager_lib",
         "//source/extensions/request_id/uuid:config",
     ] + envoy_select_admin_html([

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "envoy/extensions/http/header_validators/envoy_default/v3/header_validator.pb.h"
+#include "envoy/http/header_validator_factory.h"
 #include "envoy/server/hot_restart.h"
 #include "envoy/server/instance.h"
 #include "envoy/server/options.h"
@@ -82,6 +84,27 @@ std::vector<absl::string_view> prepend(const absl::string_view first,
   strings.insert(strings.begin(), first);
   return strings;
 }
+
+Http::HeaderValidatorFactoryPtr createHeaderValidatorFactory(
+    [[maybe_unused]] Server::Configuration::ServerFactoryContext& context) {
+  Http::HeaderValidatorFactoryPtr header_validator_factory;
+#ifdef ENVOY_ENABLE_UHV
+  // Default UHV config matches the admin HTTP validation and normalization config
+  ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig uhv_config;
+
+  ::envoy::config::core::v3::TypedExtensionConfig config;
+  config.set_name("default_envoy_uhv_for admin");
+  config.mutable_typed_config()->PackFrom(uhv_config);
+
+  auto* factory = Envoy::Config::Utility::getFactory<Http::HeaderValidatorFactoryConfig>(config);
+  ENVOY_BUG(factory != nullptr, "Default UHV is not linked into binary.");
+
+  header_validator_factory = factory->createFromProto(config.typed_config(), context);
+  ENVOY_BUG(header_validator_factory != nullptr, "Unable to create default UHV.");
+#endif
+  return header_validator_factory;
+}
+
 } // namespace
 
 AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
@@ -228,7 +251,8 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
       date_provider_(server.dispatcher().timeSource()),
       admin_filter_chain_(std::make_shared<AdminFilterChain>()),
       local_reply_(LocalReply::Factory::createDefault()),
-      ignore_global_conn_limit_(ignore_global_conn_limit) {
+      ignore_global_conn_limit_(ignore_global_conn_limit),
+      header_validator_factory_(createHeaderValidatorFactory(server.serverFactoryContext())) {
 #ifndef NDEBUG
   // Verify that no duplicate handlers exist.
   absl::flat_hash_set<absl::string_view> handlers;
@@ -491,6 +515,21 @@ void AdminImpl::addListenerToHandler(Network::ConnectionHandler* handler) {
   if (listener_) {
     handler->addListener(absl::nullopt, *listener_, server_.runtime());
   }
+}
+
+::Envoy::Http::HeaderValidatorStats&
+AdminImpl::getHeaderValidatorStats([[maybe_unused]] Http::Protocol protocol) {
+  switch (protocol) {
+  case Http::Protocol::Http10:
+  case Http::Protocol::Http11:
+    return Http::Http1::CodecStats::atomicGet(http1_codec_stats_, *server_.stats().rootScope());
+  case Http::Protocol::Http3:
+    IS_ENVOY_BUG("HTTP/3 is not supported for admin UI");
+    // Return H/2 stats object, since we do not have H/3 stats.
+  case Http::Protocol::Http2:
+    return Http::Http2::CodecStats::atomicGet(http2_codec_stats_, *server_.stats().rootScope());
+  }
+  PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
 } // namespace Server


### PR DESCRIPTION
Commit Message:
Make admin UI use the default universal header validator, when build with the ENVOY_ENABLE_UHV. UHV config matches  admin UI configuration for header validation and normalization.

Noop for the normal Envoy build.

Risk Level: Low, build flag protected
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #29503
