### PR TITLE
mobile: Fix flaky `CronetUrlRequestTest::testFailures`

### DIFF
--- a/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -1769,8 +1769,8 @@ public class CronetUrlRequestTest {
                    callback.mError.getMessage());
   }
 
-  private void throwOrCancel(FailureType failureType, ResponseStep failureStep,
-                             boolean expectResponseInfo, boolean expectError) {
+  private TestUrlRequestCallback throwOrCancel(FailureType failureType, ResponseStep failureStep,
+                                               boolean expectError) {
     if (Log.isLoggable("TESTING", Log.VERBOSE)) {
       Log.v("TESTING", "Testing " + failureType + " during " + failureStep);
     }
@@ -1790,7 +1790,6 @@ public class CronetUrlRequestTest {
       assertEquals(ResponseStep.ON_FAILED, callback.mResponseStep);
     }
     assertTrue(urlRequest.isDone());
-    assertEquals(expectResponseInfo, callback.mResponseInfo != null);
     assertEquals(expectError, callback.mError != null);
     assertEquals(expectError, callback.mOnErrorCalled);
     // When failureType is FailureType.CANCEL_ASYNC_WITHOUT_PAUSE and failureStep is
@@ -1803,29 +1802,32 @@ public class CronetUrlRequestTest {
                        failureType == FailureType.CANCEL_ASYNC_WITHOUT_PAUSE,
                    callback.mOnCanceledCalled);
     }
+    return callback;
+  }
+
+  private void throwOrCancel(FailureType failureType, ResponseStep failureStep,
+                             boolean expectResponseInfo, boolean expectError) {
+    TestUrlRequestCallback callback = throwOrCancel(failureType, failureStep, expectError);
+    assertEquals(expectResponseInfo, callback.mResponseInfo != null);
   }
 
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("https://github.com/envoyproxy/envoy/issues/30199")
   public void testFailures() throws Exception {
     throwOrCancel(FailureType.CANCEL_SYNC, ResponseStep.ON_RECEIVED_REDIRECT, false, false);
     throwOrCancel(FailureType.CANCEL_ASYNC, ResponseStep.ON_RECEIVED_REDIRECT, false, false);
-    throwOrCancel(FailureType.CANCEL_ASYNC_WITHOUT_PAUSE, ResponseStep.ON_RECEIVED_REDIRECT, false,
-                  false);
+    throwOrCancel(FailureType.CANCEL_ASYNC_WITHOUT_PAUSE, ResponseStep.ON_RECEIVED_REDIRECT, false);
     throwOrCancel(FailureType.THROW_SYNC, ResponseStep.ON_RECEIVED_REDIRECT, false, true);
 
     throwOrCancel(FailureType.CANCEL_SYNC, ResponseStep.ON_RESPONSE_STARTED, true, false);
     throwOrCancel(FailureType.CANCEL_ASYNC, ResponseStep.ON_RESPONSE_STARTED, true, false);
-    throwOrCancel(FailureType.CANCEL_ASYNC_WITHOUT_PAUSE, ResponseStep.ON_RESPONSE_STARTED, true,
-                  false);
+    throwOrCancel(FailureType.CANCEL_ASYNC_WITHOUT_PAUSE, ResponseStep.ON_RESPONSE_STARTED, false);
     throwOrCancel(FailureType.THROW_SYNC, ResponseStep.ON_RESPONSE_STARTED, true, true);
 
     throwOrCancel(FailureType.CANCEL_SYNC, ResponseStep.ON_READ_COMPLETED, true, false);
     throwOrCancel(FailureType.CANCEL_ASYNC, ResponseStep.ON_READ_COMPLETED, true, false);
-    throwOrCancel(FailureType.CANCEL_ASYNC_WITHOUT_PAUSE, ResponseStep.ON_READ_COMPLETED, true,
-                  false);
+    throwOrCancel(FailureType.CANCEL_ASYNC_WITHOUT_PAUSE, ResponseStep.ON_READ_COMPLETED, false);
     throwOrCancel(FailureType.THROW_SYNC, ResponseStep.ON_READ_COMPLETED, true, true);
   }
 


### PR DESCRIPTION
Fixes #30199.

The test cases for `CANCEL_ASYNC_WITHOUT_PAUSE` in `CronetUrlRequestTest::testFailures` will perform a cancellation asynchronously, but the order whether `onCanceled` or `onResponseStarted` is called first is is not deterministic, which means sometimes the response may be available if `onResponseStarted` is called first before `onCanceled` and sometimes the response may not be available if `onCanceled` is called first. This PR attemps to fix the issue by ignoring the assertion that checks whether the response is empty since it is not very critical for this specific test. The assertion that checks for the error remains unchanged to keep the same level of coverage.

Risk Level: low
Testing: unit test (`--runs_per_test=100`)
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
