### PR TITLE
build/setup: Dont assume `/build` writeability

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -80,11 +80,14 @@ function setup_clang_toolchain() {
   echo "clang toolchain with ${ENVOY_STDLIB} configured"
 }
 
-export BUILD_DIR=${BUILD_DIR:-/build}
-if [[ ! -d "${BUILD_DIR}" ]]
-then
-  echo "${BUILD_DIR} mount missing - did you forget -v <something>:${BUILD_DIR}? Creating."
-  mkdir -p "${BUILD_DIR}"
+if [[ -z "${BUILD_DIR}" ]]; then
+    echo "BUILD_DIR not set - defaulting to ~/.cache/envoy-bazel" >&2
+    BUILD_DIR="$(realpath ~/.cache/envoy-bazel)"
+fi
+export BUILD_DIR
+if [[ ! -d "${BUILD_DIR}" ]]; then
+    echo "${BUILD_DIR} missing - Creating." >&2
+    mkdir -p "${BUILD_DIR}"
 fi
 
 # Environment setup.

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -91,6 +91,8 @@ VOLUMES=(
     -v "${ENVOY_DOCKER_BUILD_DIR}":"${BUILD_DIR_MOUNT_DEST}"
     -v "${SOURCE_DIR}":"${SOURCE_DIR_MOUNT_DEST}")
 
+export BUILD_DIR="${BUILD_DIR_MOUNT_DEST}"
+
 if [[ -n "$ENVOY_DOCKER_IN_DOCKER" || -n "$ENVOY_SHARED_TMP_DIR" ]]; then
     # Create a "shared" directory that has the same path in/outside the container
     # This allows the host docker engine to see artefacts using a temporary path created inside the container,
@@ -111,6 +113,7 @@ fi
 docker run --rm \
        "${ENVOY_DOCKER_OPTIONS[@]}" \
        "${VOLUMES[@]}" \
+       -e BUILD_DIR \
        -e HTTP_PROXY \
        -e HTTPS_PROXY \
        -e NO_PROXY \


### PR DESCRIPTION
Currently calling `ci/build_setup.sh` without specifying a `BUILD_DIR` defaults to `/build`

This was done as this is what is mounted in the build container, but this assumption makes most of the CI unusable outside of the container.

This PR uses a cache folder in the user's home directory as a default fallback which is a much more reasonable expectation.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
