### PR TITLE
Overload manager bypass flag for listeners

### DIFF
--- a/api/envoy/api/v2/listener.proto
+++ b/api/envoy/api/v2/listener.proto
@@ -27,7 +27,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // [#protodoc-title: Listener configuration]
 // Listener :ref:`configuration overview <config_listeners>`
 
-// [#next-free-field: 23]
+// [#next-free-field: 24]
 message Listener {
   enum DrainType {
     // Drain in response to calling /healthcheck/fail admin endpoint (along with the health check
@@ -246,4 +246,9 @@ message Listener {
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by this listener.
   repeated config.filter.accesslog.v2.AccessLog access_log = 22;
+
+  // Specifies if traffic accepted by this listener should be allowed in
+  // overload scenarios (e.g. listener handles health probes or otherwise
+  // critical traffic).  Default: false
+  bool bypass_overload_manager = 23;
 }

--- a/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
@@ -391,8 +391,7 @@ message FilterStateRule {
 
   // A map of string keys to requirements. The string key is the string value
   // in the FilterState with the name specified in the *name* field above.
-  map<string, JwtRequirement>
-  requires = 3;
+  map<string, JwtRequirement> requires = 3;
 }
 
 // This is the Envoy HTTP filter config for JWT authentication.

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -53,7 +53,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 35]
+// [#next-free-field: 36]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -387,6 +387,9 @@ message Listener {
   // Whether the listener should limit connections based upon the value of
   // :ref:`global_downstream_max_connections <config_overload_manager_limiting_connections>`.
   bool ignore_global_conn_limit = 31;
+
+  // Whether the listener bypass configured overload manager actions.
+  bool bypass_overload_manager = 35;
 }
 
 // A placeholder proto so that users can explicitly configure the standard

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -614,8 +614,7 @@ message FilterStateRule {
 
   // A map of string keys to requirements. The string key is the string value
   // in the FilterState with the name specified in the ``name`` field above.
-  map<string, JwtRequirement>
-  requires = 3;
+  map<string, JwtRequirement> requires = 3;
 }
 
 // This is the Envoy HTTP filter config for JWT authentication.

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -258,6 +258,11 @@ public:
    * limit.
    */
   virtual bool ignoreGlobalConnLimit() const PURE;
+
+  /**
+   * @return bool whether the listener should bypass overload manager actions
+   */
+  virtual bool bypassOverloadManager() const PURE;
 };
 
 /**
@@ -428,6 +433,11 @@ public:
    * after being opened.
    */
   virtual void setRejectFraction(UnitFloat reject_fraction) PURE;
+
+  /**
+   * Check whether the listener should bypass overload manager actions
+   */
+  virtual bool getBypassOverloadManager() PURE;
 
   /**
    * Configures the LoadShedPoints for this listener.

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -259,6 +259,12 @@ public:
   virtual const Envoy::Config::TypedMetadata& listenerTypedMetadata() const PURE;
 
   /**
+   * @return const bool if this listener is configured with bypass_overload_manager
+   *
+   */
+  virtual bool bypassOverloadManager() PURE;
+
+  /**
    * @return OverloadManager& the overload manager for the server.
    */
   virtual OverloadManager& overloadManager() PURE;

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -270,6 +270,12 @@ public:
   virtual OverloadManager& overloadManager() PURE;
 
   /**
+   * @return NullOverloadManager& the dummy overload manager for the server for
+   * listeners that are bypassing a configured OverloadManager
+   */
+  virtual NullOverloadManager& nullOverloadManager() PURE;
+
+  /**
    * @return Http::Context& a reference to the http context.
    */
   virtual Http::Context& httpContext() PURE;

--- a/envoy/server/instance.h
+++ b/envoy/server/instance.h
@@ -139,6 +139,8 @@ public:
    */
   virtual OverloadManager& overloadManager() PURE;
 
+  virtual NullOverloadManager& nullOverloadManager() PURE;
+
   /**
    * @return the server's secret manager
    */

--- a/envoy/server/overload/overload_manager.h
+++ b/envoy/server/overload/overload_manager.h
@@ -6,6 +6,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/scaled_range_timer_manager.h"
 #include "envoy/server/overload/load_shed_point.h"
+#include "envoy/thread_local/thread_local.h"
 #include "envoy/server/overload/thread_local_overload_state.h"
 
 #include "source/common/singleton/const_singleton.h"
