### PR TITLE
generic proxy: codec validation from L7 filter

### DIFF
--- a/contrib/generic_proxy/filters/network/source/config.h
+++ b/contrib/generic_proxy/filters/network/source/config.h
@@ -23,7 +23,7 @@ public:
                                     Envoy::Server::Configuration::FactoryContext& context) override;
 
   static std::pair<CodecFactoryPtr, ProxyFactoryPtr>
-  factoriesFromProto(const envoy::config::core::v3::TypedExtensionConfig& codec_config,
+  factoriesFromProto(const TypedExtensionConfig& codec_config,
                      Server::Configuration::FactoryContext& context);
 
   static Rds::RouteConfigProviderSharedPtr
@@ -31,9 +31,10 @@ public:
                                Server::Configuration::FactoryContext& context,
                                RouteConfigProviderManager& route_config_provider_manager);
 
-  static std::vector<NamedFilterFactoryCb> filtersFactoryFromProto(
-      const ProtobufWkt::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>& filters,
-      const std::string stats_prefix, Server::Configuration::FactoryContext& context);
+  static std::vector<NamedFilterFactoryCb>
+  filtersFactoryFromProto(const ProtobufWkt::RepeatedPtrField<TypedExtensionConfig>& filters,
+                          const TypedExtensionConfig& codec_config, const std::string stats_prefix,
+                          Server::Configuration::FactoryContext& context);
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/source/interface/config.h
+++ b/contrib/generic_proxy/filters/network/source/interface/config.h
@@ -10,6 +10,8 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
 
+using TypedExtensionConfig = envoy::config::core::v3::TypedExtensionConfig;
+
 /**
  * Implemented by each generic filter and registered via Registry::registerFactory or the
  * convenience class RegisterFactory.
@@ -41,6 +43,14 @@ public:
    * @return bool true if this filter must be the last filter in a filter chain, false otherwise.
    */
   virtual bool isTerminalFilter() PURE;
+
+  /**
+   * @return absl::Status validate the codec config to see if it is compatible with the filter.
+   * If the codec config is not compatible with this filter, return an error status.
+   */
+  virtual absl::Status validateCodec(const TypedExtensionConfig& /*config*/) {
+    return absl::OkStatus();
+  }
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/test/mocks/filter.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/filter.h
@@ -65,6 +65,7 @@ public:
               (const Protobuf::Message&, Server::Configuration::ServerFactoryContext&,
                ProtobufMessage::ValidationVisitor&));
   MOCK_METHOD(std::string, name, (), (const));
+  MOCK_METHOD(absl::Status, validateCodec, (const TypedExtensionConfig&));
   MOCK_METHOD(std::set<std::string>, configTypes, ());
   MOCK_METHOD(bool, isTerminalFilter, ());
 };


### PR DESCRIPTION
Commit Message: generic proxy: codec validation from L7 filter
Additional Description:

Generic proxy provides abstract response/request to L7 filters. By this way, lots of L7 filters (rate limit, fault, etc) could be shared by different application protocols.
But it's also possible to create some application protocol specific filter. For example, one filter may cast the abstract message to specific message and do some application specific logic (like protocol conversion).

This new patch allow the filter to validate the codec and return a status at configuration loading time. 

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
