### PR TITLE
mobile: Fix data race in fetch_client

### DIFF
--- a/mobile/examples/cc/fetch_client/BUILD
+++ b/mobile/examples/cc/fetch_client/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     hdrs = [
         "fetch_client.h",
     ],
+    external_deps = ["abseil_synchronization"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",

--- a/mobile/examples/cc/fetch_client/fetch_client.cc
+++ b/mobile/examples/cc/fetch_client/fetch_client.cc
@@ -37,7 +37,10 @@ void Fetch::fetch(const std::vector<absl::string_view>& urls) {
   }
   dispatcher_->exit();
   envoy_thread->join();
-  engine_->terminate();
+  {
+    absl::MutexLock lock(&engine_mutex_);
+    engine_->terminate();
+  }
 }
 
 void Fetch::sendRequest(const absl::string_view url_string) {
@@ -49,8 +52,11 @@ void Fetch::sendRequest(const absl::string_view url_string) {
   std::cout << "Fetching url: " << url.toString() << "\n";
 
   absl::Notification request_finished;
-  Platform::StreamPrototypeSharedPtr stream_prototype =
-      engine_->streamClient()->newStreamPrototype();
+  Platform::StreamPrototypeSharedPtr stream_prototype;
+  {
+    absl::MutexLock lock(&engine_mutex_);
+    stream_prototype = engine_->streamClient()->newStreamPrototype();
+  }
   stream_prototype->setOnHeaders(
       [](Platform::ResponseHeadersSharedPtr headers, bool, envoy_stream_intel intel) {
         std::cerr << "Received headers on connection: " << intel.connection_id << "\n";
@@ -103,7 +109,12 @@ void Fetch::runEngine(absl::Notification& engine_running) {
   Platform::EngineBuilder engine_builder;
   engine_builder.addLogLevel(Envoy::Platform::LogLevel::debug);
   engine_builder.setOnEngineRunning([&engine_running]() { engine_running.Notify(); });
-  engine_ = engine_builder.build();
+
+  {
+    absl::MutexLock lock(&engine_mutex_);
+    engine_ = engine_builder.build();
+  }
+
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
 }
 

--- a/mobile/examples/cc/fetch_client/fetch_client.h
+++ b/mobile/examples/cc/fetch_client/fetch_client.h
@@ -15,6 +15,8 @@
 #include "source/exe/platform_impl.h"
 #include "source/exe/process_wide.h"
 
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
 #include "library/cc/engine_builder.h"
 #include "library/cc/stream.h"
@@ -46,7 +48,9 @@ private:
   Api::ApiPtr api_;
 
   Event::DispatcherPtr dispatcher_;
-  Platform::EngineSharedPtr engine_;
+
+  absl::Mutex engine_mutex_;
+  Platform::EngineSharedPtr engine_ ABSL_GUARDED_BY(engine_mutex_);
 };
 
 } // namespace Envoy


### PR DESCRIPTION
Without the MutexLock, tsan gives data race errors.