### PR TITLE
quic: deflake CONNECT request test with early response 

### DIFF
--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -3009,10 +3009,6 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("404", response->headers().getStatusValue());
   EXPECT_FALSE(codec_client_->disconnected());
-  // Wait to process STOP_SENDING on the client for quic.
-  if (downstreamProtocol() == Http::CodecType::HTTP3) {
-    EXPECT_TRUE(response->waitForReset());
-  }
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/12131

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2987,6 +2987,10 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectIsBlocked) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("404", response->headers().getStatusValue());
   EXPECT_TRUE(response->complete());
+  // Wait to process STOP_SENDING on the client for quic.
+  if (downstreamProtocol() == Http::CodecType::HTTP3) {
+    EXPECT_TRUE(response->waitForReset());
+  }
 }
 
 // Make sure that with override_stream_error_on_invalid_http_message true, CONNECT
@@ -3005,6 +3009,10 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("404", response->headers().getStatusValue());
   EXPECT_FALSE(codec_client_->disconnected());
+  // Wait to process STOP_SENDING on the client for quic.
+  if (downstreamProtocol() == Http::CodecType::HTTP3) {
+    EXPECT_TRUE(response->waitForReset());
+  }
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/12131


### PR DESCRIPTION
Commit Message: fix a race between receiving STOP_SENDING frame and test tear down in CONNECT request with 4xx or 5xx early response which could cause UAF of IntegrationStreamDecoder. In `DownstreamProtocolIntegrationTest.ConnectIsBlocked` IntegrationStreamDecoder is created in the test body and destroyed before test Teardown().

```
[ RUN      ] DownstreamProtocols/DownstreamProtocolIntegrationTest.ConnectIsBlocked/IPv4_Http3Downstream_HttpUpstreamBalsaParserNghttp2NoDeferredProcessingLegacy
=================================================================
==18==ERROR: AddressSanitizer: heap-use-after-free on address 0x60f0000ce448 at pc 0x00000a958af0 bp 0x7ffec37fede0 sp 0x7ffec37fedd8
READ of size 8 at 0x60f0000ce448 thread T0
    #0 0xa958aef in Envoy::Http::StreamCallbackHelper::runResetCallbacks(Envoy::Http::StreamResetReason) /proc/self/cwd/./source/common/http/codec_helper.h:51:20
    #1 0xb3047ef in Envoy::Quic::EnvoyQuicClientStream::ResetWithError(quic::QuicResetStreamError) /proc/self/cwd/source/common/quic/envoy_quic_client_stream.cc:449:3
    #2 0xb8135d1 in quic::QuicStream::Reset(quic::QuicRstStreamErrorCode) /proc/self/cwd/external/com_github_google_quiche/quiche/quic/core/quic_stream.cc:589:3
    #3 0xb2f900d in Envoy::Quic::EnvoyQuicClientStream::resetStream(Envoy::Http::StreamResetReason) /proc/self/cwd/source/common/quic/envoy_quic_client_stream.cc:215:3
    #4 0xb2f903f in non-virtual thunk to Envoy::Quic::EnvoyQuicClientStream::resetStream(Envoy::Http::StreamResetReason) /proc/self/cwd/source/common/quic/envoy_quic_client_stream.cc
    #5 0xa4d683e in Envoy::Http::CodecClient::onEvent(Envoy::Network::ConnectionEvent) /proc/self/cwd/source/common/http/codec_client.cc:122:45
    #6 0xa4d8f8c in non-virtual thunk to Envoy::Http::CodecClient::onEvent(Envoy::Network::ConnectionEvent) /proc/self/cwd/source/common/http/codec_client.cc
    #7 0xc060ded in Envoy::Network::ConnectionImplBase::raiseConnectionEvent(Envoy::Network::ConnectionEvent) /proc/self/cwd/source/common/network/connection_impl_base.cc:62:17
    #8 0xb687955 in Envoy::Quic::QuicFilterManagerConnectionImpl::onConnectionCloseEvent(quic::QuicConnectionCloseFrame const&, quic::ConnectionCloseSource, quic::ParsedQuicVersion const&) /proc/self/cwd/source/common/quic/quic_filter_manager_connection_impl.cc:177:5
    #9 0xb2d0c68 in Envoy::Quic::EnvoyQuicClientSession::OnConnectionClosed(quic::QuicConnectionCloseFrame const&, quic::ConnectionCloseSource) /proc/self/cwd/source/common/quic/envoy_quic_client_session.cc:98:3
    #10 0xb2d107f in non-virtual thunk to Envoy::Quic::EnvoyQuicClientSession::OnConnectionClosed(quic::QuicConnectionCloseFrame const&, quic::ConnectionCloseSource) /proc/self/cwd/source/common/quic/envoy_quic_client_session.cc
    #11 0xb95623c in quic::QuicConnection::TearDownLocalConnectionState(quic::QuicConnectionCloseFrame const&, quic::ConnectionCloseSource) /proc/self/cwd/external/com_github_google_quiche/quiche/quic/core/quic_connection.cc:4654:13
    #12 0xb964dd6 in quic::QuicConnection::TearDownLocalConnectionState(quic::QuicErrorCode, quic::QuicIetfTransportErrorCodes, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, quic::ConnectionCloseSource) /proc/self/cwd/external/com_github_google_quiche/quiche/quic/core/quic_connection.cc:4640:10
    #13 0xb9a92ef in quic::QuicConnection::CloseConnection(quic::QuicErrorCode, quic::QuicIetfTransportErrorCodes, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, quic::ConnectionCloseBehavior) /proc/self/cwd/external/com_github_google_quiche/quiche/quic/core/quic_connection.cc:4545:3
    #14 0xb9a888d in quic::QuicConnection::CloseConnection(quic::QuicErrorCode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, quic::ConnectionCloseBehavior) /proc/self/cwd/external/com_github_google_quiche/quiche/quic/core/quic_connection.cc:4516:3
    #15 0xb68956b in Envoy::Quic::QuicFilterManagerConnectionImpl::closeConnectionImmediately() /proc/self/cwd/source/common/quic/quic_filter_manager_connection_impl.cc:208:21
    #16 0xb68345d in Envoy::Quic::QuicFilterManagerConnectionImpl::close(Envoy::Network::ConnectionCloseType) /proc/self/cwd/source/common/quic/quic_filter_manager_connection_impl.cc
    #17 0xb6845b2 in virtual thunk to Envoy::Quic::QuicFilterManagerConnectionImpl::close(Envoy::Network::ConnectionCloseType) /proc/self/cwd/source/common/quic/quic_filter_manager_connection_impl.cc
    #18 0xa4d367e in Envoy::Http::CodecClient::close(Envoy::Network::ConnectionCloseType) /proc/self/cwd/source/common/http/codec_client.cc:62:75
    #19 0x5c01751 in Envoy::HttpIntegrationTest::cleanupUpstreamAndDownstream() /proc/self/cwd/test/integration/http_integration.cc:497:20
    #20 0x5c00de3 in Envoy::HttpIntegrationTest::~HttpIntegrationTest() /proc/self/cwd/test/integration/http_integration.cc:352:47

0x60f0000ce448 is located 8 bytes inside of 168-byte region [0x60f0000ce440,0x60f0000ce4e8)
freed by thread T0 here:
    #0 0x57c3792 in free /local/mnt/workspace/bcain_clang_hu-bcain-lv_22036/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:52:3
    #1 0x61a2c7c in Envoy::IntegrationStreamDecoder::~IntegrationStreamDecoder() /proc/self/cwd/test/integration/integration_stream_decoder.cc:27:55
    #2 0x5b3f059 in std::__1::unique_ptr<Envoy::IntegrationStreamDecoder, std::__1::default_delete<Envoy::IntegrationStreamDecoder> >::reset(Envoy::IntegrationStreamDecoder*) /opt/llvm/bin/../include/c++/v1/__memory/unique_ptr.h:54:5
    #3 0x5951543 in Envoy::DownstreamProtocolIntegrationTest_ConnectIsBlocked_Test::TestBody() /opt/llvm/bin/../include/c++/v1/__memory/unique_ptr.h:269:19
    #4 0xf1aee54 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2580:10
    #5 0xf176b32 in testing::Test::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2655:5
```

Risk Level: low, test only
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A