### PR TITLE
mobile/ci: Increase the emulator timeout to 15 minutes

### DIFF
--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 15
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -128,7 +128,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 15
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -181,7 +181,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 15
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
@@ -234,7 +234,7 @@ jobs:
     - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       name: 'Start emulator'
       with:
-        timeout_minutes: 10
+        timeout_minutes: 15
         max_attempts: 3
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -5,7 +5,10 @@ set -e
 echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_atd;x86_64' --channel=3
 echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_atd;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
-system_profiler SPHardwareDataType
+# This is only available on macOS.
+if [[ -n $(which system_profiler) ]]; then
+    system_profiler SPHardwareDataType
+fi
 
 # shellcheck disable=SC2094
 nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {


### PR DESCRIPTION
This PR increases the emulator timeout to 15 minutes from 10 minutes since I have seen a number of instances where the emulator took close to 10 minutes.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
