### PR TITLE
generic proxy: application specific status support

### DIFF
--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.cc
@@ -16,28 +16,6 @@ namespace Dubbo {
 namespace {
 
 constexpr absl::string_view VERSION_KEY = "version";
-constexpr absl::string_view UNKNOWN_RESPONSE_STATUS = "UnknownResponseStatus";
-
-#define ENUM_TO_STRING_VIEW(X)                                                                     \
-  case Common::Dubbo::ResponseStatus::X:                                                           \
-    static constexpr absl::string_view X##_VIEW = #X;                                              \
-    return X##_VIEW;
-
-absl::string_view responseStatusToStringView(Common::Dubbo::ResponseStatus status) {
-  switch (status) {
-    ENUM_TO_STRING_VIEW(Ok);
-    ENUM_TO_STRING_VIEW(ClientTimeout);
-    ENUM_TO_STRING_VIEW(ServerTimeout);
-    ENUM_TO_STRING_VIEW(BadRequest);
-    ENUM_TO_STRING_VIEW(BadResponse);
-    ENUM_TO_STRING_VIEW(ServiceNotFound);
-    ENUM_TO_STRING_VIEW(ServiceError);
-    ENUM_TO_STRING_VIEW(ServerError);
-    ENUM_TO_STRING_VIEW(ClientError);
-    ENUM_TO_STRING_VIEW(ServerThreadpoolExhaustedError);
-  }
-  return UNKNOWN_RESPONSE_STATUS;
-}
 
 Common::Dubbo::ResponseStatus genericStatusToStatus(StatusCode code) {
   switch (code) {
@@ -48,29 +26,6 @@ Common::Dubbo::ResponseStatus genericStatusToStatus(StatusCode code) {
   default:
     return Common::Dubbo::ResponseStatus::ServerError;
   }
-}
-
-StatusCode statusToGenericStatus(Common::Dubbo::ResponseStatus status) {
-  switch (status) {
-  case Common::Dubbo::ResponseStatus::Ok:
-    return StatusCode::kOk;
-  case Common::Dubbo::ResponseStatus::ClientTimeout:
-  case Common::Dubbo::ResponseStatus::ServerTimeout:
-    return StatusCode::kUnknown;
-  case Common::Dubbo::ResponseStatus::BadRequest:
-    return StatusCode::kInvalidArgument;
-  case Common::Dubbo::ResponseStatus::BadResponse:
-    return StatusCode::kUnknown;
-  case Common::Dubbo::ResponseStatus::ServiceNotFound:
-    return StatusCode::kNotFound;
-  case Common::Dubbo::ResponseStatus::ServiceError:
-  case Common::Dubbo::ResponseStatus::ServerError:
-  case Common::Dubbo::ResponseStatus::ClientError:
-    return StatusCode::kUnavailable;
-  case Common::Dubbo::ResponseStatus::ServerThreadpoolExhaustedError:
-    return StatusCode::kResourceExhausted;
-  }
-  return StatusCode::kUnavailable;
 }
 
 } // namespace
@@ -121,7 +76,7 @@ void DubboRequest::erase(absl::string_view key) {
   typed_request->mutableAttachment()->remove(key);
 }
 
-void DubboResponse::refreshGenericStatus() {
+void DubboResponse::refreshStatus() {
   ASSERT(inner_metadata_ != nullptr);
   ASSERT(inner_metadata_->hasResponse() && inner_metadata_->hasResponseStatus());
 
@@ -130,19 +85,22 @@ void DubboResponse::refreshGenericStatus() {
   const auto status = inner_metadata_->context().responseStatus();
   const auto optional_type = inner_metadata_->response().responseType();
 
+  // The final status is not ok if the response status is not ResponseStatus::Ok
+  // anyway.
+  bool response_ok = (status == Common::Dubbo::ResponseStatus::Ok);
+
+  // The final status is not ok if the response type is ResponseWithException or
+  // ResponseWithExceptionWithAttachments even if the response status is Ok.
   if (status == Common::Dubbo::ResponseStatus::Ok) {
     ASSERT(optional_type.has_value());
     auto type = optional_type.value_or(RpcResponseType::ResponseWithException);
     if (type == RpcResponseType::ResponseWithException ||
         type == RpcResponseType::ResponseWithExceptionWithAttachments) {
-      status_ = Status(StatusCode::kUnavailable, "exception_via_upstream");
-      return;
+      response_ok = false;
     }
-    status_ = absl::OkStatus();
-    return;
   }
 
-  status_ = Status(statusToGenericStatus(status), responseStatusToStringView(status));
+  status_ = StreamStatus(static_cast<uint8_t>(status), response_ok);
 }
 
 DubboCodecBase::DubboCodecBase(Common::Dubbo::DubboCodecPtr codec) : codec_(std::move(codec)) {}
@@ -152,15 +110,15 @@ ResponsePtr DubboServerCodec::respond(Status status, absl::string_view,
   const auto* typed_request = dynamic_cast<const DubboRequest*>(&origin_request);
   ASSERT(typed_request != nullptr);
 
-  Common::Dubbo::ResponseStatus response_status;
+  Common::Dubbo::ResponseStatus response_status = genericStatusToStatus(status.code());
+
   absl::optional<Common::Dubbo::RpcResponseType> optional_type;
   absl::string_view content;
-  if (status.ok()) {
-    response_status = Common::Dubbo::ResponseStatus::Ok;
+
+  if (response_status == Common::Dubbo::ResponseStatus::Ok) {
     optional_type.emplace(Common::Dubbo::RpcResponseType::ResponseWithException);
     content = "exception_via_proxy";
   } else {
-    response_status = genericStatusToStatus(status.code());
     content = status.message();
   }
 

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -55,21 +55,21 @@ public:
     ASSERT(inner_metadata_ != nullptr);
     ASSERT(inner_metadata_->hasContext());
     ASSERT(inner_metadata_->hasResponse());
-    refreshGenericStatus();
+    refreshStatus();
   }
 
-  void refreshGenericStatus();
+  void refreshStatus();
 
   // Response.
   absl::string_view protocol() const override { return DubboProtocolName; }
-  Status status() const override { return status_; }
+  StreamStatus status() const override { return status_; }
 
   // StreamFrame
   FrameFlags frameFlags() const override { return stream_frame_flags_; }
 
   FrameFlags stream_frame_flags_;
 
-  Status status_;
+  StreamStatus status_;
   Common::Dubbo::MessageMetadataSharedPtr inner_metadata_;
 };
 
@@ -151,7 +151,7 @@ class DubboServerCodec
 public:
   using DubboDecoderBase::DubboDecoderBase;
 
-  ResponsePtr respond(Status status, absl::string_view short_response_flags,
+  ResponsePtr respond(absl::Status status, absl::string_view short_response_flags,
                       const Request& request) override;
 };
 

--- a/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
@@ -107,73 +107,61 @@ TEST(DubboResponseTest, DubboResponseTest) {
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::Ok, RpcResponseType::ResponseWithValue));
-    EXPECT_EQ(StatusCode::kOk, response.status().code());
+    EXPECT_EQ(20, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::Ok, RpcResponseType::ResponseWithException));
-    EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
-    EXPECT_EQ("exception_via_upstream", response.status().message());
+    EXPECT_EQ(20, response.status().code());
   }
   {
     DubboResponse response(createDubboResponse(
         request, ResponseStatus::Ok, RpcResponseType::ResponseWithExceptionWithAttachments));
-    EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
-    EXPECT_EQ("exception_via_upstream", response.status().message());
+    EXPECT_EQ(20, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::ClientTimeout, absl::nullopt));
-    EXPECT_EQ(StatusCode::kUnknown, response.status().code());
-    EXPECT_EQ("ClientTimeout", response.status().message());
+    EXPECT_EQ(30, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::ServerTimeout, absl::nullopt));
-    EXPECT_EQ(StatusCode::kUnknown, response.status().code());
-    EXPECT_EQ(StatusCode::kUnknown, response.status().code());
-    EXPECT_EQ("ServerTimeout", response.status().message());
+    EXPECT_EQ(31, response.status().code());
   }
   {
     DubboResponse response(createDubboResponse(request, ResponseStatus::BadRequest, absl::nullopt));
-    EXPECT_EQ(StatusCode::kInvalidArgument, response.status().code());
-    EXPECT_EQ("BadRequest", response.status().message());
+    EXPECT_EQ(40, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::BadResponse, absl::nullopt));
-    EXPECT_EQ(StatusCode::kUnknown, response.status().code());
-    EXPECT_EQ("BadResponse", response.status().message());
+    EXPECT_EQ(50, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::ServiceNotFound, absl::nullopt));
-    EXPECT_EQ(StatusCode::kNotFound, response.status().code());
-    EXPECT_EQ("ServiceNotFound", response.status().message());
+    EXPECT_EQ(60, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::ServiceError, absl::nullopt));
-    EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
-    EXPECT_EQ("ServiceError", response.status().message());
+    EXPECT_EQ(70, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::ServerError, absl::nullopt));
-    EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
-    EXPECT_EQ("ServerError", response.status().message());
+    EXPECT_EQ(80, response.status().code());
   }
   {
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::ClientError, absl::nullopt));
-    EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
-    EXPECT_EQ("ClientError", response.status().message());
+    EXPECT_EQ(90, response.status().code());
   }
   {
     DubboResponse response(createDubboResponse(
         request, ResponseStatus::ServerThreadpoolExhaustedError, absl::nullopt));
-    EXPECT_EQ(StatusCode::kResourceExhausted, response.status().code());
-    EXPECT_EQ("ServerThreadpoolExhaustedError", response.status().message());
+    EXPECT_EQ(100, response.status().code());
   }
 
   // Getter and setter do nothing for response.