@@ -99,6 +100,46 @@ public:
    * Get a factory for constructing scaled timer managers that respond to overload state.
    */
   virtual Event::ScaledRangeTimerManagerFactory scaledTimerFactory() PURE;
+};
+
+/**
+ * Implementation of OverloadManager that is never overloaded. Using this instead of the real
+ * OverloadManager keeps the interface accessible even when the proxy is overloaded.
+ */
+struct NullOverloadManager : public OverloadManager {
+  struct OverloadState : public ThreadLocalOverloadState {
+    OverloadState(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
+    const OverloadActionState& getState(const std::string&) override { return inactive_; }
+    bool tryAllocateResource(OverloadProactiveResourceName, int64_t) override { return false; }
+    bool tryDeallocateResource(OverloadProactiveResourceName, int64_t) override { return false; }
+    bool isResourceMonitorEnabled(OverloadProactiveResourceName) override { return false; }
+    Event::Dispatcher& dispatcher_;
+    const OverloadActionState inactive_ = OverloadActionState::inactive();
+  };
+
+  NullOverloadManager(ThreadLocal::SlotAllocator& slot_allocator)
+      : tls_(slot_allocator.allocateSlot()) {}
+
+  void start() override {
+    tls_->set([](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return std::make_shared<OverloadState>(dispatcher);
+    });
+  }
+
+  ThreadLocalOverloadState& getThreadLocalOverloadState() override {
+    return tls_->getTyped<OverloadState>();
+  }
+  LoadShedPoint* getLoadShedPoint(absl::string_view) override { return nullptr; }
+
+  Event::ScaledRangeTimerManagerFactory scaledTimerFactory() override { return nullptr; }
+
+  bool registerForAction(const std::string&, Event::Dispatcher&, OverloadActionCb) override {
+    // This method shouldn't be called by the listener
+    IS_ENVOY_BUG("Unexpected function call");
+    return false;
+  }
+
+  ThreadLocal::SlotPtr tls_;
 };
 
 } // namespace Server

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -199,6 +199,7 @@ DispatcherImpl::createListener(Network::SocketSharedPtr&& socket, Network::TcpLi
   return std::make_unique<Network::TcpListenerImpl>(
       *this, random_generator_, runtime, std::move(socket), cb, listener_config.bindToPort(),
       listener_config.ignoreGlobalConnLimit(),
+      listener_config.bypassOverloadManager(),
       listener_config.maxConnectionsToAcceptPerSocketEvent());
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -91,8 +91,7 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
                                              const LocalInfo::LocalInfo& local_info,
                                              Upstream::ClusterManager& cluster_manager,
                                              Server::OverloadManager& overload_manager,
-                                             TimeSource& time_source,
-                                             const bool bypass_overload_manager)
+                                             TimeSource& time_source)
     : config_(config), stats_(config_.stats()),
       conn_length_(new Stats::HistogramCompletableTimespanImpl(
           stats_.named_.downstream_cx_length_ms_, time_source)),
@@ -100,7 +99,6 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
       random_generator_(random_generator), runtime_(runtime), local_info_(local_info),
       cluster_manager_(cluster_manager), listener_stats_(config_.listenerStats()),
       overload_manager_(overload_manager),
-      bypass_overload_manager_(bypass_overload_manager),
       overload_state_(overload_manager.getThreadLocalOverloadState()),
       accept_new_http_stream_(overload_manager.getLoadShedPoint(
           "envoy.load_shed_points.http_connection_manager_decode_headers")),
@@ -1165,11 +1163,10 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
 
   // Drop new requests when overloaded as soon as we have decoded the headers.
   const bool drop_request_due_to_overload =
-      !connection_manager_.bypass_overload_manager_ &&
-      ((connection_manager_.accept_new_http_stream_ != nullptr &&
+      (connection_manager_.accept_new_http_stream_ != nullptr &&
        connection_manager_.accept_new_http_stream_->shouldShedLoad()) ||
       connection_manager_.random_generator_.bernoulli(
-          connection_manager_.overload_stop_accepting_requests_ref_.value()));
+          connection_manager_.overload_stop_accepting_requests_ref_.value());
 
   if (drop_request_due_to_overload) {
     // In this one special case, do not create the filter chain. If there is a risk of memory
@@ -1664,8 +1661,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
       connection_manager_.proxy_name_, connection_manager_.clear_hop_by_hop_response_headers_);
 
   bool drain_connection_due_to_overload = false;
