### PR TITLE
mobile: Part 7: Update JNI usages with JniHelper

### DIFF
--- a/mobile/library/common/jni/android_network_utility.cc
+++ b/mobile/library/common/jni/android_network_utility.cc
@@ -77,16 +77,15 @@ call_jvm_verify_x509_cert_chain(Envoy::JNI::JniHelper& jni_helper,
   jmethodID jmid_verifyServerCertificates = jni_helper.getStaticMethodId(
       jcls_AndroidNetworkLibrary, "verifyServerCertificates",
       "([[B[B[B)Lio/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult;");
-  jobjectArray chain_byte_array = Envoy::JNI::ToJavaArrayOfByteArray(jni_helper, cert_chain);
-  jbyteArray auth_string = Envoy::JNI::ToJavaByteArray(jni_helper, auth_type);
-  jbyteArray host_string = Envoy::JNI::ToJavaByteArray(
+  Envoy::JNI::LocalRefUniquePtr<jobjectArray> chain_byte_array =
+      Envoy::JNI::ToJavaArrayOfByteArray(jni_helper, cert_chain);
+  Envoy::JNI::LocalRefUniquePtr<jbyteArray> auth_string =
+      Envoy::JNI::ToJavaByteArray(jni_helper, auth_type);
+  Envoy::JNI::LocalRefUniquePtr<jbyteArray> host_string = Envoy::JNI::ToJavaByteArray(
       jni_helper, reinterpret_cast<const uint8_t*>(hostname.data()), hostname.length());
-  Envoy::JNI::LocalRefUniquePtr<jobject> result =
-      jni_helper.callStaticObjectMethod(jcls_AndroidNetworkLibrary, jmid_verifyServerCertificates,
-                                        chain_byte_array, auth_string, host_string);
-  jni_helper.getEnv()->DeleteLocalRef(chain_byte_array);
-  jni_helper.getEnv()->DeleteLocalRef(auth_string);
-  jni_helper.getEnv()->DeleteLocalRef(host_string);
+  Envoy::JNI::LocalRefUniquePtr<jobject> result = jni_helper.callStaticObjectMethod(
+      jcls_AndroidNetworkLibrary, jmid_verifyServerCertificates, chain_byte_array.get(),
+      auth_string.get(), host_string.get());
   jni_helper.getEnv()->DeleteLocalRef(jcls_AndroidNetworkLibrary);
   return result;
 }

--- a/mobile/library/common/jni/jni_helper.h
+++ b/mobile/library/common/jni/jni_helper.h
@@ -31,6 +31,9 @@ class LocalRefDeleter {
 public:
   explicit LocalRefDeleter(JNIEnv* env) : env_(env) {}
 
+  // This is to allow move semantics in `LocalRefUniquePtr`.
+  LocalRefDeleter& operator=(const LocalRefDeleter&) { return *this; }
+
   void operator()(jobject object) const {
     if (object != nullptr) {
       env_->DeleteLocalRef(object);

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -631,8 +631,7 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_in_data = Envoy::JNI::LocalRefUniquePtr<jbyteArray>(
       nullptr, Envoy::JNI::LocalRefDeleter(jni_helper.getEnv()));
   if (data) {
-    auto x = Envoy::JNI::native_data_to_array(jni_helper, *data);
-    j_in_data = std::move(x);
+    j_in_data = Envoy::JNI::native_data_to_array(jni_helper, *data);
   }
   jlong trailers_length = -1;
   if (trailers) {

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -57,14 +57,16 @@ envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data, size_t
  * @param env, the JNI env pointer.
  * @param envoy_data, the source to copy from.
  *
- * @return jbyteArray, copied data. It is up to the function caller to clean up memory.
+ * @return jbyteArray, copied data.
  */
-jbyteArray native_data_to_array(JniHelper& jni_helper, envoy_data data);
+LocalRefUniquePtr<jbyteArray> native_data_to_array(JniHelper& jni_helper, envoy_data data);
 
-jlongArray native_stream_intel_to_array(JniHelper& jni_helper, envoy_stream_intel stream_intel);
+LocalRefUniquePtr<jlongArray> native_stream_intel_to_array(JniHelper& jni_helper,
+                                                           envoy_stream_intel stream_intel);
 
-jlongArray native_final_stream_intel_to_array(JniHelper& jni_helper,
-                                              envoy_final_stream_intel final_stream_intel);
+LocalRefUniquePtr<jlongArray>
+native_final_stream_intel_to_array(JniHelper& jni_helper,
+                                   envoy_final_stream_intel final_stream_intel);
 
 /**
  * Utility function that copies envoy_map to a java HashMap jobject.
@@ -72,9 +74,9 @@ jlongArray native_final_stream_intel_to_array(JniHelper& jni_helper,
  * @param env, the JNI env pointer.
  * @param envoy_map, the source to copy from.
  *
- * @return jobject, copied data. It is up to the function caller to clean up memory.
+ * @return jobject, copied data.
  */
-jobject native_map_to_map(JniHelper& jni_helper, envoy_map map);
+LocalRefUniquePtr<jobject> native_map_to_map(JniHelper& jni_helper, envoy_map map);
 
 LocalRefUniquePtr<jstring> native_data_to_string(JniHelper& jni_helper, envoy_data data);
 
@@ -96,14 +98,16 @@ envoy_map to_native_map(JniHelper& jni_helper, jobjectArray entries);
  * Utilities to translate C++ std library constructs to their Java counterpart.
  * The underlying data is always copied to disentangle C++ and Java objects lifetime.
  */
-jobjectArray ToJavaArrayOfByteArray(JniHelper& jni_helper, const std::vector<std::string>& v);
+LocalRefUniquePtr<jobjectArray> ToJavaArrayOfByteArray(JniHelper& jni_helper,
+                                                       const std::vector<std::string>& v);
 
-jbyteArray ToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes, size_t len);
+LocalRefUniquePtr<jbyteArray> ToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes,
+                                              size_t len);
 
-jbyteArray ToJavaByteArray(JniHelper& jni_helper, const std::string& str);
+LocalRefUniquePtr<jbyteArray> ToJavaByteArray(JniHelper& jni_helper, const std::string& str);
 
-jobjectArray ToJavaArrayOfObjectArray(JniHelper& jni_helper,
-                                      const Envoy::Types::ManagedEnvoyHeaders& map);
+LocalRefUniquePtr<jobjectArray>
+ToJavaArrayOfObjectArray(JniHelper& jni_helper, const Envoy::Types::ManagedEnvoyHeaders& map);
 
 void JavaArrayOfByteArrayToStringVector(JniHelper& jni_helper, jobjectArray array,
                                         std::vector<std::string>* out);


### PR DESCRIPTION
This PR updates the following methods:
- `New<Type>Array`
- `NewObject`

This PR also updates some functions in `jni_utility.(h|cc)` to return a smart pointer instead of a raw pointer.

Risk Level: low
Testing: unit and integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile