### PR TITLE
logger api refactoring: unified two methods to one to use factory context

### DIFF
--- a/contrib/generic_proxy/filters/network/source/file_access_log.h
+++ b/contrib/generic_proxy/filters/network/source/file_access_log.h
@@ -45,7 +45,7 @@ public:
   AccessLog::InstanceBaseSharedPtr<Context>
   createAccessLogInstance(const Protobuf::Message& config,
                           AccessLog::FilterBasePtr<Context>&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override {
+                          Server::Configuration::FactoryContext& context) override {
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
         config, context.messageValidationVisitor());
@@ -93,15 +93,8 @@ public:
 
     Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, typed_config.path()};
     return std::make_shared<FileAccessLogBase<Context>>(
-        file_info, std::move(filter), std::move(formatter), context.accessLogManager());
-  }
-
-  AccessLog::InstanceBaseSharedPtr<Context> createAccessLogInstance(
-      const Protobuf::Message& config, AccessLog::FilterBasePtr<Context>&& filter,
-      Server::Configuration::ListenerAccessLogFactoryContext& context) override {
-    return createAccessLogInstance(
-        config, std::move(filter),
-        static_cast<Server::Configuration::CommonFactoryContext&>(context));
+        file_info, std::move(filter), std::move(formatter),
+        context.getServerFactoryContext().accessLogManager());
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -708,7 +708,7 @@ TEST_F(FilterTest, NewStreamAndReplyNormally) {
       }));
 
   EXPECT_CALL(
-      *factory_context_.access_log_manager_.file_,
+      *factory_context_.server_factory_context_.access_log_manager_.file_,
       write("host-value /path-value method-value protocol-value request-value response-value -"));
 
   EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -767,7 +767,7 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithMultipleFrames) {
   auto active_stream = filter_->activeStreamsForTest().begin()->get();
 
   EXPECT_CALL(
-      *factory_context_.access_log_manager_.file_,
+      *factory_context_.server_factory_context_.access_log_manager_.file_,
       write("host-value /path-value method-value protocol-value request-value response-value -"));
 
   EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -102,9 +102,9 @@ public:
         Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig<FormatterContext>(
             sff_config, factory_context_);
 
-    return std::make_shared<FileAccessLog>(Filesystem::FilePathAndType{}, nullptr,
-                                           std::move(formatter),
-                                           factory_context_.accessLogManager());
+    return std::make_shared<FileAccessLog>(
+        Filesystem::FilePathAndType{}, nullptr, std::move(formatter),
+        factory_context_.server_factory_context_.accessLogManager());
   }
 
   std::shared_ptr<NiceMock<Tracing::MockTracer>> tracer_;

--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -25,12 +25,12 @@ public:
    * implementation is unable to produce a filter with the provided parameters, it should throw an
    * EnvoyException. The returned pointer should never be nullptr.
    * @param config supplies the custom configuration for this filter type.
-   * @param context supplies the server factory context.
+   * @param context supplies the factory context.
    * @return an instance of extension filter implementation from a config proto.
    */
   virtual FilterBasePtr<Context>
   createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-               Server::Configuration::CommonFactoryContext& context) PURE;
+               Server::Configuration::FactoryContext& context) PURE;
 
   std::string category() const override { return category_; }
 
@@ -74,21 +74,7 @@ public:
   virtual AccessLog::InstanceBaseSharedPtr<Context>
   createAccessLogInstance(const Protobuf::Message& config,
                           AccessLog::FilterBasePtr<Context>&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) PURE;
