### PR TITLE
mobile: fixing explicit flow control bugs.

### DIFF
--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -143,8 +143,9 @@ private:
   public:
     DirectStreamCallbacks(DirectStream& direct_stream, envoy_http_callbacks bridge_callbacks,
                           Client& http_client);
+    virtual ~DirectStreamCallbacks();
 
-    void closeStream();
+    void closeStream(bool end_stream = true);
     void onComplete();
     void onCancel();
     void onError();
@@ -194,6 +195,7 @@ private:
 
     void sendDataToBridge(Buffer::Instance& data, bool end_stream);
     void sendTrailersToBridge(const ResponseTrailerMap& trailers);
+    void sendErrorToBridge();
     envoy_stream_intel streamIntel();
     envoy_final_stream_intel& finalStreamIntel();
     envoy_error streamError();
@@ -305,6 +307,7 @@ private:
       if (!request_decoder_) {
         return {};
       }
+      ENVOY_BUG(request_decoder_->get(), "attempting to access deleted decoder");
       return request_decoder_->get();
     }
 

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -19,7 +19,7 @@ envoy_cc_test(
         "sandboxNetwork": "standard",
     },
     repository = "@envoy",
-    shard_count = 4,
+    shard_count = 6,
     deps = [
         ":base_client_integration_test_lib",
         "//test/common/mocks/common:common_mocks",

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -570,6 +570,23 @@ TEST_P(ClientIntegrationTest, ResetAfterResponseHeaders) {
   ASSERT_EQ(cc_.on_error_calls, 1);
 }
 
+TEST_P(ClientIntegrationTest, ResetAfterResponseHeadersExplicit) {
+  explicit_flow_control_ = true;
+  autonomous_allow_incomplete_streams_ = true;
+  initialize();
+
+  default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_HEADERS, "yes");
+  default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "1");
+
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  // Read the body chunk. This releases the error.
+  stream_->readData(100);
+
+  terminal_callback_.waitReady();
+
+  ASSERT_EQ(cc_.on_error_calls, 1);
+}
+
 TEST_P(ClientIntegrationTest, ResetAfterHeaderOnlyResponse) {
   autonomous_allow_incomplete_streams_ = true;
   initialize();
@@ -612,7 +629,6 @@ TEST_P(ClientIntegrationTest, ResetAfterData) {
 TEST_P(ClientIntegrationTest, CancelBeforeRequestHeadersSent) {
   autonomous_upstream_ = false;
   initialize();
-  ConditionalInitializer headers_callback;
 
   stream_->cancel();
 
@@ -691,16 +707,6 @@ TEST_P(ClientIntegrationTest, BasicCancelWithCompleteStream) {
   autonomous_upstream_ = false;
 
   initialize();
-  ConditionalInitializer headers_callback;
-
-  stream_prototype_->setOnHeaders(
-      [this, &headers_callback](Platform::ResponseHeadersSharedPtr headers, bool,
-                                envoy_stream_intel) {
-        cc_.status = absl::StrCat(headers->httpStatus());
-        cc_.on_headers_calls++;
-        headers_callback.setReady();
-        return nullptr;
-      });
 
   stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
 
@@ -867,6 +873,81 @@ TEST_P(ClientIntegrationTest, TimeoutOnResponsePath) {
   if (upstreamProtocol() != Http::CodecType::HTTP1) {
     ASSERT_TRUE(upstream_request_->waitForReset());
   }
+}
+
+TEST_P(ClientIntegrationTest, ResetWithBidiTraffic) {
+  autonomous_upstream_ = false;
+  initialize();
+  ConditionalInitializer headers_callback;
+
+  stream_prototype_->setOnHeaders(
+      [this, &headers_callback](Platform::ResponseHeadersSharedPtr headers, bool,
+                                envoy_stream_intel) {
+        cc_.status = absl::StrCat(headers->httpStatus());
+        cc_.on_headers_calls++;
+        headers_callback.setReady();
+        return nullptr;
+      });
+
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
+                                                        upstream_connection_));
+  ASSERT_TRUE(
+      upstream_connection_->waitForNewStream(*BaseIntegrationTest::dispatcher_, upstream_request_));
+
+  // Send response headers but no body.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  // Make sure the headers are sent up.
+  headers_callback.waitReady();
+  // Reset the stream.
+  upstream_request_->encodeResetStream();
+
+  // Encoding data should not be problematic.
+  Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
+  stream_->sendData(c_data);
+  // Make sure cancel isn't problematic.
+  stream_->cancel();
+}
+
+TEST_P(ClientIntegrationTest, ResetWithBidiTrafficExplicitData) {
+  explicit_flow_control_ = true;
+  autonomous_upstream_ = false;
+  initialize();
+  ConditionalInitializer headers_callback;
+
+  stream_prototype_->setOnHeaders(
+      [this, &headers_callback](Platform::ResponseHeadersSharedPtr headers, bool,
+                                envoy_stream_intel) {
+        cc_.status = absl::StrCat(headers->httpStatus());
+        cc_.on_headers_calls++;
+        headers_callback.setReady();
+        return nullptr;
+      });
+
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
+                                                        upstream_connection_));
+  ASSERT_TRUE(
+      upstream_connection_->waitForNewStream(*BaseIntegrationTest::dispatcher_, upstream_request_));
+
+  // Send response headers and body but no fin.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(1, false);
+  upstream_request_->encodeResetStream();
+  if (getCodecType() != Http::CodecType::HTTP3) {
+    // Make sure the headers are sent up.
+    headers_callback.waitReady();
+  }
+
+  // Encoding data should not be problematic.
+  Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
+  stream_->sendData(c_data);
+  // Make sure cancel isn't problematic.
+  stream_->cancel();
 }
 
 TEST_P(ClientIntegrationTest, Proxying) {

--- a/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
@@ -309,6 +309,9 @@ public class AndroidEnvoyExplicitFlowTest {
     assertThat(response.getEnvoyError()).isNull();
   }
 
+  // This was supposed to be a simple post, but because the stream is not properly closed, it
+  // actually ends up testing sending a post, getting a response, and Envoy resetting the
+  // "incomplete" request stream.
   @Test
   public void post_simple() throws Exception {
     mockWebServer.setDispatcher(new Dispatcher() {

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -189,7 +189,11 @@ void FakeStream::encodeResetStream() {
         return;
       }
     }
-    encoder_.getStream().resetStream(Http::StreamResetReason::LocalReset);
+    if (parent_.type() == Http::CodecType::HTTP1) {
+      parent_.connection().close(Network::ConnectionCloseType::FlushWrite);
+    } else {
+      encoder_.getStream().resetStream(Http::StreamResetReason::LocalReset);
+    }
   });
 }
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -519,6 +519,7 @@ public:
   ABSL_MUST_USE_RESULT AssertionResult postWriteRawData(std::string data);
 
   Http::ServerHeaderValidatorPtr makeHeaderValidator();
+  Http::CodecType type() const { return type_; }
 
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {


### PR DESCRIPTION
When deferring the error for the explicit flow control case, we didn't close the stream, which could result in attempting to send data to the weak pointer (now an ENVOY_BUG)

When deferring an error, we also never actually sent it.  Now forwarding it on unless the response is complete.

Risk Level: n/a (mobile only)
Testing: new tests
Docs Changes: n/a
Release Notes: n/a