### PR TITLE
[test] Fix ProtocolIntegrationTest.HittingEncoderFilterLimit

### DIFF
--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -207,6 +207,7 @@ void EnvoyQuicServerSession::ProcessUdpPacket(const quic::QuicSocketAddress& sel
       self_address == connection()->sent_server_preferred_address()) {
     connection_stats_.num_packets_rx_on_preferred_address_.inc();
   }
+  maybeApplyDelayedClose();
 }
 
 } // namespace Quic

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -156,8 +156,9 @@ void QuicFilterManagerConnectionImpl::maybeUpdateDelayCloseTimer(bool has_sent_a
   }
 }
 
-void QuicFilterManagerConnectionImpl::onWriteEventDone() {
-  // Apply delay close policy if there is any.
+void QuicFilterManagerConnectionImpl::onWriteEventDone() { maybeApplyDelayedClose(); }
+
+void QuicFilterManagerConnectionImpl::maybeApplyDelayedClose() {
   if (!hasDataToWrite() && inDelayedClose() &&
       delayed_close_state_ != DelayedCloseState::CloseAfterFlushAndWait) {
     closeConnectionImmediately();

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -177,6 +177,8 @@ protected:
                               quic::ConnectionCloseSource source,
                               const quic::ParsedQuicVersion& version);
 
+  // Apply delay close policy if there is any.
+  void maybeApplyDelayedClose();
   void closeConnectionImmediately() override;
 
   virtual bool hasDataToWrite() PURE;

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1379,9 +1379,6 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
 // Test hitting the encoder buffer filter with too many response bytes to buffer. Given the request
 // headers are sent on early, the stream/connection will be reset.
 TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
-  config_helper_.addRuntimeOverride("envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_"
-                                    "quic_no_send_alarm_unless_necessary",
-                                    "false");
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void {


### PR DESCRIPTION
Fix ProtocolIntegrationTest.HittingEncoderFilterLimit when --quic_no_send_alarm_unless_necessary is true.

Previously, the test passes because at the end of `EnvoyQuicServerSession::ProcessUdpPacket`, a send alarm is always scheduled, and `QuicFilterManagerConnectionImpl::onWriteEventDone` will be called when the alarm fires. 

With the flag=true, send alarm is only scheduled when it is necessary, so `QuicFilterManagerConnectionImpl::onWriteEventDone` may not be called. This change adds a `QuicFilterManagerConnectionImpl::maybeApplyDelayedClose` method(which does the same thing as onWriteEventDone) and always call it at the end of `EnvoyQuicServerSession::ProcessUdpPacket`. 