### PR TITLE
kafka: make broker filter rewrite metadata, find-coordinator responses

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -27,4 +27,18 @@ message KafkaBroker {
   // upstream broker instead of passing received bytes as is.
   // Disabled by default.
   bool force_response_rewrite = 2;
+
+  oneof broker_address_rewrite_spec {
+    IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
+  }
+}
+
+message IdBasedBrokerRewriteSpec {
+  repeated IdBasedBrokerRewriteRule rules = 1;
+}
+
+message IdBasedBrokerRewriteRule {
+  uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];
+  string host = 2 [(validate.rules).string = {min_len: 1}];
+  uint32 port = 3 [(validate.rules).uint32 = {lte: 65535}];
 }

--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -28,17 +28,32 @@ message KafkaBroker {
   // Disabled by default.
   bool force_response_rewrite = 2;
 
+  // Optional broker address rewrite specification.
+  // Allows the broker filter to rewrite Kafka responses so that all connections established by
+  // the Kafka clients point to Envoy.
+  // This allows Kafka cluster not to configure its 'advertised.listeners' property
+  // (as the necessary re-pointing will be done by this filter).
   oneof broker_address_rewrite_spec {
     IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
   }
 }
 
 message IdBasedBrokerRewriteSpec {
+  // Repeated rewrite rules.
   repeated IdBasedBrokerRewriteRule rules = 1;
 }
 
 message IdBasedBrokerRewriteRule {
+  // Broker ID to match - if the upstream Kafka cluster returns broker metadata for given ID, the
   uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];
+
+  // The host value to use (resembling the host part of Kafka's advertised.listeners).
+  // The value should point to the Envoy (not Kafka) listener, so that all client traffic goes
+  // through Envoy.
   string host = 2 [(validate.rules).string = {min_len: 1}];
+
+  // The port value to use (resembling the port part of Kafka's advertised.listeners).
+  // The value should point to the Envoy (not Kafka) listener, so that all client traffic goes
+  // through Envoy.
   uint32 port = 3 [(validate.rules).uint32 = {lte: 65535}];
 }

--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -33,16 +33,21 @@ message KafkaBroker {
   // the Kafka clients point to Envoy.
   // This allows Kafka cluster not to configure its 'advertised.listeners' property
   // (as the necessary re-pointing will be done by this filter).
+  // This collection of rules should cover all brokers in the cluster that is being proxied,
+  // otherwise some nodes' addresses might leak to the downstream clients.
   oneof broker_address_rewrite_spec {
+
+    // Broker address rewrite rules that match by broker ID.
     IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
   }
 }
 
+// Collection of rules matching by broker ID.
 message IdBasedBrokerRewriteSpec {
-  // Repeated rewrite rules.
   repeated IdBasedBrokerRewriteRule rules = 1;
 }
 
+// Defines a rule to rewrite
 message IdBasedBrokerRewriteRule {
   // Broker ID to match - if the upstream Kafka cluster returns broker metadata for given ID, the
   uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];

--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -46,9 +46,9 @@ message IdBasedBrokerRewriteSpec {
   repeated IdBasedBrokerRewriteRule rules = 1;
 }
 
-// Defines a rule to rewrite
+// Defines a rule to rewrite broker address data.
 message IdBasedBrokerRewriteRule {
-  // Broker ID to match - if the upstream Kafka cluster returns broker metadata for given ID, the
+  // Broker ID to match.
   uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];
 
   // The host value to use (resembling the host part of Kafka's advertised.listeners).

