### PR TITLE
[balsa] Add test to document obsolete line folding behavior.

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4864,5 +4864,57 @@ TEST_P(Http1ClientConnectionImplTest, InvalidCharacterInTrailerName) {
   EXPECT_EQ(status.message(), "http/1.1 protocol error: HPE_INVALID_HEADER_TOKEN");
 }
 
+// Obsolete line folding is forbidden per RFC9110 Section 5.5, see
+// https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values.
+TEST_P(Http1ServerConnectionImplTest, ObsFold) {
+  initialize();
+
+  StrictMock<MockRequestDecoder> decoder;
+  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    EXPECT_CALL(decoder,
+                sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
+  } else {
+    EXPECT_CALL(decoder, decodeHeaders_(_, true));
+  }
+
+  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n"
+                           "Multiline-Header: foo\r\n  bar\r\n"
+                           "\r\n");
+  auto status = codec_->dispatch(buffer);
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.message(), "http/1.1 protocol error: INVALID_HEADER_FORMAT");
+  } else {
+    EXPECT_TRUE(status.ok());
+  }
+}
+
+TEST_P(Http1ClientConnectionImplTest, ObsFold) {
+  initialize();
+
+  NiceMock<MockResponseDecoder> response_decoder;
+  Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+  if (parser_impl_ == Http1ParserImpl::HttpParser) {
+    EXPECT_CALL(response_decoder, decodeHeaders_(_, true));
+  }
+
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\n"
+                             "Multiline-Header: foo\r\n  bar\r\n"
+                             "Content-Length: 0\r\n"
+                             "\r\n");
+
+  auto status = codec_->dispatch(response);
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.message(), "http/1.1 protocol error: INVALID_HEADER_FORMAT");
+  } else {
+    EXPECT_TRUE(status.ok());
+  }
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4879,7 +4879,7 @@ TEST_P(Http1ServerConnectionImplTest, ObsFold) {
   }
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n"
-                           "Multiline-Header: foo\r\n  bar\r\n"
+                           "Multi-Line-Header: foo\r\n  bar\r\n"
                            "\r\n");
   auto status = codec_->dispatch(buffer);
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
@@ -4903,7 +4903,7 @@ TEST_P(Http1ClientConnectionImplTest, ObsFold) {
   }
 
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\n"
-                             "Multiline-Header: foo\r\n  bar\r\n"
+                             "Multi-Line-Header: foo\r\n  bar\r\n"
                              "Content-Length: 0\r\n"
                              "\r\n");
 


### PR DESCRIPTION
Commit Message: [balsa] Add test to document obsolete line folding behavior.
Additional Description: BalsaParser rejects line folding as suggested by RFC9110.
Risk Level: low, test-only
Testing: test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Balsa implementation tracking issue: #21245
Also see #31009 for additional context.

Signed-off-by: Bence Béky [bnc@google.com](mailto:bnc@google.com)
