### PR TITLE
clean server factory context and partly revert #29289

### DIFF
--- a/envoy/http/filter_factory.h
+++ b/envoy/http/filter_factory.h
@@ -23,14 +23,6 @@ class FilterChainFactoryCallbacks;
  */
 using FilterFactoryCb = std::function<void(FilterChainFactoryCallbacks& callbacks)>;
 
-// Struct of canonical filter name and HTTP stream filter factory callback.
-struct NamedHttpFilterFactoryCb {
-  // Canonical filter name.
-  std::string name;
-  // Factory function used to create filter instances.
-  Http::FilterFactoryCb factory_cb;
-};
-
 /**
  * Simple struct of additional contextual information of HTTP filter, e.g. filter config name
  * from configuration, canonical filter name, etc.

--- a/envoy/server/BUILD
+++ b/envoy/server/BUILD
@@ -175,7 +175,6 @@ envoy_cc_library(
         ":process_context_interface",
         "//envoy/access_log:access_log_interface",
         "//envoy/api:api_interface",
-        "//envoy/config:dynamic_extension_config_provider_interface",
         "//envoy/config:typed_config_interface",
         "//envoy/config:typed_metadata_interface",
         "//envoy/grpc:context_interface",

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -7,7 +7,6 @@
 #include "envoy/access_log/access_log.h"
 #include "envoy/common/random_generator.h"
 #include "envoy/config/core/v3/base.pb.h"
-#include "envoy/config/dynamic_extension_config_provider.h"
 #include "envoy/config/typed_config.h"
 #include "envoy/config/typed_metadata.h"
 #include "envoy/grpc/context.h"
@@ -37,14 +36,9 @@
 #include "source/common/protobuf/protobuf.h"
 
 namespace Envoy {
-namespace Filter {
-template <class FactoryCb, class FactoryCtx> class FilterConfigProviderManager;
-} // namespace Filter
 namespace Server {
 namespace Configuration {
 
-using HttpExtensionConfigProviderSharedPtr =
-    std::shared_ptr<Config::DynamicExtensionConfigProvider<Envoy::Http::NamedHttpFilterFactoryCb>>;
 /**
  * Common interface for downstream and upstream network filters to access server
  * wide resources. This could be treated as limited form of server factory context.
@@ -137,14 +131,6 @@ public:
   virtual ServerLifecycleNotifier& lifecycleNotifier() PURE;
 };
 
-class FactoryContext;
-
-using DownstreamHTTPFilterConfigProviderManager =
-    Filter::FilterConfigProviderManager<Http::NamedHttpFilterFactoryCb,
-                                        Server::Configuration::FactoryContext>;
-using DownstreamHTTPFilterConfigProviderManagerSharedPtr =
-    std::shared_ptr<DownstreamHTTPFilterConfigProviderManager>;
-
 /**
  * ServerFactoryContext is an specialization of common interface for downstream and upstream network
  * filters. The implementation guarantees the lifetime is no shorter than server. It could be used
@@ -209,14 +195,6 @@ public:
    * @return whether external healthchecks are currently failed or not.
    */
   virtual bool healthCheckFailed() const PURE;
