### PR TITLE
fix formatter in custom response policy

### DIFF
--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -44,8 +44,8 @@ void LocalResponsePolicy::formatBody(const Envoy::Http::RequestHeaderMap& reques
   }
 
   if (formatter_) {
-    formatter_->formatWithContext({&request_headers, &response_headers, nullptr, body},
-                                  stream_info);
+    body = formatter_->formatWithContext({&request_headers, &response_headers, nullptr, body},
+                                         stream_info);
   }
 }
 

--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -240,7 +240,7 @@ json_format:
       sendRequestAndWaitForResponse(default_request_headers_, 0, unauthorized_response_, 0);
   // Verify that we get the modified status value.
   EXPECT_EQ("499", response->headers().getStatusValue());
-  EXPECT_EQ("not allowed", response->body());
+  EXPECT_EQ("{\"message\":\"not allowed\"}\n", response->body());
   EXPECT_EQ(
       "x-bar",
       response->headers().get(::Envoy::Http::LowerCaseString("foo"))[0]->value().getStringView());


### PR DESCRIPTION

Commit Message: fix formatter in custom response policy
Additional Description: the formatter has a return value, which should be new body.
Risk Level: low
Testing: the previous test is not correct, the json response body should be {"message": "not allowed"}, not the string "not allowed" according to the configuration
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
