### PR TITLE
mobile/ci: Fix flaky start Android emulator step

### DIFF
--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0
       with:
-        java-version: '8'
+        java-version: '11'
         java-package: jdk
         architecture: x64
         distribution: zulu
@@ -75,7 +75,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 20
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -128,7 +128,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 20
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -181,7 +181,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 20
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -234,7 +234,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 20
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 20
+        timeout_minutes: 10
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -128,7 +128,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 20
+        timeout_minutes: 10
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -181,7 +181,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 20
+        timeout_minutes: 10
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -234,7 +234,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 20
+        timeout_minutes: 10
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -8,7 +8,7 @@ echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n 
 system_profiler SPHardwareDataType
 
 # shellcheck disable=SC2094
-nohup "${ANDROID_HOME}/emulator/emulator" -cores 3 -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {
+nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {
     # shellcheck disable=SC2016
     "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
 }

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_atd;x86_64'
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_atd;x86_64' --channel=3
 echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_atd;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
 system_profiler SPHardwareDataType

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -5,6 +5,7 @@ set -e
 echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
 echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
+system_profiler SPHardwareDataType
 
 # shellcheck disable=SC2094
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
-echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_apis;x86_64' --channel=3
+echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_apis;x86_64' --device pixel_4 --force
 ls "${ANDROID_HOME}/cmdline-tools/latest/bin/"
 
 # shellcheck disable=SC2094

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_apis;x86_64' --channel=3
-echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_apis;x86_64' --device pixel_4 --force
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
+echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
 
 # shellcheck disable=SC2094
-nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot  > nohup.out 2>&1 | tail -f nohup.out & {
+nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {
     # shellcheck disable=SC2016
     "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
 }

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -8,7 +8,7 @@ echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n 
 system_profiler SPHardwareDataType
 
 # shellcheck disable=SC2094
-nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {
+nohup "${ANDROID_HOME}/emulator/emulator" -cores 3 -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {
     # shellcheck disable=SC2016
     "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
 }

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -6,7 +6,8 @@ echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'syst
 echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
 ls "${ANDROID_HOME}/cmdline-tools/latest/bin/"
 
-nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
+# shellcheck disable=SC2094
+nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot  > nohup.out 2>&1 | tail -f nohup.out & {
     # shellcheck disable=SC2016
     "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
 }

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_apis;x86_64' --channel=3
 echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_apis;x86_64' --device pixel_4 --force
-ls "${ANDROID_HOME}/cmdline-tools/latest/bin/"
+"${ANDROID_HOME}"/emulator/emulator -accel-check
 
 # shellcheck disable=SC2094
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot  > nohup.out 2>&1 | tail -f nohup.out & {

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
-echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --device pixel_4 --force
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_atd;x86_64'
+echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_atd;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
 system_profiler SPHardwareDataType
 


### PR DESCRIPTION
This is an attempt to fix multiple timeout failures when starting the Android emulator by doing the following:
- Update the system image to Android 30 ATD image instead of 29. The ATD image is a headless system image that consumes less CPU and memory. 
- Use a specific hardware profile, i.e. Pixel 4 instead of the default hardware profile since the default hardware profile only has 128MB.

This also adds some logging when starting the emulator instead of redirecting everything to `/dev/null` to make debugging easier.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
