### PR TITLE
deps/lockfiles: Mark as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 /test/extensions/transport_sockets/tls/test_data/aes_128_key binary
 /test/extensions/transport_sockets/tls/test_data/ticket_key_* binary
 /test/**/*_corpus/* linguist-generated=true
+requirements.txt binary
+package.lock binary
+yarn.lock binary


### PR DESCRIPTION
This marks package lock files as binary - which means they are ignored in line counts and not merged by git (ie just overwritten)

The latter point is most likely a good thing as this breaks quite a bit currently - but i will monitor for the effect

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
