### PR TITLE
cleanup: udpa to xds naming fix in BUILD files

### DIFF
--- a/api/envoy/extensions/filters/http/credential_injector/v3/BUILD
+++ b/api/envoy/extensions/filters/http/credential_injector/v3/BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/core/v3:pkg",
-        "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@com_github_cncf_udpa//xds/annotations/v3:pkg",
+        "@com_github_cncf_xds//udpa/annotations:pkg",
+        "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/injected_credentials/generic/v3/BUILD
+++ b/api/envoy/extensions/injected_credentials/generic/v3/BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
-        "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@com_github_cncf_udpa//xds/annotations/v3:pkg",
+        "@com_github_cncf_xds//udpa/annotations:pkg",
+        "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/injected_credentials/oauth2/v3/BUILD
+++ b/api/envoy/extensions/injected_credentials/oauth2/v3/BUILD
@@ -8,7 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/config/core/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
-        "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@com_github_cncf_udpa//xds/annotations/v3:pkg",
+        "@com_github_cncf_xds//udpa/annotations:pkg",
+        "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],
 )


### PR DESCRIPTION
Commit Message: cleanup: udpa to xds naming fix in BUILD files
Additional Description:
PR #30802 updated the used repo name, and PR #27769 which was submitted concurrently did not have the same fix.
Fixing that.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A