### PR TITLE
singleton manager: enhance singleton manager to support pin

### DIFF
--- a/contrib/qat/private_key_providers/test/config_test.cc
+++ b/contrib/qat/private_key_providers/test/config_test.cc
@@ -35,7 +35,8 @@ parsePrivateKeyProviderFromV3Yaml(const std::string& yaml_string) {
 class FakeSingletonManager : public Singleton::Manager {
 public:
   FakeSingletonManager(LibQatCryptoSharedPtr libqat) : libqat_(libqat) {}
-  Singleton::InstanceSharedPtr get(const std::string&, Singleton::SingletonFactoryCb) override {
+  Singleton::InstanceSharedPtr get(const std::string&, Singleton::SingletonFactoryCb,
+                                   bool) override {
     return std::make_shared<QatManager>(libqat_);
   }
 

--- a/contrib/qat/private_key_providers/test/ops_test.cc
+++ b/contrib/qat/private_key_providers/test/ops_test.cc
@@ -44,7 +44,8 @@ public:
 class FakeSingletonManager : public Singleton::Manager {
 public:
   FakeSingletonManager(LibQatCryptoSharedPtr libqat) : libqat_(libqat) {}
-  Singleton::InstanceSharedPtr get(const std::string&, Singleton::SingletonFactoryCb) override {
+  Singleton::InstanceSharedPtr get(const std::string&, Singleton::SingletonFactoryCb,
+                                   bool) override {
     return std::make_shared<QatManager>(libqat_);
   }
 

--- a/envoy/singleton/manager.h
+++ b/envoy/singleton/manager.h
@@ -94,7 +94,8 @@ public:
    * exist.
    */
   template <class T> std::shared_ptr<T> getTyped(const std::string& name) {
-    return std::dynamic_pointer_cast<T>(get(name, [] { return nullptr; }));
+    return std::dynamic_pointer_cast<T>(get(
+        name, [] { return nullptr; }, false));
   }
 
   /**

--- a/envoy/singleton/manager.h
+++ b/envoy/singleton/manager.h
@@ -67,15 +67,31 @@ public:
    * This is a helper on top of get() that casts the object stored to the specified type. Since the
    * manager only stores pointers to the base interface, dynamic_cast provides some level of
    * protection via RTTI.
+   * @param name the unique name of the singleton instance. This should be provided by the macro
+   * SINGLETON_MANAGER_REGISTERED_NAME.
+   * @param cb supplies the singleton creation callback. This will only be called if the singleton
+   * does not already exist.
+   * @param pin supplies whether the singleton should be pinned. By default, the manager only stores
+   * a weak pointer. This allows a singleton to be cleaned up if it is not needed any more. All code
+   * that uses singletons must store the shared_ptr for as long as the singleton is needed. But if
+   * the pin is set to true, the singleton will be stored as a shared_ptr. This is useful if the
+   * users want to keep the singleton around for the lifetime of the server even if it is not used
+   * for a while.
+   * @return InstancePtr the singleton cast to the specified type. nullptr if the singleton does not
+   * exist.
    */
-  template <class T> std::shared_ptr<T> getTyped(const std::string& name, SingletonFactoryCb cb) {
-    return std::dynamic_pointer_cast<T>(get(name, cb));
+  template <class T>
+  std::shared_ptr<T> getTyped(const std::string& name, SingletonFactoryCb cb, bool pin = false) {
+    return std::dynamic_pointer_cast<T>(get(name, cb, pin));
   }
 
   /**
    * This is a non-constructing getter. Use when the caller can deal with instances where
    * the singleton being accessed may not have been constructed previously.
-   * @return InstancePtr the singleton. nullptr if the singleton does not exist.
+   * @param name the unique name of singleton instance. This should be provided by the macro
+   * SINGLETON_MANAGER_REGISTERED_NAME.
+   * @return InstancePtr the singleton cast to the specified type. nullptr if the singleton does not
+   * exist.
    */
   template <class T> std::shared_ptr<T> getTyped(const std::string& name) {
     return std::dynamic_pointer_cast<T>(get(name, [] { return nullptr; }));
@@ -83,14 +99,20 @@ public:
 
   /**
    * Get a singleton and create it if it does not exist.
-   * @param name supplies the singleton name. Must be registered via RegistrationImpl.
-   * @param singleton supplies the singleton creation callback. This will only be called if the
-   *        singleton does not already exist. NOTE: The manager only stores a weak pointer. This
-   *        allows a singleton to be cleaned up if it is not needed any more. All code that uses
-   *        singletons must store the shared_ptr for as long as the singleton is needed.
-   * @return InstancePtr the singleton.
+   * @param name the unique name of the singleton instance. This should be provided by the macro
+   * SINGLETON_MANAGER_REGISTERED_NAME.
+   * @param cb supplies the singleton creation callback. This will only be called if the singleton
+   * does not already exist.
+   * @param pin supplies whether the singleton should be pinned. By default, the manager only stores
+   * a weak pointer. This allows a singleton to be cleaned up if it is not needed any more. All code
+   * that uses singletons must store the shared_ptr for as long as the singleton is needed. But if
+   * the pin is set to true, the singleton will be stored as a shared_ptr. This is useful if the
+   * users want to keep the singleton around for the lifetime of the server even if it is not used
+   * for a while.
+   * @return InstancePtr the singleton cast to the specified type. nullptr if the singleton does not
+   * exist.
    */
-  virtual InstanceSharedPtr get(const std::string& name, SingletonFactoryCb) PURE;
+  virtual InstanceSharedPtr get(const std::string& name, SingletonFactoryCb cb, bool pin) PURE;
 };
 
 using ManagerPtr = std::unique_ptr<Manager>;

--- a/source/common/singleton/manager_impl.cc
+++ b/source/common/singleton/manager_impl.cc
@@ -8,18 +8,23 @@
 namespace Envoy {
 namespace Singleton {
 
-InstanceSharedPtr ManagerImpl::get(const std::string& name, SingletonFactoryCb cb) {
+InstanceSharedPtr ManagerImpl::get(const std::string& name, SingletonFactoryCb cb, bool pin) {
   ASSERT(run_tid_ == thread_factory_.currentThreadId());
 
   ENVOY_BUG(Registry::FactoryRegistry<Registration>::getFactory(name) != nullptr,
             "invalid singleton name '" + name + "'. Make sure it is registered.");
 
-  if (nullptr == singletons_[name].lock()) {
+  auto existing_singleton = singletons_[name].lock();
+
+  if (existing_singleton == nullptr) {
     InstanceSharedPtr singleton = cb();
-    singletons_[name] = singleton;
+    singletons_by_type_index_[index] = singleton;
+    if (pin && singleton != nullptr) {
+      pinned_singletons_.push_back(singleton);
+    }
     return singleton;
   } else {
-    return singletons_[name].lock();
+    return existing_singleton;
   }
 }
 

--- a/source/common/singleton/manager_impl.cc
+++ b/source/common/singleton/manager_impl.cc
@@ -18,7 +18,7 @@ InstanceSharedPtr ManagerImpl::get(const std::string& name, SingletonFactoryCb c
 
   if (existing_singleton == nullptr) {
     InstanceSharedPtr singleton = cb();
-    singletons_by_type_index_[index] = singleton;
+    singletons_[name] = singleton;
     if (pin && singleton != nullptr) {
       pinned_singletons_.push_back(singleton);
     }

--- a/source/common/singleton/manager_impl.h
+++ b/source/common/singleton/manager_impl.h
@@ -21,10 +21,12 @@ public:
       : thread_factory_(thread_factory), run_tid_(thread_factory.currentThreadId()) {}
 
   // Singleton::Manager
-  InstanceSharedPtr get(const std::string& name, SingletonFactoryCb cb) override;
+  InstanceSharedPtr get(const std::string& name, SingletonFactoryCb cb, bool pin) override;
 
 private:
   absl::node_hash_map<std::string, std::weak_ptr<Instance>> singletons_;
+  std::vector<InstanceSharedPtr> pinned_singletons_;
+
   Thread::ThreadFactory& thread_factory_;
   const Thread::ThreadId run_tid_;
 };

--- a/test/common/singleton/manager_impl_test.cc
+++ b/test/common/singleton/manager_impl_test.cc
@@ -14,7 +14,8 @@ namespace {
 static void deathTestWorker() {
   ManagerImpl manager(Thread::threadFactoryForTest());
 
-  manager.get("foo", [] { return nullptr; });
+  manager.get(
+      "foo", [] { return nullptr; }, false);
 }
 
 TEST(SingletonManagerImplDeathTest, NotRegistered) {

--- a/test/common/singleton/manager_impl_test.cc
+++ b/test/common/singleton/manager_impl_test.cc
@@ -41,9 +41,11 @@ TEST(SingletonManagerImplTest, Basic) {
   ManagerImpl manager(Thread::threadFactoryForTest());
 
   std::shared_ptr<TestSingleton> singleton = std::make_shared<TestSingleton>();
-  EXPECT_EQ(singleton, manager.get("test_singleton", [singleton] { return singleton; }));
+  EXPECT_EQ(singleton, manager.get(
+                           "test_singleton", [singleton] { return singleton; }, false));
   EXPECT_EQ(1UL, singleton.use_count());
-  EXPECT_EQ(singleton, manager.get("test_singleton", [] { return nullptr; }));
+  EXPECT_EQ(singleton, manager.get(
+                           "test_singleton", [] { return nullptr; }, false));
 
   EXPECT_CALL(*singleton, onDestroy());
   singleton.reset();
@@ -57,7 +59,8 @@ TEST(SingletonManagerImplTest, NonConstructingGetTyped) {
 
   std::shared_ptr<TestSingleton> singleton = std::make_shared<TestSingleton>();
   // Use a construct on first use getter.
-  EXPECT_EQ(singleton, manager.get("test_singleton", [singleton] { return singleton; }));
+  EXPECT_EQ(singleton, manager.get(
+                           "test_singleton", [singleton] { return singleton; }, false));
   // Now access should return the constructed singleton.
   EXPECT_EQ(singleton, manager.getTyped<TestSingleton>("test_singleton"));
   EXPECT_EQ(1UL, singleton.use_count());

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -283,7 +283,7 @@ public:
   FileSystemHttpCacheTestWithMockFiles() {
     ON_CALL(context_.server_factory_context_, singletonManager())
         .WillByDefault(ReturnRef(mock_singleton_manager_));
-    ON_CALL(mock_singleton_manager_, get(HasSubstr("async_file_manager_factory_singleton"), _))
+    ON_CALL(mock_singleton_manager_, get(HasSubstr("async_file_manager_factory_singleton"), _, _))
         .WillByDefault(Return(mock_async_file_manager_factory_));
     ON_CALL(*mock_async_file_manager_factory_, getAsyncFileManager(_, _))
         .WillByDefault(Return(mock_async_file_manager_));

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -265,15 +265,16 @@ class MockSingletonManager : public Singleton::ManagerImpl {
 public:
   MockSingletonManager() : Singleton::ManagerImpl(Thread::threadFactoryForTest()) {
     // By default just act like a real SingletonManager, but allow overrides.
-    ON_CALL(*this, get(_, _))
+    ON_CALL(*this, get(_, _, _))
         .WillByDefault(std::bind(&MockSingletonManager::realGet, this, std::placeholders::_1,
-                                 std::placeholders::_2));
+                                 std::placeholders::_2, std::placeholders::_3));
   }
 
   MOCK_METHOD(Singleton::InstanceSharedPtr, get,
-              (const std::string& name, Singleton::SingletonFactoryCb cb));
-  Singleton::InstanceSharedPtr realGet(const std::string& name, Singleton::SingletonFactoryCb cb) {
-    return Singleton::ManagerImpl::get(name, cb);
+              (const std::string& name, Singleton::SingletonFactoryCb cb, bool pin));
+  Singleton::InstanceSharedPtr realGet(const std::string& name, Singleton::SingletonFactoryCb cb,
+                                       bool pin) {
+    return Singleton::ManagerImpl::get(name, cb, pin);
   }
 };
 

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -368,10 +368,15 @@ public:
     // state, this is done by the test server instead.
     class FakeSingletonManager : public Singleton::Manager {
     public:
-      Singleton::InstanceSharedPtr get(const std::string&,
-                                       Singleton::SingletonFactoryCb cb) override {
-        return cb();
+      Singleton::InstanceSharedPtr get(const std::string&, Singleton::SingletonFactoryCb cb,
+                                       bool pin) override {
+        auto singleton = cb();
+        if (pin) {
+          pinned_singletons_.push_back(singleton);
+        }
+        return singleton;
       }
+      std::vector<Singleton::InstanceSharedPtr> pinned_singletons_;
     };
     FakeSingletonManager fsm;
     ON_CALL(mock_factory_ctx.server_context_, singletonManager()).WillByDefault(ReturnRef(fsm));


### PR DESCRIPTION
Commit Message: singleton manager: enhance singleton manager to support pin
Additional Description:

A new enhancement to the singleton manager:
`pin` support: By default, the singleton manager only stores a weak pointer to the instance and  the instance will be destroyed if no one keep its shared pointer. But now, if the `pin` is enabled, the manager will keep a shared pointer of the instance.

This is caused by the #29289. The #29289 introduced a new server factory context method because an object require server wide lifetime. But I think bringing these objects/methods that only make sense for specific modules/features to server factory context is not a good design. And a pinned singleton should be enough for this scenario. (And I think it could do more)

Risk Level: low, no change for now.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.