### PR TITLE
filters: allow envoy filters to be created as exception free

### DIFF
--- a/contrib/checksum/filters/http/test/config_test.cc
+++ b/contrib/checksum/filters/http/test/config_test.cc
@@ -17,7 +17,8 @@ TEST(ChecksumFilterConfigTest, ChecksumFilter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ChecksumFilterFactory factory;
   envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig proto_config;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/contrib/dynamo/filters/http/test/config_test.cc
+++ b/contrib/dynamo/filters/http/test/config_test.cc
@@ -18,7 +18,8 @@ TEST(DynamoFilterConfigTest, DynamoFilter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   DynamoFilterConfig factory;
   envoy::extensions::filters::http::dynamo::v3::Dynamo proto_config;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/contrib/golang/filters/http/test/config_test.cc
+++ b/contrib/golang/filters/http/test/config_test.cc
@@ -28,8 +28,12 @@ std::string genSoPath(std::string name) {
 TEST(GolangFilterConfigTest, InvalidateEmptyConfig) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      GolangFilterConfig().createFilterFactoryFromProto(
-          envoy::extensions::filters::http::golang::v3alpha::Config(), "stats", context),
+      ASSERT_TRUE(
+          GolangFilterConfig()
+              .createFilterFactoryFromProto(
+                  envoy::extensions::filters::http::golang::v3alpha::Config(), "stats", context)
+              .status()
+              .ok()),
       Envoy::ProtoValidationException,
       "ConfigValidationError.LibraryId: value length must be at least 1 characters");
 }
@@ -54,7 +58,8 @@ TEST(GolangFilterConfigTest, GolangFilterWithValidConfig) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GolangFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   EXPECT_CALL(filter_callback, addAccessLogHandler(_));
@@ -77,7 +82,8 @@ TEST(GolangFilterConfigTest, GolangFilterWithNilPluginConfig) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GolangFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   EXPECT_CALL(filter_callback, addAccessLogHandler(_));

--- a/contrib/golang/filters/http/test/config_test.cc
+++ b/contrib/golang/filters/http/test/config_test.cc
@@ -28,12 +28,11 @@ std::string genSoPath(std::string name) {
 TEST(GolangFilterConfigTest, InvalidateEmptyConfig) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      ASSERT_TRUE(
-          GolangFilterConfig()
-              .createFilterFactoryFromProto(
-                  envoy::extensions::filters::http::golang::v3alpha::Config(), "stats", context)
-              .status()
-              .ok()),
+      GolangFilterConfig()
+          .createFilterFactoryFromProto(envoy::extensions::filters::http::golang::v3alpha::Config(),
+                                        "stats", context)
+          .status()
+          .IgnoreError(),
       Envoy::ProtoValidationException,
       "ConfigValidationError.LibraryId: value length must be at least 1 characters");
 }

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -65,8 +65,8 @@ public:
   RetrieveDynamicMetadataFilterConfig()
       : Extensions::HttpFilters::Common::EmptyHttpFilterConfig("validate-dynamic-metadata") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamEncoderFilter(std::make_shared<::Envoy::RetrieveDynamicMetadataFilter>());
     };

--- a/contrib/squash/filters/http/test/config_test.cc
+++ b/contrib/squash/filters/http/test/config_test.cc
@@ -30,7 +30,8 @@ TEST(SquashFilterConfigFactoryTest, SquashFilterCorrectYaml) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   context.cluster_manager_.initializeClusters({"fake_cluster"}, {});
   SquashFilterConfigFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -47,7 +47,8 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
   EXPECT_CALL(context, api());
   EXPECT_CALL(context, initManager()).Times(2);
   EXPECT_CALL(context, getTransportSocketFactoryContext());
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -76,8 +77,10 @@ validity_url: "/.sxg/validity.msg"
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException, exception_message);
+  EXPECT_THROW_WITH_MESSAGE(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, exception_message);
 }
 
 } // namespace

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -78,8 +78,7 @@ validity_url: "/.sxg/validity.msg"
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
   EXPECT_THROW_WITH_MESSAGE(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, exception_message);
 }
 

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -279,9 +279,10 @@ public:
    * configuration.
    * @param stat_prefix prefix for stat logging
    * @param context supplies the filter's context.
-   * @return Http::FilterFactoryCb the factory creation function.
+   * @return  absl::StatusOr<Http::FilterFactoryCb> the factory creation function or an error if
+   * creation fails.
    */
-  virtual Http::FilterFactoryCb
+  virtual absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
                                Server::Configuration::FactoryContext& context) PURE;
 
@@ -316,7 +317,7 @@ public:
    * @param context supplies the filter's context.
    * @return Http::FilterFactoryCb the factory creation function.
    */
-  virtual Http::FilterFactoryCb
+  virtual absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
                                Server::Configuration::UpstreamFactoryContext& context) PURE;
 };

--- a/mobile/test/common/http/filters/assertion/assertion_filter_test.cc
+++ b/mobile/test/common/http/filters/assertion/assertion_filter_test.cc
@@ -549,7 +549,8 @@ match_config:
 
   TestUtility::loadFromYamlAndValidate(config_str, proto_config);
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "test", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "test", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/source/common/http/match_delegate/config.cc
+++ b/source/common/http/match_delegate/config.cc
@@ -280,7 +280,11 @@ Envoy::Http::FilterFactoryCb MatchDelegateConfig::createFilterFactoryFromProtoTy
 
   auto message = Config::Utility::translateAnyToFactoryConfig(
       proto_config.extension_config().typed_config(), context.messageValidationVisitor(), factory);
-  auto filter_factory = factory.createFilterFactoryFromProto(*message, prefix, context);
+  auto filter_factory_or_error = factory.createFilterFactoryFromProto(*message, prefix, context);
+  if (!filter_factory_or_error.ok()) {
+    throwEnvoyExceptionOrPanic(std::string(filter_factory_or_error.status().message()));
+  }
+  auto filter_factory = filter_factory_or_error.value();
 
   Factory::MatchTreeValidationVisitor validation_visitor(*factory.matchingRequirements());
 

