### PR TITLE
redis: Add support for the WATCH command

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -239,5 +239,8 @@ new_features:
 - area: stream info
   change: |
     Added time spent reading request headers to ``DownstreamTiming``.
+- area: redis
+  change: |
+    Added support for the watch command (aborts multi transactions if watched keys change).
 
 deprecated:

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -208,6 +208,7 @@ For details on each command's usage see the official
   SRANDMEMBER, Set
   SREM, Set
   SSCAN, Set
+  WATCH, String
   ZADD, Sorted Set
   ZCARD, Sorted Set
   ZCOUNT, Sorted Set

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -29,7 +29,7 @@ struct SupportedCommands {
         "persist", "pexpire", "pexpireat", "pfadd", "pfcount", "psetex", "pttl", "restore", "rpop",
         "rpush", "rpushx", "sadd", "scard", "set", "setbit", "setex", "setnx", "setrange",
         "sismember", "smembers", "spop", "srandmember", "srem", "sscan", "strlen", "ttl", "type",
-        "zadd", "zcard", "zcount", "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange",
+        "watch", "zadd", "zcard", "zcount", "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange",
         "zrangebylex", "zrangebyscore", "zrank", "zrem", "zremrangebylex", "zremrangebyrank",
         "zremrangebyscore", "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan",
         "zscore");


### PR DESCRIPTION
Commit Message: Add support for the redis WATCH command
Additional Description: Allows the WATCH command to be used.  When a WATCH is in place on a given server, any changes to a watched key will cause subsequent MULTI transactions to abort.  Having support for WATCH is important as it allows transaction-like functionality (even though redis doesn't support transactions).  There is no special client support required for WATCH.
Risk Level: Low
Testing: manual.  There doesn't appear to be CI tests for individual, supported, commands.
Docs Changes: Added "WATCH" to the supported command table.
Release Notes: Added.
Platform Specific Features: None