### PR TITLE
[balsa] Use new BalsaFrame trailers API.

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -163,10 +163,10 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   framer_.set_http_validation_policy(http_validation_policy);
 
   framer_.set_balsa_headers(&headers_);
-  framer_.set_balsa_trailer(&trailers_);
   framer_.set_balsa_visitor(this);
   framer_.set_max_header_length(max_header_length);
   framer_.set_invalid_chars_level(quiche::BalsaFrame::InvalidCharsLevel::kError);
+  framer_.EnableTrailers();
 
   switch (message_type_) {
   case MessageType::Request:
@@ -278,8 +278,8 @@ void BalsaParser::OnHeader(absl::string_view /*key*/, absl::string_view /*value*
 void BalsaParser::ProcessHeaders(const BalsaHeaders& headers) {
   validateAndProcessHeadersOrTrailersImpl(headers, /* trailers = */ false);
 }
-void BalsaParser::ProcessTrailers(const BalsaHeaders& trailer) {
-  validateAndProcessHeadersOrTrailersImpl(trailer, /* trailers = */ true);
+void BalsaParser::OnTrailers(std::unique_ptr<quiche::BalsaHeaders> trailers) {
+  validateAndProcessHeadersOrTrailersImpl(*trailers, /* trailers = */ true);
 }
 
 void BalsaParser::OnRequestFirstLineInput(absl::string_view /*line_input*/,

--- a/source/common/http/http1/balsa_parser.h
+++ b/source/common/http/http1/balsa_parser.h
@@ -43,9 +43,9 @@ private:
   void OnHeaderInput(absl::string_view input) override;
   void OnHeader(absl::string_view key, absl::string_view value) override;
   void OnTrailerInput(absl::string_view input) override;
-  void OnTrailers(std::unique_ptr<quiche::BalsaHeaders> /*trailers*/) override{};
+  void OnTrailers(std::unique_ptr<quiche::BalsaHeaders> trailers) override;
   void ProcessHeaders(const quiche::BalsaHeaders& headers) override;
-  void ProcessTrailers(const quiche::BalsaHeaders& trailer) override;
+  void ProcessTrailers(const quiche::BalsaHeaders& /*trailer*/) override{};
   void OnRequestFirstLineInput(absl::string_view line_input, absl::string_view method_input,
                                absl::string_view request_uri,
                                absl::string_view version_input) override;
@@ -61,7 +61,7 @@ private:
   void HandleError(quiche::BalsaFrameEnums::ErrorCode error_code) override;
   void HandleWarning(quiche::BalsaFrameEnums::ErrorCode error_code) override;
 
-  // Shared implementation for ProcessHeaders() and ProcessTrailers().
+  // Shared implementation for ProcessHeaders() and OnTrailers().
   void validateAndProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers, bool trailers);
 
   // Return ParserStatus::Error if `result` is CallbackResult::Error.
@@ -71,7 +71,6 @@ private:
 
   quiche::BalsaFrame framer_;
   quiche::BalsaHeaders headers_;
-  quiche::BalsaHeaders trailers_;
 
   const MessageType message_type_ = MessageType::Request;
   ParserCallbacks* connection_ = nullptr;


### PR DESCRIPTION
A new API for taking trailers has been introduced to BalsaFrame and BalsaVisitorInterface: EnableTrailers() and OnTrailers(unique_ptr<>). The old API of set_balsa_trailers() and ProcessTrailers() is deprecated. There is no behavior change.

Tracking issue: #21245

Commit Message: [balsa] Use new BalsaFrame trailers API.
Additional Description:
Risk Level: low
Testing: //test/common/http/http1:codec_impl_test and various integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser (default enabled)