### PR TITLE
docs: Clarify UPSTREAM_REMOTE_ADDRESS and UPSTREAM_HOST access log variables are the same

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -511,8 +511,11 @@ UDP
   TCP/UDP
     Not implemented ("-")
 
+.. _config_access_log_format_upstream_host:
+
 %UPSTREAM_HOST%
-  Upstream host URL (e.g., tcp://ip:port for TCP connections).
+  Upstream host URL (e.g., tcp://ip:port for TCP connections). Identical to the :ref:`UPSTREAM_REMOTE_ADDRESS
+  <config_access_log_format_upstream_remote_address>` value.
 
 %UPSTREAM_CLUSTER%
   Upstream cluster to which the upstream host belongs to. :ref:`alt_stat_name
@@ -530,9 +533,11 @@ UDP
   Local port of the upstream connection.
   IP addresses are the only address type with a port component.
 
+.. _config_access_log_format_upstream_remote_address:
+
 %UPSTREAM_REMOTE_ADDRESS%
   Remote address of the upstream connection. If the address is an IP address it includes both
-  address and port.
+  address and port. Identical to the :ref:`UPSTREAM_HOST <config_access_log_format_upstream_host>` value.
 
 %UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%
   Remote address of the upstream connection, without any port component.


### PR DESCRIPTION
These access log variables use identical code so they should always be equivalent. I was initially wondering how these variables differed, but after digging in, I found they have identical source code, so I thought this might be worth pointing out in the docs that these reflect the same value.

I suppose one of these could be deprecated if you all wanted to eliminate the duplication, but that would obviously be a bigger change. In the meantime, I thought clarifying the fact that they are the same might help clear up any confusion, like my own. It seems like `UPSTREAM_REMOTE_ADDRESS` was added more recently (https://github.com/envoyproxy/envoy/pull/19613) and is part of a more consistent set of variables, but `UPSTREAM_HOST` has been around much longer.

Current identical implementation between these two variables on `main`:

https://github.com/envoyproxy/envoy/blob/6092cdcc2f4cce51c7c6409b4452e52d0a185f42/source/common/formatter/stream_info_formatter.cc#L876-L887
https://github.com/envoyproxy/envoy/blob/6092cdcc2f4cce51c7c6409b4452e52d0a185f42/source/common/formatter/stream_info_formatter.cc#L941-L952

Also the same implementation on the `v1.27.0` tag:

https://github.com/envoyproxy/envoy/blob/v1.27.0/source/common/formatter/substitution_formatter.cc#L1128-L1140
https://github.com/envoyproxy/envoy/blob/v1.27.0/source/common/formatter/substitution_formatter.cc#L1205-L1217

Commit Message: docs: Clarify UPSTREAM_REMOTE_ADDRESS and UPSTREAM_HOST are the same 
Additional Description: N/A
Risk Level: Low (docs only)
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A