### PR TITLE
Fix envoy_domain_socket conflict flakes

### DIFF
--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -97,7 +97,7 @@ echo "Hot restart test using dynamic base id"
 TEST_INDEX=0
 function run_testsuite() {
   local BASE_ID BASE_ID_PATH HOT_RESTART_JSON="$1"
-  local SOCKET_PATH=@envoy_domain_socket
+  local SOCKET_PATH=@envoy_domain_socket_$$
   local SOCKET_MODE=0
   if [ -n "$2" ] &&  [ -n "$3" ]
   then

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -161,6 +161,7 @@ envoy_cc_test(
     srcs = envoy_select_hot_restart(["hot_restart_impl_test.cc"]),
     deps = [
         ":hot_restart_udp_forwarding_test_helper",
+        ":utility_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
@@ -175,6 +176,7 @@ envoy_cc_test(
     srcs = envoy_select_hot_restart(["hot_restarting_child_test.cc"]),
     deps = [
         ":hot_restart_udp_forwarding_test_helper",
+        ":utility_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
@@ -189,6 +191,7 @@ envoy_cc_test(
     name = "hot_restarting_parent_test",
     srcs = envoy_select_hot_restart(["hot_restarting_parent_test.cc"]),
     deps = [
+        ":utility_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
         "//source/server:hot_restarting_child",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -161,7 +161,6 @@ envoy_cc_test(
     srcs = envoy_select_hot_restart(["hot_restart_impl_test.cc"]),
     deps = [
         ":hot_restart_udp_forwarding_test_helper",
-        ":utility_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
@@ -176,7 +175,6 @@ envoy_cc_test(
     srcs = envoy_select_hot_restart(["hot_restarting_child_test.cc"]),
     deps = [
         ":hot_restart_udp_forwarding_test_helper",
-        ":utility_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
@@ -191,7 +189,6 @@ envoy_cc_test(
     name = "hot_restarting_parent_test",
     srcs = envoy_select_hot_restart(["hot_restarting_parent_test.cc"]),
     deps = [
-        ":utility_lib",
         "//source/common/stats:stats_lib",
         "//source/server:hot_restart_lib",
         "//source/server:hot_restarting_child",

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -11,6 +11,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/hot_restart.h"
 #include "test/server/hot_restart_udp_forwarding_test_helper.h"
+#include "test/server/utility.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -66,13 +67,14 @@ public:
     EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(4);
 
     // Test we match the correct stat with empty-slots before, after, or both.
-    hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0);
+    hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0);
     hot_restart_->drainParentListeners();
 
     // We close both sockets, both ends, totaling 4.
     EXPECT_CALL(os_sys_calls_, close(_)).Times(4);
   }
 
+  std::string socket_addr_ = testDomainSocketName();
   // test_addresses_ must be initialized before os_sys_calls_ sets us mocking, as
   // parseInternetAddress uses several os system calls.
   TestAddresses test_addresses_;
@@ -123,7 +125,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketAlreadyInUse) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0),
+  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0),
                Server::HotRestartDomainSocketInUseException);
 }
 
@@ -139,7 +141,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketError) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0), EnvoyException);
+  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0), EnvoyException);
 }
 
 class HotRestartUdpForwardingContextTest : public HotRestartImplTest {

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -17,7 +17,6 @@
 
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
-#include "utility.h"
 #include "gtest/gtest.h"
 
 using testing::_;

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -11,12 +11,13 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/hot_restart.h"
 #include "test/server/hot_restart_udp_forwarding_test_helper.h"
-#include "test/test_common/environment.h"
+#include "test/server/utility.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
+#include "utility.h"
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -74,8 +75,7 @@ public:
     EXPECT_CALL(os_sys_calls_, close(_)).Times(4);
   }
 
-  std::string socket_addr_ =
-      absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/envoy_domain_socket");
+  std::string socket_addr_ = testDomainSocketName();
   // test_addresses_ must be initialized before os_sys_calls_ sets us mocking, as
   // parseInternetAddress uses several os system calls.
   TestAddresses test_addresses_;

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -11,7 +11,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/hot_restart.h"
 #include "test/server/hot_restart_udp_forwarding_test_helper.h"
-#include "test/server/utility.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -74,7 +74,8 @@ public:
     EXPECT_CALL(os_sys_calls_, close(_)).Times(4);
   }
 
-  std::string socket_addr_ = testDomainSocketName();
+  std::string socket_addr_ =
+      absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/envoy_domain_socket");
   // test_addresses_ must be initialized before os_sys_calls_ sets us mocking, as
   // parseInternetAddress uses several os system calls.
   TestAddresses test_addresses_;

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -9,6 +9,7 @@
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_manager.h"
 #include "test/server/hot_restart_udp_forwarding_test_helper.h"
+#include "test/server/utility.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -93,7 +94,7 @@ public:
     hot_restarting_child_->initialize(dispatcher_);
   }
   void TearDown() override { hot_restarting_child_.reset(); }
-  std::string socket_path_{"@envoy_domain_socket"};
+  std::string socket_path_ = testDomainSocketName();
   Api::MockOsSysCalls os_sys_calls_;
   Event::MockDispatcher dispatcher_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls_};

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -9,7 +9,7 @@
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_manager.h"
 #include "test/server/hot_restart_udp_forwarding_test_helper.h"
-#include "test/test_common/environment.h"
+#include "test/server/utility.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -94,8 +94,7 @@ public:
     hot_restarting_child_->initialize(dispatcher_);
   }
   void TearDown() override { hot_restarting_child_.reset(); }
-  std::string socket_path_ =
-      absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/envoy_domain_socket");
+  std::string socket_path_ = testDomainSocketName();
   Api::MockOsSysCalls os_sys_calls_;
   Event::MockDispatcher dispatcher_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls_};

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -9,7 +9,7 @@
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_manager.h"
 #include "test/server/hot_restart_udp_forwarding_test_helper.h"
-#include "test/server/utility.h"
+#include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -94,7 +94,8 @@ public:
     hot_restarting_child_->initialize(dispatcher_);
   }
   void TearDown() override { hot_restarting_child_.reset(); }
-  std::string socket_path_ = testDomainSocketName();
+  std::string socket_path_ =
+      absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/envoy_domain_socket");
   Api::MockOsSysCalls os_sys_calls_;
   Event::MockDispatcher dispatcher_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls_};

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -7,6 +7,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_manager.h"
+#include "test/server/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -298,7 +299,7 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
     Stats::Gauge& g2 = child_store.rootScope()->gaugeFromStatName(
         dynamic.add("g2"), Stats::Gauge::ImportMode::Accumulate);
 
-    HotRestartingChild hot_restarting_child(0, 0, "@envoy_domain_socket", 0);
+    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0);
     hot_restarting_child.mergeParentStats(child_store, stats_proto);
     EXPECT_EQ(1, c1.value());
     EXPECT_EQ(1, c2.value());

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -7,7 +7,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_manager.h"
-#include "test/server/utility.h"
+#include "test/test_common/environment.h"
 
 #include "gtest/gtest.h"
 
@@ -299,7 +299,9 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
     Stats::Gauge& g2 = child_store.rootScope()->gaugeFromStatName(
         dynamic.add("g2"), Stats::Gauge::ImportMode::Accumulate);
 
-    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0);
+    std::string domain_socket =
+        absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/envoy_domain_socket");
+    HotRestartingChild hot_restarting_child(0, 0, domain_socket, 0);
     hot_restarting_child.mergeParentStats(child_store, stats_proto);
     EXPECT_EQ(1, c1.value());
     EXPECT_EQ(1, c2.value());

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -7,7 +7,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_manager.h"
-#include "test/test_common/environment.h"
+#include "test/server/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -299,9 +299,7 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
     Stats::Gauge& g2 = child_store.rootScope()->gaugeFromStatName(
         dynamic.add("g2"), Stats::Gauge::ImportMode::Accumulate);
 
