### PR TITLE
test: Increase the TIMEOUT_FACTOR when running MSAN

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1702,7 +1702,7 @@ void ConfigHelper::adjustUpstreamTimeoutForTsan(
   auto* timeout = route->mutable_timeout();
   // QUIC stream processing is slow under TSAN. Use larger timeout to prevent
   // response_timeout.
-  timeout->set_seconds(TSAN_TIMEOUT_FACTOR * timeout_ms / 1000);
+  timeout->set_seconds(TIMEOUT_FACTOR * timeout_ms / 1000);
 }
 
 envoy::config::core::v3::Http3ProtocolOptions ConfigHelper::http2ToHttp3ProtocolOptions(

--- a/test/extensions/filters/http/file_system_buffer/filter_integration_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/filter_integration_test.cc
@@ -75,7 +75,7 @@ TEST_P(FileSystemBufferIntegrationTest, RequestAndResponseWithGiantBodyBuffer) {
   // Not quite as giant as the memory buffer's integration test uses - with
   // disk operations involved that size risks timing out the test.
   testRouterRequestAndResponseWithBody(1024 * 1024, 1024 * 1024, false, false, nullptr,
-                                       std::chrono::milliseconds(25000) * TSAN_TIMEOUT_FACTOR);
+                                       std::chrono::milliseconds(25000) * TIMEOUT_FACTOR);
 }
 
 TEST_P(FileSystemBufferIntegrationTest, HeaderOnlyRequestAndResponseBuffer) {

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -537,7 +537,7 @@ std::string BaseIntegrationTest::waitForAccessLog(const std::string& filename, u
 
   // Wait a max of 1s for logs to flush to disk.
   std::string contents;
-  const int num_iterations = TSAN_TIMEOUT_FACTOR * 1000;
+  const int num_iterations = TIMEOUT_FACTOR * 1000;
   for (int i = 0; i < num_iterations; ++i) {
     contents = TestEnvironment::readFileToStringForTest(filename);
     std::vector<std::string> entries = absl::StrSplit(contents, '\n', absl::SkipEmpty());

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -244,7 +244,7 @@ bool waitForWithDispatcherRun(Event::TestTimeSystem& time_system, absl::Mutex& l
   Event::TestTimeSystem::RealTimeBound bound(timeout);
   while (bound.withinBound()) {
     // Wake up periodically to run the client dispatcher.
-    if (time_system.waitFor(lock, absl::Condition(&condition), 5ms * TSAN_TIMEOUT_FACTOR)) {
+    if (time_system.waitFor(lock, absl::Condition(&condition), 5ms * TIMEOUT_FACTOR)) {
       return true;
     }
 

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -968,8 +968,8 @@ TEST_P(Http2FloodMitigationTest, KeepAliveTimerTriggersFloodProtection) {
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) {
         auto* keep_alive = hcm.mutable_http2_protocol_options()->mutable_connection_keepalive();
-        keep_alive->mutable_interval()->set_seconds(1 * TSAN_TIMEOUT_FACTOR);
-        keep_alive->mutable_timeout()->set_seconds(2 * TSAN_TIMEOUT_FACTOR);
+        keep_alive->mutable_interval()->set_seconds(1 * TIMEOUT_FACTOR);
+        keep_alive->mutable_timeout()->set_seconds(2 * TIMEOUT_FACTOR);
       });
 
   prefillOutboundDownstreamQueue(AllFrameFloodLimit - 1);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -380,8 +380,7 @@ void HttpIntegrationTest::initialize() {
   quic_connection_persistent_info->quic_config_.SetInitialStreamFlowControlWindowToSend(
       Http3::Utility::OptionsLimits::DEFAULT_INITIAL_STREAM_WINDOW_SIZE);
   // Adjust timeouts.
-  quic::QuicTime::Delta connect_timeout =
-      quic::QuicTime::Delta::FromSeconds(5 * TSAN_TIMEOUT_FACTOR);
+  quic::QuicTime::Delta connect_timeout = quic::QuicTime::Delta::FromSeconds(5 * TIMEOUT_FACTOR);
   quic_connection_persistent_info->quic_config_.set_max_time_before_crypto_handshake(
       connect_timeout);
   quic_connection_persistent_info->quic_config_.set_max_idle_time_before_crypto_handshake(

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -307,7 +307,7 @@ protected:
   // Test sending and receiving large request and response bodies with autonomous upstream.
   void testGiantRequestAndResponse(
       uint64_t request_size, uint64_t response_size, bool set_content_length_header,
-      std::chrono::milliseconds timeout = 2 * TestUtility::DefaultTimeout * TSAN_TIMEOUT_FACTOR);
+      std::chrono::milliseconds timeout = 2 * TestUtility::DefaultTimeout * TIMEOUT_FACTOR);
 
   struct BytesCountExpectation {
     BytesCountExpectation(int wire_bytes_sent, int wire_bytes_received, int header_bytes_sent,

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -118,7 +118,7 @@ public:
 
   // TODO(htuch): This might require scaling for TSAN/ASAN/Valgrind/etc. Bump if
   // this is the cause of flakes.
-  static constexpr uint64_t IdleTimeoutMs = 300 * TSAN_TIMEOUT_FACTOR;
+  static constexpr uint64_t IdleTimeoutMs = 300 * TIMEOUT_FACTOR;
   static constexpr uint64_t RequestTimeoutMs = 200;
   bool enable_global_idle_timeout_{false};
   bool enable_per_stream_idle_timeout_{false};

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1490,7 +1490,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithRetransmission) {
     socket_swap.write_matcher_->setDestinationPort(lookupPort("http"));
     socket_swap.write_matcher_->setWriteOverride(std::move(ebadf));
     upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-    timeSystem().advanceTimeWait(std::chrono::seconds(TSAN_TIMEOUT_FACTOR));
+    timeSystem().advanceTimeWait(std::chrono::seconds(TIMEOUT_FACTOR));
   }
 
   ASSERT_TRUE(response->waitForEndStream());

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -46,12 +46,12 @@ using testing::Invoke; //  NOLINT(misc-unused-using-decls)
 
 namespace Envoy {
 
-#if defined(__has_feature) && __has_feature(thread_sanitizer)
-#define TSAN_TIMEOUT_FACTOR 3
+#if defined(__has_feature) && (__has_feature(thread_sanitizer) || __has_feature(memory_sanitizer))
+#define TIMEOUT_FACTOR 3
 #elif defined(ENVOY_CONFIG_COVERAGE)
-#define TSAN_TIMEOUT_FACTOR 3
+#define TIMEOUT_FACTOR 3
 #else
-#define TSAN_TIMEOUT_FACTOR 1
+#define TIMEOUT_FACTOR 1
 #endif
 
 /*
@@ -586,7 +586,7 @@ public:
                                  const std::string& output_format);
 
   static constexpr std::chrono::milliseconds DefaultTimeout =
-      std::chrono::milliseconds(10000) * TSAN_TIMEOUT_FACTOR;
+      std::chrono::milliseconds(10000) * TIMEOUT_FACTOR;
 
   /**
    * Return a prefix string matcher.


### PR DESCRIPTION
I have seen a number of test timeout failures when running MSAN mainly because it will use `TIMEOUT_FACTOR=1`. This PR fixes the issue by increasing the `TIMEOUT_FACTOR` to 3 similar to when running the tests with TSAN. The `TSAN_TIMEOUT_FACTOR` has been renamed to just `TIMEOUT_FACTOR` since it is also used when running MSAN.

Risk Level: low (tests only)
Testing: unit / integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a