### PR TITLE
ci: support different cases of the env vars

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -9,21 +9,12 @@ function is_windows() {
   [[ "$(uname -s)" == *NT* ]]
 }
 
-function export_env() {
-    default="$1"
-    alt="$2"
-
-    if [ -z "${!default}" ]; then
-        export "$default"="$alt"
-    fi
-}
-
 read -ra ENVOY_DOCKER_OPTIONS <<< "${ENVOY_DOCKER_OPTIONS:-}"
 
-export_env HTTP_PROXY "${http_proxy:-}"
-export_env HTTPS_PROXY "${https_proxy:-}"
-export_env NO_PROXY "${no_proxy:-}"
-export_env GOPROXY "${go_proxy:-}"
+export HTTP_PROXY="${HTTP_PROXY:-${http_proxy:-}}"
+export HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}"
+export NO_PROXY="${NO_PROXY:-${no_proxy:-}}"
+export GOPROXY="${GOPROXY:-${go_proxy:-}}"
 
 if is_windows; then
   [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-windows2019"

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -9,13 +9,21 @@ function is_windows() {
   [[ "$(uname -s)" == *NT* ]]
 }
 
+function export_env() {
+    default="$1"
+    alt="$2"
+
+    if [ -z "${!default}" ]; then
+        export "$default"="$alt"
+    fi
+}
+
 read -ra ENVOY_DOCKER_OPTIONS <<< "${ENVOY_DOCKER_OPTIONS:-}"
 
-# TODO(phlax): uppercase these env vars
-export HTTP_PROXY="${http_proxy:-}"
-export HTTPS_PROXY="${https_proxy:-}"
-export NO_PROXY="${no_proxy:-}"
-export GOPROXY="${go_proxy:-}"
+export_env HTTP_PROXY "${http_proxy:-}"
+export_env HTTPS_PROXY "${https_proxy:-}"
+export_env NO_PROXY "${no_proxy:-}"
+export_env GOPROXY "${go_proxy:-}"
 
 if is_windows; then
   [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-windows2019"


### PR DESCRIPTION
Especially for env var GOPROXY, which is the name defined in the Go standard.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: ci: support different cases of the env vars
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
