### PR TITLE
mobile: Fix xDS DiscoveryRequest ACKs in Envoy Mobile

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -135,6 +135,7 @@ void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap* bootstrap) const
     auto* list =
         bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
     list->add_patterns()->set_exact("cluster_manager.active_clusters");
+    list->add_patterns()->set_exact("cluster_manager.warming_clusters");
     list->add_patterns()->set_exact("cluster_manager.cluster_added");
     list->add_patterns()->set_exact("cluster_manager.cluster_updated");
     list->add_patterns()->set_exact("cluster_manager.cluster_removed");


### PR DESCRIPTION
In Envoy Mobile, we limit the stats exported to a specific set: https://github.com/envoyproxy/envoy/blob/e1139dad262eef175d35978337d9879c246ccb46/mobile/library/cc/engine_builder.cc#L137. It turns out that the logic in ClusterManagerImpl requires checking the `warming_clusters` guage to see if we can resume sending DiscoveryRequests for a given type (including ACKs): https://github.com/envoyproxy/envoy/blob/e1139dad262eef175d35978337d9879c246ccb46/source/common/upstream/cluster_manager_impl.cc#L1017. That ScopedResume object never gets reset to have its cleanup run (which would reduce the pauses_ count and allow DiscoveryRequests to resume), because, despite updating the warming_clusters stat, we haven't allowlisted that stat in Envoy Mobile, so the stat doesn't actually get set (a no-op stat operation occurs).

This commit fixes the immediate problem by adding warming_clusters to the set of allowed stats for Envoy Mobile and adds a CdsIntegrationTest to ensure that cluster updates work correctly along with ACK'ing.

Medium term, we should actually remove the need to depend on the warming_clusters guage in ClusterManagerImpl and instead keep track of previous warming cluster size through an internal variable in ClusterManagerImpl. Relying on stats that can have no-op implementations makes it dangerous.