### PR TITLE
test: add configuration for listeners bound timeout

### DIFF
--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -459,11 +459,7 @@ void BaseIntegrationTest::createGeneratedApiTestServer(
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0 &&
       !defer_listener_finalization_) {
 
-    // Wait for listeners to be created before invoking registerTestServerPorts() below, as that
-    // needs to know about the bound listener ports.
-    // Using 2x default timeout to cover for slow TLS implementations (no inline asm) on slow
-    // computers (e.g., Raspberry Pi) that sometimes time out on TLS listeners here.
-    Event::TestTimeSystem::RealTimeBound bound(2 * TestUtility::DefaultTimeout);
+    Event::TestTimeSystem::RealTimeBound bound(listeners_bound_timeout_ms_);
     const char* success = "listener_manager.listener_create_success";
     const char* rejected = "listener_manager.lds.update_rejected";
     for (Stats::CounterSharedPtr success_counter = test_server->counter(success),

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -474,6 +474,13 @@ protected:
 
   void checkForMissingTagExtractionRules();
 
+  // Sets the timeout to wait for listeners to be created before invoking
+  // registerTestServerPorts(), as that needs to know about the bound listener ports.
+  // Needs to be called before invoking createEnvoy() (invoked during initialize()).
+  void setListenersBoundTimeout(const std::chrono::milliseconds& duration) {
+    listeners_bound_timeout_ms_ = duration;
+  }
+
   std::unique_ptr<Stats::Store> upstream_stats_store_;
 
   // Make sure the test server will be torn down after any fake client.
@@ -526,6 +533,13 @@ protected:
   Grpc::SotwOrDelta sotw_or_delta_{Grpc::SotwOrDelta::Sotw};
 
   spdlog::level::level_enum default_log_level_;
+
+  // Timeout to wait for listeners to be created before invoking
+  // registerTestServerPorts(), as that needs to know about the bound listener ports.
+  // Using 2x default timeout to cover for slow TLS implementations (no inline asm) on slow
+  // computers (e.g., Raspberry Pi) that sometimes time out on TLS listeners herei, or when
+  // the number of listeners in a test is large.
+  std::chrono::milliseconds listeners_bound_timeout_ms_{2 * TestUtility::DefaultTimeout};
 
   // Target number of upstreams.
   uint32_t fake_upstreams_count_{1};

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1593,6 +1593,7 @@ TEST_P(IntegrationTest, AbsolutePathWithoutPort) {
 
 // Ensure that connect behaves the same with allow_absolute_url enabled and without
 TEST_P(IntegrationTest, Connect) {
+  setListenersBoundTimeout(3 * TestUtility::DefaultTimeout);
   const std::string& request = "CONNECT www.somewhere.com:80 HTTP/1.1\r\n\r\n";
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     // Clone the whole listener.


### PR DESCRIPTION
Commit Message: test: add configuration for listeners bound timeout
Additional Description:
Adds an optional timeout setting for the listeners binding at startup.
We have internal tests with many listeners, and they require this update.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
