### PR TITLE
configs: add connect_timeout to envoy-demo.yaml

### DIFF
--- a/configs/envoy-demo.yaml
+++ b/configs/envoy-demo.yaml
@@ -40,6 +40,7 @@ static_resources:
   clusters:
   - name: service_envoyproxy_io
     type: LOGICAL_DNS
+    connect_timeout: 5s
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: The envoy binary currently requires the 'connect_timeout' field to be specified; otherwise, the error 'error initializing configuration 'envoy-demo.yaml': Field 'connect_timeout' is missing in: name: "service_envoyproxy_io"' will occur.
Additional Description:
Risk Level: Low
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
