### PR TITLE
access log: Honor `omit_empty_values` for text source

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -61,6 +61,9 @@ bug_fixes:
 - area: redis
   change: |
     Fixed a bug causing crash if incoming redis key does not match against a prefix_route and catch_all_route is not defined.
+- area: access log
+  change: |
+    Fixed a bug where the `omit_empty_values` field was not honored for access logs specifying formats via `text_format_source`.
 - area: ext_proc
   change: |
     Fixed content_length related issues when body mutation by external processor is enabled. ext_proc filter removes the content

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -63,7 +63,7 @@ bug_fixes:
     Fixed a bug causing crash if incoming redis key does not match against a prefix_route and catch_all_route is not defined.
 - area: access log
   change: |
-    Fixed a bug where the `omit_empty_values` field was not honored for access logs specifying formats via `text_format_source`.
+    Fixed a bug where the omit_empty_values field was not honored for access logs specifying formats via text_format_source.
 - area: ext_proc
   change: |
     Fixed content_length related issues when body mutation by external processor is enabled. ext_proc filter removes the content

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -57,8 +57,8 @@ public:
           commands);
     case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormatSource:
       return std::make_unique<FormatterBaseImpl<FormatterContext>>(
-          Config::DataSource::read(config.text_format_source(), true, context.api()), false,
-          commands);
+          Config::DataSource::read(config.text_format_source(), true, context.api()),
+          config.omit_empty_values(), commands);
     case envoy::config::core::v3::SubstitutionFormatString::FormatCase::FORMAT_NOT_SET:
       PANIC_DUE_TO_PROTO_UNSET;
     }

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -19,7 +19,7 @@ namespace LocalReply {
 class BodyFormatter {
 public:
   BodyFormatter()
-      : formatter_(std::make_unique<Envoy::Formatter::FormatterImpl>("%LOCAL_REPLY_BODY%")),
+      : formatter_(std::make_unique<Envoy::Formatter::FormatterImpl>("%LOCAL_REPLY_BODY%", false)),
         content_type_(Http::Headers::get().ContentTypeValues.Text) {}
 
   BodyFormatter(const envoy::config::core::v3::SubstitutionFormatString& config,

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -62,6 +62,9 @@ public:
     stream_info_.stream_id_provider_ = nullptr;
   }
 
+protected:
+  void routeNameTest(std::string yaml, bool omit_empty);
+
   NiceMock<MockTimeSystem> time_source_;
   Http::TestRequestHeaderMapImpl request_headers_{{":method", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers_;
@@ -124,17 +127,7 @@ typed_config:
             output_);
 }
 
-TEST_F(AccessLogImplTest, RouteName) {
-  const std::string yaml = R"EOF(
-name: accesslog
-typed_config:
-  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-  path: /dev/null
-  log_format:
-    text_format_source:
-      inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH):256% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %ROUTE_NAME% %BYTES_RECEIVED% %BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% %UPSTREAM_WIRE_BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\"  \"%REQ(:AUTHORITY)%\"\n"
-  )EOF";
-
+void AccessLogImplTest::routeNameTest(std::string yaml, bool omit_empty) {
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
@@ -152,10 +145,46 @@ typed_config:
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_,
            AccessLog::AccessLogType::NotSet);
 
-  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 UF route-test-name 1 2 0 0 3 - "
-            "\"x.x.x.x\" "
-            "\"user-agent-set\" \"id\"  \"host\"\n",
-            output_);
+  if (omit_empty) {
+    EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 UF route-test-name 1 2 0 0 3  "
+              "\"x.x.x.x\" "
+              "\"user-agent-set\" \"id\"  \"host\"\n",
+              output_);
+  } else {
+    EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 UF route-test-name 1 2 0 0 3 - "
+              "\"x.x.x.x\" "
+              "\"user-agent-set\" \"id\"  \"host\"\n",
+              output_);
+  }
+}
+
+TEST_F(AccessLogImplTest, RouteName) {
+  const std::string yaml = R"EOF(
+name: accesslog
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+  path: /dev/null
+  log_format:
+    text_format_source:
+      inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH):256% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %ROUTE_NAME% %BYTES_RECEIVED% %BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% %UPSTREAM_WIRE_BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\"  \"%REQ(:AUTHORITY)%\"\n"
+  )EOF";
+
+  routeNameTest(yaml, false /* omit_empty */);
+}
+
+TEST_F(AccessLogImplTest, RouteNameWithOmitEmptyString) {
+  const std::string yaml = R"EOF(
+name: accesslog
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+  path: /dev/null
+  log_format:
+    text_format_source:
+      inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH):256% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %ROUTE_NAME% %BYTES_RECEIVED% %BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% %UPSTREAM_WIRE_BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\"  \"%REQ(:AUTHORITY)%\"\n"
+    omit_empty_values: true
+  )EOF";
+
+  routeNameTest(yaml, true /* omit_empty */);
 }
 
 TEST_F(AccessLogImplTest, HeadersBytes) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -3945,7 +3945,7 @@ TEST(SubstitutionFormatterTest, CompositeFormatterSuccess) {
     const std::string format = "%START_TIME(%E4n)%";
     const SystemTime start_time(std::chrono::microseconds(1522796769123456));
     EXPECT_CALL(stream_info, startTime()).WillOnce(Return(start_time));
-    FormatterImpl formatter(format);
+    FormatterImpl formatter(format, false);
     EXPECT_EQ("%E4n", formatter.formatWithContext(formatter_context, stream_info));
   }
 #endif


### PR DESCRIPTION
When formatting access logs using `text_format_source`, the `omit_empty_values` field was not honored. This patch fixes that behavior.

Fixes: #29876 
Risk Level: low