### PR TITLE
generic proxy: refactored stream API and provided default implementation

### DIFF
--- a/contrib/generic_proxy/filters/network/source/BUILD
+++ b/contrib/generic_proxy/filters/network/source/BUILD
@@ -21,7 +21,7 @@ envoy_cc_library(
         ":rds_lib",
         ":route_lib",
         ":stats_lib",
-        ":upstream_lib",
+        ":tracing_lib",
         "//contrib/generic_proxy/filters/network/source/interface:codec_interface",
         "//contrib/generic_proxy/filters/network/source/interface:proxy_config_interface",
         "//contrib/generic_proxy/filters/network/source/router:router_lib",
@@ -173,4 +173,18 @@ envoy_cc_library(
     ],
     # Ensure this factory in the source is always linked in.
     alwayslink = 1,
+)
+
+envoy_cc_library(
+    name = "tracing_lib",
+    srcs = [
+        "tracing.cc",
+    ],
+    hdrs = [
+        "tracing.h",
+    ],
+    deps = [
+        "//contrib/generic_proxy/filters/network/source/interface:stream_interface",
+        "//envoy/tracing:trace_context_interface",
+    ],
 )

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -94,7 +94,7 @@ void DubboRequest::forEach(IterateCallback callback) const {
   }
 }
 
