### PR TITLE
Fix broken fips build

### DIFF
--- a/api/bazel/envoy_http_archive.bzl
+++ b/api/bazel/envoy_http_archive.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def envoy_http_archive(name, locations, **kwargs):
+def envoy_http_archive(name, locations, location_name = None, **kwargs):
     # `existing_rule_keys` contains the names of repositories that have already
     # been defined in the Bazel workspace. By skipping repos with existing keys,
     # users can override dependency versions by using standard Bazel repository
@@ -10,7 +10,7 @@ def envoy_http_archive(name, locations, **kwargs):
         # This repository has already been defined, probably because the user
         # wants to override the version. Do nothing.
         return
-    location = locations[name]
+    location = locations[location_name or name]
 
     # HTTP tarball at a given URL. Add a BUILD file if requested.
     http_archive(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -287,6 +287,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_grpc_grpc()
     _com_github_unicode_org_icu()
     _com_github_intel_ipp_crypto_crypto_mb()
+    _com_github_intel_ipp_crypto_crypto_mb_fips()
     _com_github_intel_qatlib()
     _com_github_jbeder_yaml_cpp()
     _com_github_libevent_libevent()
@@ -529,6 +530,21 @@ def _com_github_intel_ipp_crypto_crypto_mb():
             "@envoy//bazel/foreign_cc:ipp-crypto-skip-dynamic-lib.patch",
             "@envoy//bazel/foreign_cc:ipp-crypto-bn2lebinpad.patch",
         ],
+        patch_args = ["-p1"],
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+
+def _com_github_intel_ipp_crypto_crypto_mb_fips():
+    # Temporary fix for building ipp-crypto when boringssl-fips is used.
+    # Build will fail if bn2lebinpad patch is applied. Remove this archive
+    # when upstream dependency fixes this issue.
+    external_http_archive(
+        name = "com_github_intel_ipp_crypto_crypto_mb_fips",
+        # Patch removes from CMakeLists.txt instructions to
+        # to create dynamic *.so library target. Linker fails when linking
+        # with boringssl_fips library. Envoy uses only static library
+        # anyways, so created dynamic library would not be used anyways.
+        patches = ["@envoy//bazel/foreign_cc:ipp-crypto-skip-dynamic-lib.patch"],
         patch_args = ["-p1"],
         build_file_content = BUILD_ALL_CONTENT,
     )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -547,6 +547,8 @@ def _com_github_intel_ipp_crypto_crypto_mb_fips():
         patches = ["@envoy//bazel/foreign_cc:ipp-crypto-skip-dynamic-lib.patch"],
         patch_args = ["-p1"],
         build_file_content = BUILD_ALL_CONTENT,
+        # Use existing ipp-crypto repository location name to avoid redefinition.
+        location_name = "com_github_intel_ipp_crypto_crypto_mb",
     )
 
 def _com_github_intel_qatlib():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1503,5 +1503,4 @@ def _compiled_protoc_deps(locations, versions):
             license_url = "https://github.com/protocolbuffers/protobuf/blob/v{version}/LICENSE",
         )
 
-REPOSITORY_LOCATIONS_SPEC["com_github_intel_ipp_crypto_crypto_mb_fips"] = REPOSITORY_LOCATIONS_SPEC["com_github_intel_ipp_crypto_crypto_mb"]
 _compiled_protoc_deps(REPOSITORY_LOCATIONS_SPEC, PROTOC_VERSIONS)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1503,4 +1503,5 @@ def _compiled_protoc_deps(locations, versions):
             license_url = "https://github.com/protocolbuffers/protobuf/blob/v{version}/LICENSE",
         )
 
+REPOSITORY_LOCATIONS_SPEC["com_github_intel_ipp_crypto_crypto_mb_fips"] = REPOSITORY_LOCATIONS_SPEC["com_github_intel_ipp_crypto_crypto_mb"]
 _compiled_protoc_deps(REPOSITORY_LOCATIONS_SPEC, PROTOC_VERSIONS)

--- a/contrib/cryptomb/private_key_providers/source/BUILD
+++ b/contrib/cryptomb/private_key_providers/source/BUILD
@@ -22,7 +22,10 @@ envoy_cmake(
     defines = [
         "OPENSSL_USE_STATIC_LIBS=TRUE",
     ],
-    lib_source = "@com_github_intel_ipp_crypto_crypto_mb//:all",
+    lib_source = select({
+        "//bazel:boringssl_fips": "@com_github_intel_ipp_crypto_crypto_mb_fips//:all",
+        "//conditions:default": "@com_github_intel_ipp_crypto_crypto_mb//:all",
+    }),
     out_static_libs = ["libcrypto_mb.a"],
     tags = ["skip_on_windows"],
     target_compatible_with = envoy_contrib_linux_x86_64_constraints(),


### PR DESCRIPTION
Envoy build with boringssl-fips is broken. #30001 introduces a patch to remove BoringSSL-specific definition of BN_bn2lebinpad in ipp-crypto library. It works for non-fips build but fips build fails with declaration error, remove the patch for fips build.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
