### PR TITLE
wasm: fix xds attribute support

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -456,6 +456,11 @@ Context::findValue(absl::string_view name, Protobuf::Arena* arena, bool last) co
   // In order to delegate to the StreamActivation method, we have to set the
   // context properties to match the Wasm context properties in all callbacks
   // (e.g. onLog or onEncodeHeaders) for the duration of the call.
+  if (root_local_info_) {
+    local_info_ = root_local_info_;
+  } else if (plugin_) {
+    local_info_ = &plugin()->localInfo();
+  }
   activation_info_ = info;
   activation_request_headers_ = request_headers_ ? request_headers_ : access_log_request_headers_;
   activation_response_headers_ =

--- a/test/extensions/filters/http/wasm/test_data/metadata_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/metadata_rust.rs
@@ -30,7 +30,7 @@ impl Context for TestStream {}
 impl HttpContext for TestStream {
     fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
         if self
-            .get_property(vec!["node", "metadata", "wasm_node_get_key"])
+            .get_property(vec!["xds", "node", "metadata", "wasm_node_get_key"])
             .is_none()
         {
             debug!("missing node metadata");

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -147,7 +147,7 @@ FilterHeadersStatus TestContext::onRequestHeaders(uint32_t, bool) {
     }
   } else if (test == "metadata") {
     std::string value;
-    if (!getValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
+    if (!getValue({"xds", "node", "metadata", "wasm_node_get_key"}, &value)) {
       logDebug("missing node metadata");
     }
     auto r = setFilterStateStringValue("wasm_request_set_key", "wasm_request_set_value");


### PR DESCRIPTION
Commit Message: wires `xds` attribute into wasm, follow-up to https://github.com/envoyproxy/envoy/pull/31319
Additional Description: none
Risk Level: low
Testing: done
Docs Changes: none
Release Notes: none