### PR TITLE
upstream: fix a bug of legacy lb config convertions

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -110,6 +110,10 @@ bug_fixes:
     Fixed a race condition that when multiple requests with the same authority header are sent to Envoy, sometimes some requests
     may receive 503 response with no_healthy_upstream from Envoy. The fix is guarded by runtime guard
     ``envoy.reloadable_features.dns_cache_set_first_resolve_complete``, which defaults to true.
+- area: upstream
+  change: |
+    Fixed a bug that the subset load balancer will always be used even if the subset load balancer config does not
+    contain any subset selector.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -949,7 +949,9 @@ LegacyLbPolicyConfigHelper::getTypedLbConfigFromLegacyProto(
     const ClusterProto& cluster, ProtobufMessage::ValidationVisitor& visitor) {
 
   // Handle the lb subset config case first.
-  if (cluster.has_lb_subset_config()) {
+  // Note it is possible to have a lb_subset_config without actually having any subset selectors.
+  // In this case the subset load balancer should not be used.
+  if (cluster.has_lb_subset_config() && !cluster.lb_subset_config().subset_selectors().empty()) {
     auto* lb_factory = Config::Utility::getFactoryByName<TypedLoadBalancerFactory>(
         "envoy.load_balancing_policies.subset");
     if (lb_factory != nullptr) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2628,6 +2628,36 @@ TEST_F(StaticClusterImplTest, LoadBalancingPolicyWithLbSubsetConfig) {
       EnvoyException, "cluster: load_balancing_policy cannot be combined with lb_subset_config");
 }
 
+// Empty lb_subset_config is set and it should be ignored.
+TEST_F(StaticClusterImplTest, EmptyLbSubsetConfig) {
+  const std::string yaml = R"EOF(
+    name: staticcluster
+    connect_timeout: 0.25s
+    type: static
+    lb_policy: ROUND_ROBIN
+    lb_subset_config: {}
+    load_assignment:
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 10.0.0.1
+                  port_value: 11001
+  )EOF";
+
+  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
+
+  Envoy::Upstream::ClusterFactoryContextImpl factory_context(
+      server_context_, server_context_.cluster_manager_, nullptr, ssl_context_manager_, nullptr,
+      true);
+
+  auto cluster = createCluster(cluster_config, factory_context);
+
+  EXPECT_EQ(cluster->info()->loadBalancerFactory()->name(),
+            "envoy.load_balancing_policies.round_robin");
+}
+
 // Verify that if Envoy does not have a factory for any of the load balancing policies specified in
 // the load balancing policy config, it is an error.
 TEST_F(StaticClusterImplTest, LbPolicyConfigThrowsExceptionIfNoLbPoliciesFound) {


### PR DESCRIPTION
Commit Message: upstream: fix a bug of legacy lb config convertions
Additional Description:

in the #29235, we deprecated legacy load balancer creation code path and covert the legacy load balancer config to the latest typed extensions.

However, that change introduced a bug. When a empty `lb_subset_config` (without `subset_selectors`) is provided, the conversion logic will always try to create a subset lb extension. This is not match with our previous logic and may result in unexpected load balancing results.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
