### PR TITLE
[balsa] Enable line folding.

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4832,6 +4832,7 @@ TEST_P(Http1ClientConnectionImplTest, InvalidCharacterInTrailerName) {
 // such messages (also permitted by the specification). See RFC9110 Section 5.5:
 // https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values.
 TEST_P(Http1ServerConnectionImplTest, ObsFold) {
+  // SPELLCHECKER(off)
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
@@ -4849,9 +4850,11 @@ TEST_P(Http1ServerConnectionImplTest, ObsFold) {
                            "\r\n");
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(status.ok());
+  // SPELLCHECKER(on)
 }
 
 TEST_P(Http1ClientConnectionImplTest, ObsFold) {
+  // SPELLCHECKER(off)
   initialize();
 
   NiceMock<MockResponseDecoder> response_decoder;
@@ -4873,6 +4876,7 @@ TEST_P(Http1ClientConnectionImplTest, ObsFold) {
 
   auto status = codec_->dispatch(response);
   EXPECT_TRUE(status.ok());
+  // SPELLCHECKER(on)
 }
 
 } // namespace Http


### PR DESCRIPTION
Commit Message: [balsa] Enable line folding.
Additional Description: Enable line folding in BalsaParser; remove CR and LF characters to match http-parser behavior.
Risk Level: low, BalsaParser has only recently been default-enabled, and this PR makes its behavior match that of http-parser.
Testing: test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.http1_use_balsa_parser (default enabled)

Fixes #31009.
Balsa implementation tracking issue: #21245