### PR TITLE
Clarify slow start+locality weighted lb

### DIFF
--- a/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
@@ -63,4 +63,4 @@ Once endpoints E1 and E2 exit slow start mode, their load balancing weight remai
    :align: center
 
 *Note* in case when multiple priorities are used with slow start and lower priority has just one endpoint A, during cross-priority spillover there will be no progressive increase of traffic to endpoint A, all traffic will shift at once.
-Same applies to locality weighted loadbalancing, when slow start is enabled for the upstream cluster and traffic is routed cross zone to a zone with one endpoint A, there will be no no progressive increase of traffic to endpoint A.
+Same applies to locality weighted loadbalancing, when slow start is enabled for the upstream cluster and traffic is routed cross zone to a zone with one endpoint A, there will be no progressive increase of traffic to endpoint A.

--- a/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
@@ -63,4 +63,4 @@ Once endpoints E1 and E2 exit slow start mode, their load balancing weight remai
    :align: center
 
 *Note* in case when multiple priorities are used with slow start and lower priority has just one endpoint A, during cross-priority spillover there will be no progressive increase of traffic to endpoint A, all traffic will shift at once.
-Same applies to locality weighted loadbalancing, when slow start is enabled for the upstream cluster and traffic is routed crozz zone to a zone with one endpoint A, there will be no no progressive increase of traffic to endpoint A.
+Same applies to locality weighted loadbalancing, when slow start is enabled for the upstream cluster and traffic is routed cross zone to a zone with one endpoint A, there will be no no progressive increase of traffic to endpoint A.

--- a/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
@@ -63,3 +63,4 @@ Once endpoints E1 and E2 exit slow start mode, their load balancing weight remai
    :align: center
 
 *Note* in case when multiple priorities are used with slow start and lower priority has just one endpoint A, during cross-priority spillover there will be no progressive increase of traffic to endpoint A, all traffic will shift at once.
+Same applies to locality weighted loadbalancing, when slow start is enabled for the upstream cluster and traffic is routed crozz zone to a zone with one endpoint A, there will be no no progressive increase of traffic to endpoint A.


### PR DESCRIPTION
Clarify how slow start works with weighted locality load balancing during cross zone routing. This came out as TODO from #29008.

Commit Message:
Additional Description:
Risk Level: Low
Testing: 
Docs Changes: Done
Release Notes:
Platform Specific Features:
Fixes #29008