--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -36,7 +36,6 @@ message KafkaBroker {
   // This collection of rules should cover all brokers in the cluster that is being proxied,
   // otherwise some nodes' addresses might leak to the downstream clients.
   oneof broker_address_rewrite_spec {
-
     // Broker address rewrite rules that match by broker ID.
     IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
   }

--- a/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
+++ b/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
@@ -35,7 +35,6 @@ message KafkaBroker {
   // This collection of rules should cover all brokers in the cluster that is being proxied,
   // otherwise some nodes' addresses might leak to the downstream clients.
   oneof broker_address_rewrite_spec {
-
     // Broker address rewrite rules that match by broker ID.
     IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
   }

--- a/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
+++ b/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
@@ -45,9 +45,9 @@ message IdBasedBrokerRewriteSpec {
   repeated IdBasedBrokerRewriteRule rules = 1;
 }
 
-// Defines a rule to rewrite
+// Defines a rule to rewrite broker address data.
 message IdBasedBrokerRewriteRule {
-  // Broker ID to match - if the upstream Kafka cluster returns broker metadata for given ID, the
+  // Broker ID to match.
   uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];
 
   // The host value to use (resembling the host part of Kafka's advertised.listeners).

--- a/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
+++ b/api/envoy/config/filter/network/kafka_broker/v2alpha1/kafka_broker.proto
@@ -26,4 +26,38 @@ message KafkaBroker {
   // upstream broker instead of passing received bytes as is.
   // Disabled by default.
   bool force_response_rewrite = 2;
+
+  // Optional broker address rewrite specification.
+  // Allows the broker filter to rewrite Kafka responses so that all connections established by
+  // the Kafka clients point to Envoy.
+  // This allows Kafka cluster not to configure its 'advertised.listeners' property
+  // (as the necessary re-pointing will be done by this filter).
+  // This collection of rules should cover all brokers in the cluster that is being proxied,
+  // otherwise some nodes' addresses might leak to the downstream clients.
+  oneof broker_address_rewrite_spec {
+
+    // Broker address rewrite rules that match by broker ID.
+    IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
+  }
+}
+
+// Collection of rules matching by broker ID.
+message IdBasedBrokerRewriteSpec {
+  repeated IdBasedBrokerRewriteRule rules = 1;
+}
+
+// Defines a rule to rewrite
+message IdBasedBrokerRewriteRule {
+  // Broker ID to match - if the upstream Kafka cluster returns broker metadata for given ID, the
+  uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];
+
+  // The host value to use (resembling the host part of Kafka's advertised.listeners).
+  // The value should point to the Envoy (not Kafka) listener, so that all client traffic goes
+  // through Envoy.
+  string host = 2 [(validate.rules).string = {min_len: 1}];
+
+  // The port value to use (resembling the port part of Kafka's advertised.listeners).
+  // The value should point to the Envoy (not Kafka) listener, so that all client traffic goes
+  // through Envoy.
+  uint32 port = 3 [(validate.rules).uint32 = {lte: 65535}];
 }

--- a/contrib/kafka/filters/network/source/broker/BUILD
+++ b/contrib/kafka/filters/network/source/broker/BUILD
@@ -27,11 +27,14 @@ envoy_cc_contrib_extension(
 
 envoy_cc_library(
     name = "filter_config_lib",
-    srcs = [],
+    srcs = [
+        "filter_config.cc",
+    ],
     hdrs = [
         "filter_config.h",
     ],
     deps = [
+        "//source/common/common:assert_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/kafka_broker/v3:pkg_cc_proto",
     ],
 )
@@ -51,7 +54,6 @@ envoy_cc_library(
         "//envoy/buffer:buffer_interface",
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
-        "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
     ],
 )

--- a/contrib/kafka/filters/network/source/broker/config.cc
+++ b/contrib/kafka/filters/network/source/broker/config.cc
@@ -16,10 +16,11 @@ namespace Broker {
 Network::FilterFactoryCb KafkaConfigFactory::createFilterFactoryFromProtoTyped(
     const KafkaBrokerProtoConfig& proto_config, Server::Configuration::FactoryContext& context) {
 
-  const BrokerFilterConfig filter_config{proto_config};
+  const BrokerFilterConfigSharedPtr filter_config =
+      std::make_shared<BrokerFilterConfig>(proto_config);
   return [&context, filter_config](Network::FilterManager& filter_manager) -> void {
     Network::FilterSharedPtr filter =
-        std::make_shared<KafkaBrokerFilter>(context.scope(), context.timeSource(), filter_config);
+        std::make_shared<KafkaBrokerFilter>(context.scope(), context.timeSource(), *filter_config);
     filter_manager.addFilter(filter);
   };
 }

--- a/contrib/kafka/filters/network/source/broker/filter.cc
+++ b/contrib/kafka/filters/network/source/broker/filter.cc
@@ -72,7 +72,7 @@ absl::flat_hash_map<int32_t, MonotonicTime>& KafkaMetricsFacadeImpl::getRequestA
 KafkaBrokerFilter::KafkaBrokerFilter(Stats::Scope& scope, TimeSource& time_source,
                                      const BrokerFilterConfig& filter_config)
     : KafkaBrokerFilter{filter_config, std::make_shared<KafkaMetricsFacadeImpl>(
-                                           scope, time_source, filter_config.stat_prefix_)} {};
+                                           scope, time_source, filter_config.stat_prefix())} {};
 
 KafkaBrokerFilter::KafkaBrokerFilter(const BrokerFilterConfig& filter_config,
                                      const KafkaMetricsFacadeSharedPtr& metrics)

--- a/contrib/kafka/filters/network/source/broker/filter_config.cc
+++ b/contrib/kafka/filters/network/source/broker/filter_config.cc
@@ -1,0 +1,57 @@
+#include "contrib/kafka/filters/network/source/broker/filter_config.h"
+
+#include "source/common/common/assert.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+static std::vector<RewriteRule> extractRewriteRules(const KafkaBrokerProtoConfig& proto_config) {
+  if (proto_config.has_id_based_broker_address_rewrite_spec()) {
+    std::vector<RewriteRule> result;
+    const auto& spec = proto_config.id_based_broker_address_rewrite_spec();
+    for (const auto& rule : spec.rules()) {
+      result.emplace_back(rule.id(), rule.host(), rule.port());
+    }
+    return result;
+  } else {
+    return {};
+  }
+}
+
+BrokerFilterConfig::BrokerFilterConfig(const KafkaBrokerProtoConfig& proto_config)
+    : BrokerFilterConfig{proto_config.stat_prefix(), proto_config.force_response_rewrite(),
+                         extractRewriteRules(proto_config)} {}
+
+BrokerFilterConfig::BrokerFilterConfig(const std::string& stat_prefix,
+                                       const bool force_response_rewrite,
+                                       const std::vector<RewriteRule>& broker_address_rewrite_rules)
+    : stat_prefix_{stat_prefix}, force_response_rewrite_{force_response_rewrite},
+      broker_address_rewrite_rules_{broker_address_rewrite_rules} {
+  ASSERT(!stat_prefix_.empty());
+};
+
+bool BrokerFilterConfig::needsResponseRewrite() const {
+  return force_response_rewrite_ || !broker_address_rewrite_rules_.empty();
+}
+
+absl::optional<HostAndPort>
+BrokerFilterConfig::findBrokerAddressOverride(const uint32_t broker_id) const {
+  for (const auto& rule : broker_address_rewrite_rules_) {
+    if (rule.matches(broker_id)) {
+      const HostAndPort hp = {rule.host_, rule.port_};
+      return {hp};
+    }
+  }
+  return absl::nullopt;
+}
+
+const std::string& BrokerFilterConfig::stat_prefix() const { return stat_prefix_; }
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <utility>
+
 #include "source/common/common/assert.h"
 
+#include "absl/types/optional.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.validate.h"
 
