### PR TITLE
value matcher: add OR matcher

### DIFF
--- a/api/envoy/type/matcher/v3/value.proto
+++ b/api/envoy/type/matcher/v3/value.proto
@@ -19,7 +19,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Specifies the way to match a ProtobufWkt::Value. Primitive values and ListValue are supported.
 // StructValue is not supported and is always not matched.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ValueMatcher {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.matcher.ValueMatcher";
 
@@ -56,6 +56,9 @@ message ValueMatcher {
     // If specified, a match occurs if and only if the target value is a list value and
     // is matched to this field.
     ListMatcher list_match = 6;
+
+    // If specified, a match occurs if and only if any of the alternatives in the match accept the value.
+    OrMatcher or_match = 7;
   }
 }
 
@@ -69,4 +72,9 @@ message ListMatcher {
     // If specified, at least one of the values in the list must match the value specified.
     ValueMatcher one_of = 1;
   }
+}
+
+// Specifies a list of alternatives for the match.
+message OrMatcher {
+  repeated ValueMatcher value_matchers = 1 [(validate.rules).repeated = {min_items: 2}];
 }

--- a/source/common/common/matchers.h
+++ b/source/common/common/matchers.h
@@ -172,6 +172,16 @@ private:
   ValueMatcherConstSharedPtr oneof_value_matcher_;
 };
 
+class OrMatcher : public ValueMatcher {
+public:
+  OrMatcher(const envoy::type::matcher::v3::OrMatcher& matcher);
+
+  bool match(const ProtobufWkt::Value& value) const override;
+
+private:
+  std::vector<ValueMatcherConstSharedPtr> or_matchers_;
+};
+
 class MetadataMatcher {
 public:
   MetadataMatcher(const envoy::type::matcher::v3::MetadataMatcher& matcher);

--- a/test/common/common/matchers_test.cc
+++ b/test/common/common/matchers_test.cc
@@ -184,6 +184,29 @@ TEST(MetadataTest, MatchPresentValue) {
   EXPECT_FALSE(Envoy::Matchers::MetadataMatcher(matcher).match(metadata));
 }
 
+TEST(MetadataTest, MatchStringOrBoolValue) {
+  envoy::config::core::v3::Metadata metadata;
+  Envoy::Config::Metadata::mutableMetadataValue(metadata, "envoy.filter.a", "label")
+      .set_string_value("test");
+  Envoy::Config::Metadata::mutableMetadataValue(metadata, "envoy.filter.b", "label")
+      .set_bool_value(true);
+  Envoy::Config::Metadata::mutableMetadataValue(metadata, "envoy.filter.c", "label")
+      .set_bool_value(false);
+
+  envoy::type::matcher::v3::MetadataMatcher matcher;
+  matcher.add_path()->set_key("label");
+
+  auto* or_match = matcher.mutable_value()->mutable_or_match();
+  or_match->add_value_matchers()->mutable_string_match()->set_exact("test");
+  or_match->add_value_matchers()->set_bool_match(true);
+  matcher.set_filter("envoy.filter.a");
+  EXPECT_TRUE(Envoy::Matchers::MetadataMatcher(matcher).match(metadata));
+  matcher.set_filter("envoy.filter.b");
+  EXPECT_TRUE(Envoy::Matchers::MetadataMatcher(matcher).match(metadata));
+  matcher.set_filter("envoy.filter.c");
+  EXPECT_FALSE(Envoy::Matchers::MetadataMatcher(matcher).match(metadata));
+}
+
 // Helper function to retrieve the reference of an entry in a ListMatcher from a MetadataMatcher.
 envoy::type::matcher::v3::ValueMatcher*
 listMatchEntry(envoy::type::matcher::v3::MetadataMatcher* matcher) {


### PR DESCRIPTION
Commit Message: Extend matcher to support alternatives.
Additional Description: JWT claims allow optional lists, e.g. `"x"` and `["x"]` are allowed for `aud` claim. When used for routing using dynamic metadata ([here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-routematch)), we cannot express a way to match either of these options.
Risk Level: low 
Testing: done
Docs Changes: none
Release Notes: none (minor feature)
Issues: #29681 