### PR TITLE
mobile: Enable signal handlers when running tests

### DIFF
--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -51,7 +51,6 @@ jobs:
           --build_tests_only \
           --config=test-android \
           --config=mobile-remote-ci \
-          --define=signal_trace=disabled \
           //test/java/...
 
   kotlintestslinux:
@@ -85,5 +84,4 @@ jobs:
           --build_tests_only \
           --config=test-android \
           --config=mobile-remote-ci \
-          --define=signal_trace=disabled \
           //test/kotlin/...

--- a/mobile/bazel/kotlin_test.bzl
+++ b/mobile/bazel/kotlin_test.bzl
@@ -37,6 +37,8 @@ def jvm_flags(lib_name):
         "-Djava.library.path=library/common/jni:test/common/jni",
         "-Denvoy_jni_library_name={}".format(lib_name),
         "-Xcheck:jni",
+        # Use the signal handlers defined in Envoy instead of using libjsig.so.
+        "-XX:+AllowUserSignalHandlers",
     ] + select({
         "@envoy//bazel:disable_google_grpc": ["-Denvoy_jni_google_grpc_disabled=true"],
         "//conditions:default": [],


### PR DESCRIPTION
This PR removes `--define=signal_trace=disabled` when running Java / Kotlin tests and adds `-XX:+AllowUserSignalHandlers` so that we can use Envoy-defined signal handlers (needed when `-Xcheck:jni` is enabled).

Risk Level: low (only affects tests)
Testing: unit + integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