--- a/source/common/router/upstream_codec_filter.h
+++ b/source/common/router/upstream_codec_filter.h
@@ -113,7 +113,7 @@ public:
   UpstreamCodecFilterFactory() : CommonFactoryBase("envoy.filters.http.upstream_codec") {}
 
   std::string category() const override { return "envoy.filters.http.upstream"; }
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::UpstreamFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -17,7 +17,8 @@ namespace AdmissionControl {
 
 static constexpr std::chrono::seconds defaultSamplingWindow{30};
 
-Http::FilterFactoryCb AdmissionControlFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AdmissionControlFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& config,
     const std::string& stats_prefix, DualInfo dual_info,
     Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/admission_control/config.h
+++ b/source/extensions/filters/http/admission_control/config.h
@@ -19,7 +19,7 @@ class AdmissionControlFilterFactory
 public:
   AdmissionControlFilterFactory() : DualFactoryBase("envoy.filters.http.admission_control") {}
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -15,7 +15,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace BufferFilter {
 
-Http::FilterFactoryCb BufferFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> BufferFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config, const std::string&,
     DualInfo, Server::Configuration::ServerFactoryContext&) {
   ASSERT(proto_config.has_max_request_bytes());

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -20,7 +20,7 @@ public:
   BufferFilterFactory() : DualFactoryBase("envoy.filters.http.buffer") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
       const std::string& stats_prefix, DualInfo,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -25,8 +25,10 @@ Matcher::ActionFactoryCb ExecuteFilterActionFactory::createActionFactoryCb(
 
   // First, try to create the filter factory creation function from factory context (if exists).
   if (context.factory_context_.has_value()) {
-    callback = factory.createFilterFactoryFromProto(*message, context.stat_prefix_,
-                                                    context.factory_context_.value());
+    auto callback_or_status = factory.createFilterFactoryFromProto(
+        *message, context.stat_prefix_, context.factory_context_.value());
+    THROW_IF_STATUS_NOT_OK(callback_or_status, throw);
+    callback = callback_or_status.value();
   }
 
   // If above failed, try to create the filter factory creation function from server factory

--- a/source/extensions/filters/http/compressor/config.cc
+++ b/source/extensions/filters/http/compressor/config.cc
@@ -10,7 +10,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Compressor {
 
-Http::FilterFactoryCb CompressorFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> CompressorFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   const std::string type{TypeUtil::typeUrlToDescriptorFullName(
@@ -19,7 +19,7 @@ Http::FilterFactoryCb CompressorFilterFactory::createFilterFactoryFromProtoTyped
       Registry::FactoryRegistry<
           Compression::Compressor::NamedCompressorLibraryConfigFactory>::getFactoryByType(type);
   if (config_factory == nullptr) {
-    throwEnvoyExceptionOrPanic(
+    return absl::InvalidArgumentError(
         fmt::format("Didn't find a registered implementation for type: '{}'", type));
   }
   ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(

--- a/source/extensions/filters/http/compressor/config.h
+++ b/source/extensions/filters/http/compressor/config.h
@@ -14,14 +14,14 @@ namespace Compressor {
  * Config registration for the compressor filter. @see NamedHttpFilterConfigFactory.
  */
 class CompressorFilterFactory
-    : public Common::FactoryBase<
+    : public Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::compressor::v3::Compressor,
           envoy::extensions::filters::http::compressor::v3::CompressorPerRoute> {
 public:
-  CompressorFilterFactory() : FactoryBase("envoy.filters.http.compressor") {}
+  CompressorFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.compressor") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 

--- a/source/extensions/filters/http/decompressor/config.cc
+++ b/source/extensions/filters/http/decompressor/config.cc
@@ -10,7 +10,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Decompressor {
 
-Http::FilterFactoryCb DecompressorFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   const std::string decompressor_library_type{TypeUtil::typeUrlToDescriptorFullName(
@@ -20,8 +20,8 @@ Http::FilterFactoryCb DecompressorFilterFactory::createFilterFactoryFromProtoTyp
           Compression::Decompressor::NamedDecompressorLibraryConfigFactory>::
           getFactoryByType(decompressor_library_type);
   if (decompressor_library_factory == nullptr) {
-    throwEnvoyExceptionOrPanic(fmt::format("Didn't find a registered implementation for type: '{}'",
-                                           decompressor_library_type));
+    return absl::InvalidArgumentError(fmt::format(
+        "Didn't find a registered implementation for type: '{}'", decompressor_library_type));
   }
   ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
       proto_config.decompressor_library().typed_config(), context.messageValidationVisitor(),

--- a/source/extensions/filters/http/decompressor/config.h
+++ b/source/extensions/filters/http/decompressor/config.h
@@ -14,12 +14,13 @@ namespace Decompressor {
  * Config registration for the decompressor filter. @see NamedHttpFilterConfigFactory.
  */
 class DecompressorFilterFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::decompressor::v3::Decompressor> {
+    : public Common::ExceptionFreeFactoryBase<
+          envoy::extensions::filters::http::decompressor::v3::Decompressor> {
 public:
-  DecompressorFilterFactory() : FactoryBase("envoy.filters.http.decompressor") {}
+  DecompressorFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.decompressor") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::decompressor::v3::Decompressor& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -9,7 +9,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderMutation {
 
-Http::FilterFactoryCb HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
     const ProtoConfig& config, const std::string&, DualInfo,
     Server::Configuration::ServerFactoryContext&) {
   auto filter_config = std::make_shared<HeaderMutationConfig>(config);

--- a/source/extensions/filters/http/header_mutation/config.h
+++ b/source/extensions/filters/http/header_mutation/config.h
@@ -20,7 +20,7 @@ public:
   HeaderMutationFactoryConfig() : DualFactoryBase("envoy.filters.http.header_mutation") {}
 
 private:
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProtoTyped(const ProtoConfig& proto_config,
                                     const std::string& stats_prefix, DualInfo info,
                                     Server::Configuration::ServerFactoryContext& context) override;

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -49,13 +49,13 @@ class TestHttpFilterFactory : public TestFilterFactory,
                               public Server::Configuration::NamedHttpFilterConfigFactory,
                               public Server::Configuration::UpstreamHttpFilterConfigFactory {
 public:
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::FactoryContext&) override {
     created_ = true;
     return [](Http::FilterChainFactoryCallbacks&) -> void {};
   }
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::UpstreamFactoryContext&) override {
     created_ = true;

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -654,9 +654,9 @@ TYPED_TEST(FilterConfigDiscoveryImplTestParameter, TerminalFilterInvalid) {
   }
 
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(config_discovery_test.callbacks_
-                      ->onConfigUpdate(decoded_resources.refvec_, response.version_info())
-                      .ok()),
+      config_discovery_test.callbacks_
+          ->onConfigUpdate(decoded_resources.refvec_, response.version_info())
+          .IgnoreError(),
       EnvoyException,
       "Error: terminal filter named foo of type envoy.test.filter must be the last filter "
       "in a " +

--- a/test/common/http/match_delegate/config_test.cc
+++ b/test/common/http/match_delegate/config_test.cc
@@ -248,9 +248,9 @@ xds_matcher:
 
   MatchDelegateConfig match_delegate_config;
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_FALSE(match_delegate_config.createFilterFactoryFromProto(config, "", factory_context)
-                       .status()
-                       .ok()),
+      match_delegate_config.createFilterFactoryFromProto(config, "", factory_context)
+          .status()
+          .IgnoreError(),
       EnvoyException,
       "requirement violation while creating match tree: INVALID_ARGUMENT: data input typeUrl "
       "type.googleapis.com/envoy.type.matcher.v3.HttpResponseHeaderMatchInput not permitted "

--- a/test/common/http/match_delegate/config_test.cc
+++ b/test/common/http/match_delegate/config_test.cc
@@ -21,7 +21,7 @@ struct TestFactory : public Envoy::Server::Configuration::NamedHttpFilterConfigF
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<ProtobufWkt::StringValue>();
   }
-  Envoy::Http::FilterFactoryCb
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::FactoryContext&) override {
     return [](auto& callbacks) {
@@ -96,7 +96,7 @@ xds_matcher:
         EXPECT_NE(nullptr, dynamic_cast<DelegatingStreamFilter*>(filter.get()));
       }));
   EXPECT_CALL(factory_callbacks, addAccessLogHandler(testing::IsNull()));
-  cb(factory_callbacks);
+  cb.value()(factory_callbacks);
 }
 
 TEST(MatchWrapper, PerRouteConfig) {
@@ -180,7 +180,7 @@ matcher:
         EXPECT_NE(nullptr, dynamic_cast<DelegatingStreamFilter*>(filter.get()));
       }));
   EXPECT_CALL(factory_callbacks, addAccessLogHandler(testing::IsNull()));
-  cb(factory_callbacks);
+  cb.value()(factory_callbacks);
 }
 
 TEST(MatchWrapper, QueryParamMatcherYaml) {
@@ -214,7 +214,7 @@ xds_matcher:
 
   MatchDelegateConfig match_delegate_config;
   auto cb = match_delegate_config.createFilterFactoryFromProto(config, "", factory_context);
-  EXPECT_TRUE(cb);
+  EXPECT_TRUE(cb.value());
 }
 
 TEST(MatchWrapper, WithMatcherInvalidDataInput) {
@@ -248,7 +248,9 @@ xds_matcher:
 
   MatchDelegateConfig match_delegate_config;
   EXPECT_THROW_WITH_REGEX(
-      match_delegate_config.createFilterFactoryFromProto(config, "", factory_context),
+      EXPECT_FALSE(match_delegate_config.createFilterFactoryFromProto(config, "", factory_context)
+                       .status()
+                       .ok()),
       EnvoyException,
       "requirement violation while creating match tree: INVALID_ARGUMENT: data input typeUrl "
       "type.googleapis.com/envoy.type.matcher.v3.HttpResponseHeaderMatchInput not permitted "

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -10300,8 +10300,8 @@ public:
   public:
     TestFilterConfig() : EmptyHttpFilterConfig("test.filter") {}
 
-    Http::FilterFactoryCb createFilter(const std::string&,
-                                       Server::Configuration::FactoryContext&) override {
+    absl::StatusOr<Http::FilterFactoryCb>
+    createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
       PANIC("not implemented");
     }
     ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
@@ -10325,8 +10325,8 @@ public:
   public:
     DefaultTestFilterConfig() : EmptyHttpFilterConfig("test.default.filter") {}
 
-    Http::FilterFactoryCb createFilter(const std::string&,
-                                       Server::Configuration::FactoryContext&) override {
+    absl::StatusOr<Http::FilterFactoryCb>
+    createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
       PANIC("not implemented");
     }
     ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -4294,7 +4294,7 @@ public:
   TestHttpFilterConfigFactory(TestFilterConfigFactoryBase& parent) : parent_(parent) {}
 
   // NamedNetworkFilterConfigFactory
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::FactoryContext&) override {
     PANIC("not implemented");

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -75,10 +75,11 @@ success_criteria:
   TestUtility::loadFromYamlAndValidate(yaml, proto);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(admission_control_filter_factory
-                      .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
-                                                         factory_context.getServerFactoryContext())
-                      .ok()),
+      admission_control_filter_factory
+          .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
+                                             factory_context.getServerFactoryContext())
+          .status()
+          .IgnoreError(),
       EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }
 
@@ -105,10 +106,10 @@ success_criteria:
   TestUtility::loadFromYamlAndValidate(yaml, proto);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(admission_control_filter_factory
-                      .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
-                                                         factory_context.getServerFactoryContext())
-                      .ok()),
+      admission_control_filter_factory
+          .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
+                                             factory_context.getServerFactoryContext())
+          .IgnoreError(),
       EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }
 

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -109,6 +109,7 @@ success_criteria:
       admission_control_filter_factory
           .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
                                              factory_context.getServerFactoryContext())
+          .status()
           .IgnoreError(),
       EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -75,8 +75,10 @@ success_criteria:
   TestUtility::loadFromYamlAndValidate(yaml, proto);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
-      admission_control_filter_factory.createFilterFactoryFromProtoTyped(
-          proto, "whatever", dual_info_, factory_context.getServerFactoryContext()),
+      EXPECT_TRUE(admission_control_filter_factory
+                      .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
+                                                         factory_context.getServerFactoryContext())
+                      .ok()),
       EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }
 
@@ -103,8 +105,10 @@ success_criteria:
   TestUtility::loadFromYamlAndValidate(yaml, proto);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(
-      admission_control_filter_factory.createFilterFactoryFromProtoTyped(
-          proto, "whatever", dual_info_, factory_context.getServerFactoryContext()),
+      EXPECT_TRUE(admission_control_filter_factory
+                      .createFilterFactoryFromProtoTyped(proto, "whatever", dual_info_,
+                                                         factory_context.getServerFactoryContext())
+                      .ok()),
       EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }
 

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -112,8 +112,9 @@ arn: "arn:aws:lambda:region:424242:fun"
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).value(),
-               EnvoyException);
+  EXPECT_THROW(
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
+      EnvoyException);
 }
 
 TEST(AwsLambdaFilterConfigTest, PerRouteConfigWithInvalidARNThrows) {

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -35,7 +35,8 @@ invocation_mode: asynchronous
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   auto has_expected_settings = [](std::shared_ptr<Envoy::Http::StreamFilter> stream_filter) {
     auto filter = std::static_pointer_cast<Filter>(stream_filter);
@@ -63,7 +64,8 @@ arn: "arn:aws:lambda:region:424242:function:fun"
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   auto has_expected_settings = [](std::shared_ptr<Envoy::Http::StreamFilter> stream_filter) {
     auto filter = std::static_pointer_cast<Filter>(stream_filter);
@@ -110,7 +112,7 @@ arn: "arn:aws:lambda:region:424242:fun"
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   AwsLambdaFilterFactory factory;
 
-  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context),
+  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).value(),
                EnvoyException);
 }
 

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -45,7 +45,8 @@ match_excluded_headers:
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   AwsRequestSigningFilterFactory factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/bandwidth_limit/config_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/config_test.cc
@@ -25,7 +25,7 @@ TEST(Factory, GlobalEmptyConfig) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
-  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -29,7 +29,7 @@ TEST(Factory, ValidConfig) {
   auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
-  callback(filter_callback);
+  callback.value()(filter_callback);
 }
 
 TEST(Factory, InvalidConfigNoColon) {
@@ -46,9 +46,10 @@ TEST(Factory, InvalidConfigNoColon) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException,
-                            "basic auth: invalid htpasswd format, username:password is expected");
+  EXPECT_THROW(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException);
 }
 
 TEST(Factory, InvalidConfigDuplicateUsers) {
@@ -65,8 +66,10 @@ TEST(Factory, InvalidConfigDuplicateUsers) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException, "basic auth: duplicate users");
+  EXPECT_THROW_WITH_MESSAGE(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "basic auth: duplicate users");
 }
 
 TEST(Factory, InvalidConfigNoUser) {
@@ -83,8 +86,10 @@ TEST(Factory, InvalidConfigNoUser) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException, "basic auth: empty user name or password");
+  EXPECT_THROW_WITH_MESSAGE(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "basic auth: empty user name or password");
 }
 
 TEST(Factory, InvalidConfigNoPassword) {
@@ -101,8 +106,10 @@ TEST(Factory, InvalidConfigNoPassword) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException, "basic auth: empty user name or password");
+  EXPECT_THROW_WITH_MESSAGE(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "basic auth: empty user name or password");
 }
 
 TEST(Factory, InvalidConfigNoHash) {
@@ -119,9 +126,10 @@ TEST(Factory, InvalidConfigNoHash) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException,
-                            "basic auth: invalid htpasswd format, invalid SHA hash length");
+  EXPECT_THROW_WITH_MESSAGE(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "basic auth: invalid htpasswd format, invalid SHA hash length");
 }
 
 TEST(Factory, InvalidConfigNotSHA) {
@@ -138,9 +146,10 @@ TEST(Factory, InvalidConfigNotSHA) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException,
-                            "basic auth: unsupported htpasswd format: please use {SHA}");
+  EXPECT_THROW_WITH_MESSAGE(
+      ASSERT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "basic auth: unsupported htpasswd format: please use {SHA}");
 }
 
 } // namespace BasicAuth

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -47,8 +47,7 @@ TEST(Factory, InvalidConfigNoColon) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException);
 }
 
