### PR TITLE
logging: Use std::atomic for Envoy::Logger::current_context

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -268,9 +268,6 @@ TEST_P(ClientIntegrationTest, BasicHttp2) {
 
 // Do HTTP/3 without doing the alt-svc-over-HTTP/2 dance.
 TEST_P(ClientIntegrationTest, Http3WithQuicHints) {
-#if defined(__has_feature) && __has_feature(thread_sanitizer)
-  return; // TODO(alyssawilk) debug
-#endif
   if (version_ != Network::Address::IpVersion::v4) {
     // Loopback resolves to a v4 address.
     return;

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -227,7 +227,8 @@ void Context::enableFineGrainLogger() {
       current_context.load()->fine_grain_log_format_ = kDefaultFineGrainLogFormat;
     }
     getFineGrainLogContext().setDefaultFineGrainLogLevelFormat(
-        current_context.load()->fine_grain_default_level_, current_context.load()->fine_grain_log_format_);
+        current_context.load()->fine_grain_default_level_,
+        current_context.load()->fine_grain_log_format_);
   }
 }
 

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -158,7 +158,8 @@ void DelegatingLogSink::setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; 
 
 SinkDelegate* DelegatingLogSink::tlsDelegate() { return *tlsSink(); }
 
-static Context* current_context = nullptr;
+static std::atomic<Context*> current_context = nullptr;
+static_assert(std::atomic<Context*>::is_always_lock_free);
 
 Context::Context(spdlog::level::level_enum log_level, const std::string& log_format,
                  Thread::BasicLockable& lock, bool should_escape, bool enable_fine_grain_logging)
@@ -171,7 +172,7 @@ Context::Context(spdlog::level::level_enum log_level, const std::string& log_for
 Context::~Context() {
   current_context = save_context_;
   if (current_context != nullptr) {
-    current_context->activate();
+    current_context.load()->activate();
   } else {
     Registry::getSink()->clearLock();
   }
@@ -197,7 +198,7 @@ void Context::activate() {
 
 bool Context::useFineGrainLogger() {
   if (current_context) {
-    return current_context->enable_fine_grain_logging_;
+    return current_context.load()->enable_fine_grain_logging_;
   }
   return false;
 }
@@ -219,20 +220,20 @@ void Context::changeAllLogLevels(spdlog::level::level_enum level) {
 
 void Context::enableFineGrainLogger() {
   if (current_context) {
-    current_context->enable_fine_grain_logging_ = true;
-    current_context->fine_grain_default_level_ = current_context->log_level_;
-    current_context->fine_grain_log_format_ = current_context->log_format_;
-    if (current_context->log_format_ == Logger::Logger::DEFAULT_LOG_FORMAT) {
-      current_context->fine_grain_log_format_ = kDefaultFineGrainLogFormat;
+    current_context.load()->enable_fine_grain_logging_ = true;
+    current_context.load()->fine_grain_default_level_ = current_context.load()->log_level_;
+    current_context.load()->fine_grain_log_format_ = current_context.load()->log_format_;
+    if (current_context.load()->log_format_ == Logger::Logger::DEFAULT_LOG_FORMAT) {
+      current_context.load()->fine_grain_log_format_ = kDefaultFineGrainLogFormat;
     }
     getFineGrainLogContext().setDefaultFineGrainLogLevelFormat(
-        current_context->fine_grain_default_level_, current_context->fine_grain_log_format_);
+        current_context.load()->fine_grain_default_level_, current_context.load()->fine_grain_log_format_);
   }
 }
 
 void Context::disableFineGrainLogger() {
   if (current_context) {
-    current_context->enable_fine_grain_logging_ = false;
+    current_context.load()->enable_fine_grain_logging_ = false;
   }
 }
 
@@ -240,14 +241,14 @@ std::string Context::getFineGrainLogFormat() {
   if (!current_context) { // Context is not instantiated in benchmark test
     return kDefaultFineGrainLogFormat;
   }
-  return current_context->fine_grain_log_format_;
+  return current_context.load()->fine_grain_log_format_;
 }
 
 spdlog::level::level_enum Context::getFineGrainDefaultLevel() {
   if (!current_context) {
     return spdlog::level::info;
   }
-  return current_context->fine_grain_default_level_;
+  return current_context.load()->fine_grain_default_level_;
 }
 
 std::vector<Logger>& Registry::allLoggers() {


### PR DESCRIPTION
Fixes the TSAN issue in ClientIntegrationTest.Http3WithQuicHints. The crux of the problem appears to be that Envoy and Envoy mobile both share current_context[1] to configure their logging subsystem. (Which, of course they do because they're both "Envoy")

But Envoy consults this variable when starting the UDP listener and Envoy Mobile sets this variable when starting Envoy Mobile. Annoyingly, in this test, we need to start Envoy first in order to get the IP address/port which we write into the config we use when starting Envoy Mobile.

This switches current_context to std::atomic which should be pretty low overhead, as it's guaranteed to be lock-free.

1. https://github.com/envoyproxy/envoy/blob/main/source/common/common/logger.cc#L161