### PR TITLE
mobile: Add Android xDS integration test

### DIFF
--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -182,6 +182,7 @@ envoy_cc_test_library(
     repository = "@envoy",
     deps = [
         ":base_client_integration_test_lib",
+        "@envoy//source/common/grpc:google_grpc_creds_lib",
         "@envoy//source/exe:process_wide_lib",
         "@envoy//test/integration:autonomous_upstream_lib",
         "@envoy//test/integration:utility_lib",

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -168,3 +168,28 @@ envoy_cc_test_library(
         "@envoy",
     ),
 )
+
+envoy_cc_test_library(
+    name = "xds_test_server_interface_lib",
+    srcs = [
+        "xds_test_server.cc",
+        "xds_test_server_interface.cc",
+    ],
+    hdrs = [
+        "xds_test_server.h",
+        "xds_test_server_interface.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":base_client_integration_test_lib",
+        "@envoy//source/exe:process_wide_lib",
+        "@envoy//test/integration:autonomous_upstream_lib",
+        "@envoy//test/integration:utility_lib",
+        "@envoy//test/mocks/server:transport_socket_factory_context_mocks",
+        "@envoy//test/test_common:environment_lib",
+        "@envoy_build_config//:extension_registry",
+    ] + envoy_select_signal_trace(
+        ["@envoy//source/common/signal:sigaction_lib"],
+        "@envoy",
+    ),
+)

--- a/mobile/test/common/integration/xds_test_server.cc
+++ b/mobile/test/common/integration/xds_test_server.cc
@@ -1,0 +1,80 @@
+#include "test/common/integration/xds_test_server.h"
+
+#include <utility>
+
+#include "source/common/grpc/google_grpc_creds_impl.h"
+#include "source/extensions/config_subscription/grpc/grpc_collection_subscription_factory.h"
+#include "source/extensions/config_subscription/grpc/grpc_mux_impl.h"
+#include "source/extensions/config_subscription/grpc/grpc_subscription_factory.h"
+#include "source/extensions/config_subscription/grpc/new_grpc_mux_impl.h"
+
+#include "test/integration/fake_upstream.h"
+#include "test/test_common/network_utility.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+
+XdsTestServer::XdsTestServer()
+    : api_(Api::createApiForTest(stats_store_, time_system_)),
+      version_(Network::Address::IpVersion::v4),
+      mock_buffer_factory_(new NiceMock<MockBufferFactory>),
+      dispatcher_(api_->allocateDispatcher("test_thread",
+                                           Buffer::WatermarkFactoryPtr{mock_buffer_factory_})),
+      upstream_config_(time_system_) {
+  ON_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
+      .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                               std::function<void()> above_overflow) -> Buffer::Instance* {
+        return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                           std::move(above_overflow));
+      }));
+  ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
+  ON_CALL(factory_context_, statsScope())
+      .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
+  Logger::Context logging_state(spdlog::level::level_enum::err,
+                                "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v", lock_, false, false);
+  upstream_config_.upstream_protocol_ = Http::CodecType::HTTP2;
+  Grpc::forceRegisterDefaultGoogleGrpcCredentialsFactory();
+  Config::forceRegisterAdsConfigSubscriptionFactory();
+  Config::forceRegisterGrpcConfigSubscriptionFactory();
+  Config::forceRegisterDeltaGrpcConfigSubscriptionFactory();
+  Config::forceRegisterDeltaGrpcCollectionConfigSubscriptionFactory();
+  Config::forceRegisterAggregatedGrpcCollectionConfigSubscriptionFactory();
+  Config::forceRegisterAdsCollectionConfigSubscriptionFactory();
+  Config::forceRegisterGrpcMuxFactory();
+  Config::forceRegisterNewGrpcMuxFactory();
+  xds_upstream_ = std::make_unique<FakeUpstream>(0, version_, upstream_config_);
+}
+
+std::string XdsTestServer::getHost() const {
+  return Network::Test::getLoopbackAddressUrlString(version_);
+}
+
+int XdsTestServer::getPort() const {
+  ASSERT(xds_upstream_);
+  return xds_upstream_->localAddress()->ip()->port();
+}
+
+void XdsTestServer::start() {
+  AssertionResult result = xds_upstream_->waitForHttpConnection(*dispatcher_, xds_connection_);
+  RELEASE_ASSERT(result, result.message());
+  result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+  RELEASE_ASSERT(result, result.message());
+  xds_stream_->startGrpcStream();
+}
+
+void XdsTestServer::send(const envoy::service::discovery::v3::DiscoveryResponse& response) {
+  ASSERT(xds_stream_);
+  xds_stream_->sendGrpcMessage(response);
+}
+
+void XdsTestServer::shutdown() {
+  if (xds_connection_ != nullptr) {
+    AssertionResult result = xds_connection_->close();
+    RELEASE_ASSERT(result, result.message());
+    result = xds_connection_->waitForDisconnect();
+    RELEASE_ASSERT(result, result.message());
+    xds_connection_.reset();
+  }
+}
+
+} // namespace Envoy

