### PR TITLE
mobile: Change Envoy Mobile's xDS to use EnvoyGrpc instead of GoogleGrpc

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -52,7 +52,6 @@ envoy_cc_library(
         "@envoy",
     ) + envoy_select_google_grpc(
         [
-            "@envoy//source/common/grpc:google_grpc_creds_lib",
             "@envoy//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
             "@envoy//source/extensions/config_subscription/grpc:grpc_subscription_lib",
             "@envoy//source/extensions/clusters/static:static_cluster_lib",

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -44,7 +44,7 @@ namespace Envoy {
 namespace Platform {
 
 #ifdef ENVOY_GOOGLE_GRPC
-XdsBuilder::XdsBuilder(std::string xds_server_address, const int xds_server_port)
+XdsBuilder::XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port)
     : xds_server_address_(std::move(xds_server_address)), xds_server_port_(xds_server_port) {}
 
 XdsBuilder& XdsBuilder::addInitialStreamHeader(std::string header, std::string value) {
@@ -85,27 +85,15 @@ void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const
   ads_config->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
   ads_config->set_set_node_on_first_message_only(true);
   ads_config->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+
   auto& grpc_service = *ads_config->add_grpc_services();
-  grpc_service.mutable_google_grpc()->set_target_uri(
-      fmt::format(R"({}:{})", xds_server_address_, xds_server_port_));
-  grpc_service.mutable_google_grpc()->set_stat_prefix("ads");
-  if (!ssl_root_certs_.empty()) {
-    grpc_service.mutable_google_grpc()
-        ->mutable_channel_credentials()
-        ->mutable_ssl_credentials()
-        ->mutable_root_certs()
-        ->set_inline_string(ssl_root_certs_);
-  }
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("base");
+  grpc_service.mutable_envoy_grpc()->set_authority(
+      absl::StrCat(xds_server_address_, ":", xds_server_port_));
 
   if (!xds_initial_grpc_metadata_.empty()) {
     grpc_service.mutable_initial_metadata()->Assign(xds_initial_grpc_metadata_.begin(),
                                                     xds_initial_grpc_metadata_.end());
-  }
-
-  if (!sni_.empty()) {
-    auto& channel_args =
-        *grpc_service.mutable_google_grpc()->mutable_channel_args()->mutable_args();
-    channel_args["grpc.default_authority"].set_string_value(sni_);
   }
 
   if (!rtds_resource_name_.empty()) {
@@ -353,6 +341,10 @@ EngineBuilder& EngineBuilder::setNodeMetadata(ProtobufWkt::Struct node_metadata)
 #ifdef ENVOY_GOOGLE_GRPC
 EngineBuilder& EngineBuilder::setXds(XdsBuilder xds_builder) {
   xds_builder_ = std::move(xds_builder);
+  // Add the XdsBuilder's xDS server hostname and port to the list of DNS addresses to preresolve in
+  // the `base` DFP cluster.
+  dns_preresolve_hostnames_.push_back(
+      {xds_builder_->xds_server_address_ /* host */, xds_builder_->xds_server_port_ /* port */});
   return *this;
 }
 #endif

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -49,7 +49,7 @@ public:
   //                       (https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#aggregated-xds-ads).
   // `xds_server_port`: the port on which the xDS management server listens for ADS discovery
   //                    requests.
-  XdsBuilder(std::string xds_server_address, const int xds_server_port);
+  XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port);
 
   // Adds a header to the initial HTTP metadata headers sent on the gRPC stream.
   //
@@ -111,7 +111,7 @@ private:
   friend class EngineBuilder;
 
   std::string xds_server_address_;
-  int xds_server_port_;
+  uint32_t xds_server_port_;
   std::vector<envoy::config::core::v3::HeaderValue> xds_initial_grpc_metadata_;
   std::string ssl_root_certs_;
   std::string sni_;

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -335,50 +335,35 @@ TEST(TestConfig, XdsConfig) {
 
   auto& ads_config = bootstrap->dynamic_resources().ads_config();
   EXPECT_EQ(ads_config.api_type(), envoy::config::core::v3::ApiConfigSource::GRPC);
-  EXPECT_EQ(ads_config.grpc_services(0).google_grpc().target_uri(), authority);
-  EXPECT_EQ(ads_config.grpc_services(0).google_grpc().stat_prefix(), "ads");
-  EXPECT_THAT(ads_config.grpc_services(0)
-                  .google_grpc()
-                  .channel_credentials()
-                  .ssl_credentials()
-                  .root_certs()
-                  .inline_string(),
-              IsEmpty());
-  EXPECT_THAT(ads_config.grpc_services(0).google_grpc().call_credentials(), SizeIs(0));
+  EXPECT_EQ(ads_config.grpc_services(0).envoy_grpc().cluster_name(), "base");
+  EXPECT_EQ(ads_config.grpc_services(0).envoy_grpc().authority(), authority);
+
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketAddress>
+      expected_dns_preresolve_hostnames;
+  auto& host_addr1 = *expected_dns_preresolve_hostnames.Add();
+  host_addr1.set_address(host);
+  host_addr1.set_port_value(port);
+  EXPECT_TRUE(TestUtility::repeatedPtrFieldEqual(
+      getDfpClusterConfig(*bootstrap).dns_cache_config().preresolve_hostnames(),
+      expected_dns_preresolve_hostnames));
 
   // With initial gRPC metadata.
   xds_builder = XdsBuilder(/*xds_server_address=*/host, /*xds_server_port=*/port);
   xds_builder.addInitialStreamHeader(/*header=*/"x-goog-api-key", /*value=*/"A1B2C3")
       .addInitialStreamHeader(/*header=*/"x-android-package",
                               /*value=*/"com.google.envoymobile.io.myapp");
-  xds_builder.setSslRootCerts(/*root_certs=*/"my_root_cert");
-  xds_builder.setSni(/*sni=*/host);
   engine_builder.setXds(std::move(xds_builder));
   bootstrap = engine_builder.generateBootstrap();
   auto& ads_config_with_metadata = bootstrap->dynamic_resources().ads_config();
   EXPECT_EQ(ads_config_with_metadata.api_type(), envoy::config::core::v3::ApiConfigSource::GRPC);
-  EXPECT_EQ(ads_config_with_metadata.grpc_services(0).google_grpc().target_uri(), authority);
-  EXPECT_EQ(ads_config_with_metadata.grpc_services(0).google_grpc().stat_prefix(), "ads");
-  EXPECT_EQ(ads_config_with_metadata.grpc_services(0)
-                .google_grpc()
-                .channel_credentials()
-                .ssl_credentials()
-                .root_certs()
-                .inline_string(),
-            "my_root_cert");
+  EXPECT_EQ(ads_config_with_metadata.grpc_services(0).envoy_grpc().cluster_name(), "base");
+  EXPECT_EQ(ads_config_with_metadata.grpc_services(0).envoy_grpc().authority(), authority);
   EXPECT_EQ(ads_config_with_metadata.grpc_services(0).initial_metadata(0).key(), "x-goog-api-key");
   EXPECT_EQ(ads_config_with_metadata.grpc_services(0).initial_metadata(0).value(), "A1B2C3");
   EXPECT_EQ(ads_config_with_metadata.grpc_services(0).initial_metadata(1).key(),
             "x-android-package");
   EXPECT_EQ(ads_config_with_metadata.grpc_services(0).initial_metadata(1).value(),
             "com.google.envoymobile.io.myapp");
-  EXPECT_EQ(ads_config_with_metadata.grpc_services(0)
-                .google_grpc()
-                .channel_args()
-                .args()
-                .at("grpc.default_authority")
-                .string_value(),
-            "fake-td.googleapis.com");
 }
 
 TEST(TestConfig, CopyConstructor) {


### PR DESCRIPTION
This allows us to not have to import in the google-grpc library into Envoy Mobile, limiting the binary size by up to 3.5MB.

Next, we'll add a new flag guard, ENABLE_XDS, instead of relying on ENABLE_GOOGLE_GRPC to guard the xDS APIs.