### PR TITLE
Start Full Scan from a random index for Least Request LB.

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
+++ b/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto
@@ -63,5 +63,7 @@ message LeastRequest {
   // Configuration for performing full scan on the list of hosts.
   // If this configuration is set, when selecting the host a full scan on the list hosts will be
   // used to select the one with least requests instead of using random choices.
+  // It uses a random index to start scan to avoid selecting the same host when the number of
+  // requests are the same.
   google.protobuf.BoolValue enable_full_scan = 5;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -101,6 +101,11 @@ bug_fixes:
     used for retrieval. This caused cache misses on initial use, even though the host DNS entry
     was pre-resolved. The fix is guarded by runtime guard ``envoy.reloadable_features.normalize_host_for_preresolve_dfp_dns``,
     which defaults to true.
+- area: upstream
+  change: |
+    Fixed a bug (https://github.com/envoyproxy/envoy/pull/11006) that caused the Least Request load balancer policy to choose
+    the first host of the list when the number of requests are the same during a full scan. Start the selection from a random
+    index instead of 0.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -1301,7 +1301,11 @@ HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPick(const HostVector
 
   // Do full scan if it's required explicitly.
   if (enable_full_scan_) {
-    for (const auto& sampled_host : hosts_to_use) {
+    // Choose a random index to start from preventing always picking the first host in the list.
+    const int rand_idx = random_.random() % hosts_to_use.size();
+    for (unsigned long i = 0; i < hosts_to_use.size(); i++) {
+      const HostSharedPtr& sampled_host = hosts_to_use[(rand_idx + i) % hosts_to_use.size()];
+
       if (candidate_host == nullptr) {
         // Make a first choice to start the comparisons.
         candidate_host = sampled_host;


### PR DESCRIPTION
Fixed a bug (https://github.com/envoyproxy/envoy/pull/11006) that caused the Least Request load balancer policy to choose the first host of the list when the number of requests are the same during a full scan. Start the selection from a random index instead of 0.