-
-  /**
-   * Create a particular AccessLog::Instance implementation from a config proto. If the
-   * implementation is unable to produce a factory with the provided parameters, it should throw an
-   * EnvoyException. The returned pointer should never be nullptr.
-   * @param config the custom configuration for this access log type.
-   * @param filter filter to determine whether a particular request should be logged. If no filter
-   * was specified in the configuration, argument will be nullptr.
-   * @param context general filter context through which persistent resources can be accessed.
-   */
-  virtual AccessLog::InstanceBaseSharedPtr<Context>
-  createAccessLogInstance(const Protobuf::Message& config,
-                          AccessLog::FilterBasePtr<Context>&& filter,
-                          Server::Configuration::CommonFactoryContext& context) PURE;
+                          Server::Configuration::FactoryContext& context) PURE;
 
   std::string category() const override { return category_; }
 

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -53,9 +53,9 @@ bool ComparisonFilter::compareAgainstValue(uint64_t lhs) const {
 }
 
 FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                                   Server::Configuration::CommonFactoryContext& context) {
-  Runtime::Loader& runtime = context.runtime();
-  Random::RandomGenerator& random = context.api().randomGenerator();
+                                   Server::Configuration::FactoryContext& context) {
+  Runtime::Loader& runtime = context.getServerFactoryContext().runtime();
+  Random::RandomGenerator& random = context.getServerFactoryContext().api().randomGenerator();
   ProtobufMessage::ValidationVisitor& validation_visitor = context.messageValidationVisitor();
   switch (config.filter_specifier_case()) {
   case envoy::config::accesslog::v3::AccessLogFilter::FilterSpecifierCase::kStatusCodeFilter:
@@ -156,7 +156,7 @@ bool RuntimeFilter::evaluate(const Formatter::HttpFormatterContext&,
 
 OperatorFilter::OperatorFilter(
     const Protobuf::RepeatedPtrField<envoy::config::accesslog::v3::AccessLogFilter>& configs,
-    Server::Configuration::CommonFactoryContext& context) {
+    Server::Configuration::FactoryContext& context) {
   for (const auto& config : configs) {
     auto filter = FilterFactory::fromProto(config, context);
     if (filter != nullptr) {
@@ -166,11 +166,11 @@ OperatorFilter::OperatorFilter(
 }
 
 OrFilter::OrFilter(const envoy::config::accesslog::v3::OrFilter& config,
-                   Server::Configuration::CommonFactoryContext& context)
+                   Server::Configuration::FactoryContext& context)
     : OperatorFilter(config.filters(), context) {}
 
 AndFilter::AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
-                     Server::Configuration::CommonFactoryContext& context)
+                     Server::Configuration::FactoryContext& context)
     : OperatorFilter(config.filters(), context) {}
 
 bool OrFilter::evaluate(const Formatter::HttpFormatterContext& context,
@@ -311,11 +311,8 @@ bool MetadataFilter::evaluate(const Formatter::HttpFormatterContext&,
   return default_match_;
 }
 
-namespace {
-
-template <typename FactoryContext>
-InstanceSharedPtr makeAccessLogInstance(const envoy::config::accesslog::v3::AccessLog& config,
-                                        FactoryContext& context) {
+InstanceSharedPtr AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
+                                              Server::Configuration::FactoryContext& context) {
   FilterPtr filter;
   if (config.has_filter()) {
     filter = FilterFactory::fromProto(config.filter(), context);
@@ -326,20 +323,6 @@ InstanceSharedPtr makeAccessLogInstance(const envoy::config::accesslog::v3::Acce
       config, context.messageValidationVisitor(), factory);
 
   return factory.createAccessLogInstance(*message, std::move(filter), context);
-}
-
-} // namespace
-
-InstanceSharedPtr
-AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                            Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return makeAccessLogInstance(config, context);
-}
-
-InstanceSharedPtr
-AccessLogFactory::fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                            Server::Configuration::CommonFactoryContext& context) {
-  return makeAccessLogInstance(config, context);
 }
 
 } // namespace AccessLog

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -35,7 +35,7 @@ public:
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
   static FilterPtr fromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                             Server::Configuration::CommonFactoryContext& context);
+                             Server::Configuration::FactoryContext& context);
 };
 
 /**
@@ -87,7 +87,7 @@ class OperatorFilter : public Filter {
 public:
   OperatorFilter(
       const Protobuf::RepeatedPtrField<envoy::config::accesslog::v3::AccessLogFilter>& configs,
-      Server::Configuration::CommonFactoryContext& context);
+      Server::Configuration::FactoryContext& context);
 
 protected:
   std::vector<FilterPtr> filters_;
@@ -99,7 +99,7 @@ protected:
 class AndFilter : public OperatorFilter {
 public:
   AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
-            Server::Configuration::CommonFactoryContext& context);
+            Server::Configuration::FactoryContext& context);
 
   // AccessLog::Filter
   bool evaluate(const Formatter::HttpFormatterContext& context,
@@ -112,7 +112,7 @@ public:
 class OrFilter : public OperatorFilter {
 public:
   OrFilter(const envoy::config::accesslog::v3::OrFilter& config,
-           Server::Configuration::CommonFactoryContext& context);
+           Server::Configuration::FactoryContext& context);
 
   // AccessLog::Filter
   bool evaluate(const Formatter::HttpFormatterContext& context,
@@ -265,16 +265,8 @@ public:
    * Read a filter definition from proto and instantiate an Instance. This method is used
    * to create access log instances that need access to listener properties.
    */
-  static InstanceSharedPtr
-  fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-            Server::Configuration::ListenerAccessLogFactoryContext& context);
-
-  /**
-   * Read a filter definition from proto and instantiate an Instance. This method does not
-   * have access to listener properties, for example for access loggers of admin interface.
-   */
   static InstanceSharedPtr fromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                                     Server::Configuration::CommonFactoryContext& context);
