### PR TITLE
ext_proc: refactor per route config for immutability

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -222,13 +222,13 @@ public:
   }
 
 private:
-  absl::optional<const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
+  absl::optional<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
   initProcessingMode(const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& config);
 
-  absl::optional<const envoy::config::core::v3::GrpcService>
+  absl::optional<envoy::config::core::v3::GrpcService>
   initGrpcService(const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& config);
 
-  absl::optional<const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
+  absl::optional<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
   mergeProcessingMode(const FilterConfigPerRoute& dst, const FilterConfigPerRoute& src);
 
   const bool disabled_;
@@ -340,10 +340,8 @@ private:
   // know what response to return from certain failures.
   bool sent_immediate_response_ = false;
 
-  // Set a value when the mergePerRouteConfig() method has been called.
-  // This binds the constructed config to the life of the filter to extend the
-  // lifetimes of objects created during the merge.
-  absl::optional<FilterConfigPerRoute> route_config_merged_;
+  // Set to true when the mergePerRouteConfig() method has been called.
+  bool route_config_merged_ = false;
 };
 
 extern std::string responseCaseToString(

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -210,7 +210,11 @@ public:
   explicit FilterConfigPerRoute(
       const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& config);
 
-  FilterConfigPerRoute(const FilterConfigPerRoute& dst, const FilterConfigPerRoute& src);
+  // This constructor is used as a way to merge more-specific config into less-specific config in a
+  // clearly defined way (e.g. route config into vh config). All fields on this class must be const
+  // and thus must be initialized in the ctor initialization list.
+  FilterConfigPerRoute(const FilterConfigPerRoute& less_specific,
+                       const FilterConfigPerRoute& more_specific);
 
   bool disabled() const { return disabled_; }
   const absl::optional<const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>&
@@ -229,7 +233,8 @@ private:
   initGrpcService(const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& config);
 
   absl::optional<envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>
-  mergeProcessingMode(const FilterConfigPerRoute& dst, const FilterConfigPerRoute& src);
+  mergeProcessingMode(const FilterConfigPerRoute& less_specific,
+                      const FilterConfigPerRoute& more_specific);
 
   const bool disabled_;
   const absl::optional<const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode>

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -2899,11 +2899,11 @@ TEST(OverrideTest, OverrideProcessingMode) {
       ProcessingMode::BUFFERED);
   FilterConfigPerRoute route1(cfg1);
   FilterConfigPerRoute route2(cfg2);
-  route1.merge(route2);
-  EXPECT_FALSE(route1.disabled());
-  EXPECT_EQ(route1.processingMode()->request_header_mode(), ProcessingMode::DEFAULT);
-  EXPECT_EQ(route1.processingMode()->request_body_mode(), ProcessingMode::STREAMED);
-  EXPECT_EQ(route1.processingMode()->response_body_mode(), ProcessingMode::BUFFERED);
+  FilterConfigPerRoute merged_route(route1, route2);
+  EXPECT_FALSE(merged_route.disabled());
+  EXPECT_EQ(merged_route.processingMode()->request_header_mode(), ProcessingMode::DEFAULT);
+  EXPECT_EQ(merged_route.processingMode()->request_body_mode(), ProcessingMode::STREAMED);
+  EXPECT_EQ(merged_route.processingMode()->response_body_mode(), ProcessingMode::BUFFERED);
 }
 
 // When merging two configurations, if the first processing mode is set, and
@@ -2916,9 +2916,9 @@ TEST(OverrideTest, DisableOverridesFirstMode) {
   cfg2.set_disabled(true);
   FilterConfigPerRoute route1(cfg1);
   FilterConfigPerRoute route2(cfg2);
-  route1.merge(route2);
-  EXPECT_TRUE(route1.disabled());
-  EXPECT_FALSE(route1.processingMode());
+  FilterConfigPerRoute merged_route(route1, route2);
+  EXPECT_TRUE(merged_route.disabled());
+  EXPECT_FALSE(merged_route.processingMode());
 }
 
 // When merging two configurations, if the first override is disabled, and
