### PR TITLE
http: fix HttpDatagramHandler object lifetime issue.

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -215,6 +215,9 @@ void EnvoyQuicClientStream::encodeMetadata(const Http::MetadataMapVector& /*meta
 }
 
 void EnvoyQuicClientStream::resetStream(Http::StreamResetReason reason) {
+  if (http_datagram_handler_) {
+    UnregisterHttp3DatagramVisitor();
+  }
   Reset(envoyResetReasonToQuicRstError(reason));
 }
 
@@ -527,6 +530,7 @@ bool EnvoyQuicClientStream::hasPendingData() { return BufferedDataBytes() > 0; }
 void EnvoyQuicClientStream::useCapsuleProtocol() {
   http_datagram_handler_ = std::make_unique<HttpDatagramHandler>(*this);
   http_datagram_handler_->setStreamDecoder(response_decoder_);
+  RegisterHttp3DatagramVisitor(http_datagram_handler_.get());
 }
 #endif
 

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -195,6 +195,10 @@ void EnvoyQuicServerStream::resetStream(Http::StreamResetReason reason) {
     buffer_memory_account_->clearDownstream();
   }
 
+  if (http_datagram_handler_) {
+    UnregisterHttp3DatagramVisitor();
+  }
+
   if (local_end_stream_ && !reading_stopped()) {
     // This is after 200 early response. Reset with QUIC_STREAM_NO_ERROR instead
     // of propagating original reset reason. In QUICHE if a stream stops reading
@@ -579,6 +583,7 @@ void EnvoyQuicServerStream::useCapsuleProtocol() {
   http_datagram_handler_ = std::make_unique<HttpDatagramHandler>(*this);
   ASSERT(request_decoder_ != nullptr);
   http_datagram_handler_->setStreamDecoder(request_decoder_);
+  RegisterHttp3DatagramVisitor(http_datagram_handler_.get());
 }
 #endif
 

--- a/source/common/quic/http_datagram_handler.cc
+++ b/source/common/quic/http_datagram_handler.cc
@@ -12,11 +12,7 @@
 namespace Envoy {
 namespace Quic {
 
-HttpDatagramHandler::HttpDatagramHandler(quic::QuicSpdyStream& stream) : stream_(stream) {
-  stream_.RegisterHttp3DatagramVisitor(this);
-}
-
-HttpDatagramHandler::~HttpDatagramHandler() { stream_.UnregisterHttp3DatagramVisitor(); }
+HttpDatagramHandler::HttpDatagramHandler(quic::QuicSpdyStream& stream) : stream_(stream) {}
 
 void HttpDatagramHandler::decodeCapsule(const quiche::Capsule& capsule) {
   quiche::QuicheBuffer serialized_capsule = SerializeCapsule(capsule, &capsule_buffer_allocator_);

--- a/source/common/quic/http_datagram_handler.h
+++ b/source/common/quic/http_datagram_handler.h
@@ -23,7 +23,6 @@ public:
   // Does not take ownership of the QuicSpdyStream. "stream" must refer to a valid object
   // that outlives HttpDatagramHandler.
   explicit HttpDatagramHandler(quic::QuicSpdyStream& stream);
-  ~HttpDatagramHandler() override;
 
   // quic::QuicSpdyStream::Http3DatagramVisitor
   void OnHttp3Datagram(quic::QuicStreamId stream_id, absl::string_view payload) override;

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -755,6 +755,14 @@ TEST_F(EnvoyQuicClientStreamTest, DecodeHttp3Datagram) {
   quic_session_.OnMessageReceived(datagram_fragment_);
   EXPECT_CALL(stream_callbacks_, onResetStream(_, _));
 }
+
+TEST_F(EnvoyQuicClientStreamTest, ResetStreamWithHttpDatagramHandler) {
+  setUpCapsuleProtocol(true, false);
+  EXPECT_CALL(stream_callbacks_, onResetStream(_, _));
+  quic_stream_->resetStream(Http::StreamResetReason::LocalReset);
+  EXPECT_TRUE(quic_stream_->rst_sent());
+}
+
 #endif
 
 } // namespace Quic

--- a/test/common/quic/http_datagram_handler_test.cc
+++ b/test/common/quic/http_datagram_handler_test.cc
@@ -46,9 +46,7 @@ public:
 
 class HttpDatagramHandlerTest : public ::testing::Test {
 public:
-  HttpDatagramHandlerTest() {
-    http_datagram_handler_.setStreamDecoder(&stream_decoder_);
-  };
+  HttpDatagramHandlerTest() { http_datagram_handler_.setStreamDecoder(&stream_decoder_); };
 
 protected:
   testing::NiceMock<quic::test::MockQuicConnectionHelper> connection_helper_;

--- a/test/common/quic/http_datagram_handler_test.cc
+++ b/test/common/quic/http_datagram_handler_test.cc
@@ -46,7 +46,9 @@ public:
 
 class HttpDatagramHandlerTest : public ::testing::Test {
 public:
-  HttpDatagramHandlerTest() { http_datagram_handler_.setStreamDecoder(&stream_decoder_); };
+  HttpDatagramHandlerTest() {
+    http_datagram_handler_.setStreamDecoder(&stream_decoder_);
+  };
 
 protected:
   testing::NiceMock<quic::test::MockQuicConnectionHelper> connection_helper_;


### PR DESCRIPTION
Commit Message:
stream_decoder_ member variable must outlive the HttpDatagramHandler. Previously, stream_decoder_ became a dangling pointer when the stream is reset before OnHttp3Datagram is called.
I made Envoy QUIC stream unregister the HTTP/3 Datagram visitor when the stream is reset to ensure the lifetime assumption.
Additional Description:
Risk Level: Low, this is a bug fix.
Testing: Unit tests and integration tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A