### PR TITLE
postgres: fix connection issue when downstream and upstream SSL is enabled

### DIFF
--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
@@ -46,6 +46,10 @@ void PostgresFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks&
   read_callbacks_ = &callbacks;
 }
 
+void PostgresFilter::initializeWriteFilterCallbacks(Network::WriteFilterCallbacks& callbacks) {
+  write_callbacks_ = &callbacks;
+}
+
 // Network::WriteFilter
 Network::FilterStatus PostgresFilter::onWrite(Buffer::Instance& data, bool) {
 
@@ -229,7 +233,7 @@ bool PostgresFilter::onSSLRequest() {
     }
     return true;
   });
-  read_callbacks_->connection().write(buf, false);
+  write_callbacks_->injectWriteDataToFilterChain(buf, false);
 
   return false;
 }

--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.h
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.h
@@ -102,6 +102,7 @@ public:
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
   Network::FilterStatus onNewConnection() override;
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+  void initializeWriteFilterCallbacks(Network::WriteFilterCallbacks& callbacks) override;
 
   // Network::WriteFilter
   Network::FilterStatus onWrite(Buffer::Instance& data, bool end_stream) override;
@@ -138,6 +139,7 @@ public:
 
 private:
   Network::ReadFilterCallbacks* read_callbacks_{};
+  Network::WriteFilterCallbacks* write_callbacks_{};
   PostgresFilterConfigSharedPtr config_;
   Buffer::OwnedImpl frontend_buffer_;
   Buffer::OwnedImpl backend_buffer_;

