### PR TITLE
Add release target to copy binary after build server_only

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -106,6 +106,13 @@ For a release version of the Envoy binary you can run:
 The build artifact can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy` (or wherever
 `$ENVOY_DOCKER_BUILD_DIR` points).
 
+To enable the previous behavior of the `release.server_only` target where the final binary was copied to a tar.gz file
+(e.g. envoy-binary.tar.gz), you can run:
+  
+  ```bash
+  ./ci/run_envoy_docker.sh './ci/do_ci.sh release.server_only.copy_binary
+  ```
+
 For a debug version of the Envoy binary you can run:
 
 ```bash

--- a/ci/README.md
+++ b/ci/README.md
@@ -108,9 +108,9 @@ The build artifact can be found in `/tmp/envoy-docker-build/envoy/source/exe/env
 
 To enable the previous behavior of the `release.server_only` target where the final binary was copied to a tar.gz file
 (e.g. envoy-binary.tar.gz), you can run:
-  
+
   ```bash
-  ./ci/run_envoy_docker.sh './ci/do_ci.sh release.server_only.copy_binary
+  ./ci/run_envoy_docker.sh './ci/do_ci.sh release.server_only.binary
   ```
 
 For a debug version of the Envoy binary you can run:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -857,8 +857,8 @@ case $CI_TARGET in
            "${ENVOY_BINARY_DIR}/schema_validator_tool"
         echo "Release files created in ${ENVOY_BINARY_DIR}"
         ;;
-    
-    release.server_only.copy_binary)
+
+    release.server_only.binary)
         setup_clang_toolchain
         echo "bazel release build..."
         bazel_envoy_binary_build release

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -857,6 +857,12 @@ case $CI_TARGET in
            "${ENVOY_BINARY_DIR}/schema_validator_tool"
         echo "Release files created in ${ENVOY_BINARY_DIR}"
         ;;
+    
+    release.server_only.copy_binary)
+        setup_clang_toolchain
+        echo "bazel release build..."
+        bazel_envoy_binary_build release
+        ;;
 
     release.signed)
         echo "Signing binary packages..."


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Add a release target to opt into behavior before #29646 was merged, specifically the copying of the final binary to something akin to `envoy_binary.tar.gz`

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
