### PR TITLE
fuzz: fix h10 codec validation

### DIFF
--- a/test/common/http/codec_impl_corpus/h10_empty_hostname
+++ b/test/common/http/codec_impl_corpus/h10_empty_hostname
@@ -1,0 +1,33 @@
+h1_settings {
+  server {
+    accept_http_10: true
+    default_host_for_http_10: "\000\000\000\000\000\000\000\000"
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    end_stream: true
+  }
+}
+actions {
+  mutate {
+    offset: 5
+    value: 48
+  }
+}
+actions {
+  mutate {
+    offset: 48
+    value: 48
+  }
+}

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -66,6 +66,12 @@ Http1Settings fromHttp1Settings(const test::common::http::Http1ServerSettings& s
   h1_settings.accept_http_10_ = settings.accept_http_10();
   h1_settings.default_host_for_http_10_ = settings.default_host_for_http_10();
 
+  // If the server accepts a HTTP/1.0 then the default host must be valid.
+  if (h1_settings.accept_http_10_ &&
+      !HeaderUtility::authorityIsValid(h1_settings.default_host_for_http_10_)) {
+    throw EnvoyException("Invalid Http1ServerSettings, HTTP/1.0 is enabled and "
+                         "'default_host_for_http_10' has invalid hostname, skipping test.");
+  }
   return h1_settings;
 }
 


### PR DESCRIPTION
Commit Message: fuzz: fix h10 codec validation
Additional Description:
The HTTP/1 codec fuzzer can receive any string in its [default_host_for_http_10](https://github.com/envoyproxy/envoy/blob/9a3c8967e98a6f5c5e689e3a0e30d4a3b1ff7a2a/test/common/http/codec_impl_fuzz.proto#L93) field. This PR validates that input to prevent wrong config.

Risk Level: low - tests only
Testing: added corpus entry.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
