### PR TITLE
ci/release: Dont run release tests/prechecks during actual release

### DIFF
--- a/.azure-pipelines/env.yml
+++ b/.azure-pipelines/env.yml
@@ -148,6 +148,8 @@ jobs:
       RUN_CHECKS=true
       RUN_DOCKER=true
       RUN_PACKAGING=true
+      RUN_RELEASE_TESTS=true
+
       if [[ "$(changed.mobileOnly)" == true || "$(changed.docsOnly)" == true ]]; then
           RUN_BUILD=false
           RUN_DOCKER=false
@@ -159,10 +161,14 @@ jobs:
       if [[ "$(changed.examplesOnly)" == true ]]; then
           RUN_CHECKS=false
       fi
+      if [[ "$ISSTABLEBRANCH" == True && -n "$POSTSUBMIT" && "$(state.isDev)" == false ]]; then
+          RUN_RELEASE_TESTS=false
+      fi
       echo "##vso[task.setvariable variable=build;isoutput=true]${RUN_BUILD}"
       echo "##vso[task.setvariable variable=checks;isoutput=true]${RUN_CHECKS}"
       echo "##vso[task.setvariable variable=docker;isoutput=true]${RUN_DOCKER}"
       echo "##vso[task.setvariable variable=packaging;isoutput=true]${RUN_PACKAGING}"
+      echo "##vso[task.setvariable variable=releaseTests;isoutput=true]${RUN_RELEASE_TESTS}"
 
     displayName: "Decide what to run"
     workingDirectory: $(Build.SourcesDirectory)
@@ -214,6 +220,7 @@ jobs:
       echo "env.outputs['run.build']: $(run.build)"
       echo "env.outputs['run.checks']: $(run.checks)"
       echo "env.outputs['run.packaging']: $(run.packaging)"
+      echo "env.outputs['run.releaseTests]: $(run.releaseTests)"
       echo
       echo "env.outputs['publish.githubRelease']: $(publish.githubRelease)"
       echo "env.outputs['publish.dockerhub]: $(publish.dockerhub)"

--- a/.azure-pipelines/stage/linux.yml
+++ b/.azure-pipelines/stage/linux.yml
@@ -11,6 +11,10 @@ parameters:
   displayName: "Artifact suffix"
   type: string
   default:
+- name: runTests
+  displayName: "Run release tests"
+  type: string
+  default: true
 - name: rbe
   displayName: "Use RBE"
   type: boolean
@@ -44,11 +48,17 @@ jobs:
         eq(${{ parameters.runBuild }}, 'true'))
   timeoutInMinutes: ${{ parameters.timeoutBuild }}
   pool: ${{ parameters.pool }}
+  variables:
+  - name: ciTarget
+    ${{ if eq(parameters.runTests, false) }}:
+      value: release.server_only
+    ${{ if ne(parameters.runTests, false) }}:
+      value: release
   steps:
   - template: ../ci.yml
     parameters:
       managedAgent: ${{ parameters.managedAgent }}
-      ciTarget: release
+      ciTarget: $(ciTarget)
       cacheName: "release"
       bazelBuildExtraOptions: ${{ parameters.bazelBuildExtraOptions }}
       cacheTestResults: ${{ parameters.cacheTestResults }}

--- a/.azure-pipelines/stage/prechecks.yml
+++ b/.azure-pipelines/stage/prechecks.yml
@@ -32,11 +32,18 @@ parameters:
   # a lot of change - eg protobuf changed, or a primitve proto changed.
   default: 40
 
+- name: runPrechecks
+  displayName: "Run prechecks"
+  type: string
+  default: true
 
 jobs:
 - job: prechecks
   displayName: Precheck
   timeoutInMinutes: ${{ parameters.timeoutPrechecks }}
+  condition: |
+    and(not(canceled()),
+        eq(${{ parameters.runPrechecks }}, 'true'))
   pool:
     vmImage: $(agentUbuntu)
   variables:

--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -60,6 +60,8 @@ stages:
 - stage: prechecks
   displayName: Prechecks
   dependsOn: ["env"]
+  variables:
+    RUN_PRECHECKS: $[stageDependencies.env.repo.outputs['run.releaseTests']]
   jobs:
   - template: stage/prechecks.yml
     parameters:
@@ -70,17 +72,20 @@ stages:
       authGPGKey: $(MaintainerGPGKeySecureFileDownloadPath)
       authGPGPath: $(MaintainerGPGKey.secureFilePath)
       bucketGCP: $(GcsArtifactBucket)
+      runPrechecks: variables['RUN_PRECHECKS']
 
 - stage: linux_x64
   displayName: Linux x64
   dependsOn: ${{ parameters.buildStageDeps }}
   variables:
     RUN_BUILD: $[stageDependencies.env.repo.outputs['run.build']]
+    RUN_TESTS: $[stageDependencies.env.repo.outputs['run.releaseTests']]
   jobs:
   - template: stage/linux.yml
     parameters:
       cacheTestResults: ${{ parameters.cacheTestResults }}
       runBuild: variables['RUN_BUILD']
+      runTests: variables['RUN_TESTS']
       tmpfsDockerDisabled: true
 
 - stage: linux_arm64


### PR DESCRIPTION
This is part of an effort to make releasing more immediate (#30074 )

We need to build the binary *at* commit so obviously that cant be skipped, but the tests and prechecks are not necessary  assuming we are confident with presubmit

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
