### PR TITLE
Revise CachePolicy based on what we've learned.

### DIFF
--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -60,8 +60,8 @@ enum class RequestCacheability {
   // - `requestCacheability` returns `NoStore`.
   // - CacheFilter looks in cache and finds response 2, which matches.
   // - CacheFilter serves response 2 from cache.
-  // To summarize, all 3 requests were eligble for serving from cache (though only request 3 found a
-  // match to serve), but only request 2 was allowed to have its response stored into cache.
+  // To summarize, all 3 requests were eligible for serving from cache (though only request 3 found
+  // a match to serve), but only request 2 was allowed to have its response stored into cache.
   NoStore,
 };
 


### PR DESCRIPTION
Commit Message:
Revise CachePolicy interface based on experience using a forked version.
Additional Description:
- CachePolicy can now be stored in FilterState
- CacheEntryUsability:
  - Added ttl for use in cache-status header
  - Added op==, op!= for use in tests
- requestCacheable:
  - Now returns enum, so it can say it's ok to serve from cache but not insert into cahce
  - Renamed to requestCacheability to reflect not returning a bool
- responseCacheable:
  - Now returns enum, so it can say to mark a cache key as uncacheable to enable later optimizations
  - Renamed to responseCacheability to reflect not returning a bool
  - Removed VaryHeader parameter--CacheFilter should only call responseCacheable if the Vary headers are ok
- createCacheKey: renamed to cacheKey, to avoid implying that the key must literally be created here
- Removed *CacheControl parameters--not always needed; CachePolicy implementations can make then if needed
- Removed setCallbacks--CachePolicy implementations that need FilterState should take it as a ctor parameter
Risk Level: None--not yet used
Testing: n/a--it's just an interface
Docs Changes: n/a--not yet used
Release Notes: n/a--not yet used
Platform Specific Features: n/a