### PR TITLE
bazel/updater: Fix for version

### DIFF
--- a/.github/workflows/envoy-dependency.yml
+++ b/.github/workflows/envoy-dependency.yml
@@ -66,12 +66,14 @@ jobs:
         input: |
           dependency: ${{ inputs.dependency }}
           task: ${{ inputs.task }}
-          version: ${{ inputs.version }}
+          version: "${{ inputs.version }}"
         input-format: yaml
         filter: |
-          .version[:7] as $version
+          .version as $version
           | .dependency as $dependency
           | .task as $task
+          | (try ($version | validate::sha(40) | .[:7])
+             catch $version) as $version_short
           | {}
           | if $task == "bazel" then
               .
@@ -85,9 +87,9 @@ jobs:
           | .task as $task
           | .target as $target
           | ("
-          echo \"Updating(\($task)): \($dependency) -> \($version)\"
+          echo \"Updating(\($task)): \($dependency) -> \($version_short)\"
           bazel run --config=ci //bazel:\($target) \($dependency) \($version)
-          OUTPUT=\($version)
+          OUTPUT=\($version_short)
           " | bash::output)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes an issue where the updater was incorrectly trying to use the short sha

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
