### PR TITLE
Reflection-based deterministic message hashing

### DIFF
--- a/source/common/protobuf/BUILD
+++ b/source/common/protobuf/BUILD
@@ -200,12 +200,24 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "deterministic_hash_lib",
+    srcs = ["deterministic_hash.cc"],
+    hdrs = ["deterministic_hash.h"],
+    deps = [
+        ":protobuf",
+        "//source/common/common:assert_lib",
+        "//source/common/common:hash_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "utility_lib",
     srcs = ["utility.cc"],
     external_deps = [
         "protobuf",
     ],
     deps = [
+        ":deterministic_hash_lib",
         ":message_validator_lib",
         ":protobuf",
         ":utility_lib_header",

--- a/source/common/protobuf/deterministic_hash.cc
+++ b/source/common/protobuf/deterministic_hash.cc
@@ -1,0 +1,195 @@
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+#include "source/common/protobuf/deterministic_hash.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/common/hash.h"
+
+namespace Envoy {
+namespace DeterministicProtoHash {
+namespace {
+#define REFLECTION_FOR_EACH(get_type, hash_type)                                                   \
+  if (field->is_repeated()) {                                                                      \
+    for (int i = 0; i < reflection->FieldSize(message, field); i++) {                              \
+      hash_type(reflection->GetRepeated##get_type(message, field, i));                             \
+    }                                                                                              \
+  } else {                                                                                         \
+    hash_type(reflection->Get##get_type(message, field));                                          \
+  }
+
+#define MAP_SORT_BY(get_type)                                                                      \
+  do {                                                                                             \
+    std::sort(                                                                                     \
+        map.begin(), map.end(),                                                                    \
+        [&entry_reflection, &key_field](const Protobuf::Message& a, const Protobuf::Message& b) {  \
+          return entry_reflection->Get##get_type(a, key_field) <                                   \
+                 entry_reflection->Get##get_type(b, key_field);                                    \
+        });                                                                                        \
+  } while (0)
+
+#define HASH_FIXED(v)                                                                              \
+  do {                                                                                             \
+    auto q = v;                                                                                    \
+    seed =                                                                                         \
+        HashUtil::xxHash64(absl::string_view{reinterpret_cast<const char*>(&q), sizeof(q)}, seed); \
+  } while (0)
+
+#define HASH_STRING(v)                                                                             \
+  do {                                                                                             \
+    seed = HashUtil::xxHash64(v, seed);                                                            \
+  } while (0)
+
+#define HASH_MESSAGE(v)                                                                            \
+  do {                                                                                             \
+    seed = reflectionHashMessage(reflection->GetMessage(message, field), seed);                    \
+  } while (0)
+
+uint64_t reflectionHashMessage(const Protobuf::Message& message, uint64_t seed = 0);
+uint64_t reflectionHashField(const Protobuf::Message& message,
+                             const Protobuf::FieldDescriptor* field, uint64_t seed);
+
+// To make a map serialize deterministically we need to force the order.
+// Here we're going to sort the keys into numerical order for number keys,
+// or lexigraphical order for strings, and then hash them in that order.
+uint64_t reflectionHashMapField(const Protobuf::Message& message,
+                                const Protobuf::FieldDescriptor* field, uint64_t seed) {
+  using Protobuf::FieldDescriptor;
+  const auto reflection = message.GetReflection();
+  auto entries = reflection->GetRepeatedFieldRef<Protobuf::Message>(message, field);
+  std::vector<std::reference_wrapper<const Protobuf::Message>> map(entries.begin(), entries.end());
+  auto entry_reflection = map.begin()->get().GetReflection();
+  auto entry_descriptor = map.begin()->get().GetDescriptor();
+  const FieldDescriptor* key_field = entry_descriptor->map_key();
+  const FieldDescriptor* value_field = entry_descriptor->map_value();
+  HASH_FIXED(key_field->number());
+  switch (key_field->cpp_type()) {
+  case FieldDescriptor::CPPTYPE_INT32:
+    MAP_SORT_BY(Int32);
+    break;
+  case FieldDescriptor::CPPTYPE_UINT32:
+    MAP_SORT_BY(UInt32);
+    break;
+  case FieldDescriptor::CPPTYPE_INT64:
+    MAP_SORT_BY(Int64);
+    break;
+  case FieldDescriptor::CPPTYPE_UINT64:
+    MAP_SORT_BY(UInt64);
+    break;
+  case FieldDescriptor::CPPTYPE_DOUBLE:
+    MAP_SORT_BY(Double);
+    break;
+  case FieldDescriptor::CPPTYPE_FLOAT:
+    MAP_SORT_BY(Float);
+    break;
+  case FieldDescriptor::CPPTYPE_STRING:
+    // TODO: use StringReference
+    MAP_SORT_BY(String);
+    break;
+  case FieldDescriptor::CPPTYPE_BOOL:
+  case FieldDescriptor::CPPTYPE_ENUM:
+  case FieldDescriptor::CPPTYPE_MESSAGE:
+    IS_ENVOY_BUG("invalid map key type");
+  }
+  for (const auto& entry : map) {
+    seed = reflectionHashField(entry, key_field, seed);
+    seed = reflectionHashField(entry, value_field, seed);
+  }
+  return seed;
+}
+
+uint64_t reflectionHashField(const Protobuf::Message& message,
+                             const Protobuf::FieldDescriptor* field, uint64_t seed) {
+  using Protobuf::FieldDescriptor;
+  std::cerr << "field = " << field->DebugString() << std::endl;
+  const auto reflection = message.GetReflection();
+  switch (field->cpp_type()) {
+  case FieldDescriptor::CPPTYPE_INT32:
+    REFLECTION_FOR_EACH(Int32, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_UINT32:
+    REFLECTION_FOR_EACH(UInt32, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_INT64:
+    REFLECTION_FOR_EACH(Int64, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_UINT64:
+    REFLECTION_FOR_EACH(UInt64, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_DOUBLE:
+    REFLECTION_FOR_EACH(Double, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_FLOAT:
+    REFLECTION_FOR_EACH(Float, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_BOOL:
+    REFLECTION_FOR_EACH(Bool, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_ENUM:
+    REFLECTION_FOR_EACH(EnumValue, HASH_FIXED);
+    break;
+  case FieldDescriptor::CPPTYPE_STRING:
+    // TODO: use StringReference
+    REFLECTION_FOR_EACH(String, HASH_STRING);
+    break;
+  case FieldDescriptor::CPPTYPE_MESSAGE:
+    if (field->is_map()) {
+      return reflectionHashMapField(message, field, seed);
+    }
+    REFLECTION_FOR_EACH(Message, HASH_MESSAGE);
+    break;
+  }
+  return seed;
+}
+
+absl::string_view typeUrlToDescriptorFullName(absl::string_view url) {
+  const size_t pos = url.rfind('/');
+  if (pos != absl::string_view::npos) {
+    return url.substr(pos + 1);
+  }
+  return url;
+}
+
+std::unique_ptr<Protobuf::Message> unpackAnyForReflection(const ProtobufWkt::Any& any) {
+  const Protobuf::Descriptor* descriptor =
+      Protobuf::DescriptorPool::generated_pool()->FindMessageTypeByName(
+          typeUrlToDescriptorFullName(any.type_url()));
+  if (descriptor == nullptr) {
+    return nullptr;
+  }
+  const Protobuf::Message* prototype =
+      Protobuf::MessageFactory::generated_factory()->GetPrototype(descriptor);
+  auto msg = std::unique_ptr<Protobuf::Message>(prototype->New());
+  any.UnpackTo(msg.get());
+  return msg;
+}
+
+// This is intentionally ignoring unknown fields.
+uint64_t reflectionHashMessage(const Protobuf::Message& message, uint64_t seed) {
+  using Protobuf::FieldDescriptor;
+  std::string scratch;
+  const auto reflection = message.GetReflection();
+  const auto descriptor = message.GetDescriptor();
+  if (descriptor->well_known_type() == Protobuf::Descriptor::WELLKNOWNTYPE_ANY) {
+    const ProtobufWkt::Any* any = Protobuf::DynamicCastToGenerated<ProtobufWkt::Any>(&message);
+    auto submsg = unpackAnyForReflection(*any);
+    if (submsg == nullptr) {
+      // If we wanted to handle unknown types in Any, this is where we'd have to do it.
+      return seed;
+    }
+    HASH_STRING(any->type_url());
+    return reflectionHashMessage(*submsg, seed);
+  }
+  std::vector<const FieldDescriptor*> fields;
+  reflection->ListFields(message, &fields);
+  // If we wanted to handle unknown fields, we'd need to also GetUnknownFields here.
+  for (const auto field : fields) {
+    seed = reflectionHashField(message, field, seed);
+  }
+  return seed;
+}
+} // namespace
+
+uint64_t hash(const Protobuf::Message& message) { return reflectionHashMessage(message, 0); }
+
+} // namespace DeterministicProtoHash
+} // namespace Envoy
+#endif

--- a/source/common/protobuf/deterministic_hash.h
+++ b/source/common/protobuf/deterministic_hash.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "source/common/protobuf/protobuf.h"
+
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
+namespace Envoy {
+namespace DeterministicProtoHash {
+uint64_t hash(const Protobuf::Message& message);
+}
+} // namespace Envoy
+#endif

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -10,6 +10,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/documentation_url.h"
 #include "source/common/common/fmt.h"
+#include "source/common/protobuf/deterministic_hash.h"
 #include "source/common/protobuf/message_validator_impl.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/visitor.h"
@@ -137,22 +138,11 @@ void ProtoExceptionUtil::throwProtoValidationException(const std::string& valida
 }
 
 size_t MessageUtil::hash(const Protobuf::Message& message) {
-  std::string text_format;
-
 #if defined(ENVOY_ENABLE_FULL_PROTOS)
-  {
-    Protobuf::TextFormat::Printer printer;
-    printer.SetExpandAny(true);
-    printer.SetUseFieldNumber(true);
-    printer.SetSingleLineMode(true);
-    printer.SetHideUnknownFields(true);
-    printer.PrintToString(message, &text_format);
-  }
+  return DeterministicProtoHash::hash(message);
 #else
-  absl::StrAppend(&text_format, message.SerializeAsString());
+  return HashUtil::xxHash64(message.SerializeAsString());
 #endif
-
-  return HashUtil::xxHash64(text_format);
 }
 
 #if !defined(ENVOY_ENABLE_FULL_PROTOS)

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -175,6 +175,12 @@ TEST_F(ProtobufUtilityTest, MessageUtilHash) {
   ProtobufWkt::Struct s;
   (*s.mutable_fields())["ab"].set_string_value("fgh");
   (*s.mutable_fields())["cde"].set_string_value("ij");
+  ProtobufWkt::Struct s2;
+  (*s2.mutable_fields())["ab"].set_string_value("ij");
+  (*s2.mutable_fields())["cde"].set_string_value("fgh");
+  ProtobufWkt::Struct s3;
+  (*s3.mutable_fields())["ac"].set_string_value("fgh");
+  (*s3.mutable_fields())["cdb"].set_string_value("ij");
 
   ProtobufWkt::Any a1;
   a1.PackFrom(s);
@@ -184,10 +190,19 @@ TEST_F(ProtobufUtilityTest, MessageUtilHash) {
   a2.set_value(Base64::decode("CgsKA2NkZRIEGgJpagoLCgJhYhIFGgNmZ2g="));
   ProtobufWkt::Any a3 = a1;
   a3.set_value(Base64::decode("CgsKAmFiEgUaA2ZnaAoLCgNjZGUSBBoCaWo="));
+  ProtobufWkt::Any a4, a5;
+  a4.PackFrom(s2);
+  a5.PackFrom(s3);
 
   EXPECT_EQ(MessageUtil::hash(a1), MessageUtil::hash(a2));
   EXPECT_EQ(MessageUtil::hash(a2), MessageUtil::hash(a3));
   EXPECT_NE(0, MessageUtil::hash(a1));
+  // Same keys and values but with the values in a different order should not have
+  // the same hash.
+  EXPECT_NE(MessageUtil::hash(a1), MessageUtil::hash(a4));
+  // Different keys with the values in the same order should not have the same hash.
+  EXPECT_NE(MessageUtil::hash(a1), MessageUtil::hash(a5));
+  // Struct without 'any' around it should not hash the same as struct inside 'any'.
   EXPECT_NE(MessageUtil::hash(s), MessageUtil::hash(a1));
 }
 

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -384,7 +384,9 @@ class FormatChecker:
 
     def allow_listed_for_unpack_to(self, file_path):
         return file_path.startswith("./test") or file_path in [
-            "./source/common/protobuf/utility.cc", "./source/common/protobuf/utility.h"
+            "./source/common/protobuf/deterministic_hash.cc",
+            "./source/common/protobuf/utility.cc",
+            "./source/common/protobuf/utility.h",
         ]
 
     def allow_listed_for_raw_try(self, file_path):


### PR DESCRIPTION
Commit Message: Reflection-based deterministic message hashing
Additional Description: Comparing config used to be done with "deterministic" serialization and a hash of that, but it turned out deterministic serialization was not in fact deterministic enough (`Any` messages could contain reordered maps or even other fields). The recommendation in protobuf docs is "[if you want a deterministic order do it yourself](https://github.com/protocolbuffers/protobuf/blob/a1bb147e96b6f74db6cdf3c3fcb00492472dbbfa/src/google/protobuf/io/coded_stream.h#L834-L846)". (Note that the linked comment also suggests that SetSerializationDeterministic *should* work for our purposes here, but https://github.com/protocolbuffers/protobuf/issues/5731 is the relevant unaddressed bug about Any fields.)

The prior method of achieving determinism by expanding Any via `TextFormat` serialization is slow enough that it shows up on performance graphs as a significant cost (about 1/4 of our total startup time).
![image](https://github.com/envoyproxy/envoy/assets/1923229/44d04e36-d907-4335-bcf8-65b655b26e98)

This change is quite a lot of code, but should give us a deterministic hash with a much faster runtime than transforming to and then hashing a human-readable string.

Risk Level: Maybe a little? If it's broken it might cause config updates to not apply.
Testing: Added some extra checks to the existing test case. May merit a bit more specific testing.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
