### PR TITLE
fix: minor fix to the refresh clangdb script

### DIFF
--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -5,10 +5,13 @@
 bazel_or_isk=bazelisk
 command -v bazelisk &> /dev/null || bazel_or_isk=bazel
 
-[[ -z "${EXCLUDE_CONTRIB}" ]] || opts="--exclude_contrib"
+opts=(--vscode --bazel="$bazel_or_isk")
+
+[[ -z "${EXCLUDE_CONTRIB}" ]] || opts+=(--exclude_contrib)
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk "${opts}"
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py \
+    "${opts[@]}"
 
 # Kill clangd to reload the compilation database
 pkill clangd || :


### PR DESCRIPTION
Minor fix to clangdb refresh script. The `"$opts"` will be treat as variable length arguments if the `EXCLUDE_CONTRIB` is not set. In this case, the `bazel_targets` will be empty.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
