### PR TITLE
docs: clarify requirement for ext_authz dynamic metadata

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_authz_filter.rst
@@ -182,7 +182,7 @@ Dynamic Metadata
 The External Authorization filter supports emitting dynamic metadata as an opaque ``google.protobuf.Struct``.
 
 When using a gRPC authorization server, dynamic metadata will be emitted only when the :ref:`CheckResponse
-<envoy_v3_api_msg_service.auth.v3.CheckResponse>` contains a filled :ref:`dynamic_metadata
+<envoy_v3_api_msg_service.auth.v3.CheckResponse>` contains a non-empty :ref:`dynamic_metadata
 <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field.
 
 When using an HTTP authorization server, dynamic metadata will be emitted only when there are response headers

--- a/docs/root/configuration/http/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_authz_filter.rst
@@ -191,7 +191,7 @@ from the authorization server that match the configured
 if set. For every response header that matches, the filter will emit dynamic metadata whose key is the name of the matched header and whose value is the value of the matched header.
 
 Both the HTTP and gRPC external authorization filters support a dynamic metadata field called ``ext_authz_duration`` which records the time it takes to complete an authorization request in milliseconds.
-This field will not be populated if the request does not complete. Additionally, the dynamic metadata field is under the namespace ``envoy.filters.http.ext_authz``.
+This field will not be populated if the request does not complete.
 
 Runtime
 -------

--- a/docs/root/configuration/http/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_authz_filter.rst
@@ -191,7 +191,7 @@ from the authorization server that match the configured
 if set. For every response header that matches, the filter will emit dynamic metadata whose key is the name of the matched header and whose value is the value of the matched header.
 
 Both the HTTP and gRPC external authorization filters support a dynamic metadata field called ``ext_authz_duration`` which records the time it takes to complete an authorization request in milliseconds.
-This field will not be populated if the request does not complete.
+This field will not be populated if the request does not complete. Additionally, the dynamic metadata field is under the namespace ``envoy.filters.http.ext_authz``.
 
 Runtime
 -------

--- a/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
@@ -107,5 +107,5 @@ Dynamic Metadata
 
 The External Authorization filter emits dynamic metadata as an opaque ``google.protobuf.Struct``
 *only* when the gRPC authorization server returns a :ref:`CheckResponse
-<envoy_v3_api_msg_service.auth.v3.CheckResponse>` with a filled :ref:`dynamic_metadata
+<envoy_v3_api_msg_service.auth.v3.CheckResponse>` with a non-empty :ref:`dynamic_metadata
 <envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field.

--- a/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
@@ -108,4 +108,4 @@ Dynamic Metadata
 The External Authorization filter emits dynamic metadata as an opaque ``google.protobuf.Struct``
 *only* when the gRPC authorization server returns a :ref:`CheckResponse
 <envoy_v3_api_msg_service.auth.v3.CheckResponse>` with a non-empty :ref:`dynamic_metadata
-<envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field. Additionally, the dynamic metadata field is under the namespace ``envoy.filters.network.ext_authz``.
+<envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field.

--- a/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/ext_authz_filter.rst
@@ -108,4 +108,4 @@ Dynamic Metadata
 The External Authorization filter emits dynamic metadata as an opaque ``google.protobuf.Struct``
 *only* when the gRPC authorization server returns a :ref:`CheckResponse
 <envoy_v3_api_msg_service.auth.v3.CheckResponse>` with a non-empty :ref:`dynamic_metadata
-<envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field.
+<envoy_v3_api_field_service.auth.v3.CheckResponse.dynamic_metadata>` field. Additionally, the dynamic metadata field is under the namespace ``envoy.filters.network.ext_authz``.


### PR DESCRIPTION
The `ext_authz_duration` field is only emitted if the  dynamic metadata `Struct` in the response is [non-empty](https://github.com/envoyproxy/envoy/blob/cbe2fb292899b1a8e7ebca16c540d7ca23a104a9/source/extensions/filters/http/ext_authz/ext_authz.cc#L200) (e.g. contains at least one key-value pair). Replace "filled" with "non-empty" to avoid ambiguity.