### PR TITLE
iouring: disable request timeout for test CloseConnectionWithDeferredStreams

### DIFF
--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2523,6 +2523,17 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   config_helper_.addRuntimeOverride("http.max_requests_per_io_cycle", "1");
   // Ensure premature reset detection does not get in the way
   config_helper_.addRuntimeOverride("overload.premature_reset_total_stream_count", "1001");
+  // Disable the request timeout, iouring may failed the test due to request timeout.
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        hcm.mutable_route_config()
+            ->mutable_virtual_hosts(0)
+            ->mutable_routes(0)
+            ->mutable_route()
+            ->mutable_timeout()
+            ->set_seconds(0);
+      });
   beginSession();
 
   std::string buffer;

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2535,21 +2535,9 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   ASSERT_TRUE(tcp_client_->connected());
   // Drop the downstream connection
   tcp_client_->close();
-  // NOTE (soulxu): the connection may closed before all the streams are parsed when
-  // using the iouring. So we need to check the number of reset streams equal to
-  // the number of streams recevied. Before check the number of reset stream, we need
-  // ensure all the streams are reset by checking the active connection.
-  test_server_->waitForGaugeEq("http.config_test.downstream_cx_active", 0,
-                               TestUtility::DefaultTimeout * 3);
-  auto downstream_rq_total_counter = Envoy::TestUtility::findCounter(
-      test_server_->statStore(), "http.config_test.downstream_rq_total");
-  auto downstream_rq_completed = Envoy::TestUtility::findCounter(
-      test_server_->statStore(), "http.config_test.downstream_rq_completed");
   // Test that Envoy can clean-up deferred streams
   // Make the timeout longer to accommodate non optimized builds
-  test_server_->waitForCounterEq("http.config_test.downstream_rq_rx_reset",
-                                 downstream_rq_total_counter->value() -
-                                     downstream_rq_completed->value(),
+  test_server_->waitForCounterEq("http.config_test.downstream_rq_rx_reset", kRequestsSentPerIOCycle,
                                  TestUtility::DefaultTimeout * 3);
 }
 

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2537,7 +2537,7 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   tcp_client_->close();
   // NOTE (soulxu): the connection may closed before all the streams are parsed when
   // using the iouring. So we need to check the number of reset streams equal to
-  // the number of streams received. Before check the number of reset stream, we need
+  // the number of streams recevied. Before check the number of reset stream, we need
   // ensure all the streams are reset by checking the active connection.
   test_server_->waitForGaugeEq("http.config_test.downstream_cx_active", 0,
                                TestUtility::DefaultTimeout * 3);

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2535,9 +2535,21 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   ASSERT_TRUE(tcp_client_->connected());
   // Drop the downstream connection
   tcp_client_->close();
+  // NOTE (soulxu): the connection may closed before all the streams are parsed when
+  // using the iouring. So we need to check the number of reset streams equal to
+  // the number of streams recevied. Before check the number of reset stream, we need
+  // ensure all the streams are reset by checking the active connection.
+  test_server_->waitForGaugeEq("http.config_test.downstream_cx_active", 0,
+                               TestUtility::DefaultTimeout * 3);
+  auto downstream_rq_total_counter = Envoy::TestUtility::findCounter(
+      test_server_->statStore(), "http.config_test.downstream_rq_total");
+  auto downstream_rq_completed = Envoy::TestUtility::findCounter(
+      test_server_->statStore(), "http.config_test.downstream_rq_completed");
   // Test that Envoy can clean-up deferred streams
   // Make the timeout longer to accommodate non optimized builds
-  test_server_->waitForCounterEq("http.config_test.downstream_rq_rx_reset", kRequestsSentPerIOCycle,
+  test_server_->waitForCounterEq("http.config_test.downstream_rq_rx_reset",
+                                 downstream_rq_total_counter->value() -
+                                     downstream_rq_completed->value(),
                                  TestUtility::DefaultTimeout * 3);
 }
 

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2537,7 +2537,7 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   tcp_client_->close();
   // NOTE (soulxu): the connection may closed before all the streams are parsed when
   // using the iouring. So we need to check the number of reset streams equal to
-  // the number of streams recevied. Before check the number of reset stream, we need
+  // the number of streams received. Before check the number of reset stream, we need
   // ensure all the streams are reset by checking the active connection.
   test_server_->waitForGaugeEq("http.config_test.downstream_cx_active", 0,
                                TestUtility::DefaultTimeout * 3);


### PR DESCRIPTION
Commit Message: iouring: disable request timeout for test CloseConnectionWithDeferredStreams
Additional Description:
The test `CloseConnectionWithDeferredStreams` assumes the Envoy will receive all the new streams, but this is only true for the socket API. When using the socket API, Envoy will try to drain all the data from the system buffer.

But when using the iouring, the read request was submitted in advance. The size of data drained from the system buffer depends on the initial request setup. After reading part of the data, the envoy is going to the next event loop iteration. Then the request may get timeout in the next event loop. The request timeout triggers a response to the downstream, which will lead to the Envoy finding the downstream connection already closed. Then it closes the whole filter chain and stops to receive the remaining data.

This is fixed by disabling the request timeout.
Risk Level: low
Testing: integration test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Part of Issue https://github.com/envoyproxy/envoy/issues/28395
