### PR TITLE
github/ci: Switch prechecks to pull_request_target and fix

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -82,13 +82,6 @@ outputs:
 runs:
   using: composite
   steps:
-
-  - if: ${{ inputs.check_mobile_run != 'false' }}
-    id: should_run
-    name: 'Check what to run'
-    run: ./mobile/tools/what_to_run.sh
-    shell: bash
-
   # Pull request/targets are _never_ trusted.
   #
   # For dispatch events, only specified bots are trusted.
@@ -128,6 +121,23 @@ runs:
       else
           echo "trusted=false" >> "$GITHUB_OUTPUT"
       fi
+    shell: bash
+
+    # If we are in a trusted CI run then the provided commit _must_ be either the latest for
+    # this branch, or an antecdent.
+    - run: |
+        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD; then
+            echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
+            exit 1
+        fi
+        git checkout "${{ inputs.repo_ref }}"
+      if: ${{ steps.trusted.outputs.trusted == 'true' && inputs.repo_ref }}
+      name: Check provided ref
+
+  - if: ${{ inputs.check_mobile_run != 'false' }}
+    id: should_run
+    name: 'Check what to run'
+    run: ./mobile/tools/what_to_run.sh
     shell: bash
 
   - id: context

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -89,6 +89,16 @@ runs:
     run: ./mobile/tools/what_to_run.sh
     shell: bash
 
+  # Pull request/targets are _never_ trusted.
+  #
+  # For dispatch events, only specified bots are trusted.
+  #
+  # Commits to a branch are always trusted.
+  #
+  # If code is trusted its not allowed to check out any
+  # non-ancestor commit of a stable branch.
+  #
+  # Untrusted code can check out any commit.
   - id: trusted
     name: 'Check if its a trusted run'
     run: |
@@ -109,7 +119,7 @@ runs:
               TRUSTED=
           fi
       fi
-      if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+      if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
           echo "Not trusted pull_request event"
           TRUSTED=
       fi

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -123,16 +123,17 @@ runs:
       fi
     shell: bash
 
-    # If we are in a trusted CI run then the provided commit _must_ be either the latest for
-    # this branch, or an antecdent.
-    - run: |
-        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD &> /dev/null; then
-            echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
-            exit 1
-        fi
-        git checkout "${{ inputs.repo_ref }}"
-      if: ${{ steps.trusted.outputs.trusted == 'true' && inputs.repo_ref }}
-      name: Check provided ref
+  # If we are in a trusted CI run then the provided commit _must_ be either the latest for
+  # this branch, or an antecdent.
+  - run: |
+      if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD &> /dev/null; then
+      echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
+          exit 1
+      fi
+      git checkout "${{ inputs.repo_ref }}"
+    if: ${{ steps.trusted.outputs.trusted == 'true' && inputs.repo_ref }}
+    name: Check provided ref
+    shell: bash
 
   - if: ${{ inputs.check_mobile_run != 'false' }}
     id: should_run

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -126,7 +126,7 @@ runs:
     # If we are in a trusted CI run then the provided commit _must_ be either the latest for
     # this branch, or an antecdent.
     - run: |
-        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD; then
+        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD &> /dev/null; then
             echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
             exit 1
         fi

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -136,21 +136,11 @@ jobs:
     - uses: actions/checkout@v4
       name: Checkout Envoy repository
       with:
-        fetch-depth: ${{ ! (inputs.check_mobile_run || inputs.trusted) && 1 || 0 }}
+        fetch-depth: ${{ ! (inputs.check_mobile_run || ! startsWith(github.event_name, 'pull_request')) && 1 || 0 }}
         # WARNING: This allows untrusted code to run!!!
         #  If this is set, then anything before or after in the job should be regarded as
         #  compromised.
-        ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
-    # If we are in a trusted CI run then the provided commit _must_ be either the latest for
-    # this branch, or an antecdent.
-    - run: |
-        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD; then
-            echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
-            exit 1
-        fi
-        git checkout "${{ inputs.repo_ref }}"
-      if: ${{ inputs.trusted }}
-      name: Check provided ref
+        ref: ${{ startsWith(github.event_name, 'pull_request') && inputs.repo_ref || '' }}
 
     - uses: ./.github/actions/env
       name: Generate environment variables
@@ -164,6 +154,17 @@ jobs:
         build_image_tag: ${{ inputs.build_image_tag }}
         build_image_mobile_sha: ${{ inputs.build_image_mobile_sha }}
         build_image_sha: ${{ inputs.build_image_sha }}
+
+    # If we are in a trusted CI run then the provided commit _must_ be either the latest for
+    # this branch, or an antecdent.
+    - run: |
+        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD; then
+            echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
+            exit 1
+        fi
+        git checkout "${{ inputs.repo_ref }}"
+      if: ${{ steps.env.outputs.trusted == 'true' }}
+      name: Check provided ref
 
     - name: 'Print env'
       run: |

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -155,17 +155,6 @@ jobs:
         build_image_mobile_sha: ${{ inputs.build_image_mobile_sha }}
         build_image_sha: ${{ inputs.build_image_sha }}
 
-    # If we are in a trusted CI run then the provided commit _must_ be either the latest for
-    # this branch, or an antecdent.
-    - run: |
-        if ! git merge-base --is-ancestor "${{ inputs.repo_ref }}" HEAD; then
-            echo "Provided Envoy ref (${{ inputs.repo_ref }}) is not an ancestor of current branch" >&2
-            exit 1
-        fi
-        git checkout "${{ inputs.repo_ref }}"
-      if: ${{ steps.env.outputs.trusted == 'true' }}
-      name: Check provided ref
-
     - name: 'Print env'
       run: |
         echo "version_dev=${{ steps.env.outputs.version_dev }}"

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -8,7 +8,7 @@ on:
     branches:
     - main
     - release/v*
-  pull_request:
+  pull_request_target:
     paths:
     - '**/requirements*.txt'
     - '**/go.mod'
@@ -29,7 +29,7 @@ jobs:
       check_mobile_run: false
     permissions:
       contents: read
-      statuses: write
+      containers: read
 
   prechecks:
     needs:


### PR DESCRIPTION
Currently the code checks for `inputs.trusted` before that var has been derived/set - this fixes that issue

It also switches the github deps/prechecks wf to `pull_request_target` - this will require an update in our ci policy, but is a necessary step to enabling RBE for these workflows

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
