### PR TITLE
Make hotrestart_handoff_test not port conflict

### DIFF
--- a/test/integration/hotrestart_handoff_test.py
+++ b/test/integration/hotrestart_handoff_test.py
@@ -53,7 +53,10 @@ UPSTREAM_HOST = random_loopback_host()
 ENVOY_HOST = UPSTREAM_HOST
 ENVOY_PORT = 54323
 ENVOY_ADMIN_PORT = 54324
-SOCKET_PATH = "@envoy_domain_socket"
+# Append process ID to the socket path to minimize chances of
+# conflict. We can't use TEST_TMPDIR for this because it makes
+# the socket path too long.
+SOCKET_PATH = f"@envoy_domain_socket_{os.getpid()}"
 SOCKET_MODE = 0
 ENVOY_BINARY = "./test/integration/hotrestart_main"
 


### PR DESCRIPTION
Commit Message: Make hotrestart_handoff_test not port conflict
Additional Description: There's a flake when hot restart related tests all use `@envoy_domain_socket` as the communication port path; if two such tests run in parallel, the socket can be in use and cause a failure. This change fixes hotrestart_handoff_test to avoid such conflicts (other tests still may experience it.)
Risk Level: None, test-only
Testing: Not even verified it addresses the problem, because it's a hard to repro rare flake.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
