### PR TITLE
mobile: Part 3: Update JNI usages with JniHelper

### DIFF
--- a/mobile/library/common/jni/jni_helper.cc
+++ b/mobile/library/common/jni/jni_helper.cc
@@ -135,6 +135,22 @@ PrimitiveArrayCriticalUniquePtr JniHelper::getPrimitiveArrayCritical(jarray arra
   return result;
 }
 
+#define DEFINE_SET_ARRAY_REGION(JAVA_TYPE, JNI_ARRAY_TYPE, JNI_ELEMENT_TYPE)                       \
+  void JniHelper::set##JAVA_TYPE##ArrayRegion(JNI_ARRAY_TYPE array, jsize start, jsize length,     \
+                                              const JNI_ELEMENT_TYPE* buffer) {                    \
+    env_->Set##JAVA_TYPE##ArrayRegion(array, start, length, buffer);                               \
+    rethrowException();                                                                            \
+  }
+
+DEFINE_SET_ARRAY_REGION(Byte, jbyteArray, jbyte)
+DEFINE_SET_ARRAY_REGION(Char, jcharArray, jchar)
+DEFINE_SET_ARRAY_REGION(Short, jshortArray, jshort)
+DEFINE_SET_ARRAY_REGION(Int, jintArray, jint)
+DEFINE_SET_ARRAY_REGION(Long, jlongArray, jlong)
+DEFINE_SET_ARRAY_REGION(Float, jfloatArray, jfloat)
+DEFINE_SET_ARRAY_REGION(Double, jdoubleArray, jdouble)
+DEFINE_SET_ARRAY_REGION(Boolean, jbooleanArray, jboolean)
+
 #define DEFINE_CALL_METHOD(JAVA_TYPE, JNI_TYPE)                                                    \
   JNI_TYPE JniHelper::call##JAVA_TYPE##Method(jobject object, jmethodID method_id, ...) {          \
     va_list args;                                                                                  \

--- a/mobile/library/common/jni/jni_helper.h
+++ b/mobile/library/common/jni/jni_helper.h
@@ -262,6 +262,24 @@ public:
 
   PrimitiveArrayCriticalUniquePtr getPrimitiveArrayCritical(jarray array, jboolean* is_copy);
 
+  /**
+   * Sets a region of an `array` from a `buffer` with the specified `start` index and `length`.
+   *
+   * https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#setprimitivetypearrayregion-routines
+   */
+#define DECLARE_SET_ARRAY_REGION(JAVA_TYPE, JNI_ARRAY_TYPE, JNI_ELEMENT_TYPE)                      \
+  void set##JAVA_TYPE##ArrayRegion(JNI_ARRAY_TYPE array, jsize start, jsize length,                \
+                                   const JNI_ELEMENT_TYPE* buffer);
+
+  DECLARE_SET_ARRAY_REGION(Byte, jbyteArray, jbyte)
+  DECLARE_SET_ARRAY_REGION(Char, jcharArray, jchar)
+  DECLARE_SET_ARRAY_REGION(Short, jshortArray, jshort)
+  DECLARE_SET_ARRAY_REGION(Int, jintArray, jint)
+  DECLARE_SET_ARRAY_REGION(Long, jlongArray, jlong)
+  DECLARE_SET_ARRAY_REGION(Float, jfloatArray, jfloat)
+  DECLARE_SET_ARRAY_REGION(Double, jdoubleArray, jdouble)
+  DECLARE_SET_ARRAY_REGION(Boolean, jbooleanArray, jboolean)
+
 /** A macro to create `Call<Type>Method` helper function. */
 #define DECLARE_CALL_METHOD(JAVA_TYPE, JNI_TYPE)                                                   \
   JNI_TYPE call##JAVA_TYPE##Method(jobject object, jmethodID method_id, ...);

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -280,11 +280,11 @@ static void* jvm_on_headers(const char* method, const Envoy::Types::ManagedEnvoy
   jobject j_status = jni_helper.getEnv()->NewObject(jcls_int.get(), jmid_intInit, 0);
   // Set status to "0" (FilterHeadersStatus::Continue). Signal that the intent
   // is to continue the iteration of the filter chain.
-  jni_helper.getEnv()->SetObjectArrayElement(noopResult, 0, j_status);
+  jni_helper.setObjectArrayElement(noopResult, 0, j_status);
 
   // Since the "on headers" call threw an exception set input headers as output headers.
-  jni_helper.getEnv()->SetObjectArrayElement(
-      noopResult, 1, Envoy::JNI::ToJavaArrayOfObjectArray(jni_helper, headers));
+  jni_helper.setObjectArrayElement(noopResult, 1,
+                                   Envoy::JNI::ToJavaArrayOfObjectArray(jni_helper, headers));
 
   return noopResult;
 }

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -270,8 +270,8 @@ jobjectArray ToJavaArrayOfObjectArray(JniHelper& jni_helper,
     jbyteArray key = native_data_to_array(jni_helper, map.get().entries[i].key);
     jbyteArray value = native_data_to_array(jni_helper, map.get().entries[i].value);
 
-    jni_helper.getEnv()->SetObjectArrayElement(javaArray, 2 * i, key);
-    jni_helper.getEnv()->SetObjectArrayElement(javaArray, 2 * i + 1, value);
+    jni_helper.setObjectArrayElement(javaArray, 2 * i, key);
+    jni_helper.setObjectArrayElement(javaArray, 2 * i + 1, value);
   }
 
   return javaArray;
@@ -284,7 +284,7 @@ jobjectArray ToJavaArrayOfByteArray(JniHelper& jni_helper, const std::vector<std
   for (size_t i = 0; i < v.size(); ++i) {
     jbyteArray byte_array =
         ToJavaByteArray(jni_helper, reinterpret_cast<const uint8_t*>(v[i].data()), v[i].length());
-    jni_helper.getEnv()->SetObjectArrayElement(joa, i, byte_array);
+    jni_helper.setObjectArrayElement(joa, i, byte_array);
   }
   return joa;
 }
@@ -292,7 +292,7 @@ jobjectArray ToJavaArrayOfByteArray(JniHelper& jni_helper, const std::vector<std
 jbyteArray ToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes, size_t len) {
   jbyteArray byte_array = jni_helper.getEnv()->NewByteArray(len);
   const jbyte* jbytes = reinterpret_cast<const jbyte*>(bytes);
-  jni_helper.getEnv()->SetByteArrayRegion(byte_array, /*start=*/0, len, jbytes);
+  jni_helper.setByteArrayRegion(byte_array, /*start=*/0, len, jbytes);
   return byte_array;
 }
 

--- a/mobile/test/common/jni/jni_helper_test.cc
+++ b/mobile/test/common/jni/jni_helper_test.cc
@@ -103,6 +103,24 @@ Java_io_envoyproxy_envoymobile_jni_JniHelperTest_setObjectArrayElement(JNIEnv* e
   jni_helper.setObjectArrayElement(array, index, value);
 }
 
+#define DEFINE_JNI_SET_ARRAY_REGION(JAVA_TYPE, JNI_TYPE)                                           \
+  extern "C" JNIEXPORT void JNICALL                                                                \
+      Java_io_envoyproxy_envoymobile_jni_JniHelperTest_set##JAVA_TYPE##ArrayRegion(                \
+          JNIEnv* env, jclass, JNI_TYPE array, jsize start, jsize length, JNI_TYPE buffer) {       \
+    Envoy::JNI::JniHelper jni_helper(env);                                                         \
+    auto c_buffer = jni_helper.get##JAVA_TYPE##ArrayElements(buffer, nullptr);                     \
+    env->Set##JAVA_TYPE##ArrayRegion(array, start, length, c_buffer.get());                        \
+  }
+
+DEFINE_JNI_SET_ARRAY_REGION(Byte, jbyteArray)
+DEFINE_JNI_SET_ARRAY_REGION(Char, jcharArray)
+DEFINE_JNI_SET_ARRAY_REGION(Short, jshortArray)
+DEFINE_JNI_SET_ARRAY_REGION(Int, jintArray)
+DEFINE_JNI_SET_ARRAY_REGION(Long, jlongArray)
+DEFINE_JNI_SET_ARRAY_REGION(Float, jfloatArray)
+DEFINE_JNI_SET_ARRAY_REGION(Double, jdoubleArray)
+DEFINE_JNI_SET_ARRAY_REGION(Boolean, jbooleanArray)
+
 #define DEFINE_JNI_CALL_METHOD(JAVA_TYPE, JNI_TYPE)                                                \
   extern "C" JNIEXPORT JNI_TYPE JNICALL                                                            \
       Java_io_envoyproxy_envoymobile_jni_JniHelperTest_call##JAVA_TYPE##Method(                    \

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/JniHelperTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/JniHelperTest.java
@@ -33,6 +33,18 @@ public class JniHelperTest {
                                                Object initialElement);
   public static native Object getObjectArrayElement(Object[] array, int index);
   public static native void setObjectArrayElement(Object[] array, int index, Object value);
+  public static native void setByteArrayRegion(byte[] array, int start, int index, byte[] buffer);
+  public static native void setCharArrayRegion(char[] array, int start, int index, char[] buffer);
+  public static native void setShortArrayRegion(short[] array, int start, int index,
+                                                short[] buffer);
+  public static native void setIntArrayRegion(int[] array, int start, int index, int[] buffer);
+  public static native void setLongArrayRegion(long[] array, int start, int index, long[] buffer);
+  public static native void setFloatArrayRegion(float[] array, int start, int index,
+                                                float[] buffer);
+  public static native void setDoubleArrayRegion(double[] array, int start, int index,
+                                                 double[] buffer);
+  public static native void setBooleanArrayRegion(boolean[] array, int start, int index,
+                                                  boolean[] buffer);
   public static native byte callByteMethod(Class<?> clazz, Object instance, String name,
                                            String signature);
   public static native char callCharMethod(Class<?> clazz, Object instance, String name,
@@ -185,6 +197,70 @@ public class JniHelperTest {
     Object[] array = new Object[] {1, 2, 3};
     setObjectArrayElement(array, 1, 200);
     assertThat(array).isEqualTo(new Object[] {1, 200, 3});
+  }
+
+  @Test
+  public void testSetByteArrayRegion() {
+    byte[] array = new byte[] {1, 0, 0, 0, 5};
+    byte[] buffer = new byte[] {2, 3, 4};
+    setByteArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new byte[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testSetCharArrayRegion() {
+    char[] array = new char[] {'a', ' ', ' ', ' ', 'e'};
+    char[] buffer = new char[] {'b', 'c', 'd'};
+    setCharArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new char[] {'a', 'b', 'c', 'd', 'e'});
+  }
+
+  @Test
+  public void testSetShortArrayRegion() {
+    short[] array = new short[] {1, 0, 0, 0, 5};
+    short[] buffer = new short[] {2, 3, 4};
+    setShortArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new short[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testSetIntArrayRegion() {
+    int[] array = new int[] {1, 0, 0, 0, 5};
+    int[] buffer = new int[] {2, 3, 4};
+    setIntArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new int[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testSetLongArrayRegion() {
+    long[] array = new long[] {1, 0, 0, 0, 5};
+    long[] buffer = new long[] {2, 3, 4};
+    setLongArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new long[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testSetFloatArrayRegion() {
+    float[] array = new float[] {1, 0, 0, 0, 5};
+    float[] buffer = new float[] {2, 3, 4};
+    setFloatArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new float[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testSetDoubleArrayRegion() {
+    double[] array = new double[] {1, 0, 0, 0, 5};
+    double[] buffer = new double[] {2, 3, 4};
+    setDoubleArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new double[] {1, 2, 3, 4, 5});
+  }
+
+  @Test
+  public void testSetBooleanArrayRegion() {
+    boolean[] array = new boolean[] {true, false, false, false, true};
+    boolean[] buffer = new boolean[] {true, true, true};
+    setBooleanArrayRegion(array, 1, 3, buffer);
+    assertThat(array).isEqualTo(new boolean[] {true, true, true, true, true});
   }
 
   @Test


### PR DESCRIPTION
This updates the following methods:
- `SetObjectArrayElement`
- `SetByteArrayRegion`

This PR also adds missing `Set<Primitive>ArrayRegion` methods into `JniHelper`.

Risk Level: low (refactoring)
Testing: unit and integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile