### PR TITLE
deps: update the deprecation status of libcurl

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1003,7 +1003,7 @@ def _io_opencensus_cpp():
 
 def _com_github_curl():
     # The usage by AWS extensions common utilities is deprecated and will be removed by Q3 2024 after
-    # the deprecation period of 2 releases. Please DO NOT USE curl dependency for any new extensions.
+    # the deprecation period of 2 releases. Please DO NOT USE curl dependency for any new or existing extensions.
     # See https://github.com/envoyproxy/envoy/issues/11816 & https://github.com/envoyproxy/envoy/pull/30731.
     external_http_archive(
         name = "com_github_curl",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1002,7 +1002,7 @@ def _io_opencensus_cpp():
     )
 
 def _com_github_curl():
-    # Used by OpenCensus Zipkin exporter.
+    # The usage by AWS extensions common utilities is deprecated and will be removed soon after the deprecation period.
     external_http_archive(
         name = "com_github_curl",
         build_file_content = BUILD_ALL_CONTENT + """

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1002,7 +1002,9 @@ def _io_opencensus_cpp():
     )
 
 def _com_github_curl():
-    # The usage by AWS extensions common utilities is deprecated and will be removed soon after the deprecation period.
+    # The usage by AWS extensions common utilities is deprecated and will be removed by Q3 2024 after
+    # the deprecation period of 2 releases. Please DO NOT USE curl dependency for any new extensions.
+    # See https://github.com/envoyproxy/envoy/issues/11816 & https://github.com/envoyproxy/envoy/pull/30731.
     external_http_archive(
         name = "com_github_curl",
         build_file_content = BUILD_ALL_CONTENT + """

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1068,7 +1068,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "Apache-2.0",
         license_url = "https://github.com/census-instrumentation/opencensus-cpp/blob/{version}/LICENSE",
     ),
-    # This should be removed, see https://github.com/envoyproxy/envoy/issues/11816.
+    # This is under deprecation and will be removed soon, see https://github.com/envoyproxy/envoy/issues/11816.
     com_github_curl = dict(
         project_name = "curl",
         project_desc = "Library for transferring data with URLs",
@@ -1082,7 +1082,6 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.filters.http.aws_lambda",
             "envoy.filters.http.aws_request_signing",
             "envoy.grpc_credentials.aws_iam",
-            "envoy.tracers.opencensus",
         ],
         release_date = "2023-10-11",
         cpe = "cpe:2.3:a:haxx:libcurl:*",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1068,7 +1068,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "Apache-2.0",
         license_url = "https://github.com/census-instrumentation/opencensus-cpp/blob/{version}/LICENSE",
     ),
-    # This is under deprecation and will be removed soon, see https://github.com/envoyproxy/envoy/issues/11816.
+    # Curl usage is under deprecation and will be removed by Q3 2024 before v1.31 release in July-2024.
+    # See https://github.com/envoyproxy/envoy/issues/11816 & https://github.com/envoyproxy/envoy/pull/30731.
     com_github_curl = dict(
         project_name = "curl",
         project_desc = "Library for transferring data with URLs",


### PR DESCRIPTION
Commit Message: deps: update the deprecation status of libcurl
Additional Description:
Following the merge of https://github.com/envoyproxy/envoy/pull/29880 and https://github.com/envoyproxy/envoy/pull/30626 we can mark the curl usage as deprecated. Meanwhile bazel/repositories.bzl had stale info that OpenCensus tracer was still using libcurl. 

We can continue to keep the Issue https://github.com/envoyproxy/envoy/issues/11816 open until curl is removed entirely after the deprecation time (Probably for v1.31 release).

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