-absl::optional<absl::string_view> DubboRequest::getByKey(absl::string_view key) const {
+absl::optional<absl::string_view> DubboRequest::get(absl::string_view key) const {
   if (key == VERSION_KEY) {
     return inner_metadata_->request().serviceVersion();
   }
@@ -105,7 +105,7 @@ absl::optional<absl::string_view> DubboRequest::getByKey(absl::string_view key) 
   return typed_request->attachment().lookup(key);
 }
 
-void DubboRequest::setByKey(absl::string_view key, absl::string_view val) {
+void DubboRequest::set(absl::string_view key, absl::string_view val) {
   auto* typed_request =
       dynamic_cast<Common::Dubbo::RpcRequestImpl*>(&inner_metadata_->mutableRequest());
   ASSERT(typed_request != nullptr);
@@ -113,7 +113,7 @@ void DubboRequest::setByKey(absl::string_view key, absl::string_view val) {
   typed_request->mutableAttachment()->insert(key, val);
 }
 
-void DubboRequest::removeByKey(absl::string_view key) {
+void DubboRequest::erase(absl::string_view key) {
   auto* typed_request =
       dynamic_cast<Common::Dubbo::RpcRequestImpl*>(&inner_metadata_->mutableRequest());
   ASSERT(typed_request != nullptr);

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -33,16 +33,12 @@ public:
   // Request
   absl::string_view protocol() const override { return DubboProtocolName; }
   void forEach(IterateCallback callback) const override;
-  absl::optional<absl::string_view> getByKey(absl::string_view key) const override;
-  void setByKey(absl::string_view key, absl::string_view val) override;
-  void setByReferenceKey(absl::string_view key, absl::string_view val) override {
-    setByKey(key, val);
-  }
-  void setByReference(absl::string_view key, absl::string_view val) override { setByKey(key, val); }
+  absl::optional<absl::string_view> get(absl::string_view key) const override;
+  void set(absl::string_view key, absl::string_view val) override;
   absl::string_view host() const override { return inner_metadata_->request().serviceName(); }
   absl::string_view path() const override { return inner_metadata_->request().serviceName(); }
   absl::string_view method() const override { return inner_metadata_->request().methodName(); }
-  void removeByKey(absl::string_view key) override;
+  void erase(absl::string_view key) override;
 
   // StreamFrame
   FrameFlags frameFlags() const override { return stream_frame_flags_; }
@@ -66,13 +62,6 @@ public:
 
   // Response.
   absl::string_view protocol() const override { return DubboProtocolName; }
-  void forEach(IterateCallback) const override {}
-  absl::optional<absl::string_view> getByKey(absl::string_view) const override {
-    return absl::nullopt;
-  }
-  void setByKey(absl::string_view, absl::string_view) override{};
-  void setByReferenceKey(absl::string_view, absl::string_view) override {}
-  void setByReference(absl::string_view, absl::string_view) override {}
   Status status() const override { return status_; }
 
   // StreamFrame

--- a/contrib/generic_proxy/filters/network/source/interface/stream.h
+++ b/contrib/generic_proxy/filters/network/source/interface/stream.h
@@ -138,7 +138,7 @@ public:
    *
    * @param callback supplies the iteration callback.
    */
-  virtual void forEach(IterateCallback callback) const PURE;
+  virtual void forEach(IterateCallback /*callback*/) const {};
 
   /**
    * Get generic stream metadata value by key.
@@ -146,7 +146,7 @@ public:
    * @param key The metadata key of string view type.
    * @return The optional metadata value of string_view type.
    */
-  virtual absl::optional<absl::string_view> getByKey(absl::string_view key) const PURE;
+  virtual absl::optional<absl::string_view> get(absl::string_view /*key*/) const { return {}; }
 
   /**
    * Set new generic stream metadata key/value pair.
@@ -154,25 +154,13 @@ public:
    * @param key The metadata key of string view type.
    * @param val The metadata value of string view type.
    */
-  virtual void setByKey(absl::string_view key, absl::string_view val) PURE;
+  virtual void set(absl::string_view /*key*/, absl::string_view /*val*/) {}
 
   /**
-   * Set new generic stream metadata key/value pair. The key MUST point to data that will live
-   * beyond the lifetime of any generic stream that using the string.
-   *
+   * Erase generic stream metadata by key.
    * @param key The metadata key of string view type.
-   * @param val The metadata value of string view type.
    */
-  virtual void setByReferenceKey(absl::string_view key, absl::string_view val) PURE;
-
-  /**
-   * Set new generic stream metadata key/value pair. Both key and val MUST point to data that
-   * will live beyond the lifetime of any generic stream that using the string.
-   *
-   * @param key The metadata key of string view type.
-   * @param val The metadata value of string view type.
-   */
-  virtual void setByReference(absl::string_view key, absl::string_view val) PURE;
+  virtual void erase(absl::string_view /*key*/) {}
 
   // Used for matcher.
   static constexpr absl::string_view name() { return "generic_proxy"; }
@@ -186,10 +174,33 @@ public:
  * to simplify the tracing integration. This is not a good design. This should be changed in the
  * future.
  */
-class StreamRequest : public Tracing::TraceContext, public StreamFrame {
+class StreamRequest : public StreamBase {
 public:
-  // Used for matcher.
-  static constexpr absl::string_view name() { return "generic_proxy"; }
+  /**
+   * Get request host.
+   *
+   * @return The host of generic request. The meaning of the return value may be different For
+   * different application protocols. It typically should be domain, VIP, or service name that
+   * used to represents target service instances.
+   */
+  virtual absl::string_view host() const { return {}; }
+
+  /**
+   * Get request path.
+   *
+   * @return The path of generic request. The meaning of the return value may be different For
+   * different application protocols. It typically should be RPC service name that used to
+   * represents set of method or functionality provided by target service.
+   */
+  virtual absl::string_view path() const { return {}; }
+
+  /**
+   * Get request method.
+   *
+   * @return The method of generic request. The meaning of the return value may be different For
+   * different application protocols.
+   */
+  virtual absl::string_view method() const { return {}; }
 };
 
 using StreamRequestPtr = std::unique_ptr<StreamRequest>;
@@ -221,7 +232,7 @@ public:
    *
    * @return generic response status.
    */
-  virtual Status status() const PURE;
+  virtual Status status() const { return {}; }
 };
 
 using StreamResponsePtr = std::unique_ptr<StreamResponse>;

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -30,7 +30,7 @@
 #include "contrib/generic_proxy/filters/network/source/rds_impl.h"
 #include "contrib/generic_proxy/filters/network/source/route.h"
 #include "contrib/generic_proxy/filters/network/source/stats.h"
-#include "contrib/generic_proxy/filters/network/source/upstream.h"
+#include "contrib/generic_proxy/filters/network/source/tracing.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/contrib/generic_proxy/filters/network/source/tracing.cc
+++ b/contrib/generic_proxy/filters/network/source/tracing.cc
@@ -1,0 +1,30 @@
+#include "contrib/generic_proxy/filters/network/source/tracing.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+absl::string_view TraceContextBridge::protocol() const { return request_.protocol(); }
+absl::string_view TraceContextBridge::host() const { return request_.host(); }
+absl::string_view TraceContextBridge::path() const { return request_.path(); }
+absl::string_view TraceContextBridge::method() const { return request_.method(); }
+void TraceContextBridge::forEach(IterateCallback callback) const { request_.forEach(callback); }
+absl::optional<absl::string_view> TraceContextBridge::getByKey(absl::string_view key) const {
+  return request_.get(key);
+}
+void TraceContextBridge::setByKey(absl::string_view key, absl::string_view val) {
+  request_.set(key, val);
+}
+void TraceContextBridge::setByReferenceKey(absl::string_view key, absl::string_view val) {
+  request_.set(key, val);
+}
+void TraceContextBridge::setByReference(absl::string_view key, absl::string_view val) {
+  request_.set(key, val);
+}
+void TraceContextBridge::removeByKey(absl::string_view key) { request_.erase(key); }
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/tracing.h
+++ b/contrib/generic_proxy/filters/network/source/tracing.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "envoy/tracing/trace_context.h"
+
+#include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+/*
+ * Simple wrapper around a StreamRequest that provides the TraceContext interface.
+ */
+class TraceContextBridge : public Tracing::TraceContext {
+public:
+  TraceContextBridge(StreamRequest& request) : request_(request) {}
+
+  // Tracing::TraceContext
+  absl::string_view protocol() const override;
+  absl::string_view host() const override;
+  absl::string_view path() const override;
+  absl::string_view method() const override;
+  void forEach(IterateCallback callback) const override;
+  absl::optional<absl::string_view> getByKey(absl::string_view key) const override;
+  void setByKey(absl::string_view key, absl::string_view val) override;
+  void setByReferenceKey(absl::string_view key, absl::string_view val) override;
+  void setByReference(absl::string_view key, absl::string_view val) override;
+  void removeByKey(absl::string_view key) override;
+
+private:
+  StreamRequest& request_;
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
@@ -68,21 +68,17 @@ TEST(DubboRequestTest, DubboRequestTest) {
     EXPECT_EQ("fake_service", request.host());
     EXPECT_EQ("fake_service", request.path());
     EXPECT_EQ("fake_method", request.method());
-    EXPECT_EQ("fake_version", request.getByKey("version").value());
+    EXPECT_EQ("fake_version", request.get("version").value());
   }
 
   // Get and set headers.
   {
-    EXPECT_EQ("fake_group", request.getByKey("group").value());
+    EXPECT_EQ("fake_group", request.get("group").value());
 
-    EXPECT_EQ(false, request.getByKey("custom_key").has_value());
+    EXPECT_EQ(false, request.get("custom_key").has_value());
 
-    request.setByKey("custom_key", "custom_value");
-    EXPECT_EQ("custom_value", request.getByKey("custom_key").value());
-    request.setByReference("custom_key1", "custom_value1");
-    EXPECT_EQ("custom_value1", request.getByKey("custom_key1").value());
-    request.setByReferenceKey("custom_key2", "custom_value2");
-    EXPECT_EQ("custom_value2", request.getByKey("custom_key2").value());
+    request.set("custom_key", "custom_value");
+    EXPECT_EQ("custom_value", request.get("custom_key").value());
   }
 
   // Iterate headers.
@@ -185,13 +181,9 @@ TEST(DubboResponseTest, DubboResponseTest) {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::Ok, RpcResponseType::ResponseWithValue));
 
-    EXPECT_EQ(false, response.getByKey("custom_key").has_value());
-    response.setByKey("custom_key", "custom_value");
-    EXPECT_EQ(false, response.getByKey("custom_key").has_value());
-    response.setByReference("custom_key", "custom_value");
-    EXPECT_EQ(false, response.getByKey("custom_key").has_value());
-    response.setByReferenceKey("custom_key", "custom_value");
-    EXPECT_EQ(false, response.getByKey("custom_key").has_value());
+    EXPECT_EQ(false, response.get("custom_key").has_value());
+    response.set("custom_key", "custom_value");
+    EXPECT_EQ(false, response.get("custom_key").has_value());
   }
 
   // Iterate headers.

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -18,20 +18,15 @@ public:
       callback(pair.first, pair.second);
     }
   }
-  absl::optional<absl::string_view> getByKey(absl::string_view key) const override {
+  absl::optional<absl::string_view> get(absl::string_view key) const override {
     auto iter = data_.find(key);
     if (iter == data_.end()) {
       return absl::nullopt;
     }
     return absl::make_optional<absl::string_view>(iter->second);
   }
-  void setByKey(absl::string_view key, absl::string_view val) override {
-    data_[key] = std::string(val);
-  }
-  void setByReferenceKey(absl::string_view key, absl::string_view val) override {
-    setByKey(key, val);
-  }
-  void setByReference(absl::string_view key, absl::string_view val) override { setByKey(key, val); }
+  void set(absl::string_view key, absl::string_view val) override { data_[key] = std::string(val); }
+  void erase(absl::string_view key) override { data_.erase(key); }
 
   // StreamFrame
   FrameFlags frameFlags() const override { return stream_frame_flags_; }
@@ -58,7 +53,6 @@ public:
     absl::string_view host() const override { return host_; }
     absl::string_view path() const override { return path_; }
     absl::string_view method() const override { return method_; }
-    void removeByKey(absl::string_view key) override { data_.erase(key); }
 
     std::string protocol_;
     std::string host_;

--- a/contrib/generic_proxy/filters/network/test/integration_test.cc
+++ b/contrib/generic_proxy/filters/network/test/integration_test.cc
@@ -372,7 +372,7 @@ TEST_P(IntegrationTest, RequestAndResponse) {
 
   EXPECT_NE(response_decoder_callback_->responses_[0].response_, nullptr);
   EXPECT_EQ(response_decoder_callback_->responses_[0].response_->status().code(), StatusCode::kOk);
-  EXPECT_EQ(response_decoder_callback_->responses_[0].response_->getByKey("zzzz"), "xxxx");
+  EXPECT_EQ(response_decoder_callback_->responses_[0].response_->get("zzzz"), "xxxx");
 
   cleanup();
 }
@@ -475,8 +475,8 @@ TEST_P(IntegrationTest, MultipleRequests) {
 
   EXPECT_NE(response_decoder_callback_->responses_[2].response_, nullptr);
   EXPECT_EQ(response_decoder_callback_->responses_[2].response_->status().code(), StatusCode::kOk);
-  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->getByKey("zzzz"), "xxxx");
-  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->getByKey("stream_id"), "2");
+  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("zzzz"), "xxxx");
+  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("stream_id"), "2");
 
   FakeStreamCodecFactory::FakeResponse response_1;
   response_1.protocol_ = "fake_fake_fake";
