### PR TITLE
fix generic proxy stat prefix

### DIFF
--- a/contrib/generic_proxy/filters/network/source/config.cc
+++ b/contrib/generic_proxy/filters/network/source/config.cc
@@ -124,11 +124,13 @@ Factory::createFilterFactoryFromProtoTyped(const ProxyConfig& proto_config,
     access_logs.push_back(current_access_log);
   }
 
+  const std::string stat_prefix = fmt::format("generic_proxy.{}.", proto_config.stat_prefix());
+
   const FilterConfigSharedPtr config = std::make_shared<FilterConfigImpl>(
-      proto_config.stat_prefix(), std::move(factories.first),
+      stat_prefix, std::move(factories.first),
       routeConfigProviderFromProto(proto_config, context, *route_config_provider_manager),
-      filtersFactoryFromProto(proto_config.filters(), proto_config.codec_config(),
-                              proto_config.stat_prefix(), context),
+      filtersFactoryFromProto(proto_config.filters(), proto_config.codec_config(), stat_prefix,
+                              context),
       std::move(tracer), std::move(tracing_config), std::move(access_logs), context);
 
   return [route_config_provider_manager, tracer_manager, config, &server_context,

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -57,7 +57,7 @@ public:
                    Tracing::ConnectionManagerTracingConfigPtr tracing_config,
                    std::vector<AccessLogInstanceSharedPtr>&& access_logs,
                    Envoy::Server::Configuration::FactoryContext& context)
-      : stat_prefix_(fmt::format("generic_proxy.{}.", stat_prefix)),
+      : stat_prefix_(stat_prefix),
         stats_(GenericFilterStats::generateStats(stat_prefix_, context.scope())),
         codec_factory_(std::move(codec)), route_config_provider_(std::move(route_config_provider)),
         factories_(std::move(factories)), drain_decision_(context.drainDecision()),


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: fix stats prefix for generic proxy filters
Additional Description: without this commit, generic proxy filters stats will lose the prefix generic_proxy.{}.
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
