### PR TITLE
upstream: Don't call UpstreamRequest::resetStream() more than once

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -456,6 +456,12 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
 }
 
 void UpstreamRequest::resetStream() {
+  if (reset_stream_) {
+    // resetStream() has already been called on this UpstreamRequest.
+    IS_ENVOY_BUG("UpstreamRequest::resetStream() called more than once.");
+    return;
+  }
+
   if (conn_pool_->cancelAnyPendingStream()) {
     ENVOY_STREAM_LOG(debug, "canceled pool request", *parent_.callbacks());
     ASSERT(!upstream_);


### PR DESCRIPTION
Uses the existing `reset_stream_` variable to determine if resetStream() should get run.
Logs an Envoy BUG if `resetStream()` is called more than once on the same `UpstreamRequest`.