### PR TITLE
kafka: introduce filter-config object + push broker build parts into …

### DIFF
--- a/contrib/contrib_build_config.bzl
+++ b/contrib/contrib_build_config.bzl
@@ -15,7 +15,7 @@ CONTRIB_EXTENSIONS = {
     #
 
     "envoy.filters.network.client_ssl_auth":                    "//contrib/client_ssl_auth/filters/network/source:config",
-    "envoy.filters.network.kafka_broker":                       "//contrib/kafka/filters/network/source:kafka_broker_config_lib",
+    "envoy.filters.network.kafka_broker":                       "//contrib/kafka/filters/network/source/broker:config_lib",
     "envoy.filters.network.kafka_mesh":                         "//contrib/kafka/filters/network/source/mesh:config_lib",
     "envoy.filters.network.mysql_proxy":                        "//contrib/mysql_proxy/filters/network/source:config",
     "envoy.filters.network.postgres_proxy":                     "//contrib/postgres_proxy/filters/network/source:config",

--- a/contrib/kafka/filters/network/source/BUILD
+++ b/contrib/kafka/filters/network/source/BUILD
@@ -2,7 +2,6 @@ load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_contrib_extension",
     "envoy_cc_library",
     "envoy_contrib_package",
 )
@@ -11,39 +10,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
 
