### PR TITLE
[bp/1.28] Datadog: restore "resource.name" tag (#30503)

### DIFF
--- a/source/extensions/tracers/datadog/demo/docker-compose.yaml
+++ b/source/extensions/tracers/datadog/demo/docker-compose.yaml
@@ -8,9 +8,11 @@ services:
   dd-agent:
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/run/user:/run/user:ro'
       - '/proc/:/host/proc/:ro'
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
+      - DOCKER_HOST
       - DD_API_KEY
       - DD_APM_ENABLED=true
       - DD_LOG_LEVEL=ERROR

--- a/source/extensions/tracers/datadog/demo/envoy
+++ b/source/extensions/tracers/datadog/demo/envoy
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 here=$(dirname "$0")
-"$(bazelisk info bazel-genfiles)"/source/exe/envoy-static --config-path "$here"/envoy.yaml "$@"
+"$here"/../../../../../bazel-bin/source/exe/envoy-static --config-path "$here"/envoy.yaml "$@"


### PR DESCRIPTION
Hi 👋 - I hope opening a backport like this is the right approach. We would like to have this fix so that we can upgrade to 1.27/1.28 in our cluster - without it our trace spans have incorrect names.

I ran the tests locally as follows `bazel test --config=libc++ //test`. I used libc because my development environment had an unrelated issue with using the stdlib, which I believe is related to #30837.

Commit Message: [bp/1.28] Datadog: restore "resource.name" tag (#30503)
Additional Description:
This is the backport of #30503 

Risk Level: low
Testing: local unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes: #30235 