### PR TITLE
mobile: Fix envoy_build_fixer.py bug

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -61,7 +61,6 @@ load(
     "@envoy_build_config//:extensions_build_config.bzl",
     "CONTRIB_EXTENSION_PACKAGE_VISIBILITY",
     "EXTENSION_PACKAGE_VISIBILITY",
-    "MOBILE_PACKAGE_VISIBILITY",
 )
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
@@ -81,10 +80,8 @@ def envoy_extension_package(enabled_default = True, default_visibility = EXTENSI
         flag_values = {":enabled": "True"},
     )
 
-def envoy_mobile_package():
-    # Mobile packages should only be visible to other mobile packages, not any other
-    # parts of the Envoy codebase.
-    envoy_extension_package(default_visibility = MOBILE_PACKAGE_VISIBILITY)
+def envoy_mobile_package(default_visibility = ["//visibility:public"]):
+    envoy_extension_package(default_visibility = default_visibility)
 
 def envoy_contrib_package():
     envoy_extension_package(default_visibility = CONTRIB_EXTENSION_PACKAGE_VISIBILITY)

--- a/mobile/bazel/BUILD
+++ b/mobile/bazel/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 config_setting(
     name = "envoy_mobile_swift_cxx_interop",

--- a/mobile/docs/BUILD
+++ b/mobile/docs/BUILD
@@ -1,5 +1,5 @@
 load("@base_pip3//:requirements.bzl", "requirement")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy//tools/base:envoy_python.bzl", "envoy_entry_point")
 load("@envoy//tools/python:namespace.bzl", "envoy_py_namespace")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
@@ -7,7 +7,7 @@ load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_py_namespace()
 

--- a/mobile/envoy_build_config/BUILD
+++ b/mobile/envoy_build_config/BUILD
@@ -1,8 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package", "envoy_select_enable_http3", "envoy_select_envoy_mobile_listener", "envoy_select_envoy_mobile_request_compression")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_select_enable_http3", "envoy_select_envoy_mobile_listener", "envoy_select_envoy_mobile_request_compression")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "extension_registry",

--- a/mobile/examples/BUILD
+++ b/mobile/examples/BUILD
@@ -3,8 +3,11 @@ load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 # Change to your Apple Developer Team ID as shown in
 # https://developer.apple.com/account/#!/membership

--- a/mobile/examples/cc/fetch_client/BUILD
+++ b/mobile/examples/cc/fetch_client/BUILD
@@ -1,12 +1,12 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "fetch_client_lib",

