### PR TITLE
aws: fix usage of reloadable_features.use_http_client_to_fetch_aws_credentials

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -31,8 +31,9 @@ minor_behavior_changes:
     To get the protocol, please use GetProperty("request.protocol") instead.
 - area: aws
   change: |
-    uses http async client to fetch the credentials from EC2 instance metadata and ECS task metadata providers instead of libcurl
-    which is deprecated. To revert this behavior set ``envoy.reloadable_features.use_libcurl_to_fetch_aws_credentials`` to true.
+    Added support to use http async client to fetch the credentials from EC2 instance metadata and ECS task metadata providers
+    instead of libcurl which is deprecated. By default this behavior is disabled. To enable set 
+    ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to true.
 - area: upstream
   change: |
     Fixed a reported issue (https://github.com/envoyproxy/envoy/issues/11004) that causes the Least

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -32,7 +32,7 @@ minor_behavior_changes:
 - area: aws
   change: |
     Added support to use http async client to fetch the credentials from EC2 instance metadata and ECS task metadata providers
-    instead of libcurl which is deprecated. By default this behavior is disabled. To enable set 
+    instead of libcurl which is deprecated. By default this behavior is disabled. To enable set
     ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to true.
 - area: upstream
   change: |

--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -14,7 +14,7 @@ secret access key (the session token is optional).
 3. Either EC2 instance metadata or ECS task metadata. For EC2 instance metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and
    ``Token`` are used, and credentials are cached for 1 hour. For ECS task metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and
    ``Token`` are used, and credentials are cached for 1 hour or until they expire (according to the field ``Expiration``). Note that the
-   latest update on AWS credentials provider utility provides option to use http async client functionality instead of libcurl to fetch the
+   latest update on AWS credentials provider utility provides an option to use http async client functionality instead of libcurl to fetch the
    credentials. This behavior can be changed by setting ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to ``true``.
    The usage of libcurl is on the deprecation path and will be removed soon. To fetch the credentials from either EC2 instance
    metadata or ECS task metadata a static cluster is required pointing towards the credentials provider. The static cluster name has to be

--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -14,11 +14,11 @@ secret access key (the session token is optional).
 3. Either EC2 instance metadata or ECS task metadata. For EC2 instance metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and
    ``Token`` are used, and credentials are cached for 1 hour. For ECS task metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and
    ``Token`` are used, and credentials are cached for 1 hour or until they expire (according to the field ``Expiration``). Note that the
-   latest update on AWS credentials provider utility uses http async client functionality by default instead of libcurl to fetch the
-   credentials. The usage of libcurl is on the deprecation path and will be removed soon. This behavior can be changed by setting
-   ``envoy.reloadable_features.use_libcurl_to_fetch_aws_credentials`` to ``true``. To fetch the credentials from either EC2 instance
+   latest update on AWS credentials provider utility provides option to use http async client functionality instead of libcurl to fetch the
+   credentials. This behavior can be changed by setting ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to ``true``.
+   The usage of libcurl is on the deprecation path and will be removed soon. To fetch the credentials from either EC2 instance
    metadata or ECS task metadata a static cluster is required pointing towards the credentials provider. The static cluster name has to be
    ``ec2_instance_metadata_server_internal`` for fetching from EC2 instance metadata or ``ecs_task_metadata_server_internal`` for fetching
    from ECS task metadata. If these clusters are not provided in the bootstrap configuration then either of these will be added by default.
-   The static internal cluster will still be added even if initially ``envoy.reloadable_features.use_libcurl_to_fetch_aws_credentials`` is
-   set to ``true`` so that in future if the reloadable feature is set to ``false`` the cluster config is available to fetch the credentials.
+   The static internal cluster will still be added even if initially ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` is
+   not set so that subsequently if the reloadable feature is set to ``true`` the cluster config is available to fetch the credentials.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -115,9 +115,12 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_include_histograms);
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_refresh_rtt_after_request);
 // TODO(danzh) false deprecate it once QUICHE has its own enable/disable flag.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
-// TODO(suniltheta): Once the newly added http async technique proves effective and
-// is stabilized get rid of this feature flag and code path that relies on libcurl.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_libcurl_to_fetch_aws_credentials);
+// TODO(suniltheta): Once the newly added http async technique is stabilized move it under
+// RUNTIME_GUARD so that this option becomes default enabled. Once this option proves effective
+// remove the feature flag and remove code path that relies on old technique to fetch credentials
+// via libcurl and remove the bazel steps to pull and test the curl dependency.
+get rid of this feature flag and code path that relies on
+    libcurl.FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_http_client_to_fetch_aws_credentials);
 // TODO(adisuissa): enable by default once this is tested in prod.
 FALSE_RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 // TODO(#10646) change to true when UHV is sufficiently tested

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -119,8 +119,7 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 // RUNTIME_GUARD so that this option becomes default enabled. Once this option proves effective
 // remove the feature flag and remove code path that relies on old technique to fetch credentials
 // via libcurl and remove the bazel steps to pull and test the curl dependency.
-get rid of this feature flag and code path that relies on
-    libcurl.FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_http_client_to_fetch_aws_credentials);
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_http_client_to_fetch_aws_credentials);
 // TODO(adisuissa): enable by default once this is tested in prod.
 FALSE_RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 // TODO(#10646) change to true when UHV is sufficiently tested

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -169,8 +169,8 @@ void MetadataCredentialsProviderBase::setCredentialsToAllThreads(
 }
 
 bool MetadataCredentialsProviderBase::useHttpAsyncClient() {
-  return !Runtime::runtimeFeatureEnabled(
-      "envoy.reloadable_features.use_libcurl_to_fetch_aws_credentials");
+  return Runtime::runtimeFeatureEnabled(
+      "envoy.reloadable_features.use_http_client_to_fetch_aws_credentials");
 }
 
 bool CredentialsFileCredentialsProvider::needsRefresh() {

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -298,6 +298,8 @@ public:
       : api_(Api::createApiForTest(time_system_)), raw_metadata_fetcher_(new MockMetadataFetcher) {}
 
   void setupProvider() {
+    scoped_runtime_.mergeValues(
+        {{"envoy.reloadable_features.use_http_client_to_fetch_aws_credentials", "true"}});
     ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
     provider_ = std::make_shared<InstanceProfileCredentialsProvider>(
         *api_, context_,
@@ -1123,8 +1125,6 @@ public:
       : api_(Api::createApiForTest(time_system_)) {}
 
   void setupProvider() {
-    scoped_runtime_.mergeValues(
-        {{"envoy.reloadable_features.use_libcurl_to_fetch_aws_credentials", "true"}});
     provider_ = std::make_shared<InstanceProfileCredentialsProvider>(
         *api_, absl::nullopt,
         [this](Http::RequestMessage& message) -> absl::optional<std::string> {
@@ -1439,6 +1439,8 @@ public:
   }
 
   void setupProvider() {
+    scoped_runtime_.mergeValues(
+        {{"envoy.reloadable_features.use_http_client_to_fetch_aws_credentials", "true"}});
     ON_CALL(context_, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
     provider_ = std::make_shared<TaskRoleCredentialsProvider>(
         *api_, context_,
@@ -1828,8 +1830,6 @@ public:
   }
 
   void setupProvider() {
-    scoped_runtime_.mergeValues(
-        {{"envoy.reloadable_features.use_libcurl_to_fetch_aws_credentials", "true"}});
     provider_ = std::make_shared<TaskRoleCredentialsProvider>(
         *api_, absl::nullopt,
         [this](Http::RequestMessage& message) -> absl::optional<std::string> {


### PR DESCRIPTION
Commit Message: aws: fix usage of reloadable_features.use_http_client_to_fetch_aws_credentials
Additional Description: This feature flag will be release in v1.29. In v1.30 we will flip this feature flag to be default enabled. Finally in v1.31 release this feature flag will be removed.
Risk Level:
Testing:
Docs Changes: Yes
Release Notes: Yes
Fixes: https://github.com/envoyproxy/envoy/issues/31119
