### PR TITLE
github/ci: Add back missing publishing secrets

### DIFF
--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -51,6 +51,11 @@ jobs:
       head-sha: ${{ inputs.sha }}
 
   publish:
+    secrets:
+      ENVOY_CI_SYNC_APP_ID: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_SYNC_APP_ID || '' }}
+      ENVOY_CI_SYNC_APP_KEY: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_SYNC_APP_KEY || '' }}
+      ENVOY_CI_PUBLISH_APP_ID: ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_PUBLISH_APP_ID || '' }}
+      ENVOY_CI_PUBLISH_APP_KEY:  ${{ fromJSON(needs.load.outputs.trusted) && secrets.ENVOY_CI_PUBLISH_APP_KEY || '' }}
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
