### PR TITLE
[UDP Proxy] Add onSessionComplete for UDP session filters

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/session_filters/filter.h
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/filter.h
@@ -60,10 +60,21 @@ enum class ReadFilterStatus {
   StopIteration,
 };
 
+class FilterBase {
+public:
+  virtual ~FilterBase() = default;
+
+  /**
+   * This routine is called before the access log handlers' final log() is called. Filters can use
+   * this callback to enrich the data passed in to the log handlers.
+   */
+  virtual void onSessionComplete() {}
+};
+
 /**
  * Session read filter interface.
  */
-class ReadFilter {
+class ReadFilter : public FilterBase {
 public:
   virtual ~ReadFilter() = default;
 
@@ -109,7 +120,7 @@ enum class WriteFilterStatus {
 /**
  * Session write filter interface.
  */
-class WriteFilter {
+class WriteFilter : public FilterBase {
 public:
   virtual ~WriteFilter() = default;
 

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -309,6 +309,8 @@ UdpProxyFilter::ActiveSession::~ActiveSession() {
       .connections()
       .dec();
 
+  onSessionComplete();
+
   if (!cluster_.filter_.config_->sessionAccessLogs().empty()) {
     fillSessionStreamInfo();
     for (const auto& access_log : cluster_.filter_.config_->sessionAccessLogs()) {
@@ -639,6 +641,18 @@ void UdpProxyFilter::ActiveSession::writeDownstream(Network::UdpRecvData& recv_d
     session_stats_.downstream_sess_tx_bytes_ += tx_buffer_length;
     cluster_.filter_.config_->stats().downstream_sess_tx_datagrams_.inc();
     ++session_stats_.downstream_sess_tx_datagrams_;
+  }
+}
+
+void UdpProxyFilter::ActiveSession::onSessionComplete() {
+  for (auto& active_read_filter : read_filters_) {
+    active_read_filter->read_filter_->onSessionComplete();
+  }
+
+  for (auto& active_write_filter : write_filters_) {
+    if (!active_write_filter->is_read_write_filter_) {
+      active_write_filter->write_filter_->onSessionComplete();
+    }
   }
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: Add onSessionComplete filter callback that's called before writing access log
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: