### PR TITLE
Disable ClientIntegrationTest.Http3WithQuicHints which fails TSAN

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -267,7 +267,8 @@ TEST_P(ClientIntegrationTest, BasicHttp2) {
 }
 
 // Do HTTP/3 without doing the alt-svc-over-HTTP/2 dance.
-TEST_P(ClientIntegrationTest, Http3WithQuicHints) {
+// TODO(RyanTheOptimist): Test fails with TSAN. Re-enable once fixed.
+TEST_P(ClientIntegrationTest, DISABLED_Http3WithQuicHints) {
   if (version_ != Network::Address::IpVersion::v4) {
     // Loopback resolves to a v4 address.
     return;


### PR DESCRIPTION
Disable ClientIntegrationTest.Http3WithQuicHints which fails TSAN
until we can get it fully debugged in #30324

Risk Level: Low
Testing: N/A
Docs Canges: N/A
Release Notes: N/A