### PR TITLE
mobile: Force the dfp_mixed_scheme flag to true in Envoy Mobile

### DIFF
--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -37,6 +37,7 @@ envoy_cc_library(
         "//library/common/types:c_types_lib",
         "@envoy//envoy/server:lifecycle_notifier_interface",
         "@envoy//envoy/stats:stats_interface",
+        "@envoy//source/common/runtime:runtime_lib",
         "@envoy_build_config//:extension_registry",
     ],
 )

--- a/mobile/library/common/engine.cc
+++ b/mobile/library/common/engine.cc
@@ -2,6 +2,7 @@
 
 #include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/common/lock_guard.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "library/common/bridge/utility.h"
 #include "library/common/data/utility.h"
@@ -19,6 +20,11 @@ Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
   // registry may lead to crashes at Engine shutdown. To be figured out as part of
   // https://github.com/envoyproxy/envoy-mobile/issues/332
   Envoy::Api::External::registerApi(std::string(envoy_event_tracker_api_name), &event_tracker_);
+  // Envoy Mobile always requires dfp_mixed_scheme for the TLS and cleartext DFP clusters.
+  // While dfp_mixed_scheme defaults to true, some environments force it to false (e.g. within
+  // Google), so we force it back to true in Envoy Mobile.
+  // TODO(abeyad): Remove once this is no longer needed.
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.dfp_mixed_scheme", true);
 }
 
 envoy_status_t Engine::run(const std::string config, const std::string log_level) {


### PR DESCRIPTION
Envoy Mobile always requires dfp_mixed_scheme for the TLS and cleartext DFP clusters. While dfp_mixed_scheme defaults to true, some environments (like within Google), force it to false for the Envoy use case, so we force it back to true here in Envoy Mobile, so we don't break the mobile integration tests.

Once general use of dfp_mixed_scheme is fixed everywhere, we can revert this commit.

Tested by changing dfp_mixed_scheme to FALSE_RUNTIME_GUARD and running the mobile xDS integration tests:

```
cd mobile
bazelisk test --test_output=streamed --cache_test_results=no //test/common/integration:rtds_integration_test
```