### PR TITLE
Fix undefined behavior in MockOsSysCalls::setsockopt

### DIFF
--- a/test/mocks/api/mocks.cc
+++ b/test/mocks/api/mocks.cc
@@ -1,5 +1,7 @@
 #include "mocks.h"
 
+#include <cstring>
+
 #include "source/common/common/assert.h"
 #include "source/common/common/lock_guard.h"
 
@@ -66,7 +68,9 @@ SysCallIntResult MockOsSysCalls::setsockopt(os_fd_t sockfd, int level, int optna
   }
 
   if (optlen >= sizeof(int)) {
-    boolsockopts_[SockOptKey(sockfd, level, optname)] = !!*reinterpret_cast<const int*>(optval);
+    int val = 0;
+    memcpy(&val, optval, sizeof(int));
+    boolsockopts_[SockOptKey(sockfd, level, optname)] = (val != 0);
   }
   return SysCallIntResult{0, 0};
 };


### PR DESCRIPTION
Commit Message: Fix undefined behavior in MockOsSysCalls::setsockopt
Additional Description: optval may point to an arbitrary type, and casting it to int* is a violation of strict aliasing. The correct way to use it as an int is to memcpy the contents to an int.
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
