### PR TITLE
quic: Fix potential pointer alignmnet issue in adjustNewConnectionIdForRouting

### DIFF
--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -285,9 +285,8 @@ void adjustNewConnectionIdForRouting(quic::QuicConnectionId& new_connection_id,
                                      const quic::QuicConnectionId& old_connection_id) {
   char* new_connection_id_data = new_connection_id.mutable_data();
   const char* old_connection_id_ptr = old_connection_id.data();
-  auto* first_four_bytes = reinterpret_cast<const uint32_t*>(old_connection_id_ptr);
   // Override the first 4 bytes of the new CID to the original CID's first 4 bytes.
-  safeMemcpyUnsafeDst(new_connection_id_data, first_four_bytes);
+  memcpy(new_connection_id_data, old_connection_id_ptr, 4);
 }
 
 } // namespace Quic

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -286,7 +286,7 @@ void adjustNewConnectionIdForRouting(quic::QuicConnectionId& new_connection_id,
   char* new_connection_id_data = new_connection_id.mutable_data();
   const char* old_connection_id_ptr = old_connection_id.data();
   // Override the first 4 bytes of the new CID to the original CID's first 4 bytes.
-  memcpy(new_connection_id_data, old_connection_id_ptr, 4);
+  memcpy(new_connection_id_data, old_connection_id_ptr, 4); // NOLINT(safe-memcpy)
 }
 
 } // namespace Quic


### PR DESCRIPTION
Casting old_connection_id_ptr to a uint32_t is not safe because there is no guarantee that old_connection_id_ptr is 32 bit aligned. Instead, just call memcpy() explicitly with the size of 4.

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A