@@ -2931,9 +2931,9 @@ TEST(OverrideTest, ModeOverridesFirstDisable) {
       ProcessingMode::SKIP);
   FilterConfigPerRoute route1(cfg1);
   FilterConfigPerRoute route2(cfg2);
-  route1.merge(route2);
-  EXPECT_FALSE(route1.disabled());
-  EXPECT_EQ(route1.processingMode()->request_header_mode(), ProcessingMode::SKIP);
+  FilterConfigPerRoute merged_route(route1, route2);
+  EXPECT_FALSE(merged_route.disabled());
+  EXPECT_EQ(merged_route.processingMode()->request_header_mode(), ProcessingMode::SKIP);
 }
 
 // When merging two configurations, if both are disabled, then it's still
@@ -2945,9 +2945,9 @@ TEST(OverrideTest, DisabledThingsAreDisabled) {
   cfg2.set_disabled(true);
   FilterConfigPerRoute route1(cfg1);
   FilterConfigPerRoute route2(cfg2);
-  route1.merge(route2);
-  EXPECT_TRUE(route1.disabled());
-  EXPECT_FALSE(route1.processingMode());
+  FilterConfigPerRoute merged_route(route1, route2);
+  EXPECT_TRUE(merged_route.disabled());
+  EXPECT_FALSE(merged_route.processingMode());
 }
 
 // When merging two configurations, second grpc_service overrides the first.
@@ -2960,9 +2960,9 @@ TEST(OverrideTest, GrpcServiceOverride) {
       "cluster_2");
   FilterConfigPerRoute route1(cfg1);
   FilterConfigPerRoute route2(cfg2);
-  route1.merge(route2);
-  ASSERT_TRUE(route1.grpcService().has_value());
-  EXPECT_THAT(*route1.grpcService(), ProtoEq(cfg2.overrides().grpc_service()));
+  FilterConfigPerRoute merged_route(route1, route2);
+  ASSERT_TRUE(merged_route.grpcService().has_value());
+  EXPECT_THAT(*merged_route.grpcService(), ProtoEq(cfg2.overrides().grpc_service()));
 }
 
 // When merging two configurations, unset grpc_service is equivalent to no override.
@@ -2974,9 +2974,9 @@ TEST(OverrideTest, GrpcServiceNonOverride) {
   // Leave cfg2.grpc_service unset.
   FilterConfigPerRoute route1(cfg1);
   FilterConfigPerRoute route2(cfg2);
-  route1.merge(route2);
-  ASSERT_TRUE(route1.grpcService().has_value());
-  EXPECT_THAT(*route1.grpcService(), ProtoEq(cfg1.overrides().grpc_service()));
+  FilterConfigPerRoute merged_route(route1, route2);
+  ASSERT_TRUE(merged_route.grpcService().has_value());
+  EXPECT_THAT(*merged_route.grpcService(), ProtoEq(cfg1.overrides().grpc_service()));
 }
 
 // Verify that attempts to change headers that are not allowed to be changed


### PR DESCRIPTION
Commit Message:
Config objects, including per route configs, are main thread objects and should be immutable. In practice, the ext_proc `FilterConfigPerRoute` is not mutated on the request path, but due to the config merging strategy employed in `Http::Utility::getMergedPerFilterConfig` ([link](https://github.com/envoyproxy/envoy/blob/b18ea4488a540aaab4979aea7ebeb252b77d4fe7/source/common/http/utility.h#L604)), fields on the object must be mutable in order to set them on an already-constructed object. This is because the reduce function accepted by that function as an argument takes as its first parameter a reference to the target final object.

In this PR we refactor the logic, bringing the `traversePerFilterConfig` call directly into `mergePerFilterConfig`. We add a "merge constructor" which allows us to define how each field should be set when receiving a less-specific and more-specific config. Crucially, all fields are now `const` allowing true immutability on the per-route config object.
Additional Description:
Risk Level: LOW
Testing: All existing tests pass, no new tests added due to no net-new functionality
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Additional context: https://github.com/envoyproxy/envoy/pull/30747#discussion_r1399611901
