### PR TITLE
mobile: Throw an exception when xDS is used on an unsupported Envoy Mobile

### DIFF
--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -1331,9 +1331,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
                    enable_platform_certificates_validation, runtime_guards, node_id, node_region,
                    node_zone, node_sub_zone, serialized_node_metadata, builder);
 
-#ifdef ENVOY_GOOGLE_GRPC
   std::string native_xds_address = getCppString(env, xds_address);
   if (!native_xds_address.empty()) {
+#ifdef ENVOY_GOOGLE_GRPC
     Envoy::Platform::XdsBuilder xds_builder(std::move(native_xds_address), xds_port);
     std::string native_xds_auth_header = getCppString(env, xds_auth_header);
     if (!native_xds_auth_header.empty()) {
@@ -1362,15 +1362,12 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
                                              cds_timeout_seconds);
     }
     builder.setXds(std::move(xds_builder));
-  }
 #else
-  std::string native_xds_address = getCppString(env, xds_address);
-  if (!native_xds_address.empty()) {
     throwException(env, "java/lang/UnsupportedOperationException",
                    "This library does not support xDS. Please use "
                    "io.envoyproxy.envoymobile:envoy-xds instead.");
-  }
 #endif
+  }
 
   return reinterpret_cast<intptr_t>(builder.generateBootstrap().release());
 }

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -1363,6 +1363,13 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     }
     builder.setXds(std::move(xds_builder));
   }
+#else
+  std::string native_xds_address = getCppString(env, xds_address);
+  if (!native_xds_address.empty()) {
+    throwException(env, "java/lang/UnsupportedOperationException",
+                   "This library does not support xDS. Please use "
+                   "io.envoyproxy.envoymobile:envoy-xds instead.");
+  }
 #endif
 
   return reinterpret_cast<intptr_t>(builder.generateBootstrap().release());

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -403,6 +403,13 @@ void javaByteArrayToProto(JNIEnv* env, jbyteArray source, Envoy::Protobuf::Messa
     return result;                                                                                 \
   }
 
+void throwException(JNIEnv* env, const char* java_class_name, const char* message) {
+  jclass java_class = env->FindClass(java_class_name);
+  jint error = env->ThrowNew(java_class, message);
+  RELEASE_ASSERT(error == JNI_OK, "Failed to throw an exception.");
+  env->DeleteLocalRef(java_class);
+}
+
 void callVoidMethod(JNIEnv* env, jobject object, jmethodID method_id, ...) {
   va_list args;
   va_start(args, method_id);

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -124,6 +124,9 @@ std::vector<MatcherData> javaObjectArrayToMatcherData(JNIEnv* env, jobjectArray 
 /** Parses the proto from Java's byte array and stores the output into `dest` proto. */
 void javaByteArrayToProto(JNIEnv* env, jbyteArray source, Envoy::Protobuf::MessageLite* dest);
 
+/** Throws Java exception with the specified class name and error message. */
+void throwException(JNIEnv* env, const char* java_class_name, const char* message);
+
 // Helper functions for JNI's `Call<Type>Method` with proper exception handling in order to satisfy
 // -Xcheck:jni.
 // See

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -113,14 +113,10 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   @Override
   public EnvoyStatus runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
     performRegistration(envoyConfiguration);
-    try {
-      int status = JniLibrary.runEngine(this.engineHandle, "", envoyConfiguration.createBootstrap(),
-                                        logLevel);
-      if (status == 0) {
-        return EnvoyStatus.ENVOY_SUCCESS;
-      }
-    } catch (Throwable throwable) {
-      throw throwable;
+    int status =
+        JniLibrary.runEngine(this.engineHandle, "", envoyConfiguration.createBootstrap(), logLevel);
+    if (status == 0) {
+      return EnvoyStatus.ENVOY_SUCCESS;
     }
     return EnvoyStatus.ENVOY_FAILURE;
   }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -120,7 +120,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
         return EnvoyStatus.ENVOY_SUCCESS;
       }
     } catch (Throwable throwable) {
-      // TODO: Need to have a way to log the exception somewhere.
+      throw throwable;
     }
     return EnvoyStatus.ENVOY_FAILURE;
   }


### PR DESCRIPTION
This PR adds the code to throw `java.lang.UnsupportedOperationException` when xDS feature is enabled on an unsupported Envoy Mobile AAR.

This PR also fixes a bug where it swallows every exception when trying to start Envoy.

Risk Level: low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile

