### PR TITLE
Update status for envoy.resource_monitors.downstream_connections

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1014,7 +1014,7 @@ envoy.resource_monitors.downstream_connections:
   categories:
   - envoy.resource_monitors
   security_posture: data_plane_agnostic
-  status: wip
+  status: alpha
   type_urls:
   - envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
 envoy.resource_monitors.fixed_heap:


### PR DESCRIPTION
Updating extension status of `envoy.resource_monitors.downstream_connections` to alpha, as it is functional with no known  TODOs. We have deployed it today on canary instances within prod environment. 

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