-    std::string domain_socket =
-        absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/envoy_domain_socket");
-    HotRestartingChild hot_restarting_child(0, 0, domain_socket, 0);
+    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0);
     hot_restarting_child.mergeParentStats(child_store, stats_proto);
     EXPECT_EQ(1, c1.value());
     EXPECT_EQ(1, c2.value());

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -7,11 +7,11 @@
 
 #include "source/common/protobuf/utility.h"
 
+#include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Server {
-namespace {
 
 inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::string& yaml) {
   envoy::config::listener::v3::Listener listener;
@@ -19,6 +19,10 @@ inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::
   return listener;
 }
 
-} // namespace
+inline std::string testDomainSocketName() {
+  return absl::StrCat(TestEnvironment::unixDomainSocketDirectory(), "/",
+                      TestUtility::uniqueFilename("envoy_domain_socket"));
+}
+
 } // namespace Server
 } // namespace Envoy

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -11,6 +11,7 @@
 
 namespace Envoy {
 namespace Server {
+namespace {
 
 inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::string& yaml) {
   envoy::config::listener::v3::Listener listener;
@@ -18,19 +19,6 @@ inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::
   return listener;
 }
 
-inline std::string testDomainSocketName() {
-#ifdef WIN32
-  auto pid = GetCurrentProcessId();
-#else
-  auto pid = getpid();
-#endif
-  // It seems like we should use a test tmpdir path for this socket, but unix
-  // domain socket length limits prohibit that, so instead we append the
-  // process ID to a name in the abstract namespace.
-  // Using a tmpdir in /tmp could be another option but would introduce
-  // cleanup requirements that are avoided by using the abstract namespace.
-  return absl::StrCat("@envoy_domain_socket_", pid);
-}
-
+} // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -11,7 +11,6 @@
 
 namespace Envoy {
 namespace Server {
-namespace {
 
 inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::string& yaml) {
   envoy::config::listener::v3::Listener listener;
@@ -19,6 +18,14 @@ inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::
   return listener;
 }
 
-} // namespace
+inline std::string testDomainSocketName() {
+#ifdef WIN32
+  auto pid = GetProcessId();
+#else
+  auto pid = getpid();
+#endif
+  return absl::StrCat("@envoy_domain_socket_", pid);
+}
+
 } // namespace Server
 } // namespace Envoy

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -20,7 +20,7 @@ inline envoy::config::listener::v3::Listener parseListenerFromV3Yaml(const std::
 
 inline std::string testDomainSocketName() {
 #ifdef WIN32
-  auto pid = GetProcessId();
+  auto pid = GetCurrentProcessId();
 #else
   auto pid = getpid();
 #endif

--- a/test/server/utility.h
+++ b/test/server/utility.h
@@ -24,6 +24,11 @@ inline std::string testDomainSocketName() {
 #else
   auto pid = getpid();
 #endif
+  // It seems like we should use a test tmpdir path for this socket, but unix
+  // domain socket length limits prohibit that, so instead we append the
+  // process ID to a name in the abstract namespace.
+  // Using a tmpdir in /tmp could be another option but would introduce
+  // cleanup requirements that are avoided by using the abstract namespace.
   return absl::StrCat("@envoy_domain_socket_", pid);
 }
 


### PR DESCRIPTION
Commit Message: Fix envoy_domain_socket conflict flakes
Additional Description: Various hot-restart-related tests use `@envoy_domain_socket` as a communication channel. If more than one of these tests run at the same time, a conflict can occur, resulting in a flaky failure. This change makes all these instances use `@envoy_domain_socket_{process_id}`, which should prevent those flakes.
Risk Level: Test-only.
Testing: Yes it is.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
