### PR TITLE
mobile: removing default build options from CI

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -68,10 +68,7 @@ jobs:
         cd mobile
         ./bazelw build \
             --config=mobile-remote-ci \
-             --define=admin_html=disabled \
-             --define=admin_functionality=disabled \
              --define envoy_exceptions=disabled \
-             --define envoy_mobile_listener=disabled  \
              --define=envoy_yaml=disabled \
              --copt=-fno-unwind-tables \
              --copt=-fno-exceptions \
@@ -102,7 +99,6 @@ jobs:
             --config=mobile-remote-ci \
             --define=signal_trace=disabled \
             --define=envoy_mobile_request_compression=disabled \
-            --define=envoy_enable_http_datagrams=disabled \
             --define=google_grpc=disabled \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \
             $TARGETS
@@ -135,7 +131,6 @@ jobs:
             --define=envoy_mobile_request_compression=disabled \
             --define=envoy_mobile_stats_reporting=disabled \
             --define=envoy_mobile_swift_cxx_interop=disabled \
-            --define=envoy_enable_http_datagrams=disabled \
             --define=google_grpc=disabled \
             --@envoy//bazel:http3=False \
             --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor= \

--- a/.github/workflows/mobile-core.yml
+++ b/.github/workflows/mobile-core.yml
@@ -46,6 +46,5 @@ jobs:
             --build_tests_only \
             --action_env=LD_LIBRARY_PATH \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
-            --define envoy_mobile_listener=disabled \
             --config=mobile-remote-ci \
             //test/common/...


### PR DESCRIPTION
Removing options in mobile bazelrc to make things more clear.