-  if (!connection_manager_.bypass_overload_manager_ &&
-      connection_manager_.drain_state_ == DrainState::NotDraining &&
+  if (connection_manager_.drain_state_ == DrainState::NotDraining &&
       connection_manager_.random_generator_.bernoulli(
           connection_manager_.overload_disable_keepalive_ref_.value())) {
     ENVOY_STREAM_LOG(debug, "disabling keepalive due to envoy overload", *this);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -67,8 +67,7 @@ public:
                         Random::RandomGenerator& random_generator, Http::Context& http_context,
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info,
                         Upstream::ClusterManager& cluster_manager,
-                        Server::OverloadManager& overload_manager, TimeSource& time_system,
-                        bool bypass_overload_manager);
+                        Server::OverloadManager& overload_manager, TimeSource& time_system);
   ~ConnectionManagerImpl() override;
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -597,7 +596,6 @@ private:
   Event::Dispatcher* dispatcher_{};
   ConnectionManagerListenerStats& listener_stats_;
   Server::OverloadManager& overload_manager_;
-  const bool bypass_overload_manager_;
   Server::ThreadLocalOverloadState& overload_state_;
   Server::LoadShedPoint* accept_new_http_stream_{nullptr};
   // References into the overload manager thread local state map. Using these lets us avoid a

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -67,7 +67,8 @@ public:
                         Random::RandomGenerator& random_generator, Http::Context& http_context,
                         Runtime::Loader& runtime, const LocalInfo::LocalInfo& local_info,
                         Upstream::ClusterManager& cluster_manager,
-                        Server::OverloadManager& overload_manager, TimeSource& time_system);
+                        Server::OverloadManager& overload_manager, TimeSource& time_system,
+                        bool bypass_overload_manager);
   ~ConnectionManagerImpl() override;
 
   static ConnectionManagerStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -596,6 +597,7 @@ private:
   Event::Dispatcher* dispatcher_{};
   ConnectionManagerListenerStats& listener_stats_;
   Server::OverloadManager& overload_manager_;
+  const bool bypass_overload_manager_;
   Server::ThreadLocalOverloadState& overload_state_;
   Server::LoadShedPoint* accept_new_http_stream_{nullptr};
   // References into the overload manager thread local state map. Using these lets us avoid a

--- a/source/common/network/tcp_listener_impl.cc
+++ b/source/common/network/tcp_listener_impl.cc
@@ -101,10 +101,12 @@ TcpListenerImpl::TcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::Rand
                                  Runtime::Loader& runtime, SocketSharedPtr socket,
                                  TcpListenerCallbacks& cb, bool bind_to_port,
                                  bool ignore_global_conn_limit,
+                                 bool bypass_overload_manager,
                                  uint32_t max_connections_to_accept_per_socket_event)
     : BaseListenerImpl(dispatcher, std::move(socket)), cb_(cb), random_(random), runtime_(runtime),
       bind_to_port_(bind_to_port), reject_fraction_(0.0),
       ignore_global_conn_limit_(ignore_global_conn_limit),
