### PR TITLE
fix: only enable full scan when enable_full_scan is set explicitly forleast request lb

### DIFF
--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1299,9 +1299,8 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
                                                                 const HostsSource&) {
   HostSharedPtr candidate_host = nullptr;
 
-  // Do full scan if it's required explicitly or the number of choices is equal to or larger than
-  // the hosts size.
-  if ((hosts_to_use.size() <= choice_count_) || enable_full_scan_) {
+  // Do full scan if it's required explicitly.
+  if (enable_full_scan_) {
     for (const auto& sampled_host : hosts_to_use) {
       if (candidate_host == nullptr) {
         // Make a first choice to start the comparisons.

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -176,10 +176,7 @@ public:
       }
     }
 
-    // The default number of choices for the LEAST_REQUEST policy is 2 hosts, if the number of hosts
-    // is equal to the number of choices, a full scan happens instead, this means that the same host
-    // will be chosen.
-    if (is_hash_lb_ || (GetParam() == envoy::config::cluster::v3::Cluster::LEAST_REQUEST)) {
+    if (is_hash_lb_) {
       EXPECT_EQ(hosts.size(), 1) << "Expected a single unique host to be selected for "
                                  << envoy::config::cluster::v3::Cluster::LbPolicy_Name(GetParam());
     } else {


### PR DESCRIPTION
Commit Message: fix: only enable full scan when enable_full_scan is set explicitly forleast request lb
Additional Description:

https://github.com/envoyproxy/envoy/pull/29873 introduced a minor breaking change. The full scan will be enabled automatically when host num is less than choice count.
Although from technical point, I think this change basically harmless and could make a better load balancing result, a new runtime guard should be enough.

But in practice, it effects our downstream users in a unexpected way. See https://github.com/envoyproxy/envoy/pull/30768#discussion_r1387092315

No change log is updated or added because our change log or doc doesn't mention that full scan will be enabled automatically when host num less than choice count.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
