### PR TITLE
bazel: remove unused helper functions

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1403,22 +1403,6 @@ def _rules_ruby():
 def _foreign_cc_dependencies():
     external_http_archive("rules_foreign_cc")
 
-def _is_linux(ctxt):
-    return ctxt.os.name == "linux"
-
-def _is_arch(ctxt, arch):
-    res = ctxt.execute(["uname", "-m"])
-    return arch in res.stdout
-
-def _is_linux_ppc(ctxt):
-    return _is_linux(ctxt) and _is_arch(ctxt, "ppc")
-
-def _is_linux_s390x(ctxt):
-    return _is_linux(ctxt) and _is_arch(ctxt, "s390x")
-
-def _is_linux_x86_64(ctxt):
-    return _is_linux(ctxt) and _is_arch(ctxt, "x86_64")
-
 def _com_github_maxmind_libmaxminddb():
     external_http_archive(
         name = "com_github_maxmind_libmaxminddb",


### PR DESCRIPTION
Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