+      bypass_overload_manager_(bypass_overload_manager),
       max_connections_to_accept_per_socket_event_(max_connections_to_accept_per_socket_event) {
   if (bind_to_port) {
     // Use level triggered mode to avoid potential loss of the trigger due to
@@ -143,6 +145,10 @@ void TcpListenerImpl::configureLoadShedPoints(
   ENVOY_LOG_ONCE_MISC_IF(
       trace, listener_accept_ == nullptr,
       "LoadShedPoint envoy.load_shed_points.tcp_listener_accept is not found. Is it configured?");
+}
+
+bool TcpListenerImpl::getBypassOverloadManager() {
+  return bypass_overload_manager_;
 }
 
 } // namespace Network

--- a/source/common/network/tcp_listener_impl.h
+++ b/source/common/network/tcp_listener_impl.h
@@ -19,6 +19,7 @@ public:
   TcpListenerImpl(Event::DispatcherImpl& dispatcher, Random::RandomGenerator& random,
                   Runtime::Loader& runtime, SocketSharedPtr socket, TcpListenerCallbacks& cb,
                   bool bind_to_port, bool ignore_global_conn_limit,
+                  bool bypass_overload_manager,
                   uint32_t max_connections_to_accept_per_socket_event);
   ~TcpListenerImpl() override {
     if (bind_to_port_) {
@@ -29,6 +30,7 @@ public:
   void enable() override;
   void setRejectFraction(UnitFloat reject_fraction) override;
   void configureLoadShedPoints(Server::LoadShedPointProvider& load_shed_point_provider) override;
+  bool getBypassOverloadManager() override;
 
   static const absl::string_view GlobalMaxCxRuntimeKey;
 
@@ -47,6 +49,7 @@ private:
   bool bind_to_port_;
   UnitFloat reject_fraction_;
   const bool ignore_global_conn_limit_;
+  const bool bypass_overload_manager_;
   const uint32_t max_connections_to_accept_per_socket_event_;
   Server::LoadShedPoint* listener_accept_{nullptr};
 };

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -33,6 +33,7 @@ public:
   void enable() override;
   void setRejectFraction(UnitFloat) override {}
   void configureLoadShedPoints(Server::LoadShedPointProvider&) override {}
+  bool getBypassOverloadManager() override { return false; }
 
   // Network::UdpListener
   Event::Dispatcher& dispatcher() override;

--- a/source/extensions/bootstrap/internal_listener/active_internal_listener.h
+++ b/source/extensions/bootstrap/internal_listener/active_internal_listener.h
@@ -51,6 +51,7 @@ public:
     }
 
     void setRejectFraction(UnitFloat) override {}
+    bool getBypassOverloadManager() override { return false; }
     void configureLoadShedPoints(Server::LoadShedPointProvider&) override {}
   };
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -280,7 +280,7 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoAndHopByHo
     auto hcm = std::make_shared<Http::ConnectionManagerImpl>(
         *filter_config, context.drainDecision(), context.api().randomGenerator(),
         context.httpContext(), context.runtime(), context.localInfo(), context.clusterManager(),
-        context.overloadManager(), context.mainThreadDispatcher().timeSource());
+        context.overloadManager(), context.mainThreadDispatcher().timeSource(), context.bypassOverloadManager());
     if (!clear_hop_by_hop_headers) {
       hcm->setClearHopByHopResponseHeaders(false);
     }
@@ -804,7 +804,7 @@ HttpConnectionManagerFactory::createHttpConnectionManagerFactoryFromProto(
     auto conn_manager = std::make_unique<Http::ConnectionManagerImpl>(
         *filter_config, context.drainDecision(), context.api().randomGenerator(),
         context.httpContext(), context.runtime(), context.localInfo(), context.clusterManager(),
-        context.overloadManager(), context.mainThreadDispatcher().timeSource());
+        context.overloadManager(), context.mainThreadDispatcher().timeSource(), context.bypassOverloadManager());
     if (!clear_hop_by_hop_headers) {
       conn_manager->setClearHopByHopResponseHeaders(false);
     }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -277,10 +277,12 @@ HttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProtoAndHopByHo
   // as these captured objects are also global singletons.
   return [singletons, filter_config, &context,
           clear_hop_by_hop_headers](Network::FilterManager& filter_manager) -> void {
+    Server::OverloadManager& overload_manager = context.bypassOverloadManager() ? context.nullOverloadManager() : context.overloadManager();
     auto hcm = std::make_shared<Http::ConnectionManagerImpl>(
         *filter_config, context.drainDecision(), context.api().randomGenerator(),
         context.httpContext(), context.runtime(), context.localInfo(), context.clusterManager(),
-        context.overloadManager(), context.mainThreadDispatcher().timeSource(), context.bypassOverloadManager());
+        overload_manager, context.mainThreadDispatcher().timeSource());
+
     if (!clear_hop_by_hop_headers) {
       hcm->setClearHopByHopResponseHeaders(false);
     }