@@ -13,25 +16,71 @@ namespace Broker {
 
 using KafkaBrokerProtoConfig = envoy::extensions::filters::network::kafka_broker::v3::KafkaBroker;
 
+using HostAndPort = std::pair<std::string, uint32_t>;
+
+struct IdRule {
+
+  uint32_t id_;
+  std::string host_;
+  uint32_t port_;
+
+  IdRule(const uint32_t id, const std::string host, const uint32_t port)
+      : id_{id}, host_{host}, port_{port} {};
+
+  bool matches(const uint32_t broker_id) const { return id_ == broker_id; }
+};
+
+static std::vector<IdRule> extractRewriteRules(const KafkaBrokerProtoConfig& proto_config) {
+  if (proto_config.has_id_based_broker_address_rewrite_spec()) {
+    std::vector<IdRule> result;
+    const auto& spec = proto_config.id_based_broker_address_rewrite_spec();
+    for (const auto& rule : spec.rules()) {
+      result.emplace_back(rule.id(), rule.host(), rule.port());
+    }
+    return result;
+  } else {
+    return {};
+  }
+}
+
 // Minor helper structure that contains broker filter configuration.
 struct BrokerFilterConfig {
 
   BrokerFilterConfig(const KafkaBrokerProtoConfig& proto_config)
-      : BrokerFilterConfig{proto_config.stat_prefix(), proto_config.force_response_rewrite()} {}
+      : BrokerFilterConfig{proto_config.stat_prefix(), proto_config.force_response_rewrite(),
+                           extractRewriteRules(proto_config)} {}
 
   // Visible for testing.
-  BrokerFilterConfig(const std::string& stat_prefix, bool force_response_rewrite)
-      : stat_prefix_{stat_prefix}, force_response_rewrite_{force_response_rewrite} {
+  BrokerFilterConfig(const std::string& stat_prefix, const bool force_response_rewrite,
+                     const std::vector<IdRule>& broker_address_rewrite_rules)
+      : stat_prefix_{stat_prefix}, force_response_rewrite_{force_response_rewrite},
+        broker_address_rewrite_rules_{broker_address_rewrite_rules} {
     ASSERT(!stat_prefix_.empty());
   };
 
   /**
    * Whether this configuration means that rewrite should be happening.
    */
-  bool needsResponseRewrite() const { return force_response_rewrite_; }
+  bool needsResponseRewrite() const {
+    return force_response_rewrite_ || !broker_address_rewrite_rules_.empty();
+  }
+
+  /**
+   * Returns override address for a broker.
+   */
+  absl::optional<HostAndPort> findBrokerAddressOverride(const uint32_t broker_id) const {
+    for (const auto& rule : broker_address_rewrite_rules_) {
+      if (rule.matches(broker_id)) {
+        const HostAndPort hp = {rule.host_, rule.port_};
+        return {hp};
+      }
+    }
+    return absl::nullopt;
+  }
 
   std::string stat_prefix_;
   bool force_response_rewrite_;
+  std::vector<IdRule> broker_address_rewrite_rules_;
 };
 
 } // namespace Broker

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -62,6 +62,8 @@ private:
   std::vector<RewriteRule> broker_address_rewrite_rules_;
 };
 
+using BrokerFilterConfigSharedPtr = std::shared_ptr<BrokerFilterConfig>;
+
 } // namespace Broker
 } // namespace Kafka
 } // namespace NetworkFilters

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -2,8 +2,6 @@
 
 #include <utility>
 
-#include "source/common/common/assert.h"
-
 #include "absl/types/optional.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.validate.h"
@@ -18,69 +16,50 @@ using KafkaBrokerProtoConfig = envoy::extensions::filters::network::kafka_broker
 
 using HostAndPort = std::pair<std::string, uint32_t>;
 
-struct IdRule {
+// Represents a rule matching a broker with given id.
+struct RewriteRule {
 
   uint32_t id_;
+
   std::string host_;
   uint32_t port_;
 
-  IdRule(const uint32_t id, const std::string host, const uint32_t port)
+  RewriteRule(const uint32_t id, const std::string host, const uint32_t port)
       : id_{id}, host_{host}, port_{port} {};
 
   bool matches(const uint32_t broker_id) const { return id_ == broker_id; }
 };
 
-static std::vector<IdRule> extractRewriteRules(const KafkaBrokerProtoConfig& proto_config) {
-  if (proto_config.has_id_based_broker_address_rewrite_spec()) {
-    std::vector<IdRule> result;
-    const auto& spec = proto_config.id_based_broker_address_rewrite_spec();
-    for (const auto& rule : spec.rules()) {
-      result.emplace_back(rule.id(), rule.host(), rule.port());
-    }
-    return result;
-  } else {
-    return {};
-  }
-}
+// Minor helper object that contains broker filter configuration.
+class BrokerFilterConfig {
+public:
+  virtual ~BrokerFilterConfig() = default;
 
-// Minor helper structure that contains broker filter configuration.
-struct BrokerFilterConfig {
-
-  BrokerFilterConfig(const KafkaBrokerProtoConfig& proto_config)
-      : BrokerFilterConfig{proto_config.stat_prefix(), proto_config.force_response_rewrite(),
-                           extractRewriteRules(proto_config)} {}
+  BrokerFilterConfig(const KafkaBrokerProtoConfig& proto_config);
 
   // Visible for testing.
   BrokerFilterConfig(const std::string& stat_prefix, const bool force_response_rewrite,
-                     const std::vector<IdRule>& broker_address_rewrite_rules)
-      : stat_prefix_{stat_prefix}, force_response_rewrite_{force_response_rewrite},
-        broker_address_rewrite_rules_{broker_address_rewrite_rules} {
-    ASSERT(!stat_prefix_.empty());
-  };
+                     const std::vector<RewriteRule>& broker_address_rewrite_rules);
+
+  /**
+   * Returns the prefix for stats.
+   */
+  virtual const std::string& stat_prefix() const;
 
   /**
    * Whether this configuration means that rewrite should be happening.
    */
-  bool needsResponseRewrite() const {
-    return force_response_rewrite_ || !broker_address_rewrite_rules_.empty();
-  }
+  virtual bool needsResponseRewrite() const;
 
   /**
    * Returns override address for a broker.
    */
-  absl::optional<HostAndPort> findBrokerAddressOverride(const uint32_t broker_id) const {
-    for (const auto& rule : broker_address_rewrite_rules_) {
-      if (rule.matches(broker_id)) {
-        const HostAndPort hp = {rule.host_, rule.port_};
-        return {hp};
-      }
-    }
-    return absl::nullopt;
-  }
+  virtual absl::optional<HostAndPort> findBrokerAddressOverride(const uint32_t broker_id) const;
 
+private:
   std::string stat_prefix_;
   bool force_response_rewrite_;
-  std::vector<IdRule> broker_address_rewrite_rules_;
+  std::vector<RewriteRule> broker_address_rewrite_rules_;
 };
 
 } // namespace Broker

--- a/contrib/kafka/filters/network/source/broker/rewriter.cc
+++ b/contrib/kafka/filters/network/source/broker/rewriter.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/broker/rewriter.h"
 
