### PR TITLE
azp/ci: Boost x64 build/test

### DIFF
--- a/.azure-pipelines/stages.yml
+++ b/.azure-pipelines/stages.yml
@@ -70,10 +70,10 @@ stages:
   - template: stage/linux.yml
     parameters:
       cacheTestResults: ${{ parameters.cacheTestResults }}
+      pool: envoy-x64-large
       # these are parsed differently and _must_ be expressed in this way
       runBuild: variables['RUN_BUILD']
       runTests: $(RUN_TESTS)
-      tmpfsDockerDisabled: true
 
 - stage: linux_arm64
   displayName: Linux arm64


### PR DESCRIPTION
This reverts the build/test stage to using a faster machine

I think this is justified on the basis that many other stages wait for this, so it can have a big impact.

Also in the majority of cases the larger machine is offset (at least in part) by the faster run

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
