### PR TITLE
mobile: Fix a bug where ASSERT is elided on a release build

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -877,10 +877,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     node->mutable_locality()->set_zone(node_locality_->zone);
     node->mutable_locality()->set_sub_zone(node_locality_->sub_zone);
   }
-  ProtobufWkt::Struct& metadata = *node->mutable_metadata();
   if (node_metadata_.has_value()) {
     *node->mutable_metadata() = *node_metadata_;
   }
+  ProtobufWkt::Struct& metadata = *node->mutable_metadata();
   (*metadata.mutable_fields())["app_id"].set_string_value(app_id_);
   (*metadata.mutable_fields())["app_version"].set_string_value(app_version_);
   (*metadata.mutable_fields())["device_os"].set_string_value(device_os_);

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -388,7 +388,8 @@ std::vector<MatcherData> javaObjectArrayToMatcherData(JNIEnv* env, jobjectArray 
 void javaByteArrayToProto(JNIEnv* env, jbyteArray source, Envoy::Protobuf::MessageLite* dest) {
   jbyte* bytes = env->GetByteArrayElements(source, /* isCopy= */ nullptr);
   jsize size = env->GetArrayLength(source);
-  ASSERT(dest->ParseFromArray(bytes, size));
+  bool success = dest->ParseFromArray(bytes, size);
+  RELEASE_ASSERT(success, "Failed to parse protobuf message.");
   env->ReleaseByteArrayElements(source, bytes, 0);
 }
 


### PR DESCRIPTION
This fixes a bug in the JNI code where a call to `ASSERT(some_func())` gets elided causing the code to do nothing.

Risk Level: low
Testing: unit test + manual test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