+#include "contrib/kafka/filters/network/source/external/responses.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -8,21 +10,89 @@ namespace Broker {
 
 // ResponseRewriterImpl.
 
+ResponseRewriterImpl::ResponseRewriterImpl(const BrokerFilterConfig& config) : config_{config} {};
+
 void ResponseRewriterImpl::onMessage(AbstractResponseSharedPtr response) {
   responses_to_rewrite_.push_back(response);
 }
 
 void ResponseRewriterImpl::onFailedParse(ResponseMetadataSharedPtr) {}
 
+constexpr int16_t METADATA_API_KEY = 3;
+constexpr int16_t FIND_COORDINATOR_API_KEY = 10;
+
 void ResponseRewriterImpl::process(Buffer::Instance& buffer) {
   buffer.drain(buffer.length());
   ResponseEncoder encoder{buffer};
   ENVOY_LOG(trace, "emitting {} stored responses", responses_to_rewrite_.size());
   for (auto response : responses_to_rewrite_) {
-    // At this stage we have access to responses, and can e.g. change values.
+    switch (response->apiKey()) {
+    case METADATA_API_KEY:
+      updateMetadataBrokerAddresses(response);
+      break;
+    case FIND_COORDINATOR_API_KEY:
+      updateFindCoordinatorBrokerAddresses(response);
+      break;
+    }
     encoder.encode(*response);
   }
   responses_to_rewrite_.erase(responses_to_rewrite_.begin(), responses_to_rewrite_.end());
+}
+
+void ResponseRewriterImpl::updateMetadataBrokerAddresses(
+    AbstractResponseSharedPtr& response) const {
+
+  using MetadataResponseSharedPtr = std::shared_ptr<Response<MetadataResponse>>;
+  MetadataResponseSharedPtr cast = std::dynamic_pointer_cast<Response<MetadataResponse>>(response);
+  if (nullptr == cast) {
+    throw new EnvoyException("bug: response class not matching response API key");
+  }
+  MetadataResponse& data = cast->data_;
+  std::vector<MetadataResponseBroker>& brokers = data.brokers_;
+  for (MetadataResponseBroker& broker : brokers) {
+    const absl::optional<HostAndPort> hostAndPort =
+        config_.findBrokerAddressOverride(broker.node_id_);
+    if (hostAndPort) {
+      ENVOY_LOG(info, "Changing broker [{}] from {}:{} to {}:{}", broker.node_id_, broker.host_,
+                broker.port_, hostAndPort->first, hostAndPort->second);
+      broker.host_ = hostAndPort->first;
+      broker.port_ = hostAndPort->second;
+    }
+  }
+}
+
+void ResponseRewriterImpl::updateFindCoordinatorBrokerAddresses(
+    AbstractResponseSharedPtr& response) const {
+
+  using FCSharedPtr = std::shared_ptr<Response<FindCoordinatorResponse>>;
+  FCSharedPtr cast = std::dynamic_pointer_cast<Response<FindCoordinatorResponse>>(response);
+  if (nullptr == cast) {
+    throw new EnvoyException("bug: response class not matching response API key");
+  }
+  FindCoordinatorResponse& data = cast->data_;
+
+  {
+    const absl::optional<HostAndPort> hostAndPort =
+        config_.findBrokerAddressOverride(data.node_id_);
+    if (hostAndPort) {
+      ENVOY_LOG(info, "Changing broker [{}] from {}:{} to {}:{}", data.node_id_, data.host_,
+                data.port_, hostAndPort->first, hostAndPort->second);
+      data.host_ = hostAndPort->first;
+      data.port_ = hostAndPort->second;
+    }
+  }
+
+  std::vector<Coordinator>& coordinators = data.coordinators_;
+  for (Coordinator& coordinator : coordinators) {
+    const absl::optional<HostAndPort> hostAndPort =
+        config_.findBrokerAddressOverride(coordinator.node_id_);
+    if (hostAndPort) {
+      ENVOY_LOG(info, "Changing broker [{}] from {}:{} to {}:{}", coordinator.node_id_,
+                coordinator.host_, coordinator.port_, hostAndPort->first, hostAndPort->second);
+      coordinator.host_ = hostAndPort->first;
+      coordinator.port_ = hostAndPort->second;
+    }
+  }
 }
 
 size_t ResponseRewriterImpl::getStoredResponseCountForTest() const {
@@ -41,7 +111,7 @@ void DoNothingRewriter::process(Buffer::Instance&) {}
 
 ResponseRewriterSharedPtr createRewriter(const BrokerFilterConfig& config) {
   if (config.needsResponseRewrite()) {
-    return std::make_shared<ResponseRewriterImpl>();
+    return std::make_shared<ResponseRewriterImpl>(config);
   } else {
     return std::make_shared<DoNothingRewriter>();
   }

--- a/contrib/kafka/filters/network/source/broker/rewriter.cc
+++ b/contrib/kafka/filters/network/source/broker/rewriter.cc
@@ -48,16 +48,8 @@ void ResponseRewriterImpl::updateMetadataBrokerAddresses(
     throw new EnvoyException("bug: response class not matching response API key");
   }
   MetadataResponse& data = cast->data_;
-  std::vector<MetadataResponseBroker>& brokers = data.brokers_;
-  for (MetadataResponseBroker& broker : brokers) {
-    const absl::optional<HostAndPort> hostAndPort =
-        config_.findBrokerAddressOverride(broker.node_id_);
-    if (hostAndPort) {
-      ENVOY_LOG(info, "Changing broker [{}] from {}:{} to {}:{}", broker.node_id_, broker.host_,
-                broker.port_, hostAndPort->first, hostAndPort->second);
-      broker.host_ = hostAndPort->first;
-      broker.port_ = hostAndPort->second;
-    }
+  for (MetadataResponseBroker& broker : data.brokers_) {
+    maybeUpdateHostAndPort(broker);
   }
 }
 
@@ -70,28 +62,9 @@ void ResponseRewriterImpl::updateFindCoordinatorBrokerAddresses(
     throw new EnvoyException("bug: response class not matching response API key");
   }
   FindCoordinatorResponse& data = cast->data_;
-
-  {
-    const absl::optional<HostAndPort> hostAndPort =
-        config_.findBrokerAddressOverride(data.node_id_);
-    if (hostAndPort) {
-      ENVOY_LOG(info, "Changing broker [{}] from {}:{} to {}:{}", data.node_id_, data.host_,
-                data.port_, hostAndPort->first, hostAndPort->second);
-      data.host_ = hostAndPort->first;
-      data.port_ = hostAndPort->second;
-    }
-  }
-
-  std::vector<Coordinator>& coordinators = data.coordinators_;
-  for (Coordinator& coordinator : coordinators) {
-    const absl::optional<HostAndPort> hostAndPort =
-        config_.findBrokerAddressOverride(coordinator.node_id_);
-    if (hostAndPort) {
-      ENVOY_LOG(info, "Changing broker [{}] from {}:{} to {}:{}", coordinator.node_id_,
-                coordinator.host_, coordinator.port_, hostAndPort->first, hostAndPort->second);
-      coordinator.host_ = hostAndPort->first;
-      coordinator.port_ = hostAndPort->second;
-    }
+  maybeUpdateHostAndPort(data);
+  for (Coordinator& coordinator : data.coordinators_) {
+    maybeUpdateHostAndPort(coordinator);
   }
 }
 

--- a/contrib/kafka/filters/network/source/broker/rewriter.h
+++ b/contrib/kafka/filters/network/source/broker/rewriter.h
@@ -37,6 +37,8 @@ using ResponseRewriterSharedPtr = std::shared_ptr<ResponseRewriter>;
  */
 class ResponseRewriterImpl : public ResponseRewriter, private Logger::Loggable<Logger::Id::kafka> {
 public:
+  ResponseRewriterImpl(const BrokerFilterConfig& config);
+
   // ResponseCallback
   void onMessage(AbstractResponseSharedPtr response) override;
   void onFailedParse(ResponseMetadataSharedPtr parse_failure) override;
@@ -47,6 +49,10 @@ public:
   size_t getStoredResponseCountForTest() const;
 
 private:
+  void updateMetadataBrokerAddresses(AbstractResponseSharedPtr& response) const;
+  void updateFindCoordinatorBrokerAddresses(AbstractResponseSharedPtr& response) const;
+
+  BrokerFilterConfig config_;
   std::vector<AbstractResponseSharedPtr> responses_to_rewrite_;
 };
 

--- a/contrib/kafka/filters/network/source/broker/rewriter.h
+++ b/contrib/kafka/filters/network/source/broker/rewriter.h
@@ -52,6 +52,17 @@ private:
   void updateMetadataBrokerAddresses(AbstractResponseSharedPtr& response) const;
   void updateFindCoordinatorBrokerAddresses(AbstractResponseSharedPtr& response) const;
 
+  // Helper function to update various response structures.
+  template <typename T> void maybeUpdateHostAndPort(T& arg) const {
+    const absl::optional<HostAndPort> hostAndPort = config_.findBrokerAddressOverride(arg.node_id_);
+    if (hostAndPort) {
+      ENVOY_LOG(trace, "Changing broker [{}] from {}:{} to {}:{}", arg.node_id_, arg.host_,
+                arg.port_, hostAndPort->first, hostAndPort->second);
+      arg.host_ = hostAndPort->first;
+      arg.port_ = hostAndPort->second;
+    }
+  }
+
   BrokerFilterConfig config_;
   std::vector<AbstractResponseSharedPtr> responses_to_rewrite_;
 };

--- a/contrib/kafka/filters/network/source/broker/rewriter.h
+++ b/contrib/kafka/filters/network/source/broker/rewriter.h
@@ -7,6 +7,7 @@
 #include "source/common/common/logger.h"
 
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"
+#include "contrib/kafka/filters/network/source/external/responses.h"
 #include "contrib/kafka/filters/network/source/response_codec.h"
 
 namespace Envoy {
@@ -46,12 +47,19 @@ public:
   // ResponseRewriter
   void process(Buffer::Instance& buffer) override;
 
+  /**
+   * Mutates response according to config.
+   */
+  void updateMetadataBrokerAddresses(MetadataResponse& response) const;
+
+  /**
+   * Mutates response according to config.
+   */
+  void updateFindCoordinatorBrokerAddresses(FindCoordinatorResponse& response) const;
+
   size_t getStoredResponseCountForTest() const;
 
 private:
-  void updateMetadataBrokerAddresses(AbstractResponseSharedPtr& response) const;
-  void updateFindCoordinatorBrokerAddresses(AbstractResponseSharedPtr& response) const;
-
   // Helper function to update various response structures.
   template <typename T> void maybeUpdateHostAndPort(T& arg) const {
     const absl::optional<HostAndPort> hostAndPort = config_.findBrokerAddressOverride(arg.node_id_);
@@ -63,7 +71,7 @@ private:
     }
   }
 
-  BrokerFilterConfig config_;
+  const BrokerFilterConfig& config_;
   std::vector<AbstractResponseSharedPtr> responses_to_rewrite_;
 };
 

--- a/contrib/kafka/filters/network/source/kafka_response.h
+++ b/contrib/kafka/filters/network/source/kafka_response.h
@@ -94,6 +94,11 @@ public:
   virtual uint32_t encode(Buffer::Instance& dst) const PURE;
 
   /**
+   * Convenience method for response's API key.
+   */
+  int16_t apiKey() const { return metadata_.api_key_; }
+
+  /**
    * Response's metadata.
    */
   const ResponseMetadata metadata_;
@@ -141,7 +146,7 @@ public:
     return metadata_ == rhs.metadata_ && data_ == rhs.data_;
   };
 
-  const Data data_;
+  Data data_;
 };
 
 } // namespace Kafka

--- a/contrib/kafka/filters/network/source/protocol/complex_type_template.j2
+++ b/contrib/kafka/filters/network/source/protocol/complex_type_template.j2
@@ -19,7 +19,7 @@ struct {{ complex_type.name }} {
      there are different Kafka versions that are actually composed of precisely the same fields).
   #}
   {% for field in complex_type.fields %}
-  const {{ field.field_declaration() }}_;{% endfor %}
+  {{ field.field_declaration() }}_;{% endfor %}
   {% for constructor in complex_type.compute_constructors() %}
   // constructor used in versions: {{ constructor['versions'] }}
   {{ constructor['full_declaration'] }}{% endfor %}

