### PR TITLE
tools: remove incorrect flag in generated `compiled_commands.json`

### DIFF
--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -41,6 +41,9 @@ def generate_compilation_database(args):
         if 'command' in db_entry:
             db_entry['command'] = (
                 db_entry['command'].replace('-isysroot __BAZEL_XCODE_SDKROOT__', ''))
+            db_entry['command'] = (
+                db_entry['command'].replace('DEBUG_PREFIX_MAP_PWD=.', '')
+            )
         return db_entry
 
     return list(map(replace_execroot_marker, db_entries))

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -41,8 +41,7 @@ def generate_compilation_database(args):
         if 'command' in db_entry:
             db_entry['command'] = (
                 db_entry['command'].replace('-isysroot __BAZEL_XCODE_SDKROOT__', ''))
-            db_entry['command'] = (
-                db_entry['command'].replace('DEBUG_PREFIX_MAP_PWD=.', ''))
+            db_entry['command'] = (db_entry['command'].replace('DEBUG_PREFIX_MAP_PWD=.', ''))
         return db_entry
 
     return list(map(replace_execroot_marker, db_entries))

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -42,8 +42,7 @@ def generate_compilation_database(args):
             db_entry['command'] = (
                 db_entry['command'].replace('-isysroot __BAZEL_XCODE_SDKROOT__', ''))
             db_entry['command'] = (
-                db_entry['command'].replace('DEBUG_PREFIX_MAP_PWD=.', '')
-            )
+                db_entry['command'].replace('DEBUG_PREFIX_MAP_PWD=.', ''))
         return db_entry
 
     return list(map(replace_execroot_marker, db_entries))


### PR DESCRIPTION
Commit Message: tools: remove incorrect flag in generated compiled_commands.json
Additional Description:
The command in compilation database file generated with `tools/gen_compilation_database.py //source/... //test/... --system-clang` cannot be used loaded by `clang++` since the flag is incorrect. This PR removes the incorrect flag from the command.
```
Compiler exited with error code 1: /usr/bin/clang++ -xc++ -D_FORTIFY_SOURCE=1 -fstack-protector -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -O0 -DDEBUG DEBUG_PREFIX_MAP_PWD=. -F__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks -F__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks -no-canonical-prefixes -pthread -std=c++17 -DABSL_MIN_LOG_LEVEL=4 -no-canonical-prefixes -Wno-builtin-macro-redefined -D__DATE__=redacted -D__TIMESTAMP__=redacted -D__TIME__=redacted -target arm64-apple-macosx14.0 -DFMT_HEADER_ONLY -DSPDLOG_FMT_EXTERNAL -DENVOY_ADMIN_FUNCTIONALITY -DENVOY_ENABLE_QUIC -DENVOY_ENABLE_FULL_PROTOS -DENVOY_ENABLE_YAML -DENVOY_ENABLE_HTTP_DATAGRAMS -DENVOY_MOBILE_ENABLE_LISTENER -DENVOY_MOBILE_STATS_REPORTING -DENVOY_MOBILE_REQUEST_COMPRESSION -DENVOY_GOOGLE_GRPC -DBAZEL_CURRENT_REPOSITORY= -isystem external/com_github_gabime_spdlog/include -isystem bazel-out/darwin_arm64-fastbuild/bin/external/com_github_gabime_spdlog/include -isystem external/com_github_fmtlib_fmt/include -isystem bazel-out/darwin_arm64-fastbuild/bin/external/com_github_fmtlib_fmt/include -isystem bazel-out/darwin_arm64-fastbuild/bin/external/envoy/bazel/foreign_cc/zlib/include -isystem external/com_github_jbeder_yaml_cpp/include -isystem bazel-out/darwin_arm64-fastbuild/bin/external/com_github_jbeder_yaml_cpp/include -isystem external/boringssl/src/include -isystem bazel-out/darwin_arm64-fastbuild/bin/external/boringssl/src/include -iquote . -iquote bazel-out/darwin_arm64-fastbuild/bin -iquote external/com_google_absl -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_google_absl -iquote external/com_github_gabime_spdlog -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_github_gabime_spdlog -iquote external/com_github_fmtlib_fmt -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_github_fmtlib_fmt -iquote external/com_google_protobuf -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_google_protobuf -iquote external/utf8_range -iquote bazel-out/darwin_arm64-fastbuild/bin/external/utf8_range -iquote external/envoy_api -iquote bazel-out/darwin_arm64-fastbuild/bin/external/envoy_api -iquote external/com_github_cncf_udpa -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_github_cncf_udpa -iquote external/com_google_googleapis -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_google_googleapis -iquote external/com_envoyproxy_protoc_gen_validate -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_envoyproxy_protoc_gen_validate -iquote external/com_googlesource_code_re2 -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_googlesource_code_re2 -iquote external/com_github_cyan4973_xxhash -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_github_cyan4973_xxhash -iquote external/opencensus_proto -iquote bazel-out/darwin_arm64-fastbuild/bin/external/opencensus_proto -iquote external/com_github_jbeder_yaml_cpp -iquote bazel-out/darwin_arm64-fastbuild/bin/external/com_github_jbeder_yaml_cpp -iquote external/boringssl -iquote bazel-out/darwin_arm64-fastbuild/bin/external/boringssl -x c++ -Wall -Wextra -Wnon-virtual-dtor -Woverloaded-virtual -Wold-style-cast -Wformat -Wformat-security -Wvla -Wno-deprecated-declarations -Wreturn-type -fno-limit-debug-info -Wgnu-conditional-omitted-operand -Wc++2a-extensions -Wrange-loop-analysis -Wno-range-loop-analysis -DABSL_MALLOC_HOOK_MMAP_DISABLE -DENVOY_OBJECT_TRACE_ON_DUMP -D__APPLE_USE_RFC_3542 -DENVOY_ADMIN_HTML -DENVOY_STATIC_EXTENSION_REGISTRATION -DENVOY_GOOGLE_GRPC -DENVOY_HANDLE_SIGNALS -c -fpch-preprocess -v -dD -E
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-macosx14.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
clang++: error: no such file or directory: 'DEBUG_PREFIX_MAP_PWD=.'
```

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
