### PR TITLE
mobile: Publish Android library (AAR) with xDS support

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -130,3 +130,119 @@ jobs:
             envoy-pom.xml.asc \
             envoy-sources.jar.asc \
             envoy-javadoc.jar.asc
+
+  android_xds_release_artifacts:
+    if: >-
+      ${{
+          github.repository == 'envoyproxy/envoy'
+          && (github.event.schedule
+              || !contains(github.actor, '[bot]'))
+      }}
+    needs: env
+    permissions:
+      contents: read
+      packages: read
+    name: android_xds_release_artifacts
+    runs-on: ${{ needs.env.outputs.agent_ubuntu }}
+    timeout-minutes: 120
+    container:
+      image: ${{ needs.env.outputs.build_image_ubuntu_mobile }}
+      env:
+        CC: /opt/llvm/bin/clang
+        CXX: /opt/llvm/bin/clang++
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy/envoy
+    - name: 'Build envoy_xds.aar distributable'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      working-directory: mobile
+      run: |
+        version="0.5.0.$(date '+%Y%m%d')"
+        ./bazelw build \
+          --config=mobile-remote-release-clang \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a \
+          --define=pom_version="$version" \
+          --define=google_grpc=enabled \
+          --config=mobile-release-android \
+          --linkopt=-fuse-ld=lld \
+          //:android_xds_dist
+    - name: 'Tar artifacts'
+      run: |
+        tar -czvf envoy_xds_android_aar_sources.tar.gz \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy_xds.aar \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy_xds-pom.xml \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy_xds-sources.jar \
+            bazel-bin/library/kotlin/io/envoyproxy/envoymobile/envoy_xds-javadoc.jar
+      working-directory: mobile
+    - uses: actions/upload-artifact@v3
+      with:
+        name: envoy_xds_android_aar_sources
+        path: mobile/envoy_xds_android_aar_sources.tar.gz
+
+  android_xds_release_deploy:
+    name: android_xds_release_deploy
+    needs: android_xds_release_artifacts
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy/envoy
+    - uses: actions/download-artifact@v3
+      with:
+        name: envoy_xds_android_aar_sources
+        path: .
+    - name: Expand archive
+      run: |
+        tar -xvf envoy_xds_android_aar_sources.tar.gz
+        mv bazel-bin/library/kotlin/io/envoyproxy/envoymobile/* .
+    - name: 'Configure gpg signing'
+      env:
+        GPG_KEY: ${{ secrets.EM_GPG_KEY }}
+        GPG_KEY_NAME: ${{ secrets.EM_GPG_KEY_NAME }}
+        GPG_PASSPHRASE: ${{ secrets.EM_GPG_PASSPHRASE }}
+      run: |
+        # https://github.com/keybase/keybase-issues/issues/2798
+        export GPG_TTY=$(tty)
+        # Import gpg keys and warm the passphrase to avoid the gpg
+        # passphrase prompt when initating a deploy
+        # `--pinentry-mode=loopback` could be needed to ensure we
+        # suppress the gpg prompt
+        echo $GPG_KEY | base64 --decode > signing-key
+        gpg --passphrase $GPG_PASSPHRASE --batch --import signing-key
+        shred signing-key
+
+        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab envoy_xds.aar
+        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab envoy_xds-pom.xml
+        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab envoy_xds-javadoc.jar
+        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab envoy_xds-sources.jar
+    - name: 'Release to sonatype repository'
+      env:
+        READWRITE_USER: ${{ secrets.EM_SONATYPE_USER }}
+        READWRITE_API_KEY: ${{ secrets.EM_SONATYPE_PASSWORD }}
+        SONATYPE_PROFILE_ID: ${{ secrets.EM_SONATYPE_PROFILE_ID }}
+      run: |
+        version="0.5.0.$(date '+%Y%m%d')"
+        python mobile/ci/sonatype_nexus_upload.py \
+          --profile_id=$SONATYPE_PROFILE_ID \
+          --version=$version \
+          --files \
+            envoy_xds.aar \
+            envoy_xds-pom.xml \
+            envoy_xds-sources.jar \
+            envoy_xds-javadoc.jar \
+          --signed_files \
+            envoy_xds.aar.asc \
+            envoy_xds-pom.xml.asc \
+            envoy_xds-sources.jar.asc \
+            envoy_xds-javadoc.jar.asc

--- a/mobile/BUILD
+++ b/mobile/BUILD
@@ -65,6 +65,11 @@ alias(
     actual = "//library/kotlin/io/envoyproxy/envoymobile:envoy_aar_with_artifacts",
 )
 
+alias(
+    name = "android_xds_dist",
+    actual = "//library/kotlin/io/envoyproxy/envoymobile:envoy_xds_aar_with_artifacts",
+)
+
 define_kt_toolchain(
     name = "kotlin_toolchain",
     jvm_target = "1.8",

--- a/mobile/bazel/android_artifacts.bzl
+++ b/mobile/bazel/android_artifacts.bzl
@@ -27,7 +27,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-def android_artifacts(name, android_library, manifest, archive_name, native_deps = [], proguard_rules = "", visibility = []):
+def android_artifacts(name, android_library, manifest, archive_name, native_deps = [], proguard_rules = "", visibility = [], substitutions = {}):
     """
     NOTE: The bazel android_library's implicit aar output doesn't flatten its transitive
     dependencies. Additionally, when using the kotlin rules, the kt_android_library rule
@@ -62,7 +62,7 @@ def android_artifacts(name, android_library, manifest, archive_name, native_deps
 
     # Generate other needed files for a maven publish
     _sources_name, _javadocs_name = _create_sources_javadocs(name, android_library)
-    _pom_name = _create_pom_xml(name, android_library, visibility)
+    _pom_name = _create_pom_xml(name, android_library, visibility, substitutions)
     native.genrule(
         name = name + "_with_artifacts",
         srcs = [
@@ -277,7 +277,7 @@ def _create_sources_javadocs(name, android_library):
 
     return _sources_name, _javadocs_name
 
-def _create_pom_xml(name, android_library, visibility):
+def _create_pom_xml(name, android_library, visibility, substitutions):
     """
     Creates a pom xml associated with the android_library target.
 
@@ -291,6 +291,7 @@ def _create_pom_xml(name, android_library, visibility):
         name = _pom_name,
         targets = [android_library],
         visibility = visibility,
+        substitutions = substitutions,
         template_file = "@envoy_mobile//bazel:pom_template.xml",
     )
 

--- a/mobile/bazel/pom_template.xml
+++ b/mobile/bazel/pom_template.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.envoyproxy.envoymobile</groupId>
-    <artifactId>envoy</artifactId>
+    <artifactId>pom_artifact_id</artifactId>
     <version>{pom_version}</version>
     <packaging>aar</packaging>
     <dependencies>

--- a/mobile/examples/java/hello_world/BUILD
+++ b/mobile/examples/java/hello_world/BUILD
@@ -8,8 +8,7 @@ android_binary(
     name = "hello_envoy",
     custom_package = "io.envoyproxy.envoymobile.helloenvoy",
     manifest = "AndroidManifest.xml",
-    # TODO(fredyw): Temporarily disable proguard.
-    # proguard_specs = ["//library:proguard_rules"],
+    proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_java_lib",
     ],
@@ -34,5 +33,6 @@ kt_android_library(
         artifact("androidx.recyclerview:recyclerview"),
         artifact("androidx.annotation:annotation"),
         artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.protobuf:protobuf-javalite"),
     ],
 )

--- a/mobile/examples/java/hello_world/BUILD
+++ b/mobile/examples/java/hello_world/BUILD
@@ -8,7 +8,8 @@ android_binary(
     name = "hello_envoy",
     custom_package = "io.envoyproxy.envoymobile.helloenvoy",
     manifest = "AndroidManifest.xml",
-    proguard_specs = ["//library:proguard_rules"],
+    # TODO(fredyw): Temporarily disable proguard.
+    # proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_java_lib",
     ],

--- a/mobile/examples/kotlin/hello_world/BUILD
+++ b/mobile/examples/kotlin/hello_world/BUILD
@@ -9,7 +9,8 @@ android_binary(
     name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
     manifest = "AndroidManifest.xml",
-    proguard_specs = ["//library:proguard_rules"],
+    # TODO(fredyw): Temporarily disable proguard.
+    # proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_kt_lib",
     ],

--- a/mobile/examples/kotlin/hello_world/BUILD
+++ b/mobile/examples/kotlin/hello_world/BUILD
@@ -9,8 +9,7 @@ android_binary(
     name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
     manifest = "AndroidManifest.xml",
-    # TODO(fredyw): Temporarily disable proguard.
-    # proguard_specs = ["//library:proguard_rules"],
+    proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_kt_lib",
     ],
@@ -35,6 +34,7 @@ kt_android_library(
         artifact("androidx.recyclerview:recyclerview"),
         artifact("androidx.annotation:annotation"),
         artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.protobuf:protobuf-javalite"),
     ],
 )
 

--- a/mobile/library/java/org/chromium/net/BUILD
+++ b/mobile/library/java/org/chromium/net/BUILD
@@ -24,11 +24,11 @@ android_binary(
     name = "cronet",
     srcs = [],
     manifest = "ChromiumNetManifest.xml",
-    # TODO(fredyw): Temporarily disable proguard.
-    # proguard_specs = ["//library:proguard_rules"],
+    proguard_specs = ["//library:proguard_rules"],
     visibility = ["//visibility:public"],
     deps = [
         ":net",
         "//library/java/org/chromium/net/impl:cronvoy",
+        artifact("com.google.protobuf:protobuf-javalite"),
     ],
 )

--- a/mobile/library/java/org/chromium/net/BUILD
+++ b/mobile/library/java/org/chromium/net/BUILD
@@ -24,7 +24,8 @@ android_binary(
     name = "cronet",
     srcs = [],
     manifest = "ChromiumNetManifest.xml",
-    proguard_specs = ["//library:proguard_rules"],
+    # TODO(fredyw): Temporarily disable proguard.
+    # proguard_specs = ["//library:proguard_rules"],
     visibility = ["//visibility:public"],
     deps = [
         ":net",

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_select_enable_http3", "envoy_select_envoy_mobile_request_compression")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_select_envoy_mobile_request_compression")
 load("@envoy_mobile//bazel:android_artifacts.bzl", "android_artifacts")
 load("@envoy_mobile//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
@@ -16,6 +16,25 @@ android_artifacts(
         "//conditions:default": ["//library/common/jni:libenvoy_jni.so"],
     }),
     proguard_rules = "//library:proguard_rules",
+    substitutions = {
+        "pom_artifact_id": "envoy",
+    },
+    visibility = ["//visibility:public"],
+)
+
+android_artifacts(
+    name = "envoy_xds_aar",
+    android_library = ":envoy_lib",
+    archive_name = "envoy_xds",
+    manifest = "EnvoyManifest.xml",
+    native_deps = select({
+        "@envoy//bazel:opt_build": ["//library/common/jni:libenvoy_jni.so.debug_info"],
+        "//conditions:default": ["//library/common/jni:libenvoy_jni.so"],
+    }),
+    proguard_rules = "//library:proguard_rules",
+    substitutions = {
+        "pom_artifact_id": "envoy-xds",
+    },
     visibility = ["//visibility:public"],
 )
 

--- a/mobile/library/proguard.txt
+++ b/mobile/library/proguard.txt
@@ -2,10 +2,12 @@
 -dontwarn kotlin.**
 -dontwarn org.jetbrains.annotations.NotNull
 -dontwarn org.jetbrains.annotations.Nullable
+-dontwarn com.google.protobuf.**
 
 -dontnote android.support.**
 -dontnote kotlin.**
 -dontnote com.google.devtools.build.android.**
+-dontnote com.google.protobuf.**
 
 -keepclasseswithmembernames,includedescriptorclasses class * {
     native <methods>;
@@ -57,4 +59,16 @@
 
 -keep class io.envoyproxy.envoymobile.engine.types.EnvoyLogger {
    <methods>;
+}
+
+-keep class com.google.protobuf.** {
+   *;
+}
+
+-keep class com.google.protobuf.MessageLite {
+    *;
+}
+
+-keep class com.google.protobuf.MessageLite$Builder {
+    *;
 }

--- a/mobile/library/proguard.txt
+++ b/mobile/library/proguard.txt
@@ -2,6 +2,7 @@
 -dontwarn kotlin.**
 -dontwarn org.jetbrains.annotations.NotNull
 -dontwarn org.jetbrains.annotations.Nullable
+-dontwarn com.google.protobuf.**
 
 -dontnote android.support.**
 -dontnote kotlin.**

--- a/mobile/library/proguard.txt
+++ b/mobile/library/proguard.txt
@@ -2,7 +2,6 @@
 -dontwarn kotlin.**
 -dontwarn org.jetbrains.annotations.NotNull
 -dontwarn org.jetbrains.annotations.Nullable
--dontwarn com.google.protobuf.**
 
 -dontnote android.support.**
 -dontnote kotlin.**

--- a/mobile/test/kotlin/apps/baseline/BUILD
+++ b/mobile/test/kotlin/apps/baseline/BUILD
@@ -9,8 +9,7 @@ android_binary(
     name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoybaselinetest",
     manifest = "AndroidManifest.xml",
-    # TODO(fredyw): Temporarily disable proguard.
-    # proguard_specs = ["//library:proguard_rules"],
+    proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_kt_lib",
     ],
@@ -35,6 +34,7 @@ kt_android_library(
         artifact("androidx.recyclerview:recyclerview"),
         artifact("androidx.annotation:annotation"),
         artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.protobuf:protobuf-javalite"),
     ],
 )
 

--- a/mobile/test/kotlin/apps/baseline/BUILD
+++ b/mobile/test/kotlin/apps/baseline/BUILD
@@ -9,7 +9,8 @@ android_binary(
     name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoybaselinetest",
     manifest = "AndroidManifest.xml",
-    proguard_specs = ["//library:proguard_rules"],
+    # TODO(fredyw): Temporarily disable proguard.
+    # proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_kt_lib",
     ],

--- a/mobile/test/kotlin/apps/experimental/BUILD
+++ b/mobile/test/kotlin/apps/experimental/BUILD
@@ -9,7 +9,8 @@ android_binary(
     name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoyexperimentaltest",
     manifest = "AndroidManifest.xml",
-    proguard_specs = ["//library:proguard_rules"],
+    # TODO(fredyw): Temporarily disable proguard.
+    # proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_kt_lib",
     ],

--- a/mobile/test/kotlin/apps/experimental/BUILD
+++ b/mobile/test/kotlin/apps/experimental/BUILD
@@ -9,8 +9,7 @@ android_binary(
     name = "hello_envoy_kt",
     custom_package = "io.envoyproxy.envoymobile.helloenvoyexperimentaltest",
     manifest = "AndroidManifest.xml",
-    # TODO(fredyw): Temporarily disable proguard.
-    # proguard_specs = ["//library:proguard_rules"],
+    proguard_specs = ["//library:proguard_rules"],
     deps = [
         "hello_envoy_kt_lib",
     ],
@@ -35,6 +34,7 @@ kt_android_library(
         artifact("androidx.recyclerview:recyclerview"),
         artifact("androidx.annotation:annotation"),
         artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.protobuf:protobuf-javalite"),
     ],
 )
 


### PR DESCRIPTION
This PR builds a separate Android library (AAR) that supports xDS and publishes it to Maven Central. This library will have `artifactId`: `envoy-xds`.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
