### PR TITLE
docs: fix kafka cluster reference

### DIFF
--- a/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/kafka_broker_filter.rst
@@ -154,7 +154,7 @@ in 2-node cluster:
                 socket_address:
                   address: broker1.example.org # Kafka broker's host for broker 1.
                   port_value: 9092             # Kafka broker's port for broker 1.
-  - name: broker1cluster
+  - name: broker2cluster
     connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix reference to `broker2cluster` in Kafka broker filter example docs. Currently `broker1cluster` is listed twice under clusters.
Additional Description: -
Risk Level: Low
Testing: Docs only
Docs Changes: Fix error in https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/kafka_broker_filter#config-network-filters-kafka-broker-config-no-mutation
Release Notes: -
Platform Specific Features: -