+                                     Server::Configuration::FactoryContext& context);
 
   /**
    * Template method to create an access log filter from proto configuration for non-HTTP access
@@ -283,7 +275,7 @@ public:
   template <class Context>
   static FilterBasePtr<Context>
   accessLogFilterFromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                           Server::Configuration::CommonFactoryContext& context) {
+                           Server::Configuration::FactoryContext& context) {
     if (!config.has_extension_filter()) {
       ExceptionUtil::throwEnvoyException(
           "Access log filter: only extension filter is supported by non-HTTP access loggers.");
@@ -301,7 +293,7 @@ public:
   template <class Context>
   static InstanceBaseSharedPtr<Context>
   accessLoggerFromProto(const envoy::config::accesslog::v3::AccessLog& config,
-                        Server::Configuration::CommonFactoryContext& context) {
+                        Server::Configuration::FactoryContext& context) {
     FilterBasePtr<Context> filter;
     if (config.has_filter()) {
       filter = accessLogFilterFromProto<Context>(config.filter(), context);

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -13,7 +13,7 @@ namespace AccessLoggers {
 template <class T, Filesystem::DestinationType destination_type>
 AccessLog::InstanceSharedPtr
 createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                              Server::Configuration::CommonFactoryContext& context) {
+                              Server::Configuration::FactoryContext& context) {
   const auto& fal_config =
       MessageUtil::downcastAndValidate<const T&>(config, context.messageValidationVisitor());
   Formatter::FormatterPtr formatter;
@@ -26,7 +26,8 @@ createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::Filter
   }
   Filesystem::FilePathAndType file_info{destination_type, ""};
   return std::make_shared<AccessLoggers::File::FileAccessLog>(
-      file_info, std::move(filter), std::move(formatter), context.accessLogManager());
+      file_info, std::move(filter), std::move(formatter),
+      context.getServerFactoryContext().accessLogManager());
 }
 
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -19,17 +19,10 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace File {
 
-AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
-AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::CommonFactoryContext& context) {
+AccessLog::InstanceSharedPtr
+FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
+                                              AccessLog::FilterPtr&& filter,
+                                              Server::Configuration::FactoryContext& context) {
   const auto& fal_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::file::v3::FileAccessLog&>(
       config, context.messageValidationVisitor());
@@ -68,7 +61,7 @@ AccessLog::InstanceSharedPtr FileAccessLogFactory::createAccessLogInstance(
 
   Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, fal_config.path()};
   return std::make_shared<FileAccessLog>(file_info, std::move(filter), std::move(formatter),
-                                         context.accessLogManager());
+                                         context.getServerFactoryContext().accessLogManager());
 }
 
 ProtobufTypes::MessagePtr FileAccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -14,11 +14,7 @@ class FileAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/filters/cel/config.cc
+++ b/source/extensions/access_loggers/filters/cel/config.cc
@@ -16,7 +16,7 @@ namespace CEL {
 
 Envoy::AccessLog::FilterPtr CELAccessLogExtensionFilterFactory::createFilter(
     const envoy::config::accesslog::v3::ExtensionFilter& config,
-    Server::Configuration::CommonFactoryContext& context) {
+    Server::Configuration::FactoryContext& context) {
 
   auto factory_config =
       Config::Utility::translateToFactoryConfig(config, context.messageValidationVisitor(), *this);
@@ -33,7 +33,8 @@ Envoy::AccessLog::FilterPtr CELAccessLogExtensionFilterFactory::createFilter(
   }
 
   return std::make_unique<CELAccessLogExtensionFilter>(
-      Extensions::Filters::Common::Expr::getBuilder(context), parse_status.value().expr());
+      Extensions::Filters::Common::Expr::getBuilder(context.getServerFactoryContext()),
+      parse_status.value().expr());
 #else
   throw EnvoyException("CEL is not available for use in this environment.");
 #endif

--- a/source/extensions/access_loggers/filters/cel/config.h
+++ b/source/extensions/access_loggers/filters/cel/config.h
@@ -22,7 +22,7 @@ class CELAccessLogExtensionFilterFactory : public Envoy::AccessLog::ExtensionFil
 public:
   Envoy::AccessLog::FilterPtr
   createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-               Server::Configuration::CommonFactoryContext& context) override;
+               Server::Configuration::FactoryContext& context) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override { return "envoy.access_loggers.extension_filters.cel"; }
 };

--- a/source/extensions/access_loggers/grpc/http_config.cc
+++ b/source/extensions/access_loggers/grpc/http_config.cc
@@ -18,17 +18,10 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace HttpGrpc {
 
-AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
-AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::CommonFactoryContext& context) {
+AccessLog::InstanceSharedPtr
+HttpGrpcAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
+                                                  AccessLog::FilterPtr&& filter,
+                                                  Server::Configuration::FactoryContext& context) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
@@ -36,8 +29,8 @@ AccessLog::InstanceSharedPtr HttpGrpcAccessLogFactory::createAccessLogInstance(
       config, context.messageValidationVisitor());
 
   return std::make_shared<HttpGrpcAccessLog>(
-      std::move(filter), proto_config, context.threadLocal(),
-      GrpcCommon::getGrpcAccessLoggerCacheSingleton(context));
+      std::move(filter), proto_config, context.getServerFactoryContext().threadLocal(),
+      GrpcCommon::getGrpcAccessLoggerCacheSingleton(context.getServerFactoryContext()));
 }
 
 ProtobufTypes::MessagePtr HttpGrpcAccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/grpc/http_config.h
+++ b/source/extensions/access_loggers/grpc/http_config.h
@@ -16,10 +16,7 @@ class HttpGrpcAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/grpc/tcp_config.cc
+++ b/source/extensions/access_loggers/grpc/tcp_config.cc
@@ -18,25 +18,19 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace TcpGrpc {
 
-AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
-AccessLog::InstanceSharedPtr TcpGrpcAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::CommonFactoryContext& context) {
+AccessLog::InstanceSharedPtr
+TcpGrpcAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
+                                                 AccessLog::FilterPtr&& filter,
+                                                 Server::Configuration::FactoryContext& context) {
   GrpcCommon::validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::grpc::v3::TcpGrpcAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  return std::make_shared<TcpGrpcAccessLog>(std::move(filter), proto_config, context.threadLocal(),
-                                            GrpcCommon::getGrpcAccessLoggerCacheSingleton(context));
+  return std::make_shared<TcpGrpcAccessLog>(
+      std::move(filter), proto_config, context.getServerFactoryContext().threadLocal(),
+      GrpcCommon::getGrpcAccessLoggerCacheSingleton(context.getServerFactoryContext()));
 }
 
 ProtobufTypes::MessagePtr TcpGrpcAccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/grpc/tcp_config.h
+++ b/source/extensions/access_loggers/grpc/tcp_config.h
@@ -16,11 +16,7 @@ class TcpGrpcAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -30,26 +30,19 @@ getAccessLoggerCacheSingleton(Server::Configuration::CommonFactoryContext& conte
       });
 }
 
-::Envoy::AccessLog::InstanceSharedPtr AccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
 ::Envoy::AccessLog::InstanceSharedPtr
 AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
                                           ::Envoy::AccessLog::FilterPtr&& filter,
-                                          Server::Configuration::CommonFactoryContext& context) {
+                                          Server::Configuration::FactoryContext& context) {
   validateProtoDescriptors();
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  return std::make_shared<AccessLog>(std::move(filter), proto_config, context.threadLocal(),
-                                     getAccessLoggerCacheSingleton(context));
+  return std::make_shared<AccessLog>(
+      std::move(filter), proto_config, context.getServerFactoryContext().threadLocal(),
+      getAccessLoggerCacheSingleton(context.getServerFactoryContext()));
 }
 
 ProtobufTypes::MessagePtr AccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/open_telemetry/config.h
+++ b/source/extensions/access_loggers/open_telemetry/config.h
@@ -16,11 +16,7 @@ class AccessLogFactory : public Envoy::AccessLog::AccessLogInstanceFactory {
 public:
   ::Envoy::AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-
-  ::Envoy::AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, ::Envoy::AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/stream/config.cc
+++ b/source/extensions/access_loggers/stream/config.cc
@@ -20,17 +20,10 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace File {
 
-AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
-AccessLog::InstanceSharedPtr StdoutAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::CommonFactoryContext& context) {
+AccessLog::InstanceSharedPtr
+StdoutAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
+                                                AccessLog::FilterPtr&& filter,
+                                                Server::Configuration::FactoryContext& context) {
   return AccessLoggers::createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StdoutAccessLog,
       Filesystem::DestinationType::Stdout>(config, std::move(filter), context);
@@ -49,17 +42,10 @@ std::string StdoutAccessLogFactory::name() const { return "envoy.access_loggers.
 LEGACY_REGISTER_FACTORY(StdoutAccessLogFactory, AccessLog::AccessLogInstanceFactory,
                         "envoy.stdout_access_log");
 
-AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
-AccessLog::InstanceSharedPtr StderrAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::CommonFactoryContext& context) {
+AccessLog::InstanceSharedPtr
+StderrAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
+                                                AccessLog::FilterPtr&& filter,
+                                                Server::Configuration::FactoryContext& context) {
   return createStreamAccessLogInstance<
       envoy::extensions::access_loggers::stream::v3::StderrAccessLog,
       Filesystem::DestinationType::Stderr>(config, std::move(filter), context);

--- a/source/extensions/access_loggers/stream/config.h
+++ b/source/extensions/access_loggers/stream/config.h
@@ -14,11 +14,7 @@ class StdoutAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 
@@ -32,11 +28,7 @@ class StderrAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -16,31 +16,24 @@ namespace Wasm {
 
 using Common::Wasm::PluginHandleSharedPtrThreadLocal;
 
-AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::ListenerAccessLogFactoryContext& context) {
-  return createAccessLogInstance(
-      proto_config, std::move(filter),
-      static_cast<Server::Configuration::CommonFactoryContext&>(context));
-}
-
-AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
-    const Protobuf::Message& proto_config, AccessLog::FilterPtr&& filter,
-    Server::Configuration::CommonFactoryContext& context) {
+AccessLog::InstanceSharedPtr
+WasmAccessLogFactory::createAccessLogInstance(const Protobuf::Message& proto_config,
+                                              AccessLog::FilterPtr&& filter,
+                                              Server::Configuration::FactoryContext& context) {
   const auto& config = MessageUtil::downcastAndValidate<
       const envoy::extensions::access_loggers::wasm::v3::WasmAccessLog&>(
       proto_config, context.messageValidationVisitor());
 
   auto plugin = std::make_shared<Common::Wasm::Plugin>(
-      config.config(), envoy::config::core::v3::TrafficDirection::UNSPECIFIED, context.localInfo(),
-      nullptr /* listener_metadata */);
+      config.config(), envoy::config::core::v3::TrafficDirection::UNSPECIFIED,
+      context.getServerFactoryContext().localInfo(), nullptr /* listener_metadata */);
 
   auto access_log = std::make_shared<WasmAccessLog>(plugin, nullptr, std::move(filter));
 
   auto callback = [access_log, &context, plugin](Common::Wasm::WasmHandleSharedPtr base_wasm) {
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
-    auto tls_slot =
-        ThreadLocal::TypedSlot<PluginHandleSharedPtrThreadLocal>::makeUnique(context.threadLocal());
+    auto tls_slot = ThreadLocal::TypedSlot<PluginHandleSharedPtrThreadLocal>::makeUnique(
+        context.getServerFactoryContext().threadLocal());
     tls_slot->set([base_wasm, plugin](Event::Dispatcher& dispatcher) {
       return std::make_shared<PluginHandleSharedPtrThreadLocal>(
           Common::Wasm::getOrCreateThreadLocalPlugin(base_wasm, plugin, dispatcher));
@@ -48,15 +41,18 @@ AccessLog::InstanceSharedPtr WasmAccessLogFactory::createAccessLogInstance(
     access_log->setTlsSlot(std::move(tls_slot));
   };
 
-  if (!Common::Wasm::createWasm(plugin, context.scope().createScope(""), context.clusterManager(),
-                                context.initManager(), context.mainThreadDispatcher(),
-                                context.api(), context.lifecycleNotifier(), remote_data_provider_,
-                                std::move(callback))) {
+  if (!Common::Wasm::createWasm(plugin, context.scope().createScope(""),
+                                context.getServerFactoryContext().clusterManager(),
+                                context.initManager(),
+                                context.getServerFactoryContext().mainThreadDispatcher(),
+                                context.getServerFactoryContext().api(),
+                                context.getServerFactoryContext().lifecycleNotifier(),
+                                remote_data_provider_, std::move(callback))) {
     throw Common::Wasm::WasmException(
         fmt::format("Unable to create Wasm access log {}", plugin->name_));
   }
 
-  context.api().customStatNamespaces().registerStatNamespace(
+  context.getServerFactoryContext().api().customStatNamespaces().registerStatNamespace(
       Extensions::Common::Wasm::CustomStatNamespace);
   return access_log;
 }

--- a/source/extensions/access_loggers/wasm/config.h
+++ b/source/extensions/access_loggers/wasm/config.h
@@ -17,11 +17,7 @@ class WasmAccessLogFactory : public AccessLog::AccessLogInstanceFactory,
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::ListenerAccessLogFactoryContext& context) override;
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message& config, AccessLog::FilterPtr&& filter,
-                          Server::Configuration::CommonFactoryContext& context) override;
+                          Server::Configuration::FactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -51,8 +51,9 @@ public:
   AccessLogImplTest()
       : stream_info_(time_source_), file_(new MockAccessLogFile()),
         engine_(std::make_unique<Regex::GoogleReEngine>()) {
-    ON_CALL(context_, runtime()).WillByDefault(ReturnRef(runtime_));
-    ON_CALL(context_, accessLogManager()).WillByDefault(ReturnRef(log_manager_));
+    ON_CALL(context_.server_factory_context_, runtime()).WillByDefault(ReturnRef(runtime_));
+    ON_CALL(context_.server_factory_context_, accessLogManager())
+        .WillByDefault(ReturnRef(log_manager_));
     ON_CALL(log_manager_, createAccessLog(_)).WillByDefault(Return(file_));
     ON_CALL(*file_, write(_)).WillByDefault(SaveArg<0>(&output_));
     stream_info_.addBytesReceived(1);
@@ -365,13 +366,13 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   // Value is taken from random generator.
-  EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(42));
+  EXPECT_CALL(context_.server_factory_context_.api_.random_, random()).WillOnce(Return(42));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 42, 100))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(43));
+  EXPECT_CALL(context_.server_factory_context_.api_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 0, 43, 100))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
@@ -408,13 +409,13 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   // Value is taken from random generator.
-  EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(42));
+  EXPECT_CALL(context_.server_factory_context_.api_.random_, random()).WillOnce(Return(42));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 42, 10000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(43));
+  EXPECT_CALL(context_.server_factory_context_.api_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 43, 10000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
@@ -452,13 +453,13 @@ typed_config:
 
   stream_info_.stream_id_provider_ =
       std::make_shared<StreamInfo::StreamIdProviderImpl>("000000ff-0000-0000-0000-000000000000");
-  EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(42));
+  EXPECT_CALL(context_.server_factory_context_.api_.random_, random()).WillOnce(Return(42));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 42, 1000000))
       .WillOnce(Return(true));
   EXPECT_CALL(*file_, write(_));
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  EXPECT_CALL(context_.api_.random_, random()).WillOnce(Return(43));
+  EXPECT_CALL(context_.server_factory_context_.api_.random_, random()).WillOnce(Return(43));
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("access_log.test_key", 5, 43, 1000000))
       .WillOnce(Return(false));
   EXPECT_CALL(*file_, write(_)).Times(0);