-
-  /**
-   * Returns the downstream HTTP filter config provider manager.
-   *
-   * @return DownstreamHTTPFilterConfigProviderManagerSharedPtr
-   */
-  virtual DownstreamHTTPFilterConfigProviderManagerSharedPtr
-  downstreamHttpFilterConfigProviderManager() PURE;
 };
 
 /**

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -15,8 +15,11 @@
 namespace Envoy {
 namespace Http {
 
+using DownstreamFilterConfigProviderManager =
+    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
+                                        Server::Configuration::FactoryContext>;
 using UpstreamFilterConfigProviderManager =
-    Filter::FilterConfigProviderManager<Http::NamedHttpFilterFactoryCb,
+    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
                                         Server::Configuration::UpstreamFactoryContext>;
 
 // Allows graceful handling of missing configuration for ECDS.
@@ -38,7 +41,7 @@ static Http::FilterFactoryCb MissingConfigFilterFactory =
 class FilterChainUtility : Logger::Loggable<Logger::Id::config> {
 public:
   struct FilterFactoryProvider {
-    Filter::FilterConfigProviderPtr<Http::NamedHttpFilterFactoryCb> provider;
+    Filter::FilterConfigProviderPtr<Filter::NamedHttpFilterFactoryCb> provider;
     // If true, this filter is disabled by default and must be explicitly enabled by
     // route configuration.
     bool disabled{};
@@ -52,6 +55,10 @@ public:
                                             const FilterChainOptions& options,
                                             const FilterFactoriesList& filter_factories);
 
+  static std::shared_ptr<DownstreamFilterConfigProviderManager>
+  createSingletonDownstreamFilterConfigProviderManager(
+      Server::Configuration::ServerFactoryContext& context);
+
   static std::shared_ptr<UpstreamFilterConfigProviderManager>
   createSingletonUpstreamFilterConfigProviderManager(
       Server::Configuration::ServerFactoryContext& context);
@@ -62,7 +69,7 @@ class FilterChainHelper : Logger::Loggable<Logger::Id::config> {
 public:
   using FilterFactoriesList = FilterChainUtility::FilterFactoriesList;
   using FilterConfigProviderManager =
-      Filter::FilterConfigProviderManager<Http::NamedHttpFilterFactoryCb, FilterCtx>;
+      Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb, FilterCtx>;
 
   FilterChainHelper(FilterConfigProviderManager& filter_config_provider_manager,
                     Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -29,11 +29,12 @@ Matcher::ActionFactoryCb ExecuteFilterActionFactory::createActionFactoryCb(
     Server::Configuration::FactoryContext& factory_context = context.factory_context_.value();
     Server::Configuration::ServerFactoryContext& server_factory_context =
         context.server_factory_context_.value();
-    Server::Configuration::HttpExtensionConfigProviderSharedPtr provider =
-        server_factory_context.downstreamHttpFilterConfigProviderManager()
-            ->createDynamicFilterConfigProvider(
-                config_discovery, composite_action.dynamic_config().name(), server_factory_context,
-                factory_context, server_factory_context.clusterManager(), false, "http", nullptr);
+    auto provider_manager =
+        Envoy::Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(
+            server_factory_context);
+    auto provider = provider_manager->createDynamicFilterConfigProvider(
+        config_discovery, composite_action.dynamic_config().name(), server_factory_context,
+        factory_context, server_factory_context.clusterManager(), false, "http", nullptr);
     return [provider = std::move(provider)]() -> Matcher::ActionPtr {
       auto config_value = provider->config();
       if (config_value.has_value()) {

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -4,6 +4,10 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Composite {
+
+using HttpExtensionConfigProviderSharedPtr = std::shared_ptr<
+    Config::DynamicExtensionConfigProvider<Envoy::Filter::NamedHttpFilterFactoryCb>>;
+
 void ExecuteFilterAction::createFilters(Http::FilterChainFactoryCallbacks& callbacks) const {
   cb_(callbacks);
 }
@@ -32,9 +36,10 @@ Matcher::ActionFactoryCb ExecuteFilterActionFactory::createActionFactoryCb(
     auto provider_manager =
         Envoy::Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(
             server_factory_context);
-    auto provider = provider_manager->createDynamicFilterConfigProvider(
-        config_discovery, composite_action.dynamic_config().name(), server_factory_context,
-        factory_context, server_factory_context.clusterManager(), false, "http", nullptr);
+    HttpExtensionConfigProviderSharedPtr provider =
+        provider_manager->createDynamicFilterConfigProvider(
+            config_discovery, composite_action.dynamic_config().name(), server_factory_context,
+            factory_context, server_factory_context.clusterManager(), false, "http", nullptr);
     return [provider = std::move(provider)]() -> Matcher::ActionPtr {
       auto config_value = provider->config();
       if (config_value.has_value()) {

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -231,9 +231,9 @@ Utility::Singletons Utility::createSingletons(Server::Configuration::FactoryCont
 
   auto tracer_manager = Tracing::TracerManagerImpl::singleton(context);
 
-  Server::Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr
-      filter_config_provider_manager =
-          context.serverFactoryContext().downstreamHttpFilterConfigProviderManager();
+  std::shared_ptr<Http::DownstreamFilterConfigProviderManager> filter_config_provider_manager =
+      Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(
+          server_context);
 
   return {date_provider, route_config_provider_manager, scoped_routes_config_provider_manager,
           tracer_manager, filter_config_provider_manager};

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -46,7 +46,7 @@ namespace NetworkFilters {
 namespace HttpConnectionManager {
 
 using FilterConfigProviderManager =
-    Filter::FilterConfigProviderManager<Http::NamedHttpFilterFactoryCb,
+    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
                                         Server::Configuration::FactoryContext>;
 
 /**

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -361,7 +361,6 @@ envoy_cc_library(
         "//envoy/server:factory_context_interface",
         "//envoy/server:instance_interface",
         "//source/common/config:metadata_lib",
-        "//source/common/filter:config_discovery_lib",
         "//source/common/listener_manager:listener_info_lib",
     ],
 )

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -172,9 +172,7 @@ class ServerFactoryContextImpl : public Configuration::ServerFactoryContext,
                                  public Configuration::TransportSocketFactoryContext {
 public:
   explicit ServerFactoryContextImpl(Instance& server)
-      : server_(server), server_scope_(server_.stats().createScope("")),
-        filter_config_provider_manager_(
-            std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>()) {}
+      : server_(server), server_scope_(server_.stats().createScope("")) {}
 
   // Configuration::ServerFactoryContext
   Upstream::ClusterManager& clusterManager() override { return server_.clusterManager(); }
@@ -203,10 +201,6 @@ public:
   envoy::config::bootstrap::v3::Bootstrap& bootstrap() override { return server_.bootstrap(); }
   OverloadManager& overloadManager() override { return server_.overloadManager(); }
   bool healthCheckFailed() const override { return server_.healthCheckFailed(); }
-  Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr
-  downstreamHttpFilterConfigProviderManager() override {
-    return filter_config_provider_manager_;
-  }
 
   // Configuration::TransportSocketFactoryContext
   ServerFactoryContext& serverFactoryContext() override { return *this; }
@@ -228,7 +222,6 @@ public:
 private:
   Instance& server_;
   Stats::ScopeSharedPtr server_scope_;
-  Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr filter_config_provider_manager_;
 };
 
 /**

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -275,7 +275,7 @@ public:
 // HTTP filter test
 class HttpFilterConfigDiscoveryImplTest
     : public FilterConfigDiscoveryImplTest<
-          Http::NamedHttpFilterFactoryCb, Server::Configuration::FactoryContext,
+          NamedHttpFilterFactoryCb, Server::Configuration::FactoryContext,
           HttpFilterConfigProviderManagerImpl, TestHttpFilterFactory,
           Server::Configuration::NamedHttpFilterConfigFactory,
           Server::Configuration::MockFactoryContext> {
@@ -292,7 +292,7 @@ public:
 // Upstream HTTP filter test
 class HttpUpstreamFilterConfigDiscoveryImplTest
     : public FilterConfigDiscoveryImplTest<
-          Http::NamedHttpFilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
+          NamedHttpFilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
           UpstreamHttpFilterConfigProviderManagerImpl, TestHttpFilterFactory,
           Server::Configuration::UpstreamHttpFilterConfigFactory,
           Server::Configuration::MockUpstreamFactoryContext> {

--- a/test/common/http/filter_chain_helper_test.cc
+++ b/test/common/http/filter_chain_helper_test.cc
@@ -28,8 +28,9 @@ TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabled) {
 
   for (const auto& name : {"filter_0", "filter_1", "filter_2"}) {
     auto provider =
-        std::make_unique<Filter::StaticFilterConfigProviderImpl<Http::NamedHttpFilterFactoryCb>>(
-            Http::NamedHttpFilterFactoryCb{"filter_type_name", [](FilterChainFactoryCallbacks&) {}},
+        std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::NamedHttpFilterFactoryCb>>(
+            Filter::NamedHttpFilterFactoryCb{"filter_type_name",
+                                             [](FilterChainFactoryCallbacks&) {}},
             name);
     filter_factories.push_back({std::move(provider), false});
   }
@@ -60,8 +61,9 @@ TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabledAndDe
 
   for (const auto& name : {"filter_0", "filter_1", "filter_2"}) {
     auto provider =
-        std::make_unique<Filter::StaticFilterConfigProviderImpl<Http::NamedHttpFilterFactoryCb>>(
-            Http::NamedHttpFilterFactoryCb{"filter_type_name", [](FilterChainFactoryCallbacks&) {}},
+        std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::NamedHttpFilterFactoryCb>>(
+            Filter::NamedHttpFilterFactoryCb{"filter_type_name",
+                                             [](FilterChainFactoryCallbacks&) {}},
             name);
     filter_factories.push_back({std::move(provider), true});
   }

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -10,9 +10,7 @@ using ::testing::ReturnRef;
 MockServerFactoryContext::MockServerFactoryContext()
     : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
       http_context_(store_.symbolTable()), grpc_context_(store_.symbolTable()),
-      router_context_(store_.symbolTable()),
-      filter_config_provider_manager_(
-          std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>()) {
+      router_context_(store_.symbolTable()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, mainThreadDispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
@@ -41,10 +39,6 @@ MockServerFactoryContext::~MockServerFactoryContext() = default;
 
 MockStatsConfig::MockStatsConfig() = default;
 MockStatsConfig::~MockStatsConfig() = default;
-
-StatelessMockServerFactoryContext::StatelessMockServerFactoryContext()
-    : filter_config_provider_manager_(
-          std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>()) {}
 
 MockGenericFactoryContext::~MockGenericFactoryContext() = default;
 

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -83,10 +83,6 @@ public:
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
   MOCK_METHOD(bool, healthCheckFailed, (), (const));
-  Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr
-  downstreamHttpFilterConfigProviderManager() override {
-    return filter_config_provider_manager_;
-  }
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
@@ -111,8 +107,6 @@ public:
   Router::ContextImpl router_context_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   testing::NiceMock<MockOptions> options_;
-  Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr filter_config_provider_manager_{
-      std::make_shared<Filter::HttpFilterConfigProviderManagerImpl>()};
 };
 
 class MockGenericFactoryContext : public GenericFactoryContext {
@@ -134,7 +128,7 @@ public:
 // threads. Global state in the MockServerFactoryContext causes thread safety issues in this case.
 class StatelessMockServerFactoryContext : public virtual ServerFactoryContext {
 public:
-  StatelessMockServerFactoryContext();
+  StatelessMockServerFactoryContext() = default;
   ~StatelessMockServerFactoryContext() override = default;
 
   MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
@@ -165,11 +159,6 @@ public:
   MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, (), ());
   MOCK_METHOD(OverloadManager&, overloadManager, ());
   MOCK_METHOD(bool, healthCheckFailed, (), (const));
-  Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr
-  downstreamHttpFilterConfigProviderManager() override {
-    return filter_config_provider_manager_;
-  }
-  Configuration::DownstreamHTTPFilterConfigProviderManagerSharedPtr filter_config_provider_manager_;
 };
 
 } // namespace Configuration


### PR DESCRIPTION
Commit Message: clean server factory context and partly revert #29289
Additional Description:

#29289 added ECDS support to the composite filter which is great. But it also introduced a new method to the server factory context which is not recommended.

SingletonManager is better choice to achieve this target. If more stable lifetime is necessary, then a pinned singleton instance should be enough.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
