### PR TITLE
Added missing changelogs/1.27.2.yaml

### DIFF
--- a/changelogs/1.27.2.yaml
+++ b/changelogs/1.27.2.yaml
@@ -1,0 +1,10 @@
+date: October 16, 2023
+
+bug_fixes:
+- area: tracing
+  change: |
+    Fixed a bug in the Datadog tracer where Datadog's "operation name" field would contain what should be in the "resource name" field.
+- area: http
+  change: |
+    Fixed a bug where processing of deferred streams with the value of ``http.max_requests_per_io_cycle`` more than 1,
+    can cause a crash.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

**Commit Message:** Added missing changelogs/1.27.2.yaml
**Additional Description:**

Release 1.27.2 is missing from latest docs https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history

This change adds changelog entry for `1.27.2`  by copying `https://github.com/envoyproxy/envoy/blob/v1.27.2/changelogs/current.yaml` to` changelogs/1.27.2.yaml`

**Risk Level:** Low
**Testing:** N/A
**Docs Changes:** N/A
**Release Notes:** N/A
**Platform Specific Features**: N/A