@@ -491,8 +491,8 @@ TEST_P(IntegrationTest, MultipleRequests) {
 
   EXPECT_NE(response_decoder_callback_->responses_[1].response_, nullptr);
   EXPECT_EQ(response_decoder_callback_->responses_[1].response_->status().code(), StatusCode::kOk);
-  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->getByKey("zzzz"), "yyyy");
-  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->getByKey("stream_id"), "1");
+  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("zzzz"), "yyyy");
+  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("stream_id"), "1");
 
   cleanup();
 }
@@ -606,8 +606,8 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
 
   EXPECT_NE(response_decoder_callback_->responses_[2].response_, nullptr);
   EXPECT_EQ(response_decoder_callback_->responses_[2].response_->status().code(), StatusCode::kOk);
-  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->getByKey("zzzz"), "xxxx");
-  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->getByKey("stream_id"), "2");
+  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("zzzz"), "xxxx");
+  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("stream_id"), "2");
 
   FakeStreamCodecFactory::FakeResponse response_1;
   response_1.protocol_ = "fake_fake_fake";
@@ -628,8 +628,8 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
 
   EXPECT_NE(response_decoder_callback_->responses_[1].response_, nullptr);
   EXPECT_EQ(response_decoder_callback_->responses_[1].response_->status().code(), StatusCode::kOk);
-  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->getByKey("zzzz"), "yyyy");
-  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->getByKey("stream_id"), "1");
+  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("zzzz"), "yyyy");
+  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("stream_id"), "1");
 
   cleanup();
 }


### PR DESCRIPTION
Commit Message:

When I created the Stream interface in the past, I hope it could keep same with the `TraceContext`, then we needn't additional effort to support tracing. However, it's actually a bad design. Any unrelated `TraceContext` updating require we to update all Stream implementations. And considering that we may introduce HTTP-specific optimization to the `TraceContxt` in the future (see #26687), so I finally decide to refactor the `StreamRequest` interface.

This patch includes following changes:
1. Refactored StreamRequest to avoid inheriting from TraceContext and used simpler method name.
2. Provided default implementation for most methods because we actually don't require an custom codec to implement this method if it needn't related routing feature.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
