### PR TITLE
ci/publishing: Remove postsubmit docs build

### DIFF
--- a/.azure-pipelines/env.yml
+++ b/.azure-pipelines/env.yml
@@ -174,32 +174,18 @@ jobs:
 
       PUBLISH_GITHUB_RELEASE=$(run.packaging)
       PUBLISH_DOCKERHUB=false
-      PUBLISH_DOCS=false
-      PUBLISH_DOCS_LATEST=false
-      PUBLISH_DOCS_RELEASE=false
 
       if [[ "$ISSTABLEBRANCH" == True && -n "$POSTSUBMIT" && "$NOSYNC" != true ]]; then
-          # Build docs for publishing either latest or a release build
-          PUBLISH_DOCS=true
           # main
           if [[ "$ISMAIN" == True ]]; then
               # Update the Dockerhub README
               PUBLISH_DOCKERHUB=true
-              if [[ "$(state.isDev)" == true ]]; then
-                  # Postsubmit on `main` trigger rebuild of latest docs
-                  PUBLISH_DOCS_LATEST=true
-              fi
           # Not main, and not -dev
           elif [[ "$(state.isDev)" == false ]]; then
               if [[ "$(state.versionPatch)" -eq 0 ]]; then
                   # A just-forked branch
                   PUBLISH_GITHUB_RELEASE=false
               fi
-              # A stable release, publish docs to the release
-              PUBLISH_DOCS_RELEASE=true
-          else
-              # Postsubmit for non-main/release, skip publishing docs in this case
-              PUBLISH_DOCS=false
           fi
       fi
 
@@ -210,9 +196,6 @@ jobs:
 
       echo "##vso[task.setvariable variable=githubRelease;isoutput=true]${PUBLISH_GITHUB_RELEASE}"
       echo "##vso[task.setvariable variable=dockerhub;isoutput=true]${PUBLISH_DOCKERHUB}"
-      echo "##vso[task.setvariable variable=docs;isoutput=true]${PUBLISH_DOCS}"
-      echo "##vso[task.setvariable variable=docsLatest;isoutput=true]${PUBLISH_DOCS_LATEST}"
-      echo "##vso[task.setvariable variable=docsRelease;isoutput=true]${PUBLISH_DOCS_RELEASE}"
 
     displayName: "Decide what to publish"
     workingDirectory: $(Build.SourcesDirectory)
@@ -234,9 +217,6 @@ jobs:
       echo
       echo "env.outputs['publish.githubRelease']: $(publish.githubRelease)"
       echo "env.outputs['publish.dockerhub]: $(publish.dockerhub)"
-      echo "env.outputs['publish.docs]: $(publish.docs)"
-      echo "env.outputs['publish.docsLatest]: $(publish.docsLatest)"
-      echo "env.outputs['publish.docsRelease]: $(publish.docsRelease)"
 
     displayName: "Print build environment"
 

--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -45,15 +45,6 @@ parameters:
 - name: authDockerPassword
   type: string
   default: ""
-- name: authSSHDocsKey
-  type: string
-  default: ""
-- name: authSSHDocsKeyPublic
-  type: string
-  default: ""
-- name: authSSHKeyPassphrase
-  type: string
-  default: ""
 
 - name: runDocker
   displayName: "Run Docker"
@@ -66,18 +57,6 @@ parameters:
 
 - name: publishDockerhub
   displayName: "Publish Dockerhub"
-  type: string
-  default: false
-- name: publishDocs
-  displayName: "Publish Docs"
-  type: string
-  default: false
-- name: publishDocsLatest
-  displayName: "Publish latest docs"
-  type: string
-  default: false
-- name: publishDocsRelease
-  displayName: "Publish release docs"
   type: string
   default: false
 - name: publishGithubRelease
@@ -135,6 +114,22 @@ jobs:
           DOCKER_BUILD_TIMEOUT: ${{ parameters.timeoutDockerBuild }}
           ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
           ENVOY_DOCKER_IN_DOCKER: 1
+
+      stepsPost:
+      - script: |
+          ci/run_envoy_docker.sh 'ci/do_ci.sh dockerhub-publish'
+        condition: |
+          and(not(canceled()), succeeded(),
+              eq(${{ parameters.publishDockerhub }}, 'true'))
+        displayName: "Publish Dockerhub description and README"
+        env:
+          ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+          ENVOY_RBE: "1"
+          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
+          GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
+          GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
+          DOCKERHUB_USERNAME: ${{ parameters.authDockerUser }}
+          DOCKERHUB_PASSWORD: ${{ parameters.authDockerPassword }}
 
 - job: package_x64
   displayName: Linux debs (x64)
@@ -209,58 +204,6 @@ jobs:
           set -e
           rm -rf $(Build.StagingDirectory)/.gnupg
 
