### PR TITLE
ci/website: Use commit sha when dispatching website build

### DIFF
--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -95,6 +95,13 @@ jobs:
       trusted: true
 
   publish_docs:
+    # For normal commits to Envoy main this will trigger an update in the website repo,
+    # which will update its envoy dep shas, and rebuild the website for the latest docs
+    #
+    # For commits that create a release, it instead triggers an update in the archive repo,
+    # which builds a static version of the docs for the release and commits it to the archive.
+    # In turn the archive repo triggers an update in the website so the new release docs are
+    # included in the published site
     if: ${{ inputs.trusted }}
     runs-on: ubuntu-22.04
     needs:

--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -107,3 +107,5 @@ jobs:
         ref: main
         repository: ${{ inputs.version_dev != '' && 'envoyproxy/envoy-website' || 'envoyproxy/archive' }}
         workflow: envoy-sync.yaml
+        inputs: |
+          commit_sha: ${{ inputs.version_dev != '' && github.sha || '' }}


### PR DESCRIPTION
Publishing docs can take quite a while after CI has started.

If `main` has been updated by the time the wf is dispatched then the website gets updated to the wrong hash

with https://github.com/envoyproxy/envoy-website/pull/362 this should fix that

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
