### PR TITLE
Separate envoy_py_namespace to avoid cascading dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_py_namespace")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/distribution/dockerhub/BUILD
+++ b/distribution/dockerhub/BUILD
@@ -1,5 +1,6 @@
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_gencontent", "envoy_py_namespace")
+load("//tools/base:envoy_python.bzl", "envoy_gencontent")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/mobile/BUILD
+++ b/mobile/BUILD
@@ -7,7 +7,7 @@ load(
     "xcode_schemes",
     "xcodeproj",
 )
-load("@envoy//tools/base:envoy_python.bzl", "envoy_py_namespace")
+load("@envoy//tools/python:namespace.bzl", "envoy_py_namespace")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 load("//bazel:framework_imports_extractor.bzl", "framework_imports_extractor")
 

--- a/mobile/docs/BUILD
+++ b/mobile/docs/BUILD
@@ -1,6 +1,7 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
-load("@envoy//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_py_namespace")
+load("@envoy//tools/base:envoy_python.bzl", "envoy_entry_point")
+load("@envoy//tools/python:namespace.bzl", "envoy_py_namespace")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -5,7 +5,7 @@ load(
     "envoy_package",
     "envoy_py_test_binary",
 )
-load("//tools/base:envoy_python.bzl", "envoy_py_namespace")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/base/envoy_python.bzl
+++ b/tools/base/envoy_python.bzl
@@ -10,22 +10,6 @@ ENVOY_PYTOOL_NAMESPACE = [
     "//tools:py-init",
 ]
 
-def envoy_py_namespace():
-    """Adding this to a build, injects a namespaced __init__.py, this allows namespaced
-    packages - eg envoy.base.utils to co-exist with packages created from the repo."""
-    native.genrule(
-        name = "py-init-file",
-        outs = ["__init__.py"],
-        cmd = """
-        echo "__path__ = __import__('pkgutil').extend_path(__path__, __name__)" > $@
-        """,
-    )
-    py_library(
-        name = "py-init",
-        srcs = [":py-init-file"],
-        visibility = ["//visibility:public"],
-    )
-
 def envoy_pytool_binary(
         name,
         data = None,

--- a/tools/code/BUILD
+++ b/tools/code/BUILD
@@ -6,7 +6,8 @@ load(
     "READFILTER_FUZZ_FILTERS",
     "READFILTER_NOFUZZ_FILTERS",
 )
-load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_py_namespace")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -1,7 +1,8 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@envoy_repo//:path.bzl", "PATH")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_pytool_binary")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/distribution/BUILD
+++ b/tools/distribution/BUILD
@@ -1,6 +1,7 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_pytool_binary")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -1,6 +1,7 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_pytool_binary")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/h3_request/BUILD
+++ b/tools/h3_request/BUILD
@@ -3,7 +3,8 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
 )
-load("//tools/base:envoy_python.bzl", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_pytool_binary")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/proto_format/BUILD
+++ b/tools/proto_format/BUILD
@@ -3,7 +3,8 @@ load("@envoy_repo//:path.bzl", "PATH")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_py_data", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_py_data", "envoy_pytool_binary")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/protodoc/BUILD
+++ b/tools/protodoc/BUILD
@@ -1,8 +1,9 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_jinja_env", "envoy_py_data", "envoy_py_namespace", "envoy_pytool_binary", "envoy_pytool_library")
+load("//tools/base:envoy_python.bzl", "envoy_genjson", "envoy_jinja_env", "envoy_py_data", "envoy_pytool_binary", "envoy_pytool_library")
 load("//tools/protodoc:protodoc.bzl", "protodoc_rule")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/protoprint/BUILD
+++ b/tools/protoprint/BUILD
@@ -2,8 +2,9 @@ load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_py_data", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_py_data", "envoy_pytool_binary")
 load("//tools/protoprint:protoprint.bzl", "protoprint_rule")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 

--- a/tools/python/BUILD
+++ b/tools/python/BUILD
@@ -1,0 +1,1 @@
+licenses(["notice"])  # Apache 2

--- a/tools/python/namespace.bzl
+++ b/tools/python/namespace.bzl
@@ -1,0 +1,17 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+def envoy_py_namespace():
+    """Adding this to a build, injects a namespaced __init__.py, this allows namespaced
+    packages - eg envoy.base.utils to co-exist with packages created from the repo."""
+    native.genrule(
+        name = "py-init-file",
+        outs = ["__init__.py"],
+        cmd = """
+        echo "__path__ = __import__('pkgutil').extend_path(__path__, __name__)" > $@
+        """,
+    )
+    py_library(
+        name = "py-init",
+        srcs = [":py-init-file"],
+        visibility = ["//visibility:public"],
+    )

--- a/tools/repo/BUILD
+++ b/tools/repo/BUILD
@@ -1,6 +1,7 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_py_namespace", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_pytool_binary")
+load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
 


### PR DESCRIPTION
Commit Message: Separate envoy_py_namespace to avoid cascading dependencies
Additional Description: Before this change, envoy_py_namespace cascading into a `bzl load()` dependency on `@base_pip3`, which makes binary builds that don't actually have this dependency need to pull in a bunch more repos than they actually need.
Risk Level: None, change is a no-op.
Testing: CI should tell us if anything build-related broke.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
