### PR TITLE
mobile/ci: Fail fast when running on a machine that is likely to fail

### DIFF
--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -76,7 +76,7 @@ jobs:
       name: 'Start emulator'
       with:
         timeout_minutes: 15
-        max_attempts: 3
+        max_attempts: 1
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
     #   cd mobile && ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
@@ -129,7 +129,7 @@ jobs:
       name: 'Start emulator'
       with:
         timeout_minutes: 15
-        max_attempts: 3
+        max_attempts: 1
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
@@ -182,7 +182,7 @@ jobs:
       name: 'Start emulator'
       with:
         timeout_minutes: 15
-        max_attempts: 3
+        max_attempts: 1
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
@@ -235,7 +235,7 @@ jobs:
       name: 'Start emulator'
       with:
         timeout_minutes: 15
-        max_attempts: 3
+        max_attempts: 1
         command: ./mobile/ci/start_android_emulator.sh
     # Return to using:
     #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -5,7 +5,7 @@ set -e
 check_emulator_status() {
     while true; do
         if grep -q "Running on a system with less than 6 logical cores. Setting number of virtual cores to 1" nohup.out; then
-            echo "Starting an emulator will likely to fail, please run /retest"
+            echo "Starting an emulator on this machine is likely to fail, please run /retest"
             exit 1
         elif grep -q "Boot completed" nohup.out; then
             break
@@ -14,8 +14,8 @@ check_emulator_status() {
     done
 }
 
-echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_apis;x86_64' --channel=3
-echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_apis;x86_64' --device pixel_4 --force
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_atd;x86_64' --channel=3
+echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_atd;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
 # This is only available on macOS.
 if [[ -n $(which system_profiler) ]]; then

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -2,8 +2,20 @@
 
 set -e
 
-echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_atd;x86_64' --channel=3
-echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_atd;x86_64' --device pixel_4 --force
+check_emulator_status() {
+    while true; do
+        if grep -q "Running on a system with less than 6 logical cores. Setting number of virtual cores to 1" nohup.out; then
+            echo "Starting an emulator will likely to fail, please run /retest"
+            exit 1
+        elif grep -q "Boot completed" nohup.out; then
+            break
+        fi
+        sleep 1
+    done
+}
+
+echo "y" | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-30;google_apis;x86_64' --channel=3
+echo "no" | "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-30;google_apis;x86_64' --device pixel_4 --force
 "${ANDROID_HOME}"/emulator/emulator -accel-check
 # This is only available on macOS.
 if [[ -n $(which system_profiler) ]]; then
@@ -11,7 +23,8 @@ if [[ -n $(which system_profiler) ]]; then
 fi
 
 # shellcheck disable=SC2094
-nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load  > nohup.out 2>&1 | tail -f nohup.out & {
+nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot-load > nohup.out 2>&1 | tail -f nohup.out & {
+    check_emulator_status
     # shellcheck disable=SC2016
     "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
 }

--- a/mobile/ci/start_android_emulator.sh
+++ b/mobile/ci/start_android_emulator.sh
@@ -5,7 +5,9 @@ set -e
 check_emulator_status() {
     while true; do
         if grep -q "Running on a system with less than 6 logical cores. Setting number of virtual cores to 1" nohup.out; then
-            echo "Starting an emulator on this machine is likely to fail, please run /retest"
+            echo "=================================================================================="
+            echo "ERROR: Starting an emulator on this machine is likely to fail, please run /retest"
+            echo "=================================================================================="
             exit 1
         elif grep -q "Boot completed" nohup.out; then
             break


### PR DESCRIPTION
This PR adds a logic to fail fast when starting an emulator on a machine that is likely to fail. This PR also updates the `max_attempts` to 1 so that it is much faster to retest.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