@@ -801,10 +803,12 @@ HttpConnectionManagerFactory::createHttpConnectionManagerFactoryFromProto(
   // as these captured objects are also global singletons.
   return [singletons, filter_config, &context, clear_hop_by_hop_headers](
              Network::ReadFilterCallbacks& read_callbacks) -> Http::ApiListenerPtr {
+    Server::OverloadManager& overload_manager = context.bypassOverloadManager() ? context.nullOverloadManager() : context.overloadManager();
     auto conn_manager = std::make_unique<Http::ConnectionManagerImpl>(
-        *filter_config, context.drainDecision(), context.api().randomGenerator(),
-        context.httpContext(), context.runtime(), context.localInfo(), context.clusterManager(),
-        context.overloadManager(), context.mainThreadDispatcher().timeSource(), context.bypassOverloadManager());
+            *filter_config, context.drainDecision(), context.api().randomGenerator(),
+            context.httpContext(), context.runtime(), context.localInfo(), context.clusterManager(),
+            overload_manager, context.mainThreadDispatcher().timeSource());
+
     if (!clear_hop_by_hop_headers) {
       conn_manager->setClearHopByHopResponseHeaders(false);
     }

--- a/source/extensions/listener_managers/listener_manager/connection_handler_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/connection_handler_impl.cc
@@ -267,7 +267,7 @@ void ConnectionHandlerImpl::disableListeners() {
   disable_listeners_ = true;
   for (auto& iter : listener_map_by_tag_) {
     iter.second->invokeListenerMethod([](Network::ConnectionHandler::ActiveListener& listener) {
-      if (listener.listener() != nullptr) {
+      if (listener.listener() != nullptr && !listener.listener()->getBypassOverloadManager()) {
         listener.pauseListening();
       }
     });
@@ -278,7 +278,7 @@ void ConnectionHandlerImpl::enableListeners() {
   disable_listeners_ = false;
   for (auto& iter : listener_map_by_tag_) {
     iter.second->invokeListenerMethod([](Network::ConnectionHandler::ActiveListener& listener) {
-      if (listener.listener() != nullptr) {
+      if (listener.listener() != nullptr && !listener.listener()->getBypassOverloadManager()) {
         listener.resumeListening();
       }
     });
@@ -290,7 +290,7 @@ void ConnectionHandlerImpl::setListenerRejectFraction(UnitFloat reject_fraction)
   for (auto& iter : listener_map_by_tag_) {
     iter.second->invokeListenerMethod(
         [&reject_fraction](Network::ConnectionHandler::ActiveListener& listener) {
-          if (listener.listener() != nullptr) {
+          if (listener.listener() != nullptr && !listener.listener()->getBypassOverloadManager()) {
             listener.listener()->setRejectFraction(reject_fraction);
           }
         });

--- a/source/extensions/listener_managers/listener_manager/connection_handler_impl.h
+++ b/source/extensions/listener_managers/listener_manager/connection_handler_impl.h
@@ -125,7 +125,7 @@ private:
       }
       if (auto* listener = per_address_details->listener_->listener(); listener != nullptr) {
         listener->setRejectFraction(listener_reject_fraction);
-        if (overload_manager) {
+        if (overload_manager && !config.bypassOverloadManager()) {
           listener->configureLoadShedPoints(overload_manager.value());
         }
       }

--- a/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.cc
@@ -163,6 +163,10 @@ OverloadManager& PerFilterChainFactoryContextImpl::overloadManager() {
   return parent_context_.overloadManager();
 }
 
+NullOverloadManager& PerFilterChainFactoryContextImpl::nullOverloadManager() {
+  return parent_context_.nullOverloadManager();
+}
+
 bool PerFilterChainFactoryContextImpl::bypassOverloadManager() {
   return parent_context_.bypassOverloadManager();
 }

--- a/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.cc
@@ -163,6 +163,10 @@ OverloadManager& PerFilterChainFactoryContextImpl::overloadManager() {
   return parent_context_.overloadManager();
 }
 
+bool PerFilterChainFactoryContextImpl::bypassOverloadManager() {
+  return parent_context_.bypassOverloadManager();
+}
+
 OptRef<Admin> PerFilterChainFactoryContextImpl::admin() { return parent_context_.admin(); }
 
 TimeSource& PerFilterChainFactoryContextImpl::timeSource() { return api().timeSource(); }

--- a/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.h
+++ b/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.h
@@ -74,6 +74,7 @@ public:
   Stats::Scope& serverScope() override { return parent_context_.serverScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  NullOverloadManager& nullOverloadManager() override;
   bool bypassOverloadManager() override;
   ThreadLocal::SlotAllocator& threadLocal() override;
   OptRef<Admin> admin() override;

--- a/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.h
+++ b/source/extensions/listener_managers/listener_manager/filter_chain_manager_impl.h
@@ -74,6 +74,7 @@ public:
   Stats::Scope& serverScope() override { return parent_context_.serverScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  bool bypassOverloadManager() override;
   ThreadLocal::SlotAllocator& threadLocal() override;
   OptRef<Admin> admin() override;
   const envoy::config::core::v3::Metadata& listenerMetadata() const override;

--- a/source/extensions/listener_managers/listener_manager/listener_impl.cc
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.cc
@@ -262,6 +262,9 @@ Singleton::Manager& ListenerFactoryContextBaseImpl::singletonManager() {
 OverloadManager& ListenerFactoryContextBaseImpl::overloadManager() {
   return server_.overloadManager();
 }
+NullOverloadManager& ListenerFactoryContextBaseImpl::nullOverloadManager() {
+  return server_.nullOverloadManager();
+}
 ThreadLocal::Instance& ListenerFactoryContextBaseImpl::threadLocal() {
   return server_.threadLocal();
 }
@@ -908,6 +911,9 @@ Singleton::Manager& PerListenerFactoryContextImpl::singletonManager() {
 }
 OverloadManager& PerListenerFactoryContextImpl::overloadManager() {
   return listener_factory_context_base_->overloadManager();
+}
+NullOverloadManager& PerListenerFactoryContextImpl::nullOverloadManager() {
+  return listener_factory_context_base_->nullOverloadManager();
 }
 ThreadLocal::Instance& PerListenerFactoryContextImpl::threadLocal() {
   return listener_factory_context_base_->threadLocal();

--- a/source/extensions/listener_managers/listener_manager/listener_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
@@ -145,6 +145,7 @@ public:
   Stats::Scope& scope() override;
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  bool bypassOverloadManager() override;
   ThreadLocal::Instance& threadLocal() override;
   OptRef<Admin> admin() override;
   const envoy::config::core::v3::Metadata& listenerMetadata() const override;
@@ -182,6 +183,7 @@ private:
   ProtobufMessage::ValidationVisitor& validation_visitor_;
   const Server::DrainManagerPtr drain_manager_;
   bool is_quic_;
+  bool bypass_overload_manager_;
 };
 
 class ListenerImpl;
@@ -222,6 +224,7 @@ public:
   Stats::Scope& serverScope() override { return listener_factory_context_base_->serverScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  bool bypassOverloadManager() override;
   ThreadLocal::Instance& threadLocal() override;
   OptRef<Admin> admin() override;
   const envoy::config::core::v3::Metadata& listenerMetadata() const override;
@@ -323,6 +326,7 @@ public:
   }
   const std::string& versionInfo() const { return version_info_; }
   bool reusePort() const { return reuse_port_; }
+  bool bypassOverloadManager() const override { return bypass_overload_manager_; }
   static bool getReusePortOrDefault(Server::Instance& server,
                                     const envoy::config::listener::v3::Listener& config,
                                     Network::Socket::Type socket_type);
@@ -516,6 +520,7 @@ private:
   std::shared_ptr<PerListenerFactoryContextImpl> listener_factory_context_;
   std::unique_ptr<FilterChainManagerImpl> filter_chain_manager_;
   const bool reuse_port_;
+  const bool bypass_overload_manager_;
 
   // Per-listener connection limits are only specified via runtime.
   //

--- a/source/extensions/listener_managers/listener_manager/listener_impl.h
+++ b/source/extensions/listener_managers/listener_manager/listener_impl.h
@@ -145,6 +145,7 @@ public:
   Stats::Scope& scope() override;
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  NullOverloadManager& nullOverloadManager() override;
   bool bypassOverloadManager() override;
   ThreadLocal::Instance& threadLocal() override;
   OptRef<Admin> admin() override;
@@ -224,6 +225,7 @@ public:
   Stats::Scope& serverScope() override { return listener_factory_context_base_->serverScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  NullOverloadManager& nullOverloadManager() override;
   bool bypassOverloadManager() override;
   ThreadLocal::Instance& threadLocal() override;
   OptRef<Admin> admin() override;

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -258,7 +258,7 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
       *this, server_.drainManager(), server_.api().randomGenerator(), server_.httpContext(),
       server_.runtime(), server_.localInfo(), server_.clusterManager(), null_overload_manager_,
-      server_.timeSource())});
+      server_.timeSource(), true)});
   return true;
 }
 

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -56,7 +56,6 @@ void AdminImpl::startHttpListener(const std::list<AccessLog::InstanceSharedPtr>&
   for (const auto& access_log : access_logs) {
     access_logs_.emplace_back(access_log);
   }
-  null_overload_manager_.start();
   socket_ = std::make_shared<Network::TcpListenSocket>(address, socket_options, true);
   RELEASE_ASSERT(0 == socket_->ioHandle().listen(ENVOY_TCP_BACKLOG_SIZE).return_value_,
                  "listen() failed on admin listener");
@@ -91,7 +90,6 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
           server_.api().randomGenerator())),
       profile_path_(profile_path), stats_(Http::ConnectionManagerImpl::generateStats(
                                        "http.admin.", *server_.stats().rootScope())),
-      null_overload_manager_(server_.threadLocal()),
       tracing_stats_(Http::ConnectionManagerImpl::generateTracingStats("http.admin.",
                                                                        *no_op_store_.rootScope())),
       route_config_provider_(server.timeSource()),
@@ -257,8 +255,8 @@ bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,
   // is overloaded.
   connection.addReadFilter(Network::ReadFilterSharedPtr{new Http::ConnectionManagerImpl(
       *this, server_.drainManager(), server_.api().randomGenerator(), server_.httpContext(),
-      server_.runtime(), server_.localInfo(), server_.clusterManager(), null_overload_manager_,
-      server_.timeSource(), true)});
+      server_.runtime(), server_.localInfo(), server_.clusterManager(), server_.nullOverloadManager(),
+      server_.timeSource())});
   return true;
 }
 

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -434,6 +434,7 @@ private:
     }
     Init::Manager& initManager() override { return *init_manager_; }
     bool ignoreGlobalConnLimit() const override { return ignore_global_conn_limit_; }
