### PR TITLE
[quic]fix default config for port migration

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -85,7 +85,7 @@ message QuicProtocolOptions {
       [(validate.rules).uint32 = {lte: 25165824 gte: 1}];
 
   // The number of timeouts that can occur before port migration is triggered for QUIC clients.
-  // This defaults to 1. If set to 0, port migration will not occur on path degrading.
+  // This defaults to 4. If set to 0, port migration will not occur on path degrading.
   // Timeout here refers to QUIC internal path degrading timeout mechanism, such as PTO.
   // This has no effect on server sessions.
   google.protobuf.UInt32Value num_timeouts_to_trigger_port_migration = 4

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -212,7 +212,7 @@ void EnvoyQuicClientSession::setHttp3Options(
   }
   static_cast<EnvoyQuicClientConnection*>(connection())
       ->setNumPtosForPortMigration(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          http3_options.quic_protocol_options(), num_timeouts_to_trigger_port_migration, 1));
+          http3_options.quic_protocol_options(), num_timeouts_to_trigger_port_migration, 4));
 
   if (http3_options_->quic_protocol_options().has_connection_keepalive()) {
     const uint64_t initial_interval = PROTOBUF_GET_MS_OR_DEFAULT(

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -716,6 +716,11 @@ TEST_P(QuicHttpIntegrationTest, PortMigration) {
   initialize();
   uint32_t old_port = lookupPort("http");
   codec_client_ = makeHttpConnection(old_port);
+
+  // Verify the default path degrading timeout is set correctly.
+  EXPECT_EQ(4u, quic::test::QuicSentPacketManagerPeer::GetNumPtosForPathDegrading(
+                    &quic_connection_->sent_packet_manager()));
+
   auto encoder_decoder =
       codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                                  {":path", "/test/long/url"},


### PR DESCRIPTION
Commit Message: Fix the default config for port migration. It's supposed to be 4 PTOs, but it was incorrectly set to 1.
Risk Level: low
Testing: integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: client only.
