### PR TITLE
[bp/1.25] buffer: separate the BufferFragement release and drain tracker (#28770)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,10 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: buffer
+  change: |
+    Fixed a bug (https://github.com/envoyproxy/envoy/issues/28760) that the internal listener causes an undefined
+    behavior due to the unintended release of the buffer memory.
 - area: http
   change: |
     Fixed recursion when HTTP connection is disconnected due to a high number of premature resets.

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -90,7 +90,7 @@ public:
       : capacity_(fragment.size()), storage_(nullptr),
         base_(static_cast<uint8_t*>(const_cast<void*>(fragment.data()))),
         reservable_(fragment.size()) {
-    addDrainTracker([&fragment]() { fragment.done(); });
+    releasor_ = [&fragment]() { fragment.done(); };
   }
 
   Slice(Slice&& rhs) noexcept {
@@ -101,6 +101,7 @@ public:
     reservable_ = rhs.reservable_;
     drain_trackers_ = std::move(rhs.drain_trackers_);
     account_ = std::move(rhs.account_);
+    releasor_.swap(rhs.releasor_);
 
     rhs.capacity_ = 0;
     rhs.base_ = nullptr;
@@ -119,6 +120,11 @@ public:
       reservable_ = rhs.reservable_;
       drain_trackers_ = std::move(rhs.drain_trackers_);
       account_ = std::move(rhs.account_);
+      if (releasor_) {
+        releasor_();
+      }
+      releasor_ = rhs.releasor_;
+      rhs.releasor_ = nullptr;
 
       rhs.capacity_ = 0;
       rhs.base_ = nullptr;
@@ -129,7 +135,12 @@ public:
     return *this;
   }
 
-  ~Slice() { callAndClearDrainTrackersAndCharges(); }
+  ~Slice() {
+    callAndClearDrainTrackersAndCharges();
+    if (releasor_) {
+      releasor_();
+    }
+  }
 
   /**
    * @return true if the data in the slice is mutable
@@ -307,6 +318,9 @@ public:
   void transferDrainTrackersTo(Slice& destination) {
     destination.drain_trackers_.splice(destination.drain_trackers_.end(), drain_trackers_);
     ASSERT(drain_trackers_.empty());
+    // The releasor needn't to be transferred, and actually if there is releasor, this
+    // slice can't coalesce. Then there won't be a chance to calling this method.
+    ASSERT(releasor_ == nullptr);
   }
 
   /**
@@ -397,6 +411,9 @@ protected:
   /** Account associated with this slice. This may be null. When
    * coalescing with another slice, we do not transfer over their account. */
   BufferMemoryAccountSharedPtr account_;
+
+  /** The releasor for the BufferFragment */
+  std::function<void()> releasor_;
 };
 
 class OwnedImpl;

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -395,6 +395,26 @@ TEST_F(IoHandleImplTest, ShutDownOptionsNotSupported) {
   ASSERT_DEBUG_DEATH(io_handle_peer_->shutdown(ENVOY_SHUT_RDWR), "");
 }
 
+// This test is ensure the memory created by BufferFragment won't be released
+// after the write.
+TEST_F(IoHandleImplTest, WriteBufferFragement) {
+  Buffer::OwnedImpl buf("a");
+  bool released = false;
+  auto buf_frag = Buffer::OwnedBufferFragmentImpl::create(
+      std::string(255, 'b'), [&released](const Buffer::OwnedBufferFragmentImpl* fragment) {
+        released = true;
+        delete fragment;
+      });
+  buf.addBufferFragment(*buf_frag.release());
+
+  auto result = io_handle_->write(buf);
+  EXPECT_FALSE(released);
+  EXPECT_EQ(0, buf.length());
+  io_handle_peer_->read(buf, absl::nullopt);
+  buf.drain(buf.length());
+  EXPECT_TRUE(released);
+}
+
 TEST_F(IoHandleImplTest, WriteByMove) {
   Buffer::OwnedImpl buf("0123456789");
   auto result = io_handle_peer_->write(buf);


### PR DESCRIPTION
Commit Message: [bp/1.25] buffer: separate the BufferFragement release and drain tracker (#28770)
Additional Description:
This the backport of https://github.com/envoyproxy/envoy/pull/28770

There is a requirement for the user space io handle and iouring io handle to move the write buffer to its own buffer and invoke the drain trackers. But becomes an issue for the BufferFragment, the BufferFragement's releasor is invoked by the drain tracker also. After moving with invoke drain trackers, the memory in the BufferFragment will be released too, which leads to the Buffer reference some memory already released.
Risk Level: high
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes https://github.com/envoyproxy/envoy/issues/28760
Related to issue: https://github.com/envoyproxy/envoy/issues/28395
