### PR TITLE
Implement drainManager API for config validation server instance

### DIFF
--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -119,8 +119,10 @@ void ValidationInstance::initialize(const Options& options,
   ENVOY_BUG(runtime_ != nullptr,
             "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
+  ENVOY_LOG_MISC(critical, "Drain manager is null? {}", (drain_manager_ == nullptr));
   ENVOY_BUG(drain_manager_ != nullptr,
             "Component factory should not return nullptr from createDrainManager()");
+  ENVOY_LOG_MISC(critical, "After envoy bug");
 
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>(admin()->getConfigTracker());
   ssl_context_manager_ = createContextManager("ssl_context_manager", api_->timeSource());

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -119,6 +119,7 @@ void ValidationInstance::initialize(const Options& options,
   ENVOY_BUG(runtime_ != nullptr,
             "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
+  ENVOY_LOG(critical, "Drain manager is nullptr? {}", (drain_manager_ == nullptr));
   ENVOY_BUG(drain_manager_ != nullptr,
             "Component factory should not return nullptr from createDrainManager()");
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,7 +116,11 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   runtime_ = component_factory.createRuntime(*this, initial_config);
+  ENVOY_BUG(runtime_ == nullptr,
+            "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
+  ENVOY_BUG(drain_manager_ == nullptr,
+            "Component factory should not return nullptr from createDrainManager()");
 
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>(admin()->getConfigTracker());
   ssl_context_manager_ = createContextManager("ssl_context_manager", api_->timeSource());

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,10 +116,10 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   runtime_ = component_factory.createRuntime(*this, initial_config);
-  ENVOY_BUG(drain_manager_ == nullptr,
+  ENVOY_BUG(drain_manager_ != nullptr,
             "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
-  ENVOY_BUG(drain_manager_ == nullptr,
+  ENVOY_BUG(drain_manager_ != nullptr,
             "Component factory should not return nullptr from createDrainManager()");
 
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>(admin()->getConfigTracker());

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -119,7 +119,6 @@ void ValidationInstance::initialize(const Options& options,
   ENVOY_BUG(runtime_ != nullptr,
             "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
-  ENVOY_LOG(critical, "Drain manager is nullptr? {}", (drain_manager_ == nullptr));
   ENVOY_BUG(drain_manager_ != nullptr,
             "Component factory should not return nullptr from createDrainManager()");
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -119,10 +119,8 @@ void ValidationInstance::initialize(const Options& options,
   ENVOY_BUG(runtime_ != nullptr,
             "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
-  ENVOY_LOG_MISC(critical, "Drain manager is null? {}", (drain_manager_ == nullptr));
   ENVOY_BUG(drain_manager_ != nullptr,
             "Component factory should not return nullptr from createDrainManager()");
-  ENVOY_LOG_MISC(critical, "After envoy bug");
 
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>(admin()->getConfigTracker());
   ssl_context_manager_ = createContextManager("ssl_context_manager", api_->timeSource());

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,6 +116,8 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   runtime_ = component_factory.createRuntime(*this, initial_config);
+  ENVOY_BUG(drain_manager_ == nullptr,
+            "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
   ENVOY_BUG(drain_manager_ == nullptr,
             "Component factory should not return nullptr from createDrainManager()");

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,6 +116,7 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   runtime_ = component_factory.createRuntime(*this, initial_config);
+  drain_manager_ = component_factory.createDrainManager(*this);
 
   secret_manager_ = std::make_unique<Secret::SecretManagerImpl>(admin()->getConfigTracker());
   ssl_context_manager_ = createContextManager("ssl_context_manager", api_->timeSource());

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,8 +116,6 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   runtime_ = component_factory.createRuntime(*this, initial_config);
-  ENVOY_BUG(runtime_ == nullptr,
-            "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
   ENVOY_BUG(drain_manager_ == nullptr,
             "Component factory should not return nullptr from createDrainManager()");

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,7 +116,7 @@ void ValidationInstance::initialize(const Options& options,
   thread_local_.registerThread(*dispatcher_, true);
 
   runtime_ = component_factory.createRuntime(*this, initial_config);
-  ENVOY_BUG(drain_manager_ != nullptr,
+  ENVOY_BUG(runtime_ != nullptr,
             "Component factory should not return nullptr from createRuntime()");
   drain_manager_ = component_factory.createDrainManager(*this);
   ENVOY_BUG(drain_manager_ != nullptr,

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -85,7 +85,7 @@ public:
     return dns_resolver_factory.createDnsResolver(dispatcher(), api(), typed_dns_resolver_config);
   }
   void drainListeners(OptRef<const Network::ExtraShutdownListenerOptions>) override {}
-  DrainManager& drainManager() override { PANIC("not implemented"); }
+  DrainManager& drainManager() override { return *drain_manager_; }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
   void failHealthcheck(bool) override {}
   HotRestart& hotRestart() override { PANIC("not implemented"); }
@@ -188,6 +188,7 @@ private:
   ServerFactoryContextImpl server_contexts_;
   Quic::QuicStatNames quic_stat_names_;
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
+  Server::DrainManagerPtr drain_manager_;
 };
 
 } // namespace Server

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -85,7 +85,10 @@ public:
     return dns_resolver_factory.createDnsResolver(dispatcher(), api(), typed_dns_resolver_config);
   }
   void drainListeners(OptRef<const Network::ExtraShutdownListenerOptions>) override {}
-  DrainManager& drainManager() override { return *drain_manager_; }
+  DrainManager& drainManager() override {
+    ENVOY_LOG_MISC(critical, "Call to drainManager() in server");
+    return *drain_manager_;
+  }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
   void failHealthcheck(bool) override {}
   HotRestart& hotRestart() override { PANIC("not implemented"); }

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -85,10 +85,7 @@ public:
     return dns_resolver_factory.createDnsResolver(dispatcher(), api(), typed_dns_resolver_config);
   }
   void drainListeners(OptRef<const Network::ExtraShutdownListenerOptions>) override {}
-  DrainManager& drainManager() override {
-    ENVOY_LOG_MISC(critical, "Call to drainManager() in server");
-    return *drain_manager_;
-  }
+  DrainManager& drainManager() override { return *drain_manager_; }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
   void failHealthcheck(bool) override {}
   HotRestart& hotRestart() override { PANIC("not implemented"); }

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -25,7 +25,10 @@ namespace {
 
 class NullptrComponentFactory : public TestComponentFactory {
 public:
-  DrainManagerPtr createDrainManager(Instance&) override { return nullptr; }
+  DrainManagerPtr createDrainManager(Instance&) override { 
+    ENVOY_LOG_MISC(critical, "Returning nullptr for drain manager");
+    return nullptr; 
+  }
 };
 
 // Test param is the path to the config file to validate.

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -184,6 +184,7 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
   server.failHealthcheck(true);
   server.lifecycleNotifier();
   server.secretManager();
+  server.drainManager();
   EXPECT_FALSE(server.isShutdown());
   EXPECT_FALSE(server.healthCheckFailed());
   server.grpcContext();
@@ -210,8 +211,6 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 
   ValidationListenerComponentFactory listener_component_factory(server);
   listener_component_factory.getTcpListenerConfigProviderManager();
-
-  EXPECT_NE(server.drainManager(), nullptr);
 }
 
 // TODO(rlazarus): We'd like use this setup to replace //test/config_test (that is, run it against

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -23,10 +23,9 @@ namespace Envoy {
 namespace Server {
 namespace {
 
-class NullptrComponentFactory : public ComponentFactory {
+class NullptrComponentFactory : public TestComponentFactory {
 public:
   DrainManagerPtr createDrainManager(Instance&) override { return nullptr; }
-  Runtime::LoaderPtr createRuntime(Instance&, Configuration::Initial&) override { return nullptr; }
 };
 
 // Test param is the path to the config file to validate.
@@ -217,22 +216,6 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 
   ValidationListenerComponentFactory listener_component_factory(server);
   listener_component_factory.getTcpListenerConfigProviderManager();
-}
-
-// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
-// the Envoy runtime.
-TEST_P(ValidationServerTest, RuntimeNullptrCheck) {
-  // Setup the server instance.
-  NullptrComponentFactory component_factory;
-  Thread::MutexBasicLockable access_log_lock;
-  Stats::IsolatedStoreImpl stats_store;
-  DangerousDeprecatedTestTime time_system;
-  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
-                                             Network::Address::InstanceConstSharedPtr(),
-                                             stats_store, access_log_lock, component_factory,
-                                             Thread::threadFactoryForTest(),
-                                             Filesystem::fileSystemForTest()),
-                   "Component factory should not return nullptr from createRuntime()");
 }
 
 // A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -220,22 +220,6 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 }
 
 // A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
-// the Envoy runtime.
-TEST_P(ValidationServerTest, RuntimeNullptrCheck) {
-  // Setup the server instance.
-  NullptrComponentFactory component_factory;
-  Thread::MutexBasicLockable access_log_lock;
-  Stats::IsolatedStoreImpl stats_store;
-  DangerousDeprecatedTestTime time_system;
-  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
-                                             Network::Address::InstanceConstSharedPtr(),
-                                             stats_store, access_log_lock, component_factory,
-                                             Thread::threadFactoryForTest(),
-                                             Filesystem::fileSystemForTest()),
-                   "Component factory should not return nullptr from createRuntime()");
-}
-
-// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
 // the drain manager.
 TEST_P(ValidationServerTest, DrainManagerNullptrCheck) {
   // Setup the server instance.

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -218,22 +218,6 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
   listener_component_factory.getTcpListenerConfigProviderManager();
 }
 
-// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
-// the drain manager.
-TEST_P(ValidationServerTest, DrainManagerNullptrCheck) {
-  // Setup the server instance.
-  NullptrComponentFactory component_factory;
-  Thread::MutexBasicLockable access_log_lock;
-  Stats::IsolatedStoreImpl stats_store;
-  DangerousDeprecatedTestTime time_system;
-  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
-                                             Network::Address::InstanceConstSharedPtr(),
-                                             stats_store, access_log_lock, component_factory,
-                                             Thread::threadFactoryForTest(),
-                                             Filesystem::fileSystemForTest()),
-                   "Component factory should not return nullptr from createDrainManager()");
-}
-
 // TODO(rlazarus): We'd like use this setup to replace //test/config_test (that is, run it against
 // all the example configs) but can't until light validation is implemented, mocking out access to
 // the filesystem for TLS certs, etc. In the meantime, these are the example configs that work
@@ -260,6 +244,24 @@ TEST_P(ValidationServerTest1, RunWithoutCrash) {
 
 INSTANTIATE_TEST_SUITE_P(AllConfigs, ValidationServerTest1,
                          ::testing::ValuesIn(ValidationServerTest1::getAllConfigFiles()));
+
+
+// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
+// the drain manager.
+TEST_P(RuntimeFeatureValidationServerTest, DrainManagerNullptrCheck) {
+  // Setup the server instance with a component factory that returns a null DrainManager.
+  NullptrComponentFactory component_factory;
+  Thread::MutexBasicLockable access_log_lock;
+  Stats::IsolatedStoreImpl stats_store;
+  DangerousDeprecatedTestTime time_system;
+  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
+                                             Network::Address::InstanceConstSharedPtr(),
+                                             stats_store, access_log_lock, component_factory,
+                                             Thread::threadFactoryForTest(),
+                                             Filesystem::fileSystemForTest()),
+                   "Component factory should not return nullptr from createDrainManager()");
+}
+
 
 TEST_P(RuntimeFeatureValidationServerTest, ValidRuntimeLoader) {
   Thread::MutexBasicLockable access_log_lock;

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -23,6 +23,12 @@ namespace Envoy {
 namespace Server {
 namespace {
 
+class NullptrComponentFactory : public ComponentFactory {
+public:
+  DrainManagerPtr createDrainManager(Instance&) override { return nullptr; }
+  Runtime::LoaderPtr createRuntime(Instance&, Configuration::Initial&) override { return nullptr; }
+};
+
 // Test param is the path to the config file to validate.
 class ValidationServerTest : public testing::TestWithParam<std::string> {
 public:
@@ -211,6 +217,38 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 
   ValidationListenerComponentFactory listener_component_factory(server);
   listener_component_factory.getTcpListenerConfigProviderManager();
+}
+
+// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
+// the Envoy runtime.
+TEST_P(ValidationServerTest, RuntimeNullptrCheck) {
+  // Setup the server instance.
+  NullptrComponentFactory component_factory;
+  Thread::MutexBasicLockable access_log_lock;
+  Stats::IsolatedStoreImpl stats_store;
+  DangerousDeprecatedTestTime time_system;
+  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
+                                             Network::Address::InstanceConstSharedPtr(),
+                                             stats_store, access_log_lock, component_factory,
+                                             Thread::threadFactoryForTest(),
+                                             Filesystem::fileSystemForTest()),
+                   "Component factory should not return nullptr from createRuntime()");
+}
+
+// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
+// the drain manager.
+TEST_P(ValidationServerTest, DrainManagerNullptrCheck) {
+  // Setup the server instance.
+  NullptrComponentFactory component_factory;
+  Thread::MutexBasicLockable access_log_lock;
+  Stats::IsolatedStoreImpl stats_store;
+  DangerousDeprecatedTestTime time_system;
+  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
+                                             Network::Address::InstanceConstSharedPtr(),
+                                             stats_store, access_log_lock, component_factory,
+                                             Thread::threadFactoryForTest(),
+                                             Filesystem::fileSystemForTest()),
+                   "Component factory should not return nullptr from createDrainManager()");
 }
 
 // TODO(rlazarus): We'd like use this setup to replace //test/config_test (that is, run it against

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -245,7 +245,6 @@ TEST_P(ValidationServerTest1, RunWithoutCrash) {
 INSTANTIATE_TEST_SUITE_P(AllConfigs, ValidationServerTest1,
                          ::testing::ValuesIn(ValidationServerTest1::getAllConfigFiles()));
 
-
 // A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
 // the drain manager.
 TEST_P(RuntimeFeatureValidationServerTest, DrainManagerNullptrCheck) {
@@ -261,7 +260,6 @@ TEST_P(RuntimeFeatureValidationServerTest, DrainManagerNullptrCheck) {
                                              Filesystem::fileSystemForTest()),
                    "Component factory should not return nullptr from createDrainManager()");
 }
-
 
 TEST_P(RuntimeFeatureValidationServerTest, ValidRuntimeLoader) {
   Thread::MutexBasicLockable access_log_lock;

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -25,9 +25,9 @@ namespace {
 
 class NullptrComponentFactory : public TestComponentFactory {
 public:
-  DrainManagerPtr createDrainManager(Instance&) override { 
+  DrainManagerPtr createDrainManager(Instance&) override {
     ENVOY_LOG_MISC(critical, "Returning nullptr for drain manager");
-    return nullptr; 
+    return nullptr;
   }
 };
 

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -23,11 +23,6 @@ namespace Envoy {
 namespace Server {
 namespace {
 
-class NullDrainManagerComponentFactory : public TestComponentFactory {
-public:
-  DrainManagerPtr createDrainManager(Instance&) override { return nullptr; }
-};
-
 // Test param is the path to the config file to validate.
 class ValidationServerTest : public testing::TestWithParam<std::string> {
 public:
@@ -216,22 +211,6 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 
   ValidationListenerComponentFactory listener_component_factory(server);
   listener_component_factory.getTcpListenerConfigProviderManager();
-}
-
-// A test to ensure that ENVOY_BUGs are handled when the component factory returns a nullptr for
-// the drain manager.
-TEST_P(ValidationServerTest, DrainManagerNullptrCheck) {
-  // Setup the server instance.
-  NullDrainManagerComponentFactory component_factory;
-  Thread::MutexBasicLockable access_log_lock;
-  Stats::IsolatedStoreImpl stats_store;
-  DangerousDeprecatedTestTime time_system;
-  EXPECT_ENVOY_BUG(ValidationInstance server(options_, time_system.timeSystem(),
-                                             Network::Address::InstanceConstSharedPtr(),
-                                             stats_store, access_log_lock, component_factory,
-                                             Thread::threadFactoryForTest(),
-                                             Filesystem::fileSystemForTest()),
-                   "Component factory should not return nullptr from createDrainManager()");
 }
 
 // TODO(rlazarus): We'd like use this setup to replace //test/config_test (that is, run it against

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -210,6 +210,8 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 
   ValidationListenerComponentFactory listener_component_factory(server);
   listener_component_factory.getTcpListenerConfigProviderManager();
+
+  EXPECT_NE(server.drainManager(), nullptr);
 }
 
 // TODO(rlazarus): We'd like use this setup to replace //test/config_test (that is, run it against

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -25,10 +25,7 @@ namespace {
 
 class NullptrComponentFactory : public TestComponentFactory {
 public:
-  DrainManagerPtr createDrainManager(Instance&) override {
-    ENVOY_LOG_MISC(critical, "Returning nullptr for drain manager");
-    return nullptr;
-  }
+  DrainManagerPtr createDrainManager(Instance&) override { return nullptr; }
 };
 
 // Test param is the path to the config file to validate.

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -23,10 +23,9 @@ namespace Envoy {
 namespace Server {
 namespace {
 
-class NullptrComponentFactory : public ComponentFactory {
+class NullDrainManagerComponentFactory : public TestComponentFactory {
 public:
   DrainManagerPtr createDrainManager(Instance&) override { return nullptr; }
-  Runtime::LoaderPtr createRuntime(Instance&, Configuration::Initial&) override { return nullptr; }
 };
 
 // Test param is the path to the config file to validate.
@@ -223,7 +222,7 @@ TEST_P(ValidationServerTest, DummyMethodsTest) {
 // the drain manager.
 TEST_P(ValidationServerTest, DrainManagerNullptrCheck) {
   // Setup the server instance.
-  NullptrComponentFactory component_factory;
+  NullDrainManagerComponentFactory component_factory;
   Thread::MutexBasicLockable access_log_lock;
   Stats::IsolatedStoreImpl stats_store;
   DangerousDeprecatedTestTime time_system;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Implement drainManager API for config validation server instance
Additional Description: The drainManager() API can be used in configuration validation, but the current implementation panic's on access.
Risk Level: Low
Testing: Tested on local machine with a configuration that requires a drain manager.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
