### PR TITLE
Conditionally include quic_gso_batch_writer_lib.

### DIFF
--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -532,8 +532,10 @@ envoy_cc_library(
         "//source/common/network:io_socket_error_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_lib",
-        "@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib",
-    ],
+    ] + select({
+        "//bazel:linux": ["@com_github_google_quiche//:quic_core_batch_writer_gso_batch_writer_lib"],
+        "//conditions:default": [],
+    }),
 )
 
 envoy_cc_library(


### PR DESCRIPTION
This removes an eventual blocker for using QUICHE's build files directly (once those are published for external consumption).

This should be a no-op for Envoy today, since the current quiche.BUILD target only includes the corresponding header and source files if built on Linux.

Commit Message: Conditionally include quic_gso_batch_writer_lib.
Additional Description:
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a