### PR TITLE
test: Enable XdsTest to run without the test HTTP server

### DIFF
--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -188,6 +188,7 @@ envoy_cc_test_library(
     repository = "@envoy",
     deps = [
         ":base_client_integration_test_lib",
+        "@envoy//source/common/event:libevent_lib",
         "@envoy//source/common/grpc:google_grpc_creds_lib",
         "@envoy//source/exe:process_wide_lib",
         "@envoy//test/integration:autonomous_upstream_lib",

--- a/mobile/test/common/jni/test_jni_interface.cc
+++ b/mobile/test/common/jni/test_jni_interface.cc
@@ -73,6 +73,8 @@ Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeSendDiscoveryRespons
                                                                                   jstring yaml) {
   jni_log("[XTS]", "sending DiscoveryResponse from the xDS server");
   const char* yaml_chars = env->GetStringUTFChars(yaml, /* isCopy= */ nullptr);
+  // The yaml utilities have non-relevant thread asserts.
+  Envoy::Thread::SkipAsserts skip;
   envoy::service::discovery::v3::DiscoveryResponse response;
   Envoy::TestUtility::loadFromYaml(yaml_chars, response);
   sendDiscoveryResponse(response);

--- a/mobile/test/kotlin/integration/XdsTest.kt
+++ b/mobile/test/kotlin/integration/XdsTest.kt
@@ -28,7 +28,6 @@ class XdsTest {
 
   @Before
   fun setUp() {
-    TestJni.startHttp2TestServer()
     TestJni.initXdsTestServer()
     val latch = CountDownLatch(1)
     engine =
@@ -50,7 +49,6 @@ class XdsTest {
   @After
   fun tearDown() {
     engine.terminate()
-    TestJni.shutdownTestServer()
     TestJni.shutdownXdsTestServer()
   }
 
@@ -66,15 +64,6 @@ class XdsTest {
         name: my_cluster
         type: STATIC
         connect_timeout: 5s
-        load_assignment:
-          cluster_name: xds_cluster
-          endpoints:
-            - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: ${TestJni.getServerHost()}
-                        port_value: ${TestJni.getServerPort()}
         typed_extension_protocol_options:
           envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
             "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -86,7 +75,7 @@ class XdsTest {
     """
         .trimIndent()
     TestJni.sendDiscoveryResponse(cdsResponse)
-    // There are now 3 clusters: base, base_cluster, and xds_cluster.
+    // There are now 3 clusters: base, base_cluster, and my_cluster.
     engine.waitForStatGe("cluster_manager.cluster_added", 3)
   }
 }


### PR DESCRIPTION
This required fixing a couple issues in XdsTestServer:

(1) Initialize Libevent before creating the Dispatcher. If we don't do this, and we start the XdsTestServer without starting the Http2TestServer, the LibeventScheduler fails the
Libevent::Global::initialized() assert.

(2) Add a Thread::SkipAsserts before calling the YAML to Bootstrap parsing. The YAML utilities make some non-relevant asserts on being on the main thread, which aren't applicable when calling the YAML utilities from JNI and tests.

To remove the need for the Http2TestServer, we remove the endpoints from the dynamic cluster returned in the test xDS response. This allows us to test the essential xDS behavior without depending on an endpoint for cluster initialization.