### PR TITLE
ci/verify: Bump toolshed action to fix env

### DIFF
--- a/.github/actions/do_ci/action.yml
+++ b/.github/actions/do_ci/action.yml
@@ -51,7 +51,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.0.34
+  - uses: envoyproxy/toolshed/gh-actions/github/run@actions-v0.0.35
     name: 'Run CI target ${{ inputs.target }}'
     with:
       catch-errors: ${{ inputs.catch-errors }}


### PR DESCRIPTION
I used dependabot to bump to make earlier pr work - but it seems it didnt bump this dep

ill look to see if i can see why

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
