### PR TITLE
aws: add pugixml dependency

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -610,5 +610,8 @@ envoy_cmake(
         "CMAKE_BUILD_TYPE": "Release",
     },
     lib_source = "@com_github_zeux_pugixml//:all",
-    out_static_libs = ["libpugixml.a"],
+    out_static_libs = select({
+        "//bazel:windows_x86_64": ["pugixml.lib"],
+        "//conditions:default": ["libpugixml.a"],
+    }),
 )

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -603,3 +603,12 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
 )
+
+envoy_cmake(
+    name = "pugixml",
+    cache_entries = {
+        "CMAKE_BUILD_TYPE": "Release",
+    },
+    lib_source = "@com_github_zeux_pugixml//:all",
+    out_static_libs = ["libpugixml.a"],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -300,6 +300,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_tencent_rapidjson()
     _com_github_nlohmann_json()
     _com_github_ncopa_suexec()
+    _com_github_zeux_pugixml()
     _com_google_absl()
     _com_google_googletest()
     _com_google_protobuf()
@@ -755,6 +756,16 @@ def _com_github_nlohmann_json():
     native.bind(
         name = "json",
         actual = "@com_github_nlohmann_json//:json",
+    )
+
+def _com_github_zeux_pugixml():
+    external_http_archive(
+        name = "com_github_zeux_pugixml",
+        build_file_content = BUILD_ALL_CONTENT,
+    )
+    native.bind(
+        name = "pugixml",
+        actual = "@envoy//bazel/foreign_cc:pugixml",
     )
 
 def _com_github_nodejs_http_parser():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -823,6 +823,23 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         license = "MIT",
         license_url = "https://github.com/ncopa/su-exec/blob/{version}/LICENSE",
     ),
+    com_github_zeux_pugixml = dict(
+        project_name = "pugixml",
+        project_desc = "Light-weight, simple and fast XML parser for C++ with XPath support.",
+        project_url = "https://github.com/zeux/pugixml",
+        version = "1.14",
+        sha256 = "610f98375424b5614754a6f34a491adbddaaec074e9044577d965160ec103d2e",
+        strip_prefix = "pugixml-{version}",
+        urls = ["https://github.com/zeux/pugixml/archive/v{version}.tar.gz"],
+        use_category = ["dataplane_ext"],
+        extensions = [
+            "envoy.filters.http.aws_lambda",
+            "envoy.filters.http.aws_request_signing",
+            "envoy.grpc_credentials.aws_iam",
+        ],
+        release_date = "2023-10-01",
+        cpe = "cpe:2.3:a:pugixml_project:pugixml:*",
+    ),
     com_google_googletest = dict(
         project_name = "Google Test",
         project_desc = "Google's C++ test framework",


### PR DESCRIPTION
**Commit Message:** aws: add pugixml dependency
**Additional Description:** We would like to introduce pugixml dependency into Envoy to parse the xml content. The example usecase is shown in one of the unmerged [PR 23408](https://github.com/envoyproxy/envoy/pull/23408/files#diff-3d45a55c8f415956866de60b357e7065f147e878e29b79ce3f086425affaa4b0R228) (note: tinyxml show in code will be replaced with pugixml). This external library let's us parse the `AssumeRoleWithWebIdentityResponse` provided by AWS STS service https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_Examples to fetch the AWS credentials for some of the AWS extensions such as AWS Lambda filter, AWS Request Signer filter etc.
**Risk Level:** -
**Testing:** NA
**Docs Changes:** NA
**Release Notes:** NA
**Platform Specific Features:** NA

----


The PR adds a new dependency on https://github.com/zeux/pugixml.

[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/zeux/pugixml/badge)](https://securityscorecards.dev/viewer/?uri=github.com/zeux/pugixml)
```
RESULTS
-------
Aggregate score: 5.5 / 10

Check scores:
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
|  SCORE  |          NAME          |             REASON             |                                               DOCUMENTATION/REMEDIATION                                               |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Binary-Artifacts       | no binaries found in the repo  | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#binary-artifacts       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 3 / 10  | Branch-Protection      | branch protection is not       | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#branch-protection      |
|         |                        | maximal on development and all |                                                                                                                       |
|         |                        | release branches               |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | CI-Tests               | 8 out of 8 merged PRs          | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#ci-tests               |
|         |                        | checked by a CI test -- score  |                                                                                                                       |
|         |                        | normalized to 10               |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | CII-Best-Practices     | no effort to earn an OpenSSF   | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#cii-best-practices     |
|         |                        | best practices badge detected  |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 4 / 10  | Code-Review            | found 7 unreviewed changesets  | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#code-review            |
|         |                        | out of 12 -- score normalized  |                                                                                                                       |
|         |                        | to 4                           |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Contributors           | project has 10 contributing    | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#contributors           |
|         |                        | companies or organizations     |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Dangerous-Workflow     | no dangerous workflow patterns | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#dangerous-workflow     |
|         |                        | detected                       |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | Dependency-Update-Tool | no update tool detected        | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#dependency-update-tool |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Fuzzing                | project is fuzzed              | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#fuzzing                |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | License                | license file detected          | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#license                |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Maintained             | 30 commit(s) out of 30 and 4   | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#maintained             |
|         |                        | issue activity out of 30 found |                                                                                                                       |
|         |                        | in the last 90 days -- score   |                                                                                                                       |
|         |                        | normalized to 10               |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| ?       | Packaging              | packaging workflow not         | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#packaging              |
|         |                        | detected                       |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | Pinned-Dependencies    | dependency not pinned by hash  | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#pinned-dependencies    |
|         |                        | detected -- score normalized   |                                                                                                                       |
|         |                        | to 0                           |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | SAST                   | SAST tool is not run on all    | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#sast                   |
|         |                        | commits -- score normalized to |                                                                                                                       |
|         |                        | 0                              |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Security-Policy        | security policy file detected  | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#security-policy        |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | Signed-Releases        | 0 out of 5 artifacts are       | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#signed-releases        |
|         |                        | signed or have provenance      |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 0 / 10  | Token-Permissions      | detected GitHub workflow       | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#token-permissions      |
|         |                        | tokens with excessive          |                                                                                                                       |
|         |                        | permissions                    |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| 10 / 10 | Vulnerabilities        | 0 existing vulnerabilities     | https://github.com/ossf/scorecard/blob/70c8e05d6dca69defac0fee1edbbf3fa8732af00/docs/checks.md#vulnerabilities        |
|         |                        | detected                       |                                                                                                                       |
|---------|------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------|
```


