### PR TITLE
gh/wf: Add build image updater

### DIFF
--- a/.github/workflows/_env.yml
+++ b/.github/workflows/_env.yml
@@ -16,6 +16,10 @@ on:
       build_image_mobile_sha:
         type: string
         default: f47fb698cfda583769b9d28e8d1c58cfc7774d5da4f31cd8190d8975c3850c7e
+      # this is authoritative, but is not currently used in github ci
+      build_image_gcr_sha:
+        type: string
+        default: 2a473cd9808182735d54e03b158975389948b9559b8e8fc624cfafbaf7059e62
       build_image_tag:
         type: string
         default: fdd65c6270a8507a18d5acd6cf19a18cb695e4fa

--- a/.github/workflows/envoy-dependency.yml
+++ b/.github/workflows/envoy-dependency.yml
@@ -1,0 +1,106 @@
+name: Envoy/dependency
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Select a task'
+        required: true
+        default: build-image
+        enum:
+        - build-image
+
+concurrency:
+  group: ${{ github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update_build_image:
+    if: github.event.inputs.task == 'build-image'
+    name: Update build image (PR)
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Fetch token for app auth
+      id: appauth
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.0.23
+      with:
+        app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
+        key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
+    - uses: actions/checkout@v4
+      name: Checkout Envoy repository
+      with:
+        path: envoy
+        fetch-depth: 0
+        token: ${{ steps.appauth.outputs.token }}
+    - uses: actions/checkout@v4
+      name: Checkout Envoy build tools repository
+      with:
+        repository: envoyproxy/envoy-build-tools
+        path: build-tools
+        fetch-depth: 0
+    - run: |
+        shas=(
+            tag
+            sha
+            mobile_sha
+            gcr_sha)
+        for sha in "${shas[@]}"; do
+            current_sha=$(bazel run //tools/dependency:build-image-sha "$sha")
+            echo "${sha}=${current_sha}" >> "$GITHUB_OUTPUT"
+        done
+      id: current
+      name: Current SHAs
+      working-directory: envoy
+    - run: |
+        # get current build image version
+        CONTAINER_TAG=$(git log -1 --pretty=format:"%H" "./docker")
+        echo "tag=${CONTAINER_TAG}" >> "$GITHUB_OUTPUT"
+        echo "tag_short=${CONTAINER_TAG::7}" >> "$GITHUB_OUTPUT"
+      id: build-tools
+      name: Build image SHA
+      working-directory: build-tools
+
+    - name: Check Docker SHAs
+      id: build-images
+      uses: envoyproxy/toolshed/gh-actions/docker/shas@actions-v0.0.23
+      with:
+        images: |
+           sha: envoyproxy/envoy-build-ubuntu:${{ steps.build-tools.outputs.tag }}
+           mobile_sha: envoyproxy/envoy-build-ubuntu:mobile-${{ steps.build-tools.outputs.tag }}
+           gcr_sha: gcr.io/envoy-ci/envoy-build:${{ steps.build-tools.outputs.tag }}
+
+    - run: |
+        SHA_REPLACE=(
+            "$CURRENT_ENVOY_TAG:$ENVOY_TAG"
+            "$CURRENT_ENVOY_SHA:${OUTPUT_sha}"
+            "$CURRENT_ENVOY_MOBILE_SHA:${OUTPUT_mobile_sha}"
+            "$CURRENT_ENVOY_GCR_SHA:${OUTPUT_gcr_sha}")
+        echo "replace=${SHA_REPLACE[*]}" >> "$GITHUB_OUTPUT"
+      name: Find SHAs to replace
+      id: shas
+      env:
+        ENVOY_TAG: ${{ steps.build-tools.outputs.tag }}
+        CURRENT_ENVOY_TAG: ${{ steps.current.outputs.tag }}
+        CURRENT_ENVOY_SHA: ${{ steps.current.outputs.sha }}
+        CURRENT_ENVOY_MOBILE_SHA: ${{ steps.current.outputs.mobile_sha }}
+        CURRENT_ENVOY_GCR_SHA: ${{ steps.current.outputs.gcr_sha }}
+    - run: |
+        echo "${SHA_REPLACE}" | xargs bazel run @envoy_toolshed//sha:replace "${PWD}"
+      env:
+        SHA_REPLACE: ${{ steps.shas.outputs.replace }}
+      name: Update SHAs
+      working-directory: envoy
+    - name: Create a PR
+      uses: envoyproxy/toolshed/gh-actions/github/pr@actions-v0.0.23
+      with:
+        base: main
+        body: Created by Envoy dependency bot
+        branch: dependency-envoy/build-image/latest
+        committer-name: publish-envoy[bot]
+        committer-email: 140627008+publish-envoy[bot]@users.noreply.github.com
+        title: 'deps: Bump build images -> `${{ steps.build-tools.outputs.tag_short }}`'
+        GITHUB_TOKEN: ${{ steps.appauth.outputs.token }}
+        working-directory: envoy

--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@ exports_files([
     ".coveragerc",
     "CODEOWNERS",
     "OWNERS.md",
+    ".github/workflows/_env.yml",
 ])
 
 alias(

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -1,7 +1,7 @@
 load("@base_pip3//:requirements.bzl", "requirement")
 load("@envoy_repo//:path.bzl", "PATH")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
-load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_pytool_binary")
+load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_genjson", "envoy_pytool_binary")
 load("//tools/python:namespace.bzl", "envoy_py_namespace")
 
 licenses(["notice"])  # Apache 2
@@ -73,4 +73,28 @@ genrule(
         ":cve_download",
         "//bazel:all_repository_locations",
     ],
+)
+
+envoy_genjson(
+    name = "build-images",
+    filter = """
+    .[0].on.workflow_call.inputs
+      | to_entries
+      | map(select(.key | startswith("build_image") and . != "build_image_repo")
+         | {(.key | gsub("build_image_"; "")): .value.default})
+      | add
+    """,
+    yaml_srcs = ["//:.github/workflows/_env.yml"],
+)
+
+
+sh_binary(
+    name = "build-image-sha",
+    srcs = ["version.sh"],
+    args = ["$(JQ_BIN)", "$(location :build-images)"],
+    data = [
+        ":build-images",
+        "@jq_toolchains//:resolved_toolchain",
+    ],
+    toolchains = ["@jq_toolchains//:resolved_toolchain"],
 )

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -87,11 +87,13 @@ envoy_genjson(
     yaml_srcs = ["//:.github/workflows/_env.yml"],
 )
 
-
 sh_binary(
     name = "build-image-sha",
     srcs = ["version.sh"],
-    args = ["$(JQ_BIN)", "$(location :build-images)"],
+    args = [
+        "$(JQ_BIN)",
+        "$(location :build-images)",
+    ],
     data = [
         ":build-images",
         "@jq_toolchains//:resolved_toolchain",

--- a/tools/dependency/version.sh
+++ b/tools/dependency/version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+JQ="$1"
+VERSIONS="$2"
+DEP="$3"
+
+if [[ -z "$DEP" ]]; then
+    echo "You must specify what to check version for" >&2
+    exit 1
+fi
+
+$JQ -r ".${DEP}" $VERSIONS

--- a/tools/dependency/version.sh
+++ b/tools/dependency/version.sh
@@ -11,4 +11,4 @@ if [[ -z "$DEP" ]]; then
     exit 1
 fi
 
-$JQ -r ".${DEP}" $VERSIONS
+$JQ -r ".${DEP}" "$VERSIONS"


### PR DESCRIPTION
This ~automates the tricky process of updating the build images

This iteration is very limited

- no handling of existing PRs (you must manually deleted existing/branch to update)
- no update of toolchains - this will be addressed in a follow up

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
