### PR TITLE
test: fixed race condition in postgres integration test

### DIFF
--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -610,12 +610,12 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerAgreesForSSL) {
   // Reply to Envoy with 'S' and attach TLS socket to upstream.
   upstream_data.add("S");
   ASSERT_TRUE(fake_upstream_connection_->write(upstream_data.toString()));
+  fake_upstream_connection_->clearData();
 
   config_factory_.recv_sync_.WaitForNotification();
   enableTLSOnFakeUpstream();
   config_factory_.proceed_sync_.Notify();
 
-  fake_upstream_connection_->clearData();
   ASSERT_TRUE(fake_upstream_connection_->waitForData(data.length(), &rcvd));
   // Make sure that upstream received initial postgres request, which
   // triggered upstream SSL negotiation and TLS handshake.


### PR DESCRIPTION
Commit Message:
fixed race condition in postgres integration test
Additional Description:
Typical race condition. Reply was received before calling _clearData_, which basically dropped received reply.
Risk Level: Low
Testing: Verified that previously failing test does not fail anymore.
Docs Changes: No
Release Notes: No
Platform Specific Features: No
Fixes #30330
