### PR TITLE
[mobile]add quic canonical suffix support

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -299,6 +299,11 @@ EngineBuilder& EngineBuilder::addQuicHint(std::string host, int port) {
   return *this;
 }
 
+EngineBuilder& EngineBuilder::addQuicCanonicalSuffix(std::string suffix) {
+  quic_suffixes_.emplace_back(std::move(suffix));
+  return *this;
+}
+
 #endif
 
 EngineBuilder& EngineBuilder::setForceAlwaysUsev6(bool value) {
@@ -452,6 +457,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
           cache_config.mutable_alternate_protocols_cache_options()->add_prepopulated_entries();
       entry->set_hostname(host);
       entry->set_port(port);
+    }
+    for (const auto& suffix: quic_suffixes_) {
+      cache_config.mutable_alternate_protocols_cache_options()->add_canonical_suffixes(suffix);
     }
     auto* cache_filter = hcm->add_http_filters();
     cache_filter->set_name("alternate_protocols_cache");
@@ -820,6 +828,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
                         ->add_prepopulated_entries();
       entry->set_hostname(host);
       entry->set_port(port);
+    }
+    for (const auto& suffix: quic_suffixes_) {
+      alpn_options.mutable_auto_config()
+                        ->mutable_alternate_protocols_cache_options()->add_canonical_suffixes(suffix);
     }
 
     base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -158,6 +158,7 @@ public:
   EngineBuilder& setHttp3ConnectionOptions(std::string options);
   EngineBuilder& setHttp3ClientConnectionOptions(std::string options);
   EngineBuilder& addQuicHint(std::string host, int port);
+  EngineBuilder& addQuicCanonicalSuffix(std::string suffix);
 #endif
   EngineBuilder& enableInterfaceBinding(bool interface_binding_on);
   EngineBuilder& enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on);
@@ -244,6 +245,7 @@ private:
   std::string http3_connection_options_ = "";
   std::string http3_client_connection_options_ = "";
   std::vector<std::pair<std::string, int>> quic_hints_;
