### PR TITLE
Fix segmentation fault in udp proxy filter

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
@@ -107,7 +107,7 @@ ReadFilterStatus ProxyFilter::onData(Network::UdpRecvData& data) {
 }
 
 void ProxyFilter::onLoadDnsCacheComplete(
-  const Common::DynamicForwardProxy::DnsHostInfoSharedPtr& host_info) {
+    const Common::DynamicForwardProxy::DnsHostInfoSharedPtr& host_info) {
   ENVOY_LOG(debug, "load DNS cache complete, continuing");
   ASSERT(circuit_breaker_ != nullptr);
   circuit_breaker_.reset();

--- a/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter.cc
@@ -118,12 +118,14 @@ void ProxyFilter::onLoadDnsCacheComplete(
 
   load_dns_cache_completed_ = true;
 
-  if (read_callbacks_->continueFilterChain()) {
-    while (!datagrams_buffer_.empty()) {
-      BufferedDatagramPtr buffered_datagram = std::move(datagrams_buffer_.front());
-      datagrams_buffer_.pop();
-      read_callbacks_->injectDatagramToFilterChain(*buffered_datagram);
-    }
+  if (!read_callbacks_->continueFilterChain()) {
+    return;
+  }
+
+  while (!datagrams_buffer_.empty()) {
+    BufferedDatagramPtr buffered_datagram = std::move(datagrams_buffer_.front());
+    datagrams_buffer_.pop();
+    read_callbacks_->injectDatagramToFilterChain(*buffered_datagram);
   }
 
   config_->disableBuffer();

--- a/source/extensions/filters/udp/udp_proxy/session_filters/filter.h
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/filter.h
@@ -43,8 +43,9 @@ public:
   /**
    * If a read filter stopped filter iteration, continueFilterChain() can be called to continue the
    * filter chain. It will have onNewSession() called if it was not previously called.
+   * @return false if the session is removed and no longer valid, otherwise returns true.
    */
-  virtual void continueFilterChain() PURE;
+  virtual bool continueFilterChain() PURE;
 };
 
 class WriteFilterCallbacks : public FilterCallbacks {};

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -910,7 +910,7 @@ void UdpProxyFilter::TunnelingActiveSession::onUpstreamEvent(Network::Connection
       event == Network::ConnectionEvent::LocalClose) {
     upstream_.reset();
 
-  if (!connecting || !establishUpstreamConnection()) {
+    if (!connecting || !establishUpstreamConnection()) {
       cluster_.removeSession(this);
     }
   }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -173,12 +173,13 @@ UdpProxyFilter::ActiveSession* UdpProxyFilter::ClusterInfo::createSessionWithOpt
   }
 
   new_session->createFilterChain();
-  auto new_session_ptr = new_session.get();
-  sessions_.emplace(std::move(new_session));
-  new_session_ptr->onNewSession();
+  if (new_session->onNewSession()) {
+    auto new_session_ptr = new_session.get();
+    sessions_.emplace(std::move(new_session));
+    return new_session_ptr;
+  }
 
-  // Check if the session was not removed during onNewSession().
-  return (sessions_.contains(new_session_ptr) ? new_session_ptr : nullptr);
+  return nullptr;
 }
 
 Upstream::HostConstSharedPtr UdpProxyFilter::ClusterInfo::chooseHost(
@@ -383,7 +384,7 @@ void UdpProxyFilter::UdpActiveSession::onReadReady() {
   cluster_.filter_.read_callbacks_->udpListener().flush();
 }
 
-void UdpProxyFilter::ActiveSession::onNewSession() {
+bool UdpProxyFilter::ActiveSession::onNewSession() {
   for (auto& active_read_filter : read_filters_) {
     if (active_read_filter->initialized_) {
       // The filter may call continueFilterChain() in onNewSession(), causing next
@@ -394,11 +395,11 @@ void UdpProxyFilter::ActiveSession::onNewSession() {
     active_read_filter->initialized_ = true;
     auto status = active_read_filter->read_filter_->onNewSession();
     if (status == ReadFilterStatus::StopIteration) {
-      return;
+      return true;
     }
   }
 
-  createUpstream();
+  return createUpstream();
 }
 
 void UdpProxyFilter::ActiveSession::onData(Network::UdpRecvData& data) {
@@ -468,7 +469,7 @@ void UdpProxyFilter::UdpActiveSession::writeUpstream(Network::UdpRecvData& data)
   }
 }
 
-void UdpProxyFilter::ActiveSession::onContinueFilterChain(ActiveReadFilter* filter) {
+bool UdpProxyFilter::ActiveSession::onContinueFilterChain(ActiveReadFilter* filter) {
   ASSERT(filter != nullptr);
 
   std::list<ActiveReadFilterPtr>::iterator entry = std::next(filter->entry());
@@ -480,18 +481,23 @@ void UdpProxyFilter::ActiveSession::onContinueFilterChain(ActiveReadFilter* filt
     (*entry)->initialized_ = true;
     auto status = (*entry)->read_filter_->onNewSession();
     if (status == ReadFilterStatus::StopIteration) {
-      break;
+      return true;
     }
   }
 
-  createUpstream();
+  if (!createUpstream()) {
+    cluster_.removeSession(this);
+    return false;
+  }
+
+  return true;
 }
 
-void UdpProxyFilter::UdpActiveSession::createUpstream() {
+bool UdpProxyFilter::UdpActiveSession::createUpstream() {
   if (udp_socket_) {
     // A session filter may call on continueFilterChain(), after already creating the socket,
     // so we first check that the socket was not created already.
-    return;
+    return true;
   }
 
   if (!host_) {
@@ -499,12 +505,13 @@ void UdpProxyFilter::UdpActiveSession::createUpstream() {
     if (host_ == nullptr) {
       ENVOY_LOG(debug, "cannot find any valid host.");
       cluster_.cluster_.info()->trafficStats()->upstream_cx_none_healthy_.inc();
-      return;
+      return false;
     }
   }
 
   cluster_.addSession(host_.get(), this);
   createUdpSocket(host_);
+  return true;
 }
 
 void UdpProxyFilter::UdpActiveSession::createUdpSocket(const Upstream::HostConstSharedPtr& host) {
@@ -794,26 +801,28 @@ UdpProxyFilter::TunnelingActiveSession::TunnelingActiveSession(
     ClusterInfo& cluster, Network::UdpRecvData::LocalPeerAddresses&& addresses)
     : ActiveSession(cluster, std::move(addresses), nullptr) {}
 
-void UdpProxyFilter::TunnelingActiveSession::createUpstream() {
+bool UdpProxyFilter::TunnelingActiveSession::createUpstream() {
   if (conn_pool_factory_) {
     // A session filter may call on continueFilterChain(), after already creating the upstream,
     // so we first check that the factory was not created already.
-    return;
+    return true;
   }
 
   conn_pool_factory_ = std::make_unique<TunnelingConnectionPoolFactory>();
   load_balancer_context_ = std::make_unique<UdpLoadBalancerContext>(
       cluster_.filter_.config_->hashPolicy(), addresses_.peer_, &udp_session_info_);
 
-  establishUpstreamConnection();
+  return establishUpstreamConnection();
 }
 
-void UdpProxyFilter::TunnelingActiveSession::establishUpstreamConnection() {
+bool UdpProxyFilter::TunnelingActiveSession::establishUpstreamConnection() {
   if (!createConnectionPool()) {
     ENVOY_LOG(debug, "failed to create upstream connection pool");
     cluster_.cluster_stats_.sess_tunnel_failure_.inc();
-    cluster_.removeSession(this);
+    return false;
   }
+
+  return true;
 }
 
 bool UdpProxyFilter::TunnelingActiveSession::createConnectionPool() {
@@ -901,9 +910,7 @@ void UdpProxyFilter::TunnelingActiveSession::onUpstreamEvent(Network::Connection
       event == Network::ConnectionEvent::LocalClose) {
     upstream_.reset();
 
-    if (connecting) {
-      establishUpstreamConnection();
-    } else {
+  if (!connecting || !establishUpstreamConnection()) {
       cluster_.removeSession(this);
     }
   }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -173,11 +173,12 @@ UdpProxyFilter::ActiveSession* UdpProxyFilter::ClusterInfo::createSessionWithOpt
   }
 
   new_session->createFilterChain();
-  new_session->onNewSession();
   auto new_session_ptr = new_session.get();
   sessions_.emplace(std::move(new_session));
+  new_session_ptr->onNewSession();
 
-  return new_session_ptr;
+  // Check if the session was not removed during onNewSession().
+  return (sessions_.contains(new_session_ptr) ? new_session_ptr : nullptr);
 }
 
 Upstream::HostConstSharedPtr UdpProxyFilter::ClusterInfo::chooseHost(

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -457,7 +457,7 @@ private:
     // SessionFilters::ReadFilterCallbacks
     uint64_t sessionId() const override { return parent_.sessionId(); };
     StreamInfo::StreamInfo& streamInfo() override { return parent_.streamInfo(); };
-    void continueFilterChain() override { parent_.onContinueFilterChain(this); }
+    bool continueFilterChain() override { return parent_.onContinueFilterChain(this); }
     void injectDatagramToFilterChain(Network::UdpRecvData& data) override {
       parent_.onInjectReadDatagramToFilterChain(this, data);
     }
@@ -509,13 +509,13 @@ private:
       return absl::nullopt;
     }
 
-    void onNewSession();
+    bool onNewSession();
     void onData(Network::UdpRecvData& data);
     void processUpstreamDatagram(Network::UdpRecvData& data);
     void writeDownstream(Network::UdpRecvData& data);
     void resetIdleTimer();
 
-    virtual void createUpstream() PURE;
+    virtual bool createUpstream() PURE;
     virtual void writeUpstream(Network::UdpRecvData& data) PURE;
     virtual void onIdleTimer() PURE;
 
@@ -525,7 +525,7 @@ private:
 
     uint64_t sessionId() const { return session_id_; };
     StreamInfo::StreamInfo& streamInfo() { return udp_session_info_; };
-    void onContinueFilterChain(ActiveReadFilter* filter);
+    bool onContinueFilterChain(ActiveReadFilter* filter);
     void onInjectReadDatagramToFilterChain(ActiveReadFilter* filter, Network::UdpRecvData& data);
     void onInjectWriteDatagramToFilterChain(ActiveWriteFilter* filter, Network::UdpRecvData& data);
 
@@ -595,7 +595,7 @@ private:
     ~UdpActiveSession() override = default;
 
     // ActiveSession
-    void createUpstream() override;
+    bool createUpstream() override;
     void writeUpstream(Network::UdpRecvData& data) override;
     void onIdleTimer() override;
 
@@ -644,7 +644,7 @@ private:
     ~TunnelingActiveSession() override = default;
 
     // ActiveSession
-    void createUpstream() override;
+    bool createUpstream() override;
     void writeUpstream(Network::UdpRecvData& data) override;
     void onIdleTimer() override;
 
@@ -666,7 +666,7 @@ private:
   private:
     using BufferedDatagramPtr = std::unique_ptr<Network::UdpRecvData>;
 
-    void establishUpstreamConnection();
+    bool establishUpstreamConnection();
     bool createConnectionPool();
     void maybeBufferDatagram(Network::UdpRecvData& data);
     void flushBuffer();

--- a/test/extensions/filters/udp/udp_proxy/mocks.cc
+++ b/test/extensions/filters/udp/udp_proxy/mocks.cc
@@ -15,6 +15,7 @@ namespace SessionFilters {
 MockReadFilterCallbacks::MockReadFilterCallbacks() {
   ON_CALL(*this, sessionId()).WillByDefault(Return(session_id_));
   ON_CALL(*this, streamInfo()).WillByDefault(ReturnRef(stream_info_));
+  ON_CALL(*this, continueFilterChain()).WillByDefault(Return(true));
 }
 MockReadFilterCallbacks::~MockReadFilterCallbacks() = default;
 

--- a/test/extensions/filters/udp/udp_proxy/mocks.h
+++ b/test/extensions/filters/udp/udp_proxy/mocks.h
@@ -22,7 +22,7 @@ public:
 
   MOCK_METHOD(uint64_t, sessionId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
-  MOCK_METHOD(void, continueFilterChain, ());
+  MOCK_METHOD(bool, continueFilterChain, ());
   MOCK_METHOD(void, injectDatagramToFilterChain, (Network::UdpRecvData & data));
 
   uint64_t session_id_{1};

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -207,8 +207,6 @@ TEST_P(DynamicForwardProxyIntegrationTest, EmptyDnsResponseDueToDummyHost) {
 
   client.write("hello", *listener_address);
   test_server_->waitForCounterEq("dns_cache.foo.dns_query_attempt", 1);
-  test_server_->waitForCounterEq("dns_cache.foo.dns_query_success", 1);
-  test_server_->waitForCounterEq("dns_cache.foo.host_added", 1);
 
   // The DNS response is empty, so will not be found any valid host.
   test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_none_healthy", 1);

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -319,7 +319,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferBytesOverflow) {
   EXPECT_FALSE(filter_config_->bufferEnabled());
 }
 
-TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithDnsLookupFailure) {
+TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithContinueFilterChainFailure) {
   FilterConfig config;
   config.mutable_buffer_options();
   setup(config);
@@ -338,9 +338,9 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithDnsLookupFailure) {
   EXPECT_EQ(ReadFilterStatus::StopIteration, filter_->onNewSession());
   EXPECT_EQ(ReadFilterStatus::StopIteration, filter_->onData(recv_data_stub1_));
 
-  EXPECT_CALL(callbacks_, continueFilterChain());
+  // Session is removed and no longer valid, no datagrams will be injected.
+  EXPECT_CALL(callbacks_, continueFilterChain()).WillOnce(Return(false));
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_)).Times(0);
-
   filter_->onLoadDnsCacheComplete(nullptr);
 
   EXPECT_CALL(*handle, onDestroy());

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -344,7 +344,6 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithContinueFilterChainFailure) 
   filter_->onLoadDnsCacheComplete(nullptr);
 
   EXPECT_CALL(*handle, onDestroy());
-  EXPECT_FALSE(filter_config_->bufferEnabled());
 }
 
 } // namespace

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -209,8 +209,12 @@ TEST_F(DynamicProxyFilterTest,
   EXPECT_EQ(ReadFilterStatus::StopIteration, filter_->onData(recv_data_stub1_));
 
   EXPECT_CALL(callbacks_, continueFilterChain());
-  filter_->onLoadDnsCacheComplete(
-      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>());
+
+  auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
+  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  EXPECT_CALL(*host_info, address());
+  filter_->onLoadDnsCacheComplete(host_info);
+
   EXPECT_CALL(*handle, onDestroy());
 }
 
@@ -237,8 +241,12 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithDefaultBufferConfig) {
 
   EXPECT_CALL(callbacks_, continueFilterChain());
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_)).Times(2);
-  filter_->onLoadDnsCacheComplete(
-      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>());
+
+  auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
+  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  EXPECT_CALL(*host_info, address());
+  filter_->onLoadDnsCacheComplete(host_info);
+
   EXPECT_CALL(*handle, onDestroy());
   EXPECT_FALSE(filter_config_->bufferEnabled());
 }
@@ -267,8 +275,12 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferSizeOverflow) {
 
   EXPECT_CALL(callbacks_, continueFilterChain());
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_));
-  filter_->onLoadDnsCacheComplete(
-      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>());
+
+  auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
+  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  EXPECT_CALL(*host_info, address());
+  filter_->onLoadDnsCacheComplete(host_info);
+
   EXPECT_CALL(*handle, onDestroy());
   EXPECT_FALSE(filter_config_->bufferEnabled());
 }
@@ -297,8 +309,12 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferBytesOverflow) {
 
   EXPECT_CALL(callbacks_, continueFilterChain());
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_));
-  filter_->onLoadDnsCacheComplete(
-      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>());
+
+  auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
+  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  EXPECT_CALL(*host_info, address());
+  filter_->onLoadDnsCacheComplete(host_info);
+
   EXPECT_CALL(*handle, onDestroy());
   EXPECT_FALSE(filter_config_->bufferEnabled());
 }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix segmentation fault in udp proxy filter
Additional Description: - proxy_filter.cc => Check host_info in onLoadDnsCacheComplete to verify that DNS lookup wasn't 
                                         failed (because in case of failure "read_callbacks_->continueFilterChain();" will remove the session).
                                      - udp_proxy_filter.cc => Add the session before calling "onNewSession" (because "onNewSession" will 
                                         remove the session if it failed to create upstream connection pool).
Risk Level: low, fix a bug
Testing: Unit Test
Docs Changes: None
Release Notes: None
Platform Specific Features: None