@@ -67,8 +66,7 @@ TEST(Factory, InvalidConfigDuplicateUsers) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: duplicate users");
 }
 
@@ -87,8 +85,7 @@ TEST(Factory, InvalidConfigNoUser) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: empty user name or password");
 }
 
@@ -107,8 +104,7 @@ TEST(Factory, InvalidConfigNoPassword) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: empty user name or password");
 }
 
@@ -127,8 +123,7 @@ TEST(Factory, InvalidConfigNoHash) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: invalid htpasswd format, invalid SHA hash length");
 }
 
@@ -147,8 +142,7 @@ TEST(Factory, InvalidConfigNotSHA) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      ASSERT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: unsupported htpasswd format: please use {SHA}");
 }
 

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -28,7 +28,8 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectYaml) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   BufferFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -40,7 +41,7 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProto) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   BufferFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -52,7 +53,7 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProtoUpstreamFactory) {
 
   NiceMock<Server::Configuration::MockUpstreamFactoryContext> context;
   BufferFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -67,7 +68,7 @@ TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
   config.mutable_max_request_bytes()->set_value(1028);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -80,7 +81,7 @@ TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
       *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(empty_proto.get());
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                           EnvoyException, "Proto constraint validation failed");
 }
 

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -54,8 +54,9 @@ TEST_F(CacheFilterFactoryTest, NoTypedConfig) {
 TEST_F(CacheFilterFactoryTest, UnregisteredTypedConfig) {
   config_.mutable_typed_config()->PackFrom(
       envoy::extensions::filters::http::cache::v3::CacheConfig());
-  EXPECT_THROW(factory_.createFilterFactoryFromProto(config_, "stats", context_).IgnoreError(),
-               EnvoyException);
+  EXPECT_THROW(
+      factory_.createFilterFactoryFromProto(config_, "stats", context_).status().IgnoreError(),
+      EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -25,7 +25,8 @@ protected:
 TEST_F(CacheFilterFactoryTest, Basic) {
   config_.mutable_typed_config()->PackFrom(
       envoy::extensions::http::cache::simple_http_cache::v3::SimpleHttpCacheConfig());
-  Http::FilterFactoryCb cb = factory_.createFilterFactoryFromProto(config_, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory_.createFilterFactoryFromProto(config_, "stats", context_).value();
   Http::StreamFilterSharedPtr filter;
   EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
   cb(filter_callback_);
@@ -35,7 +36,8 @@ TEST_F(CacheFilterFactoryTest, Basic) {
 
 TEST_F(CacheFilterFactoryTest, Disabled) {
   config_.mutable_disabled()->set_value(true);
-  Http::FilterFactoryCb cb = factory_.createFilterFactoryFromProto(config_, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory_.createFilterFactoryFromProto(config_, "stats", context_).value();
   Http::StreamFilterSharedPtr filter;
   EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
   cb(filter_callback_);
@@ -44,13 +46,16 @@ TEST_F(CacheFilterFactoryTest, Disabled) {
 }
 
 TEST_F(CacheFilterFactoryTest, NoTypedConfig) {
-  EXPECT_THROW(factory_.createFilterFactoryFromProto(config_, "stats", context_), EnvoyException);
+  EXPECT_THROW(
+      EXPECT_TRUE(factory_.createFilterFactoryFromProto(config_, "stats", context_).status().ok()),
+      EnvoyException);
 }
 
 TEST_F(CacheFilterFactoryTest, UnregisteredTypedConfig) {
   config_.mutable_typed_config()->PackFrom(
       envoy::extensions::filters::http::cache::v3::CacheConfig());
-  EXPECT_THROW(factory_.createFilterFactoryFromProto(config_, "stats", context_), EnvoyException);
+  EXPECT_THROW(EXPECT_TRUE(factory_.createFilterFactoryFromProto(config_, "stats", context_).ok()),
+               EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -47,14 +47,14 @@ TEST_F(CacheFilterFactoryTest, Disabled) {
 
 TEST_F(CacheFilterFactoryTest, NoTypedConfig) {
   EXPECT_THROW(
-      EXPECT_TRUE(factory_.createFilterFactoryFromProto(config_, "stats", context_).status().ok()),
+      factory_.createFilterFactoryFromProto(config_, "stats", context_).status().IgnoreError(),
       EnvoyException);
 }
 
 TEST_F(CacheFilterFactoryTest, UnregisteredTypedConfig) {
   config_.mutable_typed_config()->PackFrom(
       envoy::extensions::filters::http::cache::v3::CacheConfig());
-  EXPECT_THROW(EXPECT_TRUE(factory_.createFilterFactoryFromProto(config_, "stats", context_).ok()),
+  EXPECT_THROW(factory_.createFilterFactoryFromProto(config_, "stats", context_).IgnoreError(),
                EnvoyException);
 }
 

--- a/test/extensions/filters/http/cdn_loop/config_test.cc
+++ b/test/extensions/filters/http/cdn_loop/config_test.cc
@@ -27,7 +27,7 @@ TEST(CdnLoopFilterFactoryTest, ValidValuesWork) {
   config.set_cdn_id("cdn");
   CdnLoopFilterFactory factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   cb(filter_callbacks);
   EXPECT_NE(filter.get(), nullptr);
   EXPECT_NE(dynamic_cast<CdnLoopFilter*>(filter.get()), nullptr);
@@ -39,7 +39,7 @@ TEST(CdnLoopFilterFactoryTest, BlankCdnIdThrows) {
   envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig config;
   CdnLoopFilterFactory factory;
 
-  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                              ProtoValidationException, HasSubstr("value length must be at least"));
 }
 
@@ -50,7 +50,7 @@ TEST(CdnLoopFilterFactoryTest, InvalidCdnId) {
   config.set_cdn_id("[not-token-or-ip");
   CdnLoopFilterFactory factory;
 
-  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                              EnvoyException, HasSubstr("is not a valid CDN identifier"));
 }
 
@@ -61,7 +61,7 @@ TEST(CdnLoopFilterFactoryTest, InvalidCdnIdNonHeaderWhitespace) {
   config.set_cdn_id("\r\n");
   CdnLoopFilterFactory factory;
 
-  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                              EnvoyException, HasSubstr("is not a valid CDN identifier"));
 }
 
@@ -72,7 +72,7 @@ TEST(CdnLoopFilterFactoryTest, InvalidParsedCdnIdNotInput) {
   config.set_cdn_id("cdn,cdn");
   CdnLoopFilterFactory factory;
 
-  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                              EnvoyException, HasSubstr("is not a valid CDN identifier"));
 }
 

--- a/test/extensions/filters/http/common/empty_http_filter_config.h
+++ b/test/extensions/filters/http/common/empty_http_filter_config.h
@@ -19,10 +19,10 @@ namespace Common {
  */
 class EmptyHttpFilterConfig : public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
-  virtual Http::FilterFactoryCb createFilter(const std::string& stat_prefix,
-                                             Server::Configuration::FactoryContext& context) PURE;
+  virtual absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string& stat_prefix, Server::Configuration::FactoryContext& context) PURE;
 
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string& stat_prefix,
                                Server::Configuration::FactoryContext& context) override {
     return createFilter(stat_prefix, context);
@@ -46,11 +46,11 @@ private:
 
 class UpstreamFilterConfig : public Server::Configuration::UpstreamHttpFilterConfigFactory {
 public:
-  virtual Http::FilterFactoryCb
+  virtual absl::StatusOr<Http::FilterFactoryCb>
   createDualFilter(const std::string& stat_prefix,
                    Server::Configuration::ServerFactoryContext& context) PURE;
 
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string& stat_prefix,
                                Server::Configuration::UpstreamFactoryContext& context) override {
     return createDualFilter(stat_prefix, context.getServerFactoryContext());
@@ -61,8 +61,9 @@ class EmptyHttpDualFilterConfig : public EmptyHttpFilterConfig, public UpstreamF
 public:
   EmptyHttpDualFilterConfig(const std::string& name) : EmptyHttpFilterConfig(name) {}
 
-  Http::FilterFactoryCb createFilter(const std::string& stat_prefix,
-                                     Server::Configuration::FactoryContext& context) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string& stat_prefix,
+               Server::Configuration::FactoryContext& context) override {
     return createDualFilter(stat_prefix, context.getServerFactoryContext());
   }
 };

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -73,7 +73,7 @@ void UberFilterFuzzer::fuzz(
         proto_config, factory_context_.messageValidationVisitor(), factory);
     // Clean-up config with filter-specific logic before it runs through validations.
     cleanFuzzedConfig(proto_config.name(), message.get());
-    cb_ = factory.createFilterFactoryFromProto(*message, "stats", factory_context_);
+    cb_ = factory.createFilterFactoryFromProto(*message, "stats", factory_context_).value();
     cb_(filter_callback_);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Controlled exception {}", e.what());

--- a/test/extensions/filters/http/compressor/config_test.cc
+++ b/test/extensions/filters/http/compressor/config_test.cc
@@ -27,10 +27,10 @@ TEST(CompressorFilterFactoryTests, UnregisteredCompressorLibraryConfig) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   CompressorFilterFactory factory;
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context),
-                            EnvoyException,
-                            "Didn't find a registered implementation for type: "
-                            "'test.mock_compressor_library.Unregistered'");
+  EXPECT_THAT(
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().message(),
+      testing::HasSubstr("Didn't find a registered implementation for type: "
+                         "'test.mock_compressor_library.Unregistered'"));
 }
 
 TEST(CompressorFilterFactoryTests, EmptyPerRouteConfig) {

--- a/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
@@ -21,7 +21,7 @@ TEST(ConnectGrpcBridgeFilterConfigTest, ConnectGrpcBridgeFilter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConnectGrpcFilterConfigFactory factory;
   envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig config;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_)).Times(AtLeast(1));
   cb(filter_callback);

--- a/test/extensions/filters/http/custom_response/config_test.cc
+++ b/test/extensions/filters/http/custom_response/config_test.cc
@@ -41,7 +41,7 @@ TEST(CustomResponseFilterConfigTest, InvalidURI) {
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      factory.createFilterFactoryFromProto(filter_config, "stats", context).IgnoreError(),
       EnvoyException,
       "Invalid uri specified for redirection for custom response: "
       "%#?*s://foo.example/gateway_error");
@@ -117,7 +117,7 @@ TEST(CustomResponseFilterConfigTest, RegexRewrite) {
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      factory.createFilterFactoryFromProto(filter_config, "stats", context).IgnoreError(),
       EnvoyException, "regex_rewrite is not supported for Custom Response");
 }
 
@@ -139,7 +139,7 @@ TEST(CustomResponseFilterConfigTest, HashFragmentUri) {
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      factory.createFilterFactoryFromProto(filter_config, "stats", context).IgnoreError(),
       EnvoyException,
       "Invalid uri specified for redirection for custom response: "
       "example.foo/abc/cde#ab");
@@ -164,7 +164,7 @@ TEST(CustomResponseFilterConfigTest, HashFragmentPathRedirect) {
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      factory.createFilterFactoryFromProto(filter_config, "stats", context).IgnoreError(),
       EnvoyException,
       "#fragment is not supported for custom response. Specified "
       "path_redirect is /abc/cde#ab");

--- a/test/extensions/filters/http/custom_response/config_test.cc
+++ b/test/extensions/filters/http/custom_response/config_test.cc
@@ -25,7 +25,7 @@ TEST(CustomResponseFilterConfigTest, CustomResponseFilter) {
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
   ::Envoy::Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProto(filter_config, "stats", context);
+      factory.createFilterFactoryFromProto(filter_config, "stats", context).value();
   ::Envoy::Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -40,10 +40,11 @@ TEST(CustomResponseFilterConfigTest, InvalidURI) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(filter_config, "stats", context),
-                            EnvoyException,
-                            "Invalid uri specified for redirection for custom response: "
-                            "%#?*s://foo.example/gateway_error");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      EnvoyException,
+      "Invalid uri specified for redirection for custom response: "
+      "%#?*s://foo.example/gateway_error");
 }
 
 // Specifying neither host nor path redirect is valid when the routing decision
@@ -66,7 +67,7 @@ TEST(CustomResponseFilterConfigTest, NoHostAndPathRedirect) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_NO_THROW(factory.createFilterFactoryFromProto(filter_config, "stats", context));
+  EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok());
 }
 
 TEST(CustomResponseFilterConfigTest, PrefixRewrite) {
@@ -88,8 +89,9 @@ TEST(CustomResponseFilterConfigTest, PrefixRewrite) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(filter_config, "stats", context),
-                            EnvoyException, "prefix_rewrite is not supported for Custom Response");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      EnvoyException, "prefix_rewrite is not supported for Custom Response");
 }
 
 TEST(CustomResponseFilterConfigTest, RegexRewrite) {
@@ -114,8 +116,9 @@ TEST(CustomResponseFilterConfigTest, RegexRewrite) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(filter_config, "stats", context),
-                            EnvoyException, "regex_rewrite is not supported for Custom Response");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      EnvoyException, "regex_rewrite is not supported for Custom Response");
 }
 
 TEST(CustomResponseFilterConfigTest, HashFragmentUri) {
@@ -135,10 +138,11 @@ TEST(CustomResponseFilterConfigTest, HashFragmentUri) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(filter_config, "stats", context),
-                            EnvoyException,
-                            "Invalid uri specified for redirection for custom response: "
-                            "example.foo/abc/cde#ab");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      EnvoyException,
+      "Invalid uri specified for redirection for custom response: "
+      "example.foo/abc/cde#ab");
 }
 
 TEST(CustomResponseFilterConfigTest, HashFragmentPathRedirect) {
@@ -159,10 +163,11 @@ TEST(CustomResponseFilterConfigTest, HashFragmentPathRedirect) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(filter_config, "stats", context),
-                            EnvoyException,
-                            "#fragment is not supported for custom response. Specified "
-                            "path_redirect is /abc/cde#ab");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      EnvoyException,
+      "#fragment is not supported for custom response. Specified "
+      "path_redirect is /abc/cde#ab");
 }
 
 } // namespace

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -72,7 +72,7 @@ public:
                   config_with_hash_key, scope, skip_cluster_check);
             }));
     ExtAuthzFilterConfig factory;
-    return factory.createFilterFactoryFromProto(ext_authz_config, "stats", context_);
+    return factory.createFilterFactoryFromProto(ext_authz_config, "stats", context_).value();
   }
 
   Http::StreamFilterSharedPtr createFilterFromFilterFactory(Http::FilterFactoryCb filter_factory) {

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -40,7 +40,8 @@ TEST(HttpExtProcConfigTest, CorrectConfig) {
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/fault/config_test.cc
+++ b/test/extensions/filters/http/fault/config_test.cc
@@ -22,7 +22,7 @@ TEST(FaultFilterConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   envoy::extensions::filters::http::fault::v3::HTTPFault fault;
   fault.mutable_abort();
-  EXPECT_THROW(FaultFilterFactory().createFilterFactoryFromProto(fault, "stats", context),
+  EXPECT_THROW(FaultFilterFactory().createFilterFactoryFromProto(fault, "stats", context).value(),
                ProtoValidationException);
 }
 
@@ -40,7 +40,8 @@ TEST(FaultFilterConfigTest, FaultFilterCorrectJson) {
   const auto proto_config = convertYamlStrToProtoConfig(yaml_string);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   FaultFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -77,7 +78,7 @@ TEST(FaultFilterConfigTest, FaultFilterCorrectProto) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   FaultFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -87,7 +88,8 @@ TEST(FaultFilterConfigTest, FaultFilterEmptyProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   FaultFilterFactory factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats", context);
+      factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats", context)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/file_system_buffer/config_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/config_test.cc
@@ -52,7 +52,7 @@ public:
   captureConfigFromProto(const ProtoFileSystemBufferFilterConfig& proto_config) {
     NiceMock<Server::Configuration::MockFactoryContext> context;
     Http::FilterFactoryCb cb =
-        factory()->createFilterFactoryFromProto(proto_config, "stats", context);
+        factory()->createFilterFactoryFromProto(proto_config, "stats", context).value();
     Http::MockFilterChainFactoryCallbacks filter_callback;
     std::shared_ptr<FileSystemBufferFilterConfig> config;
     EXPECT_CALL(filter_callback, addStreamFilter(_)).WillOnce(Invoke(captureConfig(&config)));

--- a/test/extensions/filters/http/gcp_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/gcp_authn/filter_config_test.cc
@@ -35,7 +35,8 @@ TEST(GcpAuthnFilterConfigTest, GcpAuthnFilterWithCorrectProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   GcpAuthnFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(filter_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(filter_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/geoip/config_test.cc
+++ b/test/extensions/filters/http/geoip/config_test.cc
@@ -66,7 +66,8 @@ TEST(GeoipFilterConfigTest, GeoipFilterDefaultValues) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor()).Times(2);
   GeoipFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(filter_config, "geoip", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(filter_config, "geoip", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback,
               addStreamDecoderFilter(AllOf(HasUseXff(false), HasXffNumTrustedHops(0))));
@@ -90,7 +91,8 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigWithCorrectProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor()).Times(2);
   GeoipFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(filter_config, "geoip", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(filter_config, "geoip", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback,
               addStreamDecoderFilter(AllOf(HasUseXff(true), HasXffNumTrustedHops(1))));
@@ -111,9 +113,9 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigMissingProvider) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   GeoipFilterFactory factory;
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(filter_config, "geoip", context),
-                          ProtoValidationException,
-                          "Proto constraint validation failed.*value is required.*");
+  EXPECT_THROW_WITH_REGEX(
+      factory.createFilterFactoryFromProto(filter_config, "geoip", context).value(),
+      ProtoValidationException, "Proto constraint validation failed.*value is required.*");
 }
 
 TEST(GeoipFilterConfigTest, GeoipFilterConfigUnknownProvider) {

--- a/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
@@ -17,7 +17,7 @@ TEST(GrpcHttp1BridgeFilterConfigTest, GrpcHttp1BridgeFilter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GrpcHttp1BridgeFilterConfig factory;
   envoy::extensions::filters::http::grpc_http1_bridge::v3::Config config;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -29,7 +29,7 @@ withhold_grpc_frames: true
   NiceMock<Server::Configuration::MockFactoryContext> context;
   Config config_factory;
   Http::FilterFactoryCb cb =
-      config_factory.createFilterFactoryFromProto(proto_config, "stats", context);
+      config_factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
@@ -16,10 +16,13 @@ namespace {
 
 TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW(GrpcJsonTranscoderFilterConfig().createFilterFactoryFromProto(
-                   envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder(),
-                   "stats", context),
-               ProtoValidationException);
+  EXPECT_THROW(
+      GrpcJsonTranscoderFilterConfig()
+          .createFilterFactoryFromProto(
+              envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder(),
+              "stats", context)
+          .value(),
+      ProtoValidationException);
 }
 
 } // namespace

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -26,7 +26,8 @@ class GrpcStatsFilterConfigTest : public testing::Test {
 protected:
   void initialize() {
     GrpcStatsFilterConfigFactory factory;
-    Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config_, "stats", context_);
+    Http::FilterFactoryCb cb =
+        factory.createFilterFactoryFromProto(config_, "stats", context_).value();
     Http::MockFilterChainFactoryCallbacks filter_callback;
 
     ON_CALL(filter_callback, addStreamFilter(_)).WillByDefault(testing::SaveArg<0>(&filter_));

--- a/test/extensions/filters/http/grpc_web/config_test.cc
+++ b/test/extensions/filters/http/grpc_web/config_test.cc
@@ -17,7 +17,7 @@ TEST(GrpcWebFilterConfigTest, GrpcWebFilter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GrpcWebFilterConfig factory;
   envoy::extensions::filters::http::grpc_web::v3::GrpcWeb config;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/header_mutation/config_test.cc
+++ b/test/extensions/filters/http/header_mutation/config_test.cc
@@ -49,7 +49,8 @@ TEST(FactoryTest, FactoryTest) {
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory_context;
 
-  auto cb = factory->createFilterFactoryFromProto(proto_config, "test", mock_factory_context);
+  auto cb =
+      factory->createFilterFactoryFromProto(proto_config, "test", mock_factory_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -28,7 +28,7 @@ void testForbiddenConfig(const std::string& yaml) {
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   HeaderToMetadataConfig factory;
 
-  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context),
+  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).value(),
                EnvoyException);
 }
 
@@ -84,7 +84,8 @@ request_rules:
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   HeaderToMetadataConfig factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);
@@ -112,7 +113,8 @@ request_rules:
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   HeaderToMetadataConfig factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -71,11 +71,10 @@ TEST(HealthCheckFilterConfig, FailsWhenNotPassThroughButTimeoutSetYaml) {
   HealthCheckFilterConfig factory;
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW(
-      EXPECT_FALSE(factory.createFilterFactoryFromProto(proto_config, "dummy_stats_prefix", context)
-                       .status()
-                       .ok()),
-      EnvoyException);
+  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "dummy_stats_prefix", context)
+                   .status()
+                   .IgnoreError(),
+               EnvoyException);
 }
 
 TEST(HealthCheckFilterConfig, NotFailingWhenNotPassThroughAndTimeoutNotSetYaml) {
@@ -110,11 +109,11 @@ TEST(HealthCheckFilterConfig, FailsWhenNotPassThroughButTimeoutSetProto) {
   header.set_name(":path");
   header.mutable_string_match()->set_exact("foo");
 
-  EXPECT_THROW(EXPECT_FALSE(healthCheckFilterConfig
-                                .createFilterFactoryFromProto(config, "dummy_stats_prefix", context)
-                                .status()
-                                .ok()),
-               EnvoyException);
+  EXPECT_THROW(
+      healthCheckFilterConfig.createFilterFactoryFromProto(config, "dummy_stats_prefix", context)
+          .status()
+          .IgnoreError(),
+      EnvoyException);
 }
 
 TEST(HealthCheckFilterConfig, NotFailingWhenNotPassThroughAndTimeoutNotSetProto) {

--- a/test/extensions/filters/http/json_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/json_to_metadata/config_test.cc
@@ -88,13 +88,11 @@ response_rules:
   TestUtility::loadFromYaml(yaml_request, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_FALSE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json to metadata filter: neither `on_present` nor `on_missing` set");
   TestUtility::loadFromYaml(yaml_response, *proto_config);
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json to metadata filter: neither `on_present` nor `on_missing` set");
 }
 
@@ -130,13 +128,11 @@ response_rules:
   TestUtility::loadFromYaml(yaml_request, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json to metadata filter: cannot specify on_missing rule with empty value");
   TestUtility::loadFromYaml(yaml_response, *proto_config);
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json to metadata filter: cannot specify on_missing rule with empty value");
 }
 
@@ -172,13 +168,11 @@ response_rules:
   TestUtility::loadFromYaml(yaml_request, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_FALSE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json to metadata filter: cannot specify on_error rule with empty value");
   TestUtility::loadFromYaml(yaml_response, *proto_config);
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json to metadata filter: cannot specify on_error rule with empty value");
 }
 
@@ -190,8 +184,7 @@ TEST(Factory, NoRule) {
   TestUtility::loadFromYaml(yaml_empty, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "json_to_metadata_filter: Per filter configs must at least specify");
 }
 

--- a/test/extensions/filters/http/json_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/json_to_metadata/config_test.cc
@@ -57,13 +57,13 @@ response_rules:
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);
 
   TestUtility::loadFromYaml(yaml_response, *proto_config);
-  callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);
 }
@@ -87,13 +87,15 @@ response_rules:
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(yaml_request, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                          EnvoyException,
-                          "json to metadata filter: neither `on_present` nor `on_missing` set");
+  EXPECT_THROW_WITH_REGEX(
+      EXPECT_FALSE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json to metadata filter: neither `on_present` nor `on_missing` set");
   TestUtility::loadFromYaml(yaml_response, *proto_config);
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                          EnvoyException,
-                          "json to metadata filter: neither `on_present` nor `on_missing` set");
+  EXPECT_THROW_WITH_REGEX(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json to metadata filter: neither `on_present` nor `on_missing` set");
 }
 
 TEST(Factory, NoValueIntOnMissing) {
@@ -128,12 +130,14 @@ response_rules:
   TestUtility::loadFromYaml(yaml_request, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context), EnvoyException,
-      "json to metadata filter: cannot specify on_missing rule with empty value");
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json to metadata filter: cannot specify on_missing rule with empty value");
   TestUtility::loadFromYaml(yaml_response, *proto_config);
   EXPECT_THROW_WITH_REGEX(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context), EnvoyException,
-      "json to metadata filter: cannot specify on_missing rule with empty value");
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json to metadata filter: cannot specify on_missing rule with empty value");
 }
 
 TEST(Factory, NoValueIntOnError) {
@@ -167,13 +171,15 @@ response_rules:
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(yaml_request, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                          EnvoyException,
-                          "json to metadata filter: cannot specify on_error rule with empty value");
+  EXPECT_THROW_WITH_REGEX(
+      EXPECT_FALSE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json to metadata filter: cannot specify on_error rule with empty value");
   TestUtility::loadFromYaml(yaml_response, *proto_config);
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                          EnvoyException,
-                          "json to metadata filter: cannot specify on_error rule with empty value");
+  EXPECT_THROW_WITH_REGEX(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json to metadata filter: cannot specify on_error rule with empty value");
 }
 
 TEST(Factory, NoRule) {
@@ -183,9 +189,10 @@ TEST(Factory, NoRule) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(yaml_empty, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                          EnvoyException,
-                          "json_to_metadata_filter: Per filter configs must at least specify");
+  EXPECT_THROW_WITH_REGEX(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "json_to_metadata_filter: Per filter configs must at least specify");
 }
 
 } // namespace JsonToMetadata

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -27,7 +27,8 @@ TEST(HttpJwtAuthnFilterFactoryTest, GoodRemoteJwks) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -41,7 +42,8 @@ TEST(HttpJwtAuthnFilterFactoryTest, GoodLocalJwks) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   FilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -55,7 +57,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, BadLocalJwks) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   FilterFactory factory;
-  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context),
+  EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).value(),
                EnvoyException);
 }
 
