### PR TITLE
router: update query params hash policy to use new data structure

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -883,7 +883,8 @@ message RouteAction {
 
       // The name of the URL query parameter that will be used to obtain the hash
       // key. If the parameter is not present, no hash will be produced. Query
-      // parameter names are case-sensitive.
+      // parameter names are case-sensitive.  If query parameters are repeated, only
+      // the first value will be considered.
       string name = 1 [(validate.rules).string = {min_len: 1}];
     }
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -883,7 +883,7 @@ message RouteAction {
 
       // The name of the URL query parameter that will be used to obtain the hash
       // key. If the parameter is not present, no hash will be produced. Query
-      // parameter names are case-sensitive.  If query parameters are repeated, only
+      // parameter names are case-sensitive. If query parameters are repeated, only
       // the first value will be considered.
       string name = 1 [(validate.rules).string = {min_len: 1}];
     }

--- a/source/common/http/hash_policy.cc
+++ b/source/common/http/hash_policy.cc
@@ -142,11 +142,11 @@ public:
 
     const HeaderEntry* header = headers.Path();
     if (header) {
-      Http::Utility::QueryParams query_parameters =
-          Http::Utility::parseQueryString(header->value().getStringView());
-      const auto& iter = query_parameters.find(parameter_name_);
-      if (iter != query_parameters.end()) {
-        hash = HashUtil::xxHash64(iter->second);
+      Http::Utility::QueryParamsMulti query_parameters =
+          Http::Utility::QueryParamsMulti::parseQueryString(header->value().getStringView());
+      const auto val = query_parameters.getFirstValue(parameter_name_);
+      if (val.has_value()) {
+        hash = HashUtil::xxHash64(val.value());
       }
     }
     return hash;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -3205,10 +3205,19 @@ TEST_F(RouterMatcherHashPolicyTest, HashQueryParameters) {
                                                                  nullptr));
   }
   {
-    Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo?param=xyz", "GET");
-    Router::RouteConstSharedPtr route = config().route(headers, 0);
-    EXPECT_TRUE(route->routeEntry()->hashPolicy()->generateHash(nullptr, headers, add_cookie_nop_,
-                                                                nullptr));
+    Http::TestRequestHeaderMapImpl headers1 = genHeaders("www.lyft.com", "/foo?param=xyz", "GET");
+    Router::RouteConstSharedPtr route1 = config().route(headers1, 0);
+    auto val1 = route1->routeEntry()->hashPolicy()->generateHash(nullptr, headers1, add_cookie_nop_,
+                                                                 nullptr);
+    EXPECT_TRUE(val1);
+
+    // Only the first appearance of the query parameter should be considered
+    Http::TestRequestHeaderMapImpl headers2 =
+        genHeaders("www.lyft.com", "/foo?param=xyz&param=qwer", "GET");
+    Router::RouteConstSharedPtr route2 = config().route(headers2, 0);
+    auto val2 = route1->routeEntry()->hashPolicy()->generateHash(nullptr, headers2, add_cookie_nop_,
+                                                                 nullptr);
+    EXPECT_EQ(val1, val2);
   }
   {
     Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/bar?param=xyz", "GET");


### PR DESCRIPTION
Commit Message: update query params hash policy to use new data structure
Additional Description:  

#28788 fixed a bug in query param handling, and introduced a new data structure for query parameters in the process.  In that PR, I committed to going through and swapping out the old data struct for the new one, feature by feature.

This PR:
* Swaps the old data structure for the new data structure.  No behavior is changed
* Updates the docs to make clear what happens when query parameters are repeated
* Extends an existing unit test to ensure that the repeated query param behavior specified in the docs is respected

Risk Level: Low
Testing: Existing unit tests + new unit test
Docs Changes: Added clarity around (unchanged) behavior when query params are repeated.
Release Notes: N/A
Platform Specific Features: N/A

cc @ggreenway  - here's another small query param data struct replacement