### PR TITLE
mobile: Update EngineBuilder's addDnsPreresolveHostnames to add a port

### DIFF
--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -179,6 +179,11 @@ public:
 #endif
   EngineBuilder& enableDnsCache(bool dns_cache_on, int save_interval_seconds = 1);
   EngineBuilder& setForceAlwaysUsev6(bool value);
+  // Adds the hostnames that should be pre-resolved by DNS prior to the first request issued for
+  // that host. When invoked, any previous preresolve hostname entries get cleared and only the ones
+  // provided in the hostnames argument get set.
+  // TODO(abeyad): change this method and the other language APIs to take a {host,port} pair.
+  // E.g. addDnsPreresolveHost(std::string host, uint32_t port);
   EngineBuilder& addDnsPreresolveHostnames(const std::vector<std::string>& hostnames);
   EngineBuilder& addNativeFilter(std::string name, std::string typed_config);
 
@@ -253,7 +258,7 @@ private:
   std::vector<std::string> stats_sinks_;
 
   std::vector<NativeFilterConfig> native_filter_chain_;
-  std::vector<std::string> dns_preresolve_hostnames_;
+  std::vector<std::pair<std::string /* host */, uint32_t /* port */>> dns_preresolve_hostnames_;
 
   std::vector<std::pair<std::string, bool>> runtime_guards_;
   absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_;

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -15,6 +15,7 @@ envoy_cc_test(
     deps = [
         "//library/cc:engine_builder_lib",
         "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "@envoy_api//envoy/extensions/clusters/dynamic_forward_proxy/v3:pkg_cc_proto",
         "@envoy_build_config//:extension_registry",
         "@envoy_build_config//:test_extensions",
     ],


### PR DESCRIPTION
Also, we add a test to verify the addDnsPreresolveHostnames behavior.