@@ -67,7 +69,8 @@ TEST(HttpJwtAuthnFilterFactoryTest, ProviderWithoutIssuer) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   FilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/kill_request/kill_request_config_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_config_test.cc
@@ -23,7 +23,8 @@ TEST(KillRequestConfigTest, KillRequestFilterWithCorrectProto) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   KillRequestFilterFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(kill_request, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(kill_request, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -33,7 +34,8 @@ TEST(KillRequestConfigTest, KillRequestFilterWithEmptyProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   KillRequestFilterFactory factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats", context);
+      factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats", context)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -23,7 +23,7 @@ stat_prefix: test
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(0);
-  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -21,12 +21,11 @@ namespace {
 
 TEST(LuaFilterConfigTest, ValidateEmptyConfigNotFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_NO_THROW(
-      EXPECT_TRUE(LuaFilterConfig()
+  EXPECT_NO_THROW(LuaFilterConfig()
                       .createFilterFactoryFromProto(
                           envoy::extensions::filters::http::lua::v3::Lua(), "stats", context)
                       .status()
-                      .ok()));
+                      .IgnoreError());
 }
 
 TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCode) {
@@ -103,8 +102,7 @@ TEST(LuaFilterConfigTest, LuaFilterWithBothDeprecatedInlineCodeAndDefaultSourceC
   NiceMock<Server::Configuration::MockFactoryContext> context;
   LuaFilterConfig factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException,
       "Error: Only one of `inline_code` or `default_source_code` can be set for the Lua filter.");
 }

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -21,8 +21,12 @@ namespace {
 
 TEST(LuaFilterConfigTest, ValidateEmptyConfigNotFail) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_NO_THROW(LuaFilterConfig().createFilterFactoryFromProto(
-      envoy::extensions::filters::http::lua::v3::Lua(), "stats", context));
+  EXPECT_NO_THROW(
+      EXPECT_TRUE(LuaFilterConfig()
+                      .createFilterFactoryFromProto(
+                          envoy::extensions::filters::http::lua::v3::Lua(), "stats", context)
+                      .status()
+                      .ok()));
 }
 
 TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCode) {
@@ -38,7 +42,8 @@ TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCode) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   LuaFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -54,7 +59,8 @@ TEST(LuaFilterConfigTest, LuaFilterInJson) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   LuaFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -72,7 +78,8 @@ TEST(LuaFilterConfigTest, LuaFilterWithDeprecatedInlineCode) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   LuaFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -96,7 +103,9 @@ TEST(LuaFilterConfigTest, LuaFilterWithBothDeprecatedInlineCodeAndDefaultSourceC
   NiceMock<Server::Configuration::MockFactoryContext> context;
   LuaFilterConfig factory;
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context), EnvoyException,
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context).status().ok()),
+      EnvoyException,
       "Error: Only one of `inline_code` or `default_source_code` can be set for the Lua filter.");
 }
 #endif

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -68,8 +68,10 @@ config:
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                            EnvoyException, exception_message);
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_FALSE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, exception_message);
 }
 
 } // namespace
