### PR TITLE
Add HashUtil function for reliable hashing of scalar types

### DIFF
--- a/source/common/common/hash.cc
+++ b/source/common/common/hash.cc
@@ -11,6 +11,12 @@ uint64_t HashUtil::xxHash64(absl::Span<absl::string_view> input, uint64_t seed) 
   return seed;
 }
 
+// Explicit specialization for bool because its size may be implementation dependent.
+template <> uint64_t HashUtil::xxHash64Value(bool input, uint64_t seed) {
+  char b = input ? 1 : 0;
+  return XXH64(&b, 1, seed);
+}
+
 // Computes a 64-bit murmur hash 2, only works with 64-bit platforms. Revisit if support for 32-bit
 // platforms are needed.
 // from

--- a/source/common/common/hash.cc
+++ b/source/common/common/hash.cc
@@ -11,12 +11,6 @@ uint64_t HashUtil::xxHash64(absl::Span<absl::string_view> input, uint64_t seed) 
   return seed;
 }
 
-// Explicit specialization for bool because its size may be implementation dependent.
-template <> uint64_t HashUtil::xxHash64Value(bool input, uint64_t seed) {
-  char b = input ? 1 : 0;
-  return XXH64(&b, 1, seed);
-}
-
 // Computes a 64-bit murmur hash 2, only works with 64-bit platforms. Revisit if support for 32-bit
 // platforms are needed.
 // from

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -51,16 +51,16 @@ public:
       typename ValueType,
       std::enable_if_t<std::is_scalar_v<ValueType> && !std::is_enum_v<ValueType>, bool> = true>
   static uint64_t xxHash64Value(ValueType input, uint64_t seed = 0) {
-    if (absl::little_endian::IsLittleEndian()) {
-      return XXH64(reinterpret_cast<const char*>(&input), sizeof(input), seed);
-    } else {
-      char buf[sizeof(input)];
-      const char* p = reinterpret_cast<const char*>(&input);
-      for (size_t i = 0; i < sizeof(input); i++) {
-        buf[i] = p[sizeof(input) - i - 1];
-      }
-      return XXH64(buf, sizeof(input), seed);
+#if defined(ABSL_IS_LITTLE_ENDIAN)
+    return XXH64(reinterpret_cast<const char*>(&input), sizeof(input), seed);
+#else
+    char buf[sizeof(input)];
+    const char* p = reinterpret_cast<const char*>(&input);
+    for (size_t i = 0; i < sizeof(input); i++) {
+      buf[i] = p[sizeof(input) - i - 1];
     }
+    return XXH64(buf, sizeof(input), seed);
+#endif
   }
 
   /**

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -88,6 +88,12 @@ public:
   }
 };
 
+// Explicit specialization for bool because its size may be implementation dependent.
+template <> inline uint64_t HashUtil::xxHash64Value(bool input, uint64_t seed) {
+  char b = input ? 1 : 0;
+  return XXH64(&b, sizeof(b), seed);
+}
+
 /**
  * From
  * (https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=libstdc%2b%2b-v3/libsupc%2b%2b/hash_bytes.cc).

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -36,6 +36,13 @@ public:
    * src/google/protobuf/generated_message_util.cc literally just treats
    * a float the same as int32 for serialization purposes.
    *
+   * enums are excluded because they're not needed; if they were to be
+   * supported later they should have a separate function because enum
+   * sizes are implementation-specific.
+   *
+   * bools have a specialization in hash.cc because they too have
+   * implementation-specific sizes.
+   *
    * @param input supplies the value to hash.
    * @param seed supplies the hash seed which defaults to 0.
    * See https://github.com/Cyan4973/xxHash for details.

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -40,7 +40,9 @@ public:
    * @param seed supplies the hash seed which defaults to 0.
    * See https://github.com/Cyan4973/xxHash for details.
    */
-  template <typename ValueType, std::enable_if_t<std::is_scalar_v<ValueType>, bool> = true>
+  template <
+      typename ValueType,
+      std::enable_if_t<std::is_scalar_v<ValueType> && !std::is_enum_v<ValueType>, bool> = true>
   static uint64_t xxHash64Value(ValueType input, uint64_t seed = 0) {
     if (absl::little_endian::IsLittleEndian()) {
       return XXH64(reinterpret_cast<const char*>(&input), sizeof(input), seed);
@@ -52,17 +54,6 @@ public:
       }
       return XXH64(buf, sizeof(input), seed);
     }
-  }
-  // Explicit specialization for bool because its size may be implementation dependent.
-  template <> uint64_t xxHash64Value(bool input, uint64_t seed) {
-    char b = input ? 1 : 0;
-    return XXH64(&b, 1, seed);
-  }
-  // Explicit specialization for enums because their size may be implementation dependent.
-  template <typename T, std::enable_if_t<std::is_enum_v<T>, bool> = true>
-  uint64_t xxHash64Value(T input, uint64_t seed) {
-    uint32_t value = static_cast<uint32_t>(input);
-    return xxHash64Value(value, seed);
   }
 
   /**

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -40,7 +40,7 @@ public:
    * supported later they should have a separate function because enum
    * sizes are implementation-specific.
    *
-   * bools have a specialization in hash.cc because they too have
+   * bools have an inlined specialization below because they too have
    * implementation-specific sizes.
    *
    * @param input supplies the value to hash.

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -71,9 +71,11 @@ public:
       return XXH64("Inf", 3, seed);
     }
     int exp;
-    auto frac = std::frexp(input, &exp);
+    FloatingPoint frac = std::frexp(input, &exp);
     seed = xxHash64Value(exp, seed);
-    uint64_t mantissa = frac * 9223372036854775808.0; // 2^63
+    // Turn the fraction between -1 and 1 we have into an integer we can
+    // hash endian-independently, using the largest possible range.
+    int64_t mantissa = frac * 9223372036854775808.0; // 2^63
     return xxHash64Value(mantissa, seed);
   }
 

--- a/test/common/common/hash_test.cc
+++ b/test/common/common/hash_test.cc
@@ -11,6 +11,27 @@ TEST(Hash, xxHash) {
   EXPECT_EQ(17241709254077376921U, HashUtil::xxHash64(""));
 }
 
+TEST(Hash, xxHash64Value) {
+  enum Enum { A = 0, B, C };
+  enum class ClassEnum { X = 0, Y, Z };
+  // Verifying against constants should protect against surprise hash behavior
+  // changes, and, when run on a test host with different endianness, should also
+  // verify that different endianness doesn't change the result.
+  EXPECT_EQ(11149811956558368074UL, HashUtil::xxHash64Value(1234567890123456789UL));
+  EXPECT_EQ(5127252389447085590UL, HashUtil::xxHash64Value(-1234567890123456789L));
+  EXPECT_EQ(14922725725041217620UL, HashUtil::xxHash64Value(1234567890U));
+  EXPECT_EQ(12903803813495632273UL, HashUtil::xxHash64Value(-1234567890));
+  EXPECT_EQ(496866755078513886UL, HashUtil::xxHash64Value(1234567890.12345));
+  EXPECT_EQ(15789047197365695310UL, HashUtil::xxHash64Value(-1234567890.12345f));
+  EXPECT_EQ(9962287286179718960UL, HashUtil::xxHash64Value(true));
+  EXPECT_EQ(16804241149081757544UL, HashUtil::xxHash64Value(false));
+  EXPECT_EQ(9486749600008296231UL, HashUtil::xxHash64Value(false, /*seed=*/42));
+  // 0 as enum, 0 as class enum, and 0 as int32 should all hash to the same value.
+  EXPECT_EQ(4246796580750024372, HashUtil::xxHash64Value(A));
+  EXPECT_EQ(4246796580750024372, HashUtil::xxHash64Value(ClassEnum::X));
+  EXPECT_EQ(4246796580750024372, HashUtil::xxHash64Value(0));
+}
+
 TEST(Hash, xxHashWithVector) {
   absl::InlinedVector<absl::string_view, 2> v{"foo", "bar"};
   EXPECT_EQ(17745830980996999794U, HashUtil::xxHash64(absl::MakeSpan(v)));

--- a/test/common/common/hash_test.cc
+++ b/test/common/common/hash_test.cc
@@ -12,8 +12,6 @@ TEST(Hash, xxHash) {
 }
 
 TEST(Hash, xxHash64Value) {
-  enum Enum { A = 0, B, C };
-  enum class ClassEnum { X = 0, Y, Z };
   // Verifying against constants should protect against surprise hash behavior
   // changes, and, when run on a test host with different endianness, should also
   // verify that different endianness doesn't change the result.
@@ -26,10 +24,6 @@ TEST(Hash, xxHash64Value) {
   EXPECT_EQ(9962287286179718960UL, HashUtil::xxHash64Value(true));
   EXPECT_EQ(16804241149081757544UL, HashUtil::xxHash64Value(false));
   EXPECT_EQ(9486749600008296231UL, HashUtil::xxHash64Value(false, /*seed=*/42));
-  // 0 as enum, 0 as class enum, and 0 as int32 should all hash to the same value.
-  EXPECT_EQ(4246796580750024372, HashUtil::xxHash64Value(A));
-  EXPECT_EQ(4246796580750024372, HashUtil::xxHash64Value(ClassEnum::X));
-  EXPECT_EQ(4246796580750024372, HashUtil::xxHash64Value(0));
 }
 
 TEST(Hash, xxHashWithVector) {

--- a/test/common/common/hash_test.cc
+++ b/test/common/common/hash_test.cc
@@ -19,8 +19,19 @@ TEST(Hash, xxHash64Value) {
   EXPECT_EQ(5127252389447085590UL, HashUtil::xxHash64Value(-1234567890123456789L));
   EXPECT_EQ(14922725725041217620UL, HashUtil::xxHash64Value(1234567890U));
   EXPECT_EQ(12903803813495632273UL, HashUtil::xxHash64Value(-1234567890));
-  EXPECT_EQ(496866755078513886UL, HashUtil::xxHash64Value(1234567890.12345));
-  EXPECT_EQ(15789047197365695310UL, HashUtil::xxHash64Value(-1234567890.12345f));
+  EXPECT_EQ(6394838272449507810UL, HashUtil::xxHash64Value(1234567890.12345));
+  EXPECT_EQ(16086425465732342325UL, HashUtil::xxHash64Value(-1234567890.12345f));
+  // All NaN should be alike.
+  EXPECT_EQ(13464136223671999926UL, HashUtil::xxHash64Value(std::nan("")));
+  EXPECT_EQ(13464136223671999926UL, HashUtil::xxHash64Value(std::nan("1")));
+  EXPECT_EQ(13464136223671999926UL, HashUtil::xxHash64Value(std::nanf("")));
+  EXPECT_EQ(13464136223671999926UL, HashUtil::xxHash64Value(std::nanf("1")));
+  // All Inf should be alike.
+  EXPECT_EQ(16018703821796664527UL,
+            HashUtil::xxHash64Value(std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(16018703821796664527UL,
+            HashUtil::xxHash64Value(std::numeric_limits<float>::infinity()));
+
   EXPECT_EQ(9962287286179718960UL, HashUtil::xxHash64Value(true));
   EXPECT_EQ(16804241149081757544UL, HashUtil::xxHash64Value(false));
   EXPECT_EQ(9486749600008296231UL, HashUtil::xxHash64Value(false, /*seed=*/42));


### PR DESCRIPTION
Commit Message: Add HashUtil function for reliable hashing of scalar types
Additional Description: `xxHash64Value` is intended to be an improvement to https://github.com/envoyproxy/envoy/pull/30761 - in its current state that PR is not endian-safe, and this change will also make it more readable by removing a number of cast operations.
Risk Level: None, adding a function which is not yet used.
Testing: Added unit test.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Endianness!
