### PR TITLE
Revert "ext_authz: make the ext_authz filter a dual filter (#29173)"

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -78,7 +78,6 @@ message ExtAuthz {
   // 3. At least one ``authorization response header`` is added to the client request, or is used for
   // altering another client request header.
   //
-  // It is an error to set this field when the filter is configured on an upstream filter chain.
   bool clear_route_cache = 6;
 
   // Sets the HTTP status that is returned to the client when the authorization server returns an error
@@ -136,8 +135,6 @@ message ExtAuthz {
   //
   // When this field is true, Envoy will include the peer X.509 certificate, if available, in the
   // :ref:`certificate<envoy_v3_api_field_service.auth.v3.AttributeContext.Peer.certificate>`.
-  //
-  // It is an error to set this field when the filter is configured on an upstream filter chain.
   bool include_peer_certificate = 10;
 
   // Optional additional prefix to use when emitting statistics. This allows to distinguish
@@ -187,8 +184,6 @@ message ExtAuthz {
   //
   // When this field is true, Envoy will include the SNI name used for TLSClientHello, if available, in the
   // :ref:`tls_session<envoy_v3_api_field_service.auth.v3.AttributeContext.tls_session>`.
-  //
-  // It is an error to set this field when the filter is configured on an upstream filter chain.
   bool include_tls_session = 18;
 }
 

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -154,11 +154,6 @@ public:
   ~ServerFactoryContext() override = default;
 
   /**
-   * @return the server-wide http context.
-   */
-  virtual Http::Context& httpContext() PURE;
-
-  /**
    * @return the server-wide grpc context.
    */
   virtual Grpc::Context& grpcContext() PURE;

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -311,10 +311,8 @@ envoy.filters.http.dynamic_forward_proxy:
 envoy.filters.http.ext_authz:
   categories:
   - envoy.filters.http
-  - envoy.filters.http.upstream
   security_posture: robust_to_untrusted_downstream
   status: stable
-  status_upstream: alpha
   type_urls:
   - envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
   - envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -203,17 +203,15 @@ void CheckRequestUtils::createHttpCheck(
   // *cb->connection(), callbacks->streamInfo() and callbacks->decodingBuffer() are not qualified as
   // const.
   auto* cb = const_cast<Envoy::Http::StreamDecoderFilterCallbacks*>(callbacks);
-  if (cb->connection().has_value()) {
-    setAttrContextPeer(*attrs->mutable_source(), *cb->connection(), service, false,
-                       include_peer_certificate);
-    setAttrContextPeer(*attrs->mutable_destination(), *cb->connection(), EMPTY_STRING, true,
-                       include_peer_certificate);
-  }
+  setAttrContextPeer(*attrs->mutable_source(), *cb->connection(), service, false,
+                     include_peer_certificate);
+  setAttrContextPeer(*attrs->mutable_destination(), *cb->connection(), EMPTY_STRING, true,
+                     include_peer_certificate);
   setAttrContextRequest(*attrs->mutable_request(), cb->streamId(), cb->streamInfo(),
                         cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes,
                         request_header_matchers);
 
-  if (include_tls_session && cb->connection().has_value()) {
+  if (include_tls_session) {
     if (cb->connection()->ssl() != nullptr) {
       attrs->mutable_tls_session();
       if (!cb->connection()->ssl()->sni().empty()) {
@@ -242,7 +240,6 @@ void CheckRequestUtils::createTcpCheck(
                      include_peer_certificate);
   setAttrContextPeer(*attrs->mutable_destination(), cb->connection(), server_name, true,
                      include_peer_certificate);
-
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
 }
 

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -105,12 +105,11 @@ public:
 
   struct DualInfo {
     DualInfo(Server::Configuration::UpstreamFactoryContext& context)
-        : init_manager(context.initManager()), scope(context.scope()), is_upstream_filter(true) {}
+        : init_manager(context.initManager()), scope(context.scope()) {}
     DualInfo(Server::Configuration::FactoryContext& context)
-        : init_manager(context.initManager()), scope(context.scope()), is_upstream_filter(false) {}
+        : init_manager(context.initManager()), scope(context.scope()) {}
     Init::Manager& init_manager;
     Stats::Scope& scope;
-    bool is_upstream_filter;
   };
 
   Envoy::Http::FilterFactoryCb

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -9,7 +9,6 @@
 #include "envoy/grpc/async_client_manager.h"
 #include "envoy/registry/registry.h"
 
-#include "source/common/common/utility.h"
 #include "source/common/config/utility.h"
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h"
@@ -21,27 +20,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExtAuthz {
 
-Http::FilterFactoryCb ExtAuthzFilterFactory::createFilterFactoryFromProtoTyped(
+Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-    const std::string& stats_prefix, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& context) {
-  if (dual_info.is_upstream_filter) {
-    if (proto_config.clear_route_cache()) {
-      ExceptionUtil::throwEnvoyException(
-          "clear_route_cache cannot be enabled on an upstream ext_authz filter.");
-    }
-    if (proto_config.include_peer_certificate()) {
-      ExceptionUtil::throwEnvoyException(
-          "include_peer_certificate cannot be enabled on an upstream ext_authz filter.");
-    }
-    if (proto_config.include_tls_session()) {
-      ExceptionUtil::throwEnvoyException(
-          "include_tls_session cannot be enabled on an upstream ext_auth filter.");
-    }
-  }
-  const auto filter_config =
-      std::make_shared<FilterConfig>(proto_config, dual_info.scope, context.runtime(),
-                                     context.httpContext(), stats_prefix, context.bootstrap());
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  const auto filter_config = std::make_shared<FilterConfig>(
+      proto_config, context.scope(), context.runtime(), context.httpContext(), stats_prefix,
+      context.getServerFactoryContext().bootstrap());
   // The callback is created in main thread and executed in worker thread, variables except factory
   // context must be captured by value into the callback.
   Http::FilterFactoryCb callback;
@@ -67,11 +51,11 @@ Http::FilterFactoryCb ExtAuthzFilterFactory::createFilterFactoryFromProtoTyped(
     THROW_IF_NOT_OK(Config::Utility::checkTransportVersion(proto_config));
     Envoy::Grpc::GrpcServiceConfigWithHashKey config_with_hash_key =
         Envoy::Grpc::GrpcServiceConfigWithHashKey(proto_config.grpc_service());
-    callback = [&context, filter_config, timeout_ms, config_with_hash_key,
-                dual_info](Http::FilterChainFactoryCallbacks& callbacks) {
+    callback = [&context, filter_config, timeout_ms,
+                config_with_hash_key](Http::FilterChainFactoryCallbacks& callbacks) {
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
           context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClientWithHashKey(
-              config_with_hash_key, dual_info.scope, true),
+              config_with_hash_key, context.scope(), true),
           std::chrono::milliseconds(timeout_ms));
       callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, std::move(client)));
     };
@@ -81,7 +65,7 @@ Http::FilterFactoryCb ExtAuthzFilterFactory::createFilterFactoryFromProtoTyped(
 }
 
 Router::RouteSpecificFilterConfigConstSharedPtr
-ExtAuthzFilterFactory::createRouteSpecificFilterConfigTyped(
+ExtAuthzFilterConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,
     Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {
   return std::make_shared<FilterConfigPerRoute>(proto_config);
@@ -90,10 +74,8 @@ ExtAuthzFilterFactory::createRouteSpecificFilterConfigTyped(
 /**
  * Static registration for the external authorization filter. @see RegisterFactory.
  */
-LEGACY_REGISTER_FACTORY(ExtAuthzFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory,
+LEGACY_REGISTER_FACTORY(ExtAuthzFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory,
                         "envoy.ext_authz");
-LEGACY_REGISTER_FACTORY(UpstreamExtAuthzFilterFactory,
-                        Server::Configuration::UpstreamHttpFilterConfigFactory, "envoy.ext_authz");
 
 } // namespace ExtAuthz
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -14,27 +14,24 @@ namespace ExtAuthz {
 /**
  * Config registration for the external authorization filter. @see NamedHttpFilterConfigFactory.
  */
-class ExtAuthzFilterFactory
-    : public Common::DualFactoryBase<
+class ExtAuthzFilterConfig
+    : public Common::FactoryBase<
           envoy::extensions::filters::http::ext_authz::v3::ExtAuthz,
           envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute> {
 public:
-  ExtAuthzFilterFactory() : DualFactoryBase("envoy.filters.http.ext_authz") {}
+  ExtAuthzFilterConfig() : FactoryBase("envoy.filters.http.ext_authz") {}
 
 private:
   static constexpr uint64_t DefaultTimeout = 200;
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-      const std::string& stats_prefix, DualInfo dual_info,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;
 };
-
-using UpstreamExtAuthzFilterFactory = ExtAuthzFilterFactory;
 
 } // namespace ExtAuthz
 } // namespace HttpFilters

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -193,7 +193,6 @@ public:
   TimeSource& timeSource() override { return api().timeSource(); }
   AccessLog::AccessLogManager& accessLogManager() override { return server_.accessLogManager(); }
   Api::Api& api() override { return server_.api(); }
-  Http::Context& httpContext() override { return server_.httpContext(); }
   Grpc::Context& grpcContext() override { return server_.grpcContext(); }
   Router::Context& routerContext() override { return server_.routerContext(); }
   Envoy::Server::DrainManager& drainManager() override { return server_.drainManager(); }

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -38,6 +38,7 @@ public:
 
   void expectBasicHttp() {
     EXPECT_CALL(callbacks_, connection())
+        .Times(2)
         .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
     connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
     connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -200,37 +201,6 @@ TEST_F(CheckRequestUtilsTest, BasicHttp) {
   EXPECT_TRUE(request_.attributes().request().has_time());
 }
 
-// Certain connection-specific attributes cannot be included when there is no connection, even if
-// include_peer_certificate or include_tls_session are true.
-TEST_F(CheckRequestUtilsTest, BasicHttpWithNoConnection) {
-  const uint64_t size = 0;
-  envoy::service::auth::v3::CheckRequest request_;
-
-  Http::TestRequestHeaderMapImpl request_headers{{Headers::get().EnvoyAuthPartialBody.get(), "1"}};
-  EXPECT_CALL(callbacks_, connection()).WillRepeatedly(Return(std::nullopt));
-  EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
-  EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
-  EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
-  EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
-  EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
-
-  CheckRequestUtils::createHttpCheck(
-      &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
-      envoy::config::core::v3::Metadata(), request_, size,
-      /*pack_as_bytes=*/false, /*include_peer_certificate=*/true,
-      /*include_tls_session=*/true, Protobuf::Map<std::string, std::string>(), nullptr);
-
-  ASSERT_EQ(size, request_.attributes().request().http().body().size());
-  EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
-  EXPECT_EQ(request_.attributes().request().http().headers().end(),
-            request_.attributes().request().http().headers().find(
-                Headers::get().EnvoyAuthPartialBody.get()));
-  EXPECT_EQ(0, request_.attributes().source().principal().size());
-  EXPECT_EQ(0, request_.attributes().destination().principal().size());
-  EXPECT_EQ(0, request_.attributes().source().service().size());
-  EXPECT_EQ(0, request_.attributes().source().certificate().size());
-}
-
 // Verify that check request merges the duplicate headers.
 TEST_F(CheckRequestUtilsTest, BasicHttpWithDuplicateHeaders) {
   const uint64_t size = 0;
@@ -381,6 +351,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeer) {
                                                  {":path", "/bar"}};
   envoy::service::auth::v3::CheckRequest request;
   EXPECT_CALL(callbacks_, connection())
+      .Times(2)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -459,6 +430,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerCertificate) {
 // Verify that the SNI is populated correctly.
 TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
   EXPECT_CALL(callbacks_, connection())
+      .Times(5)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
@@ -482,6 +454,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
 // Verify that the SNI is populated correctly.
 TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(callbacks_, connection())
+      .Times(4)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -63,7 +63,7 @@ public:
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& ext_authz_config) {
     // Delegate call to mock async client manager to real async client manager.
     ON_CALL(context_, getServerFactoryContext()).WillByDefault(testing::ReturnRef(server_context_));
-    ON_CALL(server_context_.cluster_manager_.async_client_manager_,
+    ON_CALL(context_.cluster_manager_.async_client_manager_,
             getOrCreateRawAsyncClientWithHashKey(_, _, _))
         .WillByDefault(
             Invoke([&](const Envoy::Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
@@ -71,7 +71,7 @@ public:
               return async_client_manager_->getOrCreateRawAsyncClientWithHashKey(
                   config_with_hash_key, scope, skip_cluster_check);
             }));
-    ExtAuthzFilterFactory factory;
+    ExtAuthzFilterConfig factory;
     return factory.createFilterFactoryFromProto(ext_authz_config, "stats", context_);
   }
 
@@ -93,29 +93,6 @@ protected:
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   std::unique_ptr<TestAsyncClientManagerImpl> async_client_manager_;
 };
-
-TEST_F(ExtAuthzFilterTest, DisallowedConfigurationFieldsAsUpstreamFilter) {
-  NiceMock<Server::Configuration::MockUpstreamFactoryContext> context;
-  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
-  ON_CALL(context, getServerFactoryContext()).WillByDefault(testing::ReturnRef(server_context));
-
-  ExtAuthzFilterFactory factory;
-  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz ext_authz_config;
-  ext_authz_config.set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
-  ext_authz_config.set_clear_route_cache(true);
-  EXPECT_THROW(factory.createFilterFactoryFromProto(ext_authz_config, "stats", context),
-               EnvoyException);
-
-  ext_authz_config.set_clear_route_cache(false);
-  ext_authz_config.set_include_peer_certificate(true);
-  EXPECT_THROW(factory.createFilterFactoryFromProto(ext_authz_config, "stats", context),
-               EnvoyException);
-
-  ext_authz_config.set_include_peer_certificate(false);
-  ext_authz_config.set_include_tls_session(true);
-  EXPECT_THROW(factory.createFilterFactoryFromProto(ext_authz_config, "stats", context),
-               EnvoyException);
-}
 
 class ExtAuthzFilterHttpTest : public ExtAuthzFilterTest {
 public:

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -9,8 +9,7 @@ using ::testing::ReturnRef;
 
 MockServerFactoryContext::MockServerFactoryContext()
     : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
-      http_context_(store_.symbolTable()), grpc_context_(store_.symbolTable()),
-      router_context_(store_.symbolTable()) {
+      grpc_context_(store_.symbolTable()), router_context_(store_.symbolTable()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, mainThreadDispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -71,7 +71,6 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  Http::Context& httpContext() override { return http_context_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Router::Context& routerContext() override { return router_context_; }
   envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { return bootstrap_; }
@@ -98,7 +97,6 @@ public:
   testing::NiceMock<MockAdmin> admin_;
   Event::GlobalTimeSystem time_system_;
   testing::NiceMock<Api::MockApi> api_;
-  Http::ContextImpl http_context_;
   Grpc::ContextImpl grpc_context_;
   Router::ContextImpl router_context_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
@@ -128,7 +126,6 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
-  MOCK_METHOD(Http::Context&, httpContext, ());
   MOCK_METHOD(Grpc::Context&, grpcContext, ());
   MOCK_METHOD(Router::Context&, routerContext, ());
   MOCK_METHOD(envoy::config::bootstrap::v3::Bootstrap&, bootstrap, ());


### PR DESCRIPTION
This reverts commit 9918a0a06deaf0cb3c935566523ab3fdd7a2bab1.

Commit Message: Revert "ext_authz: make the ext_authz filter a dual filter (#29173)"
Additional Description: Causing CI flakiness
Risk Level: Low
Fixes: #29759