### PR TITLE
docs: correcting flag removal

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -104,7 +104,7 @@ removed_config_or_runtime:
     Removed ``envoy.reloadable_features.expand_agnostic_stream_lifetime`` and legacy code paths.
 - area: http
   change: |
-    removed ``envoy.reloadable_features.correctly_validate_alpn`` and legacy code paths.
+    removed ``envoy.reloadable_features.sanitize_original_path`` and legacy code paths.
 - area: maglev
   change: |
     Removed ``envoy.reloadable_features.allow_compact_maglev`` and legacy code paths.


### PR DESCRIPTION
Commit Message:
Additional Description: Previous PR https://github.com/envoyproxy/envoy/pull/30434 did remove the flag but there was a typo on the release notes. The flag `correctly_validate_alpn` was already removed in [v1.24.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.24/v1.24.0.html)
Release Notes: yes
Platform Specific Features:
Fixes: https://github.com/envoyproxy/envoy/issues/30424
