### PR TITLE
replace miscellaneous usages of query param data structure with new version

### DIFF
--- a/mobile/test/common/http/filters/test_read/filter.cc
+++ b/mobile/test/common/http/filters/test_read/filter.cc
@@ -9,11 +9,11 @@ namespace TestRead {
 Http::FilterHeadersStatus TestReadFilter::decodeHeaders(Http::RequestHeaderMap& request_headers,
                                                         bool) {
   // sample path is /failed?error=0x10000
-  Http::Utility::QueryParams query_parameters =
-      Http::Utility::parseQueryString(request_headers.Path()->value().getStringView());
-  auto error = query_parameters.find("error");
+  auto query_parameters = Http::Utility:: ::QueryParamsMulti::parseQueryString(
+      request_headers.Path()->value().getStringView());
+  auto error = query_parameters.getFirstValue("error");
   uint64_t response_flag;
-  if (error != query_parameters.end() && absl::SimpleAtoi(error->second, &response_flag)) {
+  if (error.has_value() && absl::SimpleAtoi(error.value(), &response_flag)) {
     // set response error code
     StreamInfo::StreamInfo& stream_info = decoder_callbacks_->streamInfo();
     stream_info.setResponseFlag(TestReadFilter::mapErrorToResponseFlag(response_flag));

--- a/mobile/test/common/http/filters/test_read/filter.cc
+++ b/mobile/test/common/http/filters/test_read/filter.cc
@@ -9,7 +9,7 @@ namespace TestRead {
 Http::FilterHeadersStatus TestReadFilter::decodeHeaders(Http::RequestHeaderMap& request_headers,
                                                         bool) {
   // sample path is /failed?error=0x10000
-  auto query_parameters = Http::Utility:: ::QueryParamsMulti::parseQueryString(
+  auto query_parameters = Http::Utility::QueryParamsMulti::parseQueryString(
       request_headers.Path()->value().getStringView());
   auto error = query_parameters.getFirstValue("error");
   uint64_t response_flag;

--- a/mobile/test/common/http/filters/test_read/filter.cc
+++ b/mobile/test/common/http/filters/test_read/filter.cc
@@ -19,7 +19,7 @@ Http::FilterHeadersStatus TestReadFilter::decodeHeaders(Http::RequestHeaderMap& 
     stream_info.setResponseFlag(TestReadFilter::mapErrorToResponseFlag(response_flag));
 
     // check if we want a quic server error: sample path is /failed?quic=1&error=0x10000
-    if (query_parameters.find("quic") != query_parameters.end()) {
+    if (query_parameters.getFirstValue("quic").has_value()) {
       stream_info.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
       stream_info.upstreamInfo()->setUpstreamProtocol(Http::Protocol::Http3);
     }

--- a/source/common/config/xds_resource.cc
+++ b/source/common/config/xds_resource.cc
@@ -122,11 +122,10 @@ void decodePath(absl::string_view path, std::string* resource_type, std::string&
 
 void decodeQueryParams(absl::string_view query_params,
                        xds::core::v3::ContextParams& context_params) {
-  Http::Utility::QueryParams query_params_components =
-      Http::Utility::parseQueryString(query_params);
-  for (const auto& it : query_params_components) {
+  auto query_params_components = Http::Utility::QueryParamsMulti::parseQueryString(query_params);
+  for (const auto& it : query_params_components.data()) {
     (*context_params.mutable_params())[PercentEncoding::decode(it.first)] =
-        PercentEncoding::decode(it.second);
+        PercentEncoding::decode(it.second[0]);
   }
 }
 

--- a/source/common/http/matching/inputs.h
+++ b/source/common/http/matching/inputs.h
@@ -161,15 +161,15 @@ public:
       return {Matcher::DataInputGetResult::DataAvailability::NotAvailable, absl::monostate()};
     }
 
-    Utility::QueryParams params =
-        Http::Utility::parseAndDecodeQueryString(ret->value().getStringView());
+    auto params =
+        Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(ret->value().getStringView());
 
-    auto ItParam = params.find(query_param_);
-    if (ItParam == params.end()) {
+    auto ItParam = params.getFirstValue(query_param_);
+    if (!ItParam.has_value()) {
       return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable, absl::monostate()};
     }
     return {Matcher::DataInputGetResult::DataAvailability::AllDataAvailable,
-            std::move(ItParam->second)};
+            std::move(ItParam.value())};
   }
 
 private:


### PR DESCRIPTION
Commit Message:

replace miscellaneous usages of query param data structure with new version

Additional Description:

In #24054, a new data structure for storing query parameters was introduced. In that PR, I committed to going through and ripping out all usage of the old data structure (cc @ggreenway).

This PR swaps out the old structure for the new one in a couple small, self-contained usages. No behavior changed.

Once this PR is merged, there will be one large PR to remove the old data structure from the admin server (where it is used heavily), then one more to remove the data structure itself.

Risk Level: Low
Testing: Existing unit tests appear to provide sufficient coverage.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A