### PR TITLE
filter state: add more well-known objects

### DIFF
--- a/docs/root/configuration/advanced/well_known_filter_state.rst
+++ b/docs/root/configuration/advanced/well_known_filter_state.rst
@@ -24,7 +24,7 @@ The following list of filter state objects are consumed by Envoy extensions:
        | configuration.
        | Accepts a comma-separated list of protocols as a constructor, e.g. "h2,http/1.1".
    * - ``envoy.network.upstream_subject_alt_names``
-       | Enables additional verification of the upstream peer certificate SAN names.
+     - | Enables additional verification of the upstream peer certificate SAN names.
        | Accepts a comma-separated list of SAN names as a constructor.
    * - ``envoy.tcp_proxy.cluster``
      - | :ref:`TCP proxy <config_network_filters_tcp_proxy>` dynamic cluster name selection

--- a/docs/root/configuration/advanced/well_known_filter_state.rst
+++ b/docs/root/configuration/advanced/well_known_filter_state.rst
@@ -12,6 +12,20 @@ The following list of filter state objects are consumed by Envoy extensions:
 
    * - **Filter state key**
      - **Purpose**
+   * - ``envoy.network.upstream_server_name``
+     - | Sets the transport socket option to override the
+       | `SNI <https://en.wikipedia.org/wiki/Server_Name_Indication>`
+       | in the upstream connections.
+       | Accepts a host name as a constructor, e.g. "lyft.com".
+   * - ``envoy.network.application_protocols``
+     - | Sets the transport socket option to override the
+       | `ALPN <https://en.wikipedia.org/wiki/Application-Layer Protocol Negotiation>` list
+       | in the upstream connections. This setting takes precedence over the upstream cluster
+       | configuration.
+       | Accepts a comma-separated list of protocols as a constructor, e.g. "h2,http/1.1".
+   * - ``envoy.network.upstream_subject_alt_names``
+       | Enables additional verification of the upstream peer certificate SAN names.
+       | Accepts a comma-separated list of SAN names as a constructor.
    * - ``envoy.tcp_proxy.cluster``
      - | :ref:`TCP proxy <config_network_filters_tcp_proxy>` dynamic cluster name selection
        | on a per-connection basis.

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -32,6 +32,7 @@ envoy_cc_library(
     srcs = ["application_protocol.cc"],
     hdrs = ["application_protocol.h"],
     deps = [
+        "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",
         "//source/common/common:macros",
     ],
@@ -520,6 +521,7 @@ envoy_cc_library(
     srcs = ["upstream_server_name.cc"],
     hdrs = ["upstream_server_name.h"],
     deps = [
+        "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",
         "//source/common/common:macros",
     ],
@@ -530,6 +532,7 @@ envoy_cc_library(
     srcs = ["upstream_subject_alt_names.cc"],
     hdrs = ["upstream_subject_alt_names.h"],
     deps = [
+        "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",
         "//source/common/common:macros",
     ],

--- a/source/common/network/application_protocol.cc
+++ b/source/common/network/application_protocol.cc
@@ -1,5 +1,8 @@
 #include "source/common/network/application_protocol.h"
 
+#include "envoy/registry/registry.h"
+#include "envoy/stream_info/filter_state.h"
+
 #include "source/common/common/macros.h"
 
 namespace Envoy {
@@ -8,5 +11,17 @@ namespace Network {
 const std::string& ApplicationProtocols::key() {
   CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.application_protocols");
 }
+
+class ApplicationProtocolsObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return ApplicationProtocols::key(); }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    const std::vector<std::string> parts = absl::StrSplit(data, ',');
+    return std::make_unique<ApplicationProtocols>(parts);
+  }
+};
+
+REGISTER_FACTORY(ApplicationProtocolsObjectFactory, StreamInfo::FilterState::ObjectFactory);
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/upstream_server_name.cc
+++ b/source/common/network/upstream_server_name.cc
@@ -1,5 +1,8 @@
 #include "source/common/network/upstream_server_name.h"
 
+#include "envoy/registry/registry.h"
+#include "envoy/stream_info/filter_state.h"
+
 #include "source/common/common/macros.h"
 
 namespace Envoy {
@@ -8,5 +11,17 @@ namespace Network {
 const std::string& UpstreamServerName::key() {
   CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.upstream_server_name");
 }
+
+class UpstreamServerNameObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return UpstreamServerName::key(); }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    return std::make_unique<UpstreamServerName>(data);
+  }
+};
+
+REGISTER_FACTORY(UpstreamServerNameObjectFactory, StreamInfo::FilterState::ObjectFactory);
+
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/upstream_subject_alt_names.cc
+++ b/source/common/network/upstream_subject_alt_names.cc
@@ -1,5 +1,8 @@
 #include "source/common/network/upstream_subject_alt_names.h"
 
+#include "envoy/registry/registry.h"
+#include "envoy/stream_info/filter_state.h"
+
 #include "source/common/common/macros.h"
 
 namespace Envoy {
@@ -8,5 +11,17 @@ namespace Network {
 const std::string& UpstreamSubjectAltNames::key() {
   CONSTRUCT_ON_FIRST_USE(std::string, "envoy.network.upstream_subject_alt_names");
 }
+
+class UpstreamSubjectAltNamesObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return UpstreamSubjectAltNames::key(); }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    const std::vector<std::string> parts = absl::StrSplit(data, ',');
+    return std::make_unique<UpstreamSubjectAltNames>(parts);
+  }
+};
+
+REGISTER_FACTORY(UpstreamSubjectAltNamesObjectFactory, StreamInfo::FilterState::ObjectFactory);
 } // namespace Network
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Documents and exposes well known transport socket filter state objects for dynamic extensions
Additional Description:
Risk Level: low
Testing: added
Docs Changes: yes
Release Notes: no (not a new feature)
Issue: #29681 