### PR TITLE
exe: build cleanup

### DIFF
--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -98,16 +98,15 @@ envoy_cc_library(
     name = "main_common_lib",
     srcs = [
         "main_common.cc",
-        "stripped_main_base.cc",
     ],
     hdrs = [
         "main_common.h",
-        "stripped_main_base.h",
     ],
     deps = [
         ":envoy_common_lib",
         ":platform_impl_lib",
         ":process_wide_lib",
+        ":stripped_main_base_lib",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:compiler_requirements_lib",
         "//source/common/common:perf_annotation_lib",
@@ -116,10 +115,8 @@ envoy_cc_library(
         "//source/server:hot_restart_nop_lib",
         "//source/server:options_lib",
         "//source/server/config_validation:server_lib",
-    ] + envoy_select_signal_trace([
-        "//source/common/signal:sigaction_lib",
-        ":terminate_handler_lib",
-    ]),
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ],
 )
 
 # provides a library target for Envoy server builds with the versioning information set up correctly.
@@ -149,15 +146,14 @@ envoy_cc_library(
     name = "envoy_main_common_with_core_extensions_lib",
     srcs = [
         "main_common.cc",
-        "stripped_main_base.cc",
     ],
     hdrs = [
         "main_common.h",
-        "stripped_main_base.h",
     ],
     deps = [
                ":platform_impl_lib",
                ":process_wide_lib",
+               ":stripped_main_base_lib",
                "//envoy/server:platform_interface",
                "//source/common/api:os_sys_calls_lib",
                "//source/common/common:compiler_requirements_lib",
@@ -169,10 +165,7 @@ envoy_cc_library(
                "//source/server:options_lib",
                "//source/server:server_lib",
                "//source/server/config_validation:server_lib",
-           ] + envoy_select_signal_trace([
-               "//source/common/signal:sigaction_lib",
-               ":terminate_handler_lib",
-           ]) + envoy_all_core_extensions() +
+           ] + envoy_all_core_extensions() +
            # TODO(rojkov): drop io_uring dependency when it's fully integrated.
            select({
                "//bazel:linux": ["//source/common/io:io_uring_impl_lib"],


### PR DESCRIPTION
refactoring source/exe/BUILD so only one library has stripped_main_base

Risk Level: low 
Testing: CI
Docs Changes: n/a
Release Notes: n/a