### PR TITLE
verify/packages: Force rebuild of docker image

### DIFF
--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -68,6 +68,7 @@ sh_binary(
         "$(location :distrotest.sh)",
         VERSION,
         "$(location :distros.yaml)",
+        "--rebuild",
     ],
     data = [
         ":distros.yaml",


### PR DESCRIPTION
This ensures a rebuild of the Docker image before running package verify tests

When changing the version number it was creating a mismatch between what was being tested and what was expected

This flag is probably a good idea generally as it will still rebuild from cache but will expire anything that has changed

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
