### PR TITLE
UDP Tunneling: Set response flag in udp session info

### DIFF
--- a/test/integration/udp_tunneling_integration_test.cc
+++ b/test/integration/udp_tunneling_integration_test.cc
@@ -663,8 +663,30 @@ TEST_P(UdpTunnelingIntegrationTest, ConnectionReuse) {
 }
 
 TEST_P(UdpTunnelingIntegrationTest, FailureOnBadResponseHeaders) {
-  TestConfig config{"host.com",           "target.com", 1, 30, false, "",
-                    BufferOptions{1, 30}, absl::nullopt};
+  const std::string access_log_filename =
+      TestEnvironment::temporaryPath(TestUtility::uniqueFilename());
+
+  const std::string session_access_log_config = fmt::format(R"EOF(
+  access_log:
+  - name: envoy.access_loggers.file
+    typed_config:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: {}
+      log_format:
+        text_format_source:
+          inline_string: "%UPSTREAM_REQUEST_ATTEMPT_COUNT% %RESPONSE_FLAGS%\n"
+)EOF",
+                                                            access_log_filename);
+
+  const TestConfig config{"host.com",
+                          "target.com",
+                          1,
+                          30,
+                          false,
+                          "",
+                          BufferOptions{1, 30},
+                          absl::nullopt,
+                          session_access_log_config};
   setup(config);
 
   // Initial datagram will create a session and a tunnel request.
@@ -681,6 +703,8 @@ TEST_P(UdpTunnelingIntegrationTest, FailureOnBadResponseHeaders) {
   test_server_->waitForCounterEq("cluster.cluster_0.udp.sess_tunnel_failure", 1);
   test_server_->waitForCounterEq("cluster.cluster_0.udp.sess_tunnel_success", 0);
   test_server_->waitForGaugeEq("udp.foo.downstream_sess_active", 0);
+
+  EXPECT_THAT(waitForAccessLog(access_log_filename), testing::HasSubstr("1 UF,URX"));
 }
 
 TEST_P(UdpTunnelingIntegrationTest, ConnectionAttemptRetry) {
@@ -695,7 +719,7 @@ TEST_P(UdpTunnelingIntegrationTest, ConnectionAttemptRetry) {
       path: {}
       log_format:
         text_format_source:
-          inline_string: "%UPSTREAM_REQUEST_ATTEMPT_COUNT%\n"
+          inline_string: "%UPSTREAM_REQUEST_ATTEMPT_COUNT% %RESPONSE_FLAGS%\n"
 )EOF",
                                                             access_log_filename);
 
@@ -736,7 +760,7 @@ TEST_P(UdpTunnelingIntegrationTest, ConnectionAttemptRetry) {
   sendCapsuleDownstream("response", true);
   test_server_->waitForGaugeEq("udp.foo.downstream_sess_active", 0);
 
-  EXPECT_THAT(waitForAccessLog(access_log_filename), testing::HasSubstr("2"));
+  EXPECT_THAT(waitForAccessLog(access_log_filename), testing::HasSubstr("2 UF"));
 }
 
 INSTANTIATE_TEST_SUITE_P(IpAndHttpVersions, UdpTunnelingIntegrationTest,


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: Setting response flag in udp session info
Risk Level: low
Testing: integration test.
Docs Changes:
Release Notes: None
Platform Specific Features: None
