### PR TITLE
mobile: Add initial unit tests for jni_utility.(h|cc)

### DIFF
--- a/mobile/library/common/jni/jni_utility.cc
+++ b/mobile/library/common/jni/jni_utility.cc
@@ -1,7 +1,7 @@
 #include "library/common/jni/jni_utility.h"
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "source/common/common/assert.h"
 
@@ -353,6 +353,15 @@ void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
   jsize size = jni_helper.getArrayLength(source);
   bool success = dest->ParseFromArray(bytes.get(), size);
   RELEASE_ASSERT(success, "Failed to parse protobuf message.");
+}
+
+LocalRefUniquePtr<jbyteArray> protoToJavaByteArray(JniHelper& jni_helper,
+                                                   const Envoy::Protobuf::MessageLite& source) {
+  size_t size = source.ByteSizeLong();
+  LocalRefUniquePtr<jbyteArray> byte_array = jni_helper.newByteArray(size);
+  auto bytes = jni_helper.getByteArrayElements(byte_array.get(), nullptr);
+  source.SerializeToArray(bytes.get(), size);
+  return byte_array;
 }
 
 std::string javaStringToString(JniHelper& jni_helper, jstring java_string) {

--- a/mobile/library/common/jni/jni_utility.h
+++ b/mobile/library/common/jni/jni_utility.h
@@ -124,6 +124,10 @@ void javaByteArrayToString(JniHelper& jni_helper, jbyteArray jbytes, std::string
 void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
                           Envoy::Protobuf::MessageLite* dest);
 
+/** Converts from Proto to Java byte array. */
+LocalRefUniquePtr<jbyteArray> protoToJavaByteArray(JniHelper& jni_helper,
+                                                   const Envoy::Protobuf::MessageLite& source);
+
 /** Converts from Java `String` to C++ string. */
 std::string javaStringToString(JniHelper& jni_helper, jstring java_string);
 

--- a/mobile/test/common/jni/BUILD
+++ b/mobile/test/common/jni/BUILD
@@ -103,3 +103,23 @@ cc_binary(
         ":jni_helper_test_lib",
     ],
 )
+
+cc_library(
+    name = "jni_utility_test_lib",
+    srcs = [
+        "jni_utility_test.cc",
+    ],
+    deps = [
+        "//library/common/jni:jni_utility_lib",
+    ],
+    alwayslink = True,
+)
+
+cc_binary(
+    name = "libenvoy_jni_utility_test.so",
+    testonly = True,
+    linkshared = True,
+    deps = [
+        ":jni_utility_test_lib",
+    ],
+)

--- a/mobile/test/common/jni/jni_utility_test.cc
+++ b/mobile/test/common/jni/jni_utility_test.cc
@@ -1,0 +1,17 @@
+#include <jni.h>
+
+#include "library/common/jni/jni_utility.h"
+
+// NOLINT(namespace-envoy)
+
+// This file contains JNI implementation used by
+// `test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java` unit tests.
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniUtilityTest_protoJavaByteArrayConversion(JNIEnv* env, jclass,
+                                                                               jbyteArray source) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  Envoy::ProtobufWkt::Struct s;
+  Envoy::JNI::javaByteArrayToProto(jni_helper, source, &s);
+  return Envoy::JNI::protoToJavaByteArray(jni_helper, s).release();
+}

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/BUILD
@@ -10,3 +10,17 @@ envoy_mobile_android_test(
     ],
     native_lib_name = "envoy_jni_helper_test",
 )
+
+envoy_mobile_android_test(
+    name = "jni_utility_test",
+    srcs = [
+        "JniUtilityTest.java",
+    ],
+    native_deps = [
+        "//test/common/jni:libenvoy_jni_utility_test.so",
+    ],
+    native_lib_name = "envoy_jni_utility_test",
+    deps = [
+        "@maven//:com_google_protobuf_protobuf_javalite",
+    ],
+)

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java
@@ -1,0 +1,31 @@
+package io.envoyproxy.envoymobile.jni;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class JniUtilityTest {
+  public JniUtilityTest() { System.loadLibrary("envoy_jni_utility_test"); }
+
+  //================================================================================
+  // Native methods for testing.
+  //================================================================================
+  public static native byte[] protoJavaByteArrayConversion(byte[] source);
+
+  @Test
+  public void testProtoJavaByteArrayConversion() throws Exception {
+    Struct source =
+        Struct.newBuilder()
+            .putFields("string_key", Value.newBuilder().setStringValue("string_value").build())
+            .putFields("num_key", Value.newBuilder().setNumberValue(123).build())
+            .putFields("bool_key", Value.newBuilder().setBoolValue(true).build())
+            .build();
+    Struct dest = Struct.parseFrom(protoJavaByteArrayConversion(source.toByteArray()));
+    assertThat(source).isEqualTo(dest);
+  }
+}


### PR DESCRIPTION
Prior to this PR, `jni_utility.(h|cc)` did not have any unit tests, which would make refactoring that file a bit risky. This PR sets up an initial infrastructure for writing unit tests for `jni_utility.(h|cc)` as well as adds an example unit test, so that we can slowly add unit tests for the functions defined in that file as well as requiring unit tests for future changes to that file.

Risk Level: low (adding unit tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
