### PR TITLE
proto: correct go_package of contrib

### DIFF
--- a/api/contrib/envoy/extensions/config/v3alpha/kv_store_xds_delegate_config.proto
+++ b/api/contrib/envoy/extensions/config/v3alpha/kv_store_xds_delegate_config.proto
@@ -9,7 +9,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.config.v3alpha";
 option java_outer_classname = "KvStoreXdsDelegateConfigProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/config/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/config/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#extension: envoy.xds_delegates.kv_store]

--- a/api/contrib/envoy/extensions/filters/http/checksum/v3alpha/checksum.proto
+++ b/api/contrib/envoy/extensions/filters/http/checksum/v3alpha/checksum.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.checksum.v3alpha";
 option java_outer_classname = "ChecksumProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/checksum/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/checksum/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/http/dynamo/v3/dynamo.proto
+++ b/api/contrib/envoy/extensions/filters/http/dynamo/v3/dynamo.proto
@@ -8,7 +8,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.dynamo.v3";
 option java_outer_classname = "DynamoProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamo/v3;dynamov3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/dynamo/v3;dynamov3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Dynamo]

--- a/api/contrib/envoy/extensions/filters/http/golang/v3alpha/golang.proto
+++ b/api/contrib/envoy/extensions/filters/http/golang/v3alpha/golang.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.golang.v3alpha";
 option java_outer_classname = "GolangProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/golang/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/golang/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/http/language/v3alpha/language.proto
+++ b/api/contrib/envoy/extensions/filters/http/language/v3alpha/language.proto
@@ -8,7 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.language.v3alpha";
 option java_outer_classname = "LanguageProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/language/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/language/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Language]

--- a/api/contrib/envoy/extensions/filters/http/squash/v3/squash.proto
+++ b/api/contrib/envoy/extensions/filters/http/squash/v3/squash.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.squash.v3";
 option java_outer_classname = "SquashProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/squash/v3;squashv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/squash/v3;squashv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Squash]

--- a/api/contrib/envoy/extensions/filters/http/sxg/v3alpha/sxg.proto
+++ b/api/contrib/envoy/extensions/filters/http/sxg/v3alpha/sxg.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.sxg.v3alpha";
 option java_outer_classname = "SxgProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/sxg/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/sxg/v3alpha";
 option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 

--- a/api/contrib/envoy/extensions/filters/network/client_ssl_auth/v3/client_ssl_auth.proto
+++ b/api/contrib/envoy/extensions/filters/network/client_ssl_auth/v3/client_ssl_auth.proto
@@ -14,7 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.client_ssl_auth.v3";
 option java_outer_classname = "ClientSslAuthProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/client_ssl_auth/v3;client_ssl_authv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/client_ssl_auth/v3;client_ssl_authv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Client TLS authentication]

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/action/v3/action.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/action/v3/action.proto
@@ -15,7 +15,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.action.v3";
 option java_outer_classname = "ActionProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/action/v3;actionv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/action/v3;actionv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3/dubbo.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3/dubbo.proto
@@ -9,7 +9,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.codecs.dubbo.v3";
 option java_outer_classname = "DubboProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3;dubbov3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3;dubbov3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3/matcher.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3/matcher.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.matcher.v3";
 option java_outer_classname = "MatcherProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/matcher/v3;matcherv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3;matcherv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/router/v3/router.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/router/v3/router.proto
@@ -9,7 +9,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.router.v3";
 option java_outer_classname = "RouterProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/router/v3;routerv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/router/v3;routerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.proto
@@ -16,7 +16,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.v3";
 option java_outer_classname = "GenericProxyProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3;generic_proxyv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/v3;generic_proxyv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/route.proto
+++ b/api/contrib/envoy/extensions/filters/network/generic_proxy/v3/route.proto
@@ -11,7 +11,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.v3";
 option java_outer_classname = "RouteProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3;generic_proxyv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/v3;generic_proxyv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/golang/v3alpha/golang.proto
+++ b/api/contrib/envoy/extensions/filters/network/golang/v3alpha/golang.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.golang.v3alpha";
 option java_outer_classname = "GolangProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/golang/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/golang/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -9,7 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.kafka_broker.v3";
 option java_outer_classname = "KafkaBrokerProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/kafka_broker/v3;kafka_brokerv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/kafka_broker/v3;kafka_brokerv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Kafka Broker]

--- a/api/contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha/kafka_mesh.proto
+++ b/api/contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha/kafka_mesh.proto
@@ -10,7 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.kafka_mesh.v3alpha";
 option java_outer_classname = "KafkaMeshProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/kafka_mesh/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/filters/network/mysql_proxy/v3/mysql_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/mysql_proxy/v3/mysql_proxy.proto
@@ -9,7 +9,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.mysql_proxy.v3";
 option java_outer_classname = "MysqlProxyProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/mysql_proxy/v3;mysql_proxyv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/mysql_proxy/v3;mysql_proxyv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: MySQL proxy]

--- a/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -10,7 +10,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.postgres_proxy.v3alpha";
 option java_outer_classname = "PostgresProxyProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/postgres_proxy/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha";
 option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 

--- a/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";
 option java_outer_classname = "RocketmqProxyProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rocketmq_proxy/v3;rocketmq_proxyv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3;rocketmq_proxyv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: RocketMQ Proxy]

