### PR TITLE
dns_filter: avoid 0 for transaction id in tests at current stage

### DIFF
--- a/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
@@ -645,7 +645,7 @@ TEST_F(DnsFilterTest, RepeatedTypeAQuerySuccess) {
   for (size_t i = 0; i < loopCount; i++) {
 
     // Generate a changing, non-zero query ID for each lookup
-    const uint16_t query_id = (random_.random() + i) & 0xFFFF;
+    const uint16_t query_id = (random_.random() + i) % 0xFFFF + 1;
     const std::string query =
         Utils::buildQueryForDomain(domain, DNS_RECORD_TYPE_A, DNS_RECORD_CLASS_IN, query_id);
     ASSERT_FALSE(query.empty());

--- a/test/extensions/filters/udp/dns_filter/dns_filter_test_utils.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test_utils.cc
@@ -26,7 +26,7 @@ std::string buildQueryForDomain(const std::string& name, uint16_t rec_type, uint
                                 const uint16_t query_id) {
   Random::RandomGeneratorImpl random_;
   struct DnsHeader query {};
-  uint16_t id = (query_id ? query_id : random_.random() & 0xFFFF);
+  uint16_t id = query_id ? query_id : (random_.random() % 0xFFFF) + 1;
 
   // Generate a random query ID
   query.id = id;


### PR DESCRIPTION
Commit Message:  Random transaction id generator can generate 0, while our current dns_parser apparently doesn't support 0 id. https://github.com/envoyproxy/envoy/blob/091ca544df4b190d197461f525a4accc6e644480/source/extensions/filters/udp/dns_filter/dns_parser.cc#L214-L217
In RFC1035, there is no clear objection for 0 id use though. IMO it is still based on the implementation of the clients. To unblock the release, we can avoid 0 in the test. And I also find the similar setting [non-zero query ID for each lookup in the previous tests](https://github.com/envoyproxy/envoy/blob/091ca544df4b190d197461f525a4accc6e644480/test/extensions/filters/udp/dns_filter/dns_filter_test.cc#L647) 3 years ago, though the code is also not correct.

Need further investigation for id = 0 handling based on RFC.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes: #30187  

