### PR TITLE
CI: explicitly specify the service want to start for kafka and websocket example

### DIFF
--- a/examples/kafka/verify.sh
+++ b/examples/kafka/verify.sh
@@ -4,6 +4,10 @@ export NAME=kafka
 export PORT_PROXY="${KAFKA_PORT_PROXY:-11100}"
 export PORT_ADMIN="${KAFKA_PORT_ADMIN:-11101}"
 
+# Explicitly specified the service want to start, since the `kafka-client` is expected to
+# not start.
+UPARGS="proxy kafka-server zookeeper"
+
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
 

--- a/examples/websocket/verify.sh
+++ b/examples/websocket/verify.sh
@@ -21,6 +21,8 @@ mkdir -p certs
 openssl req -batch -new -x509 -nodes -keyout certs/key.pem -out certs/cert.pem
 openssl pkcs12 -export -passout pass: -out certs/output.pkcs12 -inkey certs/key.pem -in certs/cert.pem
 
+UPARGS="proxy-ws proxy-wss-wss proxy-wss-passthrough service-ws service-wss"
+
 bring_up_example
 
 run_log "Interact with web socket ws -> ws"


### PR DESCRIPTION
Commit Message: ci: explicitly specify the service want to start for kafka example
Additional Description:
CI failed on kafka and websocket example verify test:
```
kafka is missing dependency kafka-client
ERROR: starting kafka .
```
```
websocket is missing dependency client-ws
ERROR: starting websocket .
```
Risk Level: low
Testing: CI test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
