### PR TITLE
test: use TestTraceContextImpl to replace header map in tracer tests

### DIFF
--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -183,9 +183,8 @@ public:
   }
 
   const std::string operation_name_{"test"};
-  Http::TestRequestHeaderMapImpl request_headers_{
+  Tracing::TestTraceContextImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
-  const Http::TestResponseHeaderMapImpl response_headers_{{":status", "500"}};
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
 
   std::unique_ptr<TestDriver> driver_;
@@ -317,7 +316,8 @@ TEST_F(OpenTracingDriverTest, InjectFailure) {
 
     const auto span_context_injection_error_count =
         stats_.counter("tracing.opentracing.span_context_injection_error").value();
-    EXPECT_FALSE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
+    EXPECT_FALSE(
+        request_headers_.context_map_.contains(Http::CustomHeaders::get().OtSpanContext.get()));
     span->injectContext(request_headers_, nullptr);
 
     EXPECT_EQ(span_context_injection_error_count + 1,

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -80,7 +80,7 @@ public:
   }
 
   const std::string operation_name_{"test"};
-  Http::TestRequestHeaderMapImpl request_headers_{
+  Tracing::TestTraceContextImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
 
   NiceMock<ThreadLocal::MockInstance> tls_;

--- a/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/dynamic_ot/dynamic_opentracing_driver_impl_test.cc
@@ -41,7 +41,7 @@ public:
   Stats::IsolatedStoreImpl stats_;
 
   const std::string operation_name_{"test"};
-  Http::TestRequestHeaderMapImpl request_headers_{
+  Tracing::TestTraceContextImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
 
   NiceMock<Tracing::MockConfig> config_;

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -147,7 +147,7 @@ TEST_F(OpenTelemetryDriverTest, ParseSpanContextFromHeadersTest) {
   setupValidDriver();
 
   // Add the OTLP headers to the request headers
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
   // traceparent header is "version-trace_id-parent_id-trace_flags"
   // See https://w3c.github.io/trace-context/#traceparent-header
@@ -161,9 +161,9 @@ TEST_F(OpenTelemetryDriverTest, ParseSpanContextFromHeadersTest) {
   const std::vector<std::string> v = {version, trace_id_hex, Hex::uint64ToHex(parent_span_id),
                                       trace_flags};
   const std::string parent_trace_header = absl::StrJoin(v, "-");
-  request_headers.addReferenceKey(OpenTelemetryConstants::get().TRACE_PARENT, parent_trace_header);
+  request_headers.set(OpenTelemetryConstants::get().TRACE_PARENT, parent_trace_header);
   // Also add tracestate.
-  request_headers.addReferenceKey(OpenTelemetryConstants::get().TRACE_STATE, "test=foo");
+  request_headers.set(OpenTelemetryConstants::get().TRACE_STATE, "test=foo");
 
   // Mock the random call for generating span ID so we can check it later.
   const uint64_t new_span_id = 3;
@@ -181,15 +181,15 @@ TEST_F(OpenTelemetryDriverTest, ParseSpanContextFromHeadersTest) {
   request_headers.remove(OpenTelemetryConstants::get().TRACE_STATE);
   span->injectContext(request_headers, nullptr);
 
-  auto sampled_entry = request_headers.get(OpenTelemetryConstants::get().TRACE_PARENT);
-  EXPECT_EQ(sampled_entry.size(), 1);
+  auto sampled_entry = request_headers.getByKey(OpenTelemetryConstants::get().TRACE_PARENT);
+  EXPECT_EQ(sampled_entry.has_value(), true);
   EXPECT_EQ(
-      sampled_entry[0]->value().getStringView(),
+      sampled_entry.value(),
       absl::StrJoin({version, trace_id_hex, Hex::uint64ToHex(new_span_id), trace_flags}, "-"));
 
   auto sampled_tracestate_entry = request_headers.get(OpenTelemetryConstants::get().TRACE_STATE);
-  EXPECT_EQ(sampled_tracestate_entry.size(), 1);
-  EXPECT_EQ(sampled_tracestate_entry[0]->value().getStringView(), "test=foo");
+  EXPECT_EQ(sampled_tracestate_entry.has_value(), true);
+  EXPECT_EQ(sampled_tracestate_entry.value(), "test=foo");
   constexpr absl::string_view request_yaml = R"(
 resource_spans:
   resource:
@@ -238,7 +238,7 @@ TEST_F(OpenTelemetryDriverTest, GenerateSpanContextWithoutHeadersTest) {
   setupValidDriver();
 
   // Add the OTLP headers to the request headers
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   // Mock the random call for generating trace and span IDs so we can check it later.
@@ -267,19 +267,17 @@ TEST_F(OpenTelemetryDriverTest, GenerateSpanContextWithoutHeadersTest) {
 
   // Ends in 01 because span should be sampled. See
   // https://w3c.github.io/trace-context/#trace-flags.
-  EXPECT_EQ(sampled_entry.size(), 1);
-  EXPECT_EQ(sampled_entry[0]->value().getStringView(),
-            "00-00000000000000010000000000000002-0000000000000003-01");
+  EXPECT_EQ(sampled_entry.has_value(), true);
+  EXPECT_EQ(sampled_entry.value(), "00-00000000000000010000000000000002-0000000000000003-01");
 }
 
 // Verifies a span it not created when an invalid traceparent header is received
 TEST_F(OpenTelemetryDriverTest, NullSpanWithPropagationHeaderError) {
   setupValidDriver();
   // Add an invalid OTLP header to the request headers.
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
-  request_headers.addReferenceKey(OpenTelemetryConstants::get().TRACE_PARENT,
-                                  "invalid00-0000000000000003-01");
+  request_headers.set(OpenTelemetryConstants::get().TRACE_PARENT, "invalid00-0000000000000003-01");
 
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
                                              operation_name_, {Tracing::Reason::Sampling, true});
@@ -292,7 +290,7 @@ TEST_F(OpenTelemetryDriverTest, NullSpanWithPropagationHeaderError) {
 TEST_F(OpenTelemetryDriverTest, ExportOTLPSpan) {
   // Set up driver
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
@@ -320,7 +318,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpan) {
 TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithBuffer) {
   // Set up driver
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
@@ -353,7 +351,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithFlushTimeout) {
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5000), _));
   // Set up driver
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
@@ -381,7 +379,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithFlushTimeout) {
 TEST_F(OpenTelemetryDriverTest, SpawnChildSpan) {
   // Set up driver
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   // Mock the random call for generating the parent span's IDs so we can check it later.
@@ -422,7 +420,7 @@ TEST_F(OpenTelemetryDriverTest, SpawnChildSpan) {
 TEST_F(OpenTelemetryDriverTest, SpanType) {
   // Set up driver
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   // Mock the random call for generating the parent span's IDs so we can check it later.
@@ -539,7 +537,7 @@ TEST_F(OpenTelemetryDriverTest, SpanType) {
 // Verifies spans are exported with their attributes
 TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithAttributes) {
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
@@ -608,7 +606,7 @@ resource_spans:
 // Not sampled spans are ignored
 TEST_F(OpenTelemetryDriverTest, IgnoreNotSampledSpan) {
   setupValidDriver();
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
                                              operation_name_, {Tracing::Reason::Sampling, true});
@@ -629,7 +627,7 @@ TEST_F(OpenTelemetryDriverTest, NoExportWithoutGrpcService) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
   setup(opentelemetry_config);
 
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
 
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
@@ -659,7 +657,7 @@ TEST_F(OpenTelemetryDriverTest, ExportSpanWithCustomServiceName) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
   setup(opentelemetry_config);
 
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
   NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
       context_.server_factory_context_.api_.random_;
@@ -723,7 +721,7 @@ TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanHTTP) {
   context_.server_factory_context_.cluster_manager_.initializeClusters({"my_o11y_backend"}, {});
   setupValidDriverWithHttpExporter();
 
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
   Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
                                              operation_name_, {Tracing::Reason::Sampling, true});

--- a/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
+++ b/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
@@ -77,10 +77,10 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
 
   {
     auto previous_header_value = SkyWalkingTestHelper::createPropagatedSW8HeaderValue(false, "");
-    Http::TestRequestHeaderMapImpl request_headers{{"sw8", previous_header_value},
-                                                   {":path", "/path"},
-                                                   {":method", "GET"},
-                                                   {":authority", "test.com"}};
+    Tracing::TestTraceContextImpl request_headers{{"sw8", previous_header_value},
+                                                  {":path", "/path"},
+                                                  {":method", "GET"},
+                                                  {":authority", "test.com"}};
     ON_CALL(mock_tracing_config_, operationName())
         .WillByDefault(Return(Tracing::OperationName::Ingress));
 
@@ -110,7 +110,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
 
   {
     // Create new span segment with no previous span context.
-    Http::TestRequestHeaderMapImpl new_request_headers{
+    Tracing::TestTraceContextImpl new_request_headers{
         {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
     Tracing::SpanPtr org_span =
@@ -132,11 +132,10 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
 
   {
     // Create new span segment with error propagation header.
-    Http::TestRequestHeaderMapImpl error_request_headers{
-        {":path", "/path"},
-        {":method", "GET"},
-        {":authority", "test.com"},
-        {"sw8", "xxxxxx-error-propagation-header"}};
+    Tracing::TestTraceContextImpl error_request_headers{{":path", "/path"},
+                                                        {":method", "GET"},
+                                                        {":authority", "test.com"},
+                                                        {"sw8", "xxxxxx-error-propagation-header"}};
     Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, error_request_headers,
                                                    stream_info_, "TEST_OP", decision);
     Span* span = dynamic_cast<Span*>(org_span.get());
@@ -155,7 +154,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
 
   {
     // Create new span segment with error propagation header.
-    Http::TestRequestHeaderMapImpl error_request_headers{
+    Tracing::TestTraceContextImpl error_request_headers{
         {":path", "/path"},
         {":method", "GET"},
         {":authority", "test.com"},
@@ -180,7 +179,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
   {
     // Create null span with disabled tracing.
     decision.traced = false;
-    Http::TestRequestHeaderMapImpl request_headers{
+    Tracing::TestTraceContextImpl request_headers{
         {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
     Tracing::SpanPtr org_null_span = driver_->startSpan(mock_tracing_config_, request_headers,
                                                         stream_info_, "TEST_OP", decision);
@@ -194,11 +193,10 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
   {
     // Create null span with disabled tracing.
     decision.traced = false;
-    Http::TestRequestHeaderMapImpl error_request_headers{
-        {":path", "/path"},
-        {":method", "GET"},
-        {":authority", "test.com"},
-        {"sw8", "xxxxxx-error-propagation-header"}};
+    Tracing::TestTraceContextImpl error_request_headers{{":path", "/path"},
+                                                        {":method", "GET"},
+                                                        {":authority", "test.com"},
+                                                        {"sw8", "xxxxxx-error-propagation-header"}};
     Tracing::SpanPtr org_null_span = driver_->startSpan(mock_tracing_config_, error_request_headers,
                                                         stream_info_, "TEST_OP", decision);
 
@@ -211,7 +209,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
   {
     // Create null span with disabled tracing.
     decision.traced = false;
-    Http::TestRequestHeaderMapImpl error_request_headers{
+    Tracing::TestTraceContextImpl error_request_headers{
         {":path", "/path"},
         {":method", "GET"},
         {":authority", "test.com"},
@@ -239,7 +237,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestNoClientConfig) {
   decision.reason = Tracing::Reason::Sampling;
   decision.traced = true;
 
-  Http::TestRequestHeaderMapImpl request_headers{
+  Tracing::TestTraceContextImpl request_headers{
       {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
   Tracing::SpanPtr org_span =

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -152,8 +152,8 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     // child span (EXIT span).
     EXPECT_EQ(span->spanEntity()->operationName(), first_child_span->spanEntity()->operationName());
 
-    Http::TestRequestHeaderMapImpl first_child_headers{{":authority", "test.com"},
-                                                       {":path", "/upstream/path"}};
+    Tracing::TestTraceContextImpl first_child_headers{{":authority", "test.com"},
+                                                      {":path", "/upstream/path"}};
     Upstream::HostDescriptionConstSharedPtr host{
         new testing::NiceMock<Upstream::MockHostDescription>()};
 
@@ -162,7 +162,7 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     // request.
     EXPECT_EQ("/upstream/path", first_child_span->spanEntity()->operationName());
 
-    auto sp = createSpanContext(first_child_headers.get_("sw8"));
+    auto sp = createSpanContext(std::string(first_child_headers.get("sw8").value()));
     EXPECT_EQ("CURR#SERVICE", sp->service());
     EXPECT_EQ("CURR#INSTANCE", sp->serviceInstance());
     EXPECT_EQ("/downstream/path", sp->endpoint());
@@ -189,10 +189,10 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     EXPECT_EQ(span->spanEntity()->operationName(),
               second_child_span->spanEntity()->operationName());
 
-    Http::TestRequestHeaderMapImpl second_child_headers{{":authority", "test.com"}};
+    Tracing::TestTraceContextImpl second_child_headers{{":authority", "test.com"}};
 
     second_child_span->injectContext(second_child_headers, nullptr);
-    auto sp = createSpanContext(second_child_headers.get_("sw8"));
+    auto sp = createSpanContext(std::string(second_child_headers.get("sw8").value()));
     EXPECT_EQ("CURR#SERVICE", sp->service());
     EXPECT_EQ("CURR#INSTANCE", sp->serviceInstance());
     EXPECT_EQ("/downstream/path", sp->endpoint());

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -507,13 +507,13 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
   auto span = tracer.startSpan(config_, "ingress", server_.timeSource().systemTime(),
                                absl::nullopt /*headers*/,
                                absl::nullopt /*client_ip from x-forwarded-for header*/);
-  Http::TestRequestHeaderMapImpl request_headers;
+  Tracing::TestTraceContextImpl request_headers{};
   span->injectContext(request_headers, nullptr);
   auto header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
-  ASSERT_FALSE(header.empty());
-  EXPECT_NE(header[0]->value().getStringView().find("Root="), absl::string_view::npos);
-  EXPECT_NE(header[0]->value().getStringView().find("Parent="), absl::string_view::npos);
-  EXPECT_NE(header[0]->value().getStringView().find("Sampled=1"), absl::string_view::npos);
+  ASSERT_FALSE(!header.has_value());
+  EXPECT_NE(header.value().find("Root="), absl::string_view::npos);
+  EXPECT_NE(header.value().find("Parent="), absl::string_view::npos);
+  EXPECT_NE(header.value().find("Sampled=1"), absl::string_view::npos);
 }
 
 TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
@@ -525,13 +525,13 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
                 server_.timeSource(),
                 server_.api().randomGenerator()};
   auto span = tracer.createNonSampledSpan(absl::nullopt /*headers*/);
-  Http::TestRequestHeaderMapImpl request_headers;
+  Tracing::TestTraceContextImpl request_headers{};
   span->injectContext(request_headers, nullptr);
   auto header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
-  ASSERT_FALSE(header.empty());
-  EXPECT_NE(header[0]->value().getStringView().find("Root="), absl::string_view::npos);
-  EXPECT_NE(header[0]->value().getStringView().find("Parent="), absl::string_view::npos);
-  EXPECT_NE(header[0]->value().getStringView().find("Sampled=0"), absl::string_view::npos);
+  ASSERT_FALSE(!header.has_value());
+  EXPECT_NE(header.value().find("Root="), absl::string_view::npos);
+  EXPECT_NE(header.value().find("Parent="), absl::string_view::npos);
+  EXPECT_NE(header.value().find("Sampled=0"), absl::string_view::npos);
 }
 
 TEST_F(XRayTracerTest, TraceIDFormatTest) {

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -38,12 +38,12 @@ public:
   NiceMock<Server::Configuration::MockTracerFactoryContext> context_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<Tracing::MockConfig> tracing_config_;
-  Http::TestRequestHeaderMapImpl request_headers_{
+  Tracing::TestTraceContextImpl request_headers_{
       {":authority", "api.amazon.com"}, {":path", "/"}, {":method", "GET"}};
 };
 
 TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
-  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=0");
+  request_headers_.set(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=0");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
@@ -59,7 +59,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
 }
 
 TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
-  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=1");
+  request_headers_.set(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=1");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
@@ -73,7 +73,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
 }
 
 TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
-  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=");
+  request_headers_.set(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;Sampled=");
 
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
@@ -91,7 +91,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
 }
 
 TEST_F(XRayDriverTest, XRayTraceHeaderWithoutSamplingDecision) {
-  request_headers_.addCopy(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;");
+  request_headers_.set(std::string(XRayTraceHeader), "Root=1-272793;Parent=5398ad8;");
   // sampling rules with default fixed_target = 0 & rate = 0
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", R"EOF(
 {
@@ -134,7 +134,7 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
 }
 
 TEST_F(XRayDriverTest, XForwardedForHeaderSet) {
-  request_headers_.addCopy(std::string(XForwardedForHeader), "191.251.191.251");
+  request_headers_.set(std::string(XForwardedForHeader), "191.251.191.251");
   XRayConfiguration config{"" /*daemon_endpoint*/, "test_segment_name", "" /*sampling_rules*/,
                            "" /*origin*/, aws_metadata_};
   Driver driver(config, context_);

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -879,6 +879,19 @@ public:
     for (const auto& value : values) {
       context_map_[value.first] = value.second;
     }
+    // Backwards compatibility for tracing tests.
+    if (context_map_.contains(":protocol")) {
+      context_protocol_ = context_map_[":protocol"];
+    }
+    if (context_map_.contains(":authority")) {
+      context_host_ = context_map_[":authority"];
+    }
+    if (context_map_.contains(":path")) {
+      context_path_ = context_map_[":path"];
+    }
+    if (context_map_.contains(":method")) {
+      context_method_ = context_map_[":method"];
+    }
   }
   absl::string_view protocol() const override { return context_protocol_; }
   absl::string_view host() const override { return context_host_; }
@@ -891,6 +904,9 @@ public:
       }
     }
   }
+  absl::optional<absl::string_view> get(absl::string_view key) const { return getByKey(key); }
+  void set(absl::string_view key, absl::string_view value) { setByKey(key, value); }
+  void remove(absl::string_view key) { removeByKey(key); }
   absl::optional<absl::string_view> getByKey(absl::string_view key) const override {
     auto iter = context_map_.find(key);
     if (iter == context_map_.end()) {
@@ -898,6 +914,7 @@ public:
     }
     return iter->second;
   }
+
   void setByKey(absl::string_view key, absl::string_view val) override {
     context_map_.insert({std::string(key), std::string(val)});
   }


### PR DESCRIPTION

Commit Message: test: use TestTraceContextImpl to replace header map in tracer tests
Additional Description:

Using `TestTraceContextImpl` to relace all header map tracer tests because the `TraceContext` is the actual abstraction that tracers use.

Risk Level: n/a. Test only changes.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.