### PR TITLE
mobile: Part 6: Update JNI usages with JniHelper

### DIFF
--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -351,38 +351,6 @@ MatcherData::Type StringToType(std::string type_as_string) {
   return MatcherData::EXACT;
 }
 
-std::vector<MatcherData> javaObjectArrayToMatcherData(JniHelper& jni_helper, jobjectArray array,
-                                                      std::string& cluster_name_out) {
-  const size_t len = jni_helper.getArrayLength(array);
-  std::vector<MatcherData> ret;
-  if (len == 0) {
-    return ret;
-  }
-  ASSERT((len - 1) % 3 == 0);
-  if ((len - 1) % 3 != 0) {
-    return ret;
-  }
-
-  JavaArrayOfByteToString(
-      jni_helper, static_cast<jbyteArray>(jni_helper.getEnv()->GetObjectArrayElement(array, 0)),
-      &cluster_name_out);
-  for (size_t i = 1; i < len; i += 3) {
-    std::string name;
-    std::string type_as_string;
-    std::string value;
-    LocalRefUniquePtr<jbyteArray> element1 = jni_helper.getObjectArrayElement<jbyteArray>(array, i);
-    JavaArrayOfByteToString(jni_helper, element1.get(), &name);
-    LocalRefUniquePtr<jbyteArray> element2 =
-        jni_helper.getObjectArrayElement<jbyteArray>(array, i + 1);
-    JavaArrayOfByteToString(jni_helper, element2.get(), &type_as_string);
-    LocalRefUniquePtr<jbyteArray> element3 =
-        jni_helper.getObjectArrayElement<jbyteArray>(array, i + 2);
-    JavaArrayOfByteToString(jni_helper, element3.get(), &value);
-    ret.emplace_back(MatcherData(name, StringToType(type_as_string), value));
-  }
-  return ret;
-}
-
 void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
                           Envoy::Protobuf::MessageLite* dest) {
   ArrayElementsUniquePtr<jbyteArray, jbyte> bytes =

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -113,9 +113,6 @@ void JavaArrayOfByteToBytesVector(JniHelper& jni_helper, jbyteArray array,
 
 void JavaArrayOfByteToString(JniHelper& jni_helper, jbyteArray jbytes, std::string* out);
 
-std::vector<MatcherData> javaObjectArrayToMatcherData(JniHelper& jni_helper, jobjectArray array,
-                                                      std::string& cluster_out);
-
 /** Parses the proto from Java's byte array and stores the output into `dest` proto. */
 void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
                           Envoy::Protobuf::MessageLite* dest);


### PR DESCRIPTION
This updates the following methods:
- `GetObjectArrayElement`
- `GetObjectClass`

This PR also deletes `javaObjectArrayToMatcherData` since it's unused.

Risk Level: low (refactoring)
Testing: unit and integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
