### PR TITLE
redis_proxy: fix crash if catch_all_route is not defined

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -36,6 +36,9 @@ bug_fixes:
 - area: grpc
   change: |
     Fixed a bug in gRPC async client cache which intermittently causes CPU spikes due to busy loop in timer expiration.
+- area: redis
+  change: |
+    Fixed a bug causing crash if incoming redis key does not match against a prefix_route and catch_all_route is not defined.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -106,6 +106,13 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key,
   if (value == nullptr) {
     // prefix route not found, default to catch all route.
     value = catch_all_route_;
+    // prefix route not found, check if catch_all_route is defined to fallback to.
+    if (catch_all_route_ != nullptr) {
+      value = catch_all_route_;
+    } else {
+      // no route found.
+      return value;
+    }
   }
 
   if (value->removePrefix()) {

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -69,6 +69,20 @@ TEST(PrefixRoutesTest, RoutedToCatchAll) {
   EXPECT_EQ(upstream_c, router.upstreamPool(key, stream_info)->upstream(""));
 }
 
+TEST(PrefixRoutesTest, MissingCatchAll) {
+  Upstreams upstreams;
+  upstreams.emplace("fake_clusterA", std::make_shared<ConnPool::MockInstance>());
+  upstreams.emplace("fake_clusterB", std::make_shared<ConnPool::MockInstance>());
+
+  Runtime::MockLoader runtime_;
+
+  PrefixRoutes router(createPrefixRoutes(), std::move(upstreams), runtime_);
+
+  std::string key("c:bar");
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_EQ(nullptr, router.upstreamPool(key, stream_info));
+}
+
 TEST(PrefixRoutesTest, RoutedToLongestPrefix) {
   auto upstream_a = std::make_shared<ConnPool::MockInstance>();
 


### PR DESCRIPTION
Commit Message: Fix proxy crash if catch_all_route is not defined
Additional Description: If an incoming redis key does not match against any of the prefix_routes that maybe defined, the proxy crashes if catch_all_route is not defined. This bug handles "no route" matching scenario.
Risk Level: Low
Testing: Unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/29120
[Optional Fixes commit #PR or SHA] https://github.com/envoyproxy/envoy/pull/27902 / https://github.com/envoyproxy/envoy/pull/29138 ( change was reverted )
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]