### PR TITLE
Fix quiche build file

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -3826,10 +3826,7 @@ envoy_quic_cc_library(
 envoy_quic_cc_library(
     name = "quic_core_qpack_qpack_stream_sender_delegate_lib",
     hdrs = ["quiche/quic/core/qpack/qpack_stream_sender_delegate.h"],
-    deps = [
-        ":quic_core_types_lib",
-        ":quic_platform_base",
-    ],
+    deps = [":quic_platform_base"],
 )
 
 envoy_quic_cc_library(


### PR DESCRIPTION
Commit Message: Remove the unnecessary dep in quic_core_qpack_qpack_stream_sender_delegate_lib
Additional Description: The dep was initially added to fix my local build. But the actual root cause is me not using the right build config. So let's remove it.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