--- a/mobile/test/common/integration/xds_test_server.h
+++ b/mobile/test/common/integration/xds_test_server.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "envoy/api/api.h"
+
+#include "source/common/stats/isolated_store_impl.h"
+
+#include "test/integration/fake_upstream.h"
+#include "test/mocks/server/transport_socket_factory_context.h"
+#include "test/test_common/test_time.h"
+
+namespace Envoy {
+
+/** An xDS test server. */
+class XdsTestServer {
+public:
+  XdsTestServer();
+
+  /** Starts the xDS server and returns the port number of the server. */
+  void start();
+
+  /** Gets the xDS host. */
+  std::string getHost() const;
+
+  /** Gets the xDS port. */
+  int getPort() const;
+
+  /** Sends a `DiscoveryResponse` from the xDS server. */
+  void send(const envoy::service::discovery::v3::DiscoveryResponse& response);
+
+  /** Shuts down the xDS server. */
+  void shutdown();
+
+private:
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
+  Stats::IsolatedStoreImpl stats_store_;
+  Event::GlobalTimeSystem time_system_;
+  Api::ApiPtr api_;
+  Network::Address::IpVersion version_;
+  MockBufferFactory* mock_buffer_factory_;
+  Event::DispatcherPtr dispatcher_;
+  FakeUpstreamConfig upstream_config_;
+  Thread::MutexBasicLockable lock_;
+  std::unique_ptr<FakeUpstream> xds_upstream_;
+  FakeHttpConnectionPtr xds_connection_;
+  FakeStreamPtr xds_stream_;
+};
+
+} // namespace Envoy

--- a/mobile/test/common/integration/xds_test_server_interface.cc
+++ b/mobile/test/common/integration/xds_test_server_interface.cc
@@ -17,9 +17,10 @@ void initXdsServer() {
   weak_test_server_ = strong_test_server_;
 }
 