@@ -1123,8 +1124,9 @@ typed_config:
   "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   )EOF";
 
-  ON_CALL(context_, runtime()).WillByDefault(ReturnRef(runtime_));
-  ON_CALL(context_, accessLogManager()).WillByDefault(ReturnRef(log_manager_));
+  ON_CALL(context_.server_factory_context_, runtime()).WillByDefault(ReturnRef(runtime_));
+  ON_CALL(context_.server_factory_context_, accessLogManager())
+      .WillByDefault(ReturnRef(log_manager_));
   EXPECT_CALL(log_manager_, createAccessLog(_))
       .WillOnce(Invoke(
           [this](const Envoy::Filesystem::FilePathAndType& file_info) -> AccessLogFileSharedPtr {
@@ -1143,8 +1145,9 @@ typed_config:
   "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StderrAccessLog
   )EOF";
 
-  ON_CALL(context_, runtime()).WillByDefault(ReturnRef(runtime_));
-  ON_CALL(context_, accessLogManager()).WillByDefault(ReturnRef(log_manager_));
+  ON_CALL(context_.server_factory_context_, runtime()).WillByDefault(ReturnRef(runtime_));
+  ON_CALL(context_.server_factory_context_, accessLogManager())
+      .WillByDefault(ReturnRef(log_manager_));
   EXPECT_CALL(log_manager_, createAccessLog(_))
       .WillOnce(Invoke(
           [this](const Envoy::Filesystem::FilePathAndType& file_info) -> AccessLogFileSharedPtr {
@@ -1639,7 +1642,7 @@ public:
   ~TestHeaderFilterFactory() override = default;
 
   FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::CommonFactoryContext& context) override {
+                         Server::Configuration::FactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
     const auto& header_config =
@@ -1715,7 +1718,7 @@ public:
   ~SampleExtensionFilterFactory() override = default;
 
   FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::CommonFactoryContext& context) override {
+                         Server::Configuration::FactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -104,7 +104,7 @@ public:
       upstream_log_options->mutable_upstream_log_flush_interval()->set_seconds(1);
     }
     if (upstream_log) {
-      ON_CALL(*context_.access_log_manager_.file_, write(_))
+      ON_CALL(*context_.server_factory_context_.access_log_manager_.file_, write(_))
           .WillByDefault(
               Invoke([&](absl::string_view data) { output_.push_back(std::string(data)); }));
 

--- a/test/common/tcp_proxy/tcp_proxy_test_base.h
+++ b/test/common/tcp_proxy/tcp_proxy_test_base.h
@@ -60,7 +60,7 @@ inline Config constructConfigFromYaml(const std::string& yaml,
 class TcpProxyTestBase : public testing::Test {
 public:
   TcpProxyTestBase() {
-    ON_CALL(*factory_context_.access_log_manager_.file_, write(_))
+    ON_CALL(*factory_context_.server_factory_context_.access_log_manager_.file_, write(_))
         .WillByDefault(SaveArg<0>(&access_log_data_));
     ON_CALL(filter_callbacks_.connection_.stream_info_, setUpstreamClusterInfo(_))
         .WillByDefault(Invoke([this](const Upstream::ClusterInfoConstSharedPtr& cluster_info) {

--- a/test/extensions/access_loggers/file/config_test.cc
+++ b/test/extensions/access_loggers/file/config_test.cc
@@ -22,7 +22,7 @@ namespace File {
 namespace {
 
 TEST(FileAccessLogNegativeTest, ValidateFail) {
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW(FileAccessLogFactory().createAccessLogInstance(
                    envoy::extensions::access_loggers::file::v3::FileAccessLog(), nullptr, context),
@@ -32,7 +32,7 @@ TEST(FileAccessLogNegativeTest, ValidateFail) {
 TEST(FileAccessLogNegativeTest, InvalidNameFail) {
   envoy::config::accesslog::v3::AccessLog config;
 
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_MESSAGE(AccessLog::AccessLogFactory::fromProto(config, context), EnvoyException,
                             "Didn't find a registered implementation for '' with type URL: ''");
 
@@ -56,7 +56,8 @@ public:
 
     auto file = std::make_shared<AccessLog::MockAccessLogFile>();
     Filesystem::FilePathAndType file_info{Filesystem::DestinationType::File, fal_config.path()};
-    EXPECT_CALL(context_.access_log_manager_, createAccessLog(file_info)).WillOnce(Return(file));
+    EXPECT_CALL(context_.server_factory_context_.access_log_manager_, createAccessLog(file_info))
+        .WillOnce(Return(file));
 
     AccessLog::InstanceSharedPtr logger = AccessLog::AccessLogFactory::fromProto(config, context_);
 
@@ -81,7 +82,7 @@ public:
   Http::TestResponseTrailerMapImpl response_trailers_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 
-  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
 };
 
 TEST_F(FileAccessLogTest, DEPRECATED_FEATURE_TEST(LegacyFormatEmpty)) {

--- a/test/extensions/access_loggers/grpc/http_config_test.cc
+++ b/test/extensions/access_loggers/grpc/http_config_test.cc
@@ -41,7 +41,8 @@ public:
     TestUtility::jsonConvert(http_grpc_access_log_, *message_);
 
     if (cluster_name == good_cluster) {
-      EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      EXPECT_CALL(context_.server_factory_context_.cluster_manager_.async_client_manager_,
+                  factoryForGrpcService(_, _, _))
           .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
             return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
           }));
@@ -57,7 +58,7 @@ public:
   }
 
   AccessLog::FilterPtr filter_;
-  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
   envoy::extensions::access_loggers::grpc::v3::HttpGrpcAccessLogConfig http_grpc_access_log_;
   ProtobufTypes::MessagePtr message_;
   AccessLog::AccessLogInstanceFactory* factory_{};

--- a/test/extensions/access_loggers/grpc/tcp_config_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_config_test.cc
@@ -41,7 +41,8 @@ public:
     TestUtility::jsonConvert(tcp_grpc_access_log_, *message_);
 
     if (cluster_name == good_cluster) {
-      EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      EXPECT_CALL(context_.server_factory_context_.cluster_manager_.async_client_manager_,
+                  factoryForGrpcService(_, _, _))
           .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
             return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
           }));
@@ -57,7 +58,7 @@ public:
   }
 
   AccessLog::FilterPtr filter_;
-  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
   envoy::extensions::access_loggers::grpc::v3::TcpGrpcAccessLogConfig tcp_grpc_access_log_;
   ProtobufTypes::MessagePtr message_;
   AccessLog::AccessLogInstanceFactory* factory_{};

--- a/test/extensions/access_loggers/open_telemetry/config_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/config_test.cc
@@ -31,7 +31,8 @@ public:
     message_ = factory_->createEmptyConfigProto();
     ASSERT_NE(nullptr, message_);
 
-    EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+    EXPECT_CALL(context_.server_factory_context_.cluster_manager_.async_client_manager_,
+                factoryForGrpcService(_, _, _))
         .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
         }));

--- a/test/extensions/access_loggers/stream/stream_test_base.h
+++ b/test/extensions/access_loggers/stream/stream_test_base.h
@@ -37,7 +37,8 @@ protected:
 
     auto file = std::make_shared<AccessLog::MockAccessLogFile>();
     Filesystem::FilePathAndType file_info{destination_type, ""};
-    EXPECT_CALL(context_.access_log_manager_, createAccessLog(file_info)).WillOnce(Return(file));
+    EXPECT_CALL(context_.server_factory_context_.access_log_manager_, createAccessLog(file_info))
+        .WillOnce(Return(file));
 
     AccessLog::InstanceSharedPtr logger = AccessLog::AccessLogFactory::fromProto(config, context_);
 

--- a/test/extensions/access_loggers/wasm/config_test.cc
+++ b/test/extensions/access_loggers/wasm/config_test.cc
@@ -31,12 +31,14 @@ class WasmAccessLogConfigTest
     : public testing::TestWithParam<std::tuple<std::string, std::string>> {
 protected:
   WasmAccessLogConfigTest() : api_(Api::createApiForTest(stats_store_)) {
-    ON_CALL(context_, api()).WillByDefault(ReturnRef(*api_));
+    ON_CALL(context_.server_factory_context_, api()).WillByDefault(ReturnRef(*api_));
     ON_CALL(context_, scope()).WillByDefault(ReturnRef(scope_));
     ON_CALL(context_, listenerMetadata()).WillByDefault(ReturnRef(listener_metadata_));
     ON_CALL(context_, initManager()).WillByDefault(ReturnRef(init_manager_));
-    ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
-    ON_CALL(context_, mainThreadDispatcher()).WillByDefault(ReturnRef(dispatcher_));
+    ON_CALL(context_.server_factory_context_, clusterManager())
+        .WillByDefault(ReturnRef(cluster_manager_));
+    ON_CALL(context_.server_factory_context_, mainThreadDispatcher())
+        .WillByDefault(ReturnRef(dispatcher_));
     ON_CALL(log_stream_info_, requestComplete())
         .WillByDefault(Return(std::chrono::milliseconds(30)));
   }
@@ -260,7 +262,7 @@ TEST_P(WasmAccessLogConfigTest, FailedToGetThreadLocalPlugin) {
 
   envoy::extensions::access_loggers::wasm::v3::WasmAccessLog proto_config;
   TestUtility::loadFromYaml(yaml, proto_config);
-  EXPECT_CALL(context_, threadLocal()).WillOnce(ReturnRef(threadlocal));
+  EXPECT_CALL(context_.server_factory_context_, threadLocal()).WillOnce(ReturnRef(threadlocal));
   threadlocal.registered_ = true;
   AccessLog::InstanceSharedPtr filter_instance =
       factory->createAccessLogInstance(proto_config, nullptr, context_);

--- a/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/conn_manager_test.cc
@@ -92,7 +92,7 @@ public:
       : stats_(ThriftFilterStats::generateStats("test.", *store_.rootScope())) {
     route_config_provider_manager_ =
         std::make_unique<Router::RouteConfigProviderManagerImpl>(context_.admin_);
-    ON_CALL(*context_.access_log_manager_.file_, write(_))
+    ON_CALL(*context_.server_factory_context_.access_log_manager_.file_, write(_))
         .WillByDefault(SaveArg<0>(&access_log_data_));
   }
   ~ThriftConnectionManagerTest() override {

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -203,7 +203,7 @@ public:
         upstream_address_(Network::Utility::parseInternetAddressAndPort(upstream_ip_address_)),
         peer_address_(std::move(peer_address)) {
     // Disable strict mock warnings.
-    ON_CALL(*factory_context_.access_log_manager_.file_, write(_))
+    ON_CALL(*factory_context_.server_factory_context_.access_log_manager_.file_, write(_))
         .WillByDefault(
             Invoke([&](absl::string_view data) { output_.push_back(std::string(data)); }));
     ON_CALL(os_sys_calls_, supportsIpTransparent(_)).WillByDefault(Return(true));

--- a/test/integration/fake_access_log.h
+++ b/test/integration/fake_access_log.h
@@ -30,16 +30,7 @@ class FakeAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
   AccessLog::InstanceSharedPtr
   createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
-                          Server::Configuration::ListenerAccessLogFactoryContext&) override {
-    std::lock_guard<std::mutex> guard(log_callback_lock_);
-    auto access_log_instance = std::make_shared<FakeAccessLog>(log_cb_);
-    access_log_instances_.push_back(access_log_instance);
-    return access_log_instance;
-  }
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
-                          Server::Configuration::CommonFactoryContext&) override {
+                          Server::Configuration::FactoryContext&) override {
     std::lock_guard<std::mutex> guard(log_callback_lock_);
     auto access_log_instance = std::make_shared<FakeAccessLog>(log_cb_);
     access_log_instances_.push_back(access_log_instance);

--- a/test/integration/typed_metadata_integration_test.cc
+++ b/test/integration/typed_metadata_integration_test.cc
@@ -50,23 +50,15 @@ public:
 
 class TestAccessLogFactory : public AccessLog::AccessLogInstanceFactory {
 public:
-  AccessLog::InstanceSharedPtr createAccessLogInstance(
-      const Protobuf::Message&, AccessLog::FilterPtr&&,
-      Server::Configuration::ListenerAccessLogFactoryContext& context) override {
+  AccessLog::InstanceSharedPtr
+  createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
+                          Server::Configuration::FactoryContext& context) override {
     // Check that expected listener metadata is present
     EXPECT_EQ(1, context.listenerMetadata().typed_filter_metadata().size());
     const auto iter =
         context.listenerMetadata().typed_filter_metadata().find("test.listener.typed.metadata");
     EXPECT_NE(iter, context.listenerMetadata().typed_filter_metadata().end());
     return std::make_shared<NiceMock<MockAccessLog>>();
-  }
-
-  AccessLog::InstanceSharedPtr
-  createAccessLogInstance(const Protobuf::Message&, AccessLog::FilterPtr&&,
-                          Server::Configuration::CommonFactoryContext&) override {
-    // This method should never be called in this test
-    ASSERT(false);
-    return nullptr;
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {


### PR DESCRIPTION
Commit Message: logger api refactoring: unified two methods to one to use factory context
Additional Description:

Part of factory context refactoring and clean up. This patch merged two createAccessLogInstance method to one and take the `FactoryContext` as the parameter directly.

Risk Level: low. (Parameter type only update and didn't change any logic).
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
