### PR TITLE
kafka: rewrite DescribeCluster responses

### DIFF
--- a/contrib/kafka/filters/network/source/broker/rewriter.h
+++ b/contrib/kafka/filters/network/source/broker/rewriter.h
@@ -57,15 +57,22 @@ public:
    */
   void updateFindCoordinatorBrokerAddresses(FindCoordinatorResponse& response) const;
 
+  /**
+   * Mutates response according to config.
+   */
+  void updateDescribeClusterBrokerAddresses(DescribeClusterResponse& response) const;
+
   size_t getStoredResponseCountForTest() const;
 
 private:
   // Helper function to update various response structures.
-  template <typename T> void maybeUpdateHostAndPort(T& arg) const {
-    const absl::optional<HostAndPort> hostAndPort = config_.findBrokerAddressOverride(arg.node_id_);
+  // Pointer-to-member used to handle varying field names across the structs.
+  template <typename T> void maybeUpdateHostAndPort(T& arg, const int32_t T::*node_id_field) const {
+    const int32_t node_id = arg.*node_id_field;
+    const absl::optional<HostAndPort> hostAndPort = config_.findBrokerAddressOverride(node_id);
     if (hostAndPort) {
-      ENVOY_LOG(trace, "Changing broker [{}] from {}:{} to {}:{}", arg.node_id_, arg.host_,
-                arg.port_, hostAndPort->first, hostAndPort->second);
+      ENVOY_LOG(trace, "Changing broker [{}] from {}:{} to {}:{}", node_id, arg.host_, arg.port_,
+                hostAndPort->first, hostAndPort->second);
       arg.host_ = hostAndPort->first;
       arg.port_ = hostAndPort->second;
     }

--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -171,6 +171,12 @@ in 2-node cluster:
 The address rewrite rules should cover all brokers present in the cluster - YAML blocks can be
 used to avoid repetition.
 
+The responses that can be mutated are:
+
+* metadata (all partition discovery operations),
+* find coordinator (used by consumer groups and transactions),
+* describe cluster.
+
 .. _config_network_filters_kafka_broker_debugging:
 
 Debugging


### PR DESCRIPTION
Commit Message: kafka: rewrite DescribeCluster responses
Additional Description: newer versions of Kafka support DC request that basically tells us how does the upstream cluster look like - we can amend that response as well; part of https://github.com/envoyproxy/envoy/issues/30669
Risk Level: low
Testing: unit tests, integration tests, manual testing via [envoy-kafka-tests](https://github.com/adamkotwasinski/envoy-kafka-tests/pull/10/files#diff-de48746df8477559316fbec54827b49974712b530d746181d874bbb4ea602514R151)
Docs Changes: minor doc update
Release Notes: N/A
Platform Specific Features: N/A