### PR TITLE
docs: add some clarification around the use of metadata in ExtAuthZ

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -111,7 +111,7 @@ message ExtAuthz {
   // ext_authz service. :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>`
   // is passed as an ``protobuf::Any``.
   //
-  // Please note that this field exclusively applies to the gRPC ExtAuthZ service and has no effect on the HTTP service.
+  // Please note that this field exclusively applies to the gRPC ext_authz service and has no effect on the HTTP service.
   //
   // It works in a way similar to ``metadata_context_namespaces`` but allows Envoy and ext_authz server to share
   // the protobuf message definition in order to do a safe parsing.

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -91,7 +91,10 @@ message ExtAuthz {
   type.v3.HttpStatus status_on_error = 7;
 
   // Specifies a list of metadata namespaces whose values, if present, will be passed to the
-  // ext_authz service. :ref:`filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.filter_metadata>` is passed as an opaque ``protobuf::Struct``.
+  // ext_authz service. The :ref:`filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.filter_metadata>`
+  // is passed as an opaque ``protobuf::Struct``.
+  //
+  // Please note that this field exclusively applies to the gRPC ExtAuthZ service and has no effect on the HTTP service.
   //
   // For example, if the ``jwt_authn`` filter is used and :ref:`payload_in_metadata
   // <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.payload_in_metadata>` is set,
@@ -105,10 +108,13 @@ message ExtAuthz {
   repeated string metadata_context_namespaces = 8;
 
   // Specifies a list of metadata namespaces whose values, if present, will be passed to the
-  // ext_authz service. :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>` is passed as an ``protobuf::Any``.
+  // ext_authz service. :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>`
+  // is passed as an ``protobuf::Any``.
   //
-  // It works in a way similar to ``metadata_context_namespaces`` but allows envoy and external authz server to share the protobuf message definition
-  // in order to do a safe parsing.
+  // Please note that this field exclusively applies to the gRPC ExtAuthZ service and has no effect on the HTTP service.
+  //
+  // It works in a way similar to ``metadata_context_namespaces`` but allows envoy and external authz server to share
+  // the protobuf message definition in order to do a safe parsing.
   //
   repeated string typed_metadata_context_namespaces = 16;
 

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -109,7 +109,7 @@ message ExtAuthz {
 
   // Specifies a list of metadata namespaces whose values, if present, will be passed to the
   // ext_authz service. :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>`
-  // is passed as an ``protobuf::Any``.
+  // is passed as a ``protobuf::Any``.
   //
   // Please note that this field exclusively applies to the gRPC ext_authz service and has no effect on the HTTP service.
   //

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -113,7 +113,7 @@ message ExtAuthz {
   //
   // Please note that this field exclusively applies to the gRPC ExtAuthZ service and has no effect on the HTTP service.
   //
-  // It works in a way similar to ``metadata_context_namespaces`` but allows envoy and external authz server to share
+  // It works in a way similar to ``metadata_context_namespaces`` but allows Envoy and ext_authz server to share
   // the protobuf message definition in order to do a safe parsing.
   //
   repeated string typed_metadata_context_namespaces = 16;

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -94,7 +94,7 @@ message ExtAuthz {
   // ext_authz service. The :ref:`filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.filter_metadata>`
   // is passed as an opaque ``protobuf::Struct``.
   //
-  // Please note that this field exclusively applies to the gRPC ExtAuthZ service and has no effect on the HTTP service.
+  // Please note that this field exclusively applies to the gRPC ext_authz service and has no effect on the HTTP service.
   //
   // For example, if the ``jwt_authn`` filter is used and :ref:`payload_in_metadata
   // <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.payload_in_metadata>` is set,


### PR DESCRIPTION
## Background

The docs around `metadata_context_namespaces` and `typed_metadata_context_namespaces` fields in the [ExtAuthZ filter](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto#envoy-v3-api-msg-extensions-filters-http-ext-authz-v3-buffersettings) are a little confusing as they don't specify that these are only applicable for gRPC variant and not HTTP.

Commit Message: add some clarification around the use of metadata in ExtAuthZ
Additional Description: added some clarification around `metadata_context_namespaces` and `typed_metadata_context_namespaces` fields to specify that they are only applicable for gRPC service.
Risk Level: Very Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
