### PR TITLE
[bp/1.26] Add release target to copy binary after build server_only (#30204)

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -106,6 +106,13 @@ For a release version of the Envoy binary you can run:
 The build artifact can be found in `/tmp/envoy-docker-build/envoy/source/exe/envoy` (or wherever
 `$ENVOY_DOCKER_BUILD_DIR` points).
 
+To enable the previous behavior of the `release.server_only` target where the final binary was copied to a tar.gz file
+(e.g. envoy-binary.tar.gz), you can run:
+
+  ```bash
+  ./ci/run_envoy_docker.sh './ci/do_ci.sh release.server_only.binary
+  ```
+
 For a debug version of the Envoy binary you can run:
 
 ```bash

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -825,6 +825,12 @@ case $CI_TARGET in
         echo "Release files created in ${ENVOY_BINARY_DIR}"
         ;;
 
+    release.server_only.binary)
+        setup_clang_toolchain
+        echo "bazel release build..."
+        bazel_envoy_binary_build release
+        ;;
+
     release.signed)
         echo "Signing binary packages..."
         setup_clang_toolchain


### PR DESCRIPTION
v1.26 cherry-pick of #30204