--- a/contrib/generic_proxy/filters/network/test/integration_test.cc
+++ b/contrib/generic_proxy/filters/network/test/integration_test.cc
@@ -332,8 +332,8 @@ TEST_P(IntegrationTest, RequestRouteNotFound) {
                  "unexpected timeout");
 
   EXPECT_NE(response_decoder_callback_->responses_[0].response_, nullptr);
-  EXPECT_EQ(response_decoder_callback_->responses_[0].response_->status().message(),
-            "route_not_found");
+  EXPECT_EQ(response_decoder_callback_->responses_[0].response_->status().code(),
+            static_cast<uint32_t>(absl::StatusCode::kNotFound));
 
   cleanup();
 }
@@ -362,7 +362,7 @@ TEST_P(IntegrationTest, RequestAndResponse) {
 
   FakeStreamCodecFactory::FakeResponse response;
   response.protocol_ = "fake_fake_fake";
-  response.status_ = Status();
+  response.status_ = StreamStatus();
   response.data_["zzzz"] = "xxxx";
 
   sendResponseForTest(response);
@@ -371,7 +371,7 @@ TEST_P(IntegrationTest, RequestAndResponse) {
                  "unexpected timeout");
 
   EXPECT_NE(response_decoder_callback_->responses_[0].response_, nullptr);
-  EXPECT_EQ(response_decoder_callback_->responses_[0].response_->status().code(), StatusCode::kOk);
+  EXPECT_EQ(response_decoder_callback_->responses_[0].response_->status().code(), 0);
   EXPECT_EQ(response_decoder_callback_->responses_[0].response_->get("zzzz"), "xxxx");
 
   cleanup();
@@ -464,7 +464,7 @@ TEST_P(IntegrationTest, MultipleRequests) {
 
   FakeStreamCodecFactory::FakeResponse response_2;
   response_2.protocol_ = "fake_fake_fake";
-  response_2.status_ = Status();
+  response_2.status_ = StreamStatus();
   response_2.data_["zzzz"] = "xxxx";
   response_2.data_["stream_id"] = "2";
 
@@ -474,13 +474,13 @@ TEST_P(IntegrationTest, MultipleRequests) {
                  "unexpected timeout");
 
   EXPECT_NE(response_decoder_callback_->responses_[2].response_, nullptr);
-  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->status().code(), StatusCode::kOk);
+  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->status().code(), 0);
   EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("zzzz"), "xxxx");
   EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("stream_id"), "2");
 
   FakeStreamCodecFactory::FakeResponse response_1;
   response_1.protocol_ = "fake_fake_fake";
