### PR TITLE
favor const member functions for Http::Utility::QueryParamsMulti

### DIFF
--- a/envoy/http/query_params.h
+++ b/envoy/http/query_params.h
@@ -23,11 +23,11 @@ public:
   void remove(absl::string_view key);
   void add(absl::string_view key, absl::string_view value);
   void overwrite(absl::string_view key, absl::string_view value);
-  std::string toString();
-  std::string replaceQueryString(const HeaderString& path);
+  std::string toString() const;
+  std::string replaceQueryString(const HeaderString& path) const;
   absl::optional<std::string> getFirstValue(absl::string_view key) const;
 
-  const absl::btree_map<std::string, std::vector<std::string>>& data() { return data_; }
+  const absl::btree_map<std::string, std::vector<std::string>>& data() const { return data_; }
 
   static QueryParamsMulti parseParameters(absl::string_view data, size_t start, bool decode_params);
   static QueryParamsMulti parseQueryString(absl::string_view url);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -582,7 +582,7 @@ std::string Utility::stripQueryString(const HeaderString& path) {
   return {path_str.data(), query_offset != path_str.npos ? query_offset : path_str.size()};
 }
 
-std::string Utility::QueryParamsMulti::replaceQueryString(const HeaderString& path) {
+std::string Utility::QueryParamsMulti::replaceQueryString(const HeaderString& path) const {
   std::string new_path{Http::Utility::stripQueryString(path)};
 
   if (!this->data_.empty()) {
@@ -1026,7 +1026,7 @@ RequestMessagePtr Utility::prepareHeaders(const envoy::config::core::v3::HttpUri
   return message;
 }
 
-std::string Utility::QueryParamsMulti::toString() {
+std::string Utility::QueryParamsMulti::toString() const {
   std::string out;
   std::string delim = "?";
   for (const auto& p : this->data_) {


### PR DESCRIPTION
Commit Message:
non const functions prevent us to pass parameters like `const Http::Utility::QueryParamsMulti&`
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
