### PR TITLE
docs: Fix multiple log level example in admin.rst

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -309,7 +309,7 @@ modify different aspects of the server:
 
   - To change the logging level across all loggers, set the query parameter as level=<desired_level>.
   - To change a particular logger's level, set the query parameter like so, <logger_name>=<desired_level>.
-  - To change multiple logging levels at once, set the query parameter as paths=<logger_name1>=<desired_level1>,<logger_name2>=<desired_level2>.
+  - To change multiple logging levels at once, set the query parameter as paths=<logger_name1>:<desired_level1>,<logger_name2>:<desired_level2>.
   - To list the loggers, send a POST request to the /logging endpoint without a query parameter.
 
   .. note::

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -309,7 +309,7 @@ modify different aspects of the server:
 
   - To change the logging level across all loggers, set the query parameter as level=<desired_level>.
   - To change a particular logger's level, set the query parameter like so, <logger_name>=<desired_level>.
-  - To change multiple logging levels at once, set the query parameter as paths=<logger_name1>:<desired_level1>,<logger_name2>:<desired_level2>.
+  - To change multiple logging levels at once, set the query parameter as ``paths=<logger_name1>:<desired_level1>,<logger_name2>:<desired_level2>``.
   - To list the loggers, send a POST request to the /logging endpoint without a query parameter.
 
   .. note::


### PR DESCRIPTION
Fix the example in admin.rst to use the correct syntax for setting the log level for multiple loggers.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix the example in admin.rst to use the correct syntax for setting the log level for multiple loggers.
Additional Description: N/A
Risk Level: Low (docs only)
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A