### PR TITLE
refactor to remove QueryParams in favor of QueryParamsMulti

### DIFF
--- a/envoy/http/query_params.h
+++ b/envoy/http/query_params.h
@@ -13,11 +13,6 @@ namespace Envoy {
 namespace Http {
 namespace Utility {
 
-// TODO(jmarantz): this should probably be a proper class, with methods to serialize
-// using proper formatting. Perhaps similar to
-// https://github.com/apache/incubator-pagespeed-mod/blob/master/pagespeed/kernel/http/query_params.h
-
-using QueryParams = std::map<std::string, std::string>;
 using QueryParamsVector = std::vector<std::pair<std::string, std::string>>;
 
 class QueryParamsMulti {

--- a/envoy/server/admin.h
+++ b/envoy/server/admin.h
@@ -62,7 +62,7 @@ public:
    *
    * @param The query name/value map.
    */
-  virtual Http::Utility::QueryParams queryParams() const PURE;
+  virtual Http::Utility::QueryParamsMulti queryParams() const PURE;
 };
 
 /**

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -259,37 +259,6 @@ void updateAuthority(RequestHeaderMap& headers, absl::string_view hostname, bool
 std::string createSslRedirectPath(const RequestHeaderMap& headers);
 
 /**
- * Parse a URL into query parameters.
- * @param url supplies the url to parse.
- * @return QueryParams the parsed parameters, if any.
- */
-QueryParams parseQueryString(absl::string_view url);
-
-/**
- * Parse a URL into query parameters.
- * @param url supplies the url to parse.
- * @return QueryParams the parsed and percent-decoded parameters, if any.
- */
-QueryParams parseAndDecodeQueryString(absl::string_view url);
-
-/**
- * Parse a a request body into query parameters.
- * @param body supplies the body to parse.
- * @return QueryParams the parsed parameters, if any.
- */
-QueryParams parseFromBody(absl::string_view body);
-
-/**
- * Parse query parameters from a URL or body.
- * @param data supplies the data to parse.
- * @param start supplies the offset within the data.
- * @param decode_params supplies the flag whether to percent-decode the parsed parameters (both name
- *        and value). Set to false to keep the parameters encoded.
- * @return QueryParams the parsed parameters, if any.
- */
-QueryParams parseParameters(absl::string_view data, size_t start, bool decode_params);
-
-/**
  * Finds the start of the query string in a path
  * @param path supplies a HeaderString& to search for the query string
  * @return absl::string_view starting at the beginning of the query string,
@@ -304,20 +273,6 @@ absl::string_view findQueryStringStart(const HeaderString& path);
  * @return std::string the path without query string.
  */
 std::string stripQueryString(const HeaderString& path);
-
-/**
- * Replace the query string portion of a given path with a new one.
- *
- * e.g. replaceQueryString("/foo?key=1", {key:2}) -> "/foo?key=2"
- *      replaceQueryString("/bar", {hello:there}) -> "/bar?hello=there"
- *
- * @param path the original path that may or may not contain an existing query string
- * @param params the new params whose string representation should be formatted onto
- *               the `path` above
- * @return std::string the new path whose query string has been replaced by `params` and whose path
- *         portion from `path` remains unchanged.
- */
-std::string replaceQueryString(const HeaderString& path, const QueryParams& params);
 
 /**
  * Parse a particular value out of a cookie
@@ -541,11 +496,6 @@ std::string localPathFromFilePath(const absl::string_view& file_path);
  * Prepare headers for a HttpUri.
  */
 RequestMessagePtr prepareHeaders(const envoy::config::core::v3::HttpUri& http_uri);
-
-/**
- * Serialize query-params into a string.
- */
-std::string queryParamsToString(const QueryParams& query_params);
 
 /**
  * Returns string representation of StreamResetReason.

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -286,8 +286,8 @@ void Filter::jsonizeRequest(Http::RequestHeaderMap const& headers, const Buffer:
 
   // Wrap the Query String
   if (headers.Path()) {
-    for (auto&& kv_pair :
-         Http::Utility::QueryParamsMulti::parseQueryString(headers.getPathValue()).data()) {
+    auto queryParams = Http::Utility::QueryParamsMulti::parseQueryString(headers.getPathValue());
+    for (const auto& kv_pair : queryParams.data()) {
       json_req.mutable_query_string_parameters()->insert({kv_pair.first, kv_pair.second[0]});
     }
   }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -286,8 +286,9 @@ void Filter::jsonizeRequest(Http::RequestHeaderMap const& headers, const Buffer:
 
   // Wrap the Query String
   if (headers.Path()) {
-    for (auto&& kv_pair : Http::Utility::parseQueryString(headers.getPathValue())) {
-      json_req.mutable_query_string_parameters()->insert({kv_pair.first, kv_pair.second});
+    for (auto&& kv_pair :
+         Http::Utility::QueryParamsMulti::parseQueryString(headers.getPathValue()).data()) {
+      json_req.mutable_query_string_parameters()->insert({kv_pair.first, kv_pair.second[0]});
     }
   }
 

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -273,14 +273,15 @@ ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
   // Check query parameter locations only if query parameter locations specified and Path() is not
   // null
   if (!param_locations_.empty() && headers.Path() != nullptr) {
-    const auto& params = Http::Utility::parseAndDecodeQueryString(headers.getPathValue());
+    const auto& params =
+        Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(headers.getPathValue());
     for (const auto& location_it : param_locations_) {
       const auto& param_key = location_it.first;
       const auto& location_spec = location_it.second;
-      const auto& it = params.find(param_key);
-      if (it != params.end()) {
+      const auto& it = params.getFirstValue(param_key);
+      if (it.has_value()) {
         tokens.push_back(std::make_unique<const JwtParamLocation>(
-            it->second, location_spec.issuer_checker_, param_key));
+            it.value(), location_spec.issuer_checker_, param_key));
       }
     }
   }

--- a/source/server/admin/admin_filter.cc
+++ b/source/server/admin/admin_filter.cc
@@ -61,10 +61,11 @@ const Http::RequestHeaderMap& AdminFilter::getRequestHeaders() const {
   return *request_headers_;
 }
 
-Http::Utility::QueryParams AdminFilter::queryParams() const {
+Http::Utility::QueryParamsMulti AdminFilter::queryParams() const {
   absl::string_view path = request_headers_->getPathValue();
-  Http::Utility::QueryParams query = Http::Utility::parseAndDecodeQueryString(path);
-  if (!query.empty()) {
+  Http::Utility::QueryParamsMulti query =
+      Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(path);
+  if (!query.data().empty()) {
     return query;
   }
 
@@ -73,7 +74,7 @@ Http::Utility::QueryParams AdminFilter::queryParams() const {
       Http::Headers::get().ContentTypeValues.FormUrlEncoded) {
     const Buffer::Instance* body = getRequestBody();
     if (body != nullptr) {
-      query = Http::Utility::parseFromBody(body->toString());
+      query = Http::Utility::QueryParamsMulti::parseParameters(body->toString(), 0, true);
     }
   }
 

--- a/source/server/admin/admin_filter.h
+++ b/source/server/admin/admin_filter.h
@@ -51,7 +51,7 @@ public:
   Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
     return encoder_callbacks_->http1StreamEncoderOptions();
   }
-  Http::Utility::QueryParams queryParams() const override;
+  Http::Utility::QueryParamsMulti queryParams() const override;
 
 private:
   /**

--- a/source/server/admin/admin_html.cc
+++ b/source/server/admin/admin_html.cc
@@ -15,7 +15,7 @@ Http::Code AdminImpl::handlerAdminHome(Http::ResponseHeaderMap& response_headers
   AdminHtmlUtil::renderTableBegin(response);
 
   // Prefix order is used during searching, but for printing do them in alpha order.
-  OptRef<const Http::Utility::QueryParams> no_query_params;
+  OptRef<const Http::Utility::QueryParamsMulti> no_query_params;
   uint32_t index = 0;
   for (const UrlHandler* handler : sortedHandlers()) {
     AdminHtmlUtil::renderEndpointTableRow(response, *handler, no_query_params, ++index, false,

--- a/source/server/admin/admin_html_util.cc
+++ b/source/server/admin/admin_html_util.cc
@@ -124,14 +124,14 @@ void AdminHtmlUtil::finalize(Buffer::Instance& response) { response.add("</body>
 void AdminHtmlUtil::renderHandlerParam(Buffer::Instance& response, absl::string_view id,
                                        absl::string_view name, absl::string_view path,
                                        Admin::ParamDescriptor::Type type,
-                                       OptRef<const Http::Utility::QueryParams> query,
+                                       OptRef<const Http::Utility::QueryParamsMulti> query,
                                        const std::vector<absl::string_view>& enum_choices,
                                        bool submit_on_change) {
   std::string value;
   if (query.has_value()) {
-    auto iter = query->find(std::string(name));
-    if (iter != query->end()) {
-      value = iter->second;
+    auto result = query->getFirstValue(name);
+    if (result.has_value()) {
+      value = result.value();
     }
   }
 
@@ -171,7 +171,7 @@ void AdminHtmlUtil::renderHandlerParam(Buffer::Instance& response, absl::string_
 
 void AdminHtmlUtil::renderEndpointTableRow(Buffer::Instance& response,
                                            const Admin::UrlHandler& handler,
-                                           OptRef<const Http::Utility::QueryParams> query,
+                                           OptRef<const Http::Utility::QueryParamsMulti> query,
                                            int index, bool submit_on_change, bool active) {
   absl::string_view path = handler.prefix_;
 

--- a/source/server/admin/admin_html_util.h
+++ b/source/server/admin/admin_html_util.h
@@ -88,7 +88,7 @@ public:
    * @param active indicates
    */
   static void renderEndpointTableRow(Buffer::Instance& response, const Admin::UrlHandler& handler,
-                                     OptRef<const Http::Utility::QueryParams> query, int index,
+                                     OptRef<const Http::Utility::QueryParamsMulti> query, int index,
                                      bool submit_on_change, bool active);
 
   /**
@@ -110,7 +110,7 @@ private:
   static void renderHandlerParam(Buffer::Instance& response, absl::string_view id,
                                  absl::string_view name, absl::string_view path,
                                  Admin::ParamDescriptor::Type type,
-                                 OptRef<const Http::Utility::QueryParams> query,
+                                 OptRef<const Http::Utility::QueryParamsMulti> query,
                                  const std::vector<absl::string_view>& enum_choices,
                                  bool submit_on_change);
 };

--- a/source/server/admin/config_dump_handler.cc
+++ b/source/server/admin/config_dump_handler.cc
@@ -119,24 +119,14 @@ bool trimResourceMessage(const Protobuf::FieldMask& field_mask, Protobuf::Messag
   return checkFieldMaskAndTrimMessage(outer_field_mask, message);
 }
 
-// Helper method to get the resource parameter.
-absl::optional<std::string> resourceParam(const Http::Utility::QueryParams& params) {
-  return Utility::queryParam(params, "resource");
-}
-
-// Helper method to get the mask parameter.
-absl::optional<std::string> maskParam(const Http::Utility::QueryParams& params) {
-  return Utility::queryParam(params, "mask");
-}
-
 // Helper method to get the eds parameter.
-bool shouldIncludeEdsInDump(const Http::Utility::QueryParams& params) {
-  return params.find("include_eds") != params.end();
+bool shouldIncludeEdsInDump(const Http::Utility::QueryParamsMulti& params) {
+  return params.getFirstValue("include_eds").has_value();
 }
 
 absl::StatusOr<Matchers::StringMatcherPtr>
-buildNameMatcher(const Http::Utility::QueryParams& params) {
-  const auto name_regex = Utility::queryParam(params, "name_regex");
+buildNameMatcher(const Http::Utility::QueryParamsMulti& params) {
+  const auto name_regex = params.getFirstValue("name_regex");
   if (!name_regex.has_value() || name_regex->empty()) {
     return std::make_unique<Matchers::UniversalStringMatcher>();
   }
@@ -160,9 +150,9 @@ ConfigDumpHandler::ConfigDumpHandler(ConfigTracker& config_tracker, Server::Inst
 Http::Code ConfigDumpHandler::handlerConfigDump(Http::ResponseHeaderMap& response_headers,
                                                 Buffer::Instance& response,
                                                 AdminStream& admin_stream) const {
-  Http::Utility::QueryParams query_params = admin_stream.queryParams();
-  const auto resource = resourceParam(query_params);
-  const auto mask = maskParam(query_params);
+  Http::Utility::QueryParamsMulti query_params = admin_stream.queryParams();
+  const auto resource = query_params.getFirstValue("resource");
+  const auto mask = query_params.getFirstValue("mask");
   const bool include_eds = shouldIncludeEdsInDump(query_params);
   const absl::StatusOr<Matchers::StringMatcherPtr> name_matcher = buildNameMatcher(query_params);
   if (!name_matcher.ok()) {

--- a/source/server/admin/init_dump_handler.cc
+++ b/source/server/admin/init_dump_handler.cc
@@ -8,20 +8,12 @@
 namespace Envoy {
 namespace Server {
 
-namespace {
-// Helper method to get the mask parameter.
-absl::optional<std::string> maskParam(const Http::Utility::QueryParams& params) {
-  return Utility::queryParam(params, "mask");
-}
-
-} // namespace
-
 InitDumpHandler::InitDumpHandler(Server::Instance& server) : HandlerContextBase(server) {}
 
 Http::Code InitDumpHandler::handlerInitDump(Http::ResponseHeaderMap& response_headers,
                                             Buffer::Instance& response,
                                             AdminStream& admin_stream) const {
-  const auto mask = maskParam(admin_stream.queryParams());
+  const auto mask = admin_stream.queryParams().getFirstValue("mask");
 
   envoy::admin::v3::UnreadyTargetsDumps dump = *dumpUnreadyTargets(mask);
   MessageUtil::redact(dump);

--- a/source/server/admin/logs_handler.h
+++ b/source/server/admin/logs_handler.h
@@ -42,7 +42,7 @@ private:
    *
    * @param params supplies the incoming endpoint query or post params.
    */
-  absl::Status changeLogLevel(Http::Utility::QueryParams& params);
+  absl::Status changeLogLevel(Http::Utility::QueryParamsMulti& params);
   absl::Status changeLogLevelsForComponentLoggers(
       const absl::flat_hash_map<absl::string_view, spdlog::level::level_enum>& changes);
 

--- a/source/server/admin/runtime_handler.cc
+++ b/source/server/admin/runtime_handler.cc
@@ -17,7 +17,7 @@ RuntimeHandler::RuntimeHandler(Server::Instance& server) : HandlerContextBase(se
 
 Http::Code RuntimeHandler::handlerRuntime(Http::ResponseHeaderMap& response_headers,
                                           Buffer::Instance& response, AdminStream& admin_stream) {
-  const Http::Utility::QueryParams params = admin_stream.queryParams();
+  const Http::Utility::QueryParamsMulti params = admin_stream.queryParams();
   response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
 
   // TODO(jsedgwick): Use proto to structure this output instead of arbitrary JSON.
@@ -79,15 +79,17 @@ Http::Code RuntimeHandler::handlerRuntime(Http::ResponseHeaderMap& response_head
 Http::Code RuntimeHandler::handlerRuntimeModify(Http::ResponseHeaderMap&,
                                                 Buffer::Instance& response,
                                                 AdminStream& admin_stream) {
-  Http::Utility::QueryParams params = admin_stream.queryParams();
-  if (params.empty()) {
+  Http::Utility::QueryParamsMulti params = admin_stream.queryParams();
+  if (params.data().empty()) {
     response.add("usage: /runtime_modify?key1=value1&key2=value2&keyN=valueN\n");
     response.add("       or send the parameters as form values\n");
     response.add("use an empty value to remove a previously added override");
     return Http::Code::BadRequest;
   }
   absl::node_hash_map<std::string, std::string> overrides;
-  overrides.insert(params.begin(), params.end());
+  for (const auto it : params.data()) {
+    overrides.insert({it.first, it.second[0]});
+  }
   TRY_ASSERT_MAIN_THREAD { server_.runtime().mergeValues(overrides); }
   END_TRY
   catch (const EnvoyException& e) {

--- a/source/server/admin/runtime_handler.cc
+++ b/source/server/admin/runtime_handler.cc
@@ -87,7 +87,7 @@ Http::Code RuntimeHandler::handlerRuntimeModify(Http::ResponseHeaderMap&,
     return Http::Code::BadRequest;
   }
   absl::node_hash_map<std::string, std::string> overrides;
-  for (const auto it : params.data()) {
+  for (const auto& it : params.data()) {
     overrides.insert({it.first, it.second[0]});
   }
   TRY_ASSERT_MAIN_THREAD { server_.runtime().mergeValues(overrides); }

--- a/source/server/admin/stats_params.cc
+++ b/source/server/admin/stats_params.cc
@@ -4,14 +4,14 @@ namespace Envoy {
 namespace Server {
 
 Http::Code StatsParams::parse(absl::string_view url, Buffer::Instance& response) {
-  query_ = Http::Utility::parseAndDecodeQueryString(url);
-  used_only_ = query_.find("usedonly") != query_.end();
-  pretty_ = query_.find("pretty") != query_.end();
-  prometheus_text_readouts_ = query_.find("text_readouts") != query_.end();
+  query_ = Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(url);
+  used_only_ = query_.getFirstValue("usedonly").has_value();
+  pretty_ = query_.getFirstValue("pretty").has_value();
+  prometheus_text_readouts_ = query_.getFirstValue("text_readouts").has_value();
 
-  auto filter_iter = query_.find("filter");
-  if (filter_iter != query_.end()) {
-    filter_string_ = filter_iter->second;
+  auto filter_val = query_.getFirstValue("filter");
+  if (filter_val.has_value() && !filter_val.value().empty()) {
+    filter_string_ = filter_val.value();
     re2::RE2::Options options;
     options.set_log_errors(false);
     re2_filter_ = std::make_shared<re2::RE2>(filter_string_, options);
@@ -44,14 +44,14 @@ Http::Code StatsParams::parse(absl::string_view url, Buffer::Instance& response)
     return true;
   };
 
-  auto type_iter = query_.find("type");
-  if (type_iter != query_.end() && !parse_type(type_iter->second, type_)) {
+  auto type_val = query_.getFirstValue("type");
+  if (type_val.has_value() && !type_val.value().empty() && !parse_type(type_val.value(), type_)) {
     response.add("invalid &type= param");
     return Http::Code::BadRequest;
   }
 
-  const absl::optional<std::string> hidden_value = Utility::queryParam(query_, "hidden");
-  if (hidden_value.has_value()) {
+  const absl::optional<std::string> hidden_value = query_.getFirstValue("hidden");
+  if (hidden_value.has_value() && !hidden_value.value().empty()) {
     if (hidden_value.value() == "include") {
       hidden_ = HiddenFlag::Include;
     } else if (hidden_value.value() == "only") {
@@ -65,7 +65,7 @@ Http::Code StatsParams::parse(absl::string_view url, Buffer::Instance& response)
   }
 
   const absl::optional<std::string> format_value = Utility::formatParam(query_);
-  if (format_value.has_value()) {
+  if (format_value.has_value() && !format_value.value().empty()) {
     if (format_value.value() == "prometheus") {
       format_ = StatsFormat::Prometheus;
     } else if (format_value.value() == "json") {

--- a/source/server/admin/stats_params.h
+++ b/source/server/admin/stats_params.h
@@ -69,7 +69,7 @@ struct StatsParams {
   std::string filter_string_;
   std::shared_ptr<re2::RE2> re2_filter_;
   Utility::HistogramBucketsMode histogram_buckets_mode_{Utility::HistogramBucketsMode::NoBuckets};
-  Http::Utility::QueryParams query_;
+  Http::Utility::QueryParamsMulti query_;
 
   /**
    * Determines whether a metric should be shown based on the specified query-parameters. This

--- a/source/server/admin/utils.cc
+++ b/source/server/admin/utils.cc
@@ -26,10 +26,10 @@ void populateFallbackResponseHeaders(Http::Code code, Http::ResponseHeaderMap& h
 
 // Helper method to get the histogram_buckets parameter. Returns false if histogram_buckets query
 // param is found and value is not "cumulative" or "disjoint", true otherwise.
-absl::Status histogramBucketsParam(const Http::Utility::QueryParams& params,
+absl::Status histogramBucketsParam(const Http::Utility::QueryParamsMulti& params,
                                    HistogramBucketsMode& histogram_buckets_mode) {
   absl::optional<std::string> histogram_buckets_query_param =
-      queryParam(params, "histogram_buckets");
+      params.getFirstValue("histogram_buckets");
   histogram_buckets_mode = HistogramBucketsMode::NoBuckets;
   if (histogram_buckets_query_param.has_value()) {
     if (histogram_buckets_query_param.value() == "cumulative") {
@@ -47,21 +47,8 @@ absl::Status histogramBucketsParam(const Http::Utility::QueryParams& params,
 }
 
 // Helper method to get the format parameter.
-absl::optional<std::string> formatParam(const Http::Utility::QueryParams& params) {
-  return queryParam(params, "format");
-}
-
-// Helper method to get a query parameter.
-absl::optional<std::string> queryParam(const Http::Utility::QueryParams& params,
-                                       const std::string& key) {
-  const auto iter = params.find(key);
-  if (iter != params.end()) {
-    const std::string& value = iter->second;
-    if (!value.empty()) {
-      return value;
-    }
-  }
-  return absl::nullopt;
+absl::optional<std::string> formatParam(const Http::Utility::QueryParamsMulti& params) {
+  return params.getFirstValue("format");
 }
 
 } // namespace Utility

--- a/source/server/admin/utils.h
+++ b/source/server/admin/utils.h
@@ -17,16 +17,13 @@ enum class HistogramBucketsMode { NoBuckets, Cumulative, Disjoint, Detailed };
 
 void populateFallbackResponseHeaders(Http::Code code, Http::ResponseHeaderMap& header_map);
 
-bool filterParam(Http::Utility::QueryParams params, Buffer::Instance& response,
+bool filterParam(Http::Utility::QueryParamsMulti params, Buffer::Instance& response,
                  std::shared_ptr<std::regex>& regex);
 
-absl::Status histogramBucketsParam(const Http::Utility::QueryParams& params,
+absl::Status histogramBucketsParam(const Http::Utility::QueryParamsMulti& params,
                                    HistogramBucketsMode& histogram_buckets_mode);
 
-absl::optional<std::string> formatParam(const Http::Utility::QueryParams& params);
-
-absl::optional<std::string> queryParam(const Http::Utility::QueryParams& params,
-                                       const std::string& key);
+absl::optional<std::string> formatParam(const Http::Utility::QueryParamsMulti& params);
 
 } // namespace Utility
 } // namespace Server

--- a/test/common/http/utility_fuzz_test.cc
+++ b/test/common/http/utility_fuzz_test.cc
@@ -18,8 +18,8 @@ DEFINE_PROTO_FUZZER(const test::common::http::UtilityTestCase& input) {
   }
   switch (input.utility_selector_case()) {
   case test::common::http::UtilityTestCase::kParseQueryString: {
-    // TODO(dio): Add the case when using parseAndDecodeQueryString().
-    Http::Utility::parseQueryString(input.parse_query_string());
+    Http::Utility::QueryParamsMulti::parseQueryString(input.parse_query_string());
+    Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(input.parse_query_string());
     break;
   }
   case test::common::http::UtilityTestCase::kParseCookieValue: {
@@ -58,9 +58,12 @@ DEFINE_PROTO_FUZZER(const test::common::http::UtilityTestCase& input) {
   }
   case test::common::http::UtilityTestCase::kParseParameters: {
     const auto& parse_parameters = input.parse_parameters();
-    // TODO(dio): Add a case when doing parse_parameters with decode_params flag true.
-    Http::Utility::parseParameters(parse_parameters.data(), parse_parameters.start(),
-                                   /*decode_params*/ false);
+    Http::Utility::QueryParamsMulti::parseParameters(parse_parameters.data(),
+                                                     parse_parameters.start(),
+                                                     /*decode_params*/ false);
+    Http::Utility::QueryParamsMulti::parseParameters(parse_parameters.data(),
+                                                     parse_parameters.start(),
+                                                     /*decode_params*/ true);
     break;
   }
   case test::common::http::UtilityTestCase::kFindQueryString: {

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -55,112 +55,74 @@ TEST(HttpUtility, parseQueryString) {
   using Map = absl::btree_map<std::string, Vec>;
 
   auto input = "/hello";
-  EXPECT_EQ(Utility::QueryParams(), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams(), Utility::parseAndDecodeQueryString(input));
   EXPECT_EQ(Map{}, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(Map{}, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?";
-  EXPECT_EQ(Utility::QueryParams(), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams(), Utility::parseAndDecodeQueryString(input));
   EXPECT_EQ(Map{}, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(Map{}, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello";
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseAndDecodeQueryString(input));
   auto expected = Map{{"hello", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello%26";
-  EXPECT_EQ(Utility::QueryParams({{"hello%26", ""}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello&", ""}}), Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello%26", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   expected = Map{{"hello&", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello=world";
-  EXPECT_EQ(Utility::QueryParams({{"hello", "world"}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello", "world"}}), Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello", Vec{"world"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello=";
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello%26=";
-  EXPECT_EQ(Utility::QueryParams({{"hello%26", ""}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello&", ""}}), Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello%26", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   expected = Map{{"hello&", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello=&";
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}}), Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello%26=&";
-  EXPECT_EQ(Utility::QueryParams({{"hello%26", ""}}), Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello&", ""}}), Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello%26", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   expected = Map{{"hello&", Vec{""}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?hello=&hello2=world2";
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}, {"hello2", "world2"}}),
-            Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"hello", ""}, {"hello2", "world2"}}),
-            Utility::parseAndDecodeQueryString(input));
   expected = Map{{"hello", Vec{""}}, {"hello2", Vec{"world2"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/logging?name=admin&level=trace";
-  EXPECT_EQ(Utility::QueryParams({{"name", "admin"}, {"level", "trace"}}),
-            Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"name", "admin"}, {"level", "trace"}}),
-            Utility::parseAndDecodeQueryString(input));
   expected = Map{{"name", Vec{"admin"}}, {"level", Vec{"trace"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?param_value_has_encoded_ampersand=a%26b";
-  EXPECT_EQ(Utility::QueryParams({{"param_value_has_encoded_ampersand", "a%26b"}}),
-            Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"param_value_has_encoded_ampersand", "a&b"}}),
-            Utility::parseAndDecodeQueryString(input));
   expected = Map{{"param_value_has_encoded_ampersand", Vec{"a%26b"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   expected = Map{{"param_value_has_encoded_ampersand", Vec{"a&b"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?params_has_encoded_%26=a%26b&ok=1";
-  EXPECT_EQ(Utility::QueryParams({{"params_has_encoded_%26", "a%26b"}, {"ok", "1"}}),
-            Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"params_has_encoded_&", "a&b"}, {"ok", "1"}}),
-            Utility::parseAndDecodeQueryString(input));
   expected = Map{{"params_has_encoded_%26", Vec{"a%26b"}}, {"ok", Vec{"1"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   expected = Map{{"params_has_encoded_&", Vec{"a&b"}}, {"ok", Vec{"1"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
 
   input = "/hello?params_%xy_%%yz=%xy%%yz";
-  EXPECT_EQ(Utility::QueryParams({{"params_%xy_%%yz", "%xy%%yz"}}),
-            Utility::parseQueryString(input));
-  EXPECT_EQ(Utility::QueryParams({{"params_%xy_%%yz", "%xy%%yz"}}),
-            Utility::parseAndDecodeQueryString(input));
   expected = Map{{"params_%xy_%%yz", Vec{"%xy%%yz"}}};
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseQueryString(input).data());
   EXPECT_EQ(expected, Utility::QueryParamsMulti::parseAndDecodeQueryString(input).data());
@@ -169,17 +131,6 @@ TEST(HttpUtility, parseQueryString) {
   // https://github.com/envoyproxy/envoy/issues/10926#issuecomment-651085261.
   input = "/stats?filter=%28cluster.upstream_%28rq_total%7Crq_time_sum%7Crq_time_count%7Crq_time_"
           "bucket%7Crq_xx%7Crq_complete%7Crq_active%7Ccx_active%29%29%7C%28server.version%29";
-  EXPECT_EQ(
-      Utility::QueryParams(
-          {{"filter",
-            "%28cluster.upstream_%28rq_total%7Crq_time_sum%7Crq_time_count%7Crq_time_"
-            "bucket%7Crq_xx%7Crq_complete%7Crq_active%7Ccx_active%29%29%7C%28server.version%29"}}),
-      Utility::parseQueryString(input));
-  EXPECT_EQ(
-      Utility::QueryParams(
-          {{"filter", "(cluster.upstream_(rq_total|rq_time_sum|rq_time_count|rq_time_bucket|rq_xx|"
-                      "rq_complete|rq_active|cx_active))|(server.version)"}}),
-      Utility::parseAndDecodeQueryString(input));
   expected = Map{
       {"filter",
        Vec{"%28cluster.upstream_%28rq_total%7Crq_time_sum%7Crq_time_count%7Crq_time_"
@@ -222,64 +173,29 @@ TEST(HttpUtility, stripQueryString) {
 TEST(HttpUtility, replaceQueryString) {
   // Replace with nothing
   auto params = Utility::QueryParamsMulti();
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/"), Utility::QueryParams()), "/");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/")), "/");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/?"), Utility::QueryParams()), "/");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/?")), "/");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/?x=0"), Utility::QueryParams()), "/");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/?x=0")), "/");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/a"), Utility::QueryParams()), "/a");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/a")), "/a");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/a/"), Utility::QueryParams()), "/a/");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/a/")), "/a/");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/a/?y=5"), Utility::QueryParams()), "/a/");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/a/?y=5")), "/a/");
   // Replace with x=1
   params = Utility::QueryParamsMulti::parseQueryString("/?x=1");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/"), Utility::QueryParams({{"x", "1"}})),
-            "/?x=1");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/")), "/?x=1");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/?"), Utility::QueryParams({{"x", "1"}})),
-            "/?x=1");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/?")), "/?x=1");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/?x=0"), Utility::QueryParams({{"x", "1"}})),
-            "/?x=1");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/?x=0")), "/?x=1");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/a?x=0"), Utility::QueryParams({{"x", "1"}})),
-            "/a?x=1");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/a?x=0")), "/a?x=1");
-  EXPECT_EQ(
-      Utility::replaceQueryString(HeaderString("/a/?x=0"), Utility::QueryParams({{"x", "1"}})),
-      "/a/?x=1");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/a/?x=0")), "/a/?x=1");
   // More replacements
   params = Utility::QueryParamsMulti::parseQueryString("/?x=1&z=3");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/foo"),
-                                        Utility::QueryParams({{"x", "1"}, {"z", "3"}})),
-            "/foo?x=1&z=3");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/foo")), "/foo?x=1&z=3");
   params = Utility::QueryParamsMulti::parseQueryString("/?x=1&y=5");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/foo?z=2"),
-                                        Utility::QueryParams({{"x", "1"}, {"y", "5"}})),
-            "/foo?x=1&y=5");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/foo?z=2")), "/foo?x=1&y=5");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/foo?y=9"),
-                                        Utility::QueryParams({{"x", "1"}, {"y", "5"}})),
-            "/foo?x=1&y=5");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/foo?y=9")), "/foo?x=1&y=5");
   // More path components
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/foo/bar?"),
-                                        Utility::QueryParams({{"x", "1"}, {"y", "5"}})),
-            "/foo/bar?x=1&y=5");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/foo/bar?")), "/foo/bar?x=1&y=5");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/foo/bar?y=9&a=b"),
-                                        Utility::QueryParams({{"x", "1"}, {"y", "5"}})),
-            "/foo/bar?x=1&y=5");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/foo/bar?y=9&a=b")), "/foo/bar?x=1&y=5");
   params = Utility::QueryParamsMulti::parseQueryString("/?a=b&x=1&y=5");
-  EXPECT_EQ(Utility::replaceQueryString(HeaderString("/foo/bar?y=11&z=7"),
-                                        Utility::QueryParams({{"a", "b"}, {"x", "1"}, {"y", "5"}})),
-            "/foo/bar?a=b&x=1&y=5");
   EXPECT_EQ(params.replaceQueryString(HeaderString("/foo/bar?y=11&z=7")), "/foo/bar?a=b&x=1&y=5");
   // Repeating keys
   params = Utility::QueryParamsMulti::parseQueryString("/?a=b&x=1&a=5");
@@ -1286,13 +1202,6 @@ TEST(HttpUtility, TestPrepareHeaders) {
 
   EXPECT_EQ("/x/y/z", message->headers().getPathValue());
   EXPECT_EQ("dns.name", message->headers().getHostValue());
-}
-
-TEST(HttpUtility, QueryParamsToString) {
-  EXPECT_EQ("", Utility::queryParamsToString(Utility::QueryParams({})));
-  EXPECT_EQ("?a=1", Utility::queryParamsToString(Utility::QueryParams({{"a", "1"}})));
-  EXPECT_EQ("?a=1&b=2",
-            Utility::queryParamsToString(Utility::QueryParams({{"a", "1"}, {"b", "2"}})));
 }
 
 TEST(HttpUtility, ResetReasonToString) {

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -268,7 +268,8 @@ typed_config:
 
   virtual void checkClientSecretInRequest(absl::string_view token_secret) {
     std::string request_body = oauth2_request_->body().toString();
-    const auto query_parameters = Http::Utility::parseFromBody(request_body);
+    const auto query_parameters =
+        Http::Utility::QueryParamsMulti::parseParameters(request_body, 0, true);
     auto it = query_parameters.find("client_secret");
 
     ASSERT_TRUE(it != query_parameters.end());

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -270,10 +270,10 @@ typed_config:
     std::string request_body = oauth2_request_->body().toString();
     const auto query_parameters =
         Http::Utility::QueryParamsMulti::parseParameters(request_body, 0, true);
-    auto it = query_parameters.find("client_secret");
+    auto secret = query_parameters.getFirstValue("client_secret");
 
-    ASSERT_TRUE(it != query_parameters.end());
-    EXPECT_EQ(it->second, token_secret);
+    ASSERT_TRUE(secret.has_value());
+    EXPECT_EQ(secret.value(), token_secret);
   }
 
   void waitForOAuth2Response(absl::string_view token_secret) {

--- a/test/integration/admin_html/test_server.cc
+++ b/test/integration/admin_html/test_server.cc
@@ -18,18 +18,18 @@ namespace {
  */
 Http::Code testCallback(Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                         Server::AdminStream& admin_stream) {
-  Http::Utility::QueryParams query_params = admin_stream.queryParams();
-  auto iter = query_params.find("file");
+  Http::Utility::QueryParamsMulti query_params = admin_stream.queryParams();
+  auto leafSuffix = query_params.getFirstValue("file");
   std::string prefix;
-  if (iter != query_params.end()) {
+  if (leafSuffix.has_value()) {
     prefix = "test/integration/admin_html/";
-  } else if (iter = query_params.find("src"); iter != query_params.end()) {
+  } else if (leafSuffix = query_params.getFirstValue("src"); leafSuffix.has_value()) {
     prefix = "source/server/admin/html/";
   } else {
     response.add("query param 'file' or 'src' missing");
     return Http::Code::BadRequest;
   }
-  absl::string_view leaf = iter->second;
+  absl::string_view leaf = leafSuffix.value();
 
   // ".." is not a good thing to allow into the path, even for a test server.
   if (leaf.find("..") != absl::string_view::npos) {

--- a/test/mocks/server/admin_stream.h
+++ b/test/mocks/server/admin_stream.h
@@ -26,7 +26,7 @@ public:
   MOCK_METHOD(NiceMock<Http::MockStreamDecoderFilterCallbacks>&, getDecoderFilterCallbacks, (),
               (const));
   MOCK_METHOD(Http::Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
-  MOCK_METHOD(Http::Utility::QueryParams, queryParams, (), (const));
+  MOCK_METHOD(Http::Utility::QueryParamsMulti, queryParams, (), (const));
 };
 
 /**
@@ -46,7 +46,7 @@ public:
   MOCK_METHOD(::testing::StrictMock<Http::MockStreamDecoderFilterCallbacks>&,
               getDecoderFilterCallbacks, (), (const));
   MOCK_METHOD(Http::Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
-  MOCK_METHOD(Http::Utility::QueryParams, queryParams, (), (const));
+  MOCK_METHOD(Http::Utility::QueryParamsMulti, queryParams, (), (const));
 };
 } // namespace Server
 } // namespace Envoy

--- a/test/server/admin/admin_html_util_test.cc
+++ b/test/server/admin/admin_html_util_test.cc
@@ -27,7 +27,7 @@ const Admin::UrlHandler handler() {
 class AdminHtmlUtilTest : public testing::Test {
 protected:
   Buffer::OwnedImpl response_;
-  Http::Utility::QueryParams query_params_;
+  Http::Utility::QueryParamsMulti query_params_;
 };
 
 TEST_F(AdminHtmlUtilTest, RenderTableBegin) {
@@ -54,8 +54,8 @@ TEST_F(AdminHtmlUtilTest, RenderRenderEndpointTableRowNoQuery) {
 }
 
 TEST_F(AdminHtmlUtilTest, RenderRenderEndpointTableRowWithQuery) {
-  query_params_["boolparam"] = "on";
-  query_params_["strparam"] = "str value";
+  query_params_.overwrite("boolparam", "on");
+  query_params_.overwrite("strparam", "str value");
   AdminHtmlUtil::renderEndpointTableRow(response_, handler(), query_params_, 31415, false, false);
   std::string out = response_.toString();
   EXPECT_THAT(out,

--- a/test/server/admin/stats_html_render_test.cc
+++ b/test/server/admin/stats_html_render_test.cc
@@ -29,7 +29,7 @@ const Admin::UrlHandler handler() {
 
 class StatsHtmlRenderTest : public StatsRenderTestBase {
 protected:
-  Http::Utility::QueryParams query_params_;
+  Http::Utility::QueryParamsMulti query_params_;
 };
 
 TEST_F(StatsHtmlRenderTest, String) {

--- a/test/server/admin/utils_test.cc
+++ b/test/server/admin/utils_test.cc
@@ -15,7 +15,7 @@ class UtilsTest : public testing::Test {
 protected:
   UtilsTest() = default;
 
-  Http::Utility::QueryParams query_;
+  Http::Utility::QueryParamsMulti query_;
 };
 
 // Most utils paths are covered through other tests, these tests take of
@@ -24,19 +24,19 @@ TEST_F(UtilsTest, HistogramMode) {
   Utility::HistogramBucketsMode histogram_buckets_mode = Utility::HistogramBucketsMode::Cumulative;
   EXPECT_TRUE(Utility::histogramBucketsParam(query_, histogram_buckets_mode).ok());
   EXPECT_EQ(Utility::HistogramBucketsMode::NoBuckets, histogram_buckets_mode);
-  query_["histogram_buckets"] = "none";
+  query_.overwrite("histogram_buckets", "none");
   EXPECT_TRUE(Utility::histogramBucketsParam(query_, histogram_buckets_mode).ok());
   EXPECT_EQ(Utility::HistogramBucketsMode::NoBuckets, histogram_buckets_mode);
-  query_["histogram_buckets"] = "cumulative";
+  query_.overwrite("histogram_buckets", "cumulative");
   EXPECT_TRUE(Utility::histogramBucketsParam(query_, histogram_buckets_mode).ok());
   EXPECT_EQ(Utility::HistogramBucketsMode::Cumulative, histogram_buckets_mode);
-  query_["histogram_buckets"] = "disjoint";
+  query_.overwrite("histogram_buckets", "disjoint");
   EXPECT_TRUE(Utility::histogramBucketsParam(query_, histogram_buckets_mode).ok());
   EXPECT_EQ(Utility::HistogramBucketsMode::Disjoint, histogram_buckets_mode);
-  query_["histogram_buckets"] = "detailed";
+  query_.overwrite("histogram_buckets", "detailed");
   EXPECT_TRUE(Utility::histogramBucketsParam(query_, histogram_buckets_mode).ok());
   EXPECT_EQ(Utility::HistogramBucketsMode::Detailed, histogram_buckets_mode);
-  query_["histogram_buckets"] = "garbage";
+  query_.overwrite("histogram_buckets", "garbage");
   absl::Status status = Utility::histogramBucketsParam(query_, histogram_buckets_mode);
   EXPECT_FALSE(status.ok());
   EXPECT_THAT(status.ToString(),
@@ -44,12 +44,10 @@ TEST_F(UtilsTest, HistogramMode) {
 }
 
 TEST_F(UtilsTest, QueryParam) {
-  EXPECT_FALSE(Utility::queryParam(query_, "key").has_value());
-  query_["key"] = "";
-  EXPECT_FALSE(Utility::queryParam(query_, "key").has_value());
-  query_["key"] = "value";
-  EXPECT_TRUE(Utility::queryParam(query_, "key").has_value());
-  EXPECT_EQ("value", Utility::queryParam(query_, "key").value());
+  EXPECT_FALSE(query_.getFirstValue("key").has_value());
+  query_.overwrite("key", "value");
+  EXPECT_TRUE(query_.getFirstValue("key").has_value());
+  EXPECT_EQ("value", query_.getFirstValue("key").value());
 }
 
 } // namespace Server


### PR DESCRIPTION
Commit Message:

remove old version of QueryParams data structure

Additional Description:

This is the final piece of series of PRs that began with #28788.  That PR fixed a bug in ext_authz query parameter mutation which was caused by treating query params as a `map<string, string>` when in fact they are a `map<string, vector<string>>`.

The `QueryParams` type also had a bunch of `TODO` comments around it.  @ggreenway suggested that we just replace it entirely with the new, nicely encapsulated type, and I agreed to do that.  This led to #29385, #29756, #29757, #29909, and #29910.

This PR:
* Converts the remaining usages of `QueryParams` to `QueryParamsMulti`
* Removes `QueryParams`
* Removes associated unit tests.

Risk Level: Low

Testing: Existing unit tests appear to provide sufficient coverage.  There's one test that still seems unhappy - looking at the logs, it just a flake: `failed to authorize: failed to fetch oauth token: Post "https://auth.docker.io/token": EOF`.  I tried to `/retest` it, but that didn't seem to take.  Let me know if there's anything I need to do on my end to make it happy.

Docs Changes: N/A

Release Notes: N/A

Platform Specific Features: N/A