### PR TITLE
stats: add tag extraction rule for RBAC network filter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -27,6 +27,11 @@ behavior_changes:
     Fixed tag extraction so that :ref:`stat_prefix <envoy_v3_api_msg_extensions.filters.network.connection_limit.v3.ConnectionLimit>`
     is properly extracted. This changes the Prometheus name from ``envoy_connection_limit_myprefix_limited_connections{}`` to
     ``envoy_connection_limit_limited_connections{envoy_connection_limit_prefix="myprefix"}``.
+- area: stats rbac
+  change: |
+    Fixed tag extraction so that :ref:`stat_prefix <envoy_v3_api_msg_extensions.filters.network.rbac.v3.RBAC>`
+    is properly extracted. This changes the Prometheus name from ``envoy_myprefixrbac_allowed{}`` to
+    ``envoy_rbac_allowed{envoy_rbac_prefix="myprefix"}``.
 - area: http2
   change: |
     Changes the default value of ``envoy.reloadable_features.http2_use_oghttp2`` to true. This changes the codec used for HTTP/2

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -204,6 +204,9 @@ TagNameValues::TagNameValues() {
 
   // connection_limit.(<stat_prefix>.)*
   addTokenized(CONNECTION_LIMIT_PREFIX, "connection_limit.$.**");
+
+  // (<stat_prefix>.).rbac.**
+  addTokenized(RBAC_PREFIX, "$.rbac.**");
 }
 
 void TagNameValues::addRe2(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -121,6 +121,8 @@ public:
   const std::string DNS_FILTER_PREFIX = "envoy.dns_filter_prefix";
   // Stats prefix for the Connection limit filter
   const std::string CONNECTION_LIMIT_PREFIX = "envoy.connection_limit_prefix";
+  // Stats prefix for the RBAC network filter
+  const std::string RBAC_PREFIX = "envoy.rbac_prefix";
   // Stats prefix for the TCP Proxy network filter
   const std::string TCP_PREFIX = "envoy.tcp_prefix";
   // Stats prefix for the UDP Proxy network filter

--- a/source/extensions/filters/common/rbac/utility.cc
+++ b/source/extensions/filters/common/rbac/utility.cc
@@ -12,7 +12,7 @@ namespace RBAC {
 
 RoleBasedAccessControlFilterStats
 generateStats(const std::string& prefix, const std::string& shadow_prefix, Stats::Scope& scope) {
-  const std::string final_prefix = prefix + "rbac.";
+  const std::string final_prefix = Envoy::statPrefixJoin(prefix, "rbac.");
   return {ENFORCE_RBAC_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))
               SHADOW_RBAC_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix + shadow_prefix))};
 }

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -444,6 +444,12 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   connection_limit_prefix.value_ = "my_connection_limit_prefix";
   regex_tester.testRegex("connection_limit.my_connection_limit_prefix.limited_connections",
                          "connection_limit.limited_connections", {connection_limit_prefix});
+
+  // RBAC Filter Prefix
+  Tag rbac_prefix;
+  rbac_prefix.name_ = tag_names.RBAC_PREFIX;
+  rbac_prefix.value_ = "my_rbac_prefix";
+  regex_tester.testRegex("my_rbac_prefix.rbac.allowed", "rbac.allowed", {rbac_prefix});
 }
 
 TEST(TagExtractorTest, ExtAuthzTagExtractors) {

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -249,10 +249,10 @@ TEST_F(RoleBasedAccessControlFilterTest, Allowed) {
   EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
   EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -273,10 +273,10 @@ TEST_F(RoleBasedAccessControlFilterTest, RequestedServerName) {
   EXPECT_EQ(0U, config_->stats().denied_.value());
   EXPECT_EQ(0U, config_->stats().shadow_allowed_.value());
   EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -318,10 +318,10 @@ TEST_F(RoleBasedAccessControlFilterTest, Denied) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers_, true));
   EXPECT_EQ(1U, config_->stats().denied_.value());
   EXPECT_EQ(1U, config_->stats().shadow_allowed_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   auto filter_meta = req_info_.dynamicMetadata().filter_metadata().at("envoy.filters.http.rbac");
   EXPECT_EQ("allowed", filter_meta.fields().at("prefix_shadow_engine_result").string_value());
@@ -363,10 +363,10 @@ TEST_F(RoleBasedAccessControlFilterTest, MatcherAllowed) {
   EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
   EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -387,10 +387,10 @@ TEST_F(RoleBasedAccessControlFilterTest, RequestedServerNameMatcher) {
   EXPECT_EQ(0U, config_->stats().denied_.value());
   EXPECT_EQ(0U, config_->stats().shadow_allowed_.value());
   EXPECT_EQ(1U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -432,10 +432,10 @@ TEST_F(RoleBasedAccessControlFilterTest, MatcherDenied) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers_, true));
   EXPECT_EQ(1U, config_->stats().denied_.value());
   EXPECT_EQ(1U, config_->stats().shadow_allowed_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   auto filter_meta = req_info_.dynamicMetadata().filter_metadata().at("envoy.filters.http.rbac");
   EXPECT_EQ("allowed", filter_meta.fields().at("prefix_shadow_engine_result").string_value());
@@ -485,10 +485,10 @@ TEST_F(RoleBasedAccessControlFilterTest, ShouldLog) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers_, false));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
   EXPECT_EQ(0U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -506,10 +506,10 @@ TEST_F(RoleBasedAccessControlFilterTest, ShouldNotLog) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers_, false));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
   EXPECT_EQ(0U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -527,10 +527,10 @@ TEST_F(RoleBasedAccessControlFilterTest, MatcherShouldLog) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers_, false));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
   EXPECT_EQ(0U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
@@ -548,10 +548,10 @@ TEST_F(RoleBasedAccessControlFilterTest, MatcherShouldNotLog) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers_, false));
   EXPECT_EQ(1U, config_->stats().allowed_.value());
   EXPECT_EQ(0U, config_->stats().shadow_denied_.value());
-  EXPECT_EQ("testrbac.allowed", config_->stats().allowed_.name());
-  EXPECT_EQ("testrbac.denied", config_->stats().denied_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
-  EXPECT_EQ("testrbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
+  EXPECT_EQ("test.rbac.allowed", config_->stats().allowed_.name());
+  EXPECT_EQ("test.rbac.denied", config_->stats().denied_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_allowed", config_->stats().shadow_allowed_.name());
+  EXPECT_EQ("test.rbac.prefix_.shadow_denied", config_->stats().shadow_denied_.name());
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -25,11 +25,7 @@ class RoleBasedAccessControlNetworkFilterIntegrationTest
       public BaseIntegrationTest {
 public:
   RoleBasedAccessControlNetworkFilterIntegrationTest()
-      : BaseIntegrationTest(GetParam(), rbac_config) {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat 'tcp.shadow_denied' and stat_prefix 'tcp.'.
-    skip_tag_extraction_rule_check_ = true;
-  }
+      : BaseIntegrationTest(GetParam(), rbac_config) {}
 
   static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     rbac_config = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(


### PR DESCRIPTION
This change adds a tag extraction rule for the RBAC network filter. It also adds a dot between `<stat_prefix>` and `rbac.` in the statistics namespace according to [docs of the RBAC network filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/rbac_filter#statistics) and [the RBAC http filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rbac_filter#statistics).

Commit Message: stats: add tag extraction rule for RBAC network filter
Additional Description:
Risk Level: Low
Testing: added unit tests to confirm extraction works properly
Docs Changes: N/A
Release Notes: included
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue] #21595
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

