### PR TITLE
xds: Don't rely on stats to keep track of warming clusters

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -135,7 +135,6 @@ void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap* bootstrap) const
     auto* list =
         bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
     list->add_patterns()->set_exact("cluster_manager.active_clusters");
-    list->add_patterns()->set_exact("cluster_manager.warming_clusters");
     list->add_patterns()->set_exact("cluster_manager.cluster_added");
     list->add_patterns()->set_exact("cluster_manager.cluster_updated");
     list->add_patterns()->set_exact("cluster_manager.cluster_removed");

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1009,16 +1009,16 @@ void ClusterManagerImpl::updateClusterCounts() {
       init_helper_.state() == ClusterManagerInitHelper::State::AllClustersInitialized;
   if (all_clusters_initialized && ads_mux_) {
     const auto type_url = Config::getTypeUrl<envoy::config::cluster::v3::Cluster>();
-    const uint64_t previous_warming = cm_stats_.warming_clusters_.value();
-    if (previous_warming == 0 && !warming_clusters_.empty()) {
+    if (last_recorded_warming_clusters_count_ == 0 && !warming_clusters_.empty()) {
       resume_cds_ = ads_mux_->pause(type_url);
-    } else if (previous_warming > 0 && warming_clusters_.empty()) {
+    } else if (last_recorded_warming_clusters_count_ > 0 && warming_clusters_.empty()) {
       ASSERT(resume_cds_ != nullptr);
       resume_cds_.reset();
     }
   }
   cm_stats_.active_clusters_.set(active_clusters_.size());
   cm_stats_.warming_clusters_.set(warming_clusters_.size());
+  last_recorded_warming_clusters_count_ = warming_clusters_.size();
 }
 
 ThreadLocalCluster* ClusterManagerImpl::getThreadLocalCluster(absl::string_view cluster) {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -208,7 +208,6 @@ private:
 /**
  * All cluster manager stats. @see stats_macros.h
  */
-// TODO(abeyad): do we still need the warming_clusters metric or can it be deleted?
 #define ALL_CLUSTER_MANAGER_STATS(COUNTER, GAUGE)                                                  \
   COUNTER(cluster_added)                                                                           \
   COUNTER(cluster_modified)                                                                        \
@@ -932,6 +931,13 @@ private:
   bool ads_mux_initialized_{};
   std::atomic<bool> shutdown_{};
 
+  // Records the last `warming_clusters_` map size from updateClusterCounts(). This variable is
+  // used for bookkeeping to run the `resume_cds_` cleanup that decrements the pause count and
+  // enables the resumption of DiscoveryRequests for the Cluster type url.
+  //
+  // The `warming_clusters` gauge is not suitable for this purpose, because different environments
+  // (e.g. mobile) may have different stats enabled, leading to the gauge not having a reliable
+  // previous warming clusters size value.
   std::size_t last_recorded_warming_clusters_count_{0};
 };
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -208,6 +208,7 @@ private:
 /**
  * All cluster manager stats. @see stats_macros.h
  */
+// TODO(abeyad): do we still need the warming_clusters metric or can it be deleted?
 #define ALL_CLUSTER_MANAGER_STATS(COUNTER, GAUGE)                                                  \
   COUNTER(cluster_added)                                                                           \
   COUNTER(cluster_modified)                                                                        \
@@ -930,6 +931,8 @@ private:
   bool initialized_{};
   bool ads_mux_initialized_{};
   std::atomic<bool> shutdown_{};
+
+  std::size_t last_recorded_warming_clusters_count_{0};
 };
 
 } // namespace Upstream


### PR DESCRIPTION
As discussed in https://github.com/envoyproxy/envoy/pull/30700, ClusterManagerImpl relies on the `warming_cluster` gauge to determine when DiscoveryRequests can be unpaused. However, if the stat is not allowlisted (like it wasn't in Envoy Mobile, resulting in a no-op implementation being used), there will be bugs in the resumption of the Cluster type's DiscoveryRequests.

This commit fixes the issue by introducing a "last recorded warming clusters count" variable in ClusterManagerImpl, which we use to record the previous warming clusters size. This way, we don't need to rely on the stat to do the record keeping and makes the DiscoveryRequest resumption code more robust to different stat configurations.

We don't need additional tests, since this is an internal implementation detail, and we already have tests in Envoy as well as a CDS integration test introduced in https://github.com/envoyproxy/envoy/pull/30700 that triggers the code path and validates correct behavior.
