### PR TITLE
fuzz: ensure runCleanupHooks is invoked on exit

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -1,5 +1,7 @@
 #include "test/fuzz/fuzz_runner.h"
 
+#include <cstdlib>
+
 #include "source/common/common/thread.h"
 #include "source/common/common/utility.h"
 #include "source/common/event/libevent.h"
@@ -88,5 +90,6 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
   testing::GMOCK_FLAG(verbose) = "error";
   testing::InitGoogleMock(argc, *argv);
   Envoy::Fuzz::Runner::setupEnvironment(1, *argv, spdlog::level::critical);
+  atexit(Envoy::Fuzz::runCleanupHooks);
   return 0;
 }


### PR DESCRIPTION
Commit Message: fuzz: ensure runCleanupHooks is invoked on exit
Additional Description:
#29522 introduced cleanup hooks, and assumes a call will be made to `runCleanupHooks` at the end.
Some executions don't use our custom `main` file, so this PR ensures that the function will be invoked.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