--- a/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
@@ -370,7 +370,8 @@ TEST_F(PostgresFilterTest, TerminateSSL) {
   Network::Connection::BytesSentCb cb;
   EXPECT_CALL(connection_, addBytesSentCallback(_)).WillOnce(testing::SaveArg<0>(&cb));
   Buffer::OwnedImpl buf;
-  EXPECT_CALL(write_callbacks_, injectWriteDataToFilterChain(_, false)).WillOnce(testing::SaveArg<0>(&buf));
+  EXPECT_CALL(write_callbacks_, injectWriteDataToFilterChain(_, false))
+      .WillOnce(testing::SaveArg<0>(&buf));
   data_.writeBEInt<uint32_t>(8);
   // 1234 in the most significant 16 bits and some code in the least significant 16 bits.
   data_.writeBEInt<uint32_t>(80877103); // SSL code.

--- a/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
@@ -41,11 +41,12 @@ public:
     config_ = std::make_shared<PostgresFilterConfig>(config_options, scope_);
     filter_ = std::make_unique<PostgresFilter>(config_);
 
-    filter_->initializeReadFilterCallbacks(filter_callbacks_);
+    filter_->initializeReadFilterCallbacks(read_callbacks_);
+    filter_->initializeWriteFilterCallbacks(write_callbacks_);
   }
 
   void setMetadata() {
-    EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
+    EXPECT_CALL(read_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
     EXPECT_CALL(connection_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
     ON_CALL(stream_info_, setDynamicMetadata(NetworkFilterNames::get().PostgresProxy, _))
         .WillByDefault(Invoke([this](const std::string&, const ProtobufWkt::Struct& obj) {
@@ -60,7 +61,8 @@ public:
   std::string stat_prefix_{"test."};
   std::unique_ptr<PostgresFilter> filter_;
   PostgresFilterConfigSharedPtr config_;
-  NiceMock<Network::MockReadFilterCallbacks> filter_callbacks_;
+  NiceMock<Network::MockReadFilterCallbacks> read_callbacks_;
+  NiceMock<Network::MockWriteFilterCallbacks> write_callbacks_;
   NiceMock<Network::MockConnection> connection_;
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
 
@@ -364,11 +366,11 @@ TEST_F(PostgresFilterTest, QueryMessageMetadata) {
 // Decoder::Stopped.
 TEST_F(PostgresFilterTest, TerminateSSL) {
   filter_->getConfig()->terminate_ssl_ = true;
-  EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
+  EXPECT_CALL(read_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
   Network::Connection::BytesSentCb cb;
   EXPECT_CALL(connection_, addBytesSentCallback(_)).WillOnce(testing::SaveArg<0>(&cb));
   Buffer::OwnedImpl buf;
-  EXPECT_CALL(connection_, write(_, false)).WillOnce(testing::SaveArg<0>(&buf));
+  EXPECT_CALL(write_callbacks_, injectWriteDataToFilterChain(_, false)).WillOnce(testing::SaveArg<0>(&buf));
   data_.writeBEInt<uint32_t>(8);
   // 1234 in the most significant 16 bits and some code in the least significant 16 bits.
   data_.writeBEInt<uint32_t>(80877103); // SSL code.
@@ -398,7 +400,7 @@ TEST_F(PostgresFilterTest, TerminateSSL) {
 }
 
 TEST_F(PostgresFilterTest, UpstreamSSL) {
-  EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
+  EXPECT_CALL(read_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
 
   // Configure upstream SSL to be disabled. encryptUpstream must not be called.
   filter_->getConfig()->upstream_ssl_ =
@@ -415,17 +417,17 @@ TEST_F(PostgresFilterTest, UpstreamSSL) {
   ASSERT_TRUE(filter_->shouldEncryptUpstream());
   // Simulate that upstream server agreed for SSL and conversion of upstream Transport socket was
   // successful.
-  EXPECT_CALL(filter_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(true));
+  EXPECT_CALL(read_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(true));
   filter_->encryptUpstream(true, data_);
   ASSERT_EQ(1, filter_->getStats().sessions_upstream_ssl_success_.value());
   // Simulate that upstream server agreed for SSL but conversion of upstream Transport socket
   // failed.
-  EXPECT_CALL(filter_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(false));
+  EXPECT_CALL(read_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(false));
   filter_->encryptUpstream(true, data_);
   ASSERT_EQ(1, filter_->getStats().sessions_upstream_ssl_failed_.value());
   // Simulate that upstream server does not agree for SSL. Filter should close the connection to
   // downstream client.
-  EXPECT_CALL(filter_callbacks_, startUpstreamSecureTransport()).Times(0);
+  EXPECT_CALL(read_callbacks_, startUpstreamSecureTransport()).Times(0);
   EXPECT_CALL(connection_, close(_));
   filter_->encryptUpstream(false, data_);
   ASSERT_EQ(2, filter_->getStats().sessions_upstream_ssl_failed_.value());
@@ -433,7 +435,7 @@ TEST_F(PostgresFilterTest, UpstreamSSL) {
 
 TEST_F(PostgresFilterTest, UpstreamSSLStats) {
   static_cast<DecoderImpl*>(filter_->getDecoder())->state(DecoderImpl::State::InitState);
-  EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
+  EXPECT_CALL(read_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
 
   filter_->getConfig()->upstream_ssl_ =
       envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::REQUIRE;
@@ -443,7 +445,7 @@ TEST_F(PostgresFilterTest, UpstreamSSLStats) {
 
   Buffer::OwnedImpl upstream_data;
   upstream_data.add("S");
-  EXPECT_CALL(filter_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(true));
+  EXPECT_CALL(read_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(true));
   ASSERT_THAT(Network::FilterStatus::StopIteration, filter_->onWrite(upstream_data, false));
 
   createPostgresMsg(upstream_data, "C", "SELECT blah");

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -483,11 +483,10 @@ TEST_P(UpstreamSSLRequirePostgresIntegrationTest, ServerDeniesSSLTest) {
 INSTANTIATE_TEST_SUITE_P(IpVersions, UpstreamSSLRequirePostgresIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-// Base class for parameterized tests for upstream and downstream SSL enabled.
+// Base class for parameterized tests when upstream and downstream SSL is enabled.
 class UpstreamAndDownstreamSSLIntegrationTest : public UpstreamSSLBaseIntegrationTest{
 public:
   UpstreamAndDownstreamSSLIntegrationTest()
-      // Disable downstream SSL and attach synchronization filter.
       : UpstreamSSLBaseIntegrationTest(
       // Configure upstream SSL
       std::make_tuple("upstream_ssl: REQUIRE",
@@ -517,30 +516,11 @@ public:
    )EOF",
                     TestEnvironment::runfilesPath("test/config/integration/certs/servercert.pem"),
                     TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem")))) {}
-};
 
-TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerAgreesForSSL) {
-  Buffer::OwnedImpl data;
-
-  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  //FakeRawConnectionPtr fake_upstream_connection;
-  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection_));
-
-  // Send the startup message requesting SSL.
-  // Message is 8 bytes long. The first 4 bytes contain length (8)
-  // The next 8 bytes contain message code (RequestSSL=80877103)
-  data.writeBEInt<uint32_t>(8);
-  data.writeBEInt<uint32_t>(80877103);
-
-  // Message will be processed by Postgres filter which
-  // is configured to accept SSL termination and confirm it
-  // by returning single byte 'S'.
-  ASSERT_TRUE(tcp_client->write(data.toString()));
-  data.drain(data.length());
-
-  tcp_client->waitForData("S", true);
-
-  // Attach TLS to tcp_client.
+    // Method changes IntegrationTcpClient's transport socket to TLS.
+    // Sending any traffic to newly attached TLS transport socket will trigger
+    // TLS handshake negotiation.
+    void enableTLSonTCPClient(const IntegrationTcpClientPtr& tcp_client) {
     // Setup factory and context for tls transport socket.
     // The tls transport socket will be inserted into fake_upstream when
     // Envoy's upstream starttls transport socket is converted to secure mode.
@@ -566,11 +546,52 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerAgreesForSSL) {
     Network::TransportSocketPtr ts = tls_context->createTransportSocket(options, connection->streamInfo().upstreamInfo()->upstreamHost());
       connection->transportSocket() = std::move(ts);
       connection->transportSocket()->setTransportSocketCallbacks(*connection);
+}
+};
+
+// Integration test when both downstream and upstream SSL is enabled.
+// In this scenario test client establishes SSL connection to Envoy. Envoy decrypts the traffic.
+// The traffic is encrypted again when sent to upstream server.
+// The test follows the following scenario:
+//
+// Test client                     Envoy                  Upstream
+// ----- Can I use SSL? ------------>
+// <------- Yes---------------------
+// <------- TLS handshake ---------->
+// ------ Initial postgres msg ----->
+//                                    ------ Can I use SSL? --->
+//                                    <------- Yes--------------
+//                                    <------- TLS handshake--->
+//                                    --Initial postgres msg--->
+// ------ close connection --------->
+//                                    ------ close connection--->
+// 
+TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerAgreesForSSL) {
+  Buffer::OwnedImpl data;
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection_));
+
+  // Send the startup message requesting SSL.
+  // Message is 8 bytes long. The first 4 bytes contain length (8)
+  // The next 8 bytes contain message code (RequestSSL=80877103)
+  data.writeBEInt<uint32_t>(8);
+  data.writeBEInt<uint32_t>(80877103);
+
+  // Message will be processed by Postgres filter which
+  // is configured to accept SSL termination and confirm it
+  // by returning single byte 'S'.
+  ASSERT_TRUE(tcp_client->write(data.toString()));
+  data.drain(data.length());
+
+  tcp_client->waitForData("S", true);
+
+  // Attach TLS to tcp_client.
+enableTLSonTCPClient(tcp_client);
 
    // Write initial postgres message. This should trigger SSL negotiation between test TCP client and Envoy
    // downstream transport socket. Postgres filter should ask the fake upstream server if it will accept encypted
    // connection.
-  //Buffer::OwnedImpl data;
   Buffer::OwnedImpl upstream_data;
   std::string rcvd;
   createInitialPostgresRequest(data);
@@ -604,17 +625,30 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerAgreesForSSL) {
   tcp_client->close();
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
 
-  // Make sure that the successful login bumped up the number of sessions.
   test_server_->waitForCounterEq("postgres.postgres_stats.sessions_terminated_ssl", 1);
   test_server_->waitForCounterEq("postgres.postgres_stats.sessions_upstream_ssl_success", 1);
   test_server_->waitForCounterEq("postgres.postgres_stats.sessions_upstream_ssl_failed", 0);
 }
 
+// Integration test when both downstream and upstream SSL is enabled.
+// In this scenario test client establishes SSL connection to Envoy. Envoy decrypts the traffic.
+// The traffic is encrypted again when sent to upstream server, but the server
+// rejects request for SSL.
+// The test follows the following scenario:
+//
+// Test client                     Envoy                  Upstream
+// ----- Can I use SSL? ------------>
+// <------- Yes---------------------
+// <------- TLS handshake ---------->
+// ------ Initial postgres msg ----->
+//                                    ------ Can I use SSL? --->
+//                                    <------- No---------------
+// <----- close connection ----------
+//                                    ------ close connection--->
 TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerRejectsSSL) {
   Buffer::OwnedImpl data;
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  //FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection_));
 
   // Send the startup message requesting SSL.
@@ -632,36 +666,11 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerRejectsSSL) {
   tcp_client->waitForData("S", true);
 
   // Attach TLS to tcp_client.
-    // Setup factory and context for tls transport socket.
-    // The tls transport socket will be inserted into fake_upstream when
-    // Envoy's upstream starttls transport socket is converted to secure mode.
-    std::unique_ptr<Ssl::ContextManager> tls_context_manager =
-        std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(timeSystem());
-
-    envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext upstream_tls_context;
-
-    NiceMock<Server::Configuration::MockTransportSocketFactoryContext> mock_factory_ctx;
-    ON_CALL(mock_factory_ctx.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
-    auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
-        upstream_tls_context, mock_factory_ctx);
-    static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
-    Network::UpstreamTransportSocketFactoryPtr tls_context =
-        Network::UpstreamTransportSocketFactoryPtr{
-            new Extensions::TransportSockets::Tls::ClientSslSocketFactory(
-                std::move(cfg), *tls_context_manager, *(client_stats_store->rootScope()))};
-
- Network::TransportSocketOptionsConstSharedPtr options;
-
-      auto connection =
-          dynamic_cast<Envoy::Network::ConnectionImpl*>(tcp_client->connection());
-    Network::TransportSocketPtr ts = tls_context->createTransportSocket(options, connection->streamInfo().upstreamInfo()->upstreamHost());
-      connection->transportSocket() = std::move(ts);
-      connection->transportSocket()->setTransportSocketCallbacks(*connection);
+enableTLSonTCPClient(tcp_client);
 
    // Write initial postgres message. This should trigger SSL negotiation between test TCP client and Envoy
    // downstream transport socket. Postgres filter should ask the fake upstream server if it will accept encypted
    // connection.
-  //Buffer::OwnedImpl data;
   Buffer::OwnedImpl upstream_data;
   std::string rcvd;
   createInitialPostgresRequest(data);
@@ -675,23 +684,6 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerRejectsSSL) {
   ASSERT_EQ(80877103, upstream_data.peekBEInt<uint32_t>(4));
   upstream_data.drain(upstream_data.length());
 
-  // Reply to Envoy with 'E' and attach TLS socket to upstream.
-  upstream_data.add("E");
-  ASSERT_TRUE(fake_upstream_connection_->write(upstream_data.toString()));
-#if 0
-  config_factory_.recv_sync_.WaitForNotification();
-  enableTLSOnFakeUpstream();
-  config_factory_.proceed_sync_.Notify();
-
-  fake_upstream_connection_->clearData();
-  ASSERT_TRUE(fake_upstream_connection_->waitForData(data.length(), &rcvd));
-  // Make sure that upstream received initial postgres request, which
-  // triggered upstream SSL negotiation and TLS handshake.
-  ASSERT_EQ(data.toString(), rcvd);
-
-  data.drain(data.length());
-#endif
-
   // Reply to Envoy with 'E' (SSL not allowed).
   upstream_data.add("E");
   ASSERT_TRUE(fake_upstream_connection_->write(upstream_data.toString()));
@@ -699,10 +691,11 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerRejectsSSL) {
 
   data.drain(data.length());
 
-  // Connection to client should be closed.
+  // Envoy should close the connection to test client.
   tcp_client->waitForDisconnect();
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
 
+  test_server_->waitForCounterEq("postgres.postgres_stats.sessions_terminated_ssl", 1);
   test_server_->waitForCounterEq("postgres.postgres_stats.sessions_upstream_ssl_success", 0);
   test_server_->waitForCounterEq("postgres.postgres_stats.sessions_upstream_ssl_failed", 1);
 }

--- a/test/integration/integration_tcp_client.h
+++ b/test/integration/integration_tcp_client.h
@@ -49,7 +49,7 @@ public:
   bool connected() const { return !disconnected_; }
   // clear up to the `count` number of bytes of received data
   void clearData(size_t count = std::string::npos) { payload_reader_->clearData(count); }
-  Network::Connection* connection() const {return connection_.get();}
+  Network::Connection* connection() const { return connection_.get(); }
 
 private:
   struct ConnectionCallbacks : public Network::ConnectionCallbacks {

--- a/test/integration/integration_tcp_client.h
+++ b/test/integration/integration_tcp_client.h
@@ -49,6 +49,7 @@ public:
   bool connected() const { return !disconnected_; }
   // clear up to the `count` number of bytes of received data
   void clearData(size_t count = std::string::npos) { payload_reader_->clearData(count); }
+  Network::Connection* connection() const {return connection_.get();}
 
 private:
   struct ConnectionCallbacks : public Network::ConnectionCallbacks {


### PR DESCRIPTION
Commit Message:
postgres: fix connection issue when downstream and upstream SSL is enabled
Additional Description:
The problem was with how postgres filter replied to downstream client during SSL negotiation. The reply was sent through entire filter chain instead of only through downstream filters. That caused postgres filter to receive one extra character which was not recognized by decoder and caused connection reset. 
Risk Level: Low.
Testing: Added integration test for upstream and downstream SSL connections.
Docs Changes: No.
Release Notes: No.
Platform Specific Features: No
Fixes #27808