-  response_1.status_ = Status();
+  response_1.status_ = StreamStatus();
   response_1.data_["zzzz"] = "yyyy";
   response_1.data_["stream_id"] = "1";
 
@@ -490,7 +490,7 @@ TEST_P(IntegrationTest, MultipleRequests) {
                  "unexpected timeout");
 
   EXPECT_NE(response_decoder_callback_->responses_[1].response_, nullptr);
-  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->status().code(), StatusCode::kOk);
+  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->status().code(), 0);
   EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("zzzz"), "yyyy");
   EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("stream_id"), "1");
 
@@ -589,7 +589,7 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
 
   FakeStreamCodecFactory::FakeResponse response_2;
   response_2.protocol_ = "fake_fake_fake";
-  response_2.status_ = Status();
+  response_2.status_ = StreamStatus();
   response_2.data_["zzzz"] = "xxxx";
   response_2.data_["stream_id"] = "2";
   response_2.data_["end_stream"] = "false";
@@ -605,13 +605,13 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
                  "unexpected timeout");
 
   EXPECT_NE(response_decoder_callback_->responses_[2].response_, nullptr);
-  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->status().code(), StatusCode::kOk);
+  EXPECT_EQ(response_decoder_callback_->responses_[2].response_->status().code(), 0);
   EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("zzzz"), "xxxx");
   EXPECT_EQ(response_decoder_callback_->responses_[2].response_->get("stream_id"), "2");
 
   FakeStreamCodecFactory::FakeResponse response_1;
   response_1.protocol_ = "fake_fake_fake";
-  response_1.status_ = Status();
+  response_1.status_ = StreamStatus();
   response_1.data_["zzzz"] = "yyyy";
   response_1.data_["stream_id"] = "1";
   response_1.data_["end_stream"] = "false";
@@ -627,7 +627,7 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
                  "unexpected timeout");
 
   EXPECT_NE(response_decoder_callback_->responses_[1].response_, nullptr);
-  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->status().code(), StatusCode::kOk);
+  EXPECT_EQ(response_decoder_callback_->responses_[1].response_->status().code(), 0);
   EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("zzzz"), "yyyy");
   EXPECT_EQ(response_decoder_callback_->responses_[1].response_->get("stream_id"), "1");
 


### PR DESCRIPTION
Commit Message: generic proxy: application specific status support
Additional Description:

Now, the absl::Status is used to indicate the response status but this is not a good choice in practices. The codec need to convert the application specific status to the absl::Status and this also make the logging or tracing cannot record the actual application specific status.

This patch split the status to absl::Status and StreamStatus. The former one will be used by generic proxy to indicate statuses or error types of stream. And another one will be used by the codec to tell the application specific status of stream.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.