### PR TITLE
mobile: Disable flaky test on CI

### DIFF
--- a/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -1808,6 +1808,7 @@ public class CronetUrlRequestTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
+  @Ignore("https://github.com/envoyproxy/envoy/issues/30199")
   public void testFailures() throws Exception {
     throwOrCancel(FailureType.CANCEL_SYNC, ResponseStep.ON_RECEIVED_REDIRECT, false, false);
     throwOrCancel(FailureType.CANCEL_ASYNC, ResponseStep.ON_RECEIVED_REDIRECT, false, false);


### PR DESCRIPTION
Since landing https://github.com/envoyproxy/envoy/pull/30161, which moves the Android Cronet test
to run on Linux instead of Mac, we now get pretty regular failures on the CronetUrlRequestTest, e.g. https://github.com/envoyproxy/envoy/actions/runs/6512040855/job/17688913785?pr=30198.

Disabling the test for now and have an open bug to look into this:
https://github.com/envoyproxy/envoy/issues/30199