### PR TITLE
Fix compiler warnings in unit tests.

### DIFF
--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -349,7 +349,7 @@ TEST_F(EnvoyQuicClientStreamTest, PostRequestAnd1xx) {
   size_t i = 0;
   // Receive several 10x headers, only the first 100 Continue header should be
   // delivered.
-  for (const std::string& status : {"100", "199", "100"}) {
+  for (const std::string status : {"100", "199", "100"}) {
     spdy::Http2HeaderBlock continue_header;
     continue_header[":status"] = status;
     continue_header["i"] = absl::StrCat("", i++);

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -24,7 +24,7 @@ TEST(EnvoyQuicUtilsTest, ConversionBetweenQuicAddressAndEnvoyAddress) {
   quic::QuicSocketAddress quic_uninitialized_addr;
   EXPECT_EQ(nullptr, quicAddressToEnvoyAddressInstance(quic_uninitialized_addr));
 
-  for (const std::string& ip_str : {"fd00:0:0:1::1", "1.2.3.4"}) {
+  for (const std::string ip_str : {"fd00:0:0:1::1", "1.2.3.4"}) {
     quic::QuicIpAddress quic_ip;
     quic_ip.FromString(ip_str);
     quic::QuicSocketAddress quic_addr(quic_ip, 12345);

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -2204,7 +2204,7 @@ most_specific_header_mutations_wins: true
 
 // Validate that we can't add :-prefixed or Host request headers.
 TEST_F(RouteMatcherTest, TestRequestHeadersToAddNoHostOrPseudoHeader) {
-  for (const std::string& header :
+  for (const std::string header :
        {":path", ":authority", ":method", ":scheme", ":status", ":protocol", "host"}) {
     const std::string yaml = fmt::format(R"EOF(
 virtual_hosts:
@@ -2230,7 +2230,7 @@ virtual_hosts:
 
 // Validate that we can't remove :-prefixed request headers.
 TEST_F(RouteMatcherTest, TestRequestHeadersToRemoveNoPseudoHeader) {
-  for (const std::string& header :
+  for (const std::string header :
        {":path", ":authority", ":method", ":scheme", ":status", ":protocol", "host"}) {
     const std::string yaml = fmt::format(R"EOF(
 virtual_hosts:


### PR DESCRIPTION
This commit fixes compiler warnings of the type [-Werror=range-loop-construct]

Here is one example:

```
test/common/router/config_impl_test.cc:2207:27: error: loop variable 'header' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char* const'
```
