### PR TITLE
mobile: Part 4: Update JNI usages with JniHelper

### DIFF
--- a/mobile/library/common/jni/android_jni_utility.cc
+++ b/mobile/library/common/jni/android_jni_utility.cc
@@ -22,7 +22,7 @@ bool is_cleartext_permitted(absl::string_view hostname) {
       Envoy::JNI::native_data_to_string(jni_helper, host);
   jclass jcls_AndroidNetworkLibrary =
       Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
-  jmethodID jmid_isCleartextTrafficPermitted = jni_helper.getEnv()->GetStaticMethodID(
+  jmethodID jmid_isCleartextTrafficPermitted = jni_helper.getStaticMethodId(
       jcls_AndroidNetworkLibrary, "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
   jboolean result = jni_helper.callStaticBooleanMethod(
       jcls_AndroidNetworkLibrary, jmid_isCleartextTrafficPermitted, java_host.get());
@@ -40,7 +40,7 @@ void tag_socket(int ifd, int uid, int tag) {
   jclass jcls_AndroidNetworkLibrary =
       Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
   jmethodID jmid_tagSocket =
-      jni_helper.getEnv()->GetStaticMethodID(jcls_AndroidNetworkLibrary, "tagSocket", "(III)V");
+      jni_helper.getStaticMethodId(jcls_AndroidNetworkLibrary, "tagSocket", "(III)V");
   jni_helper.callStaticVoidMethod(jcls_AndroidNetworkLibrary, jmid_tagSocket, ifd, uid, tag);
 #else
   UNREFERENCED_PARAMETER(ifd);

--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -77,7 +77,7 @@ jobject call_jvm_verify_x509_cert_chain(Envoy::JNI::JniHelper& jni_helper,
   jni_log("[Envoy]", "jvm_verify_x509_cert_chain");
   jclass jcls_AndroidNetworkLibrary =
       Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
-  jmethodID jmid_verifyServerCertificates = jni_helper.getEnv()->GetStaticMethodID(
+  jmethodID jmid_verifyServerCertificates = jni_helper.getStaticMethodId(
       jcls_AndroidNetworkLibrary, "verifyServerCertificates",
       "([[B[B[B)Lio/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult;");
   Envoy::JNI::Exception::checkAndClear("call_jvm_verify_x509_cert_chain:GetStaticMethodID");

--- a/mobile/library/common/jni/jni_helper.cc
+++ b/mobile/library/common/jni/jni_helper.cc
@@ -115,13 +115,6 @@ DEFINE_GET_ARRAY_ELEMENTS(Float, jfloatArray, jfloat)
 DEFINE_GET_ARRAY_ELEMENTS(Double, jdoubleArray, jdouble)
 DEFINE_GET_ARRAY_ELEMENTS(Boolean, jbooleanArray, jboolean)
 
-LocalRefUniquePtr<jobject> JniHelper::getObjectArrayElement(jobjectArray array, jsize index) {
-  LocalRefUniquePtr<jobject> result(env_->GetObjectArrayElement(array, index),
-                                    LocalRefDeleter(env_));
-  rethrowException();
-  return result;
-}
-
 void JniHelper::setObjectArrayElement(jobjectArray array, jsize index, jobject value) {
   env_->SetObjectArrayElement(array, index, value);
   rethrowException();

--- a/mobile/library/common/jni/jni_helper.h
+++ b/mobile/library/common/jni/jni_helper.h
@@ -251,7 +251,13 @@ public:
    *
    * https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#getobjectarrayelement
    */
-  LocalRefUniquePtr<jobject> getObjectArrayElement(jobjectArray array, jsize index);
+  template <typename T = jobject>
+  LocalRefUniquePtr<T> getObjectArrayElement(jobjectArray array, jsize index) {
+    LocalRefUniquePtr<T> result(static_cast<T>(env_->GetObjectArrayElement(array, index)),
+                                LocalRefDeleter(env_));
+    rethrowException();
+    return result;
+  }
 
   /**
    * Sets an element of a given `array` with the specified `index.

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -1448,8 +1448,8 @@ static void jvm_add_test_root_certificate(const uint8_t* cert, size_t len) {
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
   jclass jcls_AndroidNetworkLibrary =
       Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
-  jmethodID jmid_addTestRootCertificate = jni_helper.getEnv()->GetStaticMethodID(
-      jcls_AndroidNetworkLibrary, "addTestRootCertificate", "([B)V");
+  jmethodID jmid_addTestRootCertificate =
+      jni_helper.getStaticMethodId(jcls_AndroidNetworkLibrary, "addTestRootCertificate", "([B)V");
 
   jbyteArray cert_array = Envoy::JNI::ToJavaByteArray(jni_helper, cert, len);
   jni_helper.callStaticVoidMethod(jcls_AndroidNetworkLibrary, jmid_addTestRootCertificate,
@@ -1463,8 +1463,8 @@ static void jvm_clear_test_root_certificate() {
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
   jclass jcls_AndroidNetworkLibrary =
       Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
-  jmethodID jmid_clearTestRootCertificates = jni_helper.getEnv()->GetStaticMethodID(
-      jcls_AndroidNetworkLibrary, "clearTestRootCertificates", "()V");
+  jmethodID jmid_clearTestRootCertificates =
+      jni_helper.getStaticMethodId(jcls_AndroidNetworkLibrary, "clearTestRootCertificates", "()V");
 
   jni_helper.callStaticVoidMethod(jcls_AndroidNetworkLibrary, jmid_clearTestRootCertificates);
   jni_helper.getEnv()->DeleteLocalRef(jcls_AndroidNetworkLibrary);


### PR DESCRIPTION
This updates the following JNI methods:
- `Get<Type>ArrayElements`
- `GetObjectArrayElement`
- `GetStaticMethodID`

This also updates `GetObjectArrayElement` to be a template method that does an automatic casting to make the API easier to use, especially for converting `jobject` into a different type since that use case is quite common in the codebase.

Risk Level: low (refactoring)
Testing: unit and integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
