### PR TITLE
shared pool: new lambda creator for shared object and templated key

### DIFF
--- a/source/common/shared_pool/shared_pool.h
+++ b/source/common/shared_pool/shared_pool.h
@@ -116,7 +116,9 @@ private:
 
   class Element {
   public:
-    Element(const std::shared_ptr<T>& ptr) : ptr_{ptr.get()}, weak_ptr_{ptr} {}
+    Element(const std::shared_ptr<T>& ptr) : ptr_{ptr.get()}, weak_ptr_{ptr} {
+      ASSERT(ptr_ != nullptr);
+    }
 
     Element() = delete;
     Element(const Element&) = delete;
@@ -135,6 +137,8 @@ private:
       template <> size_t operator()(const Element& element) const {
         return HashFunc{}(*element.ptr_);
       }
+      // Only used for object deletion.
+      template <> size_t operator()(const T* ptr) { return HashFunc{}(*ptr); }
     };
     struct Compare {
       using is_transparent = void; // NOLINT(readability-identifier-naming)
@@ -143,6 +147,10 @@ private:
       }
       template <> bool operator()(const Element& a, const Element& b) const {
         return a.ptr_ == b.ptr_ || (EqualFunc{}(*a.ptr_, *b.ptr_));
+      }
+      // Only used for object deletion.
+      template <> bool operator()(const Element& a, const T* ptr) const {
+        return a.ptr_ == ptr || (EqualFunc{}(*a.ptr_, *ptr));
       }
     };
 

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -379,7 +379,9 @@ public:
    */
   std::shared_ptr<const envoy::config::cluster::v3::Cluster::CommonLbConfig> getCommonLbConfigPtr(
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_lb_config) override {
-    return common_lb_config_pool_->getObject(common_lb_config);
+    return common_lb_config_pool_->getObject(common_lb_config, [&common_lb_config]() {
+      return new envoy::config::cluster::v3::Cluster::CommonLbConfig(common_lb_config);
+    });
   }
 
   Config::EdsResourcesCacheOptRef edsResourcesCache() override;


### PR DESCRIPTION
Commit Message: shared pool: new lambda creator for shared object and templated key
Additional Description:

Two changes to the shared pool:
1. New Creator to create object instance. By this way, developers could use anyway to construct a instance rather than always using copy ctor.
2. Template searching key.

Combining above two points, we can use shared pool to store a parsed data and search it by original data, as long as the parsed data and original data are comparable. 


Risk Level: mid.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.