### PR TITLE
aws: add tinyxml2 dependency

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -603,3 +603,19 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
 )
+
+envoy_cmake(
+    name = "tinyxml2",
+    cache_entries = {
+        "BUILD_SHARED_LIBS": "off",
+        "BUILD_STATIC_LIBS": "on",
+        "BUILD_TESTS": "off",
+        "CMAKE_CXX_COMPILER_FORCED": "on",
+        "CMAKE_INSTALL_LIBDIR": "lib",
+    },
+    lib_source = "@com_github_leethomason_tinyxml2//:all",
+    out_static_libs = select({
+        "//bazel:windows_x86_64": ["tinyxml2.lib"],
+        "//conditions:default": ["libtinyxml2.a"],
+    }),
+)

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -615,7 +615,7 @@ envoy_cmake(
     },
     lib_source = "@com_github_leethomason_tinyxml2//:all",
     out_static_libs = select({
-        "//bazel:windows_x86_64": ["tinyxml2.lib"],
         "//conditions:default": ["libtinyxml2.a"],
     }),
+    tags = ["skip_on_windows"],
 )

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -615,7 +615,7 @@ envoy_cmake(
     },
     lib_source = "@com_github_leethomason_tinyxml2//:all",
     linkopts = select({
-        "//bazel:windows_x86_64": ["-llibc"],
+        "//bazel:windows_x86_64": ["-lpthread"],
         "//conditions:default": [],
     }),
     out_static_libs = select({

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -614,8 +614,12 @@ envoy_cmake(
         "CMAKE_INSTALL_LIBDIR": "lib",
     },
     lib_source = "@com_github_leethomason_tinyxml2//:all",
+    linkopts = select({
+        "//bazel:windows_x86_64": ["-llibc"],
+        "//conditions:default": [],
+    }),
     out_static_libs = select({
+        "//bazel:windows_x86_64": ["tinyxml2.lib"],
         "//conditions:default": ["libtinyxml2.a"],
     }),
-    tags = ["skip_on_windows"],
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -299,6 +299,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_tencent_rapidjson()
     _com_github_nlohmann_json()
     _com_github_ncopa_suexec()
+    _com_github_leethomason_tinyxml2()
     _com_google_absl()
     _com_google_googletest()
     _com_google_protobuf()
@@ -756,6 +757,16 @@ def _com_github_nlohmann_json():
     native.bind(
         name = "json",
         actual = "@com_github_nlohmann_json//:json",
+    )
+
+def _com_github_leethomason_tinyxml2():
+    external_http_archive(
+        name = "com_github_leethomason_tinyxml2",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.bind(
+        name = "tinyxml2",
+        actual = "@envoy//bazel/foreign_cc:tinyxml2",
     )
 
 def _com_github_nodejs_http_parser():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -808,6 +808,23 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "MIT",
         license_url = "https://github.com/ncopa/su-exec/blob/{version}/LICENSE",
     ),
+    com_github_leethomason_tinyxml2 = dict(
+        project_name = "TinyXML-2",
+        project_desc = "Simple, small, efficient, C++ XML parser that can be easily integrated into other programs.",
+        project_url = "https://github.com/leethomason/tinyxml2",
+        version = "9.0.0",
+        sha256 = "cc2f1417c308b1f6acc54f88eb70771a0bf65f76282ce5c40e54cfe52952702c",
+        strip_prefix = "tinyxml2-{version}",
+        urls = ["https://github.com/leethomason/tinyxml2/archive/{version}.tar.gz"],
+        use_category = ["dataplane_ext"],
+        extensions = [
+            "envoy.filters.http.aws_lambda",
+            "envoy.filters.http.aws_request_signing",
+            "envoy.grpc_credentials.aws_iam",
+        ],
+        release_date = "2021-06-06",
+        cpe = "cpe:2.3:a:tinyxml2_project:tinyxml2:*",
+    ),
     com_google_googletest = dict(
         project_name = "Google Test",
         project_desc = "Google's C++ test framework",


### PR DESCRIPTION
**Commit Message:** aws: add tinyxml2 dependency
**Additional Description:** We would like to introduce tinyxml2 dependency into Envoy to parse the xml content. The example usecase is shown in one of the unmerged [PR 23408](https://github.com/envoyproxy/envoy/pull/23408/files#diff-3d45a55c8f415956866de60b357e7065f147e878e29b79ce3f086425affaa4b0R228). This external library let's us parse the `AssumeRoleWithWebIdentityResponse` provided by AWS STS service https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_Examples to fetch the AWS credentials for some of the AWS extensions such as AWS Lambda filter, AWS Request Signer filter etc.
**Risk Level:** -
**Testing:** NA
**Docs Changes:** NA
**Release Notes:** NA
**Platform Specific Features:** NA

----

The PR adds a new dependency on https://github.com/leethomason/tinyxml2. Here's the current criteria answers:


|Criteria|Answer|
|--------|-----------|
|Cloud Native Computing Foundation (CNCF) [approved license](https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist)| [Zlib](https://github.com/leethomason/tinyxml2/blob/master/LICENSE.txt) |
|Dependencies must not substantially increase the binary size unless they are optional (i.e. confined to specific extensions)| The dependency is only used in AWS extension and compiled libtinyxml2.a file is 185KB in size.  |
|No duplication of existing dependencies| I failed to find any existing xml parser in use within Envoy. If there is I would be open to reuse that. |
|Hosted on a git repository and the archive fetch must directly reference this repository. We will NOT support intermediate artifacts built by-hand located on GCS, S3, etc.| https://github.com/leethomason/tinyxml2 |
|CVE history appears reasonable, no pathological CVE arcs| so far 1 CVE related to tinyxml2 have been registered: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=tinyxml2 which seem to be due to improper use of the library |
|Code review (ideally PRs) before merge| PRs are reviewed before merge |
|Security vulnerability process exists, with contact details and reporting/disclosure process| No documented process can be found, I think raising a github issue to get the maintainer's attention seems to be the best possible way  |
|> 1 contributor responsible for a non-trivial number of commits| [107 Contributors](https://github.com/leethomason/tinyxml2/graphs/contributors) |
|Tests run in CI|Tests are run with [github actions](https://github.com/leethomason/tinyxml2/actions)|
|High test coverage (also static/dynamic analysis, fuzzing)|Good code coverage but no fuzzing|
|Envoy can obtain advanced notification of vulnerabilities or of security releases| Unsure if this is possible. There was only 1 CVE that was reported but even that was disputed for bad API usage reasons |
|Do other significant projects have shared fate by using this dependency?| https://github.com/aws/aws-sdk-cpp |
|Releases (with release notes)| release cut as [tags](https://github.com/leethomason/tinyxml2/tags) |
|Commits/releases in last 90 days| No. Last commit was in Jan 14, 2023 |


