### PR TITLE
uri_template: supporting operator<<

### DIFF
--- a/source/extensions/path/uri_template_lib/uri_template.cc
+++ b/source/extensions/path/uri_template_lib/uri_template.cc
@@ -9,6 +9,7 @@
 #include "source/extensions/path/uri_template_lib/uri_template_internal.h"
 
 #include "absl/status/statusor.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "re2/re2.h"
@@ -23,6 +24,19 @@ using Internal::ParsedPathPattern;
 // Silence warnings about missing initializers for members of LazyRE2.
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
+
+std::ostream& operator<<(std::ostream& os, const ParsedSegment& parsed_segment) {
+  os << "{kind = ";
+  switch (parsed_segment.kind_) {
+  case RewriteStringKind::Variable:
+    os << "Variable";
+    break;
+  case RewriteStringKind::Literal:
+    os << "Literal";
+    break;
+  }
+  return os << ", value = \"" << absl::CEscape(parsed_segment.value_) << "\"}";
+}
 
 absl::StatusOr<std::string> convertPathPatternSyntaxToRegex(absl::string_view path_pattern) {
   absl::StatusOr<ParsedPathPattern> status = Internal::parsePathPatternSyntax(path_pattern);

--- a/source/extensions/path/uri_template_lib/uri_template.h
+++ b/source/extensions/path/uri_template_lib/uri_template.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <string>
 
 #include "source/extensions/path/uri_template_lib/uri_template_internal.h"
@@ -26,6 +27,8 @@ struct ParsedSegment {
   ParsedSegment(absl::string_view value, RewriteStringKind kind) : value_(value), kind_(kind) {}
   absl::string_view value_;
   RewriteStringKind kind_;
+
+  friend std::ostream& operator<<(std::ostream& os, const ParsedSegment& parsed_segment);
 };
 
 // Stores string literals and regex capture indexes for rewriting paths

--- a/test/extensions/path/uri_template_lib/uri_template_test.cc
+++ b/test/extensions/path/uri_template_lib/uri_template_test.cc
@@ -73,12 +73,12 @@ TEST_P(ParseRewriteHelperSuccess, ParseRewriteHelperSuccessTest) {
 
   // The following is to exercise operator<< in ParseSegments.
   const auto& parsed_segments_vec = result.value();
-  std::stringstream concat_segments;
+  std::stringstream all_segments_str;
   for (const auto& parsed_segment : parsed_segments_vec) {
-    concat_segments << parsed_segment;
+    all_segments_str << parsed_segment;
   }
-  EXPECT_THAT(concat_segments.str(), HasSubstr("kind = Literal, value ="));
-  EXPECT_THAT(concat_segments.str(), HasSubstr("kind = Variable, value ="));
+  EXPECT_THAT(all_segments_str.str(), HasSubstr("kind = Literal, value ="));
+  EXPECT_THAT(all_segments_str.str(), HasSubstr("kind = Variable, value ="));
 }
 
 class ParseRewriteHelperFailure : public testing::TestWithParam<std::string> {};

--- a/test/extensions/path/uri_template_lib/uri_template_test.cc
+++ b/test/extensions/path/uri_template_lib/uri_template_test.cc
@@ -21,6 +21,7 @@ namespace {
 
 using ::Envoy::StatusHelpers::IsOkAndHolds;
 using ::Envoy::StatusHelpers::StatusIs;
+using testing::HasSubstr;
 
 // Capture regex for /{var1}/{var2}/{var3}/{var4}/{var5}
 static constexpr absl::string_view kCaptureRegex = "/(?P<var1>[a-zA-Z0-9-._~%!$&'()+,;:@]+)/"
@@ -67,7 +68,17 @@ TEST_P(ParseRewriteHelperSuccess, ParseRewriteHelperSuccessTest) {
   std::string pattern = GetParam();
   SCOPED_TRACE(pattern);
 
-  EXPECT_OK(parseRewritePattern(pattern));
+  const auto result = parseRewritePattern(pattern);
+  EXPECT_OK(result);
+
+  // The following is to exercise operator<< in ParseSegments.
+  const auto& parsed_segments_vec = result.value();
+  std::stringstream concat_segments;
+  for (const auto& parsed_segment : parsed_segments_vec) {
+    concat_segments << parsed_segment;
+  }
+  EXPECT_THAT(concat_segments.str(), HasSubstr("kind = Literal, value ="));
+  EXPECT_THAT(concat_segments.str(), HasSubstr("kind = Variable, value ="));
 }
 
 class ParseRewriteHelperFailure : public testing::TestWithParam<std::string> {};


### PR DESCRIPTION
Commit Message: uri_template: supporting operator<<
Additional Description:
This minor change adds pretty-print support for thr uri_template `ParsedSegment`.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A