### PR TITLE
connect_grpc_bridge: support requests with no body

### DIFF
--- a/source/extensions/filters/http/connect_grpc_bridge/filter.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/filter.cc
@@ -289,6 +289,12 @@ Http::FilterHeadersStatus ConnectGrpcBridgeFilter::decodeHeaders(Http::RequestHe
         compression[0]->value() != Http::CustomHeaders::get().AcceptEncodingValues.Identity) {
       unary_payload_frame_flags_ |= Envoy::Grpc::GRPC_FH_COMPRESSED;
     }
+
+    if (end_stream) {
+      headers.removeContentLength();
+      Grpc::Encoder().prependFrameHeader(unary_payload_frame_flags_, request_buffer_);
+      decoder_callbacks_->addDecodedData(request_buffer_, true);
+    }
   } else {
     Http::Utility::QueryParamsMulti query_parameters =
         Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(headers.getPathValue());

--- a/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
@@ -444,9 +444,8 @@ TEST_F(ConnectGrpcBridgeFilterTest, UnaryRequestWithNoBodyNorTrailers) {
   Buffer::OwnedImpl data{};
 
   EXPECT_CALL(decoder_callbacks_, addDecodedData(_, true))
-      .WillOnce(Invoke(([&](Buffer::Instance& d, bool) {
-        EXPECT_EQ('\0', d.drainInt<uint8_t>());
-      })));
+      .WillOnce(
+          Invoke(([&](Buffer::Instance& d, bool) { EXPECT_EQ('\0', d.drainInt<uint8_t>()); })));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, true));
 }

--- a/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
@@ -437,6 +437,20 @@ TEST_F(ConnectGrpcBridgeFilterTest, UnaryGetRequestTimeout) {
   EXPECT_EQ(false, request_headers_.has(Http::CustomHeaders::get().ConnectTimeoutMs));
 }
 
+TEST_F(ConnectGrpcBridgeFilterTest, UnaryRequestWithNoBodyNorTrailers) {
+  request_headers_.setCopy(Http::CustomHeaders::get().ConnectProtocolVersion, "1");
+  request_headers_.setContentType("application/proto");
+
+  Buffer::OwnedImpl data{};
+
+  EXPECT_CALL(decoder_callbacks_, addDecodedData(_, true))
+      .WillOnce(Invoke(([&](Buffer::Instance& d, bool) {
+        EXPECT_EQ('\0', d.drainInt<uint8_t>());
+      })));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, true));
+}
+
 TEST_F(ConnectGrpcBridgeFilterTest, StreamingSupportedContentType) {
   request_headers_.setContentType("application/connect+proto");
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, false));


### PR DESCRIPTION
Commit Message: connect_grpc_bridge: support requests with no body
Additional Description:

gRPC calls with no body are sent with Content-Length: 0 from the browser and makes `decodeData` to not be called. It's worth noting that when using `buf curl` this doesn't happen because `buf` sends the request with `Transfer-Encoding: chunked` which makes the body non-zero even in the empty case (which is `\x30\x0d\x0a\x0d\x0a`)

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a