@@ -130,7 +132,8 @@ config:
   EXPECT_CALL(context, api());
   EXPECT_CALL(context, initManager()).Times(2);
   EXPECT_CALL(context, getTransportSocketFactoryContext());
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -193,8 +196,10 @@ config:
   TestUtility::loadFromYaml(yaml, *proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(*proto_config, "stats", context),
-                          EnvoyException, "value does not match regex pattern");
+  EXPECT_THROW_WITH_REGEX(
+      EXPECT_FALSE(
+          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      EnvoyException, "value does not match regex pattern");
 }
 
 } // namespace Oauth2

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -69,8 +69,7 @@ config:
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_FALSE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, exception_message);
 }
 
@@ -197,8 +196,7 @@ config:
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_REGEX(
-      EXPECT_FALSE(
-          factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().ok()),
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "value does not match regex pattern");
 }
 

--- a/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
@@ -30,7 +30,8 @@ TEST(OriginalSrcHttpConfigFactoryTest, TestCreateFactory) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "", context).value();
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   Http::StreamDecoderFilterSharedPtr added_filter;

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -23,8 +23,9 @@ TEST(RateLimitFilterConfigTest, ValidateFail) {
   envoy::extensions::filters::http::ratelimit::v3::RateLimit config;
   config.mutable_rate_limit_service()->set_transport_api_version(
       envoy::config::core::v3::ApiVersion::V3);
-  EXPECT_THROW(RateLimitFilterConfig().createFilterFactoryFromProto(config, "stats", context),
-               ProtoValidationException);
+  EXPECT_THROW(
+      RateLimitFilterConfig().createFilterFactoryFromProto(config, "stats", context).value(),
+      ProtoValidationException);
 }
 
 TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
@@ -50,7 +51,8 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
       }));
 
   RateLimitFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -66,7 +68,7 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
       *dynamic_cast<envoy::extensions::filters::http::ratelimit::v3::RateLimit*>(
           factory.createEmptyConfigProto().get());
 
-  EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context),
+  EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context).value(),
                EnvoyException);
 }
 

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -30,7 +30,7 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidProto) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RoleBasedAccessControlFilterConfigFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);
@@ -50,7 +50,7 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidMatcherProto) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RoleBasedAccessControlFilterConfigFactory factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context);
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/router/config_test.cc
+++ b/test/extensions/filters/http/router/config_test.cc
@@ -29,7 +29,8 @@ TEST(RouterFilterConfigTest, SimpleRouterFilterConfig) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RouterFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats.", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats.", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -45,7 +46,8 @@ TEST(RouterFilterConfigTest, DEPRECATED_FEATURE_TEST(SimpleRouterFilterConfigWit
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RouterFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats.", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats.", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -73,7 +75,7 @@ TEST(RouterFilterConfigTest, RouterFilterWithUnsupportedStrictHeaderCheck) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RouterFilterConfig factory;
   EXPECT_THROW_WITH_REGEX(
-      factory.createFilterFactoryFromProto(router_config, "stats.", context),
+      factory.createFilterFactoryFromProto(router_config, "stats.", context).value(),
       ProtoValidationException,
       "Proto constraint validation failed \\(RouterValidationError.StrictCheckHeaders");
 }
@@ -84,7 +86,8 @@ TEST(RouterFilterConfigTest, RouterV2Filter) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RouterFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(router_config, "stats.", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(router_config, "stats.", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
@@ -94,7 +97,8 @@ TEST(RouterFilterConfigTest, RouterFilterWithEmptyProtoConfig) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RouterFilterConfig factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats.", context);
+      factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats.", context)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/set_metadata/config_test.cc
+++ b/test/extensions/filters/http/set_metadata/config_test.cc
@@ -36,7 +36,8 @@ value:
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
   SetMetadataConfig factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -82,8 +82,9 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
       EnvoyException,
       "Didn't find a registered implementation for name: 'envoy.http.stateful_session.not_exist'");
 
-  EXPECT_NO_THROW(EXPECT_TRUE(
-      factory.createFilterFactoryFromProto(empty_proto_config, "stats", context).status().ok()));
+  EXPECT_NO_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context)
+                      .status()
+                      .IgnoreError());
   EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
                                                           context.messageValidationVisitor()));
 }

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -66,7 +66,8 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
   StatefulSessionFactoryConfig factory;
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);
@@ -81,7 +82,8 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTest) {
       EnvoyException,
       "Didn't find a registered implementation for name: 'envoy.http.stateful_session.not_exist'");
 
-  EXPECT_NO_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context));
+  EXPECT_NO_THROW(EXPECT_TRUE(
+      factory.createFilterFactoryFromProto(empty_proto_config, "stats", context).status().ok()));
   EXPECT_NO_THROW(factory.createRouteSpecificFilterConfig(empty_proto_route_config, server_context,
                                                           context.messageValidationVisitor()));
 }

--- a/test/extensions/filters/http/tap/tap_filter_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_test.cc
@@ -148,7 +148,7 @@ TEST(TapFilterConfigTest, InvalidProto) {
   TestUtility::loadFromYaml(filter_config, config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   TapFilterFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                             EnvoyException,
                             "Error: Specifying admin streaming output without configuring admin.");
 }
