### PR TITLE
[geoip] Lookup country and region iso code instead of name

### DIFF
--- a/source/extensions/geoip_providers/maxmind/geoip_provider.cc
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.cc
@@ -11,7 +11,7 @@ namespace Maxmind {
 namespace {
 static constexpr const char* MMDB_CITY_LOOKUP_ARGS[] = {"city", "names", "en"};
 static constexpr const char* MMDB_REGION_LOOKUP_ARGS[] = {"subdivisions", "0", "names", "en"};
-static constexpr const char* MMDB_COUNTRY_LOOKUP_ARGS[] = {"country", "names", "en"};
+static constexpr const char* MMDB_COUNTRY_LOOKUP_ARGS[] = {"country", "iso_code"};
 static constexpr const char* MMDB_ASN_LOOKUP_ARGS[] = {"autonomous_system_number"};
 static constexpr const char* MMDB_ANON_LOOKUP_ARGS[] = {"is_anonymous", "is_anonymous_vpn",
                                                         "is_hosting_provider", "is_tor_exit_node",
@@ -151,7 +151,7 @@ void GeoipProvider::lookupInCityDb(
         if (config_->isLookupEnabledForHeader(config_->countryHeader())) {
           populateGeoLookupResult(mmdb_lookup_result, lookup_result,
                                   config_->countryHeader().value(), MMDB_COUNTRY_LOOKUP_ARGS[0],
-                                  MMDB_COUNTRY_LOOKUP_ARGS[1], MMDB_COUNTRY_LOOKUP_ARGS[2]);
+                                  MMDB_COUNTRY_LOOKUP_ARGS[1]);
         }
         if (lookup_result.size() > n_prev_hits) {
           config_->incHit("city_db");

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.cc
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.cc
@@ -10,7 +10,7 @@ namespace Maxmind {
 
 namespace {
 static constexpr const char* MMDB_CITY_LOOKUP_ARGS[] = {"city", "names", "en"};
-static constexpr const char* MMDB_REGION_LOOKUP_ARGS[] = {"subdivisions", "0", "names", "en"};
+static constexpr const char* MMDB_REGION_LOOKUP_ARGS[] = {"subdivisions", "0", "iso_code"};
 static constexpr const char* MMDB_COUNTRY_LOOKUP_ARGS[] = {"country", "iso_code"};
 static constexpr const char* MMDB_ASN_LOOKUP_ARGS[] = {"autonomous_system_number"};
 static constexpr const char* MMDB_ANON_LOOKUP_ARGS[] = {"is_anonymous", "is_anonymous_vpn",
@@ -145,8 +145,7 @@ void GeoipProvider::lookupInCityDb(
         if (config_->isLookupEnabledForHeader(config_->regionHeader())) {
           populateGeoLookupResult(mmdb_lookup_result, lookup_result,
                                   config_->regionHeader().value(), MMDB_REGION_LOOKUP_ARGS[0],
-                                  MMDB_REGION_LOOKUP_ARGS[1], MMDB_REGION_LOOKUP_ARGS[2],
-                                  MMDB_REGION_LOOKUP_ARGS[3]);
+                                  MMDB_REGION_LOOKUP_ARGS[1], MMDB_REGION_LOOKUP_ARGS[2]);
         }
         if (config_->isLookupEnabledForHeader(config_->countryHeader())) {
           populateGeoLookupResult(mmdb_lookup_result, lookup_result,

--- a/test/extensions/filters/http/geoip/geoip_filter_integration_test.cc
+++ b/test/extensions/filters/http/geoip/geoip_filter_integration_test.cc
@@ -78,10 +78,10 @@ TEST_P(GeoipFilterIntegrationTest, GeoDataPopulatedNoXff) {
                            .get(Http::LowerCaseString("x-geo-city"))[0]
                            ->value()
                            .getStringView());
-  EXPECT_EQ("England", upstream_request_->headers()
-                           .get(Http::LowerCaseString("x-geo-region"))[0]
-                           ->value()
-                           .getStringView());
+  EXPECT_EQ("ENG", upstream_request_->headers()
+                       .get(Http::LowerCaseString("x-geo-region"))[0]
+                       ->value()
+                       .getStringView());
   EXPECT_EQ("GB", upstream_request_->headers()
                       .get(Http::LowerCaseString("x-geo-country"))[0]
                       ->value()
@@ -113,10 +113,10 @@ TEST_P(GeoipFilterIntegrationTest, GeoDataPopulatedUseXff) {
                            .get(Http::LowerCaseString("x-geo-city"))[0]
                            ->value()
                            .getStringView());
-  EXPECT_EQ("England", upstream_request_->headers()
-                           .get(Http::LowerCaseString("x-geo-region"))[0]
-                           ->value()
-                           .getStringView());
+  EXPECT_EQ("ENG", upstream_request_->headers()
+                       .get(Http::LowerCaseString("x-geo-region"))[0]
+                       ->value()
+                       .getStringView());
   EXPECT_EQ("GB", upstream_request_->headers()
                       .get(Http::LowerCaseString("x-geo-country"))[0]
                       ->value()

--- a/test/extensions/filters/http/geoip/geoip_filter_integration_test.cc
+++ b/test/extensions/filters/http/geoip/geoip_filter_integration_test.cc
@@ -82,10 +82,10 @@ TEST_P(GeoipFilterIntegrationTest, GeoDataPopulatedNoXff) {
                            .get(Http::LowerCaseString("x-geo-region"))[0]
                            ->value()
                            .getStringView());
-  EXPECT_EQ("United Kingdom", upstream_request_->headers()
-                                  .get(Http::LowerCaseString("x-geo-country"))[0]
-                                  ->value()
-                                  .getStringView());
+  EXPECT_EQ("GB", upstream_request_->headers()
+                      .get(Http::LowerCaseString("x-geo-country"))[0]
+                      ->value()
+                      .getStringView());
   EXPECT_EQ("15169", upstream_request_->headers()
                          .get(Http::LowerCaseString("x-geo-asn"))[0]
                          ->value()
@@ -117,10 +117,10 @@ TEST_P(GeoipFilterIntegrationTest, GeoDataPopulatedUseXff) {
                            .get(Http::LowerCaseString("x-geo-region"))[0]
                            ->value()
                            .getStringView());
-  EXPECT_EQ("United Kingdom", upstream_request_->headers()
-                                  .get(Http::LowerCaseString("x-geo-country"))[0]
-                                  ->value()
-                                  .getStringView());
+  EXPECT_EQ("GB", upstream_request_->headers()
+                      .get(Http::LowerCaseString("x-geo-country"))[0]
+                      ->value()
+                      .getStringView());
   EXPECT_EQ("15169", upstream_request_->headers()
                          .get(Http::LowerCaseString("x-geo-asn"))[0]
                          ->value()
@@ -160,10 +160,10 @@ TEST_P(GeoipFilterIntegrationTest, GeoHeadersOverridenInRequest) {
                           .get(Http::LowerCaseString("x-geo-city"))[0]
                           ->value()
                           .getStringView());
-  EXPECT_EQ("United Kingdom", upstream_request_->headers()
-                                  .get(Http::LowerCaseString("x-geo-country"))[0]
-                                  ->value()
-                                  .getStringView());
+  EXPECT_EQ("GB", upstream_request_->headers()
+                      .get(Http::LowerCaseString("x-geo-country"))[0]
+                      ->value()
+                      .getStringView());
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
   test_server_->waitForCounterEq("http.config_test.geoip.total", 1);

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -82,7 +82,7 @@ TEST_F(GeoipProviderTest, ValidConfigCityAndIspDbsSuccessfulLookup) {
   const auto& city_it = captured_lookup_response_.find("x-geo-city");
   EXPECT_EQ("Boxford", city_it->second);
   const auto& region_it = captured_lookup_response_.find("x-geo-region");
-  EXPECT_EQ("England", region_it->second);
+  EXPECT_EQ("ENG", region_it->second);
   const auto& country_it = captured_lookup_response_.find("x-geo-country");
   EXPECT_EQ("GB", country_it->second);
   const auto& asn_it = captured_lookup_response_.find("x-geo-asn");

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -84,7 +84,7 @@ TEST_F(GeoipProviderTest, ValidConfigCityAndIspDbsSuccessfulLookup) {
   const auto& region_it = captured_lookup_response_.find("x-geo-region");
   EXPECT_EQ("England", region_it->second);
   const auto& country_it = captured_lookup_response_.find("x-geo-country");
-  EXPECT_EQ("United Kingdom", country_it->second);
+  EXPECT_EQ("GB", country_it->second);
   const auto& asn_it = captured_lookup_response_.find("x-geo-asn");
   EXPECT_EQ("15169", asn_it->second);
 }


### PR DESCRIPTION
According to [API docs
](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/geoip_providers/common/v3/common.proto#envoy-v3-api-msg-extensions-geoip-providers-common-v3-commongeoipproviderconfig) geolocation provider will populate country header with ISO country code, but currently it populates that header with country name instead.

Commit Message:
Additional Description:
Risk Level: Low
Testing: Done
Docs Changes: NA
Release Notes:
Platform Specific Features:
