### PR TITLE
Propagate route metadata in ext_authz

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -28,7 +28,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 21]
+// [#next-free-field: 23]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -119,6 +119,18 @@ message ExtAuthz {
   // the protobuf message definition in order to do a safe parsing.
   //
   repeated string typed_metadata_context_namespaces = 16;
+
+  // Specifies a list of route metadata namespaces whose values, if present, will be passed to the
+  // ext_authz service at :ref:`route_metadata_context <envoy_v3_api_field_service.auth.v3.AttributeContext.route_metadata_context>` in
+  // :ref:`CheckRequest <envoy_v3_api_field_service.auth.v3.CheckRequest.attributes>`.
+  // :ref:`filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.filter_metadata>` is passed as an opaque ``protobuf::Struct``.
+  repeated string route_metadata_context_namespaces = 21;
+
+  // Specifies a list of route metadata namespaces whose values, if present, will be passed to the
+  // ext_authz service at :ref:`route_metadata_context <envoy_v3_api_field_service.auth.v3.AttributeContext.route_metadata_context>` in
+  // :ref:`CheckRequest <envoy_v3_api_field_service.auth.v3.CheckRequest.attributes>`.
+  // :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` is passed as an ``protobuf::Any``.
+  repeated string route_typed_metadata_context_namespaces = 22;
 
   // Specifies if the filter is enabled.
   //

