### PR TITLE
bazel: Patch aspect lib to resolve external build issue

### DIFF
--- a/bazel/aspect.patch
+++ b/bazel/aspect.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/private/yq.bzl b/lib/private/yq.bzl
+index 29ca3d7..c8cd5eb 100644
+--- a/lib/private/yq.bzl
++++ b/lib/private/yq.bzl
+@@ -71,10 +71,13 @@ def _yq_impl(ctx):
+ 
+     # For split operations, yq outputs files in the same directory so we
+     # must cd to the correct output dir before executing it
+-    bin_dir = "/".join([ctx.bin_dir.path, ctx.label.package]) if ctx.label.package else ctx.bin_dir.path
++    bin_dir = ctx.bin_dir.path
++    if ctx.label.workspace_name:
++        bin_dir = "%s/external/%s" % (bin_dir, ctx.label.workspace_name)
++    bin_dir = "/".join([bin_dir, ctx.label.package]) if ctx.label.package else bin_dir
+     escape_bin_dir = _escape_path(bin_dir)
+     cmd = "cd {bin_dir} && {yq} {args} {eval_cmd} {expression} {sources} {maybe_out}".format(
+-        bin_dir = ctx.bin_dir.path + "/" + ctx.label.package,
++        bin_dir = bin_dir,
+         yq = escape_bin_dir + yq_bin.path,
+         eval_cmd = "eval" if len(inputs) <= 1 else "eval-all",
+         args = " ".join(args),

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -339,7 +339,12 @@ def envoy_dependencies(skip_targets = []):
         patches = ["@envoy//bazel:rules_pkg.patch"],
     )
     external_http_archive("com_github_aignas_rules_shellcheck")
-    external_http_archive("aspect_bazel_lib")
+    external_http_archive(
+        "aspect_bazel_lib",
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:aspect.patch"],
+    )
+
     _com_github_fdio_vpp_vcl()
 
     # Unconditional, since we use this only for compiler-agnostic fuzzing utils.


### PR DESCRIPTION
upstream issue is https://github.com/aspect-build/bazel-lib/issues/548 pr is: https://github.com/aspect-build/bazel-lib/pull/547

Currently the websites and archive patch this independently

This caused a breakage (in all 3) when aspect lib was updated

https://github.com/envoyproxy/envoy-website/issues/368

This should prevent that until there is some upstream resolution

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
