### PR TITLE
[mobile]Split java proto proguard rule into a separate spec file

### DIFF
--- a/mobile/library/BUILD
+++ b/mobile/library/BUILD
@@ -2,6 +2,9 @@ licenses(["notice"])  # Apache 2
 
 filegroup(
     name = "proguard_rules",
-    srcs = ["proguard.txt"],
+    srcs = [
+        "java_proto_proguard.txt",
+        "proguard.txt",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/mobile/library/java_proto_proguard.txt
+++ b/mobile/library/java_proto_proguard.txt
@@ -1,0 +1,11 @@
+-keep class com.google.protobuf.** {
+   *;
+}
+
+-keep class com.google.protobuf.MessageLite {
+   *;
+}
+
+-keep class com.google.protobuf.MessageLite$Builder {
+   *;
+}

--- a/mobile/library/proguard.txt
+++ b/mobile/library/proguard.txt
@@ -60,15 +60,3 @@
 -keep class io.envoyproxy.envoymobile.engine.types.EnvoyLogger {
    <methods>;
 }
-
--keep class com.google.protobuf.** {
-   *;
-}
-
--keep class com.google.protobuf.MessageLite {
-    *;
-}
-
--keep class com.google.protobuf.MessageLite$Builder {
-    *;
-}


### PR DESCRIPTION
Commit Message: Split java proto proguard rule into a separate spec file
Additional Description: This makes it easier to modify and patch different proguard spec files.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile only
