### PR TITLE
Make config_validation not have hot_restart panics

### DIFF
--- a/source/server/config_validation/BUILD
+++ b/source/server/config_validation/BUILD
@@ -100,6 +100,7 @@ envoy_cc_library(
         "//source/common/thread_local:thread_local_lib",
         "//source/common/version:version_lib",
         "//source/server:configuration_lib",
+        "//source/server:hot_restart_nop_lib",
         "//source/server:server_lib",
         "//source/server:utils_lib",
         "//source/server/admin:admin_lib",

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -28,6 +28,7 @@
 #include "source/server/config_validation/api.h"
 #include "source/server/config_validation/cluster_manager.h"
 #include "source/server/config_validation/dns.h"
+#include "source/server/hot_restart_nop_impl.h"
 #include "source/server/server.h"
 
 #include "absl/types/optional.h"
@@ -88,7 +89,7 @@ public:
   DrainManager& drainManager() override { return *drain_manager_; }
   AccessLog::AccessLogManager& accessLogManager() override { return access_log_manager_; }
   void failHealthcheck(bool) override {}
-  HotRestart& hotRestart() override { PANIC("not implemented"); }
+  HotRestart& hotRestart() override { return nop_hot_restart_; }
   Init::Manager& initManager() override { return init_manager_; }
   ServerLifecycleNotifier& lifecycleNotifier() override { return *this; }
   ListenerManager& listenerManager() override { return *listener_manager_; }
@@ -189,6 +190,7 @@ private:
   Quic::QuicStatNames quic_stat_names_;
   Filter::TcpListenerFilterConfigProviderManagerImpl tcp_listener_config_provider_manager_;
   Server::DrainManagerPtr drain_manager_;
+  HotRestartNopImpl nop_hot_restart_;
 };
 
 } // namespace Server


### PR DESCRIPTION
Commit Message: Make config_validation not have hot_restart panics
Additional Description: Now that there is a call to `server_.hotRestart()` (introduced in https://github.com/envoyproxy/envoy/commit/bd7225e068a45ebda184036fb851af7fa97e8500) that can apparently occur in the validation context, that can provoke a panic. Instead of panicking, we should just do nothing, which is easily achieved by using the `HotRestartNopImpl` class.
Risk Level: Fix.
Testing: The code path that provokes this should have been already tested; fixing it first seems more important than testing it. Plan to add that test later but no time right now.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
