### PR TITLE
Fix intermittent cpu spike in grpc async client

### DIFF
--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -1,5 +1,7 @@
 #include "source/common/grpc/async_client_manager_impl.h"
 
+#include <chrono>
+
 #include "envoy/config/core/v3/grpc_service.pb.h"
 #include "envoy/stats/scope.h"
 
@@ -8,7 +10,6 @@
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/match.h"
-#include <chrono>
 
 #ifdef ENVOY_GOOGLE_GRPC
 #include "source/common/grpc/google_async_client_impl.h"

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -208,8 +208,7 @@ void AsyncClientManagerImpl::RawAsyncClientCache::evictEntriesAndResetEvictionTi
         // since 'now' and 'next_expire' are in nanoseconds, the following condition is to check if
         // the difference between them is less than 1 second. If we don't do this, the timer will
         // be enabled with 0 seconds, which will cause the timer to fire immediately. This will
-        // cpu spike. Autoscalers will see this as a spike in traffic and will scale up the pods
-        // to cause unnecessary cost/churn.
+        // cause cpu spike.
         (std ::chrono::duration_cast<std::chrono::seconds>(next_expire - now).count() == 0)) {
       // Erase the expired entry.
       lru_map_.erase(lru_list_.back().config_with_hash_key_);

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -204,7 +204,13 @@ void AsyncClientManagerImpl::RawAsyncClientCache::evictEntriesAndResetEvictionTi
   // Evict all the entries that have expired.
   while (!lru_list_.empty()) {
     MonotonicTime next_expire = lru_list_.back().accessed_time_ + EntryTimeoutInterval;
-    if (now >= next_expire) {
+    if ((now >= next_expire) ||
+        // since 'now' and 'next_expire' are in nanoseconds, the following condition is to check if
+        // the difference between them is less than 1 second. If we don't do this, the timer will
+        // be enabled with 0 seconds, which will cause the timer to fire immediately. This will
+        // cpu spike. Autoscalers will see this as a spike in traffic and will scale up the pods
+        // to cause unnecessary cost/churn.
+        (std ::chrono::duration_cast<std::chrono::seconds>(next_expire - now).count() == 0)) {
       // Erase the expired entry.
       lru_map_.erase(lru_list_.back().config_with_hash_key_);
       lru_list_.pop_back();

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -206,21 +206,17 @@ void AsyncClientManagerImpl::RawAsyncClientCache::evictEntriesAndResetEvictionTi
   // Evict all the entries that have expired.
   while (!lru_list_.empty()) {
     MonotonicTime next_expire = lru_list_.back().accessed_time_ + EntryTimeoutInterval;
-    std::chrono::milliseconds time_to_next_expire_sec =
+    std::chrono::seconds time_to_next_expire_sec =
         std::chrono::duration_cast<std::chrono::seconds>(next_expire - now);
-    if ((now >= next_expire) ||
-        // since 'now' and 'next_expire' are in nanoseconds, the following condition is to
-        // check if the difference between them is less than 1 second. If we don't do this, the
-        // timer will be enabled with 0 seconds, which will cause the timer to fire immediately.
-        // This will cause cpu spike.
-        (time_to_next_expire_sec.count() == 0)) {
+    // since 'now' and 'next_expire' are in nanoseconds, the following condition is to
+    // check if the difference between them is less than 1 second. If we don't do this, the
+    // timer will be enabled with 0 seconds, which will cause the timer to fire immediately.
+    // This will cause cpu spike.
+    if (time_to_next_expire_sec.count() <= 0) {
       // Erase the expired entry.
       lru_map_.erase(lru_list_.back().config_with_hash_key_);
       lru_list_.pop_back();
     } else {
-      if (time_to_next_expire_sec.count() == 0) {
-        timer_enabled_with_0_duration_count_++;
-      }
       cache_eviction_timer_->enableTimer(time_to_next_expire_sec);
       return;
     }

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -66,6 +66,7 @@ public:
                   const RawAsyncClientSharedPtr& client);
 
     RawAsyncClientSharedPtr getCache(const GrpcServiceConfigWithHashKey& config_with_hash_key);
+    int32_t timer_enabled_with_0_duration_count_ = 0;
 
   private:
     void evictEntriesAndResetEvictionTimer();

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -66,7 +66,6 @@ public:
                   const RawAsyncClientSharedPtr& client);
 
     RawAsyncClientSharedPtr getCache(const GrpcServiceConfigWithHashKey& config_with_hash_key);
-    int32_t timer_enabled_with_0_duration_count_ = 0;
 
   private:
     void evictEntriesAndResetEvictionTimer();

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -42,12 +42,6 @@ public:
                                      Event::Dispatcher::RunType::NonBlock);
     }
   }
-  void waitForMilliSeconds(int ms) {
-    for (int i = 0; i < ms; i++) {
-      time_system_.advanceTimeAndRun(std::chrono::milliseconds(1), *dispatcher_,
-                                     Event::Dispatcher::RunType::NonBlock);
-    }
-  }
 
 protected:
   Event::SimulatedTimeSystem time_system_;
@@ -70,35 +64,6 @@ TEST_F(RawAsyncClientCacheTest, CacheEviction) {
   EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), foo_client.get());
   waitForSeconds(51);
   EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), nullptr);
