### PR TITLE
[bp/1.28] CI: explicitly specify the service want to start for kafka and websoc…

### DIFF
--- a/examples/kafka/verify.sh
+++ b/examples/kafka/verify.sh
@@ -4,6 +4,10 @@ export NAME=kafka
 export PORT_PROXY="${KAFKA_PORT_PROXY:-11100}"
 export PORT_ADMIN="${KAFKA_PORT_ADMIN:-11101}"
 
+# Explicitly specified the service want to start, since the `kafka-client` is expected to
+# not start.
+UPARGS="proxy kafka-server zookeeper"
+
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
 

--- a/examples/websocket/verify.sh
+++ b/examples/websocket/verify.sh
@@ -21,6 +21,8 @@ mkdir -p certs
 openssl req -batch -new -x509 -nodes -keyout certs/key.pem -out certs/cert.pem
 openssl pkcs12 -export -passout pass: -out certs/output.pkcs12 -inkey certs/key.pem -in certs/cert.pem
 
+UPARGS="proxy-ws proxy-wss-wss proxy-wss-passthrough service-ws service-wss"
+
 bring_up_example
 
 run_log "Interact with web socket ws -> ws"


### PR DESCRIPTION
…ket example (#31175)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