--- a/mobile/examples/java/hello_world/BUILD
+++ b/mobile/examples/java/hello_world/BUILD
@@ -1,8 +1,11 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_binary(
     name = "hello_envoy",

--- a/mobile/examples/kotlin/hello_world/BUILD
+++ b/mobile/examples/kotlin/hello_world/BUILD
@@ -1,9 +1,12 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_binary(
     name = "hello_envoy_kt",

--- a/mobile/examples/kotlin/shared/BUILD
+++ b/mobile/examples/kotlin/shared/BUILD
@@ -1,7 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 kt_android_library(
     name = "hello_envoy_shared_lib",

--- a/mobile/examples/objective-c/hello_world/BUILD
+++ b/mobile/examples/objective-c/hello_world/BUILD
@@ -1,7 +1,10 @@
-load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 objc_library(
     name = "appmain",

--- a/mobile/examples/swift/async_await/BUILD
+++ b/mobile/examples/swift/async_await/BUILD
@@ -1,7 +1,10 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 swift_library(
     name = "appmain",

--- a/mobile/examples/swift/hello_world/BUILD
+++ b/mobile/examples/swift/hello_world/BUILD
@@ -1,8 +1,11 @@
-load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 swift_library(
     name = "appmain",

--- a/mobile/experimental/swift/BUILD
+++ b/mobile/experimental/swift/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_swift_test(
     name = "quic_stream_test",

--- a/mobile/library/BUILD
+++ b/mobile/library/BUILD
@@ -1,4 +1,8 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 filegroup(
     name = "proguard_rules",

--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package", "envoy_select_envoy_mobile_request_compression", "envoy_select_google_grpc")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package", "envoy_select_envoy_mobile_request_compression", "envoy_select_google_grpc")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "engine_builder_lib",

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package", "envoy_select_signal_trace")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package", "envoy_select_signal_trace")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "envoy_main_interface_lib",

--- a/mobile/library/common/api/BUILD
+++ b/mobile/library/common/api/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "external_api_lib",

--- a/mobile/library/common/bridge/BUILD
+++ b/mobile/library/common/bridge/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "utility_lib",

--- a/mobile/library/common/buffer/BUILD
+++ b/mobile/library/common/buffer/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "bridge_fragment_lib",

--- a/mobile/library/common/common/BUILD
+++ b/mobile/library/common/common/BUILD
@@ -1,9 +1,9 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 selects.config_setting_group(
     name = "use_android_system_helper",

--- a/mobile/library/common/config/BUILD
+++ b/mobile/library/common/config/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "certificates_lib",

--- a/mobile/library/common/data/BUILD
+++ b/mobile/library/common/data/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "utility_lib",

--- a/mobile/library/common/event/BUILD
+++ b/mobile/library/common/event/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "provisional_dispatcher_lib",

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/BUILD
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/BUILD
@@ -22,5 +22,6 @@ envoy_cc_extension(
         "@envoy//envoy/server:listener_manager_interface",
         "@envoy//source/server:api_listener_lib",
         "@envoy//source/server:listener_manager_factory_lib",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
     ],
 )

--- a/mobile/library/common/http/BUILD
+++ b/mobile/library/common/http/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "client_lib",

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines", "envoy_mobile_package")
 load("//bazel:android_debug_info.bzl", "android_debug_info")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 # TODO(jpsim): Migrate these to use `envoy_cc_library`
 

--- a/mobile/library/common/jni/import/BUILD
+++ b/mobile/library/common/jni/import/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 cc_library(
     name = "jni_import_lib",

--- a/mobile/library/common/jni/types/BUILD
+++ b/mobile/library/common/jni/types/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 cc_library(
     name = "jni_exception_lib",

--- a/mobile/library/common/network/BUILD
+++ b/mobile/library/common/network/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "connectivity_manager_lib",

--- a/mobile/library/common/stats/BUILD
+++ b/mobile/library/common/stats/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "utility_lib",

--- a/mobile/library/common/stream_info/BUILD
+++ b/mobile/library/common/stream_info/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "extra_stream_info_lib",

--- a/mobile/library/common/thread/BUILD
+++ b/mobile/library/common/thread/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "lock_guard_lib",

--- a/mobile/library/common/types/BUILD
+++ b/mobile/library/common/types/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "c_types_lib",

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,7 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@rules_java//java:defs.bzl", "java_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_library(
     name = "envoy_engine_lib",

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/BUILD
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@rules_java//java:defs.bzl", "java_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 java_library(
     name = "envoy_c_types_lib",

--- a/mobile/library/java/io/envoyproxy/envoymobile/utilities/BUILD
+++ b/mobile/library/java/io/envoyproxy/envoymobile/utilities/BUILD
@@ -1,7 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_library(
     name = "utilities",

--- a/mobile/library/java/org/chromium/net/BUILD
+++ b/mobile/library/java/org/chromium/net/BUILD
@@ -1,7 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 # Cronet API fork
 

--- a/mobile/library/java/org/chromium/net/impl/BUILD
+++ b/mobile/library/java/org/chromium/net/impl/BUILD
@@ -1,7 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 # Android libraries for cronvoy
 

--- a/mobile/library/java/org/chromium/net/urlconnection/BUILD
+++ b/mobile/library/java/org/chromium/net/urlconnection/BUILD
@@ -1,7 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 # Android libraries for urlconnection
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -1,10 +1,12 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_select_envoy_mobile_request_compression")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package", "envoy_select_envoy_mobile_request_compression")
 load("@envoy_mobile//bazel:android_artifacts.bzl", "android_artifacts")
 load("@envoy_mobile//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_artifacts(
     name = "envoy_aar",

--- a/mobile/library/objective-c/BUILD
+++ b/mobile/library/objective-c/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("//bazel:apple.bzl", "envoy_objc_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 exports_files([
     "EnvoyEngine.h",

--- a/mobile/library/swift/BUILD
+++ b/mobile/library/swift/BUILD
@@ -1,12 +1,14 @@
-load("//bazel:apple.bzl", "envoy_mobile_swift_copts")
-load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
-load("//bazel:swift_header_collector.bzl", "swift_header_collector")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_xcframework")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_defines", "envoy_mobile_package")
+load("//bazel:apple.bzl", "envoy_mobile_swift_copts")
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
+load("//bazel:swift_header_collector.bzl", "swift_header_collector")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 swift_library(
     name = "ios_lib",

--- a/mobile/library/swift/EnvoyCxxSwiftInterop/BUILD
+++ b/mobile/library/swift/EnvoyCxxSwiftInterop/BUILD
@@ -1,7 +1,9 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_c_module")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_cc_library(
     name = "cxx_swift_interop_lib",

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "send_headers_test",

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "envoy_config_test",

--- a/mobile/test/common/BUILD
+++ b/mobile/test/common/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "engine_common_test",

--- a/mobile/test/common/bridge/BUILD
+++ b/mobile/test/common/bridge/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "utility_test",

--- a/mobile/test/common/buffer/BUILD
+++ b/mobile/test/common/buffer/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "bridge_fragment_test",

--- a/mobile/test/common/common/BUILD
+++ b/mobile/test/common/common/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "lambda_logger_delegate_test",

--- a/mobile/test/common/data/BUILD
+++ b/mobile/test/common/data/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "utility_test",

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/BUILD
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
@@ -6,7 +6,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_extension_cc_test(
     name = "platform_bridge_cert_validator_test",

--- a/mobile/test/common/extensions/filters/http/network_configuration/BUILD
+++ b/mobile/test/common/extensions/filters/http/network_configuration/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
@@ -6,7 +6,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_extension_cc_test(
     name = "network_configuration_filter_test",

--- a/mobile/test/common/extensions/filters/http/platform_bridge/BUILD
+++ b/mobile/test/common/extensions/filters/http/platform_bridge/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
@@ -6,7 +6,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_extension_cc_test(
     name = "platform_bridge_filter_test",

--- a/mobile/test/common/extensions/key_value/platform/BUILD
+++ b/mobile/test/common/extensions/key_value/platform/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
@@ -6,7 +6,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_extension_cc_test(
     name = "platform_store_test",

--- a/mobile/test/common/extensions/retry/options/network_configuration/BUILD
+++ b/mobile/test/common/extensions/retry/options/network_configuration/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
@@ -6,7 +6,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_extension_cc_test(
     name = "network_configuration_retry_options_test",

--- a/mobile/test/common/extensions/stat_sinks/metrics_service/BUILD
+++ b/mobile/test/common/extensions/stat_sinks/metrics_service/BUILD
@@ -1,4 +1,4 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
@@ -6,7 +6,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_extension_cc_test(
     name = "mobile_grpc_streamer_test",

--- a/mobile/test/common/http/BUILD
+++ b/mobile/test/common/http/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "client_test",

--- a/mobile/test/common/http/filters/assertion/BUILD
+++ b/mobile/test/common/http/filters/assertion/BUILD
@@ -2,13 +2,13 @@ load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/route_cache_reset/BUILD
+++ b/mobile/test/common/http/filters/route_cache_reset/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/test_accessor/BUILD
+++ b/mobile/test/common/http/filters/test_accessor/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/test_event_tracker/BUILD
+++ b/mobile/test/common/http/filters/test_event_tracker/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/test_kv_store/BUILD
+++ b/mobile/test/common/http/filters/test_kv_store/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/test_logger/BUILD
+++ b/mobile/test/common/http/filters/test_logger/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/test_read/BUILD
+++ b/mobile/test/common/http/filters/test_read/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/http/filters/test_remote_response/BUILD
+++ b/mobile/test/common/http/filters/test_remote_response/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_proto_library(
     name = "filter",

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -2,14 +2,14 @@ load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test",
     "envoy_cc_test_library",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_select_google_grpc",
     "envoy_select_signal_trace",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "client_integration_test",

--- a/mobile/test/common/jni/BUILD
+++ b/mobile/test/common/jni/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_so_to_jni_lib")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 # Library which contains all the JNI related targets and test extensions
 cc_library(

--- a/mobile/test/common/mocks/common/BUILD
+++ b/mobile/test/common/mocks/common/BUILD
@@ -1,12 +1,12 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",
-    "envoy_package",
+    "envoy_mobile_package",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_mock(
     name = "common_mocks",

--- a/mobile/test/common/mocks/event/BUILD
+++ b/mobile/test/common/mocks/event/BUILD
@@ -1,12 +1,12 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_mock",
-    "envoy_package",
+    "envoy_mobile_package",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_mock(
     name = "event_mocks",

--- a/mobile/test/common/network/BUILD
+++ b/mobile/test/common/network/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "connectivity_manager_test",

--- a/mobile/test/common/stats/BUILD
+++ b/mobile/test/common/stats/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "utility_test",

--- a/mobile/test/common/stream_info/BUILD
+++ b/mobile/test/common/stream_info/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "extra_stream_info_test",

--- a/mobile/test/common/thread/BUILD
+++ b/mobile/test/common/thread/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_test(
     name = "lock_guard_test",

--- a/mobile/test/java/integration/BUILD
+++ b/mobile/test/java/integration/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_mobile_android_test(
     name = "android_engine_start_test",

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test", "envoy_mobile_jni_kt_test", "envoy_mobile_kt_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_jni_kt_test(
     name = "envoy_configuration_test",

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/BUILD
@@ -1,10 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 android_library(
     name = "testing",

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/BUILD
@@ -1,4 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_android_test(
     name = "jni_helper_test",

--- a/mobile/test/java/io/envoyproxy/envoymobile/utilities/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/utilities/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_mobile_android_test(
     name = "certificate_verification_tests",

--- a/mobile/test/java/org/chromium/net/BUILD
+++ b/mobile/test/java/org/chromium/net/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_mobile_android_test(
     name = "net_tests",

--- a/mobile/test/java/org/chromium/net/impl/BUILD
+++ b/mobile/test/java/org/chromium/net/impl/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_mobile_android_test(
     name = "cronvoy_test",

--- a/mobile/test/java/org/chromium/net/testing/BUILD
+++ b/mobile/test/java/org/chromium/net/testing/BUILD
@@ -1,10 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_library")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 android_library(
     name = "testing",

--- a/mobile/test/java/org/chromium/net/urlconnection/BUILD
+++ b/mobile/test/java/org/chromium/net/urlconnection/BUILD
@@ -1,9 +1,9 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_mobile_android_test(
     name = "urlconnection_test",

--- a/mobile/test/kotlin/apps/baseline/BUILD
+++ b/mobile/test/kotlin/apps/baseline/BUILD
@@ -1,9 +1,12 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_binary(
     name = "hello_envoy_kt",

--- a/mobile/test/kotlin/apps/experimental/BUILD
+++ b/mobile/test/kotlin/apps/experimental/BUILD
@@ -1,9 +1,12 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
 load("@rules_detekt//detekt:defs.bzl", "detekt")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 android_binary(
     name = "hello_envoy_kt",

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -1,5 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test", "envoy_mobile_jni_kt_test")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_jni_kt_test(
     name = "engine_start_test",

--- a/mobile/test/kotlin/integration/proxying/BUILD
+++ b/mobile/test/kotlin/integration/proxying/BUILD
@@ -1,5 +1,10 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_android_test")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_kt_library(
     name = "proxy_lib",

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_jni_kt_test", "envoy_mobile_kt_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_jni_kt_test(
     name = "engine_builder_test",

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/stats/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/stats/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_kt_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_kt_test(
     name = "element_test",

--- a/mobile/test/non_hermetic/BUILD
+++ b/mobile/test/non_hermetic/BUILD
@@ -1,13 +1,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_test_binary",
-    "envoy_package",
+    "envoy_mobile_package",
     "envoy_select_google_grpc",
 )
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 # This is a envoy_cc_test_binary instead of an envoy_cc_test because we don't want it to be run
 # when `bazel test //test/...` is called.

--- a/mobile/test/objective-c/BUILD
+++ b/mobile/test/objective-c/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_objc_test", "envoy_objc_library")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_objc_test(
     name = "envoy_bridge_utility_test",

--- a/mobile/test/performance/BUILD
+++ b/mobile/test/performance/BUILD
@@ -1,8 +1,8 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_binary", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_binary", "envoy_mobile_package")
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_mobile_package()
 
 envoy_cc_binary(
     name = "test_binary_size",

--- a/mobile/test/swift/BUILD
+++ b/mobile/test/swift/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_swift_test(
     name = "test",

--- a/mobile/test/swift/apps/baseline/BUILD
+++ b/mobile/test/swift/apps/baseline/BUILD
@@ -1,8 +1,11 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 swift_library(
     name = "appmain",

--- a/mobile/test/swift/apps/experimental/BUILD
+++ b/mobile/test/swift/apps/experimental/BUILD
@@ -1,8 +1,11 @@
-load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 swift_library(
     name = "appmain",

--- a/mobile/test/swift/cxx/BUILD
+++ b/mobile/test/swift/cxx/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_swift_test(
     name = "test",

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 # TODO(jpsim): Fix remote execution for all the tests in this file.
 

--- a/mobile/test/swift/stats/BUILD
+++ b/mobile/test/swift/stats/BUILD
@@ -1,6 +1,9 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
 load("@envoy_mobile//bazel:apple.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
 
 envoy_mobile_swift_test(
     name = "test",

--- a/mobile/tools/check_format.sh
+++ b/mobile/tools/check_format.sh
@@ -41,10 +41,7 @@ FORMAT_ARGS+=(
     ./library/objective-c ./test/java ./test/java
     ./test/objective-c ./test/swift ./experimental/swift
     --build_fixer_check_excluded_paths
-    ./envoy ./BUILD ./dist ./examples ./library/java
-    ./library/kotlin ./library/objective-c ./library/swift
-    ./library/common/extensions ./test/java ./test/kotlin ./test/objective-c
-    ./test/swift ./experimental/swift)
+    ./envoy ./BUILD ./dist)
 
 export ENVOY_BAZEL_PREFIX="@envoy" && ./bazelw run @envoy//tools/code_format:check_format -- "${ENVOY_FORMAT_ACTION}" --path "$PWD" "${FORMAT_ARGS[@]}"
 

--- a/tools/code_format/envoy_build_fixer.py
+++ b/tools/code_format/envoy_build_fixer.py
@@ -2,7 +2,7 @@
 
 # Enforces:
 # - License headers on Envoy BUILD files
-# - envoy_package() or envoy_extension_package() top-level invocation for standard Envoy package setup.
+# -  or envoy_extension_package() top-level invocation for standard Envoy package setup.
 # - Infers API dependencies from source files.
 # - Misc. cleanups: avoids redundant blank lines, removes unused loads.
 # - Maybe more later?
@@ -71,12 +71,12 @@ def run_buildozer(cmds, contents):
         return r.stdout.decode('utf-8')
 
 
-# Add an Apache 2 license and envoy_package() import and rule as needed.
+# Add an Apache 2 license and  import and rule as needed.
 def fix_package_and_license(path, contents):
     regex_to_use = PACKAGE_LOAD_BLOCK_REGEX
     package_string = 'envoy_package'
 
-    if 'source/extensions' in path:
+    if 'source/extensions' in path or 'library/common/extensions' in path:
         regex_to_use = EXTENSION_PACKAGE_LOAD_BLOCK_REGEX
         package_string = 'envoy_extension_package'
 
@@ -84,7 +84,7 @@ def fix_package_and_license(path, contents):
         regex_to_use = CONTRIB_PACKAGE_LOAD_BLOCK_REGEX
         package_string = 'envoy_contrib_package'
 
-    if 'mobile/' in path:
+    if os.getcwd().endswith('mobile') and 'library/common/extensions' not in path:
         regex_to_use = MOBILE_PACKAGE_LOAD_BLOCK_REGEX
         package_string = 'envoy_mobile_package'
 

--- a/tools/code_format/envoy_build_fixer.py
+++ b/tools/code_format/envoy_build_fixer.py
@@ -2,7 +2,9 @@
 
 # Enforces:
 # - License headers on Envoy BUILD files
-# -  or envoy_extension_package() top-level invocation for standard Envoy package setup.
+# - envoy_package() top-level invocation for standard Envoy package setup.
+# - envoy_mobile_package() top-level invocation for standard Envoy Mobile package setup.
+# - envoy_extension_package() top-level invocation for Envoy extensions.
 # - Infers API dependencies from source files.
 # - Misc. cleanups: avoids redundant blank lines, removes unused loads.
 # - Maybe more later?
@@ -88,15 +90,15 @@ def fix_package_and_license(path, contents):
         regex_to_use = MOBILE_PACKAGE_LOAD_BLOCK_REGEX
         package_string = 'envoy_mobile_package'
 
-    # Ensure we have an envoy_package import load if this is a real Envoy package. We also allow
-    # the prefix to be overridden if envoy is included in a larger workspace.
+    # Ensure we have an envoy_package / envoy_mobile_package import load if this is a real Envoy package.
+    # We also allow the prefix to be overridden if envoy is included in a larger workspace.
     if re.search(ENVOY_RULE_REGEX, contents):
         new_load = 'new_load {}//bazel:envoy_build_system.bzl %s' % package_string
         contents = run_buildozer([
             (new_load.format(os.getenv("ENVOY_BAZEL_PREFIX", "")), '__pkg__'),
         ], contents)
         # Envoy package is inserted after the load block containing the
-        # envoy_package import.
+        # envoy_package / envoy_mobile_package import.
         package_and_parens = package_string + '()'
         if package_and_parens[:-1] not in contents:
             contents = re.sub(regex_to_use, r'\1\n%s\n\n' % package_and_parens, contents)

--- a/tools/code_format/envoy_build_fixer.py
+++ b/tools/code_format/envoy_build_fixer.py
@@ -73,7 +73,7 @@ def run_buildozer(cmds, contents):
         return r.stdout.decode('utf-8')
 
 
-# Add an Apache 2 license and  import and rule as needed.
+# Add an Apache 2 license, envoy_package / envoy_mobile_package import and rule as needed.
 def fix_package_and_license(path, contents):
     regex_to_use = PACKAGE_LOAD_BLOCK_REGEX
     package_string = 'envoy_package'


### PR DESCRIPTION
This PR fixes a formatter bug that is supposed to automatically add `envoy_mobile_package()` as well as adding `license()` into Envoy Mobile `BUILD` files, mainly because for Envoy Mobile, we always run `tools/check_format.sh` from the `mobile` directory. Most of the changes in these files were made by running `tools/check_format.sh fix` with some manual modifications.

Risk Level: low (formatting fixes only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
