### PR TITLE
connect_grpc_bridge: remove request content-length

### DIFF
--- a/source/extensions/filters/http/connect_grpc_bridge/filter.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/filter.cc
@@ -290,8 +290,9 @@ Http::FilterHeadersStatus ConnectGrpcBridgeFilter::decodeHeaders(Http::RequestHe
       unary_payload_frame_flags_ |= Envoy::Grpc::GRPC_FH_COMPRESSED;
     }
 
+    headers.removeContentLength();
+
     if (end_stream) {
-      headers.removeContentLength();
       Grpc::Encoder().prependFrameHeader(unary_payload_frame_flags_, request_buffer_);
       decoder_callbacks_->addDecodedData(request_buffer_, true);
     }

--- a/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/connect_grpc_bridge_filter_test.cc
@@ -450,6 +450,14 @@ TEST_F(ConnectGrpcBridgeFilterTest, UnaryRequestWithNoBodyNorTrailers) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, true));
 }
 
+TEST_F(ConnectGrpcBridgeFilterTest, UnaryRequestRemovesContentLength) {
+  request_headers_.setCopy(Http::CustomHeaders::get().ConnectProtocolVersion, "1");
+  request_headers_.setContentType(Http::Headers::get().ContentTypeValues.Grpc);
+  request_headers_.setContentLength(1337);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, false));
+  EXPECT_EQ("", request_headers_.get_("content-length"));
+}
+
 TEST_F(ConnectGrpcBridgeFilterTest, StreamingSupportedContentType) {
   request_headers_.setContentType("application/connect+proto");
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, false));


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: connect_grpc_bridge: remove request content-length
Additional Description:

We need to always remove Content-Length since the request on the other side of the filter is chunked with a different body size.

Risk Level: Low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a