-- job: docs
-  displayName: Publish docs
-  dependsOn: []
-  condition: |
-    and(not(canceled()),
-        eq(${{ parameters.publishDocs }}, 'true'))
-  pool:
-    vmImage: $(agentUbuntu)
-  steps:
-  - template: ../ci.yml
-    parameters:
-      ciTarget: docs
-      cacheName: docs
-      cacheVersion: $(cacheKeyBazel)
-      publishEnvoy: false
-      publishTestResults: false
-      env:
-        CI_BRANCH: $(Build.SourceBranch)
-      stepsPost:
-
-      - script: |
-          ci/run_envoy_docker.sh 'ci/do_ci.sh dockerhub-publish'
-        condition: |
-          and(not(canceled()),
-              eq(${{ parameters.publishDockerhub }}, 'true'))
-        displayName: "Publish Dockerhub description and README"
-        env:
-          ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
-          ENVOY_RBE: "1"
-          BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --config=rbe-google --jobs=$(RbeJobs)"
-          GCP_SERVICE_ACCOUNT_KEY: ${{ parameters.authGCP }}
-          GCS_ARTIFACT_BUCKET: ${{ parameters.bucketGCP }}
-          DOCKERHUB_USERNAME: ${{ parameters.authDockerUser }}
-          DOCKERHUB_PASSWORD: ${{ parameters.authDockerPassword }}
-
-      # Publish docs to the website
-      - task: InstallSSHKey@0
-        condition: |
-          and(not(canceled()),
-              eq(${{ parameters.publishDocsRelease }}, 'true'))
-        inputs:
-          hostName: $(authGithubSSHKeyPublic)
-          sshPublicKey: "${{ parameters.authSSHDocsKeyPublic }}"
-          sshPassphrase: "${{ parameters.authSSHKeyPassphrase }}"
-          sshKeySecureFile: "${{ parameters.authSSHDocsKey }}"
-      - script: docs/publish.sh
-        condition: |
-          and(not(canceled()),
-              eq(${{ parameters.publishDocsRelease }}, 'true'))
-        displayName: "Publish release docs"
-        workingDirectory: $(Build.SourcesDirectory)
-
 - job: signed_release
   displayName: Signed binaries
   dependsOn:
@@ -301,7 +244,7 @@ jobs:
           pathGPGConfiguredHome: /build/.gnupg
           pathGPGHome: $(Build.StagingDirectory)/.gnupg
 - job: success
-  dependsOn: ["docker", "docs", "signed_release"]
+  dependsOn: ["docker", "signed_release"]
   displayName: Success (linux artefacts)
   pool:
     vmImage: $(agentUbuntu)
@@ -312,7 +255,6 @@ jobs:
   condition: |
     and(
       in(dependencies.docker.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-      in(dependencies.docs.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
       in(dependencies.signed_release.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'))
   steps:
   - checkout: none

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -57,7 +57,6 @@ stages:
   jobs:
   - template: env.yml
 
-
 - stage: prechecks
   displayName: Prechecks
   dependsOn: ["env"]
@@ -123,9 +122,6 @@ stages:
     RUN_PACKAGING: $[stageDependencies.env.repo.outputs['run.packaging']]
     PUBLISH_GITHUB_RELEASE: $[stageDependencies.env.repo.outputs['publish.githubRelease']]
     PUBLISH_DOCKERHUB: $[stageDependencies.env.repo.outputs['publish.dockerhub']]
-    PUBLISH_DOCS: $[stageDependencies.env.repo.outputs['publish.docs']]
-    PUBLISH_DOCS_LATEST: $[stageDependencies.env.repo.outputs['publish.docsLatest']]
-    PUBLISH_DOCS_RELEASE: $[stageDependencies.env.repo.outputs['publish.docsRelease']]
   jobs:
   - template: stage/publish.yml
     parameters:
@@ -138,17 +134,11 @@ stages:
       authGPGPassphrase: $(MaintainerGPGKeyPassphrase)
       authGPGKey: $(MaintainerGPGKeySecureFileDownloadPath)
       authGPGPath: $(MaintainerGPGKey.secureFilePath)
-      authSSHDocsKeyPublic: $(DocsPublicKey)
-      authSSHDocsKey: $(DocsPrivateKey)
-      authSSHKeyPassphrase: $(SshDeployKeyPassphrase)
       bucketGCP: $(GcsArtifactBucket)
       timeoutDockerBuild: ${{ parameters.timeoutDockerBuild }}
       timeoutDockerPublish: ${{ parameters.timeoutDockerPublish }}
       runDocker: variables['RUN_DOCKER']
       runPackaging: variables['RUN_PACKAGING']
-      publishDocs: variables['PUBLISH_DOCS']
-      publishDocsLatest: variables['PUBLISH_DOCS_LATEST']
-      publishDocsRelease: variables['PUBLISH_DOCS_RELEASE']
       publishDockerhub: variables['PUBLISH_DOCKERHUB']
       publishGithubRelease: variables['PUBLISH_GITHUB_RELEASE']
 

--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -37,18 +37,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish_docs:
-    if: ${{ inputs.trusted }}
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.0.18
-      with:
-        app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
-        key: "${{ secrets.ENVOY_CI_SYNC_APP_KEY }}"
-        ref: main
-        repository: "envoyproxy/envoy-website"
-        workflow: envoy-sync.yaml
-
   publish_ci:
     if: ${{ ! inputs.trusted }}
     name: ${{ matrix.name || matrix.target }}
@@ -105,3 +93,17 @@ jobs:
       run_pre_with: ${{ matrix.run_pre_with }}
       env: ${{ matrix.env }}
       trusted: true
+
+  publish_docs:
+    if: ${{ inputs.trusted }}
+    runs-on: ubuntu-22.04
+    needs:
+    - publish
+    steps:
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@actions-v0.0.18
+      with:
+        app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
+        key: "${{ secrets.ENVOY_CI_SYNC_APP_KEY }}"
+        ref: main
+        repository: ${ inputs.version_dev != '' && 'envoyproxy/envoy-website' || 'envoyproxy/archive' }
+        workflow: envoy-sync.yaml


### PR DESCRIPTION
this is now handled downstream

For normal commits to Envoy `main` this will trigger an update in the website repo, which will update its envoy dep shas, and rebuild the website for the latest docs

For commits that create a release, it instead triggers an update in the archive repo, which builds a static version of the docs for the release and commits it to the archive. In turn the archive repo triggers an update in the website so the new release docs are included in the published site

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
