### PR TITLE
mobile: Create test utilities for dealing with stats

### DIFF
--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -293,7 +293,19 @@ envoy_mobile_android_test(
         "//test/common/jni:libenvoy_jni_with_test_extensions_jnilib",
     ],
     deps = [
+        ":test_utilities",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+    ],
+)
+
+envoy_mobile_kt_library(
+    name = "test_utilities",
+    srcs = [
+        "TestUtilities.kt",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "@maven//:junit_junit",
     ],
 )

--- a/mobile/test/kotlin/integration/TestUtilities.kt
+++ b/mobile/test/kotlin/integration/TestUtilities.kt
@@ -1,0 +1,52 @@
+package test.kotlin.integration
+
+import io.envoyproxy.envoymobile.Engine
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import org.junit.Assert.fail
+
+/**
+ * Gets the stats in the form of `Map<String, String>`.
+ */
+fun Engine.getStats(): Map<String, String> {
+  // `dumpStats()` produces the following format:
+  // key1: value1
+  // key2: value2
+  // key3: value3
+  // ...
+  val lines = dumpStats().split("\n")
+  return lines.mapNotNull {
+    val keyValue = it.split(": ")
+    if (keyValue.size == 2) {
+      Pair(keyValue[0], keyValue[1])
+    } else {
+      null
+    }
+  }.toMap()
+}
+
+/**
+ * Waits for 5 seconds (default) until the stat of the given [name] is greater
+ * than equal the specified [expectedValue].
+ *
+ * @throws java.lang.AssertionError throw when the the operation timed out
+ * waiting for the stat value to be greater than the [expectedValue].
+ */
+fun Engine.waitForStatGe(
+  name: String, expectedValue: Long,
+  timeout: Duration = 5.seconds,
+) {
+  val waitTime = Instant.now().plusMillis(timeout.toLong(DurationUnit.MILLISECONDS))
+  var currentValue = getStats()[name]
+  while (currentValue == null || currentValue.toLong() < expectedValue) {
+    if (Instant.now() > waitTime) {
+      fail("Timed out waiting for $name to be greater than equal $expectedValue")
+    }
+    TimeUnit.MILLISECONDS.sleep(10)
+    currentValue = getStats()[name]
+  }
+}
+

--- a/mobile/test/kotlin/integration/XdsTest.kt
+++ b/mobile/test/kotlin/integration/XdsTest.kt
@@ -58,10 +58,8 @@ class XdsTest {
 
   @Test
   fun `test xDS with CDS`() {
-    // TODO(fredyw): The current way of asserting the stats is not great. Expose
-    // some utilities from C++ through JNI to make it easy checking the stats.
     // There are 2 initial clusters: base and base_clear.
-    assertThat(engine.dumpStats()).contains("cluster_manager.cluster_added: 2")
+    engine.waitForStatGe("cluster_manager.cluster_added",  2)
     val cdsResponse = """
       version_info: v1
       resources:
@@ -88,9 +86,7 @@ class XdsTest {
       nonce: nonce1
     """.trimIndent()
     TestJni.sendDiscoveryResponse(cdsResponse)
-    // Give some time until the new cluster is added.
-    TimeUnit.SECONDS.sleep(1)
     // There are now 3 clusters: base, base_cluster, and xds_cluster.
-    assertThat(engine.dumpStats()).contains("cluster_manager.cluster_added: 3")
+    engine.waitForStatGe("cluster_manager.cluster_added", 3)
   }
 }


### PR DESCRIPTION
This PR creates test utilities that can be useful for asserting stats in the integration tests. This PR also updates `XdsTest` to use these test utilities.

Risk Level: n/a (test only)
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
