### PR TITLE
test: Move MockedUpdatedClusterManagerImpl to cluster_manager_impl_test

### DIFF
--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -159,18 +159,6 @@ public:
   Server::MockOptions& options_ = server_context_.options_;
 };
 
-// Helper to intercept calls to postThreadLocalClusterUpdate.
-class MockLocalClusterUpdate {
-public:
-  MOCK_METHOD(void, post,
-              (uint32_t priority, const HostVector& hosts_added, const HostVector& hosts_removed));
-};
-
-class MockLocalHostsRemoved {
-public:
-  MOCK_METHOD(void, post, (const HostVector&));
-};
-
 // A test version of ClusterManagerImpl that provides a way to get a non-const handle to the
 // clusters, which is necessary in order to call updateHosts on the priority set.
 class TestClusterManagerImpl : public ClusterManagerImpl {
@@ -229,45 +217,6 @@ protected:
       : ClusterManagerImpl(bootstrap, factory, stats, tls, runtime, local_info, log_manager,
                            main_thread_dispatcher, admin, validation_context, api, http_context,
                            grpc_context, router_context, server) {}
-};
-
-// Override postThreadLocalClusterUpdate so we can test that merged updates calls
-// it with the right values at the right times.
-class MockedUpdatedClusterManagerImpl : public TestClusterManagerImpl {
-public:
-  using TestClusterManagerImpl::TestClusterManagerImpl;
-
-  MockedUpdatedClusterManagerImpl(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
-                                  ClusterManagerFactory& factory, Stats::Store& stats,
-                                  ThreadLocal::Instance& tls, Runtime::Loader& runtime,
-                                  const LocalInfo::LocalInfo& local_info,
-                                  AccessLog::AccessLogManager& log_manager,
-                                  Event::Dispatcher& main_thread_dispatcher, Server::Admin& admin,
-                                  ProtobufMessage::ValidationContext& validation_context,
-                                  Api::Api& api, MockLocalClusterUpdate& local_cluster_update,
-                                  MockLocalHostsRemoved& local_hosts_removed,
-                                  Http::Context& http_context, Grpc::Context& grpc_context,
-                                  Router::Context& router_context, Server::Instance& server)
-      : TestClusterManagerImpl(bootstrap, factory, stats, tls, runtime, local_info, log_manager,
-                               main_thread_dispatcher, admin, validation_context, api, http_context,
-                               grpc_context, router_context, server),
-        local_cluster_update_(local_cluster_update), local_hosts_removed_(local_hosts_removed) {}
-
-protected:
-  void postThreadLocalClusterUpdate(ClusterManagerCluster&,
-                                    ThreadLocalClusterUpdateParams&& params) override {
-    for (const auto& per_priority : params.per_priority_update_params_) {
-      local_cluster_update_.post(per_priority.priority_, per_priority.hosts_added_,
-                                 per_priority.hosts_removed_);
-    }
-  }
-
-  void postThreadLocalRemoveHosts(const Cluster&, const HostVector& hosts_removed) override {
-    local_hosts_removed_.post(hosts_removed);
-  }
-
-  MockLocalClusterUpdate& local_cluster_update_;
-  MockLocalHostsRemoved& local_hosts_removed_;
 };
 
 } // namespace Upstream


### PR DESCRIPTION
The class is only used within cluster_manager_impl_test and is very specific in its behavior, so I think it makes more sense to locate it in the same file as the test that uses it, instead of keeping it in test_cluster_manager.h.