### PR TITLE
quic: fix flaky gso test

### DIFF
--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -607,10 +607,9 @@ TEST_P(UdpListenerImplTest, UdpGroBasic) {
       }))
       .WillRepeatedly(Return(Api::SysCallSizeResult{-1, EAGAIN}));
 
-  EXPECT_CALL(listener_callbacks_, onReadReady()).WillOnce(Invoke([&](){
-    dispatcher_->exit();
-  }));
-  EXPECT_CALL(listener_callbacks_, onData(_)).Times(4u)
+  EXPECT_CALL(listener_callbacks_, onReadReady()).WillOnce(Invoke([&]() { dispatcher_->exit(); }));
+  EXPECT_CALL(listener_callbacks_, onData(_))
+      .Times(4u)
       .WillRepeatedly(Invoke([&](const UdpRecvData& data) -> void {
         validateRecvCallbackParams(data, client_data.size());
 

--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -607,14 +607,10 @@ TEST_P(UdpListenerImplTest, UdpGroBasic) {
       }))
       .WillRepeatedly(Return(Api::SysCallSizeResult{-1, EAGAIN}));
 
-  EXPECT_CALL(listener_callbacks_, onReadReady());
-  EXPECT_CALL(listener_callbacks_, onData(_))
-      .WillOnce(Invoke([&](const UdpRecvData& data) -> void {
-        validateRecvCallbackParams(data, client_data.size());
-
-        const std::string data_str = data.buffer_->toString();
-        EXPECT_EQ(data_str, client_data[num_packets_received_by_listener_ - 1]);
-      }))
+  EXPECT_CALL(listener_callbacks_, onReadReady()).WillOnce(Invoke([&](){
+    dispatcher_->exit();
+  }));
+  EXPECT_CALL(listener_callbacks_, onData(_)).Times(4u)
       .WillRepeatedly(Invoke([&](const UdpRecvData& data) -> void {
         validateRecvCallbackParams(data, client_data.size());
 
@@ -624,7 +620,6 @@ TEST_P(UdpListenerImplTest, UdpGroBasic) {
 
   EXPECT_CALL(listener_callbacks_, onWriteReady(_)).WillOnce(Invoke([&](const Socket& socket) {
     EXPECT_EQ(&socket.ioHandle(), &server_socket_->ioHandle());
-    dispatcher_->exit();
   }));
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);


### PR DESCRIPTION
Commit Message: potential fix to flakiness caused by missing Read event when I/O event callback is triggered. 

```
test/common/network/udp_listener_impl_test.cc:610: Failure
Actual function call count doesn't match EXPECT_CALL(listener_callbacks_, onReadReady())...
         Expected: to be called once
           Actual: never called - unsatisfied and active
```
This indicates Read event is not present when the test is unblocked. Maybe a Write only event is bubbled up at the beginning.

Risk Level: low, test only
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #29310