### PR TITLE
ci/publishing: Improve/automate release messaging

### DIFF
--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -28,6 +28,8 @@ on:
         type: string
       given_ref:
         type: string
+      sha:
+        type: string
     secrets:
       ENVOY_CI_SYNC_APP_ID:
       ENVOY_CI_SYNC_APP_KEY:
@@ -52,6 +54,7 @@ jobs:
             bucket: envoy-pr
           env: |
             export ENVOY_PUBLISH_DRY_RUN=1
+            export ENVOY_COMMIT=${{ inputs.sha }}
     uses: ./.github/workflows/_ci.yml
     with:
       target: ${{ matrix.target }}

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -55,6 +55,7 @@ jobs:
       version_dev: ${{ needs.env.outputs.version_dev }}
       given_ref: ${{ inputs.ref }}
       repo_ref: ${{ inputs.ref }}
+      sha: ${{ inputs.sha }}
     permissions:
       contents: write
     secrets:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -786,9 +786,11 @@ case $CI_TARGET in
     publish)
         setup_clang_toolchain
         BUILD_SHA="$(git rev-parse HEAD)"
+        ENVOY_COMMIT="${ENVOY_COMMIT:-${BUILD_SHA}}"
         VERSION_DEV="$(cut -d- -f2 < VERSION.txt)"
         PUBLISH_ARGS=(
-            --publish-commitish="$BUILD_SHA"
+            --publish-commitish="$ENVOY_COMMIT"
+            --publish-commit-message
             --publish-assets=/build/release.signed/release.signed.tar.zst)
         if [[ "$VERSION_DEV" == "dev" ]] || [[ -n "$ENVOY_PUBLISH_DRY_RUN" ]]; then
             PUBLISH_ARGS+=(--dry-run)

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -9,7 +9,7 @@ colorama
 coloredlogs
 cryptography>=41.0.1
 dependatool>=0.2.2
-envoy.base.utils>=0.4.12
+envoy.base.utils>=0.4.14
 envoy.code.check>=0.5.8
 envoy.dependency.check>=0.1.10
 envoy.distribution.release>=0.0.9

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -436,9 +436,9 @@ docutils==0.19 \
     #   envoy-docs-sphinx-runner
     #   sphinx
     #   sphinx-rtd-theme
-envoy-base-utils==0.4.13 \
-    --hash=sha256:58a35870e15ca00e921f9ab8266c6a1f83dc40f830bf0f1002e940aae2067a06 \
-    --hash=sha256:a3a1f1289ad7fabb33766699912d06a81385f4e3619f6bec80d5bdaab5e606a8
+envoy-base-utils==0.4.14 \
+    --hash=sha256:90a576b24bb0275594e34cb731d1115e4e7428c7435231dea3427cfe4581f6de \
+    --hash=sha256:a200d000079b47979f58c4bee58bd40416acf101244eb464901891379e2b5894
     # via
     #   -r requirements.in
     #   envoy-code-check


### PR DESCRIPTION
The updated tool accepts some new args and improves the release commit message:

`release --release-message-path`

allows additional commit message content to be included from file

`publish --publish-commit-message`

this uses the last commit message (ie releaes commit) as the body/description of the release

it would do this anyway but submitting as a body ensures correct rendering

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