@@ -170,7 +170,7 @@ TEST(TapFilterConfigTest, NeitherMatchNorMatchConfig) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   TapFilterFactory factory;
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context).value(),
                             EnvoyException,
                             fmt::format("Neither match nor match_config is set in TapConfig: {}",
                                         config.common_config().static_config().DebugString()));

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -199,8 +199,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasmInvalidConfig) {
   TestUtility::loadFromYaml(invalid_yaml, proto_config);
   WasmFilterConfig factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
   const std::string valid_yaml =
       TestEnvironment::substitute(absl::StrCat(R"EOF(
@@ -272,8 +271,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadInlineBadCode) {
   TestUtility::loadFromYaml(yaml, proto_config);
   WasmFilterConfig factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
 }
 
@@ -368,8 +366,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailOnUncachedThenSucceed) {
           }));
 
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher_, ready());
@@ -446,13 +443,11 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   // Case 1: fail and fetch in the background, got 503, cache failure.
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
   // Fail a second time because we are in-progress.
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
   async_callbacks->onSuccess(
       request, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
@@ -468,8 +463,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager2));
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher2, ready());
@@ -498,8 +492,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager3));
 
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher3, ready());
@@ -558,8 +551,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager5));
 
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(
-          factory.createFilterFactoryFromProto(proto_config2, "stats", context_).status().ok()),
+      factory.createFilterFactoryFromProto(proto_config2, "stats", context_).status().IgnoreError(),
       WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher_, ready());

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -94,7 +94,8 @@ TEST_P(WasmFilterConfigTest, JsonLoadFromFileWasm) {
   envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
   TestUtility::loadFromJson(json, proto_config);
   WasmFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -128,7 +129,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasm) {
   {
     WasmFilterConfig factory;
     Http::FilterFactoryCb cb =
-        factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+        factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
     EXPECT_CALL(init_watcher_, ready());
     context_.initManager().initialize(init_watcher_);
     EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -165,7 +166,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasmFailOpenOk) {
   envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
   TestUtility::loadFromYaml(yaml, proto_config);
   WasmFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -196,8 +198,10 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasmInvalidConfig) {
   envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
   TestUtility::loadFromYaml(invalid_yaml, proto_config);
   WasmFilterConfig factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
   const std::string valid_yaml =
       TestEnvironment::substitute(absl::StrCat(R"EOF(
   config:
@@ -215,7 +219,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromFileWasmInvalidConfig) {
       value: "valid"
   )EOF"));
   TestUtility::loadFromYaml(valid_yaml, proto_config);
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -241,7 +246,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadInlineWasm) {
   envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
   TestUtility::loadFromYaml(yaml, proto_config);
   WasmFilterConfig factory;
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -265,8 +271,10 @@ TEST_P(WasmFilterConfigTest, YamlLoadInlineBadCode) {
   envoy::extensions::filters::http::wasm::v3::Wasm proto_config;
   TestUtility::loadFromYaml(yaml, proto_config);
   WasmFilterConfig factory;
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
 }
 
 TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasm) {
@@ -308,7 +316,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasm) {
             return &request;
           }));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -358,8 +367,10 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailOnUncachedThenSucceed) {
             return &request;
           }));
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -370,7 +381,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailOnUncachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager2));
 
-  auto cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  auto cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
 
   EXPECT_CALL(init_watcher2, ready());
   init_manager2.initialize(init_watcher2);
@@ -434,11 +445,15 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
           }));
 
   // Case 1: fail and fetch in the background, got 503, cache failure.
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
   // Fail a second time because we are in-progress.
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
   async_callbacks->onSuccess(
       request, Http::ResponseMessagePtr{new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                    new Http::TestResponseHeaderMapImpl{{":status", "503"}}})});
@@ -452,8 +467,10 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
   Init::ExpectableWatcherImpl init_watcher2;
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager2));
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher2, ready());
   init_manager2.initialize(init_watcher2);
@@ -480,8 +497,10 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager3));
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher3, ready());
   init_manager3.initialize(init_watcher3);
@@ -493,7 +512,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager4));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
 
   EXPECT_CALL(init_watcher4, ready());
   init_manager4.initialize(init_watcher4);
@@ -537,8 +557,10 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager5));
 
-  EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config2, "stats", context_),
-                            WasmException, "Unable to create Wasm HTTP filter ");
+  EXPECT_THROW_WITH_MESSAGE(
+      EXPECT_TRUE(
+          factory.createFilterFactoryFromProto(proto_config2, "stats", context_).status().ok()),
+      WasmException, "Unable to create Wasm HTTP filter ");
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -550,7 +572,7 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager6));
 
-  factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
 
   EXPECT_CALL(init_watcher6, ready());
   init_manager6.initialize(init_watcher6);
@@ -562,7 +584,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteWasmFailCachedThenSucceed) {
 
   EXPECT_CALL(context_, initManager()).WillRepeatedly(ReturnRef(init_manager7));
 
-  Http::FilterFactoryCb cb2 = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb2 =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
 
   EXPECT_CALL(init_watcher7, ready());
   init_manager7.initialize(init_watcher7);
@@ -614,7 +637,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteConnectionReset) {
             return &request;
           }));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
 }
@@ -659,7 +683,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessWith503) {
             return &request;
           }));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
 }
@@ -704,7 +729,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessIncorrectSha256) {
             return &request;
           }));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
 }
@@ -772,7 +798,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteMultipleRetries) {
       }));
   EXPECT_CALL(*retry_timer_, disableTimer());
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Initialized);
@@ -820,7 +847,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessBadcode) {
             return nullptr;
           }));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
 
@@ -890,7 +918,8 @@ TEST_P(WasmFilterConfigTest, YamlLoadFromRemoteSuccessBadcodeFailOpen) {
             return nullptr;
           }));
 
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context_).value();
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/integration/filters/add_body_filter.cc
+++ b/test/integration/filters/add_body_filter.cc
@@ -124,7 +124,7 @@ public:
   AddBodyFilterFactory() : DualFactoryBase("add-body-filter") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const test::integration::filters::AddBodyFilterConfig& proto_config, const std::string&,
       DualInfo, Server::Configuration::ServerFactoryContext&) override {
     auto filter_config = std::make_shared<AddBodyFilterConfig>(

--- a/test/integration/filters/add_header_filter.cc
+++ b/test/integration/filters/add_header_filter.cc
@@ -26,8 +26,8 @@ public:
 class AddHeaderFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpDualFilterConfig {
 public:
   AddHeaderFilterConfig() : EmptyHttpDualFilterConfig("add-header-filter") {}
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::AddHeaderFilter>());
     };
@@ -68,7 +68,7 @@ public:
     return std::make_unique<test::integration::filters::AddHeaderFilterConfig>();
   }
 
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string&,
                                Server::Configuration::UpstreamFactoryContext& context) override {
 

--- a/test/integration/filters/add_trailers_filter.cc
+++ b/test/integration/filters/add_trailers_filter.cc
@@ -36,8 +36,8 @@ class AddTrailersStreamFilterConfig
 public:
   AddTrailersStreamFilterConfig() : EmptyHttpDualFilterConfig("add-trailers-filter") {}
 
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::AddTrailersStreamFilter>());
     };

--- a/test/integration/filters/backpressure_filter.cc
+++ b/test/integration/filters/backpressure_filter.cc
@@ -41,8 +41,8 @@ class BackpressureConfig : public Extensions::HttpFilters::Common::EmptyHttpFilt
 public:
   BackpressureConfig() : EmptyHttpFilterConfig("backpressure-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::BackpressureFilter>());
     };

--- a/test/integration/filters/buffer_continue_filter.cc
+++ b/test/integration/filters/buffer_continue_filter.cc
@@ -59,8 +59,8 @@ class BufferContinueFilterConfig
 public:
   BufferContinueFilterConfig() : EmptyHttpDualFilterConfig("buffer-continue-filter") {}
 
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::BufferContinueStreamFilter>());
     };

--- a/test/integration/filters/clear_route_cache_filter.cc
+++ b/test/integration/filters/clear_route_cache_filter.cc
@@ -23,8 +23,8 @@ class ClearRouteCacheFilterConfig : public Extensions::HttpFilters::Common::Empt
 public:
   ClearRouteCacheFilterConfig() : EmptyHttpFilterConfig("clear-route-cache") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::ClearRouteCacheFilter>());
     };

--- a/test/integration/filters/common.h
+++ b/test/integration/filters/common.h
@@ -15,8 +15,8 @@ class SimpleFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpDual
 public:
   SimpleFilterConfig() : EmptyHttpDualFilterConfig(T::name) {}
 
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<T>());
     };

