### PR TITLE
v1.24: Prevent recursion during premature reset check (#30270)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,3 +5,6 @@ bug_fixes:
   change: |
     Fixed a bug where processing of deferred streams with the value of ``http.max_requests_per_io_cycle`` more than 1,
     can cause a crash.
+- area: http
+  change: |
+    Fixed recursion when HTTP connection is disconnected due to a high number of premature resets.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -605,7 +605,7 @@ void ConnectionManagerImpl::maybeDrainDueToPrematureResets() {
     return;
   }
 
-  if (drain_state_ == DrainState::NotDraining) {
+  if (read_callbacks_->connection().state() == Network::Connection::State::Open) {
     stats_.named_.downstream_rq_too_many_premature_resets_.inc();
     doConnectionClose(Network::ConnectionCloseType::NoFlush, absl::nullopt,
                       "too_many_premature_resets");

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2225,7 +2225,7 @@ TEST_P(Http2FrameIntegrationTest, ResettingDeferredRequestsTriggersPrematureRese
 TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   // Use large number of requests to ensure close is detected while there are
   // still some deferred streams.
-  const int kRequestsSentPerIOCycle = 1000;
+  const int kRequestsSentPerIOCycle = 20000;
   config_helper_.addRuntimeOverride("http.max_requests_per_io_cycle", "1");
   // Ensure premature reset detection does not get in the way
   config_helper_.addRuntimeOverride("overload.premature_reset_total_stream_count", "1001");
@@ -2233,8 +2233,7 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
 
   std::string buffer;
   for (int i = 0; i < kRequestsSentPerIOCycle; ++i) {
-    auto request = Http2Frame::makeRequest(Http2Frame::makeClientStreamId(i), "a", "/",
-                                           {{"response_data_blocks", "0"}, {"no_trailers", "1"}});
+    auto request = Http2Frame::makeRequest(Http2Frame::makeClientStreamId(i), "a", "/");
     absl::StrAppend(&buffer, std::string(request));
   }
 


### PR DESCRIPTION
Backport #30270 into v1.24