### PR TITLE
[balsa] Add tests to document that header value with null char is rejected.

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -27,8 +27,8 @@
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
-#include "absl/strings/string_view.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Commit Message: [balsa] Add tests to document that header value with null char is rejected.
Additional Description: Add tests to document that both BalsaParser and http-parser rejects a message that has a header value with null character in it.
Risk Level: low, test-only
Testing: test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Balsa implementation tracking issue: #21245