### PR TITLE
skip flushOutput(attempt to write) on closed connection

### DIFF
--- a/changelogs/1.28.0.yaml
+++ b/changelogs/1.28.0.yaml
@@ -52,6 +52,9 @@ behavior_changes:
     mitigates CPU starvation by connections that simultaneously send high number of requests by allowing requests from other
     connections to make progress. This runtime value can be set to 1 in the presence of abusive HTTP/2 or HTTP/3 connections.
     By default this limit is disabled.
+- area: http
+  change: |
+    In the http codec, skip flushing the bytes to the network when the connection is closed.
 
 minor_behavior_changes:
 - area: ext_authz

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -262,6 +262,9 @@ void StreamEncoderImpl::encodeData(Buffer::Instance& data, bool end_stream) {
 }
 
 void StreamEncoderImpl::flushOutput(bool end_encode) {
+  if (connection_.connection().state() != Network::Connection::State::Open) {
+    return;
+  }
   auto encoded_bytes = connection_.flushOutput(end_encode);
   bytes_meter_->addWireBytesSent(encoded_bytes);
 }

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -122,7 +122,6 @@ FilterStatus FilterManagerImpl::onWrite(ActiveWriteFilter* filter,
   // Filter could return status == FilterStatus::StopIteration immediately, close the connection and
   // use callback to call this function.
   if (connection_.state() != Connection::State::Open) {
-    buffer_source.getWriteBuffer().buffer.drain(buffer_source.getWriteBuffer().buffer.length());
     return FilterStatus::StopIteration;
   }
 

--- a/source/common/network/filter_manager_impl.cc
+++ b/source/common/network/filter_manager_impl.cc
@@ -122,6 +122,7 @@ FilterStatus FilterManagerImpl::onWrite(ActiveWriteFilter* filter,
   // Filter could return status == FilterStatus::StopIteration immediately, close the connection and
   // use callback to call this function.
   if (connection_.state() != Connection::State::Open) {
+    buffer_source.getWriteBuffer().buffer.drain(buffer_source.getWriteBuffer().buffer.length());
     return FilterStatus::StopIteration;
   }
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1325,6 +1325,31 @@ TEST_P(Http1ServerConnectionImplTest, BadRequestStartedStream) {
   EXPECT_TRUE(isCodecProtocolError(status));
 }
 
+TEST_P(Http1ServerConnectionImplTest, WriteAttemptOnClosedConnection) {
+  initialize();
+  NiceMock<MockRequestDecoder> decoder;
+  Buffer::OwnedImpl local_buffer;
+
+  Http::ResponseEncoder* response_encoder = nullptr;
+  EXPECT_CALL(callbacks_, newStream(_, _))
+      .WillOnce(Invoke([&](Http::ResponseEncoder& encoder, bool) -> Http::RequestDecoder& {
+        response_encoder = &encoder;
+        return decoder;
+      }));
+
+  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
+  auto status = codec_->dispatch(buffer);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(0U, buffer.length());
+
+  ON_CALL(connection_, state()).WillByDefault(Return(Network::Connection::State::Closed));
+  EXPECT_CALL(connection_, write(_, _)).Times(0);
+
+  TestResponseHeaderMapImpl headers{{":status", "200"}};
+  response_encoder->encodeHeaders(headers, true);
+  EXPECT_EQ(response_encoder->getStream().bytesMeter().get()->wireBytesSent(), 0);
+}
+
 TEST_P(Http1ServerConnectionImplTest, FloodProtection) {
   initialize();
 
@@ -3019,8 +3044,8 @@ TEST_P(Http1ClientConnectionImplTest, PrematureUpgradeResponse) {
   initialize();
 
   // make sure upgradeAllowed doesn't cause crashes if run with no pending response.
-  Buffer::OwnedImpl response(
-      "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: "
+                             "upgrade\r\nUpgrade: websocket\r\n\r\n");
   auto status = codec_->dispatch(response);
   EXPECT_TRUE(isPrematureResponseError(status));
 }
@@ -3041,8 +3066,8 @@ TEST_P(Http1ClientConnectionImplTest, UpgradeResponse) {
 
   // Send upgrade headers
   EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
-  Buffer::OwnedImpl response(
-      "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: "
+                             "upgrade\r\nUpgrade: websocket\r\n\r\n");
   auto status = codec_->dispatch(response);
 
   // Send body payload
@@ -3242,7 +3267,8 @@ TEST_P(Http1ClientConnectionImplTest, LowWatermarkDuringClose) {
 
   EXPECT_CALL(response_decoder, decodeHeaders_(_, true))
       .WillOnce(Invoke([&](ResponseHeaderMapPtr&, bool) {
-        // Fake a call for going below the low watermark. Make sure no stream callbacks get called.
+        // Fake a call for going below the low watermark. Make sure no stream callbacks get
+        // called.
         EXPECT_CALL(stream_callbacks, onBelowWriteBufferLowWatermark()).Times(0);
         static_cast<ClientConnection*>(codec_.get())
             ->onUnderlyingConnectionBelowWriteBufferLowWatermark();
@@ -3255,29 +3281,32 @@ TEST_P(Http1ClientConnectionImplTest, LowWatermarkDuringClose) {
 TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejected) {
   // Default limit of 60 KiB
   std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
-  testTrailersExceedLimit(/*trailer_string*/ long_string,
-                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-                          /*enable_trailers*/ true,
-                          /*expect_error*/ true);
+  testTrailersExceedLimit(
+      /*trailer_string*/ long_string,
+      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+      /*enable_trailers*/ true,
+      /*expect_error*/ true);
 }
 
 // Test that long trailer fields are consistently rejected.
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejected) {
   // Construct partial headers with a long field name that exceeds the default limit of 60KiB.
   std::string long_string = "bigfield" + std::string(60 * 1024, 'q');
-  testTrailersExceedLimit(/*trailer_string*/ long_string,
-                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-                          /*enable_trailers*/ true,
-                          /*expect_error*/ true);
+  testTrailersExceedLimit(
+      /*trailer_string*/ long_string,
+      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+      /*enable_trailers*/ true,
+      /*expect_error*/ true);
 }
 
 // Tests that the default limit for the number of request headers is 100.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersRejected) {
   // Send a request with 101 headers.
-  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
-                          /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
-                          /*enable_trailers*/ true,
-                          /*expect_error*/ true);
+  testTrailersExceedLimit(
+      /*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
+      /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
+      /*enable_trailers*/ true,
+      /*expect_error*/ true);
 }
 
 // Test if trailers which should be rejected are ignored if trailers are disabled.
@@ -3286,29 +3315,32 @@ TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejectedIgnored) {
   // Send overly long trailers. http_parser will allow this if trailers are
   // disabled, balsa will not.
   std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
-  testTrailersExceedLimit(/*trailer_string*/ long_string,
-                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-                          /*enable_trailers*/ false,
-                          /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
+  testTrailersExceedLimit(
+      /*trailer_string*/ long_string,
+      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+      /*enable_trailers*/ false,
+      /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejectedIgnored) {
   // Send one overly long trailer. http_parser will allow this if trailers are
   // disabled, balsa will not.
   std::string long_string = "bigfield" + std::string(60 * 1024, 'q') + ": value\r\n\r\n\r\n";
-  testTrailersExceedLimit(/*trailer_string*/ long_string,
-                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-                          /*enable_trailers*/ false,
-                          /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
+  testTrailersExceedLimit(
+      /*trailer_string*/ long_string,
+      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+      /*enable_trailers*/ false,
+      /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
 // Tests that the default limit for the number of request headers is 100.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersIgnored) {
   // Send a request with 101 headers. Both balsa and http_parser ignore this
   // with trailers disabled.
-  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
-                          /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
-                          /*enable_trailers*/ false, /* expect_error */ false);
+  testTrailersExceedLimit(
+      /*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
+      /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
+      /*enable_trailers*/ false, /* expect_error */ false);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeRequestUrlRejected) {
@@ -3500,8 +3532,8 @@ TEST_P(Http1ServerConnectionImplTest, RuntimeLazyReadDisableTest) {
   }
 }
 
-// Tests the scenario where the client sends pipelined requests and the requests reach Envoy at the
-// same time.
+// Tests the scenario where the client sends pipelined requests and the requests reach Envoy at
+// the same time.
 TEST_P(Http1ServerConnectionImplTest, PipedRequestWithSingleEvent) {
   TestScopedRuntime scoped_runtime;
 
@@ -4421,8 +4453,8 @@ TEST_P(Http1ServerConnectionImplTest, NoContentLengthRequest) {
   EXPECT_EQ(kBody.length(), buffer.length());
 }
 
-// Regression test for #24557: A read of zero bytes can signal the end of response body if there is
-// no Content-Length header. A subsequent response should be properly parsed.
+// Regression test for #24557: A read of zero bytes can signal the end of response body if there
+// is no Content-Length header. A subsequent response should be properly parsed.
 TEST_P(Http1ClientConnectionImplTest, NoContentLengthResponse) {
   initialize();
   InSequence s;
@@ -4457,8 +4489,8 @@ TEST_P(Http1ClientConnectionImplTest, NoContentLengthResponse) {
       EXPECT_CALL(decoder, decodeData(BufferStringEqual("foo"), false));
     } else {
       // This is actually a bug in http-parser: even though it already called
-      // `Parser::onMessageComplete()`, it does not parse the next read as a new response but as if
-      // it was more body.
+      // `Parser::onMessageComplete()`, it does not parse the next read as a new response but as
+      // if it was more body.
       EXPECT_CALL(decoder, decodeData(BufferStringEqual(kResponseWithBody), false));
     }
     Buffer::OwnedImpl buffer(kResponseWithBody);

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -3044,8 +3044,8 @@ TEST_P(Http1ClientConnectionImplTest, PrematureUpgradeResponse) {
   initialize();
 
   // make sure upgradeAllowed doesn't cause crashes if run with no pending response.
-  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: "
-                             "upgrade\r\nUpgrade: websocket\r\n\r\n");
+  Buffer::OwnedImpl response(
+      "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
   auto status = codec_->dispatch(response);
   EXPECT_TRUE(isPrematureResponseError(status));
 }
@@ -3066,8 +3066,8 @@ TEST_P(Http1ClientConnectionImplTest, UpgradeResponse) {
 
   // Send upgrade headers
   EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
-  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: "
-                             "upgrade\r\nUpgrade: websocket\r\n\r\n");
+  Buffer::OwnedImpl response(
+      "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: upgrade\r\nUpgrade: websocket\r\n\r\n");
   auto status = codec_->dispatch(response);
 
   // Send body payload
@@ -3267,8 +3267,7 @@ TEST_P(Http1ClientConnectionImplTest, LowWatermarkDuringClose) {
 
   EXPECT_CALL(response_decoder, decodeHeaders_(_, true))
       .WillOnce(Invoke([&](ResponseHeaderMapPtr&, bool) {
-        // Fake a call for going below the low watermark. Make sure no stream callbacks get
-        // called.
+        // Fake a call for going below the low watermark. Make sure no stream callbacks get called.
         EXPECT_CALL(stream_callbacks, onBelowWriteBufferLowWatermark()).Times(0);
         static_cast<ClientConnection*>(codec_.get())
             ->onUnderlyingConnectionBelowWriteBufferLowWatermark();
@@ -3281,32 +3280,29 @@ TEST_P(Http1ClientConnectionImplTest, LowWatermarkDuringClose) {
 TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejected) {
   // Default limit of 60 KiB
   std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
-  testTrailersExceedLimit(
-      /*trailer_string*/ long_string,
-      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-      /*enable_trailers*/ true,
-      /*expect_error*/ true);
+  testTrailersExceedLimit(/*trailer_string*/ long_string,
+                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+                          /*enable_trailers*/ true,
+                          /*expect_error*/ true);
 }
 
 // Test that long trailer fields are consistently rejected.
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejected) {
   // Construct partial headers with a long field name that exceeds the default limit of 60KiB.
   std::string long_string = "bigfield" + std::string(60 * 1024, 'q');
-  testTrailersExceedLimit(
-      /*trailer_string*/ long_string,
-      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-      /*enable_trailers*/ true,
-      /*expect_error*/ true);
+  testTrailersExceedLimit(/*trailer_string*/ long_string,
+                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+                          /*enable_trailers*/ true,
+                          /*expect_error*/ true);
 }
 
 // Tests that the default limit for the number of request headers is 100.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersRejected) {
   // Send a request with 101 headers.
-  testTrailersExceedLimit(
-      /*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
-      /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
-      /*enable_trailers*/ true,
-      /*expect_error*/ true);
+  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
+                          /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
+                          /*enable_trailers*/ true,
+                          /*expect_error*/ true);
 }
 
 // Test if trailers which should be rejected are ignored if trailers are disabled.
@@ -3315,32 +3311,29 @@ TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejectedIgnored) {
   // Send overly long trailers. http_parser will allow this if trailers are
   // disabled, balsa will not.
   std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
-  testTrailersExceedLimit(
-      /*trailer_string*/ long_string,
-      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-      /*enable_trailers*/ false,
-      /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
+  testTrailersExceedLimit(/*trailer_string*/ long_string,
+                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+                          /*enable_trailers*/ false,
+                          /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejectedIgnored) {
   // Send one overly long trailer. http_parser will allow this if trailers are
   // disabled, balsa will not.
   std::string long_string = "bigfield" + std::string(60 * 1024, 'q') + ": value\r\n\r\n\r\n";
-  testTrailersExceedLimit(
-      /*trailer_string*/ long_string,
-      /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
-      /*enable_trailers*/ false,
-      /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
+  testTrailersExceedLimit(/*trailer_string*/ long_string,
+                          /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
+                          /*enable_trailers*/ false,
+                          /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
 // Tests that the default limit for the number of request headers is 100.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersIgnored) {
   // Send a request with 101 headers. Both balsa and http_parser ignore this
   // with trailers disabled.
-  testTrailersExceedLimit(
-      /*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
-      /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
-      /*enable_trailers*/ false, /* expect_error */ false);
+  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
+                          /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
+                          /*enable_trailers*/ false, /* expect_error */ false);
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeRequestUrlRejected) {
@@ -3532,8 +3525,8 @@ TEST_P(Http1ServerConnectionImplTest, RuntimeLazyReadDisableTest) {
   }
 }
 
-// Tests the scenario where the client sends pipelined requests and the requests reach Envoy at
-// the same time.
+// Tests the scenario where the client sends pipelined requests and the requests reach Envoy at the
+// same time.
 TEST_P(Http1ServerConnectionImplTest, PipedRequestWithSingleEvent) {
   TestScopedRuntime scoped_runtime;
 
@@ -4453,8 +4446,8 @@ TEST_P(Http1ServerConnectionImplTest, NoContentLengthRequest) {
   EXPECT_EQ(kBody.length(), buffer.length());
 }
 
-// Regression test for #24557: A read of zero bytes can signal the end of response body if there
-// is no Content-Length header. A subsequent response should be properly parsed.
+// Regression test for #24557: A read of zero bytes can signal the end of response body if there is
+// no Content-Length header. A subsequent response should be properly parsed.
 TEST_P(Http1ClientConnectionImplTest, NoContentLengthResponse) {
   initialize();
   InSequence s;
@@ -4489,8 +4482,8 @@ TEST_P(Http1ClientConnectionImplTest, NoContentLengthResponse) {
       EXPECT_CALL(decoder, decodeData(BufferStringEqual("foo"), false));
     } else {
       // This is actually a bug in http-parser: even though it already called
-      // `Parser::onMessageComplete()`, it does not parse the next read as a new response but as
-      // if it was more body.
+      // `Parser::onMessageComplete()`, it does not parse the next read as a new response but as if
+      // it was more body.
       EXPECT_CALL(decoder, decodeData(BufferStringEqual(kResponseWithBody), false));
     }
     Buffer::OwnedImpl buffer(kResponseWithBody);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
fixes: #26994 
assertion failure happens in [flushOutput](https://github.com/envoyproxy/envoy/blob/main/source/common/http/http1/codec_impl.cc#L354). Assertion expects that after `connection().write(*output_buffer_, false);`, `output_buffer_->length()` is 0. If connection is closed, `write` returns early without draining the buffer and hence the assertion failure. 
In the first commit of this PR, I did this draining in `write` to fix the issue. @soulxu then suggested alternative to return even earlier and skip `flushOutput` altogether if connection state is found closed. Hence, fixing the issue by skipping `flushOutput`

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
