### PR TITLE
grpc_http1_bridge: add <ignore_query_params> option

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_http1_bridge/v3/config.proto
@@ -26,4 +26,7 @@ message Config {
   // For the requests that went through this upgrade the filter will also strip the frame before forwarding the
   // response to the client.
   bool upgrade_protobuf_to_grpc = 1;
+
+  // If true then query parameters in request's URL path will be removed.
+  bool ignore_query_parameters = 2;
 }

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -19,6 +19,19 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1Bridge {
 
+// Some client requests' URLs may contain query params. gRPC upstream servers can not
+// handle these requests, and may return error such as "unknown method". So we remove
+// query params here.
+void Http1BridgeFilter::removeQueryParams(Http::RequestHeaderMap& headers) {
+  absl::string_view path = headers.Path()->value().getStringView();
+  size_t pos = path.find("?");
+  if (pos != absl::string_view::npos) {
+    absl::string_view new_path = path.substr(0, pos);
+    headers.setPath(new_path);
+    decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
+  }
+}
+
 Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   const bool protobuf_request = Grpc::Common::isProtobufRequestHeaders(headers);
   if (upgrade_protobuf_ && protobuf_request) {
@@ -30,13 +43,15 @@ Http::FilterHeadersStatus Http1BridgeFilter::decodeHeaders(Http::RequestHeaderMa
   }
 
   const bool grpc_request = Grpc::Common::isGrpcRequestHeaders(headers);
-
   const absl::optional<Http::Protocol>& protocol = decoder_callbacks_->streamInfo().protocol();
   ASSERT(protocol);
   if (protocol.value() < Http::Protocol::Http2 && grpc_request) {
     do_bridging_ = true;
   }
 
+  if (do_briging_ && ignored_query_parameters_) {
+    ignoreQueryParams(headers);
+  }
   return Http::FilterHeadersStatus::Continue;
 }
 

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -57,6 +57,7 @@ public:
 
 private:
   void setupStatTracking(const Http::RequestHeaderMap& headers);
+  void removeQueryParams(Http::RequestHeaderMap& headers);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -22,7 +22,8 @@ public:
   explicit Http1BridgeFilter(
       Grpc::Context& context,
       const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config)
-      : context_(context), upgrade_protobuf_(proto_config.upgrade_protobuf_to_grpc()) {}
+      : context_(context), upgrade_protobuf_(proto_config.upgrade_protobuf_to_grpc()),
+        ignore_query_parameters_(proto_config.ignore_query_parameters()) {}
 
   // Http::StreamFilterBase
   void onDestroy() override {}
@@ -64,6 +65,7 @@ private:
   bool do_framing_{};
   Grpc::Context& context_;
   bool upgrade_protobuf_{};
+  bool upgrade_query_parameters_{};
 };
 
 } // namespace GrpcHttp1Bridge


### PR DESCRIPTION
Commit Message: add <ignore_query_params> option for grpc_http1_bridge filter
Additional Description: Some client requests' URLs may contain query params. gRPC upstream servers can not handle these requests, and may return error such as "unknown method". So we remove query params here.
Risk Level: 
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
