### PR TITLE
fake_upstream: subtract already read bytes from required frame length

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -194,15 +194,18 @@ public:
     if (!waitForData(client_dispatcher, 5, timeout)) {
       return testing::AssertionFailure() << "Timed out waiting for start of gRPC message.";
     }
+    int last_body_size = 0;
     {
       absl::MutexLock lock(&lock_);
+      last_body_size = body_.length();
       if (!grpc_decoder_.decode(body_, decoded_grpc_frames_)) {
         return testing::AssertionFailure()
                << "Couldn't decode gRPC data frame: " << body_.toString();
       }
     }
     if (decoded_grpc_frames_.empty()) {
-      if (!waitForData(client_dispatcher, grpc_decoder_.length(), bound.timeLeft())) {
+      if (!waitForData(client_dispatcher, grpc_decoder_.length() - last_body_size,
+                       bound.timeLeft())) {
         return testing::AssertionFailure() << "Timed out waiting for end of gRPC message.";
       }
       {


### PR DESCRIPTION
Additional Description: when reading gRPC frame in ``FakeStream``, in case a gRPC frame is received in multiple data payloads, it's required to subtract the count of bytes already read on previous payloads from the expected bytes left to wait for. Otherwise - ``FakeStream`` will keep waiting for the original frame length, although the ``body_`` has already been drained from the first data payload.