### PR TITLE
mobile: Export clusters updated/removed stats

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -148,6 +148,8 @@ void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap* bootstrap) const
         bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
     list->add_patterns()->set_exact("cluster_manager.active_clusters");
     list->add_patterns()->set_exact("cluster_manager.cluster_added");
+    list->add_patterns()->set_exact("cluster_manager.cluster_updated");
+    list->add_patterns()->set_exact("cluster_manager.cluster_removed");
     // Allow SDS related stats.
     list->add_patterns()->mutable_safe_regex()->set_regex("sds\\..*");
     list->add_patterns()->mutable_safe_regex()->set_regex(".*\\.ssl_context_update_by_sds");

--- a/mobile/test/common/integration/cds_integration_test.cc
+++ b/mobile/test/common/integration/cds_integration_test.cc
@@ -55,6 +55,8 @@ protected:
     // Wait for cluster to be added
     ASSERT_TRUE(waitForCounterGe("cluster_manager.cluster_added", 1));
     ASSERT_TRUE(waitForGaugeGe("cluster_manager.active_clusters", cluster_count + 1));
+    ASSERT_TRUE(waitForGaugeGe("cluster_manager.updated_clusters", 0));
+    ASSERT_TRUE(waitForGaugeGe("cluster_manager.cluster_removed", 0));
   }
 
   bool use_xdstp_{false};


### PR DESCRIPTION
This PR exports `cluster_manager.updated_clusters` and `cluster_manager.cluster_removed` when CDS is used in Envoy Mobile.

Commit Message:
Additional Description:
Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
