### PR TITLE
mobile: Use Java 11 to build Android apps on macOS

### DIFF
--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
       with:
-        java-version: '8'
+        java-version: '11'
         java-package: jdk
         architecture: x64
         distribution: zulu
@@ -170,7 +170,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
       with:
-        java-version: '8'
+        java-version: '11'
         java-package: jdk
         architecture: x64
         distribution: zulu
@@ -223,7 +223,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
       with:
-        java-version: '8'
+        java-version: '11'
         java-package: jdk
         architecture: x64
         distribution: zulu

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-echo "y" | "${ANDROID_HOME}/tools/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
-echo "no" | "${ANDROID_HOME}/tools/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
-ls "${ANDROID_HOME}/tools/bin/"
+echo "y" | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
+echo "no" | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
+ls "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/"
 
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
     # shellcheck disable=SC2016

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-echo "y" | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
-echo "no" | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
-ls "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/"
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
+echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
+ls "${ANDROID_HOME}/cmdline-tools/latest/bin/"
 
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
     # shellcheck disable=SC2016


### PR DESCRIPTION
The plan is to use Java 11 throughout to reduce the number of JDKs installed. In the follow-up PR, the Linux Docker image for mobile will be updated to use Java 11.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
