### PR TITLE
mobile: Remove redundant check in Client::getStream()

### DIFF
--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -659,9 +659,9 @@ Client::DirectStreamSharedPtr Client::getStream(envoy_stream_t stream,
   if (direct_stream_pair_it != streams_.end()) {
     return direct_stream_pair_it->second;
   }
-  if (direct_stream_pair_it == streams_.end() && get_stream_filters == ALLOW_FOR_ALL_STREAMS) {
-    direct_stream_pair_it = closed_streams_.find(stream);
-    if (direct_stream_pair_it != closed_streams_.end()) {
+  if (get_stream_filters == ALLOW_FOR_ALL_STREAMS) {
+    if (direct_stream_pair_it = closed_streams_.find(stream);
+        direct_stream_pair_it != closed_streams_.end()) {
       return direct_stream_pair_it->second;
     }
   }

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -660,8 +660,8 @@ Client::DirectStreamSharedPtr Client::getStream(envoy_stream_t stream,
     return direct_stream_pair_it->second;
   }
   if (get_stream_filters == ALLOW_FOR_ALL_STREAMS) {
-    if (direct_stream_pair_it = closed_streams_.find(stream);
-        direct_stream_pair_it != closed_streams_.end()) {
+    direct_stream_pair_it = closed_streams_.find(stream);
+    if (direct_stream_pair_it != closed_streams_.end()) {
       return direct_stream_pair_it->second;
     }
   }


### PR DESCRIPTION
This is just a cleanup of the getStream() branch checks to simplify reading the code.
No functional change was introduced in this commit.