### PR TITLE
ci/publish: Fix checked out ref for postsubmit

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -96,21 +96,26 @@ jobs:
       with:
         image_tag: ${{ inputs.cache_build_image }}
 
-    # If the run is "trusted" (ie has access to secrets) then it should
-    # **not** set the ref and should use the code of the calling context.
-    - if: ${{ inputs.repo_ref && inputs.trusted }}
-      run: |
-        echo '`repo_ref` should not be set for trusted CI runs'
-        exit 1
-
     - uses: actions/checkout@v4
       name: Checkout Envoy repository
       with:
-        fetch-depth: ${{ inputs.repo_fetch_depth }}
+        fetch-depth: ${{ ! inputs.trusted && inputs.repo_fetch_depth || 0 }}
         # WARNING: This allows untrusted code to run!!!
         #  If this is set, then anything before or after in the job should be regarded as
         #  compromised.
         ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
+
+    # If we are in a trusted CI run then the provided commit _must_ be either the latest for
+    # this branch, or an antecdent.
+    - run: |
+        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD; then
+            echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
+            exit 1
+        fi
+        git checkout "${{ inputs.repo_ref }}"
+      if: ${{ inputs.trusted }}
+      name: Check provided ref
+
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy/envoy
 

--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -93,6 +93,7 @@ jobs:
       run_pre_with: ${{ matrix.run_pre_with }}
       env: ${{ matrix.env }}
       trusted: true
+      repo_ref: ${{ inputs.repo_ref }}
 
   publish_docs:
     # For normal commits to Envoy main this will trigger an update in the website repo,

--- a/.github/workflows/_stage_verify.yml
+++ b/.github/workflows/_stage_verify.yml
@@ -50,4 +50,4 @@ jobs:
       run_pre_with: ${{ matrix.run_pre_with }}
       env: ${{ matrix.env }}
       trusted: ${{ inputs.trusted }}
-      repo_ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
+      repo_ref: ${{ inputs.repo_ref }}

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -54,7 +54,7 @@ jobs:
       trusted: ${{ needs.env.outputs.trusted == 'true' && true || false }}
       version_dev: ${{ needs.env.outputs.version_dev }}
       given_ref: ${{ inputs.ref }}
-      repo_ref: ${{ needs.env.outputs.trusted != 'true' && inputs.ref || '' }}
+      repo_ref: ${{ inputs.ref }}
     permissions:
       contents: write
     secrets:
@@ -69,4 +69,4 @@ jobs:
     with:
       trusted: ${{ needs.env.outputs.trusted == 'true' && true || false }}
       given_ref: ${{ inputs.ref }}
-      repo_ref: ${{ needs.env.outputs.trusted != 'true' && needs.env.outputs.repo_ref || '' }}
+      repo_ref: ${{ needs.env.outputs.repo_ref }}


### PR DESCRIPTION
Currently when the publishing ci is triggered in postsubmit, it just uses the latest commit of the branch (main/release/etc)

This fixes it to use the correct commit, and adds a check to ensure it is a commit of that branch.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
