### PR TITLE
Add some missing external dependencies

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -789,6 +789,10 @@ def _com_google_absl():
         actual = "@com_google_absl//absl/base",
     )
     native.bind(
+        name = "abseil_btree",
+        actual = "@com_google_absl//absl/container:btree",
+    )
+    native.bind(
         name = "abseil_flat_hash_map",
         actual = "@com_google_absl//absl/container:flat_hash_map",
     )

--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -163,6 +163,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "query_params_interface",
     hdrs = ["query_params.h"],
+    external_deps = ["abseil_btree"],
 )
 
 envoy_cc_library(

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -207,7 +207,10 @@ envoy_cc_library(
         "json_escape_string.h",
         "logger.h",
     ],
-    external_deps = ["abseil_synchronization"],
+    external_deps = [
+        "abseil_synchronization",
+        "abseil_flat_hash_map",
+    ],
     deps = [
         ":base_logger_lib",
         ":fmt_lib",

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -150,6 +150,7 @@ envoy_cc_library(
     srcs = ["dependency_manager.cc"],
     hdrs = ["dependency_manager.h"],
     external_deps = [
+        "abseil_flat_hash_set",
         "abseil_status",
     ],
     deps = [

--- a/source/common/quic/platform/BUILD
+++ b/source/common/quic/platform/BUILD
@@ -60,6 +60,7 @@ envoy_quiche_platform_impl_cc_library(
     hdrs = ["quiche_time_utils_impl.h"],
     external_deps = [
         "abseil_base",
+        "abseil_optional",
         "abseil_time",
     ],
 )

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
     name = "custom_stat_namespaces_lib",
     srcs = ["custom_stat_namespaces_impl.cc"],
     hdrs = ["custom_stat_namespaces_impl.h"],
+    external_deps = ["abseil_flat_hash_set"],
     deps = [
         "//envoy/stats:custom_stat_namespaces_interface",
         "//source/common/common:assert_lib",


### PR DESCRIPTION
Commit Message: Add some missing external dependencies
Additional Description: These targets clearly do depend on the abseil targets being added. I'm not sure why it builds in CI without this change, but it seems like a good change to be more precise regardless, and it doesn't build in at least one external build environment when these deps are not specified.
Risk Level: None, no-op change.
Testing: Does not fail to build in sample external environment after the changes.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
