### PR TITLE
logging: Add has() methods for to HttpFormatterContext

### DIFF
--- a/envoy/formatter/http_formatter_context.h
+++ b/envoy/formatter/http_formatter_context.h
@@ -81,16 +81,31 @@ public:
   const Http::RequestHeaderMap& requestHeaders() const;
 
   /**
+   * @return false if no request headers are available.
+   */
+  bool hasRequestHeaders() const { return request_headers_ != nullptr; }
+
+  /**
    * @return const Http::ResponseHeaderMap& the response headers. Empty respnose header map if
    * no response headers are available.
    */
   const Http::ResponseHeaderMap& responseHeaders() const;
 
   /**
+   * @return false if no response headers are available.
+   */
+  bool hasResponseHeaders() const { return response_headers_ != nullptr; }
+
+  /**
    * @return const Http::ResponseTrailerMap& the response trailers. Empty response trailer map
    * if no response trailers are available.
    */
   const Http::ResponseTrailerMap& responseTrailers() const;
+
+  /**
+   * @return false if no response trailers are available.
+   */
+  bool hasResponseTrailers() const { return response_trailers_ != nullptr; }
 
   /**
    * @return absl::string_view the local reply body. Empty if no local reply body.


### PR DESCRIPTION
logging: Add has() methods for to HttpFormatterContext

HttpFormatterContext was recently added to store request headers, response headers and trailers. It provides simple accessors for those which return the static empty maps if not present. However, there are some envoy users which would like to test if the headers are present or not.
