### PR TITLE
oauth2: Add default expiry for RFC compliance

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -133,6 +133,9 @@ message OAuth2Config {
   google.protobuf.BoolValue use_refresh_token = 12;
 
   // The default lifetime in seconds of the access token, if omitted by the authorization server.
+  //
+  // If this value is not set, it will default to ``0s``. In this case, the expiry must be set by
+  // the authorization server or the OAuth flow will fail.
   google.protobuf.Duration default_expires_in = 13;
 }
 

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -7,6 +7,7 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "envoy/type/matcher/v3/path.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
@@ -73,7 +74,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -130,6 +131,9 @@ message OAuth2Config {
   // `RFC 6749 section 6 <https://datatracker.ietf.org/doc/html/rfc6749#section-6>`_), provided that the OAuth server supports that.
   // Default value is false.
   google.protobuf.BoolValue use_refresh_token = 12;
+
+  // The default lifetime in seconds of the access token, if omitted by the authorization server.
+  google.protobuf.Duration default_expires_in = 13;
 }
 
 // Filter config.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -158,6 +158,12 @@ bug_fixes:
 - area: ext_authz
   change: |
     Fixed a bug to ensure the proper functioning of the ``with_request_body`` feature within the per-route ExtAuthZ filter.
+- area: oauth
+  change: |
+    Add :ref:`default_expires_in <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.default_expires_in>` configuration
+    setting. The OAuth spec does not dictate that an authorization server must respond with an expiry. Envoy currently
+    fails any OAuth flow if the expiry is not set. This setting allows you to provide a default in this case to ensure
+    the OAuth flow can succeed.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -61,6 +61,12 @@
     return DurationUtil::durationToMilliseconds(msg.field_name());                                 \
   }((message)))
 
+// Obtain the milliseconds value of a google.protobuf.Duration field if set. Otherwise, return the
+// default value.
+#define PROTOBUF_GET_SECONDS_OR_DEFAULT(message, field_name, default_value)                        \
+  ((message).has_##field_name() ? DurationUtil::durationToSeconds((message).field_name())          \
+                                : (default_value))
+
 // Obtain the seconds value of a google.protobuf.Duration field if set. Otherwise, throw an
 // EnvoyException.
 #define PROTOBUF_GET_SECONDS_REQUIRED(message, field_name)                                         \

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -72,8 +72,8 @@ Http::FilterFactoryCb OAuth2Config::createFilterFactoryFromProtoTyped(
 
   return
       [&context, config, &cluster_manager](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-        std::unique_ptr<OAuth2Client> oauth_client =
-            std::make_unique<OAuth2ClientImpl>(cluster_manager, config->oauthTokenEndpoint());
+        std::unique_ptr<OAuth2Client> oauth_client = std::make_unique<OAuth2ClientImpl>(
+            cluster_manager, config->oauthTokenEndpoint(), config->defaultExpiresIn());
         callbacks.addStreamFilter(std::make_shared<OAuth2Filter>(
             config, std::move(oauth_client), context.serverFactoryContext().timeSource()));
       };

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -196,7 +196,8 @@ FilterConfig::FilterConfig(
       pass_through_header_matchers_(headerMatchers(proto_config.pass_through_matcher())),
       cookie_names_(proto_config.credentials().cookie_names()),
       auth_type_(getAuthType(proto_config.auth_type())),
-      use_refresh_token_(proto_config.use_refresh_token().value()) {
+      use_refresh_token_(proto_config.use_refresh_token().value()),
+      default_expires_in_(PROTOBUF_GET_SECONDS_OR_DEFAULT(proto_config, default_expires_in, 0)) {
   if (!cluster_manager.clusters().hasCluster(oauth_token_endpoint_.cluster())) {
     throw EnvoyException(fmt::format("OAuth2 filter: unknown cluster '{}' in config. Please "
                                      "specify which cluster to direct OAuth requests to.",

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -142,7 +142,6 @@ public:
   const std::vector<Http::HeaderUtility::HeaderData>& passThroughMatchers() const {
     return pass_through_header_matchers_;
   }
-
   const envoy::config::core::v3::HttpUri& oauthTokenEndpoint() const {
     return oauth_token_endpoint_;
   }
@@ -160,6 +159,7 @@ public:
   const CookieNames& cookieNames() const { return cookie_names_; }
   const AuthType& authType() const { return auth_type_; }
   bool useRefreshToken() const { return use_refresh_token_; }
+  const std::chrono::seconds defaultExpiresIn() const { return default_expires_in_; }
 
 private:
   static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -182,6 +182,7 @@ private:
   const CookieNames cookie_names_;
   const AuthType auth_type_;
   const bool use_refresh_token_{};
+  const std::chrono::seconds default_expires_in_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -159,7 +159,7 @@ public:
   const CookieNames& cookieNames() const { return cookie_names_; }
   const AuthType& authType() const { return auth_type_; }
   bool useRefreshToken() const { return use_refresh_token_; }
-  const std::chrono::seconds defaultExpiresIn() const { return default_expires_in_; }
+  std::chrono::seconds defaultExpiresIn() const { return default_expires_in_; }
 
 private:
   static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);

--- a/source/extensions/filters/http/oauth2/oauth_client.h
+++ b/source/extensions/filters/http/oauth2/oauth_client.h
@@ -43,8 +43,9 @@ public:
 
 class OAuth2ClientImpl : public OAuth2Client, Logger::Loggable<Logger::Id::oauth2> {
 public:
-  OAuth2ClientImpl(Upstream::ClusterManager& cm, const envoy::config::core::v3::HttpUri& uri)
-      : cm_(cm), uri_(uri) {}
+  OAuth2ClientImpl(Upstream::ClusterManager& cm, const envoy::config::core::v3::HttpUri& uri,
+                   const std::chrono::seconds default_expires_in)
+      : cm_(cm), uri_(uri), default_expires_in_(default_expires_in) {}
 
   ~OAuth2ClientImpl() override {
     if (in_flight_request_ != nullptr) {
@@ -79,6 +80,7 @@ private:
 
   Upstream::ClusterManager& cm_;
   const envoy::config::core::v3::HttpUri uri_;
+  const std::chrono::seconds default_expires_in_;
 
   // Tracks any outstanding in-flight requests, allowing us to cancel the request
   // if the filter ends before the request completes.

--- a/test/extensions/filters/http/oauth2/oauth_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_test.cc
@@ -15,6 +15,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using namespace std::chrono_literals;
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -45,7 +47,7 @@ public:
     uri.set_uri("auth.com/oauth/token");
     uri.mutable_timeout()->set_seconds(1);
     cm_.initializeThreadLocalClusters({"auth"});
-    client_ = std::make_shared<OAuth2ClientImpl>(cm_, uri);
+    client_ = std::make_shared<OAuth2ClientImpl>(cm_, uri, 0s);
   }
 
   ABSL_MUST_USE_RESULT
@@ -101,7 +103,74 @@ TEST_F(OAuth2ClientTest, RequestAccessTokenSuccess) {
   client_->setCallbacks(*mock_callbacks_);
   client_->asyncGetAccessToken("a", "b", "c", "d");
   EXPECT_EQ(1, callbacks_.size());
-  EXPECT_CALL(*mock_callbacks_, onGetAccessTokenSuccess(_, _, _, _));
+  EXPECT_CALL(*mock_callbacks_, onGetAccessTokenSuccess("golden ticket", _, _, 1000s));
+  Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
+  ASSERT_TRUE(popPendingCallback(
+      [&](auto* callback) { callback->onSuccess(request, std::move(mock_response)); }));
+}
+
+TEST_F(OAuth2ClientTest, RequestAccessTokenMissingExpiresIn) {
+  std::string json = R"EOF(
+    {
+      "access_token": "golden ticket"
+    }
+    )EOF";
+  Http::ResponseHeaderMapPtr mock_response_headers{new Http::TestResponseHeaderMapImpl{
+      {Http::Headers::get().Status.get(), "200"},
+      {Http::Headers::get().ContentType.get(), "application/json"},
+  }};
+  Http::ResponseMessagePtr mock_response(
+      new Http::ResponseMessageImpl(std::move(mock_response_headers)));
+  mock_response->body().add(json);
+
+  EXPECT_CALL(cm_.thread_local_cluster_.async_client_, send_(_, _, _))
+      .WillRepeatedly(
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            callbacks_.push_back(&cb);
+            return &request_;
+          }));
+
+  client_->setCallbacks(*mock_callbacks_);
+  client_->asyncGetAccessToken("a", "b", "c", "d");
+  EXPECT_EQ(1, callbacks_.size());
+  EXPECT_CALL(*mock_callbacks_, sendUnauthorizedResponse());
+  Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
+  ASSERT_TRUE(popPendingCallback(
+      [&](auto* callback) { callback->onSuccess(request, std::move(mock_response)); }));
+}
+
+TEST_F(OAuth2ClientTest, RequestAccessTokenDefaultExpiresIn) {
+  std::string json = R"EOF(
+    {
+      "access_token": "golden ticket"
+    }
+    )EOF";
+  Http::ResponseHeaderMapPtr mock_response_headers{new Http::TestResponseHeaderMapImpl{
+      {Http::Headers::get().Status.get(), "200"},
+      {Http::Headers::get().ContentType.get(), "application/json"},
+  }};
+  Http::ResponseMessagePtr mock_response(
+      new Http::ResponseMessageImpl(std::move(mock_response_headers)));
+  mock_response->body().add(json);
+
+  EXPECT_CALL(cm_.thread_local_cluster_.async_client_, send_(_, _, _))
+      .WillRepeatedly(
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            callbacks_.push_back(&cb);
+            return &request_;
+          }));
+
+  envoy::config::core::v3::HttpUri uri;
+  uri.set_cluster("auth");
+  uri.set_uri("auth.com/oauth/token");
+  uri.mutable_timeout()->set_seconds(1);
+  client_ = std::make_shared<OAuth2ClientImpl>(cm_, uri, 2000s);
+  client_->setCallbacks(*mock_callbacks_);
+  client_->asyncGetAccessToken("a", "b", "c", "d");
+  EXPECT_EQ(1, callbacks_.size());
+  EXPECT_CALL(*mock_callbacks_, onGetAccessTokenSuccess("golden ticket", _, _, 2000s));
   Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
   ASSERT_TRUE(popPendingCallback(
       [&](auto* callback) { callback->onSuccess(request, std::move(mock_response)); }));


### PR DESCRIPTION
Currently this filter does not work with Github - which would seem like one of the most likely use cases

This is a revival of https://github.com/envoyproxy/envoy/pull/14625

Should fix #14542

Unblocks #31534 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