-std::string getXdsServerHost() {
+const char* getXdsServerHost() {
   if (auto server = testServer()) {
-    return server->getHost();
+    const char* host = strdup(server->getHost().c_str());
+    return host;
   }
   return ""; // failure
 }

--- a/mobile/test/common/integration/xds_test_server_interface.cc
+++ b/mobile/test/common/integration/xds_test_server_interface.cc
@@ -1,0 +1,53 @@
+#include "test/common/integration/xds_test_server_interface.h"
+
+#include "test/common/integration/xds_test_server.h"
+
+#include "extension_registry.h"
+
+// NOLINT(namespace-envoy)
+
+static std::shared_ptr<Envoy::XdsTestServer> strong_test_server_;
+static std::weak_ptr<Envoy::XdsTestServer> weak_test_server_;
+
+static std::shared_ptr<Envoy::XdsTestServer> testServer() { return weak_test_server_.lock(); }
+
+void initXdsServer() {
+  Envoy::ExtensionRegistry::registerFactories();
+  strong_test_server_ = std::make_shared<Envoy::XdsTestServer>();
+  weak_test_server_ = strong_test_server_;
+}
+
+std::string getXdsServerHost() {
+  if (auto server = testServer()) {
+    return server->getHost();
+  }
+  return ""; // failure
+}
+
+int getXdsServerPort() {
+  if (auto server = testServer()) {
+    return server->getPort();
+  }
+  return -1; // failure
+}
+
+void startXdsServer() {
+  if (auto server = testServer()) {
+    server->start();
+  }
+}
+
+void sendDiscoveryResponse(const envoy::service::discovery::v3::DiscoveryResponse& response) {
+  if (auto server = testServer()) {
+    ASSERT(server);
+    server->send(response);
+  }
+}
+
+void shutdownXdsServer() {
+  // Reset the primary handle to the test_server,
+  // but retain it long enough to synchronously shutdown.
+  auto server = strong_test_server_;
+  strong_test_server_.reset();
+  server->shutdown();
+}

--- a/mobile/test/common/integration/xds_test_server_interface.h
+++ b/mobile/test/common/integration/xds_test_server_interface.h
@@ -15,7 +15,7 @@ void initXdsServer();
 
 /** Gets the xDS server host. `initXdsServer` must be called prior to calling this function.
  */
-std::string getXdsServerHost();
+const char* getXdsServerHost();
 
 /**
  * Gets the xDS server port. `initXdsServer` must be called prior to calling this function.

--- a/mobile/test/common/integration/xds_test_server_interface.h
+++ b/mobile/test/common/integration/xds_test_server_interface.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/service/discovery/v3/discovery.pb.h"
+
+// NOLINT(namespace-envoy)
+
+#ifdef __cplusplus
+extern "C" { // functions
+#endif
+
+/** Initializes xDS server. */
+void initXdsServer();
+
+/** Gets the xDS server host. `initXdsServer` must be called prior to calling this function.
+ */
+std::string getXdsServerHost();
+
+/**
+ * Gets the xDS server port. `initXdsServer` must be called prior to calling this function.
+ */
+int getXdsServerPort();
+
+/**
+ * Starts the xDS server. `initXdsServer` must be called prior to calling this function.
+ */
+void startXdsServer();
+
+/**
+ * Sends the `DiscoveryResponse`. `startXdsServer` must be called prior to calling this function.
+ */
+void sendDiscoveryResponse(const envoy::service::discovery::v3::DiscoveryResponse& response);
+
+/**
+ * Shuts down the xDS server. `startXdsServer` must be called prior to calling this function.
+ */
+void shutdownXdsServer();
+
+#ifdef __cplusplus
+} // functions
+#endif