+  std::vector<std::string> quic_suffixes_;
   bool always_use_v6_ = false;
   int dns_min_refresh_seconds_ = 60;
   int max_connections_per_host_ = 7;

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -1211,7 +1211,7 @@ void configureBuilder(JNIEnv* env, jstring grpc_stats_domain, jlong connect_time
                       jboolean enable_dns_cache, jlong dns_cache_save_interval_seconds,
                       jboolean enable_drain_post_dns_refresh, jboolean enable_http3,
                       jstring http3_connection_options, jstring http3_client_connection_options,
-                      jobjectArray quic_hints, jboolean enable_gzip_decompression,
+                      jobjectArray quic_hints, jobjectArray quic_canonical_suffixes, jboolean enable_gzip_decompression,
                       jboolean enable_brotli_decompression, jboolean enable_socket_tagging,
                       jboolean enable_interface_binding,
                       jlong h2_connection_keepalive_idle_interval_milliseconds,
@@ -1252,6 +1252,11 @@ void configureBuilder(JNIEnv* env, jstring grpc_stats_domain, jlong connect_time
   for (std::pair<std::string, std::string>& entry : hints) {
     builder.addQuicHint(entry.first, stoi(entry.second));
   }
+  std::vector<std::string> suffixes = javaObjectArrayToStringVector(env, quic_canonical_suffixes);
+  for (std::string& suffix : suffixes) {
+    builder.addQuicCanonicalSuffix(suffix);
+  }
+
 #endif
   builder.enableInterfaceBinding(enable_interface_binding == JNI_TRUE);
   builder.enableDrainPostDnsRefresh(enable_drain_post_dns_refresh == JNI_TRUE);
@@ -1300,7 +1305,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     jlong dns_min_refresh_seconds, jobjectArray dns_preresolve_hostnames, jboolean enable_dns_cache,
     jlong dns_cache_save_interval_seconds, jboolean enable_drain_post_dns_refresh,
     jboolean enable_http3, jstring http3_connection_options,
-    jstring http3_client_connection_options, jobjectArray quic_hints,
+    jstring http3_client_connection_options, jobjectArray quic_hints, jobjectArray quic_canonical_suffixes,
     jboolean enable_gzip_decompression, jboolean enable_brotli_decompression,
     jboolean enable_socket_tagging, jboolean enable_interface_binding,
     jlong h2_connection_keepalive_idle_interval_milliseconds,
@@ -1321,7 +1326,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
                    dns_query_timeout_seconds, dns_min_refresh_seconds, dns_preresolve_hostnames,
                    enable_dns_cache, dns_cache_save_interval_seconds, enable_drain_post_dns_refresh,
                    enable_http3, http3_connection_options, http3_client_connection_options,
-                   quic_hints, enable_gzip_decompression, enable_brotli_decompression,
+                   quic_hints, quic_canonical_suffixes, enable_gzip_decompression, enable_brotli_decompression,
                    enable_socket_tagging, enable_interface_binding,
                    h2_connection_keepalive_idle_interval_milliseconds,
                    h2_connection_keepalive_timeout_seconds, max_connections_per_host,

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -40,6 +40,7 @@ public class EnvoyConfiguration {
   public final String http3ConnectionOptions;
   public final String http3ClientConnectionOptions;
   public final Map<String, String> quicHints;
+  public final List<String> quicCanonicalSuffixes;
   public final Boolean enableGzipDecompression;
   public final Boolean enableBrotliDecompression;
   public final Boolean enableSocketTagging;
@@ -109,6 +110,8 @@ public class EnvoyConfiguration {
    *     HTTP/3.
    * @param quicHints                                     A list of host port pairs that's known
    *     to speak QUIC.
+   * @param quicCanonicalSuffixes                         A list of canonical suffixes that are
+   *     known to speak QUIC.
    * @param enableGzipDecompression                       whether to enable response gzip
    *     decompression.
    *     compression.
@@ -166,7 +169,7 @@ public class EnvoyConfiguration {
       int dnsMinRefreshSeconds, List<String> dnsPreresolveHostnames, boolean enableDNSCache,
       int dnsCacheSaveIntervalSeconds, boolean enableDrainPostDnsRefresh, boolean enableHttp3,
       String http3ConnectionOptions, String http3ClientConnectionOptions,
-      Map<String, Integer> quicHints, boolean enableGzipDecompression,
+      Map<String, Integer> quicHints, List<String> quicCanonicalSuffixes, boolean enableGzipDecompression,
       boolean enableBrotliDecompression, boolean enableSocketTagging,
       boolean enableInterfaceBinding, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
       int h2ConnectionKeepaliveTimeoutSeconds, int maxConnectionsPerHost, int statsFlushSeconds,
@@ -200,6 +203,7 @@ public class EnvoyConfiguration {
     for (Map.Entry<String, Integer> hostAndPort : quicHints.entrySet()) {
       this.quicHints.put(hostAndPort.getKey(), String.valueOf(hostAndPort.getValue()));
     }
+    this.quicCanonicalSuffixes = quicCanonicalSuffixes;
     this.enableGzipDecompression = enableGzipDecompression;
     this.enableBrotliDecompression = enableBrotliDecompression;
     this.enableSocketTagging = enableSocketTagging;
@@ -265,12 +269,13 @@ public class EnvoyConfiguration {
     byte[][] dnsPreresolve = JniBridgeUtility.stringsToJniBytes(dnsPreresolveHostnames);
     byte[][] runtimeGuards = JniBridgeUtility.mapToJniBytes(this.runtimeGuards);
     byte[][] quicHints = JniBridgeUtility.mapToJniBytes(this.quicHints);
+    byte[][] quicSuffixes = JniBridgeUtility.stringsToJniBytes(quicCanonicalSuffixes);
 
     return JniLibrary.createBootstrap(
         grpcStatsDomain, connectTimeoutSeconds, dnsRefreshSeconds, dnsFailureRefreshSecondsBase,
         dnsFailureRefreshSecondsMax, dnsQueryTimeoutSeconds, dnsMinRefreshSeconds, dnsPreresolve,
         enableDNSCache, dnsCacheSaveIntervalSeconds, enableDrainPostDnsRefresh, enableHttp3,
-        http3ConnectionOptions, http3ClientConnectionOptions, quicHints, enableGzipDecompression,
+        http3ConnectionOptions, http3ClientConnectionOptions, quicHints, quicSuffixes, enableGzipDecompression,
         enableBrotliDecompression, enableSocketTagging, enableInterfaceBinding,
         h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
         maxConnectionsPerHost, statsFlushSeconds, streamIdleTimeoutSeconds,

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -311,7 +311,7 @@ public class JniLibrary {
       long dnsQueryTimeoutSeconds, long dnsMinRefreshSeconds, byte[][] dnsPreresolveHostnames,
       boolean enableDNSCache, long dnsCacheSaveIntervalSeconds, boolean enableDrainPostDnsRefresh,
       boolean enableHttp3, String http3ConnectionOptions, String http3ClientConnectionOptions,
-      byte[][] quicHints, boolean enableGzipDecompression, boolean enableBrotliDecompression,
+      byte[][] quicHints, byte[][] quicCanonicalSuffixes, boolean enableGzipDecompression, boolean enableBrotliDecompression,
       boolean enableSocketTagging, boolean enableInterfaceBinding,
       long h2ConnectionKeepaliveIdleIntervalMilliseconds, long h2ConnectionKeepaliveTimeoutSeconds,
       long maxConnectionsPerHost, long statsFlushSeconds, long streamIdleTimeoutSeconds,

--- a/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
@@ -50,6 +50,7 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
   // See setters below for verbose descriptions.
   private final Context mApplicationContext;
   private final Map<String, Integer> mQuicHints = new HashMap<>();
+  private final List<String> mQuicCanonicalSuffixes = new LinkedList<>();
   private final List<Pkp> mPkps = new LinkedList<>();
   private boolean mPublicKeyPinningBypassForLocalTrustAnchorsEnabled;
   private String mUserAgent;
@@ -226,6 +227,13 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
   }
 
   Map<String, Integer> quicHints() { return mQuicHints; }
+
+  public CronvoyEngineBuilderImpl addQuicCanonicalSuffix(String suffix) {
+    mQuicCanonicalSuffixes.add(suffix);
+    return this;
+  }
+
+  List<String> quicCanonicalSuffixes() { return mQuicCanonicalSuffixes; }
 
   @Override
   public CronvoyEngineBuilderImpl addPublicKeyPins(String hostName, Set<byte[]> pinsSha256,

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -127,7 +127,7 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
         mDnsFailureRefreshSecondsMax, mDnsQueryTimeoutSeconds, mDnsMinRefreshSeconds,
         mDnsPreresolveHostnames, mEnableDNSCache, mDnsCacheSaveIntervalSeconds,
         mEnableDrainPostDnsRefresh, quicEnabled(), quicConnectionOptions(),
-        quicClientConnectionOptions(), quicHints(), mEnableGzipDecompression, brotliEnabled(),
+        quicClientConnectionOptions(), quicHints(), quicCanonicalSuffixes(), mEnableGzipDecompression, brotliEnabled(),
         mEnableSocketTag, mEnableInterfaceBinding, mH2ConnectionKeepaliveIdleIntervalMilliseconds,
         mH2ConnectionKeepaliveTimeoutSeconds, mMaxConnectionsPerHost, mStatsFlushSeconds,
         mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion, mAppId,

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -161,6 +161,7 @@ open class EngineBuilder(private val configuration: BaseConfiguration = Standard
   private var http3ConnectionOptions = ""
   private var http3ClientConnectionOptions = ""
   private var quicHints = mutableMapOf<String, Int>()
+  private var quicCanonicalSuffixes = mutableListOf<String>()
   private var enableGzipDecompression = true
   private var enableBrotliDecompression = false
   private var enableSocketTagging = false
@@ -663,6 +664,18 @@ open class EngineBuilder(private val configuration: BaseConfiguration = Standard
   }
 
   /**
+   * Add a host suffix that's known to speak QUIC
+   *
+   * @param suffix the suffix string
+   * @return This builder.
+   */
+  fun addQuicCanonicalSuffix(suffix: String): EngineBuilder {
+    this.quicCanonicalSuffixes.add(suffix)
+    return this
+  }
+  
+
+  /**
    * Builds and runs a new Engine instance with the provided configuration.
    *
    * @return A new instance of Envoy.
@@ -686,6 +699,7 @@ open class EngineBuilder(private val configuration: BaseConfiguration = Standard
         http3ConnectionOptions,
         http3ClientConnectionOptions,
         quicHints,
+        quicCanonicalSuffixes,
         enableGzipDecompression,
         enableBrotliDecompression,
         enableSocketTagging,

--- a/mobile/library/objective-c/EnvoyConfiguration.h
+++ b/mobile/library/objective-c/EnvoyConfiguration.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UInt32 dnsCacheSaveIntervalSeconds;
 @property (nonatomic, assign) BOOL enableHttp3;
 @property (nonatomic, strong) NSDictionary<NSString *, NSNumber *> *quicHints;
+@property (nonatomic, strong) NSArray<NSString *> *quicCanonicalSuffixes;
 @property (nonatomic, assign) BOOL enableGzipDecompression;
 @property (nonatomic, assign) BOOL enableBrotliDecompression;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
@@ -78,6 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
                       dnsCacheSaveIntervalSeconds:(UInt32)dnsCacheSaveIntervalSeconds
                                       enableHttp3:(BOOL)enableHttp3
                                         quicHints:(NSDictionary<NSString *, NSNumber *> *)quicHints
+                            quicCanonicalSuffixes:(NSArray<NSString *> *)quicCanonicalSuffixes
                           enableGzipDecompression:(BOOL)enableGzipDecompression
                         enableBrotliDecompression:(BOOL)enableBrotliDecompression
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -79,6 +79,7 @@
                       dnsCacheSaveIntervalSeconds:(UInt32)dnsCacheSaveIntervalSeconds
                                       enableHttp3:(BOOL)enableHttp3
                                         quicHints:(NSDictionary<NSString *, NSNumber *> *)quicHints
+                            quicCanonicalSuffixes:(NSArray<NSString *> *)quicCanonicalSuffixes
                           enableGzipDecompression:(BOOL)enableGzipDecompression
                         enableBrotliDecompression:(BOOL)enableBrotliDecompression
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding
@@ -140,6 +141,7 @@
   self.dnsCacheSaveIntervalSeconds = dnsCacheSaveIntervalSeconds;
   self.enableHttp3 = enableHttp3;
   self.quicHints = quicHints;
+  self.quicCanonicalSuffixes = quicCanonicalSuffixes;
   self.enableGzipDecompression = enableGzipDecompression;
   self.enableBrotliDecompression = enableBrotliDecompression;
   self.enableInterfaceBinding = enableInterfaceBinding;
@@ -200,6 +202,9 @@
   builder.enableHttp3(self.enableHttp3);
   for (NSString *host in self.quicHints) {
     builder.addQuicHint([host toCXXString], [[self.quicHints objectForKey:host] intValue]);
+  }
+  for (NSString *suffix in self.quicCanonicalSuffixes) {
+    builder.addQuicCanonicalSuffix([suffix toCXXString]);
   }
 #endif
 

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -161,6 +161,7 @@ open class EngineBuilder: NSObject {
   private var enableHttp3: Bool = false
 #endif
   private var quicHints: [String: Int] = [:]
+  private var quicCanonicalSuffixes: [String] = []
   private var enableInterfaceBinding: Bool = false
   private var enforceTrustChainVerification: Bool = true
   private var enablePlatformCertificateValidation: Bool = false
@@ -376,6 +377,17 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func addQuicHint(_ host: String, _ port: Int) -> Self {
     self.quicHints[host] = port
+    return self
+  }
+
+  /// Add a host suffix that's known to support QUIC.
+  ///
+  /// - parameter suffix: the string representation of the host suffix
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addQuicCanonicalSuffix(_ suffix: String) -> Self {
+    self.quicCanonicalSuffix.append(suffix)
     return self
   }
 #endif
@@ -800,6 +812,7 @@ open class EngineBuilder: NSObject {
       dnsCacheSaveIntervalSeconds: self.dnsCacheSaveIntervalSeconds,
       enableHttp3: self.enableHttp3,
       quicHints: self.quicHints.mapValues { NSNumber(value: $0) },
+      quicCanonialSuffixes: self.quicCanonialSuffixes,
       enableGzipDecompression: self.enableGzipDecompression,
       enableBrotliDecompression: self.enableBrotliDecompression,
       enableInterfaceBinding: self.enableInterfaceBinding,
@@ -873,6 +886,9 @@ private extension EngineBuilder {
     cxxBuilder.enableHttp3(self.enableHttp3)
     for (host, port) in self.quicHints {
       cxxBuilder.addQuicHint(host.toCXX(), Int32(port))
+    }
+    for (suffix) in self.quicCanonicalSuffixes {
+      cxxBuilder.addQuicCanonicalSuffix(suffix.toCXX())
     }
 #endif
     cxxBuilder.enableGzipDecompression(self.enableGzipDecompression)

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -38,6 +38,8 @@ TEST(TestConfig, ConfigIsApplied) {
       .setHttp3ClientConnectionOptions("MPQC")
       .addQuicHint("www.abc.com", 443)
       .addQuicHint("www.def.com", 443)
+      .addQuicCanonicalSuffix(".opq.com")
+      .addQuicCanonicalSuffix(".xyz.com")
 #endif
       .addConnectTimeoutSeconds(123)
       .addDnsRefreshSeconds(456)
@@ -74,6 +76,8 @@ TEST(TestConfig, ConfigIsApplied) {
       "client_connection_options: \"MPQC\"",
       "hostname: \"www.abc.com\"",
       "hostname: \"www.def.com\"",
+      "canonical_suffixes: \".opq.com\"",
+      "canonical_suffixes: \".xyz.com\"",
 #endif
       "key: \"dns_persistent_cache\" save_interval { seconds: 101 }",
       "key: \"always_use_v6\" value { bool_value: true }",

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -72,7 +72,10 @@ public:
     if (add_quic_hints_) {
       auto address = fake_upstreams_[0]->localAddress();
       auto upstream_port = fake_upstreams_[0]->localAddress()->ip()->port();
-      builder_.addQuicHint("www.lyft.com", upstream_port);
+      // With canonical suffix, having a quic hint of foo.lyft.com will make
+      // www.lyft.com being recognized as QUIC ready.
+      builder_.addQuicCanonicalSuffix(".lyft.com");
+      builder_.addQuicHint("foo.lyft.com", upstream_port);
       ASSERT(test_key_value_store_);
 
       // Force www.lyft.com to resolve to the fake upstream. It's the only domain

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -81,6 +81,7 @@ class EnvoyConfigurationTest {
     http3ConnectionOptions: String = "5RTO",
     http3ClientConnectionOptions: String = "MPQC",
     quicHints: Map<String, Int> = mapOf("www.abc.com" to 443, "www.def.com" to 443),
+    quicCanonicalSuffixes: MutableList<String> = mutableListOf(".opq.com", ".xyz.com"),
     enableGzipDecompression: Boolean = true,
     enableBrotliDecompression: Boolean = false,
     enableSocketTagging: Boolean = false,
@@ -133,6 +134,7 @@ class EnvoyConfigurationTest {
       http3ConnectionOptions,
       http3ClientConnectionOptions,
       quicHints,
+      quicCanonicalSuffixes,
       enableGzipDecompression,
       enableBrotliDecompression,
       enableSocketTagging,
@@ -208,6 +210,8 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("hostname: www.abc.com");
     assertThat(resolvedTemplate).contains("hostname: www.def.com");
     assertThat(resolvedTemplate).contains("port: 443");
+    assertThat(resolvedTemplate).contains("canonical_suffixes: .opq.com");
+    assertThat(resolvedTemplate).contains("canonical_suffixes: .xyz.com");
     assertThat(resolvedTemplate).contains("connection_options: 5RTO");
     assertThat(resolvedTemplate).contains("client_connection_options: MPQC");
 


### PR DESCRIPTION
Commit Message: add quic canonical suffix support.
Additional Description: This completes the functionality of QUIC hints.
Risk Level: Low
Testing: unit and integration tests
Docs Changes: api doc change
Release Notes: n/a
Platform Specific Features: mobile only