### PR TITLE
Shard multiplexed_upstream_integration_test to prevent overall timeout

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -849,6 +849,7 @@ envoy_cc_test(
     srcs = [
         "multiplexed_upstream_integration_test.cc",
     ],
+    shard_count = 4,
     tags = [
         "cpu:3",
     ],


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
