### PR TITLE
Add value printer for future gtest upgrade

### DIFF
--- a/source/extensions/path/uri_template_lib/uri_template.cc
+++ b/source/extensions/path/uri_template_lib/uri_template.cc
@@ -9,6 +9,7 @@
 #include "source/extensions/path/uri_template_lib/uri_template_internal.h"
 
 #include "absl/status/statusor.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "re2/re2.h"
@@ -23,6 +24,18 @@ using Internal::ParsedPathPattern;
 // Silence warnings about missing initializers for members of LazyRE2.
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
+
+std::ostream& operator<<(std::ostream& os, const ParsedSegment& parsed_segment) {
+  os << "{value = \"" << absl::CEscape(parsed_segment.value_) << "\", kind = ";
+  switch (parsed_segment.kind_) {
+  case RewriteStringKind::Variable:
+    os << "Variable";
+    break;
+  case RewriteStringKind::Literal:
+    os << "Literal";
+  }
+  return os << "}";
+}
 
 absl::StatusOr<std::string> convertPathPatternSyntaxToRegex(absl::string_view path_pattern) {
   absl::StatusOr<ParsedPathPattern> status = Internal::parsePathPatternSyntax(path_pattern);

--- a/source/extensions/path/uri_template_lib/uri_template.h
+++ b/source/extensions/path/uri_template_lib/uri_template.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <string>
 
 #include "source/extensions/path/uri_template_lib/uri_template_internal.h"
@@ -26,6 +27,8 @@ struct ParsedSegment {
   ParsedSegment(absl::string_view value, RewriteStringKind kind) : value_(value), kind_(kind) {}
   absl::string_view value_;
   RewriteStringKind kind_;
+
+  friend std::ostream& operator<<(std::ostream& os, const ParsedSegment& parsed_segment);
 };
 
 // Stores string literals and regex capture indexes for rewriting paths

--- a/source/extensions/path/uri_template_lib/uri_template.h
+++ b/source/extensions/path/uri_template_lib/uri_template.h
@@ -28,6 +28,7 @@ struct ParsedSegment {
   absl::string_view value_;
   RewriteStringKind kind_;
 
+  // Value printer needed for unit tests only.
   friend std::ostream& operator<<(std::ostream& os, const ParsedSegment& parsed_segment);
 };
 


### PR DESCRIPTION
Additional Description:
New gtest version needs value printer for the ParsedSegment unit tests.

Risk Level: Low, test only
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
