### PR TITLE
mobile: Use TestEnvironment::runfilesPath for the cert paths

### DIFF
--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -16,9 +16,9 @@ Network::DownstreamTransportSocketFactoryPtr TestServer::createQuicUpstreamTlsCo
   envoy::extensions::transport_sockets::tls::v3::TlsCertificate* certs =
       tls_context.mutable_common_tls_context()->add_tls_certificates();
   certs->mutable_certificate_chain()->set_filename(
-      "../envoy/test/config/integration/certs/upstreamcert.pem");
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
   certs->mutable_private_key()->set_filename(
-      "../envoy/test/config/integration/certs/upstreamkey.pem");
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
   envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport quic_config;
   quic_config.mutable_downstream_tls_context()->MergeFrom(tls_context);
 
@@ -36,12 +36,12 @@ Network::DownstreamTransportSocketFactoryPtr TestServer::createUpstreamTlsContex
   envoy::extensions::transport_sockets::tls::v3::TlsCertificate* certs =
       tls_context.mutable_common_tls_context()->add_tls_certificates();
   certs->mutable_certificate_chain()->set_filename(
-      "../envoy/test/config/integration/certs/upstreamcert.pem");
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
   certs->mutable_private_key()->set_filename(
-      "../envoy/test/config/integration/certs/upstreamkey.pem");
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
   auto* ctx = tls_context.mutable_common_tls_context()->mutable_validation_context();
   ctx->mutable_trusted_ca()->set_filename(
-      "../envoy/test/config/integration/certs/upstreamcacert.pem");
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
   tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
   auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
       tls_context, factory_context);
@@ -54,6 +54,13 @@ Network::DownstreamTransportSocketFactoryPtr TestServer::createUpstreamTlsContex
 TestServer::TestServer()
     : api_(Api::createApiForTest(stats_store_, time_system_)),
       version_(Network::Address::IpVersion::v4), upstream_config_(time_system_), port_(0) {
+  std::string runfiles_error;
+  runfiles_ = std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles>{
+      bazel::tools::cpp::runfiles::Runfiles::Create("", &runfiles_error)};
+  RELEASE_ASSERT(TestEnvironment::getOptionalEnvVar("NORUNFILES").has_value() ||
+                     runfiles_ != nullptr,
+                 runfiles_error);
+  TestEnvironment::setRunfiles(runfiles_.get());
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope())
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -56,7 +56,7 @@ TestServer::TestServer()
       version_(Network::Address::IpVersion::v4), upstream_config_(time_system_), port_(0) {
   std::string runfiles_error;
   runfiles_ = std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles>{
-      bazel::tools::cpp::runfiles::Runfiles::Create("", &runfiles_error)};
+      bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&runfiles_error)};
   RELEASE_ASSERT(TestEnvironment::getOptionalEnvVar("NORUNFILES").has_value() ||
                      runfiles_ != nullptr,
                  runfiles_error);

--- a/mobile/test/common/integration/test_server.h
+++ b/mobile/test/common/integration/test_server.h
@@ -9,6 +9,8 @@
 #include "test/integration/autonomous_upstream.h"
 #include "test/mocks/server/transport_socket_factory_context.h"
 
+#include "tools/cpp/runfiles/runfiles.h"
+
 namespace Envoy {
 
 enum class TestServerType {
@@ -31,6 +33,7 @@ private:
   ProcessWide process_wide;
   Thread::MutexBasicLockable lock;
   Extensions::TransportSockets::Tls::ContextManagerImpl context_manager_{time_system_};
+  std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles> runfiles_;
 
   Network::DownstreamTransportSocketFactoryPtr createQuicUpstreamTlsContext(
       testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>&);


### PR DESCRIPTION
This PR updates the cert paths to use `TestEnvironment::runfilesPath` so that we can use `data` attribute without relying on the actual directory structure between Envoy Core and Envoy Mobile. This PR will make the code more portable and this is also best practice that Bazel recommends.

Risk Level: low (only affects tests)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
