### PR TITLE
Undeprecate global_downstream_max_connections key (#30620)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -2,6 +2,10 @@ date: Pending
 
 behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+- area: listener
+  change: |
+    undeprecated runtime key ``overload.global_downstream_max_connections`` until :ref:`downstream connections monitor
+    <envoy_v3_api_msg_extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig>` extension becomes stable.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/common/network/tcp_listener_impl.cc
+++ b/source/common/network/tcp_listener_impl.cc
@@ -25,14 +25,15 @@ bool TcpListenerImpl::rejectCxOverGlobalLimit() const {
   if (ignore_global_conn_limit_) {
     return false;
   }
-
+  // TODO(nezdolik): deprecate `overload.global_downstream_max_connections` key once
+  // downstream connections monitor extension is stable.
   if (track_global_cx_limit_in_overload_manager_) {
-    // Check if deprecated runtime flag `overload.global_downstream_max_connections` is configured
+    // Check if runtime flag `overload.global_downstream_max_connections` is configured
     // simultaneously with downstream connections monitor in overload manager.
     if (runtime_.threadsafeSnapshot()->get(GlobalMaxCxRuntimeKey)) {
       ENVOY_LOG_ONCE_MISC(
           warn,
-          "Global downstream connections limits is configured via deprecated runtime key {} and in "
+          "Global downstream connections limits is configured via runtime key {} and in "
           "{}. Using overload manager config.",
           GlobalMaxCxRuntimeKey,
           Server::OverloadProactiveResources::get().GlobalDownstreamMaxConnections);

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -801,15 +801,6 @@ void InstanceImpl::onRuntimeReady() {
       shutdown();
     });
   }
-
-  // TODO (nezdolik): Fully deprecate this runtime key in the next release.
-  if (runtime().snapshot().get(Network::TcpListenerImpl::GlobalMaxCxRuntimeKey)) {
-    ENVOY_LOG(warn,
-              "Usage of the deprecated runtime key {}, consider switching to "
-              "`envoy.resource_monitors.downstream_connections` instead."
-              "This runtime key will be removed in future.",
-              Network::TcpListenerImpl::GlobalMaxCxRuntimeKey);
-  }
 }
 
 void InstanceImpl::startWorkers() {
@@ -895,7 +886,8 @@ RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatch
 
   // If there is no global limit to the number of active connections, warn on startup.
   if (!overload_manager.getThreadLocalOverloadState().isResourceMonitorEnabled(
-          Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections)) {
+          Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections) &&
+      !instance.runtime().snapshot().get(Network::TcpListenerImpl::GlobalMaxCxRuntimeKey)) {
     ENVOY_LOG(warn, "There is no configured limit to the number of allowed active downstream "
                     "connections. Configure a "
                     "limit in `envoy.resource_monitors.downstream_connections` resource monitor.");

--- a/test/extensions/resource_monitors/downstream_connections/cx_limit_overload_integration_test.cc
+++ b/test/extensions/resource_monitors/downstream_connections/cx_limit_overload_integration_test.cc
@@ -104,7 +104,7 @@ TEST_F(GlobalDownstreamCxLimitIntegrationTest, GlobalLimitSetViaRuntimeKeyAndOve
   config_helper_.addRuntimeOverride("overload.global_downstream_max_connections", "3");
   initializeOverloadManager(2);
   const std::string log_line =
-      "Global downstream connections limits is configured via deprecated runtime key "
+      "Global downstream connections limits is configured via runtime key "
       "overload.global_downstream_max_connections and in "
       "envoy.resource_monitors.global_downstream_max_connections. Using overload manager "
       "config.";

--- a/test/integration/cx_limit_integration_test.cc
+++ b/test/integration/cx_limit_integration_test.cc
@@ -136,18 +136,6 @@ TEST_P(ConnectionLimitIntegrationTest, TestListenerLimit) {
   doTest(init_func, "downstream_cx_overflow");
 }
 
-TEST_P(ConnectionLimitIntegrationTest, TestDeprecationWarningForGlobalCxRuntimeLimit) {
-  std::function<void()> init_func = [this]() {
-    setGlobalLimit(4);
-    initialize();
-  };
-  const std::string log_line =
-      "Usage of the deprecated runtime key overload.global_downstream_max_connections, "
-      "consider switching to `envoy.resource_monitors.downstream_connections` instead."
-      "This runtime key will be removed in future.";
-  EXPECT_LOG_CONTAINS("warn", log_line, { init_func(); });
-}
-
 // TODO (nezdolik) move this test to overload manager test suite, once runtime key is fully
 // deprecated.
 TEST_P(ConnectionLimitIntegrationTest, TestEmptyGlobalCxRuntimeLimit) {


### PR DESCRIPTION
Backport for https://github.com/envoyproxy/envoy/pull/30620

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
