### PR TITLE
bazel: remove deprecated `bazel` prefixes in docker CI

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -285,7 +285,7 @@ Envoy can also be built with the Docker image used for CI, by installing Docker 
 On Linux, run:
 
 ```
-./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
+./ci/run_envoy_docker.sh './ci/do_ci.sh dev'
 ```
 
 From a Windows host with Docker installed, the Windows containers feature enabled, and bash (installed via

--- a/ci/README.md
+++ b/ci/README.md
@@ -119,7 +119,7 @@ To leverage a [bazel remote cache](https://github.com/envoyproxy/envoy/tree/main
 the BAZEL_BUILD_EXTRA_OPTIONS environment variable
 
 ```bash
-./ci/run_envoy_docker.sh "BAZEL_BUILD_EXTRA_OPTIONS='--remote_cache=http://127.0.0.1:28080' ./ci/do_ci.sh bazel.release"
+./ci/run_envoy_docker.sh "BAZEL_BUILD_EXTRA_OPTIONS='--remote_cache=http://127.0.0.1:28080' ./ci/do_ci.sh release"
 ```
 
 The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:

--- a/support/README.md
+++ b/support/README.md
@@ -69,5 +69,5 @@ To run clang-tidy under Docker, run the following (this creates a full
 compilation db and takes a long time):
 
 ```console
-./ci/run_envoy_docker.sh ci/do_ci.sh bazel.clang_tidy
+./ci/run_envoy_docker.sh ci/do_ci.sh clang_tidy
 ```


### PR DESCRIPTION
The build emits a warning when you use `bazel.`-prefixed CI commands.

Commit Message: bazel: remove deprecated `bazel` prefixes in docker CI
Additional Description: The build emits a warning when you use `bazel.`-prefixed CI commands.
Risk Level: Low
Testing: I have invoked commands with a `bazel.` prefix and observed warnings that went away when it was removed.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

@phlax I [was advised](https://github.com/envoyproxy/envoy/pull/29877#discussion_r1347920828) to ping you for review.