### PR TITLE
tools: slack notification for first pass reviewers

### DIFF
--- a/tools/repo/notify.py
+++ b/tools/repo/notify.py
@@ -55,10 +55,11 @@ MAINTAINERS = {
 # notifications but not result in a PR not getting assigned a
 # maintainer owner.
 FIRST_PASS = {
-    'dmitri-d': 'UB1883Q5S',
-    'tonya11en': 'U989BG2CW',
-    'esmet': 'U01BCGBUUAE',
-    'mathetake': 'UG9TD2FSB',
+    'silverstar194': 'U03LNPC8JN9',
+    'nezdolik': 'UDYUWRL13',
+    'daixiang0': 'U020CJG6UU8',
+    'botengyao': 'U037YUAK147',
+    'tyxia': 'U023U1ZN9SP',
 }
 
 # Only notify API reviewers who aren't maintainers.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

I assume this change will let first-pass reviewers receive slack notifications.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