-# Kafka network filter.
-# Broker filter public docs: https://envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/kafka_broker_filter
-
-envoy_cc_contrib_extension(
-    name = "kafka_broker_config_lib",
-    srcs = ["broker/config.cc"],
-    hdrs = ["broker/config.h"],
-    deps = [
-        ":kafka_broker_filter_lib",
-        "//source/extensions/filters/network:well_known_names",
-        "//source/extensions/filters/network/common:factory_base_lib",
-        "@envoy_api//contrib/envoy/extensions/filters/network/kafka_broker/v3:pkg_cc_proto",
-    ],
-)
-
-envoy_cc_library(
-    name = "kafka_broker_filter_lib",
-    srcs = ["broker/filter.cc"],
-    hdrs = [
-        "broker/filter.h",
-        "external/request_metrics.h",
-        "external/response_metrics.h",
-    ],
-    deps = [
-        ":kafka_request_codec_lib",
-        ":kafka_response_codec_lib",
-        "//envoy/buffer:buffer_interface",
-        "//envoy/network:connection_interface",
-        "//envoy/network:filter_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/common:minimal_logger_lib",
-    ],
-)
+# Common code for Kafka filters (Kafka type abstractions, protocol, metrics, etc.).
 
 envoy_cc_library(
     name = "abstract_codec_lib",
@@ -199,6 +166,16 @@ py_binary(
 py_library(
     name = "kafka_protocol_generator_lib",
     srcs = ["protocol/generator.py"],
+)
+
+envoy_cc_library(
+    name = "kafka_metrics_lib",
+    hdrs = [
+        "external/request_metrics.h",
+        "external/response_metrics.h",
+    ],
+    deps = [
+    ],
 )
 
 envoy_cc_library(

--- a/contrib/kafka/filters/network/source/broker/BUILD
+++ b/contrib/kafka/filters/network/source/broker/BUILD
@@ -1,0 +1,56 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_contrib_extension",
+    "envoy_cc_library",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+# Kafka-broker network filter.
+# Broker filter public docs: https://envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/kafka_broker_filter
+
+envoy_cc_contrib_extension(
+    name = "config_lib",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":filter_config_lib",
+        ":filter_lib",
+        "//source/extensions/filters/network:well_known_names",
+        "//source/extensions/filters/network/common:factory_base_lib",
+        "@envoy_api//contrib/envoy/extensions/filters/network/kafka_broker/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_config_lib",
+    srcs = [],
+    hdrs = [
+        "filter_config.h",
+    ],
+    deps = [
+        "@envoy_api//contrib/envoy/extensions/filters/network/kafka_broker/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_lib",
+    srcs = ["filter.cc"],
+    hdrs = [
+        "filter.h",
+    ],
+    deps = [
+        ":filter_config_lib",
+        "//contrib/kafka/filters/network/source:kafka_metrics_lib",
+        "//contrib/kafka/filters/network/source:kafka_request_codec_lib",
+        "//contrib/kafka/filters/network/source:kafka_response_codec_lib",
+        "//envoy/buffer:buffer_interface",
+        "//envoy/network:connection_interface",
+        "//envoy/network:filter_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:minimal_logger_lib",
+    ],
+)

--- a/contrib/kafka/filters/network/source/broker/config.cc
+++ b/contrib/kafka/filters/network/source/broker/config.cc
@@ -5,6 +5,7 @@
 #include "envoy/stats/scope.h"
 
 #include "contrib/kafka/filters/network/source/broker/filter.h"
+#include "contrib/kafka/filters/network/source/broker/filter_config.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -15,13 +16,10 @@ namespace Broker {
 Network::FilterFactoryCb KafkaConfigFactory::createFilterFactoryFromProtoTyped(
     const KafkaBrokerProtoConfig& proto_config, Server::Configuration::FactoryContext& context) {
 
-  ASSERT(!proto_config.stat_prefix().empty());
-
-  const std::string& stat_prefix = proto_config.stat_prefix();
-
-  return [&context, stat_prefix](Network::FilterManager& filter_manager) -> void {
+  const BrokerFilterConfig filter_config{proto_config};
+  return [&context, filter_config](Network::FilterManager& filter_manager) -> void {
     Network::FilterSharedPtr filter =
-        std::make_shared<KafkaBrokerFilter>(context.scope(), context.timeSource(), stat_prefix);
+        std::make_shared<KafkaBrokerFilter>(context.scope(), context.timeSource(), filter_config);
     filter_manager.addFilter(filter);
   };
 }

--- a/contrib/kafka/filters/network/source/broker/filter.cc
+++ b/contrib/kafka/filters/network/source/broker/filter.cc
@@ -70,9 +70,9 @@ absl::flat_hash_map<int32_t, MonotonicTime>& KafkaMetricsFacadeImpl::getRequestA
 }
 
 KafkaBrokerFilter::KafkaBrokerFilter(Stats::Scope& scope, TimeSource& time_source,
-                                     const std::string& stat_prefix)
-    : KafkaBrokerFilter{
-          std::make_shared<KafkaMetricsFacadeImpl>(scope, time_source, stat_prefix)} {};
+                                     const BrokerFilterConfig& filter_config)
+    : KafkaBrokerFilter{std::make_shared<KafkaMetricsFacadeImpl>(scope, time_source,
+                                                                 filter_config.stat_prefix_)} {};
 
 KafkaBrokerFilter::KafkaBrokerFilter(const KafkaMetricsFacadeSharedPtr& metrics)
     : metrics_{metrics}, response_decoder_{new ResponseDecoder({metrics})},

--- a/contrib/kafka/filters/network/source/broker/filter.h
+++ b/contrib/kafka/filters/network/source/broker/filter.h
@@ -6,6 +6,7 @@
 #include "source/common/common/logger.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "contrib/kafka/filters/network/source/broker/filter_config.h"
 #include "contrib/kafka/filters/network/source/external/request_metrics.h"
 #include "contrib/kafka/filters/network/source/external/response_metrics.h"
 #include "contrib/kafka/filters/network/source/parser.h"
@@ -138,7 +139,8 @@ public:
    * Creates decoders that eventually update prefixed metrics stored in scope, using time source for
    * duration calculation.
    */
-  KafkaBrokerFilter(Stats::Scope& scope, TimeSource& time_source, const std::string& stat_prefix);
+  KafkaBrokerFilter(Stats::Scope& scope, TimeSource& time_source,
+                    const BrokerFilterConfig& filter_config);
 
   /**
    * Visible for testing.

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "source/common/common/assert.h"
+
+#include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.h"
+#include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+using KafkaBrokerProtoConfig = envoy::extensions::filters::network::kafka_broker::v3::KafkaBroker;
+
+// Minor helper structure that contains broker filter configuration.
+// Right now this object is very anemic but it might contain some business logic in the future such
+// as "Does this topic apply?".
+struct BrokerFilterConfig {
+
+  BrokerFilterConfig(const KafkaBrokerProtoConfig& proto_config)
+      : BrokerFilterConfig{proto_config.stat_prefix()} {}
+
+  // Visible for testing.
+  BrokerFilterConfig(const std::string& stat_prefix) : stat_prefix_{stat_prefix} {
+    ASSERT(!stat_prefix_.empty());
+  };
+
+  std::string stat_prefix_;
+};
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/test/BUILD
+++ b/contrib/kafka/filters/network/test/BUILD
@@ -247,7 +247,7 @@ envoy_cc_test(
     srcs = ["metrics_integration_test.cc"],
     deps = [
         ":message_utilities",
-        "//contrib/kafka/filters/network/source:kafka_broker_filter_lib",
+        "//contrib/kafka/filters/network/source:kafka_metrics_lib",
         "//test/common/stats:stat_test_utility_lib",
     ],
 )

--- a/contrib/kafka/filters/network/test/broker/BUILD
+++ b/contrib/kafka/filters/network/test/broker/BUILD
@@ -12,7 +12,7 @@ envoy_cc_test(
     name = "config_unit_test",
     srcs = ["config_unit_test.cc"],
     deps = [
-        "//contrib/kafka/filters/network/source:kafka_broker_config_lib",
+        "//contrib/kafka/filters/network/source/broker:config_lib",
         "//test/mocks/server:factory_context_mocks",
     ],
 )
@@ -21,7 +21,7 @@ envoy_cc_test(
     name = "filter_unit_test",
     srcs = ["filter_unit_test.cc"],
     deps = [
-        "//contrib/kafka/filters/network/source:kafka_broker_filter_lib",
+        "//contrib/kafka/filters/network/source/broker:filter_lib",
         "//envoy/event:timer_interface",
         "//test/mocks/network:network_mocks",
         "//test/mocks/stats:stats_mocks",
@@ -32,7 +32,7 @@ envoy_cc_test(
     name = "filter_protocol_test",
     srcs = ["filter_protocol_test.cc"],
     deps = [
-        "//contrib/kafka/filters/network/source:kafka_broker_filter_lib",
+        "//contrib/kafka/filters/network/source/broker:filter_lib",
         "//contrib/kafka/filters/network/test:buffer_based_test_lib",
         "//contrib/kafka/filters/network/test:message_utilities",
         "//test/common/stats:stat_test_utility_lib",

--- a/contrib/kafka/filters/network/test/broker/filter_protocol_test.cc
+++ b/contrib/kafka/filters/network/test/broker/filter_protocol_test.cc
@@ -35,7 +35,7 @@ protected:
   Stats::TestUtil::TestStore store_;
   Stats::Scope& scope_{*store_.rootScope()};
   Event::TestRealTimeSystem time_source_;
-  KafkaBrokerFilter testee_{scope_, time_source_, "prefix"};
+  KafkaBrokerFilter testee_{scope_, time_source_, {"prefix"}};
 
   Network::FilterStatus consumeRequestFromBuffer() {
     return testee_.onData(RequestB::buffer_, false);


### PR DESCRIPTION
Commit Message: kafka: introduce filter-config object + push broker build parts into its own file
Additional Description: new config object allows for easier future expansion (it's just a struct), while the BUILD file work was just to split the broker-vs-common parts
Risk Level: Low
Testing: automated test + protocol tests in https://github.com/adamkotwasinski/envoy-kafka-tests/tree/main/src/test/java/envoy/broker
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
