### PR TITLE
[Envoy Mobile]Implement QUICHE_LOG with ABSL_LOG

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -2764,7 +2764,18 @@ envoy_cc_library(
         ":quiche_common_platform_iovec",
         ":quiche_common_platform_logging",
         ":quiche_common_platform_prefetch",
-        "@envoy//source/common/quic/platform:quiche_logging_impl_lib",
+    ],
+)
+
+envoy_quiche_platform_impl_cc_library(
+    name = "quiche_common_mobile_quiche_logging_lib",
+    hdrs = [
+        "quiche/common/platform/default/quiche_platform_impl/quiche_logging_impl.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log:absl_check",
+        "@com_google_absl//absl/log:absl_log",
     ],
 )
 
@@ -4680,8 +4691,15 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
-        "@envoy//source/common/quic/platform:quiche_logging_impl_lib",
-    ],
+    ] + select({
+        "@platforms//os:android": [
+            "@envoy//source/common/quic/platform:mobile_quiche_bug_tracker_impl_lib",
+        ],
+        "@platforms//os:ios": [
+            "@envoy//source/common/quic/platform:mobile_quiche_bug_tracker_impl_lib",
+        ],
+        "//conditions:default": ["@envoy//source/common/quic/platform:quiche_logging_impl_lib"],
+    }),
 )
 
 envoy_cc_library(
@@ -4694,8 +4712,15 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
-        "@envoy//source/common/quic/platform:quiche_logging_impl_lib",
-    ],
+    ] + select({
+        "@platforms//os:android": [
+            ":quiche_common_mobile_quiche_logging_lib",
+        ],
+        "@platforms//os:ios": [
+            ":quiche_common_mobile_quiche_logging_lib",
+        ],
+        "//conditions:default": ["@envoy//source/common/quic/platform:quiche_logging_impl_lib"],
+    }),
 )
 
 envoy_cc_library(

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -83,6 +83,17 @@ envoy_quiche_platform_impl_cc_library(
 )
 
 envoy_quiche_platform_impl_cc_library(
+    name = "mobile_quiche_bug_tracker_impl_lib",
+    hdrs = [
+        "mobile_quiche_bug_tracker_impl.h",
+    ],
+    tags = ["nofips"],
+    deps = [
+        "@com_github_google_quiche//:quiche_common_mobile_quiche_logging_lib",
+    ],
+)
+
+envoy_quiche_platform_impl_cc_library(
     name = "quic_base_impl_lib",
     external_deps = [
         "abseil_base",

--- a/source/common/quic/platform/mobile_quiche_bug_tracker_impl.h
+++ b/source/common/quic/platform/mobile_quiche_bug_tracker_impl.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+//
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "quiche/common/platform/api/quiche_logging.h"
+
+#define QUICHE_BUG_IMPL(b) QUICHE_DLOG(DFATAL) << #b ": "
+#define QUICHE_BUG_IF_IMPL(b, condition) QUICHE_DLOG_IF(DFATAL, condition) << #b ": "
+#define QUICHE_PEER_BUG_IMPL(b) QUICHE_DLOG(DFATAL)
+#define QUICHE_PEER_BUG_IF_IMPL(b, condition) QUICHE_DLOG_IF(DFATAL, condition)


### PR DESCRIPTION
Commit Message: Use ABSL_LOG for quiche logging on Envoy Mobile
Additional Description: There are 2 benefits:
1. ABSL_LOG will log to logcat to help with debug on Android.
2. ABSL_DLOG will be compiled out in opt build and thus reduces EM's binary size.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
