### PR TITLE
[Maxmind] Try build extension for osx

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -617,10 +617,11 @@ envoy_cmake(
 )
 
 envoy_cc_library(
-    name = "maxmind_linux",
+    name = "maxmind_linux_apple",
     srcs = [],
     deps = select({
         "//bazel:linux": [":maxmind"],
+        "//bazel:apple": [":maxmind"],
         "//conditions:default": [],
     }),
 )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1462,5 +1462,5 @@ def _com_github_maxmind_libmaxminddb():
     )
     native.bind(
         name = "maxmind",
-        actual = "@envoy//bazel/foreign_cc:maxmind_linux",
+        actual = "@envoy//bazel/foreign_cc:maxmind_linux_apple",
     )


### PR DESCRIPTION
This patch attempts (but fails) to fix Maxmind extension not being available on Osx due to past intentional [limiting](https://github.com/envoyproxy/envoy/pull/28490/commits/d5fdbf7ec0027a74c1d1c0d800d636ae382f26b2) of the extension to only be available on Linux. 

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes: TBD
Platform Specific Features:
Attempts to Fix #30764
