### PR TITLE
mobile: Update pom.xml with a protobuf-javalite transitive dependency

### DIFF
--- a/mobile/bazel/pom_template.xml
+++ b/mobile/bazel/pom_template.xml
@@ -5,11 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.envoyproxy.envoymobile</groupId>
-    <artifactId>pom_artifact_id</artifactId>
+    <artifactId>{pom_artifact_id}</artifactId>
     <version>{pom_version}</version>
     <packaging>aar</packaging>
     <dependencies>
         {generated_bzl_deps}
+        {pom_extra_dependencies}
     </dependencies>
 
     <name>Envoy Mobile</name>

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -17,7 +17,8 @@ android_artifacts(
     }),
     proguard_rules = "//library:proguard_rules",
     substitutions = {
-        "pom_artifact_id": "envoy",
+        "{pom_artifact_id}": "envoy",
+        "{pom_extra_dependencies}": "",
     },
     visibility = ["//visibility:public"],
 )
@@ -33,7 +34,13 @@ android_artifacts(
     }),
     proguard_rules = "//library:proguard_rules",
     substitutions = {
-        "pom_artifact_id": "envoy-xds",
+        "{pom_artifact_id}": "envoy-xds",
+        "{pom_extra_dependencies}": """
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-javalite</artifactId>
+            <version>3.24.4</version>
+        </dependency>""",
     },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This is to allow depending on `io.envoyproxy.envoymobile:envoy-xds` without having to manually add `com.google.protobuf:protobuf-javalite` dependency.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
