### PR TITLE
Make EXPECT_ENVOY_BUG not leak between test cases

### DIFF
--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -110,17 +110,9 @@ TEST_F(QuicPlatformTest, QuicClientStats) {
 
 TEST_F(QuicPlatformTest, QuicExpectBug) {
   auto bug = [](const char* error_message) { QUIC_BUG(bug_id) << error_message; };
-
   auto peer_bug = [](const char* error_message) { QUIC_PEER_BUG(bug_id) << error_message; };
   EXPECT_QUIC_BUG(bug("bug one is expected"), "bug one");
   EXPECT_QUIC_BUG(bug("bug two is expected"), "bug two");
-#ifdef NDEBUG
-  // The 3rd triggering in release mode should not be logged.
-  EXPECT_LOG_NOT_CONTAINS("error", "bug three", bug("bug three is expected"));
-#else
-  EXPECT_QUIC_BUG(bug("bug three is expected"), "bug three");
-#endif
-
   EXPECT_QUIC_PEER_BUG(peer_bug("peer_bug_1 is expected"), "peer_bug_1");
   EXPECT_QUIC_PEER_BUG(peer_bug("peer_bug_2 is expected"), "peer_bug_2");
 }

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -1150,21 +1150,18 @@ TEST_F(CacheFilterDeathTest, StreamTimeoutDuringLookup) {
 }
 
 TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndInitialIsBug) {
-  GTEST_SKIP(); // TODO(issue #29217): Remove skip.
   EXPECT_ENVOY_BUG(
       CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation, FilterState::Initial),
       "Unexpected filter state in requestCacheStatus");
 }
 
 TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDecodeServingFromCacheIsBug) {
-  GTEST_SKIP(); // TODO(issue #29217): Remove skip.
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
                                                     FilterState::DecodeServingFromCache),
                    "Unexpected filter state in requestCacheStatus");
 }
 
 TEST(LookupStatusDeathTest, ResolveLookupStatusRequireValidationAndDestroyedIsBug) {
-  GTEST_SKIP(); // TODO(issue #29217): Remove skip.
   EXPECT_ENVOY_BUG(CacheFilter::resolveLookupStatus(CacheEntryStatus::RequiresValidation,
                                                     FilterState::Destroyed),
                    "Unexpected filter state in requestCacheStatus");

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -98,7 +98,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
 #define EXPECT_LOG_CONTAINS_ALL_OF_HELPER(expected_messages, stmt, escaped)                        \
   do {                                                                                             \
     ASSERT_FALSE(expected_messages.empty()) << "Expected messages cannot be empty.";               \
-    resetEnvoyBugCountersForTest();                                                                \
+    ::Envoy::Assert::resetEnvoyBugCountersForTest();                                               \
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
     Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();       \
     sink_ptr->setShouldEscape(escaped);                                                            \

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -97,6 +97,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
 #define EXPECT_LOG_CONTAINS_ALL_OF_HELPER(expected_messages, stmt, escaped)                        \
   do {                                                                                             \
     ASSERT_FALSE(expected_messages.empty()) << "Expected messages cannot be empty.";               \
+    EnvoyBugState::get().clear();                                                                  \
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
     Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();       \
     sink_ptr->setShouldEscape(escaped);                                                            \

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -97,7 +97,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
 #define EXPECT_LOG_CONTAINS_ALL_OF_HELPER(expected_messages, stmt, escaped)                        \
   do {                                                                                             \
     ASSERT_FALSE(expected_messages.empty()) << "Expected messages cannot be empty.";               \
-    EnvoyBugState::get().clear();                                                                  \
+    resetEnvoyBugCountersForTest();                                                                \
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
     Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();       \
     sink_ptr->setShouldEscape(escaped);                                                            \

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
 
 #include "absl/strings/str_join.h"


### PR DESCRIPTION
Commit Message: Make EXPECT_ENVOY_BUG not leak between test cases
Additional Description: Resolves #29217 (the problem is in release mode, bug-logs have exponential 'drop', which means if you EXPECT_ENVOY_BUG for the same line more than 2 times in a whole test suite, at least one of them will fail in coverage runs, without either this change, explicitly calling to clear the bug counters, or some common call to clear the bug counters deeper in the test framework.)
Risk Level: Negligible, test-only
Testing: Yes it is
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
