### PR TITLE
deps/tooling: Make cve data preload optional

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -31,6 +31,6 @@ jobs:
           TODAY_DATE=$(date -u -I"date")
           export TODAY_DATE
           bazel run //tools/dependency:check --action_env=TODAY_DATE -- -c release_issues --fix
-          bazel run //tools/dependency:check --action_env=TODAY_DATE -- -c cves -w error
+          bazel run --//tools/dependency:preload_cve_data //tools/dependency:check --action_env=TODAY_DATE -- -c cves -w error
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -16,6 +16,7 @@ on:
     - 'WORKSPACE'
     - '.github/workflows/envoy-prechecks.yml'
     - '.github/workflows/_*.yml'
+    - 'tools/dependency/BUILD'
 
 concurrency:
   group: ${{ github.event.inputs.head_ref || github.run_id }}-${{ github.workflow }}

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -514,6 +514,7 @@ case $CI_TARGET in
         TODAY_DATE=$(date -u -I"date")
         export TODAY_DATE
         bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/dependency:check \
+              --//tools/dependency:preload_cve_data \
               --action_env=TODAY_DATE \
               -- -v warn \
                  -c cves release_dates releases

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -1,4 +1,5 @@
 load("@base_pip3//:requirements.bzl", "requirement")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@envoy_repo//:path.bzl", "PATH")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_entry_point", "envoy_genjson", "envoy_pytool_binary")
@@ -10,18 +11,34 @@ envoy_package()
 
 envoy_py_namespace()
 
+bool_flag(
+    name = "preload_cve_data",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "preloaded_cve_data",
+    flag_values = {
+        ":preload_cve_data": "true",
+    },
+)
+
 envoy_entry_point(
     name = "check",
     args = [
         "--repository_locations=$(location //bazel:all_repository_locations)",
         "--cve_config=$(location :cve.yaml)",
-        "--cve_data=$(location :cve_data)",
-    ],
+    ] + select({
+        ":preloaded_cve_data": ["--cve_data=$(location :cve_data)"],
+        "//conditions:default": [],
+    }),
     data = [
         ":cve.yaml",
-        ":cve_data",
         "//bazel:all_repository_locations",
-    ],
+    ] + select({
+        ":preloaded_cve_data": [":cve_data"],
+        "//conditions:default": [],
+    }),
     pkg = "envoy.dependency.check",
     deps = [requirement("orjson")],
 )


### PR DESCRIPTION
the dep checker tool can load the cve data dynamically or (for the purposes of bazel) from an existing file

currently it always downloads the file (subject to bazel caches)

this makes the preloading optional

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
