### PR TITLE
[Geoip Filter] Fix links in docs

### DIFF
--- a/docs/root/configuration/http/http_filters/geoip_filter.rst
+++ b/docs/root/configuration/http/http_filters/geoip_filter.rst
@@ -19,7 +19,7 @@ Configuration
 
 Geolocation Providers
 ---------------------
-Currently only `Maxmind <https://www.maxmind.com/en/geoip2-services-and-databases>` geolocation provider is supported.
+Currently only `Maxmind <https://www.maxmind.com/en/geoip2-services-and-databases>`_ geolocation provider is supported.
 This provider should be configured with the type URL ``type.googleapis.com/envoy.extensions.geoip_providers.maxmind.v3.MaxMindConfig``.
 
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.geoip_providers.maxmind.v3.MaxMindConfig>`
@@ -66,8 +66,8 @@ comes from the owning HTTP connection manager.
    ``rq_total``, Counter, Total number of requests for which geolocation filter was invoked.
 
 Besides Geolocation filter level statisctics, there is statistics emitted by the :ref:`Maxmind geolocation provider <envoy_v3_api_msg_extensions.geoip_providers.maxmind.v3.MaxMindConfig>`
-per geolocation database type (rooted at ``<stat_prefix>.maxmind.``). Database type can be one of `city_db <https://www.maxmind.com/en/geoip2-city>`,
-`isp_db <https://www.maxmind.com/en/geoip2-isp-database>`, `anon_db <https://dev.maxmind.com/geoip/docs/databases/anonymous-ip>`.
+per geolocation database type (rooted at ``<stat_prefix>.maxmind.``). Database type can be one of `city_db <https://www.maxmind.com/en/geoip2-city>`_,
+`isp_db <https://www.maxmind.com/en/geoip2-isp-database>`_, `anon_db <https://dev.maxmind.com/geoip/docs/databases/anonymous-ip>`_.
 
 .. csv-table::
    :header: Name, Type, Description


### PR DESCRIPTION
Currently all links in geoip filter docs look like this:
![Screenshot 2023-10-16 at 22 54 33](https://github.com/envoyproxy/envoy/assets/14430883/507ff039-fc52-498d-b3ff-98338cea27e4)
This patch fixes the links.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes: Done
Release Notes:
Platform Specific Features:
