### PR TITLE
filters: Handle possible missing port info in AlternateProtocolsCache

### DIFF
--- a/source/extensions/filters/http/alternate_protocols_cache/filter.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.cc
@@ -86,7 +86,7 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
     // available.
     hostname = encoder_callbacks_->streamInfo().upstreamInfo()->upstreamSslConnection()->sni();
   }
-  const uint32_t port = host->address()->ip()->port();
+  const uint32_t port = (host->address() ? host->address()->ip()->port() : 443);
   Http::HttpServerPropertiesCache::Origin origin(Http::Headers::get().SchemeValues.Https, hostname,
                                                  port);
   cache->setAlternatives(origin, protocols);

--- a/source/extensions/filters/http/alternate_protocols_cache/filter.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.cc
@@ -86,7 +86,8 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
     // available.
     hostname = encoder_callbacks_->streamInfo().upstreamInfo()->upstreamSslConnection()->sni();
   }
-  const uint32_t port = (host->address() ? host->address()->ip()->port() : 443);
+  auto host_addr = host->address();
+  const uint32_t port = (host_addr ? host_addr->ip()->port() : 443);
   Http::HttpServerPropertiesCache::Origin origin(Http::Headers::get().SchemeValues.Https, hostname,
                                                  port);
   cache->setAlternatives(origin, protocols);


### PR DESCRIPTION
Previously, to get the Origin, we would use the host->address() to get
the port.  However, it's possible that host->address() is not set,
resulting in a SIGSEGV.

In this commit, we check if host->address() is set, and if not, we use
the default port of 443.

Fixes #31250