### PR TITLE
ci/publishing: Assorted fixes/cleanups for gh wfs

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -76,6 +76,10 @@ on:
       env:
         type: string
 
+    secrets:
+      app_id:
+      app_key:
+
 concurrency:
   group: |
     ${{ github.actor != 'trigger-release-envoy[bot]'
@@ -96,6 +100,14 @@ jobs:
       with:
         image_tag: ${{ inputs.cache_build_image }}
 
+    - if: ${{ inputs.trusted && secrets.app_id && secrets.app_key }}
+      name: Fetch token for app auth
+      id: appauth
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.0.18
+      with:
+        app_id: ${{ secrets.app_id }}
+        key: ${{ secrets.app_key }}
+
     - uses: actions/checkout@v4
       name: Checkout Envoy repository
       with:
@@ -104,6 +116,7 @@ jobs:
         #  If this is set, then anything before or after in the job should be regarded as
         #  compromised.
         ref: ${{ ! inputs.trusted && inputs.repo_ref || '' }}
+        token: ${{ (inputs.trusted && secrets.app_id && secrets.app_key) && steps.appauth.outputs.token || secrets.GITHUB_TOKEN }}
 
     # If we are in a trusted CI run then the provided commit _must_ be either the latest for
     # this branch, or an antecdent.

--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -27,10 +27,6 @@ on:
         type: boolean
         default: false
 
-      start_check_status:
-        type: string
-        default:
-
       repo_ref:
         type: string
         default:
@@ -172,16 +168,6 @@ jobs:
         if [[ -n "${{ steps.env.outputs.repo_ref_pr_number }}" ]]; then
             echo "PR: https://github.com/envoyproxy/envoy/pull/${{ steps.env.outputs.repo_ref_pr_number }}"
         fi
-
-  check:
-    if: ${{ inputs.start_check_status && github.event_name != 'pull_request' }}
-    uses: ./.github/workflows/_workflow-start.yml
-    permissions:
-      contents: read
-      statuses: write
-    with:
-      workflow_name: ${{ inputs.start_check_status }}
-      sha: ${{ inputs.repo_ref_sha }}
 
   cache:
     if: ${{ inputs.prime_build_image }}

--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -26,13 +26,13 @@ on:
         default: ''
       repo_ref:
         type: string
-      given_ref:
-        type: string
       sha:
         type: string
     secrets:
       ENVOY_CI_SYNC_APP_ID:
       ENVOY_CI_SYNC_APP_KEY:
+      ENVOY_CI_PUBLISH_APP_ID:
+      ENVOY_CI_PUBLISH_APP_KEY:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}-publish
@@ -50,7 +50,7 @@ jobs:
           name: github
           run_pre: ./.github/actions/publish/release/setup
           run_pre_with: |
-            ref: ${{ inputs.given_ref }}
+            ref: ${{ inputs.repo_ref }}
             bucket: envoy-pr
           env: |
             export ENVOY_PUBLISH_DRY_RUN=1
@@ -71,7 +71,8 @@ jobs:
     if: ${{ inputs.trusted }}
     name: ${{ matrix.name || matrix.target }}
     permissions:
-      contents: write
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -80,9 +81,10 @@ jobs:
           name: github
           run_pre: ./.github/actions/publish/release/setup
           run_pre_with: |
-            ref: ${{ inputs.given_ref }}
+            ref: ${{ inputs.repo_ref }}
             bucket: envoy-postsubmit
           env: |
+            export ENVOY_COMMIT=${{ inputs.sha }}
             if [[ '${{ inputs.version_dev }}' == 'dev' ]]; then
                 export ENVOY_PUBLISH_DRY_RUN=1
             fi
@@ -97,6 +99,9 @@ jobs:
       env: ${{ matrix.env }}
       trusted: true
       repo_ref: ${{ inputs.repo_ref }}
+    secrets:
+      app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
+      app_key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
   publish_docs:
     # For normal commits to Envoy main this will trigger an update in the website repo,

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -30,8 +30,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      # TODO(phlax): figure out how to remove this
-      statuses: write
 
   prechecks:
     needs:

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -35,32 +35,43 @@ jobs:
     with:
       check_mobile_run: false
       prime_build_image: true
-      start_check_status: Verify/examples
       repo_ref: ${{ inputs.ref }}
       repo_ref_sha: ${{ inputs.sha }}
       repo_ref_name: ${{ inputs.head_ref }}
+    permissions:
+      contents: read
+      packages: read
 
+  check:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/_workflow-start.yml
     permissions:
       contents: read
       statuses: write
+    with:
+      workflow_name: Verify/examples
+      sha: ${{ inputs.sha }}
 
   publish:
     needs:
     - env
+    - check
     uses: ./.github/workflows/_stage_publish.yml
     name: Publish ${{ needs.env.outputs.repo_ref_title }}
     with:
       build_image_ubuntu: ${{ needs.env.outputs.build_image_ubuntu }}
       trusted: ${{ needs.env.outputs.trusted == 'true' && true || false }}
       version_dev: ${{ needs.env.outputs.version_dev }}
-      given_ref: ${{ inputs.ref }}
       repo_ref: ${{ inputs.ref }}
       sha: ${{ inputs.sha }}
     permissions:
-      contents: write
+      contents: read
+      packages: read
     secrets:
       ENVOY_CI_SYNC_APP_ID: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
       ENVOY_CI_SYNC_APP_KEY: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
+      ENVOY_CI_PUBLISH_APP_ID: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
+      ENVOY_CI_PUBLISH_APP_KEY: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
   verify:
     uses: ./.github/workflows/_stage_verify.yml

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   androidbuild:
     if: ${{ needs.env.outputs.mobile_android_build == 'true' }}

--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -20,7 +20,6 @@ jobs:
       prime_build_image: true
     permissions:
       contents: read
-      statuses: write
 
   kotlintestsmac:
     if: ${{ needs.env.outputs.mobile_android_tests == 'true' }}

--- a/.github/workflows/mobile-asan.yml
+++ b/.github/workflows/mobile-asan.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   asan:
     if: ${{ needs.env.outputs.mobile_asan == 'true' }}

--- a/.github/workflows/mobile-cc_tests.yml
+++ b/.github/workflows/mobile-cc_tests.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   cctests:
     if: ${{ needs.env.outputs.mobile_cc_tests == 'true' }}

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   cc_test_no_yaml:
     needs: env

--- a/.github/workflows/mobile-core.yml
+++ b/.github/workflows/mobile-core.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   unittests:
     if: ${{ github.repository == 'envoyproxy/envoy' }}

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   coverage:
     if: ${{ needs.env.outputs.mobile_coverage == 'true' }}

--- a/.github/workflows/mobile-docs.yml
+++ b/.github/workflows/mobile-docs.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   docs:
     if: ${{ github.repository == 'envoyproxy/envoy' }}

--- a/.github/workflows/mobile-format.yml
+++ b/.github/workflows/mobile-format.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   formatall:
     if: ${{ needs.env.outputs.mobile_formatting == 'true' }}

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   iosbuild:
     if: ${{ needs.env.outputs.mobile_ios_build == 'true' }}

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   swifttests:
     if: ${{ needs.env.outputs.mobile_ios_tests == 'true' }}

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -15,7 +15,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   android_release_artifacts:
     if: >-

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   validate_swiftpm_example:
     if: ${{ needs.env.outputs.mobile_release_validation == 'true' }}

--- a/.github/workflows/mobile-tsan.yml
+++ b/.github/workflows/mobile-tsan.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.github/workflows/_env.yml
     permissions:
       contents: read
-      statuses: write
 
   tsan:
     if: ${{ needs.env.outputs.mobile_tsan == 'true' }}

--- a/tools/base/requirements.in
+++ b/tools/base/requirements.in
@@ -9,7 +9,7 @@ colorama
 coloredlogs
 cryptography>=41.0.1
 dependatool>=0.2.2
-envoy.base.utils>=0.4.14
+envoy.base.utils>=0.4.15
 envoy.code.check>=0.5.8
 envoy.dependency.check>=0.1.10
 envoy.distribution.release>=0.0.9

--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -436,9 +436,9 @@ docutils==0.19 \
     #   envoy-docs-sphinx-runner
     #   sphinx
     #   sphinx-rtd-theme
-envoy-base-utils==0.4.14 \
-    --hash=sha256:90a576b24bb0275594e34cb731d1115e4e7428c7435231dea3427cfe4581f6de \
-    --hash=sha256:a200d000079b47979f58c4bee58bd40416acf101244eb464901891379e2b5894
+envoy-base-utils==0.4.15 \
+    --hash=sha256:7c614a4f9765cfe4512bdc00a15fba69b04490c7028a545c6bc41449bc4b2020 \
+    --hash=sha256:b40c9a0375a2f750c384a61c511e50d947802295de30b8138e2a1f23d4d5a377
     # via
     #   -r requirements.in
     #   envoy-code-check


### PR DESCRIPTION
Hopefully this fixes a number of issues

- switches to using correct bot for publishing
- fixes issue on postsubmit where `ENVOY_SHA` was not being set
- separates out status setting from `_env.yml` this requires permissions and is only required by the triggered wf
- bumps `envoy.base.utils` to improve publishing ci feedback
- thins vars a little

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
