### PR TITLE
android: Fix Netlink message length in Android's getifaddrs

### DIFF
--- a/third_party/android/ifaddrs-android.h
+++ b/third_party/android/ifaddrs-android.h
@@ -174,7 +174,7 @@ inline int getifaddrs(ifaddrs** result) {
     memset(&addrRequest, 0, sizeof(addrRequest));
     addrRequest.netlinkHeader.nlmsg_flags = NLM_F_REQUEST | NLM_F_MATCH;
     addrRequest.netlinkHeader.nlmsg_type = RTM_GETADDR;
-    addrRequest.netlinkHeader.nlmsg_len = NLMSG_ALIGN(NLMSG_LENGTH(sizeof(addrRequest)));
+    addrRequest.netlinkHeader.nlmsg_len = NLMSG_ALIGN(NLMSG_LENGTH(sizeof(ifaddrmsg)));
     addrRequest.msg.ifa_family = AF_UNSPEC; // All families.
     addrRequest.msg.ifa_index = 0; // All interfaces.
     if (!sendNetlinkMessage(fd.get(), &addrRequest, addrRequest.netlinkHeader.nlmsg_len)) {


### PR DESCRIPTION
This was discovered through figuring out another bug within Google's build environment when upgrading the NDK version to 26.

Thankfully, there are no users of this code right now.

Risk Level: Low (no users right now)
Testing: Within Google's build infra where an upgrade to NDK26 was available
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: Android only