-}
-
-TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEvictionBusyLoop) {
-  envoy::config::core::v3::GrpcService grpc_service;
-  RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
-  // two entries are added to the cache
-  for (int i = 1; i <= 2; i++) {
-    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
-    GrpcServiceConfigWithHashKey config_with_hash_key(grpc_service);
-    client_cache_.setCache(config_with_hash_key, foo_client);
-  }
-
-  // waiting for 49.2 secs to make sure that for the entry which is not accessed, time to expire is
-  // less than 1 second, ~0.8 secs
-  waitForMilliSeconds(49200);
-
-  // Access first cache entry to so that evictEntriesAndResetEvictionTimer() gets called.
-  // Since we are getting first entry, access time of first entry will be updated to current time.
-  grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(1));
-  GrpcServiceConfigWithHashKey config_with_hash_key_1(grpc_service);
-  EXPECT_EQ(client_cache_.getCache(config_with_hash_key_1).get(), foo_client.get());
-
-  // Verifying that though the time to expire for second entry ~0.8 sec, it is considered as expired
-  // to avoid the busy loop which could happen if we timer is enabled with 0(0.8 rounded off to 0)
-  // duration.
-  EXPECT_EQ(client_cache_.timer_enabled_with_0_duration_count_, 0);
-  grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(2));
-  GrpcServiceConfigWithHashKey config_with_hash_key_2(grpc_service);
-  EXPECT_EQ(client_cache_.getCache(config_with_hash_key_2).get(), nullptr);
 }
 
 TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEviction) {
@@ -145,6 +110,59 @@ TEST_F(RawAsyncClientCacheTest, GetExpiredButNotEvictedCacheEntry) {
                                  Event::Dispatcher::RunType::NonBlock);
   // Cache entry has been evicted because it is accessed after timer fire.
   EXPECT_EQ(client_cache_.getCache(config_with_hash_key).get(), nullptr);
+}
+
+class RawAsyncClientCacheTestBusyLoop : public testing::Test {
+public:
+  RawAsyncClientCacheTestBusyLoop() {
+    timer_ = new Event::MockTimer();
+    EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Invoke([this](Event::TimerCb) {
+      return timer_;
+    }));
+    client_cache_ = std::make_unique<AsyncClientManagerImpl::RawAsyncClientCache>(dispatcher_);
+    EXPECT_CALL(*timer_, enableTimer(testing::Not(std::chrono::milliseconds(0)), _))
+        .Times(testing::AtLeast(1));
+  }
+
+  void waitForMilliSeconds(int ms) {
+    for (int i = 0; i < ms; i++) {
+      time_system_.advanceTimeAndRun(std::chrono::milliseconds(1), dispatcher_,
+                                     Event::Dispatcher::RunType::NonBlock);
+    }
+  }
+
+protected:
+  Event::SimulatedTimeSystem time_system_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  Event::MockTimer* timer_;
+  std::unique_ptr<AsyncClientManagerImpl::RawAsyncClientCache> client_cache_;
+};
+
+TEST_F(RawAsyncClientCacheTestBusyLoop, MultipleCacheEntriesEvictionBusyLoop) {
+  envoy::config::core::v3::GrpcService grpc_service;
+  RawAsyncClientSharedPtr foo_client = std::make_shared<MockAsyncClient>();
+  // two entries are added to the cache
+  for (int i = 1; i <= 2; i++) {
+    grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(i));
+    GrpcServiceConfigWithHashKey config_with_hash_key(grpc_service);
+    client_cache_->setCache(config_with_hash_key, foo_client);
+  }
+  // waiting for 49.2 secs to make sure that for the entry which is not accessed, time to expire is
+  // less than 1 second, ~0.8 secs
+  waitForMilliSeconds(49200);
+
+  // Access first cache entry to so that evictEntriesAndResetEvictionTimer() gets called.
+  // Since we are getting first entry, access time of first entry will be updated to current time.
+  grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(1));
+  GrpcServiceConfigWithHashKey config_with_hash_key_1(grpc_service);
+  EXPECT_EQ(client_cache_->getCache(config_with_hash_key_1).get(), foo_client.get());
+
+  // Verifying that though the time to expire for second entry ~0.8 sec, it is considered as expired
+  // to avoid the busy loop which could happen if timer gets enabled with 0(0.8 rounded off to 0)
+  // duration.
+  grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(2));
+  GrpcServiceConfigWithHashKey config_with_hash_key_2(grpc_service);
+  EXPECT_EQ(client_cache_->getCache(config_with_hash_key_2).get(), nullptr);
 }
 
 class AsyncClientManagerImplTest : public testing::Test {

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -93,7 +93,7 @@ TEST_F(RawAsyncClientCacheTest, MultipleCacheEntriesEvictionBusyLoop) {
   EXPECT_EQ(client_cache_.getCache(config_with_hash_key_1).get(), foo_client.get());
 
   // Verifying that though the time to expire for second entry ~0.8 sec, it is considered as expired
-  // to avoid the busy loop which could happen if we timer is enabled with 0(0.8 rouded off to 0)
+  // to avoid the busy loop which could happen if we timer is enabled with 0(0.8 rounded off to 0)
   // duration.
   EXPECT_EQ(client_cache_.timer_enabled_with_0_duration_count_, 0);
   grpc_service.mutable_envoy_grpc()->set_cluster_name(std::to_string(2));


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
In grpc async client, if timer expiry handler function gets fired where time to next_expiry is less than 1 sec, a loop gets created where timer gets enabled with 0 secs expiry again and again until 'now' becomes as next_expiry. This causes random cpu spikes. If there is HPA configured on cpu, this will result in scale up and scale down on proxies.

I added some logs while debugging it. Sharing here might help understanding the issue more clearly:
```
AsyncClientManagerImpl::evictEntriesAndResetEvictionTimer
[2023-09-08 10:27:32.640][22][info][grpc] [external/envoy/source/common/grpc/async_client_manager_impl.cc:198] AsyncClientManagerImpl::evictEntriesAndResetEvictionTimer next_expire: 966826645315069, now 966825877367850
[2023-09-08 10:27:32.640][22][info][grpc] [external/envoy/source/common/grpc/async_client_manager_impl.cc:208] AsyncClientManagerImpl::evictEntriesAndResetEvictionTimer enable timer: 0
[2023-09-08 10:27:32.640][22][info][grpc] [external/envoy/source/common/grpc/async_client_manager_impl.cc:193] AsyncClientManagerImpl::evictEntriesAndResetEvictionTimer
[2023-09-08 10:27:32.640][22][info][grpc] [external/envoy/source/common/grpc/async_client_manager_impl.cc:198] AsyncClientManagerImpl::evictEntriesAndResetEvictionTimer next_expire: 966826645315069, now 966825877389741
[2023-09-08 10:27:32.640][22][info][grpc] [external/envoy/source/common/grpc/async_client_manager_impl.cc:208] AsyncClientManagerImpl::evictEntriesAndResetEvictionTimer enable timer: 0
```
When this condition hits, logs get filled because of the loop I mentioned in the beginning.

Fix is simple that in the `if` condition for expiry consider this round off thing as well.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
