### PR TITLE
api_listener: fixing a lifetime issue with the weak pointer wrapper in the HCM

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -180,6 +180,13 @@ private:
                               public DownstreamStreamFilterCallbacks {
     ActiveStream(ConnectionManagerImpl& connection_manager, uint32_t buffer_limit,
                  Buffer::BufferMemoryAccountSharedPtr account);
+
+    // Event::DeferredDeletable
+    void deleteIsPending() override {
+      // The stream should not be accessed once deferred delete has been called.
+      still_alive_.reset();
+    }
+
     void completeRequest();
 
     const Network::Connection* connection();


### PR DESCRIPTION
the HCM active stream shouldn't be used when in the deferredDelete queue.
Fixing the weak pointer wrapper lifetime by invalidating the pointer when the class is added to the list, rather than when it's deleted.

Risk Level: low: normal envoy use not affected only Envoy mobile and other newStreamHandle users
Testing: new tests
Docs Changes: n/a
Release Notes: n/a