### PR TITLE
Update references to Connect RPC

### DIFF
--- a/api/envoy/extensions/filters/http/connect_grpc_bridge/v3/config.proto
+++ b/api/envoy/extensions/filters/http/connect_grpc_bridge/v3/config.proto
@@ -13,10 +13,10 @@ option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/fil
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 
-// [#protodoc-title: Buf Connect to gRPC] Buf Connect to gRPC bridge
+// [#protodoc-title: Connect RPC to gRPC] Connect RPC to gRPC bridge
 // :ref:`configuration overview <config_http_filters_connect_grpc_bridge>`.
 // [#extension: envoy.filters.http.connect_grpc_bridge]
 
-// Buf Connect gRPC bridge filter configuration
+// Connect RPC to gRPC bridge filter configuration
 message FilterConfig {
 }

--- a/docs/root/configuration/http/http_filters/connect_grpc_bridge_filter.rst
+++ b/docs/root/configuration/http/http_filters/connect_grpc_bridge_filter.rst
@@ -7,11 +7,11 @@ Connect-gRPC Bridge
 * This filter should be configured with the type URL ``type.googleapis.com/envoy.extensions.filters.http.connect_grpc_bridge.v3.FilterConfig``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.connect_grpc_bridge.v3.FilterConfig>`
 
-This filter enables a Buf Connect client to connect to a compliant gRPC server.
-More information on the Buf Connect protocol can be found `here <https://connect.build/docs/protocol>`_.
+This filter enables a Connect RPC client to connect to a compliant gRPC server.
+More information on the Connect protocol can be found `here <https://connectrpc.com/docs/protocol>`_.
 
 HTTP GET support
 ----------------
-This filter supports `Buf Connect HTTP GET requests <https://connect.build/docs/protocol#unary-get-request>`_. The
+This filter supports `Connect HTTP GET requests <https://connectrpc.com/docs/protocol#unary-get-request>`_. The
 ``Connect-Version-Query`` parameter must be specified in requests in order for them to be translated by this filter,
 which will be done automatically when using a Connect implementation.

--- a/docs/root/configuration/http/http_filters/grpc_stats_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_stats_filter.rst
@@ -30,10 +30,10 @@ and :ref:`stats_for_all_methods <envoy_v3_api_field_extensions.filters.http.grpc
 
 To enable *upstream_rq_time* (v3 API only) see :ref:`enable_upstream_stats <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.enable_upstream_stats>`.
 
-Buf Connect
+Connect RPC
 -----------
 
-In addition to supporting gRPC, this filter also transparently supports telemetry for RPC calls using the `Buf Connect protocol <https://connect.build>`_.
+In addition to supporting gRPC, this filter also transparently supports telemetry for RPC calls using the `Connect protocol <https://connectrpc.com>`_.
 
 Connect calls will be counted in the same stats as equivalent gRPC calls.
 

--- a/docs/root/intro/arch_overview/other_protocols/grpc.rst
+++ b/docs/root/intro/arch_overview/other_protocols/grpc.rst
@@ -34,8 +34,8 @@ Envoy supports multiple gRPC bridges:
 * :ref:`grpc_http1_reverse_bridge filter <config_http_filters_grpc_http1_reverse_bridge>` which allows gRPC requests to be sent to Envoy
   and then translated to HTTP/1.1 when sent to the upstream. The response is then converted back into gRPC when sent to the downstream.
   This filter can also optionally manage the gRPC frame header, allowing the upstream to not have to be gRPC aware at all.
-* :ref:`connect_grpc_bridge filter <config_http_filters_connect_grpc_bridge>` which allows Buf Connect requests to be sent to Envoy.
-  Envoy then translates the requests to gRPC to be sent to the upstream. The response is converted back into the Buf Connect protocol
+* :ref:`connect_grpc_bridge filter <config_http_filters_connect_grpc_bridge>` which allows Connect requests to be sent to Envoy.
+  Envoy then translates the requests to gRPC to be sent to the upstream. The response is converted back into the Connect protocol
   to be sent back to the downstream. HTTP/1.1 requests will be upgraded to HTTP/2 or HTTP/3 when needed.
 
 .. _arch_overview_grpc_services:

--- a/source/common/grpc/codec.h
+++ b/source/common/grpc/codec.h
@@ -12,7 +12,7 @@ namespace Grpc {
 const uint8_t GRPC_FH_DEFAULT = 0b0u;
 // Last bit for a compressed message.
 const uint8_t GRPC_FH_COMPRESSED = 0b1u;
-// Bit specifies end-of-stream response in Buf Connect.
+// Bit specifies end-of-stream response in Connect.
 const uint8_t CONNECT_FH_EOS = 0b10u;
 
 constexpr uint64_t GRPC_FRAME_HEADER_SIZE = sizeof(uint8_t) + sizeof(uint32_t);

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -64,14 +64,14 @@ public:
 
   /**
    * @param headers the headers to parse.
-   * @return bool indicating whether the header is a Buf Connect request header.
+   * @return bool indicating whether the header is a Connect request header.
    * This is determined by checking for the connect protocol version header and a path header.
    */
   static bool isConnectRequestHeaders(const Http::RequestHeaderMap& headers);
 
   /**
    * @param headers the headers to parse.
-   * @return bool indicating whether the header is a Buf Connect streaming request header.
+   * @return bool indicating whether the header is a Connect streaming request header.
    * This is determined by checking for the connect streaming content type and a path header.
    */
   static bool isConnectStreamingRequestHeaders(const Http::RequestHeaderMap& headers);
@@ -93,7 +93,7 @@ public:
 
   /**
    * @param headers the headers to parse.
-   * @return bool indicating whether the header is a Buf Connect streaming response header.
+   * @return bool indicating whether the header is a Connect streaming response header.
    */
   static bool isConnectStreamingResponseHeaders(const Http::ResponseHeaderMap& headers);
 

--- a/source/extensions/filters/http/connect_grpc_bridge/BUILD
+++ b/source/extensions/filters/http/connect_grpc_bridge/BUILD
@@ -7,7 +7,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-# L7 HTTP filter that translates Buf Connect to gRPC.
+# L7 HTTP filter that translates Connect RPC to gRPC.
 
 envoy_extension_package()
 

--- a/source/extensions/filters/http/connect_grpc_bridge/config.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb ConnectGrpcFilterConfigFactory::createFilterFactoryFromPro
 }
 
 /**
- * Static registration for the Buf Connect stats filter. @see RegisterFactory.
+ * Static registration for the Connect RPC stats filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(ConnectGrpcFilterConfigFactory,
                  Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/connect_grpc_bridge/end_stream_response.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/end_stream_response.cc
@@ -13,7 +13,7 @@ namespace {
 /**
  * Returns the appropriate error status code for a given gRPC status.
  *
- * https://connect.build/docs/protocol#error-codes
+ * https://connectrpc.com/docs/protocol#error-codes
  */
 std::string statusCodeToString(const Grpc::Status::GrpcStatus status) {
   using WellKnownGrpcStatus = Grpc::Status::WellKnownGrpcStatus;
@@ -122,7 +122,7 @@ bool serializeJson(const EndStreamResponse& response, std::string& out) {
 /**
  * Gets the appropriate HTTP status code for a given gRPC status.
  *
- * https://connect.build/docs/protocol#error-codes
+ * https://connectrpc.com/docs/protocol#error-codes
  */
 uint64_t statusCodeToConnectUnaryStatus(const Grpc::Status::GrpcStatus status) {
   using WellKnownGrpcStatus = Grpc::Status::WellKnownGrpcStatus;

--- a/source/extensions/filters/http/connect_grpc_bridge/end_stream_response.h
+++ b/source/extensions/filters/http/connect_grpc_bridge/end_stream_response.h
@@ -28,9 +28,9 @@ struct EndStreamResponse {
 };
 
 /**
- * Serializes a Buf Connect Error object to JSON.
+ * Serializes a Connect Error object to JSON.
  *
- * https://connect.build/docs/protocol#error-end-stream
+ * https://connectrpc.com/docs/protocol#error-end-stream
  *
  * @param error Error object to serialize.
  * @param out String to store result in.
@@ -39,9 +39,9 @@ struct EndStreamResponse {
 bool serializeJson(const Error& error, std::string& out);
 
 /**
- * Serializes a Buf Connect EndStreamResponse object to JSON.
+ * Serializes a Connect EndStreamResponse object to JSON.
  *
- * https://connect.build/docs/protocol#error-end-stream
+ * https://connectrpc.com/docs/protocol#error-end-stream
  *
  * @param response EndStreamResponse object to serialize.
  * @param out String to store result in.

--- a/source/extensions/filters/http/connect_grpc_bridge/filter.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/filter.cc
@@ -18,10 +18,10 @@ namespace ConnectGrpcBridge {
 namespace {
 
 struct RcDetailsValues {
-  // The Buf Connect gRPC bridge tried to buffer a unary request that was too large for the
+  // The Connect RPC to gRPC bridge tried to buffer a unary request that was too large for the
   // configured decoder buffer limit.
   const std::string ConnectBridgeUnaryRequestTooLarge = "connect_bridge_unary_request_too_large";
-  // The Buf Connect gRPC bridge tried to buffer a unary response that was too large for the
+  // The Connect RPC to gRPC bridge tried to buffer a unary response that was too large for the
   // configured encoder buffer limit.
   const std::string ConnectBridgeUnaryResponseTooLarge = "connect_bridge_unary_response_too_large";
 };

--- a/source/extensions/filters/http/grpc_stats/response_frame_counter.h
+++ b/source/extensions/filters/http/grpc_stats/response_frame_counter.h
@@ -11,7 +11,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcStats {
 
-// An adaptation of the gRPC frame inspector that handles the Buf Connect end-of-stream frame.
+// An adaptation of the gRPC frame inspector that handles the Connect end-of-stream frame.
 class ResponseFrameCounter : protected Grpc::FrameInspector {
 public:
   uint64_t inspect(const Buffer::Instance& input);


### PR DESCRIPTION
Connect is now "Connect RPC" and lives at connectrpc.com. This PR updates inline and published documentation to reflect these changes.