### PR TITLE
Datadog: restore "resource.name" tag

### DIFF
--- a/source/extensions/tracers/datadog/demo/docker-compose.yaml
+++ b/source/extensions/tracers/datadog/demo/docker-compose.yaml
@@ -8,9 +8,11 @@ services:
   dd-agent:
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/run/user:/run/user:ro'
       - '/proc/:/host/proc/:ro'
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
+      - DOCKER_HOST
       - DD_API_KEY
       - DD_APM_ENABLED=true
       - DD_LOG_LEVEL=ERROR

--- a/source/extensions/tracers/datadog/demo/envoy
+++ b/source/extensions/tracers/datadog/demo/envoy
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 here=$(dirname "$0")
-"$(bazelisk info bazel-genfiles)"/source/exe/envoy-static --config-path "$here"/envoy.yaml "$@"
+"$here"/../../../../../bazel-bin/source/exe/envoy-static --config-path "$here"/envoy.yaml "$@"


### PR DESCRIPTION
These changes restore the Dataodog tracer's ability to set the Datadog notion of span "resource name" by setting a special tag named "resource.name".

This was previously possible with the OpenTracing-based implementation of Datadog tracing, but I removed the capability when I moved Envoy's Datadog extension away from OpenTracing.

It turns out that [customers were using this feature][1]. This pull request restores it.

Please consider backporting this revision as a bug fix once it is merged.

## Testing
I modified some existing unit tests.

Also, by applying the patch below, I used the Datadog "demo" with a local build of Envoy to verify that a `request_header`-based custom tag for the tag "resource.name" really does result in a change to the resource name:
```diff
diff --git a/source/extensions/tracers/datadog/demo/envoy.yaml b/source/extensions/tracers/datadog/demo/envoy.yaml
index 839ba18aac..305c76059f 100644
--- a/source/extensions/tracers/datadog/demo/envoy.yaml
+++ b/source/extensions/tracers/datadog/demo/envoy.yaml
@@ -18,6 +18,13 @@ static_resources:
                 "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
                 collector_cluster: datadog_agent
                 service_name: envoy-demo
+            custom_tags:
+            - tag: "header.thing"
+              request_header:
+                name: "x-thing"
+            - tag: "resource.name"
+              request_header:
+                name: "x-datadog-resource"
           access_log:
           - name: envoy.access_loggers.file
             typed_config:
```

------------------------

Commit Message: restore ability to set resource name by tag in Datadog tracer
Additional Description:
Risk Level: low
Testing: See modified unit tests. Also performed manual integration testing with the Datadog "demo."
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

[1]: https://github.com/envoyproxy/envoy/pull/29932#issuecomment-1772193588