### PR TITLE
mobile: Fix envoy-xds AAR

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -162,14 +162,16 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       working-directory: mobile
       run: |
+        # --define=google_grpc=enabled must be defined last because
+        # --config=mobile-release-android has --define=google_grpc=disabled
         version="0.5.0.$(date '+%Y%m%d')"
         ./bazelw build \
           --config=mobile-remote-release-clang \
           --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
           --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a \
           --define=pom_version="$version" \
-          --define=google_grpc=enabled \
           --config=mobile-release-android \
+          --define=google_grpc=enabled \
           --linkopt=-fuse-ld=lld \
           //:android_xds_dist
     - name: 'Tar artifacts'


### PR DESCRIPTION
`--config=mobile-release-android` has `--define=google_grpc=disabled` and if it appears after `--define=google_grpc=enabled`, it will set `--define=google_grpc=disabled` because the last one set wins. This PR fixes this issue by moving the `--define=google_grpc=enabled` last since xDS feature in Envoy Mobile requires Google gRPC.

Risk Level: low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