--- a/contrib/kafka/filters/network/test/broker/BUILD
+++ b/contrib/kafka/filters/network/test/broker/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
+    "envoy_cc_test_library",
     "envoy_contrib_package",
 )
 
@@ -32,6 +33,7 @@ envoy_cc_test(
     name = "filter_protocol_test",
     srcs = ["filter_protocol_test.cc"],
     deps = [
+        ":mock_filter_config_test_lib",
         "//contrib/kafka/filters/network/source/broker:filter_lib",
         "//contrib/kafka/filters/network/test:buffer_based_test_lib",
         "//contrib/kafka/filters/network/test:message_utilities",
@@ -44,7 +46,17 @@ envoy_cc_test(
     name = "rewriter_unit_test",
     srcs = ["rewriter_unit_test.cc"],
     deps = [
+        ":mock_filter_config_test_lib",
         "//contrib/kafka/filters/network/source/broker:rewriter_lib",
         "//source/common/buffer:buffer_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "mock_filter_config_test_lib",
+    srcs = [],
+    hdrs = ["mock_filter_config.h"],
+    deps = [
+        "//contrib/kafka/filters/network/source/broker:filter_config_lib",
     ],
 )

--- a/contrib/kafka/filters/network/test/broker/BUILD
+++ b/contrib/kafka/filters/network/test/broker/BUILD
@@ -48,6 +48,7 @@ envoy_cc_test(
     deps = [
         ":mock_filter_config_test_lib",
         "//contrib/kafka/filters/network/source/broker:rewriter_lib",
+        "//contrib/kafka/filters/network/test:message_utilities",
         "//source/common/buffer:buffer_lib",
     ],
 )

--- a/contrib/kafka/filters/network/test/broker/BUILD
+++ b/contrib/kafka/filters/network/test/broker/BUILD
@@ -48,7 +48,6 @@ envoy_cc_test(
     deps = [
         ":mock_filter_config_test_lib",
         "//contrib/kafka/filters/network/source/broker:rewriter_lib",
-        "//contrib/kafka/filters/network/test:message_utilities",
         "//source/common/buffer:buffer_lib",
     ],
 )

--- a/contrib/kafka/filters/network/test/broker/filter_protocol_test.cc
+++ b/contrib/kafka/filters/network/test/broker/filter_protocol_test.cc
@@ -12,6 +12,7 @@
 #include "contrib/kafka/filters/network/source/broker/filter.h"
 #include "contrib/kafka/filters/network/source/external/requests.h"
 #include "contrib/kafka/filters/network/source/external/responses.h"
+#include "contrib/kafka/filters/network/test/broker/mock_filter_config.h"
 #include "contrib/kafka/filters/network/test/buffer_based_test.h"
 #include "contrib/kafka/filters/network/test/message_utilities.h"
 #include "gtest/gtest.h"
@@ -35,7 +36,7 @@ protected:
   Stats::TestUtil::TestStore store_;
   Stats::Scope& scope_{*store_.rootScope()};
   Event::TestRealTimeSystem time_source_;
-  KafkaBrokerFilter testee_{scope_, time_source_, {"prefix", false}};
+  KafkaBrokerFilter testee_{scope_, time_source_, BrokerFilterConfig{"prefix", false, {}}};
 
   Network::FilterStatus consumeRequestFromBuffer() {
     return testee_.onData(RequestB::buffer_, false);

--- a/contrib/kafka/filters/network/test/broker/integration_test/envoy_config_yaml.j2
+++ b/contrib/kafka/filters/network/test/broker/integration_test/envoy_config_yaml.j2
@@ -10,7 +10,12 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
           stat_prefix: testfilter
-          force_response_rewrite: true
+          id_based_broker_address_rewrite_spec:
+            rules:
+            - id: 0
+              host: 127.0.0.1
+              port: {{ data['kafka_envoy_port'] }}
+            # More ids go here if we add brokers to the test cluster.
       - name: tcp
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy

--- a/contrib/kafka/filters/network/test/broker/integration_test/kafka_server_properties.j2
+++ b/contrib/kafka/filters/network/test/broker/integration_test/kafka_server_properties.j2
@@ -1,6 +1,6 @@
 broker.id=0
 listeners=PLAINTEXT://127.0.0.1:{{ data['kafka_real_port'] }}
-advertised.listeners=PLAINTEXT://127.0.0.1:{{ data['kafka_envoy_port'] }}
+advertised.listeners=PLAINTEXT://127.0.0.1:{{ data['kafka_real_port'] }}
 
 num.network.threads=3
 num.io.threads=8

--- a/contrib/kafka/filters/network/test/broker/mock_filter_config.h
+++ b/contrib/kafka/filters/network/test/broker/mock_filter_config.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "contrib/kafka/filters/network/source/broker/filter_config.h"
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Kafka {
+namespace Broker {
+
+class MockBrokerFilterConfig : public BrokerFilterConfig {
+public:
+  MOCK_METHOD((const std::string&), stat_prefix, (), (const));
+  MOCK_METHOD(bool, needsResponseRewrite, (), (const));
+  MOCK_METHOD((absl::optional<HostAndPort>), findBrokerAddressOverride, (const uint32_t), (const));
+  MockBrokerFilterConfig() : BrokerFilterConfig{"prefix", false, {}} {};
+};
+
+} // namespace Broker
+} // namespace Kafka
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/kafka/filters/network/test/broker/rewriter_unit_test.cc
+++ b/contrib/kafka/filters/network/test/broker/rewriter_unit_test.cc
@@ -2,7 +2,9 @@
 
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"
 #include "contrib/kafka/filters/network/source/broker/rewriter.h"
+#include "contrib/kafka/filters/network/source/external/responses.h"
 #include "contrib/kafka/filters/network/test/broker/mock_filter_config.h"
+#include "contrib/kafka/filters/network/test/message_utilities.h"
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -65,6 +67,68 @@ TEST(ResponseRewriterImplUnitTest, ShouldRewriteBuffer) {
   // then - 2
   ASSERT_EQ(testee.getStoredResponseCountForTest(), 0);
   ASSERT_EQ(buffer->length(), (3 * 4) + 7 + 13 + 42); // 4 bytes for message length
+}
+
+template <typename T>
+static void assertAddress(const T& arg, const std::string& host, const int32_t port) {
+  ASSERT_EQ(arg.host_, host);
+  ASSERT_EQ(arg.port_, port);
+}
+
+TEST(ResponseRewriterImplUnitTest, ShouldRewriteMetadataResponse) {
+  // given
+  MetadataResponseBroker b1 = {13, "host1", 1111};
+  MetadataResponseBroker b2 = {42, "host2", 2222};
+  MetadataResponseBroker b3 = {77, "host3", 3333};
+  std::vector<MetadataResponseBroker> brokers = {b1, b2, b3};
+  MetadataResponse mr = {brokers, {}};
+
+  MockBrokerFilterConfig config;
+  absl::optional<HostAndPort> r1 = {{"nh1", 4444}};
+  EXPECT_CALL(config, findBrokerAddressOverride(b1.node_id_)).WillOnce(Return(r1));
+  absl::optional<HostAndPort> r2 = absl::nullopt;
+  EXPECT_CALL(config, findBrokerAddressOverride(b2.node_id_)).WillOnce(Return(r2));
+  absl::optional<HostAndPort> r3 = {{"nh3", 6666}};
+  EXPECT_CALL(config, findBrokerAddressOverride(b3.node_id_)).WillOnce(Return(r3));
+  ResponseRewriterImpl testee{config};
+
+  // when
+  testee.updateMetadataBrokerAddresses(mr);
+
+  // then
+  assertAddress(mr.brokers_[0], r1->first, r1->second);
+  assertAddress(mr.brokers_[1], b2.host_, b2.port_);
+  assertAddress(mr.brokers_[2], r3->first, r3->second);
+}
+
+TEST(ResponseRewriterImplUnitTest, ShouldRewriteFindCoordinatorResponse) {
+  // given
+
+  FindCoordinatorResponse fcr = {0, 13, "host1", 1111};
+  Coordinator c1 = {"k1", 1, "ch1", 2222, 0, {}, {}};
+  Coordinator c2 = {"k2", 2, "ch2", 3333, 0, {}, {}};
+  Coordinator c3 = {"k3", 3, "ch3", 4444, 0, {}, {}};
+  fcr.coordinators_ = {c1, c2, c3};
+
+  MockBrokerFilterConfig config;
+  absl::optional<HostAndPort> fcrhp = {{"nh1", 4444}};
+  EXPECT_CALL(config, findBrokerAddressOverride(fcr.node_id_)).WillOnce(Return(fcrhp));
+  absl::optional<HostAndPort> cr1 = {{"nh1", 4444}};
+  EXPECT_CALL(config, findBrokerAddressOverride(c1.node_id_)).WillOnce(Return(cr1));
+  absl::optional<HostAndPort> cr2 = absl::nullopt;
+  EXPECT_CALL(config, findBrokerAddressOverride(c2.node_id_)).WillOnce(Return(cr2));
+  absl::optional<HostAndPort> cr3 = {{"nh3", 6666}};
+  EXPECT_CALL(config, findBrokerAddressOverride(c3.node_id_)).WillOnce(Return(cr3));
+  ResponseRewriterImpl testee{config};
+
+  // when
+  testee.updateFindCoordinatorBrokerAddresses(fcr);
+
+  // then
+  assertAddress(fcr, fcrhp->first, fcrhp->second);
+  assertAddress(fcr.coordinators_[0], cr1->first, cr1->second);
+  assertAddress(fcr.coordinators_[1], c2.host_, c2.port_);
+  assertAddress(fcr.coordinators_[2], cr3->first, cr3->second);
 }
 
 TEST(ResponseRewriterUnitTest, ShouldCreateProperRewriter) {

--- a/contrib/kafka/filters/network/test/broker/rewriter_unit_test.cc
+++ b/contrib/kafka/filters/network/test/broker/rewriter_unit_test.cc
@@ -4,7 +4,6 @@
 #include "contrib/kafka/filters/network/source/broker/rewriter.h"
 #include "contrib/kafka/filters/network/source/external/responses.h"
 #include "contrib/kafka/filters/network/test/broker/mock_filter_config.h"
-#include "contrib/kafka/filters/network/test/message_utilities.h"
 #include "gtest/gtest.h"
 
 using testing::_;

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -7,9 +7,17 @@ The Apache Kafka broker filter decodes the client protocol for
 `Apache Kafka <https://kafka.apache.org/>`_, both the requests and responses in the payload.
 The message versions in `Kafka 3.5.1 <http://kafka.apache.org/35/protocol.html#protocol_api_keys>`_
 are supported (apart from ConsumerGroupHeartbeat).
-The filter attempts not to influence the communication between client and brokers, so the messages
-that could not be decoded (due to Kafka client or broker running a newer version than supported by
-this filter) are forwarded as-is.
+
+By default the filter attempts not to influence the communication between client and brokers, so
+the messages that could not be decoded (due to Kafka client or broker running a newer version than
+supported by this filter) are forwarded as-is. However this requires the upstream Kafka cluster to
+be configured in proxy-aware fashion (see :ref:`config_network_filters_kafka_broker_config_no_mutation`).
+
+If configured to mutate the received traffic, Envoy broker filter can be used to proxy a Kafka broker
+without any changes in the broker configuration.
+This requires the broker filter to be provided with rewrite rules so the addresses advertised by
+the Kafka brokers can be changed to the Envoy listener addresses
+(see :ref:`config_network_filters_kafka_broker_config_with_mutation`).
 
 * This filter should be configured with the type URL ``type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.network.kafka_broker.v3.KafkaBroker>`
@@ -23,21 +31,22 @@ this filter) are forwarded as-is.
    The kafka_broker filter is experimental and is currently under active development.
    Capabilities will be expanded over time and the configuration structures are likely to change.
 
-.. _config_network_filters_kafka_broker_config:
+.. _config_network_filters_kafka_broker_config_no_mutation:
 
-Configuration
--------------
+Configuration (no traffic mutation)
+-----------------------------------
 
-The Kafka Broker filter should be chained with the TCP proxy filter as shown
-in the configuration snippet below:
+The Kafka Broker filter can run without rewriting any requests / responses.
+
+The filter should be chained with the TCP proxy filter as shown in the snippet below:
 
 .. code-block:: yaml
 
   listeners:
   - address:
       socket_address:
-        address: 127.0.0.1 # Host that Kafka clients should connect to.
-        port_value: 19092  # Port that Kafka clients should connect to.
+        address: 127.0.0.1 # Host that Kafka clients should connect to (i.e. bootstrap.servers).
+        port_value: 19092  # Port that Kafka clients should connect to (i.e. bootstrap.servers).
     filter_chains:
     - filters:
       - name: envoy.filters.network.kafka_broker
@@ -61,10 +70,11 @@ in the configuration snippet below:
           - endpoint:
               address:
                 socket_address:
-                  address: 127.0.0.1 # Kafka broker's host
-                  port_value: 9092 # Kafka broker's port.
+                  address: 127.0.0.1 # Kafka broker's host.
+                  port_value: 9092   # Kafka broker's port.
 
-The Kafka broker needs to advertise the Envoy listener port instead of its own.
+The Kafka broker then needs to advertise the Envoy listener port instead of its own -
+this makes the downstream clients make any new connections to Envoy only.
 
 .. code-block:: text
 
@@ -75,6 +85,111 @@ The Kafka broker needs to advertise the Envoy listener port instead of its own.
   # Advertised listener value needs to be equal to Envoy's listener
   # (will make clients discovering this broker talk to it through Envoy).
   advertised.listeners=PLAINTEXT://127.0.0.1:19092
+
+.. _config_network_filters_kafka_broker_config_with_mutation:
+
+Configuration (with traffic mutation)
+-------------------------------------
+
+The Kafka Broker filter can mutate the contents of received responses to enable easier proxying
+of Kafka clusters.
+
+The below example shows a configuration for an Envoy instance that attempts to proxy brokers
+in 2-node cluster:
+
+.. code-block:: yaml
+
+  listeners:
+  - address: # This listener proxies broker 1.
+      socket_address:
+        address: envoy.example.org # Host that Kafka clients should connect to (i.e. bootstrap.servers).
+        port_value: 19092          # Port that Kafka clients should connect to (i.e. bootstrap.servers).
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.kafka_broker
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
+          stat_prefix: exampleprefix1
+          id_based_broker_address_rewrite_spec: &kafka_rewrite_spec
+            rules:
+            - id: 1
+              host: envoy.example.org
+              port: 19092
+            - id: 2
+              host: envoy.example.org
+              port: 19093
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: tcp
+          cluster: broker1cluster
+  - address: # This listener proxies broker 2.
+      socket_address:
+        address: envoy.example.org # Host that Kafka clients should connect to (i.e. bootstrap.servers).
+        port_value: 19093          # Port that Kafka clients should connect to (i.e. bootstrap.servers).
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.kafka_broker
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
+          stat_prefix: exampleprefix2
+          id_based_broker_address_rewrite_spec: *kafka_rewrite_spec
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: tcp
+          cluster: broker2cluster
+
+  clusters:
+  - name: broker1cluster
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: some_service
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: broker1.example.org # Kafka broker's host for broker 1.
+                  port_value: 9092             # Kafka broker's port for broker 1.
+  - name: broker1cluster
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: some_service
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: broker2.example.org # Kafka broker's host for broker 2.
+                  port_value: 9092             # Kafka broker's port for broker 2.
+
+The address rewrite rules should cover all brokers present in the cluster - YAML blocks can be
+used to avoid repetition.
+
+.. _config_network_filters_kafka_broker_debugging:
+
+Debugging
+---------
+
+Java clients can see the hosts used if they set the log level of
+`org.apache.kafka.clients.NetworkClient` to `debug` - only Envoy's listeners should be visible
+in the logs.
+
+.. code-block:: text
+
+  [DEBUG] [NetworkClient] Initiating connection to node localhost:19092 (id: -1 rack: null) using address localhost/127.0.0.1
+  [DEBUG] [NetworkClient] Completed connection to node -1. Fetching API versions.
+  [DEBUG] [NetworkClient] Initiating connection to node localhost:19092 (id: 1 rack: null) using address localhost/127.0.0.1
+  [DEBUG] [NetworkClient] Completed connection to node 1. Fetching API versions.
+  [DEBUG] [NetworkClient] Initiating connection to node localhost:19094 (id: 3 rack: null) using address localhost/127.0.0.1
+  [DEBUG] [NetworkClient] Initiating connection to node localhost:19093 (id: 2 rack: null) using address localhost/127.0.0.1
+  [DEBUG] [NetworkClient] Completed connection to node 2. Fetching API versions.
+  [DEBUG] [NetworkClient] Completed connection to node 3. Fetching API versions.
 
 .. _config_network_filters_kafka_broker_stats:
 


### PR DESCRIPTION
Commit Message: kafka: make broker filter rewrite metadata, find-coordinator responses
Additional Description:
New optional ability - Kafka client does the server discovery via metadata/find-coordinator requests (this way it knows which nodes actually host the Kafka partitions to send/receive from).
This makes proxying Kafka harder than usual because the Kafka broker itself needs to advertise itself with _proxy's_ listener. To make our lives a bit easier - why not let the filter rewrite the responses so that someone can just put Envoy proxies in front of the cluster. Possibly even multiple "Envoy fleets" if we want to play with multitenancy etc. Part of https://github.com/envoyproxy/envoy/issues/30669

Risk Level: low
Testing: unit + integration tests; manual tests with https://github.com/adamkotwasinski/envoy-kafka-tests
Docs Changes: .rst changes for new feature
Release Notes: N/A
Platform Specific Features: N/A

![envoy-kafka-rewrite](https://github.com/envoyproxy/envoy/assets/17969711/1d9ba001-447c-4c4a-b4ec-c32eaedbd362)