+    bool bypassOverloadManager() const override { return true; }
 
     AdminImpl& parent_;
     const std::string name_;

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -107,6 +107,8 @@ void ValidationInstance::initialize(const Options& options,
   overload_manager_ = std::make_unique<OverloadManagerImpl>(
       dispatcher(), *stats().rootScope(), threadLocal(), bootstrap_.overload_manager(),
       messageValidationContext().staticValidationVisitor(), *api_, options_);
+  null_overload_manager_ = std::make_unique<NullOverloadManager>(threadLocal());
+
   Configuration::InitialImpl initial_config(bootstrap_);
   initial_config.initAdminAccessLog(bootstrap_, *this);
   admin_ = std::make_unique<Server::ValidationAdmin>(initial_config.admin().address());

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -99,6 +99,7 @@ public:
   void shutdownAdmin() override {}
   Singleton::Manager& singletonManager() override { return *singleton_manager_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
+  NullOverloadManager& nullOverloadManager() override { return *null_overload_manager_; }
   bool healthCheckFailed() override { return false; }
   const Options& options() override { return options_; }
   time_t startTimeCurrentEpoch() override { PANIC("not implemented"); }
@@ -180,6 +181,7 @@ private:
   std::unique_ptr<Upstream::ValidationClusterManagerFactory> cluster_manager_factory_;
   std::unique_ptr<ListenerManager> listener_manager_;
   std::unique_ptr<OverloadManager> overload_manager_;
+  std::unique_ptr<NullOverloadManager> null_overload_manager_;
   MutexTracer* mutex_tracer_{nullptr};
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/source/server/factory_context_impl.cc
+++ b/source/server/factory_context_impl.cc
@@ -27,6 +27,7 @@ Envoy::Runtime::Loader& FactoryContextImpl::runtime() { return server_.runtime()
 Stats::Scope& FactoryContextImpl::scope() { return global_scope_; }
 Singleton::Manager& FactoryContextImpl::singletonManager() { return server_.singletonManager(); }
 OverloadManager& FactoryContextImpl::overloadManager() { return server_.overloadManager(); }
+NullOverloadManager& FactoryContextImpl::nullOverloadManager() { return server_.nullOverloadManager(); }
 bool FactoryContextImpl::bypassOverloadManager() { return config_.bypass_overload_manager(); }
 ThreadLocal::SlotAllocator& FactoryContextImpl::threadLocal() { return server_.threadLocal(); }
 OptRef<Admin> FactoryContextImpl::admin() { return server_.admin(); }

--- a/source/server/factory_context_impl.cc
+++ b/source/server/factory_context_impl.cc
@@ -27,6 +27,7 @@ Envoy::Runtime::Loader& FactoryContextImpl::runtime() { return server_.runtime()
 Stats::Scope& FactoryContextImpl::scope() { return global_scope_; }
 Singleton::Manager& FactoryContextImpl::singletonManager() { return server_.singletonManager(); }
 OverloadManager& FactoryContextImpl::overloadManager() { return server_.overloadManager(); }
+bool FactoryContextImpl::bypassOverloadManager() { return config_.bypass_overload_manager(); }
 ThreadLocal::SlotAllocator& FactoryContextImpl::threadLocal() { return server_.threadLocal(); }
 OptRef<Admin> FactoryContextImpl::admin() { return server_.admin(); }
 TimeSource& FactoryContextImpl::timeSource() { return server_.timeSource(); }

--- a/source/server/factory_context_impl.h
+++ b/source/server/factory_context_impl.h
@@ -31,6 +31,7 @@ public:
   Stats::Scope& serverScope() override { return *server_.stats().rootScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  bool bypassOverloadManager() override;
   ThreadLocal::SlotAllocator& threadLocal() override;
   OptRef<Admin> admin() override;
   TimeSource& timeSource() override;

--- a/source/server/factory_context_impl.h
+++ b/source/server/factory_context_impl.h
@@ -31,6 +31,7 @@ public:
   Stats::Scope& serverScope() override { return *server_.stats().rootScope(); }
   Singleton::Manager& singletonManager() override;
   OverloadManager& overloadManager() override;
+  NullOverloadManager& nullOverloadManager() override;
   bool bypassOverloadManager() override;
   ThreadLocal::SlotAllocator& threadLocal() override;
   OptRef<Admin> admin() override;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -157,6 +157,7 @@ public:
   RunHelper(Instance& instance, const Options& options, Event::Dispatcher& dispatcher,
             Upstream::ClusterManager& cm, AccessLog::AccessLogManager& access_log_manager,
             Init::Manager& init_manager, OverloadManager& overload_manager,
+            NullOverloadManager& null_overload_manager,
             std::function<void()> workers_start_cb);
 
 private:
@@ -265,6 +266,7 @@ public:
   Secret::SecretManager& secretManager() override { return *secret_manager_; }
   Envoy::MutexTracer* mutexTracer() override { return mutex_tracer_; }
   OverloadManager& overloadManager() override { return *overload_manager_; }
+  NullOverloadManager& nullOverloadManager() override { return *null_overload_manager_; }
   Runtime::Loader& runtime() override;
   void shutdown() override;
   bool isShutdown() final { return shutdown_; }
@@ -387,6 +389,8 @@ private:
   Upstream::ProdClusterInfoFactory info_factory_;
   Upstream::HdsDelegatePtr hds_delegate_;
   std::unique_ptr<OverloadManagerImpl> overload_manager_;
+  // Used for listeners which explicitly bypass overload manager
+  std::unique_ptr<NullOverloadManager> null_overload_manager_;
   std::vector<BootstrapExtensionPtr> bootstrap_extensions_;
   Envoy::MutexTracer* mutex_tracer_;
   Grpc::ContextImpl grpc_context_;

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -294,7 +294,7 @@ public:
   AdminImpl::NullScopedRouteConfigProvider& scopedRouteConfigProvider() {
     return scoped_route_config_provider_;
   }
-  AdminImpl::NullOverloadManager& overloadManager() { return admin_.null_overload_manager_; }
+  AdminImpl::NullOverloadManager& overloadManager() { return server_.nullOverloadManager(); }
   AdminImpl::NullOverloadManager::OverloadState& overloadState() { return overload_state_; }
   AdminImpl::AdminListenSocketFactory& socketFactory() { return socket_factory_; }
   AdminImpl::AdminListener& listener() { return listener_; }


### PR DESCRIPTION
WIP + missing tests and release notes.  Opening for discussion.

Pulled the NullOverloadManager instantiation out of admin and moved it into server, so that it can be used across any listeners that want to bypass overload manager.  A health probe listener for example.

On a related note, while working on this I tried a "stop_accepting_requests" action in conjunction with "shrink_heap" and it seems once memory crosses the threshold, it never comes back down regardless of the shrink heap action, so it just keeps rejecting requests indefinitely.  I'm not really sure what the point of the overload manager with memory thresholds is if the memory never comes back down.  This seems true for both gperftools and tcmalloc.