### PR TITLE
devex: Move VS Code specific settings to customizations/vscode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,34 +16,38 @@
   "containerEnv": {
     "ENVOY_SRCDIR": "${containerWorkspaceFolder}",
   },
-  "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash",
-    "bazel.buildifierFixOnFormat": true,
-    "clangd.path": "/opt/llvm/bin/clangd",
-    "python.pythonPath": "/usr/bin/python3",
-    "python.formatting.provider": "yapf",
-    "python.formatting.yapfArgs": [
-      "--style=${workspaceFolder}/.style.yapf"
-    ],
-    "files.exclude": {
-      "**/.clangd/**": true,
-      "**/bazel-*/**": true
-    },
-    "files.watcherExclude": {
-      "**/.clangd/**": true,
-      "**/bazel-*/**": true
-    }
-  },
   "remoteUser": "vscode",
   "containerUser": "vscode",
   "postCreateCommand": ".devcontainer/setup.sh",
-  "extensions": [
-    "github.vscode-pull-request-github",
-    "zxh404.vscode-proto3",
-    "bazelbuild.vscode-bazel",
-    "llvm-vs-code-extensions.vscode-clangd",
-    "vadimcn.vscode-lldb",
-    "webfreak.debug",
-    "ms-python.python"
-  ]
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+        "bazel.buildifierFixOnFormat": true,
+        "clangd.path": "/opt/llvm/bin/clangd",
+        "python.pythonPath": "/usr/bin/python3",
+        "python.formatting.provider": "yapf",
+        "python.formatting.yapfArgs": [
+          "--style=${workspaceFolder}/.style.yapf"
+        ],
+        "files.exclude": {
+          "**/.clangd/**": true,
+          "**/bazel-*/**": true
+        },
+        "files.watcherExclude": {
+          "**/.clangd/**": true,
+          "**/bazel-*/**": true
+        }
+      },
+      "extensions": [
+        "github.vscode-pull-request-github",
+        "zxh404.vscode-proto3",
+        "bazelbuild.vscode-bazel",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "vadimcn.vscode-lldb",
+        "webfreak.debug",
+        "ms-python.python"
+      ]
+    }
+  },
 }


### PR DESCRIPTION
VS Code specific customizations should go to `customizations/vsocde` as per https://containers.dev/supporting. This change will also enable supporting other tools to use devcontainer for developing Envoy.

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a