### PR TITLE
ci: explicitly specify the service want to start for websocket example

### DIFF
--- a/examples/websocket/verify.sh
+++ b/examples/websocket/verify.sh
@@ -21,6 +21,10 @@ mkdir -p certs
 openssl req -batch -new -x509 -nodes -keyout certs/key.pem -out certs/cert.pem
 openssl pkcs12 -export -passout pass: -out certs/output.pkcs12 -inkey certs/key.pem -in certs/cert.pem
 
+# Explicitly specified the service want to start, since the `client-ws` is expected to
+# not start.
+UPARGS="proxy-ws proxy-wss-wss proxy-wss-passthrough service-ws service-wss"
+
 bring_up_example
 
 run_log "Interact with web socket ws -> ws"


### PR DESCRIPTION
Commit Message: ci: explicitly specify the service want to start for websocket example
Additional Description:
CI failed on websocket example verify test.
```
websocket is missing dependency client-ws
ERROR: starting websocket .
```

Risk Level: low
Testing: CI fix
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

