### PR TITLE
[geoip] Fix population of anonymous headers

### DIFF
--- a/api/envoy/extensions/geoip_providers/common/v3/common.proto
+++ b/api/envoy/extensions/geoip_providers/common/v3/common.proto
@@ -39,26 +39,31 @@ message CommonGeoipProviderConfig {
 
     // If set, the IP address will be checked if it belongs to any type of anonymization network (e.g. VPN, public proxy etc)
     // and header will be populated with the check result. Header value will be set to either "true" or "false" depending on the check result.
+    // If target IP is not found in the anonymous database, header value will be set to "false".
     string is_anon = 5
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 
     // If set, the IP address will be checked if it belongs to a VPN and header will be populated with the check result.
     // Header value will be set to either "true" or "false" depending on the check result.
+    // If target IP is not found in the anonymous database, header value will be set to "false".
     string anon_vpn = 6
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 
     // If set, the IP address will be checked if it belongs to a hosting provider and header will be populated with the check result.
     // Header value will be set to either "true" or "false" depending on the check result.
+    // If target IP is not found in the anonymous database, header value will be set to "false".
     string anon_hosting = 7
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 
     // If set, the IP address will be checked if it belongs to a TOR exit node and header will be populated with the check result.
     // Header value will be set to either "true" or "false" depending on the check result.
+    // If target IP is not found in the anonymous database, header value will be set to "false".
     string anon_tor = 8
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 
     // If set, the IP address will be checked if it belongs to a public proxy and header will be populated with the check result.
     // Header value will be set to either "true" or "false" depending on the check result.
+    // If target IP is not found in the anonymous database, header value will be set to "false".
     string anon_proxy = 9
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
   }

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.h
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.h
@@ -77,6 +77,22 @@ private:
 using GeoipProviderConfigSharedPtr = std::shared_ptr<GeoipProviderConfig>;
 
 using MaxmindDbPtr = std::unique_ptr<MMDB_s>;
+
+struct GeoDbLookupResult {
+  MMDB_lookup_result_s& mmdb_lookup_result_;
+  absl::flat_hash_map<std::string, std::string>& lookup_result_;
+  bool is_anon_lookup_;
+  bool any_hit_;
+
+  GeoDbLookupResult(MMDB_lookup_result_s& mmdb_lookup_result,
+                    absl::flat_hash_map<std::string, std::string>& lookup_result,
+                    bool is_anon_lookup)
+      : mmdb_lookup_result_(mmdb_lookup_result), lookup_result_(lookup_result),
+        is_anon_lookup_(is_anon_lookup), any_hit_(false){};
+
+  void markHit() { any_hit_ = true; }
+};
+
 class GeoipProvider : public Envoy::Geolocation::Driver,
                       public Logger::Loggable<Logger::Id::geolocation> {
 
@@ -108,8 +124,7 @@ private:
   void lookupInAnonDb(const Network::Address::InstanceConstSharedPtr& remote_address,
                       absl::flat_hash_map<std::string, std::string>& lookup_result) const;
   template <typename... Params>
-  void populateGeoLookupResult(MMDB_lookup_result_s& mmdb_lookup_result,
-                               absl::flat_hash_map<std::string, std::string>& lookup_result,
+  void populateGeoLookupResult(GeoDbLookupResult& geo_db_lookup_result,
                                const std::string& result_key, Params... lookup_params) const;
   // A shared_ptr to keep the provider singleton alive as long as any of its providers are in use.
   const Singleton::InstanceSharedPtr owner_;

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -231,7 +231,9 @@ TEST_F(GeoipProviderTest, ValidConfigEmptyLookupResult) {
   auto lookup_cb_std = lookup_cb.AsStdFunction();
   EXPECT_CALL(lookup_cb, Call(_)).WillRepeatedly(SaveArg<0>(&captured_lookup_response_));
   provider_->lookup(std::move(lookup_rq), std::move(lookup_cb_std));
-  EXPECT_EQ(0, captured_lookup_response_.size());
+  EXPECT_EQ(1, captured_lookup_response_.size());
+  const auto& anon_it = captured_lookup_response_.find("x-geo-anon");
+  EXPECT_EQ("false", anon_it->second);
   expectStats("anon_db", 1, 0);
 }
 


### PR DESCRIPTION
Currently, when IP is looked up in the anonymous database and lookup result is empty, geolocation anonymous headers will not be populated, while they should be populated with "false" value instead (meaning that IP is not anonymous).

Commit Message:
Additional Description:
Risk Level: Low (wip extension)
Testing: Unit test
Docs Changes: Done
Release Notes:
Platform Specific Features:

