### PR TITLE
mobile: Use camelCase for function names

### DIFF
--- a/mobile/library/common/common/default_system_helper_android.cc
+++ b/mobile/library/common/common/default_system_helper_android.cc
@@ -5,15 +5,15 @@
 namespace Envoy {
 
 bool DefaultSystemHelper::isCleartextPermitted(absl::string_view hostname) {
-  return JNI::is_cleartext_permitted(hostname);
+  return JNI::isCleartextPermitted(hostname);
 }
 
 envoy_cert_validation_result
 DefaultSystemHelper::validateCertificateChain(const std::vector<std::string>& certs,
                                               absl::string_view hostname) {
-  return JNI::verify_x509_cert_chain(certs, hostname);
+  return JNI::verifyX509CertChain(certs, hostname);
 }
 
-void DefaultSystemHelper::cleanupAfterCertificateValidation() { JNI::jvm_detach_thread(); }
+void DefaultSystemHelper::cleanupAfterCertificateValidation() { JNI::jvmDetachThread(); }
 
 } // namespace Envoy

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -511,7 +511,7 @@ void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_
   ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
   RequestHeaderMapPtr internal_headers = Utility::toRequestHeaders(headers);
 
-  // This is largely a check for the android platform: is_cleartext_permitted
+  // This is largely a check for the android platform: isCleartextPermitted
   // is a no-op for other platforms.
   if (internal_headers->getSchemeValue() != "https" &&
       !SystemHelper::getInstance().isCleartextPermitted(internal_headers->getHostValue())) {

--- a/mobile/library/common/jni/android_jni_interface.cc
+++ b/mobile/library/common/jni/android_jni_interface.cc
@@ -1,8 +1,5 @@
-#include "library/common/jni/android_network_utility.h"
 #include "library/common/jni/import/jni_import.h"
-#include "library/common/jni/jni_support.h"
 #include "library/common/jni/jni_utility.h"
-#include "library/common/main_interface.h"
 
 // NOLINT(namespace-envoy)
 
@@ -12,6 +9,6 @@ extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
                                                                    jclass, // class
                                                                    jobject class_loader) {
-  Envoy::JNI::set_class_loader(env->NewGlobalRef(class_loader));
+  Envoy::JNI::setClassLoader(env->NewGlobalRef(class_loader));
   return ENVOY_SUCCESS;
 }

--- a/mobile/library/common/jni/android_jni_utility.cc
+++ b/mobile/library/common/jni/android_jni_utility.cc
@@ -12,13 +12,13 @@
 namespace Envoy {
 namespace JNI {
 
-bool is_cleartext_permitted(absl::string_view hostname) {
+bool isCleartextPermitted(absl::string_view hostname) {
 #if defined(__ANDROID_API__)
   envoy_data host = Envoy::Data::Utility::copyToBridgeData(hostname);
-  JniHelper jni_helper(get_env());
-  LocalRefUniquePtr<jstring> java_host = native_data_to_string(jni_helper, host);
+  JniHelper jni_helper(getEnv());
+  LocalRefUniquePtr<jstring> java_host = envoyDataToJavaString(jni_helper, host);
   LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
-      find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
+      findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
   jmethodID jmid_isCleartextTrafficPermitted = jni_helper.getStaticMethodId(
       jcls_AndroidNetworkLibrary.get(), "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
   jboolean result = jni_helper.callStaticBooleanMethod(
@@ -31,11 +31,11 @@ bool is_cleartext_permitted(absl::string_view hostname) {
 #endif
 }
 
-void tag_socket(int ifd, int uid, int tag) {
+void tagSocket(int ifd, int uid, int tag) {
 #if defined(__ANDROID_API__)
-  JniHelper jni_helper(get_env());
+  JniHelper jni_helper(getEnv());
   LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
-      find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
+      findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
   jmethodID jmid_tagSocket =
       jni_helper.getStaticMethodId(jcls_AndroidNetworkLibrary.get(), "tagSocket", "(III)V");
   jni_helper.callStaticVoidMethod(jcls_AndroidNetworkLibrary.get(), jmid_tagSocket, ifd, uid, tag);

--- a/mobile/library/common/jni/android_jni_utility.h
+++ b/mobile/library/common/jni/android_jni_utility.h
@@ -5,17 +5,16 @@
 namespace Envoy {
 namespace JNI {
 
-/* For android, calls up through JNI to see if cleartext is permitted for this
- * host.
+/**
+ * For android, calls up through JNI to see if cleartext is permitted for this host.
  * For other platforms simply returns true.
  */
-bool is_cleartext_permitted(absl::string_view hostname);
+bool isCleartextPermitted(absl::string_view hostname);
 
-/* For android, calls up through JNI to apply
- * host.
- * For other platforms simply returns true.
+/**
+ * For android, calls up through JNI to apply host. For other platforms simply returns true.
  */
-void tag_socket(int ifd, int uid, int tag);
+void tagSocket(int ifd, int uid, int tag);
 
 } // namespace JNI
 } // namespace Envoy

--- a/mobile/library/common/jni/android_network_utility.h
+++ b/mobile/library/common/jni/android_network_utility.h
@@ -12,17 +12,18 @@
 namespace Envoy {
 namespace JNI {
 
-/* Calls up through JNI to validate given certificates.
+/**
+ * Calls up through JNI to validate given certificates.
  */
-Envoy::JNI::LocalRefUniquePtr<jobject>
-call_jvm_verify_x509_cert_chain(Envoy::JNI::JniHelper& jni_helper,
-                                const std::vector<std::string>& cert_chain, std::string auth_type,
-                                absl::string_view hostname);
+LocalRefUniquePtr<jobject> callJvmVerifyX509CertChain(JniHelper& jni_helper,
+                                                      const std::vector<std::string>& cert_chain,
+                                                      std::string auth_type,
+                                                      absl::string_view hostname);
 
-envoy_cert_validation_result verify_x509_cert_chain(const std::vector<std::string>& certs,
-                                                    absl::string_view hostname);
+envoy_cert_validation_result verifyX509CertChain(const std::vector<std::string>& certs,
+                                                 absl::string_view hostname);
 
-void jvm_detach_thread();
+void jvmDetachThread();
 
 } // namespace JNI
 } // namespace Envoy

--- a/mobile/library/common/jni/jni_interface.cc
+++ b/mobile/library/common/jni/jni_interface.cc
@@ -40,7 +40,7 @@ static void jvm_on_engine_running(void* context) {
   }
 
   jni_log("[Envoy]", "jvm_on_engine_running");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmonEngineRunningContext =
       jni_helper.getObjectClass(j_context);
@@ -59,8 +59,8 @@ static void jvm_on_log(envoy_data data, const void* context) {
     return;
   }
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
-  Envoy::JNI::LocalRefUniquePtr<jstring> str = Envoy::JNI::native_data_to_string(jni_helper, data);
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
+  Envoy::JNI::LocalRefUniquePtr<jstring> str = Envoy::JNI::envoyDataToJavaString(jni_helper, data);
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmLoggerContext =
@@ -87,9 +87,9 @@ static void jvm_on_track(envoy_map events, const void* context) {
     return;
   }
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   Envoy::JNI::LocalRefUniquePtr<jobject> events_hashmap =
-      Envoy::JNI::native_map_to_map(jni_helper, events);
+      Envoy::JNI::envoyMapToJavaMap(jni_helper, events);
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_EnvoyEventTracker =
@@ -118,8 +118,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   const jobject retained_logger_context = env->NewGlobalRef(envoy_logger_context);
   envoy_logger logger = {nullptr, nullptr, nullptr};
   if (envoy_logger_context != nullptr) {
-    logger =
-        envoy_logger{jvm_on_log, Envoy::JNI::jni_delete_const_global_ref, retained_logger_context};
+    logger = envoy_logger{jvm_on_log, Envoy::JNI::jniDeleteConstGlobalRef, retained_logger_context};
   }
 
   envoy_event_tracker event_tracker = {nullptr, nullptr};
@@ -171,8 +170,9 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
     jlong engine, jstring elements, jobjectArray tags, jint count) {
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::JNI::StringUtfUniquePtr native_elements = jni_helper.getStringUtfChars(elements, nullptr);
-  jint result = record_counter_inc(engine, native_elements.get(),
-                                   Envoy::JNI::to_native_tags(jni_helper, tags), count);
+  jint result = record_counter_inc(
+      engine, native_elements.get(),
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyStatsTags(jni_helper, tags), count);
   return result;
 }
 
@@ -196,7 +196,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_dumpStats(JNIEnv* env,
   }
 
   Envoy::JNI::JniHelper jni_helper(env);
-  Envoy::JNI::LocalRefUniquePtr<jstring> str = Envoy::JNI::native_data_to_string(jni_helper, data);
+  Envoy::JNI::LocalRefUniquePtr<jstring> str = Envoy::JNI::envoyDataToJavaString(jni_helper, data);
   release_envoy_data(data);
 
   return str.release();
@@ -206,7 +206,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_dumpStats(JNIEnv* env,
 
 static void passHeaders(const char* method, const Envoy::Types::ManagedEnvoyHeaders& headers,
                         jobject j_context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmCallbackContext =
       jni_helper.getObjectClass(j_context);
   jmethodID jmid_passHeader =
@@ -221,10 +221,10 @@ static void passHeaders(const char* method, const Envoy::Types::ManagedEnvoyHead
 
     // Create platform byte array for header key
     Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_key =
-        Envoy::JNI::native_data_to_array(jni_helper, headers.get().entries[i].key);
+        Envoy::JNI::envoyDataToJavaByteArray(jni_helper, headers.get().entries[i].key);
     // Create platform byte array for header value
     Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_value =
-        Envoy::JNI::native_data_to_array(jni_helper, headers.get().entries[i].value);
+        Envoy::JNI::envoyDataToJavaByteArray(jni_helper, headers.get().entries[i].value);
 
     // Pass this header pair to the platform
     jni_helper.callVoidMethod(j_context, jmid_passHeader, j_key.get(), j_value.get(),
@@ -243,7 +243,7 @@ static void passHeaders(const char* method, const Envoy::Types::ManagedEnvoyHead
 static void* jvm_on_headers(const char* method, const Envoy::Types::ManagedEnvoyHeaders& headers,
                             bool end_stream, envoy_stream_intel stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_headers");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
   passHeaders("passHeader", headers, j_context);
 
@@ -253,7 +253,7 @@ static void* jvm_on_headers(const char* method, const Envoy::Types::ManagedEnvoy
       jni_helper.getMethodId(jcls_JvmCallbackContext.get(), method, "(JZ[J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
   Envoy::JNI::LocalRefUniquePtr<jobject> result =
@@ -285,7 +285,7 @@ static void* jvm_on_headers(const char* method, const Envoy::Types::ManagedEnvoy
 
   // Since the "on headers" call threw an exception set input headers as output headers.
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
-      Envoy::JNI::ToJavaArrayOfObjectArray(jni_helper, headers);
+      Envoy::JNI::envoyHeadersToJavaArrayOfObjectArray(jni_helper, headers);
   jni_helper.setObjectArrayElement(noopResult.get(), 1, j_headers.get());
 
   return noopResult.release();
@@ -300,7 +300,7 @@ static void* jvm_on_response_headers(envoy_headers headers, bool end_stream,
 static envoy_filter_headers_status
 jvm_http_filter_on_request_headers(envoy_headers input_headers, bool end_stream,
                                    envoy_stream_intel stream_intel, const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   const auto headers = Envoy::Types::ManagedEnvoyHeaders(input_headers);
   jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
       "onRequestHeaders", headers, end_stream, stream_intel, const_cast<void*>(context)));
@@ -315,8 +315,9 @@ jvm_http_filter_on_request_headers(envoy_headers input_headers, bool end_stream,
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
       jni_helper.getObjectArrayElement<jobjectArray>(result, 1);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_headers native_headers = Envoy::JNI::to_native_headers(jni_helper, j_headers.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_headers native_headers =
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_headers.get());
 
   jni_helper.getEnv()->DeleteLocalRef(result);
 
@@ -327,7 +328,7 @@ jvm_http_filter_on_request_headers(envoy_headers input_headers, bool end_stream,
 static envoy_filter_headers_status
 jvm_http_filter_on_response_headers(envoy_headers input_headers, bool end_stream,
                                     envoy_stream_intel stream_intel, const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   const auto headers = Envoy::Types::ManagedEnvoyHeaders(input_headers);
   jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
       "onResponseHeaders", headers, end_stream, stream_intel, const_cast<void*>(context)));
@@ -342,8 +343,9 @@ jvm_http_filter_on_response_headers(envoy_headers input_headers, bool end_stream
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
       jni_helper.getObjectArrayElement<jobjectArray>(result, 1);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_headers native_headers = Envoy::JNI::to_native_headers(jni_helper, j_headers.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_headers native_headers =
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_headers.get());
 
   jni_helper.getEnv()->DeleteLocalRef(result);
 
@@ -354,7 +356,7 @@ jvm_http_filter_on_response_headers(envoy_headers input_headers, bool end_stream
 static void* jvm_on_data(const char* method, envoy_data data, bool end_stream,
                          envoy_stream_intel stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_data");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmCallbackContext =
@@ -363,9 +365,9 @@ static void* jvm_on_data(const char* method, envoy_data data, bool end_stream,
       jni_helper.getMethodId(jcls_JvmCallbackContext.get(), method, "([BZ[J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_data =
-      Envoy::JNI::native_data_to_array(jni_helper, data);
+      Envoy::JNI::envoyDataToJavaByteArray(jni_helper, data);
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
   jobject result = jni_helper
                        .callObjectMethod(j_context, jmid_onData, j_data.get(),
                                          end_stream ? JNI_TRUE : JNI_FALSE, j_stream_intel.get())
@@ -384,7 +386,7 @@ static void* jvm_on_response_data(envoy_data data, bool end_stream, envoy_stream
 static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data, bool end_stream,
                                                                 envoy_stream_intel stream_intel,
                                                                 const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onRequestData", data, end_stream, stream_intel, const_cast<void*>(context)));
 
@@ -399,15 +401,16 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_data =
       jni_helper.getObjectArrayElement<jobjectArray>(result, 1);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_data native_data = Envoy::JNI::buffer_to_native_data(jni_helper, j_data.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_data native_data = Envoy::JNI::javaByteBufferToEnvoyData(jni_helper, j_data.get());
 
   envoy_headers* pending_headers = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (unboxed_status == kEnvoyFilterDataStatusResumeIteration) {
     Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
         jni_helper.getObjectArrayElement<jobjectArray>(result, 2);
-    pending_headers = Envoy::JNI::to_native_headers_ptr(jni_helper, j_headers.get());
+    pending_headers =
+        Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_headers.get());
   }
 
   jni_helper.getEnv()->DeleteLocalRef(result);
@@ -420,7 +423,7 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
 static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream,
                                                                  envoy_stream_intel stream_intel,
                                                                  const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_data("onResponseData", data, end_stream, stream_intel, const_cast<void*>(context)));
 
@@ -435,15 +438,16 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_data =
       jni_helper.getObjectArrayElement<jobjectArray>(result, 1);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_data native_data = Envoy::JNI::buffer_to_native_data(jni_helper, j_data.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_data native_data = Envoy::JNI::javaByteBufferToEnvoyData(jni_helper, j_data.get());
 
   envoy_headers* pending_headers = nullptr;
   // Avoid out-of-bounds access to array when checking for optional pending entities.
   if (unboxed_status == kEnvoyFilterDataStatusResumeIteration) {
     Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
         jni_helper.getObjectArrayElement<jobjectArray>(result, 2);
-    pending_headers = Envoy::JNI::to_native_headers_ptr(jni_helper, j_headers.get());
+    pending_headers =
+        Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_headers.get());
   }
 
   jni_helper.getEnv()->DeleteLocalRef(result);
@@ -464,7 +468,7 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers,
                              envoy_stream_intel stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_trailers");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
   passHeaders("passHeader", trailers, j_context);
 
@@ -474,7 +478,7 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers,
       jni_helper.getMethodId(jcls_JvmCallbackContext.get(), method, "(J[J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
   jobject result = jni_helper
@@ -493,7 +497,7 @@ static void* jvm_on_response_trailers(envoy_headers trailers, envoy_stream_intel
 static envoy_filter_trailers_status
 jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel stream_intel,
                                     const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onRequestTrailers", trailers, stream_intel, const_cast<void*>(context)));
 
@@ -509,8 +513,9 @@ jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel s
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_trailers =
       jni_helper.getObjectArrayElement<jobjectArray>(result, 1);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_headers native_trailers = Envoy::JNI::to_native_headers(jni_helper, j_trailers.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_headers native_trailers =
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_trailers.get());
 
   envoy_headers* pending_headers = nullptr;
   envoy_data* pending_data = nullptr;
@@ -518,10 +523,11 @@ jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel s
   if (unboxed_status == kEnvoyFilterTrailersStatusResumeIteration) {
     Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
         jni_helper.getObjectArrayElement<jobjectArray>(result, 2);
-    pending_headers = Envoy::JNI::to_native_headers_ptr(jni_helper, j_headers.get());
+    pending_headers =
+        Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_headers.get());
 
     Envoy::JNI::LocalRefUniquePtr<jobject> j_data = jni_helper.getObjectArrayElement(result, 3);
-    pending_data = Envoy::JNI::buffer_to_native_data_ptr(jni_helper, j_data.get());
+    pending_data = Envoy::JNI::javaByteBufferToEnvoyDataPtr(jni_helper, j_data.get());
   }
 
   jni_helper.getEnv()->DeleteLocalRef(result);
@@ -535,7 +541,7 @@ jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel s
 static envoy_filter_trailers_status
 jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel stream_intel,
                                      const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobjectArray result = static_cast<jobjectArray>(
       jvm_on_trailers("onResponseTrailers", trailers, stream_intel, const_cast<void*>(context)));
 
@@ -551,8 +557,9 @@ jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel 
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_trailers =
       jni_helper.getObjectArrayElement<jobjectArray>(result, 1);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_headers native_trailers = Envoy::JNI::to_native_headers(jni_helper, j_trailers.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_headers native_trailers =
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_trailers.get());
 
   envoy_headers* pending_headers = nullptr;
   envoy_data* pending_data = nullptr;
@@ -560,10 +567,11 @@ jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel 
   if (unboxed_status == kEnvoyFilterTrailersStatusResumeIteration) {
     Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
         jni_helper.getObjectArrayElement<jobjectArray>(result, 2);
-    pending_headers = Envoy::JNI::to_native_headers_ptr(jni_helper, j_headers.get());
+    pending_headers =
+        Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_headers.get());
 
     Envoy::JNI::LocalRefUniquePtr<jobject> j_data = jni_helper.getObjectArrayElement(result, 3);
-    pending_data = Envoy::JNI::buffer_to_native_data_ptr(jni_helper, j_data.get());
+    pending_data = Envoy::JNI::javaByteBufferToEnvoyDataPtr(jni_helper, j_data.get());
   }
 
   jni_helper.getEnv()->DeleteLocalRef(result);
@@ -579,7 +587,7 @@ static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks ca
 
   jni_log("[Envoy]", "jvm_http_filter_set_request_callbacks");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmCallbackContext =
       jni_helper.getObjectClass(j_context);
@@ -599,7 +607,7 @@ static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
 
   jni_log("[Envoy]", "jvm_http_filter_set_response_callbacks");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmCallbackContext =
       jni_helper.getObjectClass(j_context);
@@ -620,7 +628,7 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
                           const void* context) {
   jni_log("[Envoy]", "jvm_on_resume");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   jlong headers_length = -1;
   if (headers) {
@@ -630,7 +638,7 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_in_data = Envoy::JNI::LocalRefUniquePtr<jbyteArray>(
       nullptr, Envoy::JNI::LocalRefDeleter(jni_helper.getEnv()));
   if (data) {
-    j_in_data = Envoy::JNI::native_data_to_array(jni_helper, *data);
+    j_in_data = Envoy::JNI::envoyDataToJavaByteArray(jni_helper, *data);
   }
   jlong trailers_length = -1;
   if (trailers) {
@@ -638,7 +646,7 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
     passHeaders("passTrailer", *trailers, j_context);
   }
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmCallbackContext =
       jni_helper.getObjectClass(j_context);
@@ -657,10 +665,12 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_trailers =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 3);
 
-  int unboxed_status = Envoy::JNI::unbox_integer(jni_helper, status.get());
-  envoy_headers* pending_headers = Envoy::JNI::to_native_headers_ptr(jni_helper, j_headers.get());
-  envoy_data* pending_data = Envoy::JNI::buffer_to_native_data_ptr(jni_helper, j_data.get());
-  envoy_headers* pending_trailers = Envoy::JNI::to_native_headers_ptr(jni_helper, j_trailers.get());
+  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  envoy_headers* pending_headers =
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_headers.get());
+  envoy_data* pending_data = Envoy::JNI::javaByteBufferToEnvoyDataPtr(jni_helper, j_data.get());
+  envoy_headers* pending_trailers =
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_trailers.get());
 
   return (envoy_filter_resume_status){/*status*/ unboxed_status,
                                       /*pending_headers*/ pending_headers,
@@ -688,7 +698,7 @@ static void* call_jvm_on_complete(envoy_stream_intel stream_intel,
                                   envoy_final_stream_intel final_stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_complete");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmObserverContext =
@@ -697,9 +707,9 @@ static void* call_jvm_on_complete(envoy_stream_intel stream_intel,
                                                      "([J[J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_final_stream_intel =
-      Envoy::JNI::native_final_stream_intel_to_array(jni_helper, final_stream_intel);
+      Envoy::JNI::envoyFinalStreamIntelToJavaLongArray(jni_helper, final_stream_intel);
   jobject result = jni_helper
                        .callObjectMethod(j_context, jmid_onComplete, j_stream_intel.get(),
                                          j_final_stream_intel.get())
@@ -711,7 +721,7 @@ static void* call_jvm_on_complete(envoy_stream_intel stream_intel,
 static void* call_jvm_on_error(envoy_error error, envoy_stream_intel stream_intel,
                                envoy_final_stream_intel final_stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_error");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmObserverContext =
@@ -720,11 +730,11 @@ static void* call_jvm_on_error(envoy_error error, envoy_stream_intel stream_inte
                                                   "(I[BI[J[J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_error_message =
-      Envoy::JNI::native_data_to_array(jni_helper, error.message);
+      Envoy::JNI::envoyDataToJavaByteArray(jni_helper, error.message);
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_final_stream_intel =
-      Envoy::JNI::native_final_stream_intel_to_array(jni_helper, final_stream_intel);
+      Envoy::JNI::envoyFinalStreamIntelToJavaLongArray(jni_helper, final_stream_intel);
 
   jobject result =
       jni_helper
@@ -739,7 +749,7 @@ static void* call_jvm_on_error(envoy_error error, envoy_stream_intel stream_inte
 static void* jvm_on_error(envoy_error error, envoy_stream_intel stream_intel,
                           envoy_final_stream_intel final_stream_intel, void* context) {
   void* result = call_jvm_on_error(error, stream_intel, final_stream_intel, context);
-  Envoy::JNI::jni_delete_global_ref(context);
+  Envoy::JNI::jniDeleteGlobalRef(context);
   return result;
 }
 
@@ -747,7 +757,7 @@ static void* call_jvm_on_cancel(envoy_stream_intel stream_intel,
                                 envoy_final_stream_intel final_stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_cancel");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmObserverContext =
@@ -756,9 +766,9 @@ static void* call_jvm_on_cancel(envoy_stream_intel stream_intel,
       jni_helper.getMethodId(jcls_JvmObserverContext.get(), "onCancel", "([J[J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_final_stream_intel =
-      Envoy::JNI::native_final_stream_intel_to_array(jni_helper, final_stream_intel);
+      Envoy::JNI::envoyFinalStreamIntelToJavaLongArray(jni_helper, final_stream_intel);
 
   jobject result = jni_helper
                        .callObjectMethod(j_context, jmid_onCancel, j_stream_intel.get(),
@@ -771,14 +781,14 @@ static void* call_jvm_on_cancel(envoy_stream_intel stream_intel,
 static void* jvm_on_complete(envoy_stream_intel stream_intel,
                              envoy_final_stream_intel final_stream_intel, void* context) {
   void* result = call_jvm_on_complete(stream_intel, final_stream_intel, context);
-  Envoy::JNI::jni_delete_global_ref(context);
+  Envoy::JNI::jniDeleteGlobalRef(context);
   return result;
 }
 
 static void* jvm_on_cancel(envoy_stream_intel stream_intel,
                            envoy_final_stream_intel final_stream_intel, void* context) {
   void* result = call_jvm_on_cancel(stream_intel, final_stream_intel, context);
-  Envoy::JNI::jni_delete_global_ref(context);
+  Envoy::JNI::jniDeleteGlobalRef(context);
   return result;
 }
 
@@ -797,7 +807,7 @@ static void jvm_http_filter_on_cancel(envoy_stream_intel stream_intel,
 static void* jvm_on_send_window_available(envoy_stream_intel stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_send_window_available");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmObserverContext =
@@ -806,7 +816,7 @@ static void* jvm_on_send_window_available(envoy_stream_intel stream_intel, void*
       jcls_JvmObserverContext.get(), "onSendWindowAvailable", "([J)Ljava/lang/Object;");
 
   Envoy::JNI::LocalRefUniquePtr<jlongArray> j_stream_intel =
-      Envoy::JNI::native_stream_intel_to_array(jni_helper, stream_intel);
+      Envoy::JNI::envoyStreamIntelToJavaLongArray(jni_helper, stream_intel);
 
   jobject result =
       jni_helper.callObjectMethod(j_context, jmid_onSendWindowAvailable, j_stream_intel.get())
@@ -818,7 +828,7 @@ static void* jvm_on_send_window_available(envoy_stream_intel stream_intel, void*
 // JvmKeyValueStoreContext
 static envoy_data jvm_kv_store_read(envoy_data key, const void* context) {
   jni_log("[Envoy]", "jvm_kv_store_read");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
 
@@ -827,17 +837,17 @@ static envoy_data jvm_kv_store_read(envoy_data key, const void* context) {
   jmethodID jmid_read =
       jni_helper.getMethodId(jcls_JvmKeyValueStoreContext.get(), "read", "([B)[B");
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_key =
-      Envoy::JNI::native_data_to_array(jni_helper, key);
+      Envoy::JNI::envoyDataToJavaByteArray(jni_helper, key);
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_value =
       jni_helper.callObjectMethod<jbyteArray>(j_context, jmid_read, j_key.get());
-  envoy_data native_data = Envoy::JNI::array_to_native_data(jni_helper, j_value.get());
+  envoy_data native_data = Envoy::JNI::javaByteArrayToEnvoyData(jni_helper, j_value.get());
 
   return native_data;
 }
 
 static void jvm_kv_store_remove(envoy_data key, const void* context) {
   jni_log("[Envoy]", "jvm_kv_store_remove");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
 
@@ -846,13 +856,13 @@ static void jvm_kv_store_remove(envoy_data key, const void* context) {
   jmethodID jmid_remove =
       jni_helper.getMethodId(jcls_JvmKeyValueStoreContext.get(), "remove", "([B)V");
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_key =
-      Envoy::JNI::native_data_to_array(jni_helper, key);
+      Envoy::JNI::envoyDataToJavaByteArray(jni_helper, key);
   jni_helper.callVoidMethod(j_context, jmid_remove, j_key.get());
 }
 
 static void jvm_kv_store_save(envoy_data key, envoy_data value, const void* context) {
   jni_log("[Envoy]", "jvm_kv_store_save");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
 
@@ -861,9 +871,9 @@ static void jvm_kv_store_save(envoy_data key, envoy_data value, const void* cont
   jmethodID jmid_save =
       jni_helper.getMethodId(jcls_JvmKeyValueStoreContext.get(), "save", "([B[B)V");
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_key =
-      Envoy::JNI::native_data_to_array(jni_helper, key);
+      Envoy::JNI::envoyDataToJavaByteArray(jni_helper, key);
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_value =
-      Envoy::JNI::native_data_to_array(jni_helper, value);
+      Envoy::JNI::envoyDataToJavaByteArray(jni_helper, value);
   jni_helper.callVoidMethod(j_context, jmid_save, j_key.get(), j_value.get());
 }
 
@@ -872,7 +882,7 @@ static void jvm_kv_store_save(envoy_data key, envoy_data value, const void* cont
 static const void* jvm_http_filter_init(const void* context) {
   jni_log("[Envoy]", "jvm_filter_init");
 
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
   jobject j_context = static_cast<jobject>(const_cast<void*>(c_filter->static_context));
@@ -896,7 +906,7 @@ static const void* jvm_http_filter_init(const void* context) {
 // EnvoyStringAccessor
 
 static envoy_data jvm_get_string(const void* context) {
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmStringAccessorContext =
       jni_helper.getObjectClass(j_context);
@@ -904,7 +914,7 @@ static envoy_data jvm_get_string(const void* context) {
       jni_helper.getMethodId(jcls_JvmStringAccessorContext.get(), "getEnvoyString", "()[B");
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> j_data =
       jni_helper.callObjectMethod<jbyteArray>(j_context, jmid_getString);
-  envoy_data native_data = Envoy::JNI::array_to_native_data(jni_helper, j_data.get());
+  envoy_data native_data = Envoy::JNI::javaByteArrayToEnvoyData(jni_helper, j_data.get());
 
   return native_data;
 }
@@ -991,7 +1001,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
   api->on_resume_response = jvm_http_filter_on_resume_response;
   api->on_cancel = jvm_http_filter_on_cancel;
   api->on_error = jvm_http_filter_on_error;
-  api->release_filter = Envoy::JNI::jni_delete_const_global_ref;
+  api->release_filter = Envoy::JNI::jniDeleteConstGlobalRef;
   api->static_context = retained_context;
   api->instance_context = nullptr;
 
@@ -1054,7 +1064,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   }
   return send_data(static_cast<envoy_engine_t>(engine_handle),
                    static_cast<envoy_stream_t>(stream_handle),
-                   Envoy::JNI::buffer_to_native_data(jni_helper, data, length), end_stream);
+                   Envoy::JNI::javaByteBufferToEnvoyData(jni_helper, data, length), end_stream);
 }
 
 // The Java counterpart guarantees to invoke this method with a non-null jbyteArray where the
@@ -1073,16 +1083,16 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendDataByteArray(JNIEnv* env, 
   }
   return send_data(static_cast<envoy_engine_t>(engine_handle),
                    static_cast<envoy_stream_t>(stream_handle),
-                   Envoy::JNI::array_to_native_data(jni_helper, data, length), end_stream);
+                   Envoy::JNI::javaByteArrayToEnvoyData(jni_helper, data, length), end_stream);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
     JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobjectArray headers,
     jboolean end_stream) {
   Envoy::JNI::JniHelper jni_helper(env);
-  return send_headers(static_cast<envoy_engine_t>(engine_handle),
-                      static_cast<envoy_stream_t>(stream_handle),
-                      Envoy::JNI::to_native_headers(jni_helper, headers), end_stream);
+  return send_headers(
+      static_cast<envoy_engine_t>(engine_handle), static_cast<envoy_stream_t>(stream_handle),
+      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, headers), end_stream);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
@@ -1091,7 +1101,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
   jni_log("[Envoy]", "jvm_send_trailers");
   return send_trailers(static_cast<envoy_engine_t>(engine_handle),
                        static_cast<envoy_stream_t>(stream_handle),
-                       Envoy::JNI::to_native_headers(jni_helper, trailers));
+                       Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, trailers));
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetStream(
@@ -1134,17 +1144,6 @@ void setString(Envoy::JNI::JniHelper& jni_helper, jstring java_string, EngineBui
   if (!java_string_str.empty()) {
     (builder->*setter)(java_string_str);
   }
-}
-
-// Convert jstring to std::string
-std::string getCppString(Envoy::JNI::JniHelper& jni_helper, jstring java_string) {
-  if (!java_string) {
-    return "";
-  }
-  Envoy::JNI::StringUtfUniquePtr native_java_string =
-      jni_helper.getStringUtfChars(java_string, nullptr);
-  std::string cpp_string(native_java_string.get());
-  return cpp_string;
 }
 
 // Converts a java byte array to a C++ string.
@@ -1246,9 +1245,10 @@ void configureBuilder(Envoy::JNI::JniHelper& jni_helper, jstring grpc_stats_doma
   builder.enableSocketTagging(enable_socket_tagging == JNI_TRUE);
 #ifdef ENVOY_ENABLE_QUIC
   builder.enableHttp3(enable_http3 == JNI_TRUE);
-  builder.setHttp3ConnectionOptions(getCppString(jni_helper, http3_connection_options));
+  builder.setHttp3ConnectionOptions(
+      Envoy::JNI::javaStringToString(jni_helper, http3_connection_options));
   builder.setHttp3ClientConnectionOptions(
-      getCppString(jni_helper, http3_client_connection_options));
+      Envoy::JNI::javaStringToString(jni_helper, http3_client_connection_options));
   auto hints = javaObjectArrayToStringPairVector(jni_helper, quic_hints);
   for (const std::pair<std::string, std::string>& entry : hints) {
     builder.addQuicHint(entry.first, stoi(entry.second));
@@ -1287,14 +1287,15 @@ void configureBuilder(Envoy::JNI::JniHelper& jni_helper, jstring grpc_stats_doma
   std::vector<std::string> hostnames =
       javaObjectArrayToStringVector(jni_helper, dns_preresolve_hostnames);
   builder.addDnsPreresolveHostnames(hostnames);
-  std::string native_node_id = getCppString(jni_helper, node_id);
+  std::string native_node_id = Envoy::JNI::javaStringToString(jni_helper, node_id);
   if (!native_node_id.empty()) {
     builder.setNodeId(native_node_id);
   }
-  std::string native_node_region = getCppString(jni_helper, node_region);
+  std::string native_node_region = Envoy::JNI::javaStringToString(jni_helper, node_region);
   if (!native_node_region.empty()) {
-    builder.setNodeLocality(native_node_region, getCppString(jni_helper, node_zone),
-                            getCppString(jni_helper, node_sub_zone));
+    builder.setNodeLocality(native_node_region,
+                            Envoy::JNI::javaStringToString(jni_helper, node_zone),
+                            Envoy::JNI::javaStringToString(jni_helper, node_sub_zone));
   }
   Envoy::ProtobufWkt::Struct node_metadata;
   Envoy::JNI::javaByteArrayToProto(jni_helper, serialized_node_metadata, &node_metadata);
@@ -1339,7 +1340,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
                    enable_platform_certificates_validation, runtime_guards, node_id, node_region,
                    node_zone, node_sub_zone, serialized_node_metadata, builder);
 
-  std::string native_xds_address = getCppString(jni_helper, xds_address);
+  std::string native_xds_address = Envoy::JNI::javaStringToString(jni_helper, xds_address);
   if (!native_xds_address.empty()) {
 #ifdef ENVOY_GOOGLE_GRPC
     Envoy::Platform::XdsBuilder xds_builder(std::move(native_xds_address), xds_port);
@@ -1348,22 +1349,23 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     for (const std::pair<std::string, std::string>& entry : initial_metadata) {
       xds_builder.addInitialStreamHeader(entry.first, entry.second);
     }
-    std::string native_root_certs = getCppString(jni_helper, xds_root_certs);
+    std::string native_root_certs = Envoy::JNI::javaStringToString(jni_helper, xds_root_certs);
     if (!native_root_certs.empty()) {
       xds_builder.setSslRootCerts(std::move(native_root_certs));
     }
-    std::string native_sni = getCppString(jni_helper, xds_sni);
+    std::string native_sni = Envoy::JNI::javaStringToString(jni_helper, xds_sni);
     if (!native_sni.empty()) {
       xds_builder.setSni(std::move(native_sni));
     }
-    std::string native_rtds_resource_name = getCppString(jni_helper, rtds_resource_name);
+    std::string native_rtds_resource_name =
+        Envoy::JNI::javaStringToString(jni_helper, rtds_resource_name);
     if (!native_rtds_resource_name.empty()) {
       xds_builder.addRuntimeDiscoveryService(std::move(native_rtds_resource_name),
                                              rtds_timeout_seconds);
     }
     if (enable_cds == JNI_TRUE) {
-      xds_builder.addClusterDiscoveryService(getCppString(jni_helper, cds_resources_locator),
-                                             cds_timeout_seconds);
+      xds_builder.addClusterDiscoveryService(
+          Envoy::JNI::javaStringToString(jni_helper, cds_resources_locator), cds_timeout_seconds);
     }
     builder.setXds(std::move(xds_builder));
 #else
@@ -1411,23 +1413,23 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
 static void jvm_add_test_root_certificate(const uint8_t* cert, size_t len) {
   jni_log("[Envoy]", "jvm_add_test_root_certificate");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
-      Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
+      Envoy::JNI::findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
   jmethodID jmid_addTestRootCertificate = jni_helper.getStaticMethodId(
       jcls_AndroidNetworkLibrary.get(), "addTestRootCertificate", "([B)V");
 
   Envoy::JNI::LocalRefUniquePtr<jbyteArray> cert_array =
-      Envoy::JNI::ToJavaByteArray(jni_helper, cert, len);
+      Envoy::JNI::byteArrayToJavaByteArray(jni_helper, cert, len);
   jni_helper.callStaticVoidMethod(jcls_AndroidNetworkLibrary.get(), jmid_addTestRootCertificate,
                                   cert_array.get());
 }
 
 static void jvm_clear_test_root_certificate() {
   jni_log("[Envoy]", "jvm_clear_test_root_certificate");
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::get_env());
+  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
-      Envoy::JNI::find_class("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
+      Envoy::JNI::findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
   jmethodID jmid_clearTestRootCertificates = jni_helper.getStaticMethodId(
       jcls_AndroidNetworkLibrary.get(), "clearTestRootCertificates", "()V");
 
@@ -1442,11 +1444,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_callCertificateVerificationFrom
   std::string auth_type;
   std::string host;
 
-  Envoy::JNI::JavaArrayOfByteArrayToStringVector(jni_helper, certChain, &cert_chain);
-  Envoy::JNI::JavaArrayOfByteToString(jni_helper, jauthType, &auth_type);
-  Envoy::JNI::JavaArrayOfByteToString(jni_helper, jhost, &host);
+  Envoy::JNI::javaArrayOfByteArrayToStringVector(jni_helper, certChain, &cert_chain);
+  Envoy::JNI::javaByteArrayToString(jni_helper, jauthType, &auth_type);
+  Envoy::JNI::javaByteArrayToString(jni_helper, jhost, &host);
 
-  return call_jvm_verify_x509_cert_chain(jni_helper, cert_chain, auth_type, host).release();
+  return callJvmVerifyX509CertChain(jni_helper, cert_chain, auth_type, host).release();
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -1454,7 +1456,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_callAddTestRootCertificateFromN
     JNIEnv* env, jclass, jbyteArray jcert) {
   Envoy::JNI::JniHelper jni_helper(env);
   std::vector<uint8_t> cert;
-  Envoy::JNI::JavaArrayOfByteToBytesVector(jni_helper, jcert, &cert);
+  Envoy::JNI::javaByteArrayToByteVector(jni_helper, jcert, &cert);
   jvm_add_test_root_certificate(cert.data(), cert.size());
 }
 

--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -14,49 +14,49 @@ namespace JNI {
 
 static jobject static_class_loader = nullptr;
 
-void set_class_loader(jobject class_loader) { static_class_loader = class_loader; }
+void setClassLoader(jobject class_loader) { static_class_loader = class_loader; }
 
-jobject get_class_loader() {
+jobject getClassLoader() {
   RELEASE_ASSERT(static_class_loader,
-                 "find_class() is used before calling AndroidJniLibrary.load()");
+                 "findClass() is used before calling AndroidJniLibrary.load()");
   return static_class_loader;
 }
 
-LocalRefUniquePtr<jclass> find_class(const char* class_name) {
-  JniHelper jni_helper(get_env());
+LocalRefUniquePtr<jclass> findClass(const char* class_name) {
+  JniHelper jni_helper(getEnv());
   LocalRefUniquePtr<jclass> class_loader = jni_helper.findClass("java/lang/ClassLoader");
   jmethodID find_class_method = jni_helper.getMethodId(class_loader.get(), "loadClass",
                                                        "(Ljava/lang/String;)Ljava/lang/Class;");
   LocalRefUniquePtr<jstring> str_class_name = jni_helper.newStringUtf(class_name);
   LocalRefUniquePtr<jclass> clazz = jni_helper.callObjectMethod<jclass>(
-      get_class_loader(), find_class_method, str_class_name.get());
+      getClassLoader(), find_class_method, str_class_name.get());
   return clazz;
 }
 
-JNIEnv* get_env() { return Envoy::JNI::Env::get(); }
+JNIEnv* getEnv() { return Envoy::JNI::Env::get(); }
 
-void jni_delete_global_ref(void* context) {
-  JNIEnv* env = get_env();
+void jniDeleteGlobalRef(void* context) {
+  JNIEnv* env = getEnv();
   jobject ref = static_cast<jobject>(context);
   env->DeleteGlobalRef(ref);
 }
 
-void jni_delete_const_global_ref(const void* context) {
-  jni_delete_global_ref(const_cast<void*>(context));
+void jniDeleteConstGlobalRef(const void* context) {
+  jniDeleteGlobalRef(const_cast<void*>(context));
 }
 
-int unbox_integer(JniHelper& jni_helper, jobject boxedInteger) {
+int javaIntegerTotInt(JniHelper& jni_helper, jobject boxed_integer) {
   LocalRefUniquePtr<jclass> jcls_Integer = jni_helper.findClass("java/lang/Integer");
   jmethodID jmid_intValue = jni_helper.getMethodId(jcls_Integer.get(), "intValue", "()I");
-  return jni_helper.callIntMethod(boxedInteger, jmid_intValue);
+  return jni_helper.callIntMethod(boxed_integer, jmid_intValue);
 }
 
-envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data) {
+envoy_data javaByteArrayToEnvoyData(JniHelper& jni_helper, jbyteArray j_data) {
   size_t data_length = static_cast<size_t>(jni_helper.getArrayLength(j_data));
-  return array_to_native_data(jni_helper, j_data, data_length);
+  return javaByteArrayToEnvoyData(jni_helper, j_data, data_length);
 }
 
-envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data, size_t data_length) {
+envoy_data javaByteArrayToEnvoyData(JniHelper& jni_helper, jbyteArray j_data, size_t data_length) {
   uint8_t* native_bytes = static_cast<uint8_t*>(safe_malloc(data_length));
   Envoy::JNI::PrimitiveArrayCriticalUniquePtr<void> critical_data =
       jni_helper.getPrimitiveArrayCritical(j_data, nullptr);
@@ -64,13 +64,13 @@ envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data, size_t
   return {data_length, native_bytes, free, native_bytes};
 }
 
-LocalRefUniquePtr<jstring> native_data_to_string(JniHelper& jni_helper, envoy_data data) {
+LocalRefUniquePtr<jstring> envoyDataToJavaString(JniHelper& jni_helper, envoy_data data) {
   // Ensure we get a null-terminated string, the data coming in via envoy_data might not be.
   std::string str(reinterpret_cast<const char*>(data.bytes), data.length);
   return jni_helper.newStringUtf(str.c_str());
 }
 
-LocalRefUniquePtr<jbyteArray> native_data_to_array(JniHelper& jni_helper, envoy_data data) {
+LocalRefUniquePtr<jbyteArray> envoyDataToJavaByteArray(JniHelper& jni_helper, envoy_data data) {
   LocalRefUniquePtr<jbyteArray> j_data = jni_helper.newByteArray(data.length);
   PrimitiveArrayCriticalUniquePtr<void> critical_data =
       jni_helper.getPrimitiveArrayCritical(j_data.get(), nullptr);
@@ -79,8 +79,8 @@ LocalRefUniquePtr<jbyteArray> native_data_to_array(JniHelper& jni_helper, envoy_
   return j_data;
 }
 
-LocalRefUniquePtr<jlongArray> native_stream_intel_to_array(JniHelper& jni_helper,
-                                                           envoy_stream_intel stream_intel) {
+LocalRefUniquePtr<jlongArray> envoyStreamIntelToJavaLongArray(JniHelper& jni_helper,
+                                                              envoy_stream_intel stream_intel) {
   LocalRefUniquePtr<jlongArray> j_array = jni_helper.newLongArray(4);
   PrimitiveArrayCriticalUniquePtr<jlong> critical_array =
       jni_helper.getPrimitiveArrayCritical<jlong*>(j_array.get(), nullptr);
@@ -93,8 +93,8 @@ LocalRefUniquePtr<jlongArray> native_stream_intel_to_array(JniHelper& jni_helper
 }
 
 LocalRefUniquePtr<jlongArray>
-native_final_stream_intel_to_array(JniHelper& jni_helper,
-                                   envoy_final_stream_intel final_stream_intel) {
+envoyFinalStreamIntelToJavaLongArray(JniHelper& jni_helper,
+                                     envoy_final_stream_intel final_stream_intel) {
   LocalRefUniquePtr<jlongArray> j_array = jni_helper.newLongArray(16);
   PrimitiveArrayCriticalUniquePtr<jlong> critical_array =
       jni_helper.getPrimitiveArrayCritical<jlong*>(j_array.get(), nullptr);
@@ -119,7 +119,7 @@ native_final_stream_intel_to_array(JniHelper& jni_helper,
   return j_array;
 }
 
-LocalRefUniquePtr<jobject> native_map_to_map(JniHelper& jni_helper, envoy_map map) {
+LocalRefUniquePtr<jobject> envoyMapToJavaMap(JniHelper& jni_helper, envoy_map map) {
   LocalRefUniquePtr<jclass> jcls_hashMap = jni_helper.findClass("java/util/HashMap");
   jmethodID jmid_hashMapInit = jni_helper.getMethodId(jcls_hashMap.get(), "<init>", "(I)V");
   LocalRefUniquePtr<jobject> j_hashMap =
@@ -127,15 +127,15 @@ LocalRefUniquePtr<jobject> native_map_to_map(JniHelper& jni_helper, envoy_map ma
   jmethodID jmid_hashMapPut = jni_helper.getMethodId(
       jcls_hashMap.get(), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
   for (envoy_map_size_t i = 0; i < map.length; i++) {
-    LocalRefUniquePtr<jstring> key = native_data_to_string(jni_helper, map.entries[i].key);
-    LocalRefUniquePtr<jstring> value = native_data_to_string(jni_helper, map.entries[i].value);
+    LocalRefUniquePtr<jstring> key = envoyDataToJavaString(jni_helper, map.entries[i].key);
+    LocalRefUniquePtr<jstring> value = envoyDataToJavaString(jni_helper, map.entries[i].value);
     LocalRefUniquePtr<jobject> ignored =
         jni_helper.callObjectMethod(j_hashMap.get(), jmid_hashMapPut, key.get(), value.get());
   }
   return j_hashMap;
 }
 
-envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data) {
+envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data) {
   // Returns -1 if the buffer is not a direct buffer.
   jlong data_length = jni_helper.getDirectBufferCapacity(j_data);
 
@@ -147,14 +147,14 @@ envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data) {
     jmethodID jmid_array = jni_helper.getMethodId(jcls_ByteBuffer.get(), "array", "()[B");
     LocalRefUniquePtr<jbyteArray> array =
         jni_helper.callObjectMethod<jbyteArray>(j_data, jmid_array);
-    envoy_data native_data = array_to_native_data(jni_helper, array.get());
+    envoy_data native_data = javaByteArrayToEnvoyData(jni_helper, array.get());
     return native_data;
   }
 
-  return buffer_to_native_data(jni_helper, j_data, static_cast<size_t>(data_length));
+  return javaByteBufferToEnvoyData(jni_helper, j_data, static_cast<size_t>(data_length));
 }
 
-envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data, size_t data_length) {
+envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data, size_t data_length) {
   // Returns nullptr if the buffer is not a direct buffer.
   uint8_t* direct_address = jni_helper.getDirectBufferAddress<uint8_t*>(j_data);
 
@@ -166,20 +166,20 @@ envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data, size_t d
     jmethodID jmid_array = jni_helper.getMethodId(jcls_ByteBuffer.get(), "array", "()[B");
     LocalRefUniquePtr<jbyteArray> array =
         jni_helper.callObjectMethod<jbyteArray>(j_data, jmid_array);
-    envoy_data native_data = array_to_native_data(jni_helper, array.get(), data_length);
+    envoy_data native_data = javaByteArrayToEnvoyData(jni_helper, array.get(), data_length);
     return native_data;
   }
 
   envoy_data native_data;
   native_data.bytes = direct_address;
   native_data.length = data_length;
-  native_data.release = jni_delete_global_ref;
+  native_data.release = jniDeleteGlobalRef;
   native_data.context = jni_helper.newGlobalRef(j_data).release();
 
   return native_data;
 }
 
-envoy_data* buffer_to_native_data_ptr(JniHelper& jni_helper, jobject j_data) {
+envoy_data* javaByteBufferToEnvoyDataPtr(JniHelper& jni_helper, jobject j_data) {
   // Note: This check works for LocalRefs and GlobalRefs, but will not work for WeakGlobalRefs.
   // Such usage would generally be inappropriate anyways; like C++ weak_ptrs, one should
   // acquire a new strong reference before attempting to interact with an object held by
@@ -190,15 +190,16 @@ envoy_data* buffer_to_native_data_ptr(JniHelper& jni_helper, jobject j_data) {
   }
 
   envoy_data* native_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_map_entry)));
-  *native_data = buffer_to_native_data(jni_helper, j_data);
+  *native_data = javaByteBufferToEnvoyData(jni_helper, j_data);
   return native_data;
 }
 
-envoy_headers to_native_headers(JniHelper& jni_helper, jobjectArray headers) {
-  return to_native_map(jni_helper, headers);
+envoy_headers javaArrayOfObjectArrayToEnvoyHeaders(JniHelper& jni_helper, jobjectArray headers) {
+  return javaArrayOfObjectArrayToEnvoyMap(jni_helper, headers);
 }
 
-envoy_headers* to_native_headers_ptr(JniHelper& jni_helper, jobjectArray headers) {
+envoy_headers* javaArrayOfObjectArrayToEnvoyHeadersPtr(JniHelper& jni_helper,
+                                                       jobjectArray headers) {
   // Note: This check works for LocalRefs and GlobalRefs, but will not work for WeakGlobalRefs.
   // Such usage would generally be inappropriate anyways; like C++ weak_ptrs, one should
   // acquire a new strong reference before attempting to interact with an object held by
@@ -209,15 +210,15 @@ envoy_headers* to_native_headers_ptr(JniHelper& jni_helper, jobjectArray headers
   }
 
   envoy_headers* native_headers = static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_map_entry)));
-  *native_headers = to_native_headers(jni_helper, headers);
+  *native_headers = javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, headers);
   return native_headers;
 }
 
-envoy_stats_tags to_native_tags(JniHelper& jni_helper, jobjectArray tags) {
-  return to_native_map(jni_helper, tags);
+envoy_stats_tags javaArrayOfObjectArrayToEnvoyStatsTags(JniHelper& jni_helper, jobjectArray tags) {
+  return javaArrayOfObjectArrayToEnvoyMap(jni_helper, tags);
 }
 
-envoy_map to_native_map(JniHelper& jni_helper, jobjectArray entries) {
+envoy_map javaArrayOfObjectArrayToEnvoyMap(JniHelper& jni_helper, jobjectArray entries) {
   // Note that headers is a flattened array of key/value pairs.
   // Therefore, the length of the native header array is n envoy_data or n/2 envoy_map_entry.
   envoy_map_size_t length = jni_helper.getArrayLength(entries);
@@ -231,12 +232,12 @@ envoy_map to_native_map(JniHelper& jni_helper, jobjectArray entries) {
   for (envoy_map_size_t i = 0; i < length; i += 2) {
     // Copy native byte array for header key
     LocalRefUniquePtr<jbyteArray> j_key = jni_helper.getObjectArrayElement<jbyteArray>(entries, i);
-    envoy_data entry_key = array_to_native_data(jni_helper, j_key.get());
+    envoy_data entry_key = javaByteArrayToEnvoyData(jni_helper, j_key.get());
 
     // Copy native byte array for header value
     LocalRefUniquePtr<jbyteArray> j_value =
         jni_helper.getObjectArrayElement<jbyteArray>(entries, i + 1);
-    envoy_data entry_value = array_to_native_data(jni_helper, j_value.get());
+    envoy_data entry_value = javaByteArrayToEnvoyData(jni_helper, j_value.get());
 
     entry_array[i / 2] = {entry_key, entry_value};
   }
@@ -246,15 +247,17 @@ envoy_map to_native_map(JniHelper& jni_helper, jobjectArray entries) {
 }
 
 LocalRefUniquePtr<jobjectArray>
-ToJavaArrayOfObjectArray(JniHelper& jni_helper, const Envoy::Types::ManagedEnvoyHeaders& map) {
+envoyHeadersToJavaArrayOfObjectArray(JniHelper& jni_helper,
+                                     const Envoy::Types::ManagedEnvoyHeaders& map) {
   LocalRefUniquePtr<jclass> jcls_byte_array = jni_helper.findClass("java/lang/Object");
   LocalRefUniquePtr<jobjectArray> javaArray =
       jni_helper.newObjectArray(2 * map.get().length, jcls_byte_array.get(), nullptr);
 
   for (envoy_map_size_t i = 0; i < map.get().length; i++) {
-    LocalRefUniquePtr<jbyteArray> key = native_data_to_array(jni_helper, map.get().entries[i].key);
+    LocalRefUniquePtr<jbyteArray> key =
+        envoyDataToJavaByteArray(jni_helper, map.get().entries[i].key);
     LocalRefUniquePtr<jbyteArray> value =
-        native_data_to_array(jni_helper, map.get().entries[i].value);
+        envoyDataToJavaByteArray(jni_helper, map.get().entries[i].value);
 
     jni_helper.setObjectArrayElement(javaArray.get(), 2 * i, key.get());
     jni_helper.setObjectArrayElement(javaArray.get(), 2 * i + 1, value.get());
@@ -263,34 +266,34 @@ ToJavaArrayOfObjectArray(JniHelper& jni_helper, const Envoy::Types::ManagedEnvoy
   return javaArray;
 }
 
-LocalRefUniquePtr<jobjectArray> ToJavaArrayOfByteArray(JniHelper& jni_helper,
-                                                       const std::vector<std::string>& v) {
+LocalRefUniquePtr<jobjectArray>
+vectorStringToJavaArrayOfByteArray(JniHelper& jni_helper, const std::vector<std::string>& v) {
   LocalRefUniquePtr<jclass> jcls_byte_array = jni_helper.findClass("[B");
   LocalRefUniquePtr<jobjectArray> joa =
       jni_helper.newObjectArray(v.size(), jcls_byte_array.get(), nullptr);
 
   for (size_t i = 0; i < v.size(); ++i) {
-    LocalRefUniquePtr<jbyteArray> byte_array =
-        ToJavaByteArray(jni_helper, reinterpret_cast<const uint8_t*>(v[i].data()), v[i].length());
+    LocalRefUniquePtr<jbyteArray> byte_array = byteArrayToJavaByteArray(
+        jni_helper, reinterpret_cast<const uint8_t*>(v[i].data()), v[i].length());
     jni_helper.setObjectArrayElement(joa.get(), i, byte_array.get());
   }
   return joa;
 }
 
-LocalRefUniquePtr<jbyteArray> ToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes,
-                                              size_t len) {
+LocalRefUniquePtr<jbyteArray> byteArrayToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes,
+                                                       size_t len) {
   LocalRefUniquePtr<jbyteArray> byte_array = jni_helper.newByteArray(len);
   const jbyte* jbytes = reinterpret_cast<const jbyte*>(bytes);
   jni_helper.setByteArrayRegion(byte_array.get(), /*start=*/0, len, jbytes);
   return byte_array;
 }
 
-LocalRefUniquePtr<jbyteArray> ToJavaByteArray(JniHelper& jni_helper, const std::string& str) {
+LocalRefUniquePtr<jbyteArray> stringToJavaByteArray(JniHelper& jni_helper, const std::string& str) {
   const uint8_t* str_bytes = reinterpret_cast<const uint8_t*>(str.data());
-  return ToJavaByteArray(jni_helper, str_bytes, str.size());
+  return byteArrayToJavaByteArray(jni_helper, str_bytes, str.size());
 }
 
-void JavaArrayOfByteArrayToStringVector(JniHelper& jni_helper, jobjectArray array,
+void javaArrayOfByteArrayToStringVector(JniHelper& jni_helper, jobjectArray array,
                                         std::vector<std::string>* out) {
   ASSERT(out);
   ASSERT(array);
@@ -309,14 +312,13 @@ void JavaArrayOfByteArrayToStringVector(JniHelper& jni_helper, jobjectArray arra
   }
 }
 
-void JavaArrayOfByteToString(JniHelper& jni_helper, jbyteArray jbytes, std::string* out) {
+void javaByteArrayToString(JniHelper& jni_helper, jbyteArray jbytes, std::string* out) {
   std::vector<uint8_t> bytes;
-  JavaArrayOfByteToBytesVector(jni_helper, jbytes, &bytes);
+  javaByteArrayToByteVector(jni_helper, jbytes, &bytes);
   *out = std::string(bytes.begin(), bytes.end());
 }
 
-void JavaArrayOfByteToBytesVector(JniHelper& jni_helper, jbyteArray array,
-                                  std::vector<uint8_t>* out) {
+void javaByteArrayToByteVector(JniHelper& jni_helper, jbyteArray array, std::vector<uint8_t>* out) {
   const size_t len = jni_helper.getArrayLength(array);
   out->resize(len);
 
@@ -351,6 +353,15 @@ void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
   jsize size = jni_helper.getArrayLength(source);
   bool success = dest->ParseFromArray(bytes.get(), size);
   RELEASE_ASSERT(success, "Failed to parse protobuf message.");
+}
+
+std::string javaStringToString(JniHelper& jni_helper, jstring java_string) {
+  if (!java_string) {
+    return "";
+  }
+  StringUtfUniquePtr native_java_string = jni_helper.getStringUtfChars(java_string, nullptr);
+  std::string cpp_string(native_java_string.get());
+  return cpp_string;
 }
 
 } // namespace JNI

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -15,22 +15,22 @@ namespace Envoy {
 namespace JNI {
 
 // TODO(Augustyniak): Replace the usages of this global method with Envoy::JNI::Env::get()
-JNIEnv* get_env();
+JNIEnv* getEnv();
 
-void set_class_loader(jobject class_loader);
+void setClassLoader(jobject class_loader);
 
 /**
  * Finds a class with a given name using a class loader provided with the use
- * of `set_class_loader` function. The class loader is supposed to come from
+ * of `setClassLoader` function. The class loader is supposed to come from
  * application's context and should be associated with project's code - Java classes
  * defined by the project. For finding classes of Java built in-types use
  * `env->FindClass(...)` method instead as it is lighter to use.
  *
  * Read more about why you cannot use `env->FindClass(...)` to look for Java classes
- * defined by the project and a pattern used by the implementation of `find_class` helper
+ * defined by the project and a pattern used by the implementation of `findClass` helper
  * method at https://developer.android.com/training/articles/perf-jni#native-libraries.
  *
- * The method works on Android targets only as the `set_class_loader` method is not
+ * The method works on Android targets only as the `setClassLoader` method is not
  * called by JVM-only targets.
  *
  * @param class_name, the name of the class to find (i.e.
@@ -39,87 +39,93 @@ void set_class_loader(jobject class_loader);
  * @return jclass, the class with a provided `class_name` or NULL if
  *         it couldn't be found.
  */
-LocalRefUniquePtr<jclass> find_class(const char* class_name);
+LocalRefUniquePtr<jclass> findClass(const char* class_name);
 
-void jni_delete_global_ref(void* context);
+void jniDeleteGlobalRef(void* context);
 
-void jni_delete_const_global_ref(const void* context);
+void jniDeleteConstGlobalRef(const void* context);
 
-int unbox_integer(JniHelper& jni_helper, jobject boxedInteger);
+/** Converts `java.lang.Integer` to C++ `int`. */
+int javaIntegerTotInt(JniHelper& jni_helper, jobject boxed_integer);
 
-envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data);
+/** Converts from Java byte array to `envoy_data`. */
+envoy_data javaByteArrayToEnvoyData(JniHelper& jni_helper, jbyteArray j_data);
 
-envoy_data array_to_native_data(JniHelper& jni_helper, jbyteArray j_data, size_t data_length);
+/** Converts from Java byte array with the specified length to `envoy_data`. */
+envoy_data javaByteArrayToEnvoyData(JniHelper& jni_helper, jbyteArray j_data, size_t data_length);
 
-/**
- * Utility function that copies envoy_data to jbyteArray.
- *
- * @param env, the JNI env pointer.
- * @param envoy_data, the source to copy from.
- *
- * @return jbyteArray, copied data.
- */
-LocalRefUniquePtr<jbyteArray> native_data_to_array(JniHelper& jni_helper, envoy_data data);
+/** Converts from `envoy_data` to Java byte array. */
+LocalRefUniquePtr<jbyteArray> envoyDataToJavaByteArray(JniHelper& jni_helper, envoy_data data);
 
-LocalRefUniquePtr<jlongArray> native_stream_intel_to_array(JniHelper& jni_helper,
-                                                           envoy_stream_intel stream_intel);
+/** Converts from `envoy_stream_intel` to Java long array. */
+LocalRefUniquePtr<jlongArray> envoyStreamIntelToJavaLongArray(JniHelper& jni_helper,
+                                                              envoy_stream_intel stream_intel);
 
+/** Converts from `envoy_final_stream_intel` to Java long array. */
 LocalRefUniquePtr<jlongArray>
-native_final_stream_intel_to_array(JniHelper& jni_helper,
-                                   envoy_final_stream_intel final_stream_intel);
+envoyFinalStreamIntelToJavaLongArray(JniHelper& jni_helper,
+                                     envoy_final_stream_intel final_stream_intel);
 
-/**
- * Utility function that copies envoy_map to a java HashMap jobject.
- *
- * @param env, the JNI env pointer.
- * @param envoy_map, the source to copy from.
- *
- * @return jobject, copied data.
- */
-LocalRefUniquePtr<jobject> native_map_to_map(JniHelper& jni_helper, envoy_map map);
+/** Converts from Java `Map` to `envoy_map`. */
+LocalRefUniquePtr<jobject> envoyMapToJavaMap(JniHelper& jni_helper, envoy_map map);
 
-LocalRefUniquePtr<jstring> native_data_to_string(JniHelper& jni_helper, envoy_data data);
+/** Converts from `envoy_data` to Java `String`. */
+LocalRefUniquePtr<jstring> envoyDataToJavaString(JniHelper& jni_helper, envoy_data data);
 
-envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data);
+/** Converts from Java `ByteBuffer` to `envoy_data`. */
+envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data);
 
-envoy_data buffer_to_native_data(JniHelper& jni_helper, jobject j_data, size_t data_length);
+/** Converts from Java `ByteBuffer` to `envoy_data` with the given length. */
+envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data, size_t data_length);
 
-envoy_data* buffer_to_native_data_ptr(JniHelper& jni_helper, jobject j_data);
+/** Returns the pointer of conversion from Java `ByteBuffer` to `envoy_data`. */
+envoy_data* javaByteBufferToEnvoyDataPtr(JniHelper& jni_helper, jobject j_data);
 
-envoy_headers to_native_headers(JniHelper& jni_helper, jobjectArray headers);
+/** Converts from Java array of object array[2] (key-value pairs) to `envoy_headers`. */
+envoy_headers javaArrayOfObjectArrayToEnvoyHeaders(JniHelper& jni_helper, jobjectArray headers);
 
-envoy_headers* to_native_headers_ptr(JniHelper& jni_helper, jobjectArray headers);
+/** Returns the pointer of conversion from Java array of object array[2] (key-value pairs) to
+ * `envoy_headers`. */
+envoy_headers* javaArrayOfObjectArrayToEnvoyHeadersPtr(JniHelper& jni_helper, jobjectArray headers);
 
-envoy_stats_tags to_native_tags(JniHelper& jni_helper, jobjectArray tags);
+/** Converts from Java array of object array[2] (key-value pairs) to `envoy_stats_tags`. */
+envoy_stats_tags javaArrayOfObjectArrayToEnvoyStatsTags(JniHelper& jni_helper, jobjectArray tags);
 
-envoy_map to_native_map(JniHelper& jni_helper, jobjectArray entries);
+/** Converts from Java array of object array[2] (key-value pairs) to `envoy_map`. */
+envoy_map javaArrayOfObjectArrayToEnvoyMap(JniHelper& jni_helper, jobjectArray entries);
 
-/**
- * Utilities to translate C++ std library constructs to their Java counterpart.
- * The underlying data is always copied to disentangle C++ and Java objects lifetime.
- */
-LocalRefUniquePtr<jobjectArray> ToJavaArrayOfByteArray(JniHelper& jni_helper,
-                                                       const std::vector<std::string>& v);
-
-LocalRefUniquePtr<jbyteArray> ToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes,
-                                              size_t len);
-
-LocalRefUniquePtr<jbyteArray> ToJavaByteArray(JniHelper& jni_helper, const std::string& str);
-
+/** Converts from `ManagedEnvoyHeaders` to Java array of object array[2] (key-value pairs). */
 LocalRefUniquePtr<jobjectArray>
-ToJavaArrayOfObjectArray(JniHelper& jni_helper, const Envoy::Types::ManagedEnvoyHeaders& map);
+envoyHeadersToJavaArrayOfObjectArray(JniHelper& jni_helper,
+                                     const Envoy::Types::ManagedEnvoyHeaders& map);
 
-void JavaArrayOfByteArrayToStringVector(JniHelper& jni_helper, jobjectArray array,
+/** Converts from C++ vector of strings to Java array of byte array. */
+LocalRefUniquePtr<jobjectArray>
+vectorStringToJavaArrayOfByteArray(JniHelper& jni_helper, const std::vector<std::string>& v);
+
+/** Converts from C++ byte array to Java byte array. */
+LocalRefUniquePtr<jbyteArray> byteArrayToJavaByteArray(JniHelper& jni_helper, const uint8_t* bytes,
+                                                       size_t len);
+
+/** Converts from C++ string to Java byte array. */
+LocalRefUniquePtr<jbyteArray> stringToJavaByteArray(JniHelper& jni_helper, const std::string& str);
+
+/** Converts from Java array of byte array to C++ vector of strings. */
+void javaArrayOfByteArrayToStringVector(JniHelper& jni_helper, jobjectArray array,
                                         std::vector<std::string>* out);
 
-void JavaArrayOfByteToBytesVector(JniHelper& jni_helper, jbyteArray array,
-                                  std::vector<uint8_t>* out);
+/** Converts from Java byte array to C++ vector of bytes. */
+void javaByteArrayToByteVector(JniHelper& jni_helper, jbyteArray array, std::vector<uint8_t>* out);
 
-void JavaArrayOfByteToString(JniHelper& jni_helper, jbyteArray jbytes, std::string* out);
+/** Converts from Java byte array to C++ string. */
+void javaByteArrayToString(JniHelper& jni_helper, jbyteArray jbytes, std::string* out);
 
-/** Parses the proto from Java's byte array and stores the output into `dest` proto. */
+/** Parses the proto from Java byte array and stores the output into `dest` proto. */
 void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
                           Envoy::Protobuf::MessageLite* dest);
+
+/** Converts from Java `String` to C++ string. */
+std::string javaStringToString(JniHelper& jni_helper, jstring java_string);
 
 } // namespace JNI
 } // namespace Envoy

--- a/mobile/library/common/network/socket_tag_socket_option_impl.cc
+++ b/mobile/library/common/network/socket_tag_socket_option_impl.cc
@@ -27,7 +27,7 @@ bool SocketTagSocketOptionImpl::setOption(
   // Further, this only works for sockets which have a raw fd and will be a no-op
   // otherwise.
   int fd = socket.ioHandle().fdDoNotUse();
-  JNI::tag_socket(fd, uid_, traffic_stats_tag_);
+  JNI::tagSocket(fd, uid_, traffic_stats_tag_);
   return true;
 }
 


### PR DESCRIPTION
This PR refactors some functions that have mixed code styles from PascalCase to snake_case into camelCase, which is the Envoy code convention. Some functions have been renamed to give better names as well as adding more comments into the functions.

Risk Level: low (refactoring)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
