### PR TITLE
config/logging: Switch no admin warning -> info

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -36,9 +36,6 @@ behavior_changes:
     Handle empty response bodies in grpc_http1_reverse_bridge. This may cause problems for clients expecting the filter to crash
     for empty responses.  This behavioral change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.grpc_http1_reverse_bridge_handle_empty_response`` to false.
-- area: admin
-  change: |
-    Switch no admin ``warning`` -> ``info``.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
@@ -66,6 +63,9 @@ minor_behavior_changes:
     Flip the runtime guard ``envoy.reloadable_features.defer_processing_backedup_streams`` to be on by default.
     This feature improves flow control within the proxy by deferring work on the receiving end if the other
     end is backed up.
+- area: admin
+  change: |
+    Switch no admin ``warning`` -> ``info``.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -38,7 +38,7 @@ behavior_changes:
     ``envoy.reloadable_features.grpc_http1_reverse_bridge_handle_empty_response`` to false.
 - area: admin
   change: |
-    Switch no admin ``warning`` -> ``info``
+    Switch no admin ``warning`` -> ``info``.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -38,7 +38,7 @@ behavior_changes:
     ``envoy.reloadable_features.grpc_http1_reverse_bridge_handle_empty_response`` to false.
 - area: admin
   change: |
-    Switch no admin `warning` -> `info`
+    Switch no admin ``warning`` -> ``info``
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -36,6 +36,9 @@ behavior_changes:
     Handle empty response bodies in grpc_http1_reverse_bridge. This may cause problems for clients expecting the filter to crash
     for empty responses.  This behavioral change can be temporarily reverted by setting runtime guard
     ``envoy.reloadable_features.grpc_http1_reverse_bridge_handle_empty_response`` to false.
+- area: admin
+  change: |
+    Switch no admin `warning` -> `info`
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -714,7 +714,7 @@ void InstanceBase::initializeOrThrow(Network::Address::InstanceConstSharedPtr lo
     throwEnvoyExceptionOrPanic("Admin address configured but admin support compiled out");
 #endif
   } else {
-    ENVOY_LOG(warn, "No admin address given, so no admin HTTP server started.");
+    ENVOY_LOG(info, "No admin address given, so no admin HTTP server started.");
   }
   if (admin_) {
     config_tracker_entry_ = admin_->getConfigTracker().add(


### PR DESCRIPTION
This warning is unhelpful, given that its preferable to have no admin configured, than configured badly.

It also doesnt seem correct to assume that a user _should_ have admin configured, or that they should be warned if not.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