--- a/api/envoy/service/auth/v3/attribute_context.proto
+++ b/api/envoy/service/auth/v3/attribute_context.proto
@@ -38,7 +38,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // - field mask to send
 // - which return values from request_context are copied back
 // - which return values are copied into request_headers]
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message AttributeContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.auth.v2.AttributeContext";
@@ -182,6 +182,9 @@ message AttributeContext {
 
   // Dynamic metadata associated with the request.
   config.core.v3.Metadata metadata_context = 11;
+
+  // Metadata associated with the selected route.
+  config.core.v3.Metadata route_metadata_context = 13;
 
   // TLS session details of the underlying connection.
   // This is not populated by default and will be populated if ext_authz filter's

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -124,5 +124,15 @@ new_features:
     New config parameter :ref:`charge_cluster_response_stats
     <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.charge_cluster_response_stats>`
     for not incrementing cluster statistics on ext_authz response. Default true, no behavior change.
+- area: ext_authz
+  change: |
+    forward :ref:`filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.filter_metadata>` selected by
+    :ref:`route_metadata_context_namespaces
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.route_metadata_context_namespaces>`
+    and :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` selected by
+    :ref:`route_typed_metadata_context_namespaces
+    <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.route_typed_metadata_context_namespaces>`
+    from the metadata of the selected route to external auth service.
+    This metadata propagation is independent from the dynamic metadata from connection and request.
 
 deprecated:

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -192,6 +192,7 @@ void CheckRequestUtils::createHttpCheck(
     const Envoy::Http::RequestHeaderMap& headers,
     Protobuf::Map<std::string, std::string>&& context_extensions,
     envoy::config::core::v3::Metadata&& metadata_context,
+    envoy::config::core::v3::Metadata&& route_metadata_context,
     envoy::service::auth::v3::CheckRequest& request, uint64_t max_request_bytes, bool pack_as_bytes,
     bool include_peer_certificate, bool include_tls_session,
     const Protobuf::Map<std::string, std::string>& destination_labels,
@@ -224,6 +225,7 @@ void CheckRequestUtils::createHttpCheck(
   // Fill in the context extensions and metadata context.
   (*attrs->mutable_context_extensions()) = std::move(context_extensions);
   (*attrs->mutable_metadata_context()) = std::move(metadata_context);
+  (*attrs->mutable_route_metadata_context()) = std::move(route_metadata_context);
 }
 
 void CheckRequestUtils::createTcpCheck(

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -93,6 +93,7 @@ public:
                               const Envoy::Http::RequestHeaderMap& headers,
                               Protobuf::Map<std::string, std::string>&& context_extensions,
                               envoy::config::core::v3::Metadata&& metadata_context,
+                              envoy::config::core::v3::Metadata&& route_metadata_context,
                               envoy::service::auth::v3::CheckRequest& request,
                               uint64_t max_request_bytes, bool pack_as_bytes,
                               bool include_peer_certificate, bool include_tls_session,

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -1,6 +1,9 @@
 #include "source/extensions/filters/http/ext_authz/ext_authz.h"
 
 #include <chrono>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "envoy/config/core/v3/base.pb.h"
 
@@ -14,6 +17,46 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace ExtAuthz {
+
+namespace {
+
+using MetadataProto = ::envoy::config::core::v3::Metadata;
+
+void fillMetadataContext(const std::vector<const MetadataProto*>& source_metadata,
+                         const std::vector<std::string>& metadata_context_namespaces,
+                         const std::vector<std::string>& typed_metadata_context_namespaces,
+                         MetadataProto& metadata_context) {
+  for (const auto& context_key : metadata_context_namespaces) {
+    for (const MetadataProto* metadata : source_metadata) {
+      if (metadata == nullptr) {
+        continue;
+      }
+      const auto& filter_metadata = metadata->filter_metadata();
+      if (const auto metadata_it = filter_metadata.find(context_key);
+          metadata_it != filter_metadata.end()) {
+        (*metadata_context.mutable_filter_metadata())[metadata_it->first] = metadata_it->second;
+        break;
+      }
+    }
+  }
+
+  for (const auto& context_key : typed_metadata_context_namespaces) {
+    for (const MetadataProto* metadata : source_metadata) {
+      if (metadata == nullptr) {
+        continue;
+      }
+      const auto& typed_filter_metadata = metadata->typed_filter_metadata();
+      if (const auto metadata_it = typed_filter_metadata.find(context_key);
+          metadata_it != typed_filter_metadata.end()) {
+        (*metadata_context.mutable_typed_filter_metadata())[metadata_it->first] =
+            metadata_it->second;
+        break;
+      }
+    }
+  }
+}
+
+} // namespace
 
 void FilterConfigPerRoute::merge(const FilterConfigPerRoute& other) {
   // We only merge context extensions here, and leave boolean flags untouched since those flags are
@@ -41,47 +84,29 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
     context_extensions = maybe_merged_per_route_config.value().takeContextExtensions();
   }
 
+  // If metadata_context_namespaces or typed_metadata_context_namespaces is specified,
+  // pass matching filter metadata to the ext_authz service.
+  // If metadata key is set in both the connection and request metadata,
+  // then the value will be the request metadata value.
   envoy::config::core::v3::Metadata metadata_context;
+  fillMetadataContext({&decoder_callbacks_->streamInfo().dynamicMetadata(),
+                       &decoder_callbacks_->connection()->streamInfo().dynamicMetadata()},
+                      config_->metadataContextNamespaces(),
+                      config_->typedMetadataContextNamespaces(), metadata_context);
 
-  // If metadata_context_namespaces is specified, pass matching filter metadata to the ext_authz
-  // service. If metadata key is set in both the connection and request metadata then the value
-  // will be the request metadata value.
-  const auto& connection_metadata =
-      decoder_callbacks_->connection()->streamInfo().dynamicMetadata().filter_metadata();
-  const auto& request_metadata =
-      decoder_callbacks_->streamInfo().dynamicMetadata().filter_metadata();
-  for (const auto& context_key : config_->metadataContextNamespaces()) {
-    if (const auto metadata_it = request_metadata.find(context_key);
-        metadata_it != request_metadata.end()) {
-      (*metadata_context.mutable_filter_metadata())[metadata_it->first] = metadata_it->second;
-    } else if (const auto metadata_it = connection_metadata.find(context_key);
-               metadata_it != connection_metadata.end()) {
-      (*metadata_context.mutable_filter_metadata())[metadata_it->first] = metadata_it->second;
-    }
-  }
-
-  // If typed_metadata_context_namespaces is specified, pass matching typed filter metadata to the
-  // ext_authz service. If metadata key is set in both the connection and request metadata then
-  // the value will be the request metadata value.
-  const auto& connection_typed_metadata =
-      decoder_callbacks_->connection()->streamInfo().dynamicMetadata().typed_filter_metadata();
-  const auto& request_typed_metadata =
-      decoder_callbacks_->streamInfo().dynamicMetadata().typed_filter_metadata();
-  for (const auto& context_key : config_->typedMetadataContextNamespaces()) {
-    if (const auto metadata_it = request_typed_metadata.find(context_key);
-        metadata_it != request_typed_metadata.end()) {
-      (*metadata_context.mutable_typed_filter_metadata())[metadata_it->first] = metadata_it->second;
-    } else if (const auto metadata_it = connection_typed_metadata.find(context_key);
-               metadata_it != connection_typed_metadata.end()) {
-      (*metadata_context.mutable_typed_filter_metadata())[metadata_it->first] = metadata_it->second;
-    }
+  // Fill route_metadata_context from the selected route's metadata.
+  envoy::config::core::v3::Metadata route_metadata_context;
+  if (decoder_callbacks_->route() != nullptr) {
+    fillMetadataContext({&decoder_callbacks_->route()->metadata()},
+                        config_->routeMetadataContextNamespaces(),
+                        config_->routeTypedMetadataContextNamespaces(), route_metadata_context);
   }
 
   Filters::Common::ExtAuthz::CheckRequestUtils::createHttpCheck(
       decoder_callbacks_, headers, std::move(context_extensions), std::move(metadata_context),
-      check_request_, config_->maxRequestBytes(), config_->packAsBytes(),
-      config_->includePeerCertificate(), config_->includeTLSSession(), config_->destinationLabels(),
-      config_->requestHeaderMatchers());
+      std::move(route_metadata_context), check_request_, config_->maxRequestBytes(),
+      config_->packAsBytes(), config_->includePeerCertificate(), config_->includeTLSSession(),
+      config_->destinationLabels(), config_->requestHeaderMatchers());
 
   ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server", *decoder_callbacks_);
   // Store start time of ext_authz filter call

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -88,6 +88,11 @@ public:
                                      config.metadata_context_namespaces().end()),
         typed_metadata_context_namespaces_(config.typed_metadata_context_namespaces().begin(),
                                            config.typed_metadata_context_namespaces().end()),
+        route_metadata_context_namespaces_(config.route_metadata_context_namespaces().begin(),
+                                           config.route_metadata_context_namespaces().end()),
+        route_typed_metadata_context_namespaces_(
+            config.route_typed_metadata_context_namespaces().begin(),
+            config.route_typed_metadata_context_namespaces().end()),
         include_peer_certificate_(config.include_peer_certificate()),
         include_tls_session_(config.include_tls_session()),
         charge_cluster_response_stats_(
@@ -169,6 +174,14 @@ public:
     return typed_metadata_context_namespaces_;
   }
 
+  const std::vector<std::string>& routeMetadataContextNamespaces() {
+    return route_metadata_context_namespaces_;
+  }
+
+  const std::vector<std::string>& routeTypedMetadataContextNamespaces() {
+    return route_typed_metadata_context_namespaces_;
+  }
+
   const ExtAuthzFilterStats& stats() const { return stats_; }
 
   void incCounter(Stats::Scope& scope, Stats::StatName name) {
@@ -231,6 +244,8 @@ private:
 
   const std::vector<std::string> metadata_context_namespaces_;
   const std::vector<std::string> typed_metadata_context_namespaces_;
+  const std::vector<std::string> route_metadata_context_namespaces_;
+  const std::vector<std::string> route_typed_metadata_context_namespaces_;
 
   const bool include_peer_certificate_;
   const bool include_tls_session_;

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -184,6 +184,7 @@ public:
     attributes->clear_source();
     attributes->clear_destination();
     attributes->clear_metadata_context();
+    attributes->clear_route_metadata_context();
     attributes->mutable_request()->clear_time();
     http_request->clear_id();
     http_request->clear_headers();


### PR DESCRIPTION
Commit Message:
Add the ability to ext_authz that collect spcified namespaces from route metadata, and propagate them to external auth service. #30252

Additional Description:
The instruction of what namespace to select from route metadata, and the field in CheckRequest where the metadata context from route is filled are totally separate from those metadata context from connection or request.

Risk Level: Low
Testing: Unit tests
Docs Changes: Proto description updated.
Release Notes: Updated changelog
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