--- a/mobile/test/common/jni/BUILD
+++ b/mobile/test/common/jni/BUILD
@@ -30,6 +30,7 @@ cc_library(
     deps = [
         "//library/common/jni:envoy_jni_lib",
         "//test/common/integration:test_server_interface_lib",
+        "//test/common/integration:xds_test_server_interface_lib",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,

--- a/mobile/test/common/jni/test_jni_interface.cc
+++ b/mobile/test/common/jni/test_jni_interface.cc
@@ -1,9 +1,10 @@
 #include <jni.h>
 
 #include "test/common/integration/test_server_interface.h"
+#include "test/common/integration/xds_test_server_interface.h"
+#include "test/test_common/utility.h"
 
 #include "library/common/jni/jni_support.h"
-#include "library/common/jni/jni_utility.h"
 
 // NOLINT(namespace-envoy)
 
@@ -35,6 +36,55 @@ Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeShutdownTestServer(J
                                                                                jclass clazz) {
   jni_log("[QTS]", "shutting down server");
   shutdown_server();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeInitXdsTestServer(JNIEnv* env,
+                                                                              jclass clazz) {
+  jni_log("[XTS]", "initializing xDS server");
+  initXdsServer();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartXdsTestServer(JNIEnv* env,
+                                                                               jclass clazz) {
+  jni_log("[XTS]", "starting xDS server");
+  startXdsServer();
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetXdsTestServerHost(JNIEnv* env,
+                                                                                 jclass clazz) {
+  jni_log("[XTS]", "getting xDS server host");
+  return env->NewStringUTF(getXdsServerHost().c_str());
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetXdsTestServerPort(JNIEnv* env,
+                                                                                 jclass clazz) {
+  jni_log("[XTS]", "getting xDS server port");
+  return getXdsServerPort();
+}
+
+#ifdef ENVOY_ENABLE_YAML
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeSendDiscoveryResponse(JNIEnv* env,
+                                                                                  jclass clazz,
+                                                                                  jstring yaml) {
+  jni_log("[XTS]", "sending DiscoveryResponse from the xDS server");
+  const char* yaml_chars = env->GetStringUTFChars(yaml, /* isCopy= */ nullptr);
+  envoy::service::discovery::v3::DiscoveryResponse response;
+  Envoy::TestUtility::loadFromYaml(yaml_chars, response);
+  sendDiscoveryResponse(response);
+  env->ReleaseStringUTFChars(yaml, yaml_chars);
+}
+#endif
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeShutdownXdsTestServer(JNIEnv* env,
+                                                                                  jclass clazz) {
+  jni_log("[XTS]", "shutting down xDS server");
+  shutdownXdsServer();
 }
 
 #ifdef ENVOY_ENABLE_YAML

--- a/mobile/test/common/jni/test_jni_interface.cc
+++ b/mobile/test/common/jni/test_jni_interface.cc
@@ -56,7 +56,7 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetXdsTestServerHost(JNIEnv* env,
                                                                                  jclass clazz) {
   jni_log("[XTS]", "getting xDS server host");
-  return env->NewStringUTF(getXdsServerHost().c_str());
+  return env->NewStringUTF(getXdsServerHost());
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/TestJni.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/TestJni.java
@@ -2,7 +2,6 @@ package io.envoyproxy.envoymobile.engine.testing;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration;
-import io.envoyproxy.envoymobile.engine.JniLibrary;
 
 /**
  * Wrapper class for test JNI functions
@@ -10,6 +9,19 @@ import io.envoyproxy.envoymobile.engine.JniLibrary;
 public final class TestJni {
 
   private static final AtomicBoolean sServerRunning = new AtomicBoolean();
+  private static final AtomicBoolean xdsServerRunning = new AtomicBoolean();
+
+  /**
+   * Initializes the xDS test server.
+   *
+   * @throws IllegalStateException if it's already started.
+   */
+  public static void initXdsTestServer() {
+    if (xdsServerRunning.get()) {
+      throw new IllegalStateException("xDS server is already running");
+    }
+    nativeInitXdsTestServer();
+  }
 
   /*
    * Starts the server. Throws an {@link IllegalStateException} if already started.
@@ -32,6 +44,28 @@ public final class TestJni {
   }
 
   /**
+   * Starts the xDS test server.
+   *
+   * @throws IllegalStateException if it's already started.
+   */
+  public static void startXdsTestServer() {
+    if (!xdsServerRunning.compareAndSet(false, true)) {
+      throw new IllegalStateException("xDS server is already running");
+    }
+    nativeStartXdsTestServer();
+  }
+
+  /**
+   * Sends the `DiscoveryResponse` message in the YAML format.
+   */
+  public static void sendDiscoveryResponse(String yaml) {
+    if (!xdsServerRunning.get()) {
+      throw new IllegalStateException("xDS server is not running");
+    }
+    nativeSendDiscoveryResponse(yaml);
+  }
+
+  /**
    * Shutdowns the server. No-op if the server is already shutdown.
    */
   public static void shutdownTestServer() {
@@ -41,11 +75,31 @@ public final class TestJni {
     nativeShutdownTestServer();
   }
 
+  /**
+   * Shutdowns the xDS test server. No-op if the server is already shutdown.
+   */
+  public static void shutdownXdsTestServer() {
+    if (!xdsServerRunning.compareAndSet(true, false)) {
+      return;
+    }
+    nativeShutdownXdsTestServer();
+  }
+
   public static String getServerURL() {
     return "https://" + getServerHost() + ":" + getServerPort();
   }
 
   public static String getServerHost() { return "test.example.com"; }
+
+  /**
+   * Gets the xDS test server host.
+   */
+  public static String getXdsTestServerHost() { return nativeGetXdsTestServerHost(); }
+
+  /**
+   * Gets the xDS test server port.
+   */
+  public static int getXdsTestServerPort() { return nativeGetXdsTestServerPort(); }
 
   /**
    * Returns the server attributed port. Throws an {@link IllegalStateException} if not started.
@@ -68,6 +122,18 @@ public final class TestJni {
   private static native void nativeShutdownTestServer();
 
   private static native int nativeGetServerPort();
+
+  private static native void nativeInitXdsTestServer();
+
+  private static native String nativeGetXdsTestServerHost();
+
+  private static native int nativeGetXdsTestServerPort();
+
+  private static native void nativeStartXdsTestServer();
+
+  private static native void nativeSendDiscoveryResponse(String yaml);
+
+  private static native int nativeShutdownXdsTestServer();
 
   private static native String nativeCreateYaml(long bootstrap);
 

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -206,7 +206,6 @@ envoy_mobile_jni_kt_test(
     ],
 )
 
-#envoy_mobile_jni_kt_test(
 envoy_mobile_android_test(
     name = "send_data_test",
     srcs = [
@@ -281,5 +280,20 @@ envoy_mobile_android_test(
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+    ],
+)
+
+envoy_mobile_android_test(
+    name = "xds_test",
+    srcs = [
+        "XdsTest.kt",
+    ],
+    native_deps = [
+        "//test/common/jni:libenvoy_jni_with_test_extensions.so",
+        "//test/common/jni:libenvoy_jni_with_test_extensions_jnilib",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
     ],
 )

--- a/mobile/test/kotlin/integration/XdsTest.kt
+++ b/mobile/test/kotlin/integration/XdsTest.kt
@@ -1,0 +1,96 @@
+package test.kotlin.integration
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.envoyproxy.envoymobile.AndroidEngineBuilder
+import io.envoyproxy.envoymobile.Engine
+import io.envoyproxy.envoymobile.LogLevel
+import io.envoyproxy.envoymobile.XdsBuilder
+import io.envoyproxy.envoymobile.engine.AndroidJniLibrary
+import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.TestJni
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class XdsTest {
+  private val appContext: Context = ApplicationProvider.getApplicationContext()
+  private lateinit var engine: Engine
+
+  init {
+    AndroidJniLibrary.loadTestLibrary()
+    JniLibrary.load()
+  }
+
+  @Before
+  fun setUp() {
+    TestJni.startHttp2TestServer()
+    TestJni.initXdsTestServer()
+    val latch = CountDownLatch(1)
+    engine = AndroidEngineBuilder(appContext)
+      .addLogLevel(LogLevel.DEBUG)
+      .setOnEngineRunning {
+        latch.countDown()
+      }
+      .setXds(
+        XdsBuilder(
+          TestJni.getXdsTestServerHost(),
+          TestJni.getXdsTestServerPort(),
+        ).addClusterDiscoveryService()
+      )
+      .build()
+    latch.await()
+    TestJni.startXdsTestServer()
+  }
+
+  @After
+  fun tearDown() {
+    engine.terminate()
+    TestJni.shutdownTestServer()
+    TestJni.shutdownXdsTestServer()
+  }
+
+  @Test
+  fun `test xDS with CDS`() {
+    // TODO(fredyw): The current way of asserting the stats is not great. Expose
+    // some utilities from C++ through JNI to make it easy checking the stats.
+    // There are 2 initial clusters: base and base_clear.
+    assertThat(engine.dumpStats()).contains("cluster_manager.cluster_added: 2")
+    val cdsResponse = """
+      version_info: v1
+      resources:
+      - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+        name: my_cluster
+        type: STATIC
+        connect_timeout: 5s
+        load_assignment:
+          cluster_name: xds_cluster
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: ${TestJni.getServerHost()}
+                        port_value: ${TestJni.getServerPort()}
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options:
+                {}
+      type_url: type.googleapis.com/envoy.config.cluster.v3.Cluster
+      nonce: nonce1
+    """.trimIndent()
+    TestJni.sendDiscoveryResponse(cdsResponse)
+    // Give some time until the new cluster is added.
+    TimeUnit.SECONDS.sleep(1)
+    // There are now 3 clusters: base, base_cluster, and xds_cluster.
+    assertThat(engine.dumpStats()).contains("cluster_manager.cluster_added: 3")
+  }
+}


### PR DESCRIPTION
This PR adds an xDS test server to make it easy testing xDS functionality for Android tests as well as adding a simple xDS integration test for Android.

Risk Level: n/a (test only)
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
