### PR TITLE
mobile: Part 9: Update JNI usages with JniHelper

### DIFF
--- a/mobile/library/common/jni/jni_helper.cc
+++ b/mobile/library/common/jni/jni_helper.cc
@@ -43,7 +43,6 @@ LocalRefUniquePtr<jthrowable> JniHelper::exceptionOccurred() {
 
 GlobalRefUniquePtr<jobject> JniHelper::newGlobalRef(jobject object) {
   GlobalRefUniquePtr<jobject> result(env_->NewGlobalRef(object), GlobalRefDeleter(env_));
-  RELEASE_ASSERT(result != nullptr, "Failed calling NewGlobalRef.");
   return result;
 }
 
@@ -118,14 +117,6 @@ DEFINE_GET_ARRAY_ELEMENTS(Boolean, jbooleanArray, jboolean)
 void JniHelper::setObjectArrayElement(jobjectArray array, jsize index, jobject value) {
   env_->SetObjectArrayElement(array, index, value);
   rethrowException();
-}
-
-PrimitiveArrayCriticalUniquePtr JniHelper::getPrimitiveArrayCritical(jarray array,
-                                                                     jboolean* is_copy) {
-  PrimitiveArrayCriticalUniquePtr result(env_->GetPrimitiveArrayCritical(array, is_copy),
-                                         PrimitiveArrayCriticalDeleter(env_, array));
-  rethrowException();
-  return result;
 }
 
 #define DEFINE_SET_ARRAY_REGION(JAVA_TYPE, JNI_ARRAY_TYPE, JNI_ELEMENT_TYPE)                       \

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -888,9 +888,9 @@ static const void* jvm_http_filter_init(const void* context) {
   Envoy::JNI::LocalRefUniquePtr<jobject> j_filter =
       jni_helper.callObjectMethod(j_context, jmid_create);
   jni_log_fmt("[Envoy]", "j_filter: %p", j_filter.get());
-  jobject retained_filter = jni_helper.getEnv()->NewGlobalRef(j_filter.get());
+  Envoy::JNI::GlobalRefUniquePtr<jobject> retained_filter = jni_helper.newGlobalRef(j_filter.get());
 
-  return retained_filter;
+  return retained_filter.release();
 }
 
 // EnvoyStringAccessor
@@ -1150,10 +1150,9 @@ std::string getCppString(Envoy::JNI::JniHelper& jni_helper, jstring java_string)
 // Converts a java byte array to a C++ string.
 std::string javaByteArrayToString(Envoy::JNI::JniHelper& jni_helper, jbyteArray j_data) {
   size_t data_length = static_cast<size_t>(jni_helper.getArrayLength(j_data));
-  char* critical_data =
-      static_cast<char*>(jni_helper.getEnv()->GetPrimitiveArrayCritical(j_data, 0));
-  std::string ret(critical_data, data_length);
-  jni_helper.getEnv()->ReleasePrimitiveArrayCritical(j_data, critical_data, 0);
+  Envoy::JNI::PrimitiveArrayCriticalUniquePtr<char> critical_data =
+      jni_helper.getPrimitiveArrayCritical<char*>(j_data, nullptr);
+  std::string ret(critical_data.get(), data_length);
   return ret;
 }
 

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -58,9 +58,9 @@ envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data) {
 
 envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data, size_t data_length) {
   uint8_t* native_bytes = static_cast<uint8_t*>(safe_malloc(data_length));
-  void* critical_data = jni_helper.getEnv()->GetPrimitiveArrayCritical(j_data, 0);
-  memcpy(native_bytes, critical_data, data_length); // NOLINT(safe-memcpy)
-  jni_helper.getEnv()->ReleasePrimitiveArrayCritical(j_data, critical_data, 0);
+  Envoy::JNI::PrimitiveArrayCriticalUniquePtr<void> critical_data =
+      jni_helper.getPrimitiveArrayCritical(j_data, nullptr);
+  memcpy(native_bytes, critical_data.get(), data_length); // NOLINT(safe-memcpy)
   return {data_length, native_bytes, free, native_bytes};
 }
 
@@ -72,29 +72,23 @@ LocalRefUniquePtr<jstring> native_data_to_string(JniHelper& jni_helper, envoy_da
 
 LocalRefUniquePtr<jbyteArray> native_data_to_array(JniHelper& jni_helper, envoy_data data) {
   LocalRefUniquePtr<jbyteArray> j_data = jni_helper.newByteArray(data.length);
-  void* critical_data = jni_helper.getEnv()->GetPrimitiveArrayCritical(j_data.get(), nullptr);
+  PrimitiveArrayCriticalUniquePtr<void> critical_data =
+      jni_helper.getPrimitiveArrayCritical(j_data.get(), nullptr);
   RELEASE_ASSERT(critical_data != nullptr, "unable to allocate memory in jni_utility");
-  memcpy(critical_data, data.bytes, data.length); // NOLINT(safe-memcpy)
-  // Here '0' (for which there is no named constant) indicates we want to commit the changes back
-  // to the JVM and free the c array, where applicable.
-  // TODO: potential perf improvement. Check if copied via isCopy, and optimize memory handling.
-  jni_helper.getEnv()->ReleasePrimitiveArrayCritical(j_data.get(), critical_data, 0);
+  memcpy(critical_data.get(), data.bytes, data.length); // NOLINT(safe-memcpy)
   return j_data;
 }
 
 LocalRefUniquePtr<jlongArray> native_stream_intel_to_array(JniHelper& jni_helper,
                                                            envoy_stream_intel stream_intel) {
   LocalRefUniquePtr<jlongArray> j_array = jni_helper.newLongArray(4);
-  jlong* critical_array =
-      static_cast<jlong*>(jni_helper.getEnv()->GetPrimitiveArrayCritical(j_array.get(), nullptr));
+  PrimitiveArrayCriticalUniquePtr<jlong> critical_array =
+      jni_helper.getPrimitiveArrayCritical<jlong*>(j_array.get(), nullptr);
   RELEASE_ASSERT(critical_array != nullptr, "unable to allocate memory in jni_utility");
-  critical_array[0] = static_cast<jlong>(stream_intel.stream_id);
-  critical_array[1] = static_cast<jlong>(stream_intel.connection_id);
-  critical_array[2] = static_cast<jlong>(stream_intel.attempt_count);
-  critical_array[3] = static_cast<jlong>(stream_intel.consumed_bytes_from_response);
-  // Here '0' (for which there is no named constant) indicates we want to commit the changes back
-  // to the JVM and free the c array, where applicable.
-  jni_helper.getEnv()->ReleasePrimitiveArrayCritical(j_array.get(), critical_array, 0);
+  critical_array.get()[0] = static_cast<jlong>(stream_intel.stream_id);
+  critical_array.get()[1] = static_cast<jlong>(stream_intel.connection_id);
+  critical_array.get()[2] = static_cast<jlong>(stream_intel.attempt_count);
+  critical_array.get()[3] = static_cast<jlong>(stream_intel.consumed_bytes_from_response);
   return j_array;
 }
 
@@ -102,30 +96,26 @@ LocalRefUniquePtr<jlongArray>
 native_final_stream_intel_to_array(JniHelper& jni_helper,
                                    envoy_final_stream_intel final_stream_intel) {
   LocalRefUniquePtr<jlongArray> j_array = jni_helper.newLongArray(16);
-  jlong* critical_array =
-      static_cast<jlong*>(jni_helper.getEnv()->GetPrimitiveArrayCritical(j_array.get(), nullptr));
+  PrimitiveArrayCriticalUniquePtr<jlong> critical_array =
+      jni_helper.getPrimitiveArrayCritical<jlong*>(j_array.get(), nullptr);
   RELEASE_ASSERT(critical_array != nullptr, "unable to allocate memory in jni_utility");
 
-  critical_array[0] = static_cast<jlong>(final_stream_intel.stream_start_ms);
-  critical_array[1] = static_cast<jlong>(final_stream_intel.dns_start_ms);
-  critical_array[2] = static_cast<jlong>(final_stream_intel.dns_end_ms);
-  critical_array[3] = static_cast<jlong>(final_stream_intel.connect_start_ms);
-  critical_array[4] = static_cast<jlong>(final_stream_intel.connect_end_ms);
-  critical_array[5] = static_cast<jlong>(final_stream_intel.ssl_start_ms);
-  critical_array[6] = static_cast<jlong>(final_stream_intel.ssl_end_ms);
-  critical_array[7] = static_cast<jlong>(final_stream_intel.sending_start_ms);
-  critical_array[8] = static_cast<jlong>(final_stream_intel.sending_end_ms);
-  critical_array[9] = static_cast<jlong>(final_stream_intel.response_start_ms);
-  critical_array[10] = static_cast<jlong>(final_stream_intel.stream_end_ms);
-  critical_array[11] = static_cast<jlong>(final_stream_intel.socket_reused);
-  critical_array[12] = static_cast<jlong>(final_stream_intel.sent_byte_count);
-  critical_array[13] = static_cast<jlong>(final_stream_intel.received_byte_count);
-  critical_array[14] = static_cast<jlong>(final_stream_intel.response_flags);
-  critical_array[15] = static_cast<jlong>(final_stream_intel.upstream_protocol);
-
-  // Here '0' (for which there is no named constant) indicates we want to commit the changes back
-  // to the JVM and free the c array, where applicable.
-  jni_helper.getEnv()->ReleasePrimitiveArrayCritical(j_array.get(), critical_array, 0);
+  critical_array.get()[0] = static_cast<jlong>(final_stream_intel.stream_start_ms);
+  critical_array.get()[1] = static_cast<jlong>(final_stream_intel.dns_start_ms);
+  critical_array.get()[2] = static_cast<jlong>(final_stream_intel.dns_end_ms);
+  critical_array.get()[3] = static_cast<jlong>(final_stream_intel.connect_start_ms);
+  critical_array.get()[4] = static_cast<jlong>(final_stream_intel.connect_end_ms);
+  critical_array.get()[5] = static_cast<jlong>(final_stream_intel.ssl_start_ms);
+  critical_array.get()[6] = static_cast<jlong>(final_stream_intel.ssl_end_ms);
+  critical_array.get()[7] = static_cast<jlong>(final_stream_intel.sending_start_ms);
+  critical_array.get()[8] = static_cast<jlong>(final_stream_intel.sending_end_ms);
+  critical_array.get()[9] = static_cast<jlong>(final_stream_intel.response_start_ms);
+  critical_array.get()[10] = static_cast<jlong>(final_stream_intel.stream_end_ms);
+  critical_array.get()[11] = static_cast<jlong>(final_stream_intel.socket_reused);
+  critical_array.get()[12] = static_cast<jlong>(final_stream_intel.sent_byte_count);
+  critical_array.get()[13] = static_cast<jlong>(final_stream_intel.received_byte_count);
+  critical_array.get()[14] = static_cast<jlong>(final_stream_intel.response_flags);
+  critical_array.get()[15] = static_cast<jlong>(final_stream_intel.upstream_protocol);
   return j_array;
 }
 
@@ -184,7 +174,7 @@ envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data, size_t d
   native_data.bytes = direct_address;
   native_data.length = data_length;
   native_data.release = jni_delete_global_ref;
-  native_data.context = jni_helper.getEnv()->NewGlobalRef(j_data);
+  native_data.context = jni_helper.newGlobalRef(j_data).release();
 
   return native_data;
 }


### PR DESCRIPTION
This PR updates the following methods:
- `NewGlobalRef`
- `GetPrimitiveArrayCritical`

This should be the last PR that updates the JNI usages to `JniHelper`. Most JNI code has been updated to use automatic memory management, except in few places.

Risk Level: low
Testing: unit and integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
