### PR TITLE
configs: fix and add CONNECT-UDP configs

### DIFF
--- a/configs/proxy_connect_udp_http3_downstream.yaml
+++ b/configs/proxy_connect_udp_http3_downstream.yaml
@@ -67,3 +67,14 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 10002
+    transport_socket:
+      name: envoy.transport_sockets.quic
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport
+        upstream_tls_context:
+          common_tls_context:
+            tls_certificates:
+            - certificate_chain:
+                filename: certs/servercert.pem
+              private_key:
+                filename: certs/serverkey.pem

--- a/configs/proxy_connect_udp_http3_downstream.yaml
+++ b/configs/proxy_connect_udp_http3_downstream.yaml
@@ -46,8 +46,8 @@ static_resources:
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          http2_protocol_options:
-            allow_connect: true
+          http3_protocol_options:
+            allow_extended_connect: true
           upgrade_configs:
           - upgrade_type: CONNECT-UDP
   clusters:
@@ -56,7 +56,8 @@ static_resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http2_protocol_options: {}
+          http3_protocol_options:
+            allow_extended_connect: true
     load_assignment:
       cluster_name: cluster_0
       endpoints:

--- a/configs/terminate_http3_connect_udp_dns_resolution.yaml
+++ b/configs/terminate_http3_connect_udp_dns_resolution.yaml
@@ -52,7 +52,7 @@ static_resources:
               '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
-                dns_lookup_family: ALL
+                dns_lookup_family: V4_ONLY
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -69,4 +69,4 @@ static_resources:
         '@type': type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: ALL
+          dns_lookup_family: V4_ONLY

--- a/configs/terminate_http3_connect_udp_dns_resolution.yaml
+++ b/configs/terminate_http3_connect_udp_dns_resolution.yaml
@@ -1,4 +1,5 @@
 # This configuration terminates a CONNECT-UDP request and sends UDP payloads directly over UDP to the target.
+# The configured dynamic forward proxy enables DNS resolution at the proxy to suppot arbitrary target domain names.
 static_resources:
   listeners:
   - name: listener_0
@@ -40,12 +41,18 @@ static_resources:
                   connect_matcher:
                     {}
                 route:
-                  cluster: service_google
+                  cluster: dynamic_forward_proxy_cluster
                   upgrade_configs:
                   - upgrade_type: CONNECT-UDP
                     connect_config:
                       {}
           http_filters:
+          - name: envoy.filters.http.dynamic_forward_proxy
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+              dns_cache_config:
+                name: dynamic_forward_proxy_cache_config
+                dns_lookup_family: ALL
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -54,17 +61,12 @@ static_resources:
           upgrade_configs:
           - upgrade_type: CONNECT-UDP
   clusters:
-  - name: service_google
-    type: LOGICAL_DNS
-    # Comment out the following line to test on v6 networks
-    dns_lookup_family: V4_ONLY
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: service_google
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: www.google.com
-                port_value: 443
+  - name: dynamic_forward_proxy_cluster
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config:
+          name: dynamic_forward_proxy_cache_config
+          dns_lookup_family: ALL


### PR DESCRIPTION
Commit Message:
Enabling CONNECT-UDP support requires `allow_extended_connect` option set, which was missing in the existing config examples. I fixed this issue and also added another example config that utilizes the dynamic forward proxy filter for DNS resolution.
Additional Description:
Risk Level: Low, config only change.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A