### PR TITLE
contrib: Fix libqatzip build errors on local clang-15

### DIFF
--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -24,7 +24,7 @@ configure_make(
     ],
     env = select({
         "//bazel:clang_build": {
-            "CFLAGS": "-Wno-error=newline-eof",
+            "CFLAGS": "-Wno-error=newline-eof -Wno-error=strict-prototypes -Wno-error=unused-but-set-variable",
         },
         "//conditions:default": {},
     }),


### PR DESCRIPTION
Add the related "-Wno-error" build options to suppress the warning errors:
	[-Werror,-Wstrict-prototypes]
	[-Werror,-Wunused-but-set-variable]

make[1]: Entering directory '../envoy/bazel-out/k8-opt/bin/contrib/qat/compression/qatzip/compressor/source/qatzip.build_tmpdir/src'
  CC       libqatzip_la-qatzip.lo
In file included from qatzip.c:67:
./qatzip_internal.h:460:25: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
void streamBufferCleanup();
                        ^
                         void
qatzip.c:1703:18: error: variable 'sleep_cnt' set but not used [-Werror,-Wunused-but-set-variable]
    unsigned int sleep_cnt = 0;
                 ^
qatzip.c:2626:18: error: variable 'sleep_cnt' set but not used [-Werror,-Wunused-but-set-variable]
    unsigned int sleep_cnt = 0;
                 ^
3 errors generated.
make[1]: *** [Makefile:521: libqatzip_la-qatzip.lo] Error 1