### PR TITLE
golang filter: need to provide a plugin configuration in the http filter if the configuration is required

### DIFF
--- a/docs/root/_configs/go/golang-with-per-route-config.yaml
+++ b/docs/root/_configs/go/golang-with-per-route-config.yaml
@@ -20,6 +20,10 @@ static_resources:
               library_id: my-configurable-plugin-id
               library_path: "lib/my_configurable_plugin.so"
               plugin_name: my_configurable_plugin
+              plugin_config:
+                "@type": type.googleapis.com/xds.type.v3.TypedStruct
+                value:
+                  foo: default_foo
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/docs/root/_configs/go/golang-with-per-virtualhost-config.yaml
+++ b/docs/root/_configs/go/golang-with-per-virtualhost-config.yaml
@@ -20,6 +20,10 @@ static_resources:
               library_id: my-configurable-plugin-id
               library_path: "lib/my_configurable_plugin.so"
               plugin_name: my_configurable_plugin
+              plugin_config:
+                "@type": type.googleapis.com/xds.type.v3.TypedStruct
+                value:
+                  foo: default_foo
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
Currently, when the plugin requires a plugin configuration, using these per-route configuration examples will cause an error: `proto: mismatched message type: got "xds.type.v3.TypedStruct", want ""`. Even the filter level's configuration is only used to define the filter order.

One solution is to provide an empty xds.TypedStruct{}  as fallback. But then I thought about it, and an empty configuration is not necessarily a valid configuration. And technically, if there is no perRoute configuration, then the filter will still be executed. So it looks like the only way to go is to change the config file and add plugin configuration to it.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: golang filter: need to provide a plugin configuration in the http filter if the configuration is required
Additional Description:
Risk Level:
Testing:
Docs Changes: Change the examples to ensure they always work
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