--- a/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
+++ b/api/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";
 option java_outer_classname = "RouteProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rocketmq_proxy/v3;rocketmq_proxyv3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3;rocketmq_proxyv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Rocketmq Proxy Route Configuration]

--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/router/v3alpha/router.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/router/v3alpha/router.proto
@@ -7,7 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.router.v3alpha";
 option java_outer_classname = "RouterProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sip_proxy/router/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/router/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Router]

--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
@@ -13,7 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.tra.v3alpha";
 option java_outer_classname = "TraProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sip_proxy/tra/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: TRA]

--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/route.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/route.proto
@@ -8,7 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.v3alpha";
 option java_outer_classname = "RouteProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sip_proxy/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Sip Proxy Route Configuration]

--- a/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
@@ -14,7 +14,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.v3alpha";
 option java_outer_classname = "SipProxyProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sip_proxy/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Sip Proxy]

--- a/api/contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha/hyperscan.proto
+++ b/api/contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha/hyperscan.proto
@@ -8,7 +8,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.matching.input_matchers.hyperscan.v3alpha";
 option java_outer_classname = "HyperscanProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/matching/input_matchers/hyperscan/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Hyperscan matcher]

--- a/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
+++ b/api/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
@@ -7,7 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.network.connection_balance.dlb.v3alpha";
 option java_outer_classname = "DlbProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/network/connection_balance/dlb/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Dlb connection balancer configuration]

--- a/api/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto
+++ b/api/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto
@@ -13,7 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.private_key_providers.cryptomb.v3alpha";
 option java_outer_classname = "CryptombProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/private_key_providers/cryptomb/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: CryptoMb private key provider]

--- a/api/contrib/envoy/extensions/private_key_providers/qat/v3alpha/qat.proto
+++ b/api/contrib/envoy/extensions/private_key_providers/qat/v3alpha/qat.proto
@@ -13,7 +13,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.private_key_providers.qat.v3alpha";
 option java_outer_classname = "QatProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/private_key_providers/qat/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/qat/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: `QAT` private key provider]

--- a/api/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha/hyperscan.proto
+++ b/api/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha/hyperscan.proto
@@ -7,7 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.regex_engines.hyperscan.v3alpha";
 option java_outer_classname = "HyperscanProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/regex_engines/hyperscan/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Hyperscan]

--- a/api/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha/golang.proto
+++ b/api/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha/golang.proto
@@ -12,7 +12,7 @@ import "validate/validate.proto";
 option java_package = "io.envoyproxy.envoy.extensions.router.cluster_specifier.golang.v3alpha";
 option java_outer_classname = "GolangProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/router/cluster_specifier/golang/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 option (xds.annotations.v3.file_status).work_in_progress = true;
 

--- a/api/contrib/envoy/extensions/vcl/v3alpha/vcl_socket_interface.proto
+++ b/api/contrib/envoy/extensions/vcl/v3alpha/vcl_socket_interface.proto
@@ -7,7 +7,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.extensions.vcl.v3alpha";
 option java_outer_classname = "VclSocketInterfaceProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/vcl/v3alpha";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/vcl/v3alpha";
 option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -219,12 +219,15 @@ def format_header_from_file(
     # Workaround packages in generated go code conflicting by transforming:
     # foo/bar/v2 to use barv2 as the package in the generated code
     golang_package_name = ""
+    golang_package_base = file_proto.package.replace(".", "/")
+    if file_proto.name.startswith('contrib/'):
+        golang_package_base = 'contrib/' + golang_package_base
     if file_proto.package.split(".")[-1] in ("v2", "v3"):
         name = "".join(file_proto.package.split(".")[-2:])
         golang_package_name = ";" + name
     options.go_package = "".join([
         "github.com/envoyproxy/go-control-plane/",
-        file_proto.package.replace(".", "/"), golang_package_name
+        golang_package_base, golang_package_name
     ])
 
     # This is a workaround for C#/Ruby namespace conflicts between packages and

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -226,9 +226,7 @@ def format_header_from_file(
         name = "".join(file_proto.package.split(".")[-2:])
         golang_package_name = ";" + name
     options.go_package = "".join([
-        "github.com/envoyproxy/go-control-plane/",
-        golang_package_base, golang_package_name
-    ])
+        "github.com/envoyproxy/go-control-plane/", golang_package_base, golang_package_name])
 
     # This is a workaround for C#/Ruby namespace conflicts between packages and
     # objects, see https://github.com/envoyproxy/envoy/pull/3854.

--- a/tools/protoprint/protoprint.py
+++ b/tools/protoprint/protoprint.py
@@ -225,8 +225,8 @@ def format_header_from_file(
     if file_proto.package.split(".")[-1] in ("v2", "v3"):
         name = "".join(file_proto.package.split(".")[-2:])
         golang_package_name = ";" + name
-    options.go_package = "".join([
-        "github.com/envoyproxy/go-control-plane/", golang_package_base, golang_package_name])
+    options.go_package = "".join(
+        ["github.com/envoyproxy/go-control-plane/", golang_package_base, golang_package_name])
 
     # This is a workaround for C#/Ruby namespace conflicts between packages and
     # objects, see https://github.com/envoyproxy/envoy/pull/3854.


### PR DESCRIPTION

Commit Message: proto: correct go_package of contrib
Additional Description:
This fixes up the go_package descriptor on contrib/ protos. I am not sure how the bazel protoc stuff works, but standard proto compiler seems trip up on this being incorrect, and generate invalid imports

Risk Level: Low
Testing: Manual
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
