### PR TITLE
rlqs: update and document failure mode behaviors

### DIFF
--- a/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
+++ b/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
@@ -202,8 +202,7 @@ message RateLimitQuotaBucketSettings {
     //    <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
     //    message.
     //
-    // If the field is not set, the ``ExpiredAssignmentBehavior`` time is **not limited**:
-    // it applies to the bucket until replaced by an ``active`` assignment.
+    // If not set, defaults to zero, and the bucket is abandoned immediately.
     google.protobuf.Duration expired_assignment_behavior_timeout = 1
         [(validate.rules).duration = {gt {}}];
 
@@ -389,6 +388,12 @@ message RateLimitQuotaBucketSettings {
   //
   // After sending the initial report, the data plane is to continue reporting the bucket usage with
   // the internal specified in this field.
+  //
+  // If for any reason RLQS client doesn't receive the initial assignment for the reported bucket,
+  // the data plane will eventually consider the bucket abandoned and stop sending the usage
+  // reports. This is explained in more details at :ref:`Rate Limit Quota Service (RLQS)
+  // <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.
+  //
   // [#comment: 100000000 nanoseconds = 0.1 seconds]
   google.protobuf.Duration reporting_interval = 2 [(validate.rules).duration = {
     required: true

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -43,6 +43,14 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.abandon_action>`
 // it.
 //
+// If for any reason the RLQS client doesn't receive the initial assignment for the reported bucket,
+// in order to prevent memory exhaustion, the data plane will limit the time such bucket
+// is retained. The exact time to wait for the initial assignment is chosen by the filter,
+// and may vary based on the implementation.
+// Once the duration ends, the data plane will stop reporting bucket usage, reject any enqueued
+// requests, and purge the bucket from the memory. Subsequent requests matched into the bucket
+// will re-initialize the bucket in the "no assignment" state, restarting the reports.
+//
 // Refer to Rate Limit Quota :ref:`configuration overview <config_http_filters_rate_limit_quota>`
 // for further details.
 

--- a/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
@@ -30,7 +30,7 @@ Bucket definitions can be overridden by the virtual host or route configurations
 
 Initially all Envoy's quota assignments are empty. The rate limit quota filter requests quota assignment from RLQS when the request matches to a bucket for the first time.
 The behavior of the filter while it waits for the initial assignment is determined by the ``no_assignment_behavior`` value. In this state, requests can either all be
-immediately allowed, denied or enqueued [1]_ until quota assignment is received.
+immediately allowed, denied until quota assignment is received.
 
 A quota assignment may have an associated :ref:`time to live <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction.assignment_time_to_live>`.
 The RLQS is expected to update the assignment before the TTL runs out. If RLQS failed to update the assignment and its TTL
@@ -50,14 +50,12 @@ if it has not yet received a rate limit quota or to the
 connection could not be re-established by the time the existing quota expired.
 
 In case the RLQS client doesn't receive the initial bucket assignment (for any reason, including
-RLQS server connection failures) within predetermined [2]_ time, such buckets will eventually be
-purged from memory. Any enqueued [1]_ requests will be rejected (only applies when "no assignment behavior"
-is to enqueue). Subsequent requests matched into the bucket will re-initialize the bucket in the "no assignment"
-state, restarting the reports. This is explained in more details at
+RLQS server connection failures) within predetermined [1]_ time, such buckets will eventually be
+purged from memory. Subsequent requests matched into the bucket will re-initialize the bucket
+in the "no assignment" state, restarting the reports. This is explained in more details at
 :ref:`Rate Limit Quota Service (RLQS) <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.
 
-.. [1] Enqueuing (blocking) requests while waiting for the initial assigned is not currently supported.
-.. [2] The exact time to wait for the initial assignment is chosen by the filter, and may vary based on the implementation.
+.. [1] The exact time to wait for the initial assignment is chosen by the filter, and may vary based on the implementation.
 
 Example 1
 ^^^^^^^^^

--- a/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
@@ -8,7 +8,7 @@ Rate Limit Quota (Work-In-Progress)
   The Rate Limit Quota filter is currently under active development and is not ready for use yet.
   Capabilities and the configuration structures could be changed.
 
-* Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`
+*  Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig>`
 
 This filter provides implementation of the global rate limit quota :ref:`protocol <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.
@@ -30,7 +30,7 @@ Bucket definitions can be overridden by the virtual host or route configurations
 
 Initially all Envoy's quota assignments are empty. The rate limit quota filter requests quota assignment from RLQS when the request matches to a bucket for the first time.
 The behavior of the filter while it waits for the initial assignment is determined by the ``no_assignment_behavior`` value. In this state, requests can either all be
-immediately allowed, denied or enqueued until quota assignment is received.
+immediately allowed, denied or enqueued [1]_ until quota assignment is received.
 
 A quota assignment may have an associated :ref:`time to live <envoy_v3_api_field_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.QuotaAssignmentAction.assignment_time_to_live>`.
 The RLQS is expected to update the assignment before the TTL runs out. If RLQS failed to update the assignment and its TTL
@@ -40,11 +40,24 @@ has expired, the filter can be configured to continue using the last quota assig
 The rate limit quota filter reports the request load for each bucket to the RLQS with the configured ``reporting_interval``. The RLQS may rebalance quota assignments based on the request
 load that each Envoy receives and push new quota assignments to Envoy instances.
 
-When the connection to RLQS server fails, the filter will fall back to either the
+Failure modes
+^^^^^^^^^^^^^
+
+In case the connection to RLQS server fails, the filter will fall back to either the
 :ref:`no assignment behavior <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.no_assignment_behavior>`
 if it has not yet received a rate limit quota or to the
 :ref:`expired assignment behavior <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.expired_assignment_behavior>` if
 connection could not be re-established by the time the existing quota expired.
+
+In case RLQS client, for any reason (including RLQS server connection failures), doesn't receive
+the initial bucket assignment within predetermined [2]_ time such bucket eventually will be purged
+from the memory. Any enqueued [1]_ requests will be rejected (only applies when "no assignment behavior"
+is to enqueue). Subsequent requests matched into the bucket will re-initialize the bucket in the "no assignment"
+state, restarting the reports. This is explained in more details at
+:ref:`Rate Limit Quota Service (RLQS) <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.
+
+.. [1] Enqueuing (blocking) requests while waiting for the initial assigned is not currently supported.
+.. [2] The exact time to wait for the initial assignment is chosen by the filter, and may vary based on the implementation.
 
 Example 1
 ^^^^^^^^^

--- a/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
@@ -49,9 +49,9 @@ if it has not yet received a rate limit quota or to the
 :ref:`expired assignment behavior <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings.expired_assignment_behavior>` if
 connection could not be re-established by the time the existing quota expired.
 
-In case RLQS client, for any reason (including RLQS server connection failures), doesn't receive
-the initial bucket assignment within predetermined [2]_ time such bucket eventually will be purged
-from the memory. Any enqueued [1]_ requests will be rejected (only applies when "no assignment behavior"
+In case the RLQS client doesn't receive the initial bucket assignment (for any reason, including
+RLQS server connection failures) within predetermined [2]_ time, such buckets will eventually be
+purged from memory. Any enqueued [1]_ requests will be rejected (only applies when "no assignment behavior"
 is to enqueue). Subsequent requests matched into the bucket will re-initialize the bucket in the "no assignment"
 state, restarting the reports. This is explained in more details at
 :ref:`Rate Limit Quota Service (RLQS) <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.

--- a/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
@@ -8,7 +8,7 @@ Rate Limit Quota (Work-In-Progress)
   The Rate Limit Quota filter is currently under active development and is not ready for use yet.
   Capabilities and the configuration structures could be changed.
 
-*  Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`
+* Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig>`
 
 This filter provides implementation of the global rate limit quota :ref:`protocol <envoy_v3_api_file_envoy/service/rate_limit_quota/v3/rlqs.proto>`.


### PR DESCRIPTION
RLQS documentation updates intended to prevent memory exhaustion caused by the number of tracked buckets.

- Changes the default behavior of unset ExpiredAssignmentBehavior.expired_assignment_behavior_timeout from "retain unlimited time" to "abandon immediately"
- Clarifies the retention policy for the buckets that never received the initial assignment.
- Clarifies the implementation details for evicting buckets that never received the initial assignment.

---

Commit Message: rlqs: update and document failure mode behaviors
Additional Description: RLQS documentation updates intended to prevent memory exhaustion caused by the number of tracked buckets.
Risk Level: Low
Testing: do_ci.sh 
Docs Changes:
- Changes the default behavior of unset ExpiredAssignmentBehavior.expired_assignment_behavior_timeout from "retain unlimited time" to "abandon immediately"
- Clarifies the retention policy for the buckets that never received the initial assignment.
- Clarifies the implementation details for evicting buckets that never received the initial assignment.
Release Notes: **not sure if we need it for the work_in_progress protocol**
Platform Specific Features: N/A

FYI @tyxia @markdroth
