### PR TITLE
ci/verify: Use self-hosted vm for x64 job

### DIFF
--- a/.azure-pipelines/stage/verify.yml
+++ b/.azure-pipelines/stage/verify.yml
@@ -12,8 +12,7 @@ jobs:
   displayName: Debs (x64)
   condition: and(not(canceled()), succeeded(), ne(stageDependencies.env.repo.outputs['changed.mobileOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.docsOnly'], 'true'), ne(stageDependencies.env.repo.outputs['changed.examplesOnly'], 'true'))
   timeoutInMinutes: 120
-  pool:
-    vmImage: $(agentUbuntu)
+  pool: envoy-x64-small
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -27,6 +26,7 @@ jobs:
       ciTarget: verify_distro
       cacheName: verify_distro
       publishTestResults: false
+      tmpfsDockerDisabled: true
       env:
         ENVOY_DOCKER_IN_DOCKER: 1
 


### PR DESCRIPTION
This should fix a bad merge causing diskspace issues in the x64 verify job

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