--- a/test/integration/filters/crash_filter.cc
+++ b/test/integration/filters/crash_filter.cc
@@ -80,7 +80,7 @@ public:
   CrashFilterFactory() : DualFactoryBase("crash-filter") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const test::integration::filters::CrashFilterConfig& proto_config, const std::string&,
       DualInfo, Server::Configuration::ServerFactoryContext&) override {
     auto filter_config = std::make_shared<CrashFilterConfig>(

--- a/test/integration/filters/eds_ready_filter.cc
+++ b/test/integration/filters/eds_ready_filter.cc
@@ -57,7 +57,7 @@ class EdsReadyFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpFi
 public:
   EdsReadyFilterConfig() : EmptyHttpFilterConfig("eds-ready-filter") {}
 
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilter(const std::string&,
                Server::Configuration::FactoryContext& factory_context) override {
     return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {

--- a/test/integration/filters/encode1xx_local_reply_filter.cc
+++ b/test/integration/filters/encode1xx_local_reply_filter.cc
@@ -26,8 +26,8 @@ class Encode1xxLocalReplyFilterConfig
 public:
   Encode1xxLocalReplyFilterConfig() : EmptyHttpFilterConfig("encode1xx-local-reply-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<Encode1xxLocalReplyFilter>());
     };

--- a/test/integration/filters/encoder_decoder_buffer_filter.cc
+++ b/test/integration/filters/encoder_decoder_buffer_filter.cc
@@ -39,8 +39,8 @@ class EncoderDecoderBufferFilterConfig
 public:
   EncoderDecoderBufferFilterConfig() : EmptyHttpDualFilterConfig("encoder-decoder-buffer-filter") {}
 
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::EncoderDecoderBufferStreamFilter>());
     };

--- a/test/integration/filters/header_to_proxy_filter.cc
+++ b/test/integration/filters/header_to_proxy_filter.cc
@@ -38,8 +38,8 @@ class HeaderToProxyFilterConfig : public Extensions::HttpFilters::Common::EmptyH
 public:
   HeaderToProxyFilterConfig() : EmptyHttpFilterConfig("header-to-proxy-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::HeaderToProxyFilter>());
     };

--- a/test/integration/filters/listener_typed_metadata_filter.cc
+++ b/test/integration/filters/listener_typed_metadata_filter.cc
@@ -58,8 +58,8 @@ public:
   ListenerTypedMetadataFilterFactory() : EmptyHttpFilterConfig(std::string(kFilterName)) {}
 
 private:
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext& context) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext& context) override {
 
     // Main assertions to ensure the metadata from the listener was parsed correctly.
     const auto& typed_metadata = context.listenerTypedMetadata();

--- a/test/integration/filters/modify_buffer_filter.cc
+++ b/test/integration/filters/modify_buffer_filter.cc
@@ -47,8 +47,8 @@ class ModifyBufferFilterConfig : public Extensions::HttpFilters::Common::EmptyHt
 public:
   ModifyBufferFilterConfig() : EmptyHttpFilterConfig("modify-buffer-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::ModifyBufferStreamFilter>());
     };

--- a/test/integration/filters/on_local_reply_filter.cc
+++ b/test/integration/filters/on_local_reply_filter.cc
@@ -47,8 +47,8 @@ public:
 class OnLocalReplyFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpDualFilterConfig {
 public:
   OnLocalReplyFilterConfig() : EmptyHttpDualFilterConfig("on-local-reply-filter") {}
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::OnLocalReplyFilter>());
     };

--- a/test/integration/filters/pause_filter.cc
+++ b/test/integration/filters/pause_filter.cc
@@ -66,8 +66,8 @@ class TestPauseFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpF
 public:
   TestPauseFilterConfig() : EmptyHttpFilterConfig("pause-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       // ABSL_GUARDED_BY insists the lock be held when the guarded variables are passed by
       // reference.

--- a/test/integration/filters/pause_filter_for_quic.cc
+++ b/test/integration/filters/pause_filter_for_quic.cc
@@ -67,8 +67,8 @@ class TestPauseFilterConfigForQuic : public Extensions::HttpFilters::Common::Emp
 public:
   TestPauseFilterConfigForQuic() : EmptyHttpFilterConfig("pause-filter-for-quic") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       // ABSL_GUARDED_BY insists the lock be held when the guarded variables are passed by
       // reference.

--- a/test/integration/filters/process_context_filter.cc
+++ b/test/integration/filters/process_context_filter.cc
@@ -40,7 +40,7 @@ class ProcessContextFilterConfig : public Extensions::HttpFilters::Common::Empty
 public:
   ProcessContextFilterConfig() : EmptyHttpFilterConfig("process-context-filter") {}
 
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilter(const std::string&,
                Server::Configuration::FactoryContext& factory_context) override {
     return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {

--- a/test/integration/filters/random_pause_filter.cc
+++ b/test/integration/filters/random_pause_filter.cc
@@ -49,8 +49,8 @@ class RandomPauseFilterConfig : public Extensions::HttpFilters::Common::EmptyHtt
 public:
   RandomPauseFilterConfig() : EmptyHttpFilterConfig("random-pause-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       absl::WriterMutexLock m(&rand_lock_);
       if (rng_ == nullptr) {

--- a/test/integration/filters/repick_cluster_filter.cc
+++ b/test/integration/filters/repick_cluster_filter.cc
@@ -30,8 +30,8 @@ class RepickClusterFilterConfig : public Extensions::HttpFilters::Common::EmptyH
 public:
   RepickClusterFilterConfig() : EmptyHttpFilterConfig("repick-cluster-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(
           std::make_shared<::Envoy::RepickClusterFilter::RepickClusterFilter>());

--- a/test/integration/filters/request_metadata_filter.cc
+++ b/test/integration/filters/request_metadata_filter.cc
@@ -52,8 +52,8 @@ class AddRequestMetadataStreamFilterConfig
     : public Extensions::HttpFilters::Common::EmptyHttpFilterConfig {
 public:
   AddRequestMetadataStreamFilterConfig() : EmptyHttpFilterConfig("request-metadata-filter") {}
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::RequestMetadataStreamFilter>());
     };

--- a/test/integration/filters/reset_idle_timer_filter.cc
+++ b/test/integration/filters/reset_idle_timer_filter.cc
@@ -23,8 +23,8 @@ class ResetIdleTimerFilterConfig : public Extensions::HttpFilters::Common::Empty
 public:
   ResetIdleTimerFilterConfig() : EmptyHttpFilterConfig("reset-idle-timer-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::ResetIdleTimerFilter>());
     };

--- a/test/integration/filters/reset_stream_filter.cc
+++ b/test/integration/filters/reset_stream_filter.cc
@@ -22,8 +22,8 @@ public:
 class ResetFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpDualFilterConfig {
 public:
   ResetFilterConfig() : EmptyHttpDualFilterConfig("reset-stream-filter") {}
-  Http::FilterFactoryCb createDualFilter(const std::string&,
-                                         Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::ResetFilter>());
     };

--- a/test/integration/filters/response_metadata_filter.cc
+++ b/test/integration/filters/response_metadata_filter.cc
@@ -77,8 +77,8 @@ class AddMetadataStreamFilterConfig
 public:
   AddMetadataStreamFilterConfig() : EmptyHttpFilterConfig("response-metadata-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamFilter(std::make_shared<::Envoy::ResponseMetadataStreamFilter>());
     };

--- a/test/integration/filters/tee_filter.cc
+++ b/test/integration/filters/tee_filter.cc
@@ -48,8 +48,8 @@ public:
   }
 };
 
-Http::FilterFactoryCb StreamTeeFilterConfig::createFilter(const std::string&,
-                                                          Server::Configuration::FactoryContext&) {
+absl::StatusOr<Http::FilterFactoryCb>
+StreamTeeFilterConfig::createFilter(const std::string&, Server::Configuration::FactoryContext&) {
   return [this](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter = std::make_shared<StreamTeeFilter>();
     // TODO(kbaichoo): support multiple connections.

--- a/test/integration/filters/tee_filter.h
+++ b/test/integration/filters/tee_filter.h
@@ -41,8 +41,8 @@ class StreamTeeFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpF
 public:
   StreamTeeFilterConfig() : EmptyHttpFilterConfig("stream-tee-filter") {}
 
-  Http::FilterFactoryCb createFilter(const std::string&,
-                                     Server::Configuration::FactoryContext&) override;
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override;
   bool inspectStreamTee(uint32_t stream_id, std::function<void(const StreamTee&)> inspector);
   bool setEncodeDataCallback(uint32_t stream_id,
                              std::function<Http::FilterDataStatus(

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -67,7 +67,7 @@ public:
     grpc_service->mutable_envoy_grpc()->set_cluster_name("sds_cluster");
   }
 
-  Http::FilterFactoryCb
+  virtual absl::StatusOr<Http::FilterFactoryCb>
   createFilter(const std::string&,
                Server::Configuration::FactoryContext& factory_context) override {
     auto secret_provider =

--- a/test/server/filter_config_test.cc
+++ b/test/server/filter_config_test.cc
@@ -19,7 +19,7 @@ class TestHttpFilterConfigFactory : public Server::Configuration::NamedHttpFilte
 public:
   TestHttpFilterConfigFactory() = default;
 
-  Http::FilterFactoryCb
+  absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
                                Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
@@ -48,7 +48,7 @@ TEST(NamedHttpFilterConfigFactoryTest, CreateFilterFactory) {
   Server::Configuration::MockFactoryContext context;
   ProtobufTypes::MessagePtr message{new Envoy::ProtobufWkt::Struct()};
 
-  factory.createFilterFactoryFromProto(*message, stats_prefix, context);
+  EXPECT_TRUE(factory.createFilterFactoryFromProto(*message, stats_prefix, context).status().ok());
 }
 
 TEST(NamedHttpFilterConfigFactoryTest, Dependencies) {
@@ -57,7 +57,7 @@ TEST(NamedHttpFilterConfigFactoryTest, Dependencies) {
   Server::Configuration::MockFactoryContext context;
   ProtobufTypes::MessagePtr message{new Envoy::ProtobufWkt::Struct()};
 
-  factory.createFilterFactoryFromProto(*message, stats_prefix, context);
+  EXPECT_TRUE(factory.createFilterFactoryFromProto(*message, stats_prefix, context).status().ok());
 
   EXPECT_EQ(factory.dependencies()->decode_required().size(), 1);
 }


### PR DESCRIPTION
I tried my best here to keep churn minimal, so the default APIs are the same for almost all cc code (though not for tests) and you opt into exceptionless filters.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

https://github.com/envoyproxy/envoy-mobile/issues/176