### PR TITLE
jwt_authn: Allow to extract keys from jwt struct claims

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -762,9 +762,4 @@ message JwtClaimToHeader {
   // String separated with "." in case of nested claims. The nested claim name must use dot "." to separate
   // the JSON name path.
   string claim_name = 2 [(validate.rules).string = {min_len: 1}];
-
-  // If the claim name refers to an object type (e.g. tenants: {"key": {}}), this field can be used to
-  // return the value serialized as JSON (base64 encoded). Note that if the claim refers to a field of
-  // any primitive type, this flag will be ignored.
-  bool allow_serialize_object = 3;
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -763,8 +763,8 @@ message JwtClaimToHeader {
   // the JSON name path.
   string claim_name = 2 [(validate.rules).string = {min_len: 1}];
 
-  // If the claim name refers to a struct type (e.g. tenants: {"key": {}}), this field can be used to
-  // return a comma separated list of keys from the struct. This is useful for cases where the struct
-  // represents a list of elements such as tenants: {"key": {}, "key2": {}}.
-  bool list_claim_keys = 3;
+  // If the claim name refers to an object type (e.g. tenants: {"key": {}}), this field can be used to
+  // return the value serialized as JSON (base64 encoded). Note that if the claim refers to a field of
+  // any primitive type, this flag will be ignored.
+  bool allow_serialize_object = 3;
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -762,4 +762,9 @@ message JwtClaimToHeader {
   // String separated with "." in case of nested claims. The nested claim name must use dot "." to separate
   // the JSON name path.
   string claim_name = 2 [(validate.rules).string = {min_len: 1}];
+
+  // If the claim name refers to a struct type (e.g. tenants: {"key": {}}), this field can be used to
+  // return a comma separated list of keys from the struct. This is useful for cases where the struct
+  // represents a list of elements such as tenants: {"key": {}, "key2": {}}.
+  bool list_claim_keys = 3;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -20,5 +20,12 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: jwt
+  change: |
+    Added a new field `list_claim_keys` on
+    :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.claim_to_headers>`
+    to extract keys from JWT token claims. This field enables the retrieval of keys from custom JWT
+    token claims, such as `{"tenants": {"bitdrift": {}}` (in this case a claim_name of `tenants
+    would extract the key "bitdrift").
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -25,7 +25,7 @@ new_features:
     Added a new field `list_claim_keys` on
     :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.claim_to_headers>`
     to extract keys from JWT token claims. This field enables the retrieval of keys from custom JWT
-    token claims, such as `{"tenants": {"bitdrift": {}}` (in this case a claim_name of `tenants
-    would extract the key "bitdrift").
+    token claims, such as `{"tenants": {"bitdrift": {}}` (in this case a claim_name of `tenants`
+    would extract the key `bitdrift`).
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,9 +22,7 @@ removed_config_or_runtime:
 new_features:
 - area: jwt
   change: |
-    Added a new field ``allow_serialize_object`` on
-    :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.claim_to_headers>`
-    to serialize custom claim objects from JWT tokens. When set to true, the filter will serialize the
-    claim as JSON and encode it to Base64.
+    The jwt filter can now serialize non-primitive custom claims when maping claims to headers.
+    These claims will be serialized as JSON and encoded as Base64.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,10 +22,9 @@ removed_config_or_runtime:
 new_features:
 - area: jwt
   change: |
-    Added a new field ``list_claim_keys`` on
+    Added a new field ``allow_serialize_object`` on
     :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.claim_to_headers>`
-    to extract keys from JWT token claims. This field enables the retrieval of keys from custom JWT
-    token claims, such as ``{"tenants": {"bitdrift": {}}`` (in this case a claim_name of ``tenants``
-    would extract the key ``bitdrift``).
+    to serialize custom claim objects from JWT tokens. When set to true, the filter will serialize the
+    claim as JSON and encode it to Base64.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -22,10 +22,10 @@ removed_config_or_runtime:
 new_features:
 - area: jwt
   change: |
-    Added a new field `list_claim_keys` on
+    Added a new field ``list_claim_keys`` on
     :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.claim_to_headers>`
     to extract keys from JWT token claims. This field enables the retrieval of keys from custom JWT
-    token claims, such as `{"tenants": {"bitdrift": {}}` (in this case a claim_name of `tenants`
-    would extract the key `bitdrift`).
+    token claims, such as ``{"tenants": {"bitdrift": {}}`` (in this case a claim_name of ``tenants``
+    would extract the key ``bitdrift``).
 
 deprecated:

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -276,9 +276,8 @@ The field :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt
         claim_name: nested.claim.key
       - header_name: x-jwt-tenants
         claim_name: tenants
-        allow_serialize_object: true
 
-JWT claim ("sub", "nested.claim.key" and "tenants") will be added to HTTP headers as following format:
+In this example the `tenants` claim is an object, therefore the JWT claim ("sub", "nested.claim.key" and "tenants") will be added to HTTP headers as following format:
 
 .. code-block::
 

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -274,10 +274,14 @@ The field :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt
         claim_name: sub
       - header_name: x-jwt-claim-nested-key
         claim_name: nested.claim.key
+      - header_name: x-jwt-tenants
+        claim_name: tenants
+        list_claim_keys: true
 
-JWT claim ("sub" and "nested.claim.key") will be added to HTTP headers as following format:
+JWT claim ("sub", "nested.claim.key" and "tenants") will be added to HTTP headers as following format:
 
 .. code-block::
 
     x-jwt-claim-sub: <JWT Claim>
     x-jwt-claim-nested-key: <JWT Claim>
+    x-jwt-tenants: <Comma-separated JWT Claim>

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -276,7 +276,7 @@ The field :ref:`claim_to_headers <envoy_v3_api_field_extensions.filters.http.jwt
         claim_name: nested.claim.key
       - header_name: x-jwt-tenants
         claim_name: tenants
-        list_claim_keys: true
+        allow_serialize_object: true
 
 JWT claim ("sub", "nested.claim.key" and "tenants") will be added to HTTP headers as following format:
 
@@ -284,4 +284,4 @@ JWT claim ("sub", "nested.claim.key" and "tenants") will be added to HTTP header
 
     x-jwt-claim-sub: <JWT Claim>
     x-jwt-claim-nested-key: <JWT Claim>
-    x-jwt-tenants: <Comma-separated JWT Claim>
+    x-jwt-tenants: <Base64 encoded JSON JWT Claim>

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -155,13 +155,12 @@ TEST_F(AuthenticatorTest, TestClaimToHeader) {
   EXPECT_EQ(headers.get_("x-jwt-bool-claim"), "true");
   EXPECT_EQ(headers.get_("x-jwt-int-claim"), "9999");
 
-  // This check verifies whether the claim with the allow_serialize_object value set is
+  // This check verifies whether the claim with non-primitive type are
   // successfully serialized and added to headers.
   std::string expected_json = "[\"str1\",\"str2\"]";
 
   ASSERT_EQ(headers.get_("x-jwt-claim-object-key"),
             Envoy::Base64::encode(expected_json.data(), expected_json.size()));
-  EXPECT_EQ(headers.get_("x-jwt-claim-primitive-key"), "9999");
 }
 
 // This test verifies when wrong claim is passed in claim_to_headers

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -153,6 +153,11 @@ TEST_F(AuthenticatorTest, TestClaimToHeader) {
   EXPECT_EQ(headers.get_("x-jwt-claim-nested"), "value1");
   EXPECT_EQ(headers.get_("x-jwt-bool-claim"), "true");
   EXPECT_EQ(headers.get_("x-jwt-int-claim"), "9999");
+
+  // This check verifies whether the claim with the list_claim_keys value set is
+  // successfully added to header.
+  ASSERT_THAT(absl::StrSplit(headers.get_("x-jwt-claim-list-key"), ','),
+              testing::UnorderedElementsAre("key-2", "key-3", "key-4", "key-5"));
 }
 
 // This test verifies when wrong claim is passed in claim_to_headers
@@ -172,6 +177,7 @@ TEST_F(AuthenticatorTest, TestClaimToHeaderWithHeaderReplace) {
   EXPECT_EQ(headers.get_("x-jwt-claim-nested"), "value1");
   EXPECT_FALSE(headers.has("x-jwt-claim-nested-wrong"));
   EXPECT_FALSE(headers.has("x-jwt-unsupported-type-claim"));
+  EXPECT_FALSE(headers.has("x-jwt-claim-list-key-wrong"));
 }
 
 // This test verifies the Jwt is forwarded if "forward" flag is set.

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -99,10 +99,6 @@ providers:
       claim_name: "nested.nested-2.key-4"
     - header_name: "x-jwt-claim-object-key"
       claim_name: "nested.nested-2.key-5"
-      allow_serialize_object: true
-    - header_name: "x-jwt-claim-primitive-key"
-      claim_name: "nested.nested-2.key-4"
-      allow_serialize_object: true
 rules:
 - match:
     path: "/"

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -97,6 +97,12 @@ providers:
       claim_name: "nested.nested-2.key-3"
     - header_name: "x-jwt-int-claim"
       claim_name: "nested.nested-2.key-4"
+    - header_name: "x-jwt-claim-list-key"
+      claim_name: "nested.nested-2"
+      list_claim_keys: true
+    - header_name: "x-jwt-claim-list-key-wrong"
+      claim_name: "nested.nested-2.key-4"
+      list_claim_keys: true
 rules:
 - match:
     path: "/"

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -97,12 +97,12 @@ providers:
       claim_name: "nested.nested-2.key-3"
     - header_name: "x-jwt-int-claim"
       claim_name: "nested.nested-2.key-4"
-    - header_name: "x-jwt-claim-list-key"
-      claim_name: "nested.nested-2"
-      list_claim_keys: true
-    - header_name: "x-jwt-claim-list-key-wrong"
+    - header_name: "x-jwt-claim-object-key"
+      claim_name: "nested.nested-2.key-5"
+      allow_serialize_object: true
+    - header_name: "x-jwt-claim-primitive-key"
       claim_name: "nested.nested-2.key-4"
-      list_claim_keys: true
+      allow_serialize_object: true
 rules:
 - match:
     path: "/"


### PR DESCRIPTION
Commit Message: Allow to extract object from jwt struct claims
Additional Description:

Serialize non-primitive custom claim objects from JWT tokens. The JWT filter will now serialize these claim as JSON and encode it to Base64.

Risk Level: Low
Testing: unit test
Docs Changes: Updated `docs/root/configuration/http/http_filters/jwt_authn_filter.rst`
Release Notes: Updated `changelogs/current.yaml`