### PR TITLE
[backport 1.27]Check upstreamInfo's filter state as well in grpc access logs (#30057)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,6 +5,10 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: access_log
+  change: |
+    When emitting grpc logs, only downstream filter state was used. Now, both downstream and upstream filter states will be tried
+    to find the keys configured in filter_state_objects_to_log.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.h
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.h
@@ -24,6 +24,9 @@ public:
       const StreamInfo::StreamInfo& stream_info);
 };
 
+bool extractFilterStateData(const StreamInfo::FilterState& filter_state, const std::string& key,
+                            envoy::data::accesslog::v3::AccessLogCommon& common_access_log);
+
 } // namespace GrpcCommon
 } // namespace AccessLoggers
 } // namespace Extensions

--- a/test/extensions/access_loggers/grpc/BUILD
+++ b/test/extensions/access_loggers/grpc/BUILD
@@ -35,6 +35,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.access_loggers.http_grpc"],
     deps = [
         "//source/extensions/access_loggers/grpc:grpc_access_log_utils",
+        "//source/extensions/filters/common/expr:cel_state_lib",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stream_info:stream_info_mocks",

--- a/test/extensions/access_loggers/grpc/grpc_access_log_utils_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_utils_test.cc
@@ -1,6 +1,9 @@
 #include "envoy/data/accesslog/v3/accesslog.pb.h"
 
+#include "source/common/http/header_map_impl.h"
+#include "source/common/stream_info/filter_state_impl.h"
 #include "source/extensions/access_loggers/grpc/grpc_access_log_utils.h"
+#include "source/extensions/filters/common/expr/cel_state.h"
 
 #include "test/mocks/stream_info/mocks.h"
 
@@ -10,6 +13,8 @@ namespace AccessLoggers {
 namespace GrpcCommon {
 namespace {
 
+using Filters::Common::Expr::CelStatePrototype;
+using Filters::Common::Expr::CelStateType;
 using testing::_;
 using testing::Return;
 
@@ -51,6 +56,105 @@ TEST(UtilityResponseFlagsToAccessLogResponseFlagsTest, All) {
   common_access_log_expected.mutable_response_flags()->set_dns_resolution_failure(true);
 
   EXPECT_EQ(common_access_log_expected.DebugString(), common_access_log.DebugString());
+}
+
+// key is present only in downstream streamInfo's filter state
+TEST(UtilityExtractCommonAccessLogPropertiesTest, FilterStateFromDownstream) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(stream_info, hasResponseFlag(_)).WillByDefault(Return(true));
+  envoy::data::accesslog::v3::AccessLogCommon common_access_log;
+  envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig config;
+  config.mutable_filter_state_objects_to_log()->Add("downstream_peer");
+  CelStatePrototype prototype(true, CelStateType::Bytes, "",
+                              StreamInfo::FilterState::LifeSpan::FilterChain);
+  auto state = std::make_unique<::Envoy::Extensions::Filters::Common::Expr::CelState>(prototype);
+  state->setValue("value_from_downstream_peer");
+  stream_info.filter_state_->setData("downstream_peer", std::move(state),
+                                     StreamInfo::FilterState::StateType::Mutable,
+                                     StreamInfo::FilterState::LifeSpan::Connection);
+
+  Utility::extractCommonAccessLogProperties(
+      common_access_log, *Http::StaticEmptyHeaders::get().request_headers.get(), stream_info,
+      config, envoy::data::accesslog::v3::AccessLogType::TcpConnectionEnd);
+
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->contains("downstream_peer"), true);
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->count("downstream_peer"), 1);
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->size(), 1);
+  auto any = (*(common_access_log.mutable_filter_state_objects()))["downstream_peer"];
+  ProtobufWkt::BytesValue gotState;
+  any.UnpackTo(&gotState);
+  EXPECT_EQ(gotState.value(), "value_from_downstream_peer");
+}
+
+// key is present only in the upstream streamInfo's filter state
+TEST(UtilityExtractCommonAccessLogPropertiesTest, FilterStateFromUpstream) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(stream_info, hasResponseFlag(_)).WillByDefault(Return(true));
+  envoy::data::accesslog::v3::AccessLogCommon common_access_log;
+  envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig config;
+  config.mutable_filter_state_objects_to_log()->Add("upstream_peer");
+  CelStatePrototype prototype(true, CelStateType::Bytes, "",
+                              StreamInfo::FilterState::LifeSpan::FilterChain);
+  auto state = std::make_unique<::Envoy::Extensions::Filters::Common::Expr::CelState>(prototype);
+  auto filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
+  state->setValue("value_from_upstream_peer");
+  filter_state->setData("upstream_peer", std::move(state),
+                        StreamInfo::FilterState::StateType::Mutable,
+                        StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info.upstreamInfo()->setUpstreamFilterState(filter_state);
+
+  Utility::extractCommonAccessLogProperties(
+      common_access_log, *Http::StaticEmptyHeaders::get().request_headers.get(), stream_info,
+      config, envoy::data::accesslog::v3::AccessLogType::TcpConnectionEnd);
+
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->contains("upstream_peer"), true);
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->count("upstream_peer"), 1);
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->size(), 1);
+  auto any = (*(common_access_log.mutable_filter_state_objects()))["upstream_peer"];
+  ProtobufWkt::BytesValue gotState;
+  any.UnpackTo(&gotState);
+  EXPECT_EQ(gotState.value(), "value_from_upstream_peer");
+}
+
+// key is present in both the streamInfo's filter state
+TEST(UtilityExtractCommonAccessLogPropertiesTest,
+     FilterStateFromDownstreamIfSameKeyInBothStreamInfo) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(stream_info, hasResponseFlag(_)).WillByDefault(Return(true));
+  envoy::data::accesslog::v3::AccessLogCommon common_access_log;
+  envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig config;
+  config.mutable_filter_state_objects_to_log()->Add("same_key");
+  CelStatePrototype prototype(true, CelStateType::Bytes, "",
+                              StreamInfo::FilterState::LifeSpan::FilterChain);
+  auto downstream_state =
+      std::make_unique<::Envoy::Extensions::Filters::Common::Expr::CelState>(prototype);
+  downstream_state->setValue("value_from_downstream_peer");
+  stream_info.filter_state_->setData("same_key", std::move(downstream_state),
+                                     StreamInfo::FilterState::StateType::Mutable,
+                                     StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto upstream_state =
+      std::make_unique<::Envoy::Extensions::Filters::Common::Expr::CelState>(prototype);
+  auto filter_state =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::FilterChain);
+  upstream_state->setValue("value_from_upstream_peer");
+  filter_state->setData("same_key", std::move(upstream_state),
+                        StreamInfo::FilterState::StateType::Mutable,
+                        StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info.upstreamInfo()->setUpstreamFilterState(filter_state);
+
+  Utility::extractCommonAccessLogProperties(
+      common_access_log, *Http::StaticEmptyHeaders::get().request_headers.get(), stream_info,
+      config, envoy::data::accesslog::v3::AccessLogType::TcpConnectionEnd);
+
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->contains("same_key"), true);
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->count("same_key"), 1);
+  ASSERT_EQ(common_access_log.mutable_filter_state_objects()->size(), 1);
+  auto any = (*(common_access_log.mutable_filter_state_objects()))["same_key"];
+  ProtobufWkt::BytesValue gotState;
+  any.UnpackTo(&gotState);
+  EXPECT_EQ(gotState.value(), "value_from_downstream_peer");
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message:

At client side, if metadata exchange filter is an upstream filter, received filter state gets stored in the upstream streaminfo. While emitting access logs, streaminfo passed to the extractCommonAccessLogProperties() is the downstream side streaminfo. filter_state_objects_to_log keys must be searched in the usptream streaminfo's filter state as well.

Additional Description:
Risk Level: low
Testing: done
Docs Changes: no
Release Notes: yes

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
backport of https://github.com/envoyproxy/envoy/pull/30057
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
