### PR TITLE
[bp/1.28] generic proxy refactoring part 3: merge decoder and encoder to same interface (#30381)

### DIFF
--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -139,7 +139,8 @@ void DubboResponse::refreshGenericStatus() {
 
 DubboCodecBase::DubboCodecBase(Common::Dubbo::DubboCodecPtr codec) : codec_(std::move(codec)) {}
 
-ResponsePtr DubboMessageCreator::response(Status status, const Request& origin_request) {
+ResponsePtr DubboServerCodec::respond(Status status, absl::string_view,
+                                      const Request& origin_request) {
   const auto* typed_request = dynamic_cast<const DubboRequest*>(&origin_request);
   ASSERT(typed_request != nullptr);
 

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -90,14 +90,14 @@ public:
   Common::Dubbo::DubboCodecPtr codec_;
 };
 
-template <class DecoderType, class MessageType, class CallBackType>
-class DubboDecoderBase : public DubboCodecBase, public DecoderType {
+template <class CodecType, class DecoderMessageType, class EncoderMessageType, class CallBackType>
+class DubboDecoderBase : public DubboCodecBase, public CodecType {
 public:
   using DubboCodecBase::DubboCodecBase;
 
-  void setDecoderCallback(CallBackType& callback) override { callback_ = &callback; }
+  void setCodecCallbacks(CallBackType& callback) override { callback_ = &callback; }
 
-  void decode(Buffer::Instance& buffer) override {
+  void decode(Buffer::Instance& buffer, bool) override {
     if (metadata_ == nullptr) {
       metadata_ = std::make_shared<Common::Dubbo::MessageMetadata>();
     }
@@ -129,7 +129,7 @@ public:
 
       ASSERT(decode_status == Common::Dubbo::DecodeStatus::Success);
 
-      auto message = std::make_unique<MessageType>(metadata_);
+      auto message = std::make_unique<DecoderMessageType>(metadata_);
       message->stream_frame_flags_ = {{static_cast<uint64_t>(metadata_->requestId()),
                                        !metadata_->context().isTwoWay(), false,
                                        metadata_->context().heartbeat()},
@@ -143,67 +143,43 @@ public:
     }
   }
 
+  void encode(const StreamFrame& frame, EncodingCallbacks& callbacks) override {
+    ASSERT(dynamic_cast<const EncoderMessageType*>(&frame) != nullptr);
+    const auto* typed_message = static_cast<const EncoderMessageType*>(&frame);
+
+    Buffer::OwnedImpl buffer;
+    codec_->encode(buffer, *typed_message->inner_metadata_);
+    callbacks.onEncodingSuccess(buffer, true);
+  }
+
   Common::Dubbo::MessageMetadataSharedPtr metadata_;
   CallBackType* callback_{};
 };
 
-using DubboRequestDecoder = DubboDecoderBase<RequestDecoder, DubboRequest, RequestDecoderCallback>;
-using DubboResponseDecoder =
-    DubboDecoderBase<ResponseDecoder, DubboResponse, ResponseDecoderCallback>;
-
-class DubboRequestEncoder : public RequestEncoder, public DubboCodecBase {
+class DubboServerCodec
+    : public DubboDecoderBase<ServerCodec, DubboRequest, DubboResponse, ServerCodecCallbacks> {
 public:
-  using DubboCodecBase::DubboCodecBase;
+  using DubboDecoderBase::DubboDecoderBase;
 
-  void encode(const StreamFrame& request, RequestEncoderCallback& callback) override {
-    ASSERT(dynamic_cast<const DubboRequest*>(&request) != nullptr);
-    const auto* typed_request = static_cast<const DubboRequest*>(&request);
-
-    Buffer::OwnedImpl buffer;
-    codec_->encode(buffer, *typed_request->inner_metadata_);
-    callback.onEncodingSuccess(buffer, true);
-  }
+  ResponsePtr respond(Status status, absl::string_view short_response_flags,
+                      const Request& request) override;
 };
 
-class DubboResponseEncoder : public ResponseEncoder, public DubboCodecBase {
+class DubboClientCodec
+    : public DubboDecoderBase<ClientCodec, DubboResponse, DubboRequest, ClientCodecCallbacks> {
 public:
-  using DubboCodecBase::DubboCodecBase;
-
-  void encode(const StreamFrame& response, ResponseEncoderCallback& callback) override {
-    ASSERT(dynamic_cast<const DubboResponse*>(&response) != nullptr);
-    const auto* typed_response = static_cast<const DubboResponse*>(&response);
-
-    Buffer::OwnedImpl buffer;
-    codec_->encode(buffer, *typed_response->inner_metadata_);
-    callback.onEncodingSuccess(buffer, true);
-  }
-};
-
-class DubboMessageCreator : public MessageCreator {
-public:
-  ResponsePtr response(Status status, const Request& origin_request) override;
+  using DubboDecoderBase::DubboDecoderBase;
 };
 
 class DubboCodecFactory : public CodecFactory {
 public:
-  RequestDecoderPtr requestDecoder() const override {
-    return std::make_unique<DubboRequestDecoder>(
+  ServerCodecPtr createServerCodec() const override {
+    return std::make_unique<DubboServerCodec>(
         Common::Dubbo::DubboCodec::codecFromSerializeType(Common::Dubbo::SerializeType::Hessian2));
   }
-  ResponseDecoderPtr responseDecoder() const override {
-    return std::make_unique<DubboResponseDecoder>(
+  ClientCodecPtr createClientCodec() const override {
+    return std::make_unique<DubboClientCodec>(
         Common::Dubbo::DubboCodec::codecFromSerializeType(Common::Dubbo::SerializeType::Hessian2));
-  }
-  RequestEncoderPtr requestEncoder() const override {
-    return std::make_unique<DubboRequestEncoder>(
-        Common::Dubbo::DubboCodec::codecFromSerializeType(Common::Dubbo::SerializeType::Hessian2));
-  }
-  ResponseEncoderPtr responseEncoder() const override {
-    return std::make_unique<DubboResponseEncoder>(
-        Common::Dubbo::DubboCodec::codecFromSerializeType(Common::Dubbo::SerializeType::Hessian2));
-  }
-  MessageCreatorPtr messageCreator() const override {
-    return std::make_unique<DubboMessageCreator>();
   }
 };
 

--- a/contrib/generic_proxy/filters/network/source/interface/codec.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec.h
@@ -14,68 +14,78 @@ namespace NetworkFilters {
 namespace GenericProxy {
 
 /**
- * Decoder of request.
+ * Server codec that used to decode downstream request and encode upstream response.
+ * This codec is used by downstream connection.
  */
-class RequestDecoder {
+class ServerCodec {
 public:
-  virtual ~RequestDecoder() = default;
+  virtual ~ServerCodec() = default;
 
-  // The decode() method may be called multiple times for single request or response.
-  // So an independent setDecoderCallback() is used to set decoding callback.
-  virtual void setDecoderCallback(RequestDecoderCallback& callback) PURE;
-  virtual void decode(Buffer::Instance& buffer) PURE;
+  /**
+   * Set callbacks of server codec.
+   * @param callbacks callbacks of server codec. This callback will have same lifetime
+   * as the server codec.
+   */
+  virtual void setCodecCallbacks(ServerCodecCallbacks& callbacks) PURE;
+
+  /**
+   * Decode request frame from downstream connection.
+   * @param buffer data to decode.
+   * @param end_stream whether this is the last data of the downstream connection.
+   */
+  virtual void decode(Buffer::Instance& buffer, bool end_stream) PURE;
+
+  /**
+   * Encode response frame.
+   * @param frame response frame to encode.
+   * @param callbacks callbacks of encoding. This callback should be used to notify the
+   * generic proxy filter that the response is encoded and should be called only once.
+   */
+  virtual void encode(const StreamFrame& frame, EncodingCallbacks& callbacks) PURE;
+
+  /**
+   * Create a response frame with specified status and flags.
+   * @param status status of the response.
+   * @param short_response_flags short flags of the response.
+   * @param request origin request that the response is created for.
+   */
+  virtual ResponsePtr respond(Status status, absl::string_view short_response_flags,
+                              const Request& request) PURE;
 };
 
 /**
- * Decoder of response.
+ * Client codec that used to decode upstream response and encode downstream request.
+ * This codec is used by upstream connection.
  */
-class ResponseDecoder {
+class ClientCodec {
 public:
-  virtual ~ResponseDecoder() = default;
-
-  // The decode() method may be called multiple times for single request or response.
-  // So an independent setDecoderCallback() is used to set decoding callback.
-  virtual void setDecoderCallback(ResponseDecoderCallback& callback) PURE;
-  virtual void decode(Buffer::Instance& buffer) PURE;
-};
-
-/*
- * Encoder of request.
- * TODO(wbpcode): to merge RequestEncoder and ResponseDecoder into one class. By
- * this way, it possible to support stream remapping in the future.
- */
-class RequestEncoder {
-public:
-  virtual ~RequestEncoder() = default;
-
-  virtual void encode(const StreamFrame&, RequestEncoderCallback& callback) PURE;
-};
-
-/*
- * Encoder of response.
- */
-class ResponseEncoder {
-public:
-  virtual ~ResponseEncoder() = default;
-
-  virtual void encode(const StreamFrame&, ResponseEncoderCallback& callback) PURE;
-};
-
-class MessageCreator {
-public:
-  virtual ~MessageCreator() = default;
+  virtual ~ClientCodec() = default;
 
   /**
-   * Create local response message for local reply.
+   * Set callbacks of client codec.
+   * @param callbacks callbacks of client codec. This callback will have same lifetime
+   * as the client codec.
    */
-  virtual ResponsePtr response(Status status, const Request& origin_request) PURE;
+  virtual void setCodecCallbacks(ClientCodecCallbacks& callbacks) PURE;
+
+  /**
+   * Decode response frame from upstream connection.
+   * @param buffer data to decode.
+   * @param end_stream whether this is the last data of the upstream connection.
+   */
+  virtual void decode(Buffer::Instance& buffer, bool end_stream) PURE;
+
+  /**
+   * Encode request frame.
+   * @param frame request frame to encode.
+   * @param callbacks callbacks of encoding. This callbacks should be used to notify the
+   * generic proxy filter that the request is encoded and should be called only once.
+   */
+  virtual void encode(const StreamFrame& frame, EncodingCallbacks& callbacks) PURE;
 };
 
-using RequestDecoderPtr = std::unique_ptr<RequestDecoder>;
-using ResponseDecoderPtr = std::unique_ptr<ResponseDecoder>;
-using RequestEncoderPtr = std::unique_ptr<RequestEncoder>;
-using ResponseEncoderPtr = std::unique_ptr<ResponseEncoder>;
-using MessageCreatorPtr = std::unique_ptr<MessageCreator>;
+using ServerCodecPtr = std::unique_ptr<ServerCodec>;
+using ClientCodecPtr = std::unique_ptr<ClientCodec>;
 
 /**
  * Factory used to create generic stream encoder and decoder. If the developer wants to add
@@ -86,30 +96,15 @@ class CodecFactory {
 public:
   virtual ~CodecFactory() = default;
 
-  /*
-   * Create request decoder.
+  /**
+   * Create a server codec instance.
    */
-  virtual RequestDecoderPtr requestDecoder() const PURE;
-
-  /*
-   * Create response decoder.
-   */
-  virtual ResponseDecoderPtr responseDecoder() const PURE;
-
-  /*
-   * Create request encoder.
-   */
-  virtual RequestEncoderPtr requestEncoder() const PURE;
-
-  /*
-   * Create response encoder.
-   */
-  virtual ResponseEncoderPtr responseEncoder() const PURE;
+  virtual ServerCodecPtr createServerCodec() const PURE;
 
   /**
-   * Create message creator.
+   * Create a client codec instance.
    */
-  virtual MessageCreatorPtr messageCreator() const PURE;
+  virtual ClientCodecPtr createClientCodec() const PURE;
 };
 
 using CodecFactoryPtr = std::unique_ptr<CodecFactory>;

--- a/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
@@ -13,11 +13,11 @@ namespace NetworkFilters {
 namespace GenericProxy {
 
 /**
- * Decoder callback of request.
+ * Callbacks of ServerCodec.
  */
-class RequestDecoderCallback {
+class ServerCodecCallbacks {
 public:
-  virtual ~RequestDecoderCallback() = default;
+  virtual ~ServerCodecCallbacks() = default;
   /**
    * If request decoding success then this method will be called.
    * @param frame request frame from decoding. Frist frame should be StreamRequest
@@ -51,11 +51,11 @@ public:
 };
 
 /**
- * Decoder callback of Response.
+ * Callbacks of ClientCodec.
  */
-class ResponseDecoderCallback {
+class ClientCodecCallbacks {
 public:
-  virtual ~ResponseDecoderCallback() = default;
+  virtual ~ClientCodecCallbacks() = default;
 
   /**
    * If response decoding success then this method will be called.
@@ -91,29 +91,14 @@ public:
 };
 
 /**
- * Encoder callback of request.
+ * Callback of request/response frame.
  */
-class RequestEncoderCallback {
+class EncodingCallbacks {
 public:
-  virtual ~RequestEncoderCallback() = default;
+  virtual ~EncodingCallbacks() = default;
 
   /**
-   * If request encoding success then this method will be called.
-   * @param buffer encoding result buffer.
-   * @param end_stream if last frame is encoded.
-   */
-  virtual void onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) PURE;
-};
-
-/**
- * Encoder callback of Response.
- */
-class ResponseEncoderCallback {
-public:
-  virtual ~ResponseEncoderCallback() = default;
-
-  /**
-   * If response encoding success then this method will be called.
+   * If encoding success then this method will be called to notify the generic proxy.
    * @param buffer encoding result buffer.
    * @param end_stream if last frame is encoded.
    */

--- a/contrib/generic_proxy/filters/network/source/upstream.cc
+++ b/contrib/generic_proxy/filters/network/source/upstream.cc
@@ -44,15 +44,14 @@ void UpstreamConnection::cleanUp(bool close_connection) {
   }
 }
 
-void UpstreamConnection::onUpstreamData(Buffer::Instance& data, bool) {
+void UpstreamConnection::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!is_cleaned_up_);
-  ASSERT(response_decoder_ != nullptr);
 
   if (data.length() == 0) {
     return;
   }
 
-  response_decoder_->decode(data);
+  client_codec_->decode(data, end_stream);
 }
 
 void UpstreamConnection::onPoolFailure(ConnectionPool::PoolFailureReason reason,

--- a/contrib/generic_proxy/filters/network/source/upstream.h
+++ b/contrib/generic_proxy/filters/network/source/upstream.h
@@ -36,9 +36,11 @@ public:
   void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
   void onEvent(Network::ConnectionEvent) override;
 
+  ClientCodecPtr& clientCodec() { return client_codec_; }
+
 protected:
-  UpstreamConnection(Upstream::TcpPoolData&& tcp_pool_data, ResponseDecoderPtr&& response_decoder)
-      : tcp_pool_data_(std::move(tcp_pool_data)), response_decoder_(std::move(response_decoder)) {}
+  UpstreamConnection(Upstream::TcpPoolData&& tcp_pool_data, ClientCodecPtr&& client_codec)
+      : tcp_pool_data_(std::move(tcp_pool_data)), client_codec_(std::move(client_codec)) {}
 
   virtual void onEventImpl(Network::ConnectionEvent event) PURE;
   virtual void onPoolSuccessImpl() PURE;
@@ -46,7 +48,7 @@ protected:
                                  absl::string_view transport_failure_reason) PURE;
 
   Upstream::TcpPoolData tcp_pool_data_;
-  ResponseDecoderPtr response_decoder_;
+  ClientCodecPtr client_codec_;
 
   bool is_cleaned_up_{};
   // Whether the upstream connection is created. This will be set to true when the initialize()

--- a/contrib/generic_proxy/filters/network/test/fake_codec.cc
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.cc
@@ -7,21 +7,12 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
 
-RequestDecoderPtr FakeStreamCodecFactory::requestDecoder() const {
-  return std::make_unique<FakeRequestDecoder>();
+ServerCodecPtr FakeStreamCodecFactory::createServerCodec() const {
+  return std::make_unique<FakeServerCodec>();
 }
 
-ResponseDecoderPtr FakeStreamCodecFactory::responseDecoder() const {
-  return std::make_unique<FakeResponseDecoder>();
-}
-RequestEncoderPtr FakeStreamCodecFactory::requestEncoder() const {
-  return std::make_unique<FakeRequestEncoder>();
-}
-ResponseEncoderPtr FakeStreamCodecFactory::responseEncoder() const {
-  return std::make_unique<FakeResponseEncoder>();
-}
-MessageCreatorPtr FakeStreamCodecFactory::messageCreator() const {
-  return std::make_unique<FakeMessageCreator>();
+ClientCodecPtr FakeStreamCodecFactory::createClientCodec() const {
+  return std::make_unique<FakeClientCodec>();
 }
 
 CodecFactoryPtr

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -74,7 +74,7 @@ public:
     Status status_;
   };
 
-  class FakeRequestDecoder : public RequestDecoder {
+  class FakeServerCodec : public ServerCodec {
   public:
     bool parseRequestBody() {
       std::string body(message_size_.value(), 0);
@@ -119,8 +119,8 @@ public:
       return true;
     }
 
-    void setDecoderCallback(RequestDecoderCallback& callback) override { callback_ = &callback; }
-    void decode(Buffer::Instance& buffer) override {
+    void setCodecCallbacks(ServerCodecCallbacks& callback) override { callback_ = &callback; }
+    void decode(Buffer::Instance& buffer, bool) override {
       buffer_.move(buffer);
       while (true) {
         if (!message_size_.has_value()) {
@@ -144,12 +144,39 @@ public:
       }
     }
 
+    void encode(const StreamFrame& response, EncodingCallbacks& callback) override {
+      const FakeResponse* typed_response = dynamic_cast<const FakeResponse*>(&response);
+      ASSERT(typed_response != nullptr);
+
+      std::string body;
+      body.reserve(512);
+      body = typed_response->protocol_ + "|" + std::string(typed_response->status_.message()) + "|";
+      for (const auto& pair : typed_response->data_) {
+        body += pair.first + ":" + pair.second + ";";
+      }
+      // Additional 4 bytes for status.
+      encoding_buffer_.writeBEInt<uint32_t>(body.size() + 4);
+      encoding_buffer_.writeBEInt<uint32_t>(
+          static_cast<int32_t>(typed_response->status_.raw_code()));
+      encoding_buffer_.add(body);
+
+      callback.onEncodingSuccess(encoding_buffer_, response.frameFlags().endStream());
+    }
+
+    ResponsePtr respond(Status status, absl::string_view, const Request&) override {
+      auto response = std::make_unique<FakeResponse>();
+      response->status_ = status;
+      response->protocol_ = "fake_protocol_for_test";
+      return response;
+    }
+
     absl::optional<uint32_t> message_size_;
     Buffer::OwnedImpl buffer_;
-    RequestDecoderCallback* callback_{};
+    Buffer::OwnedImpl encoding_buffer_;
+    ServerCodecCallbacks* callback_{};
   };
 
-  class FakeResponseDecoder : public ResponseDecoder {
+  class FakeClientCodec : public ClientCodec {
   public:
     bool parseResponseBody() {
       int32_t status_code = buffer_.peekBEInt<int32_t>();
@@ -197,8 +224,8 @@ public:
       return true;
     }
 
-    void setDecoderCallback(ResponseDecoderCallback& callback) override { callback_ = &callback; }
-    void decode(Buffer::Instance& buffer) override {
+    void setCodecCallbacks(ClientCodecCallbacks& callback) override { callback_ = &callback; }
+    void decode(Buffer::Instance& buffer, bool) override {
       buffer_.move(buffer);
       while (true) {
         if (!message_size_.has_value()) {
@@ -228,14 +255,7 @@ public:
       }
     }
 
-    absl::optional<uint32_t> message_size_;
-    Buffer::OwnedImpl buffer_;
-    ResponseDecoderCallback* callback_{};
-  };
-
-  class FakeRequestEncoder : public RequestEncoder {
-  public:
-    void encode(const StreamFrame& request, RequestEncoderCallback& callback) override {
+    void encode(const StreamFrame& request, EncodingCallbacks& callback) override {
       const FakeRequest* typed_request = dynamic_cast<const FakeRequest*>(&request);
       ASSERT(typed_request != nullptr);
 
@@ -246,53 +266,20 @@ public:
       for (const auto& pair : typed_request->data_) {
         body += pair.first + ":" + pair.second + ";";
       }
-      buffer_.writeBEInt<uint32_t>(body.size());
-      buffer_.add(body);
+      encoding_buffer_.writeBEInt<uint32_t>(body.size());
+      encoding_buffer_.add(body);
 
-      callback.onEncodingSuccess(buffer_, request.frameFlags().endStream());
+      callback.onEncodingSuccess(encoding_buffer_, request.frameFlags().endStream());
     }
 
+    absl::optional<uint32_t> message_size_;
     Buffer::OwnedImpl buffer_;
+    Buffer::OwnedImpl encoding_buffer_;
+    ClientCodecCallbacks* callback_{};
   };
 
-  class FakeResponseEncoder : public ResponseEncoder {
-  public:
-    void encode(const StreamFrame& response, ResponseEncoderCallback& callback) override {
-      const FakeResponse* typed_response = dynamic_cast<const FakeResponse*>(&response);
-      ASSERT(typed_response != nullptr);
-
-      std::string body;
-      body.reserve(512);
-      body = typed_response->protocol_ + "|" + std::string(typed_response->status_.message()) + "|";
-      for (const auto& pair : typed_response->data_) {
-        body += pair.first + ":" + pair.second + ";";
-      }
-      // Additional 4 bytes for status.
-      buffer_.writeBEInt<uint32_t>(body.size() + 4);
-      buffer_.writeBEInt<uint32_t>(static_cast<int32_t>(typed_response->status_.raw_code()));
-      buffer_.add(body);
-
-      callback.onEncodingSuccess(buffer_, response.frameFlags().endStream());
-    }
-
-    Buffer::OwnedImpl buffer_;
-  };
-
-  class FakeMessageCreator : public MessageCreator {
-  public:
-    ResponsePtr response(Status status, const Request&) override {
-      auto response = std::make_unique<FakeResponse>();
-      response->status_ = status;
-      response->protocol_ = "fake_protocol_for_test";
-      return response;
-    }
-  };
-
-  RequestDecoderPtr requestDecoder() const override;
-  ResponseDecoderPtr responseDecoder() const override;
-  RequestEncoderPtr requestEncoder() const override;
-  ResponseEncoderPtr responseEncoder() const override;
-  MessageCreatorPtr messageCreator() const override;
+  ServerCodecPtr createServerCodec() const override;
+  ClientCodecPtr createClientCodec() const override;
 };
 
 class FakeStreamCodecFactoryConfig : public CodecFactoryConfig {

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.cc
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.cc
@@ -12,16 +12,10 @@ namespace NetworkFilters {
 namespace GenericProxy {
 
 MockCodecFactory::MockCodecFactory() {
-  ON_CALL(*this, requestDecoder())
-      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockRequestDecoder>>())));
-  ON_CALL(*this, responseDecoder())
-      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockResponseDecoder>>())));
-  ON_CALL(*this, requestEncoder())
-      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockRequestEncoder>>())));
-  ON_CALL(*this, responseEncoder())
-      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockResponseEncoder>>())));
-  ON_CALL(*this, messageCreator())
-      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockMessageCreator>>())));
+  ON_CALL(*this, createServerCodec())
+      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockServerCodec>>())));
+  ON_CALL(*this, createClientCodec())
+      .WillByDefault(Return(ByMove(std::make_unique<NiceMock<MockClientCodec>>())));
 }
 
 MockProxyFactory::MockProxyFactory() = default;

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.h
@@ -8,7 +8,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
 
-class MockRequestDecoderCallback : public RequestDecoderCallback {
+class MockServerCodecCallbacks : public ServerCodecCallbacks {
 public:
   MOCK_METHOD(void, onDecodingSuccess, (StreamFramePtr request));
   MOCK_METHOD(void, onDecodingFailure, ());
@@ -16,7 +16,7 @@ public:
   MOCK_METHOD(OptRef<Network::Connection>, connection, ());
 };
 
-class MockResponseDecoderCallback : public ResponseDecoderCallback {
+class MockClientCodecCallbacks : public ClientCodecCallbacks {
 public:
   MOCK_METHOD(void, onDecodingSuccess, (StreamFramePtr response));
   MOCK_METHOD(void, onDecodingFailure, ());
@@ -24,55 +24,32 @@ public:
   MOCK_METHOD(OptRef<Network::Connection>, connection, ());
 };
 
-class MockRequestEncoderCallback : public RequestEncoderCallback {
+class MockEncodingCallbacks : public EncodingCallbacks {
 public:
   MOCK_METHOD(void, onEncodingSuccess, (Buffer::Instance & buffer, bool end_stream));
 };
 
-/**
- * Encoder callback of Response.
- */
-class MockResponseEncoderCallback : public ResponseEncoderCallback {
+class MockServerCodec : public ServerCodec {
 public:
-  MOCK_METHOD(void, onEncodingSuccess, (Buffer::Instance & buffer, bool end_stream));
+  MOCK_METHOD(void, setCodecCallbacks, (ServerCodecCallbacks & callbacks));
+  MOCK_METHOD(void, decode, (Buffer::Instance & buffer, bool end_stream));
+  MOCK_METHOD(void, encode, (const StreamFrame&, EncodingCallbacks& callbacks));
+  MOCK_METHOD(ResponsePtr, respond, (Status status, absl::string_view, const Request&));
 };
 
-class MockRequestDecoder : public RequestDecoder {
+class MockClientCodec : public ClientCodec {
 public:
-  MOCK_METHOD(void, setDecoderCallback, (RequestDecoderCallback & callback));
-  MOCK_METHOD(void, decode, (Buffer::Instance & buffer));
-};
-
-class MockResponseDecoder : public ResponseDecoder {
-public:
-  MOCK_METHOD(void, setDecoderCallback, (ResponseDecoderCallback & callback));
-  MOCK_METHOD(void, decode, (Buffer::Instance & buffer));
-};
-
-class MockRequestEncoder : public RequestEncoder {
-public:
-  MOCK_METHOD(void, encode, (const StreamFrame&, RequestEncoderCallback& callback));
-};
-
-class MockResponseEncoder : public ResponseEncoder {
-public:
-  MOCK_METHOD(void, encode, (const StreamFrame&, ResponseEncoderCallback& callback));
-};
-
-class MockMessageCreator : public MessageCreator {
-public:
-  MOCK_METHOD(ResponsePtr, response, (Status status, const Request&));
+  MOCK_METHOD(void, setCodecCallbacks, (ClientCodecCallbacks & callbacks));
+  MOCK_METHOD(void, decode, (Buffer::Instance & buffer, bool end_stream));
+  MOCK_METHOD(void, encode, (const StreamFrame&, EncodingCallbacks& callbacks));
 };
 
 class MockCodecFactory : public CodecFactory {
 public:
   MockCodecFactory();
 
-  MOCK_METHOD(RequestDecoderPtr, requestDecoder, (), (const));
-  MOCK_METHOD(ResponseDecoderPtr, responseDecoder, (), (const));
-  MOCK_METHOD(RequestEncoderPtr, requestEncoder, (), (const));
-  MOCK_METHOD(ResponseEncoderPtr, responseEncoder, (), (const));
-  MOCK_METHOD(MessageCreatorPtr, messageCreator, (), (const));
+  MOCK_METHOD(ServerCodecPtr, createServerCodec, (), (const));
+  MOCK_METHOD(ClientCodecPtr, createClientCodec, (), (const));
 };
 
 class MockProxyFactory : public ProxyFactory {


### PR DESCRIPTION
* generic proxy refactoring part 3: merge decoder and encoder to same interface



* fix test



---------

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
