### PR TITLE
mobile: changing the lifetime of k-v store

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -835,16 +835,20 @@ EngineSharedPtr EngineBuilder::build() {
 
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.
-    auto* api = new envoy_kv_store();
-    *api = store->asEnvoyKeyValueStore();
-    register_platform_api(name.c_str(), api);
+    if (!Api::External::retrieveApi(name, true)) {
+      auto* api = new envoy_kv_store();
+      *api = store->asEnvoyKeyValueStore();
+      register_platform_api(name.c_str(), api);
+    }
   }
 
   for (const auto& [name, accessor] : string_accessors_) {
     // TODO(RyanTheOptimist): This leaks, but it's tied to the life of the engine.
-    auto* api = new envoy_string_accessor();
-    *api = StringAccessor::asEnvoyStringAccessor(accessor);
-    register_platform_api(name.c_str(), api);
+    if (!Api::External::retrieveApi(name, true)) {
+      auto* api = new envoy_string_accessor();
+      *api = StringAccessor::asEnvoyStringAccessor(accessor);
+      register_platform_api(name.c_str(), api);
+    }
   }
 
   Engine* engine = new Engine(envoy_engine);

--- a/mobile/library/common/api/external.cc
+++ b/mobile/library/common/api/external.cc
@@ -24,9 +24,11 @@ void registerApi(std::string name, void* api) {
 // before any reads occur.
 // TODO(alyssawilk, abeyad): gracefully handle the case where an Api by the given name is not
 // registered.
-void* retrieveApi(std::string name) {
+void* retrieveApi(std::string name, bool allow_absent) {
   void* api = registry_[name];
-  RELEASE_ASSERT(api != nullptr, fmt::format("{} not registered", name));
+  if (!allow_absent) {
+    RELEASE_ASSERT(api != nullptr, fmt::format("{} not registered", name));
+  }
   return api;
 }
 

--- a/mobile/library/common/api/external.h
+++ b/mobile/library/common/api/external.h
@@ -14,7 +14,7 @@ void registerApi(std::string name, void* api);
 /**
  * Retrieve an external runtime API for usage (e.g. in extensions).
  */
-void* retrieveApi(std::string name);
+void* retrieveApi(std::string name, bool allow_absent = false);
 
 } // namespace External
 } // namespace Api

