### PR TITLE
HCM: prevent scoped-route invalid HeaderValueExtractor key config

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -1054,7 +1054,9 @@ message ScopedRoutes {
         // .. note::
         //
         //   If the header appears multiple times only the first value is used.
-        string name = 1 [(validate.rules).string = {min_len: 1}];
+        string name = 1 [
+          (validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+        ];
 
         // The element separator (e.g., ';' separates 'a;b;c;d').
         // Default: empty string. This causes the entirety of the header field to be extracted.

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/hcm_header_value_extractor_key_name
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/hcm_header_value_extractor_key_name
@@ -1,0 +1,12 @@
+config {
+  name: "envoy.filters.network.http_connection_manager"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    value: "\022\002--B\002\020\001\250\001\001\372\001\310\001\n\001Z\022\257\001\n\254\001\n\251\001\n\240\001$config {\n  name: \"envoy.filters.network.http_connection_manager\"\n  typed_config {\n    type_url: \"type.googleapis.com/envoy.extensions.filters.network.http_conn\022\002T+\030&\"\021\n\017\n\001e\032\010\n\006\n\004$v21*\000\350\002\004\270\003\001"
+  }
+}
+actions {
+  on_data {
+    data: "PUT                                           /2.0nnnnnn\n\n\n\n\022r\n"
+  }
+}


### PR DESCRIPTION
Commit Message: HCM: prevent scoped-route invalid HeaderValueExtractor key config
Additional Description:
Prior to this PR the [name](https://github.com/envoyproxy/envoy/blob/1eb64ee65f37853a3693fe5f5d616e6d4b5277fa/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#L1057) field in `HeaderValueExtractor` could have been any string. This limits it to valid HTTP header names.
Risk Level: low
Testing: Added fuzz test
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes fuzz issue [60277](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60277)