### PR TITLE
build: Remove decommissioned (in v5.x) bazel attribute

### DIFF
--- a/api/bazel/cc_proto_descriptor_library/builddefs.bzl
+++ b/api/bazel/cc_proto_descriptor_library/builddefs.bzl
@@ -332,7 +332,6 @@ cc_proto_descriptor_library_aspect = aspect(
     attr_aspects = ["deps"],
     fragments = ["cpp"],
     toolchains = use_cpp_toolchain(),
-    incompatible_use_toolchain_transition = True,
 )
 
 cc_proto_descriptor_library = rule(


### PR DESCRIPTION
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
