### PR TITLE
otlp_stat_sink: mitigate test flakes

### DIFF
--- a/test/extensions/stats_sinks/open_telemetry/open_telemetry_integration_test.cc
+++ b/test/extensions/stats_sinks/open_telemetry/open_telemetry_integration_test.cc
@@ -61,7 +61,7 @@ public:
       metrics_sink->mutable_typed_config()->PackFrom(sink_config);
 
       bootstrap.mutable_stats_flush_interval()->CopyFrom(
-          Protobuf::util::TimeUtil::MillisecondsToDuration(300));
+          Protobuf::util::TimeUtil::MillisecondsToDuration(500));
     });
 
     HttpIntegrationTest::initialize();


### PR DESCRIPTION
Additional Description: This change will mitigate the test flakes as described in #29518. Requires further investigation to understand root cause
Risk Level: low