--- a/mobile/library/common/extensions/key_value/platform/config.cc
+++ b/mobile/library/common/extensions/key_value/platform/config.cc
@@ -18,28 +18,27 @@ constexpr absl::string_view PlatformStoreName{"reserved.platform_store"};
 class PlatformInterfaceImpl : public PlatformInterface,
                               public Logger::Loggable<Logger::Id::filter> {
 public:
-  PlatformInterfaceImpl()
-      : bridged_store_(*static_cast<envoy_kv_store*>(
-            Api::External::retrieveApi(std::string(PlatformStoreName)))) {}
+  PlatformInterfaceImpl() = default;
 
   ~PlatformInterfaceImpl() override {}
 
   std::string read(const std::string& key) const override {
+    envoy_kv_store& bridged_store =
+        *static_cast<envoy_kv_store*>(Api::External::retrieveApi(std::string(PlatformStoreName)));
     envoy_data bridged_key = Data::Utility::copyToBridgeData(key);
-    envoy_data bridged_value = bridged_store_.read(bridged_key, bridged_store_.context);
+    envoy_data bridged_value = bridged_store.read(bridged_key, bridged_store.context);
     std::string result = Data::Utility::copyToString(bridged_value);
     release_envoy_data(bridged_value);
     return result;
   }
 
   void save(const std::string& key, const std::string& contents) override {
+    envoy_kv_store& bridged_store =
+        *static_cast<envoy_kv_store*>(Api::External::retrieveApi(std::string(PlatformStoreName)));
     envoy_data bridged_key = Data::Utility::copyToBridgeData(key);
     envoy_data bridged_value = Data::Utility::copyToBridgeData(contents);
-    bridged_store_.save(bridged_key, bridged_value, bridged_store_.context);
+    bridged_store.save(bridged_key, bridged_value, bridged_store.context);
   }
-
-private:
-  envoy_kv_store& bridged_store_;
 };
 
 PlatformInterfaceImpl& getPlatformInterfaceImplSingleton() {

--- a/mobile/library/common/extensions/key_value/platform/config.cc
+++ b/mobile/library/common/extensions/key_value/platform/config.cc
@@ -22,9 +22,12 @@ public:
 
   ~PlatformInterfaceImpl() override {}
 
+  envoy_kv_store* bridgedStore() const {
+    return static_cast<envoy_kv_store*>(Api::External::retrieveApi(std::string(PlatformStoreName)));
+  }
+
   std::string read(const std::string& key) const override {
-    envoy_kv_store& bridged_store =
-        *static_cast<envoy_kv_store*>(Api::External::retrieveApi(std::string(PlatformStoreName)));
+    envoy_kv_store& bridged_store = *bridgedStore();
     envoy_data bridged_key = Data::Utility::copyToBridgeData(key);
     envoy_data bridged_value = bridged_store.read(bridged_key, bridged_store.context);
     std::string result = Data::Utility::copyToString(bridged_value);
@@ -33,8 +36,7 @@ public:
   }
 
   void save(const std::string& key, const std::string& contents) override {
-    envoy_kv_store& bridged_store =
-        *static_cast<envoy_kv_store*>(Api::External::retrieveApi(std::string(PlatformStoreName)));
+    envoy_kv_store& bridged_store = *bridgedStore();
     envoy_data bridged_key = Data::Utility::copyToBridgeData(key);
     envoy_data bridged_value = Data::Utility::copyToBridgeData(contents);
     bridged_store.save(bridged_key, bridged_value, bridged_store.context);

--- a/mobile/library/common/extensions/key_value/platform/config.cc
+++ b/mobile/library/common/extensions/key_value/platform/config.cc
@@ -18,29 +18,28 @@ constexpr absl::string_view PlatformStoreName{"reserved.platform_store"};
 class PlatformInterfaceImpl : public PlatformInterface,
                               public Logger::Loggable<Logger::Id::filter> {
 public:
-  PlatformInterfaceImpl() = default;
+  PlatformInterfaceImpl()
+      : bridged_store_(*static_cast<envoy_kv_store*>(
+            Api::External::retrieveApi(std::string(PlatformStoreName)))) {}
 
   ~PlatformInterfaceImpl() override {}
 
-  envoy_kv_store* bridgedStore() const {
-    return static_cast<envoy_kv_store*>(Api::External::retrieveApi(std::string(PlatformStoreName)));
-  }
-
   std::string read(const std::string& key) const override {
-    envoy_kv_store& bridged_store = *bridgedStore();
     envoy_data bridged_key = Data::Utility::copyToBridgeData(key);
-    envoy_data bridged_value = bridged_store.read(bridged_key, bridged_store.context);
+    envoy_data bridged_value = bridged_store_.read(bridged_key, bridged_store_.context);
     std::string result = Data::Utility::copyToString(bridged_value);
     release_envoy_data(bridged_value);
     return result;
   }
 
   void save(const std::string& key, const std::string& contents) override {
-    envoy_kv_store& bridged_store = *bridgedStore();
     envoy_data bridged_key = Data::Utility::copyToBridgeData(key);
     envoy_data bridged_value = Data::Utility::copyToBridgeData(contents);
-    bridged_store.save(bridged_key, bridged_value, bridged_store.context);
+    bridged_store_.save(bridged_key, bridged_value, bridged_store_.context);
   }
+
+private:
+  envoy_kv_store& bridged_store_;
 };
 
 PlatformInterfaceImpl& getPlatformInterfaceImplSingleton() {

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -271,10 +271,6 @@ TEST_P(ClientIntegrationTest, BasicHttp2) {
 
 // Do HTTP/3 without doing the alt-svc-over-HTTP/2 dance.
 TEST_P(ClientIntegrationTest, Http3WithQuicHints) {
-  if (version_ != Network::Address::IpVersion::v4) {
-    // Loopback resolves to a v4 address.
-    return;
-  }
   EXPECT_CALL(helper_handle_->mock_helper(), isCleartextPermitted(_)).Times(0);
   EXPECT_CALL(helper_handle_->mock_helper(), validateCertificateChain(_, _));
   EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation());

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -48,6 +48,13 @@ protected:
 class ClientIntegrationTest : public BaseClientIntegrationTest,
                               public testing::TestWithParam<Network::Address::IpVersion> {
 public:
+  static void SetUpTestCase() {
+    test_key_value_store_ = std::make_shared<TestKeyValueStore>();
+  }
+  static void TearDownTestCase() {
+    test_key_value_store_.reset();
+  }
+
   ClientIntegrationTest() : BaseClientIntegrationTest(/*ip_version=*/GetParam()) {
     // For H3 tests.
     Network::forceRegisterUdpDefaultWriterFactoryFactory();
@@ -76,7 +83,6 @@ public:
       // www.lyft.com being recognized as QUIC ready.
       builder_.addQuicCanonicalSuffix(".lyft.com");
       builder_.addQuicHint("foo.lyft.com", upstream_port);
-      ASSERT(test_key_value_store_);
 
       // Force www.lyft.com to resolve to the fake upstream. It's the only domain
       // name the certs work for so we want that in the request, but we need to
@@ -100,8 +106,10 @@ public:
 protected:
   std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
   bool add_quic_hints_ = false;
-  std::shared_ptr<TestKeyValueStore> test_key_value_store_;
+  static std::shared_ptr<TestKeyValueStore> test_key_value_store_;
 };
+
+std::shared_ptr<TestKeyValueStore> ClientIntegrationTest::test_key_value_store_{};
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClientIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
@@ -279,7 +287,6 @@ TEST_P(ClientIntegrationTest, Http3WithQuicHints) {
   builder_.enablePlatformCertificatesValidation(true);
   // Create a k-v store for DNS lookup which createEnvoy() will use to point
   // www.lyft.com -> fake H3 backend.
-  test_key_value_store_ = std::make_shared<TestKeyValueStore>();
   builder_.addKeyValueStore("reserved.platform_store", test_key_value_store_);
   builder_.enableDnsCache(true, 1);
   upstream_tls_ = true;

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -48,12 +48,8 @@ protected:
 class ClientIntegrationTest : public BaseClientIntegrationTest,
                               public testing::TestWithParam<Network::Address::IpVersion> {
 public:
-  static void SetUpTestCase() {
-    test_key_value_store_ = std::make_shared<TestKeyValueStore>();
-  }
-  static void TearDownTestCase() {
-    test_key_value_store_.reset();
-  }
+  static void SetUpTestCase() { test_key_value_store_ = std::make_shared<TestKeyValueStore>(); }
+  static void TearDownTestCase() { test_key_value_store_.reset(); }
 
   ClientIntegrationTest() : BaseClientIntegrationTest(/*ip_version=*/GetParam()) {
     // For H3 tests.


### PR DESCRIPTION
previously the singleton nature of the PlatformInterfaceImpl meant a first envoy engine would setAPI to set the location of the platform bridge k-v store, we'd retreiveApi locate it and use it.  A subsequent engine would allocate setApi to a new location (for YT hopefully the same k-v store) but we'd never retreiveApi and use it.  We now don't allocate it - the original API will be used for the lifetime of the engines existing to better handle MultiEnvoyMobile deployments.

This updates the test to use the same k-v store across tests, as deployments also need to have a shared store across engines.

This fixes a failure mode in the H3 test where a second test pointed at the store for the first test.

Risk Level: medium
Testing: yes
Docs Changes: no
Release Notes: no