### PR TITLE
mobile: Add a flag to specify the artifact ID when publishing to Maven

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -119,6 +119,7 @@ jobs:
         version="0.5.0.$(date '+%Y%m%d')"
         python mobile/ci/sonatype_nexus_upload.py \
           --profile_id=$SONATYPE_PROFILE_ID \
+          --artifact_id=envoy \
           --version=$version \
           --files \
             envoy.aar \
@@ -235,6 +236,7 @@ jobs:
         version="0.5.0.$(date '+%Y%m%d')"
         python mobile/ci/sonatype_nexus_upload.py \
           --profile_id=$SONATYPE_PROFILE_ID \
+          --artifact_id=envoy-xds \
           --version=$version \
           --files \
             envoy_xds.aar \


### PR DESCRIPTION
This PR adds a `--artifact_id` flag in the `sonatype_nexus_upload.py` to allow specifying the artifact ID when publishing to Maven Central.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a