### PR TITLE
Revert "Resolver: switching to statusor (#31312)"

### DIFF
--- a/envoy/network/resolver.h
+++ b/envoy/network/resolver.h
@@ -24,9 +24,9 @@ public:
   /**
    * Resolve a custom address string and port to an Address::Instance.
    * @param socket_address supplies the socket address to resolve.
-   * @return InstanceConstSharedPtr appropriate Address::Instance or an error status.
+   * @return InstanceConstSharedPtr appropriate Address::Instance.
    */
-  virtual absl::StatusOr<InstanceConstSharedPtr>
+  virtual InstanceConstSharedPtr
   resolve(const envoy::config::core::v3::SocketAddress& socket_address) PURE;
 
   std::string category() const override { return "envoy.resolvers"; }

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -223,9 +223,7 @@ std::string listenerStatsScope(const envoy::config::listener::v3::Listener& conf
   if (config.has_internal_listener()) {
     return absl::StrCat("envoy_internal_", config.name());
   }
-  auto address_or_error = Network::Address::resolveProtoAddress(config.address());
-  THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-  return address_or_error.value()->asString();
+  return Network::Address::resolveProtoAddress(config.address())->asString();
 }
 } // namespace
 
@@ -310,9 +308,7 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
   } else {
     // All the addresses should be same socket type, so get the first address's socket type is
     // enough.
-    auto address_or_error = Network::Address::resolveProtoAddress(config.address());
-    THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-    auto address = std::move(address_or_error.value());
+    auto address = Network::Address::resolveProtoAddress(config.address());
     checkIpv4CompatAddress(address, config.address());
     addresses_.emplace_back(address);
     address_opts_list.emplace_back(std::ref(config.socket_options()));
@@ -325,10 +321,8 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
                         "support same socket type for all the addresses.",
                         name_));
       }
-      auto addresses_or_error =
+      auto additional_address =
           Network::Address::resolveProtoAddress(config.additional_addresses(i).address());
-      THROW_IF_STATUS_NOT_OK(addresses_or_error, throw);
-      auto additional_address = std::move(addresses_or_error.value());
       checkIpv4CompatAddress(address, config.additional_addresses(i).address());
       addresses_.emplace_back(additional_address);
       if (config.additional_addresses(i).has_socket_options()) {

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -468,9 +468,7 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
           name));
     }
     if (!api_listener_ && !added_via_api) {
-      auto listener_or_error = HttpApiListener::create(config, server_, config.name());
-      THROW_IF_STATUS_NOT_OK(listener_or_error, throw);
-      api_listener_ = std::move(listener_or_error.value());
+      api_listener_ = std::make_unique<HttpApiListener>(config, server_, config.name());
       return true;
     } else {
       ENVOY_LOG(warn, "listener {} can not be added because currently only one ApiListener is "

--- a/source/common/network/resolver_impl.h
+++ b/source/common/network/resolver_impl.h
@@ -14,17 +14,17 @@ namespace Address {
 /**
  * Create an Instance from a envoy::config::core::v3::Address.
  * @param address supplies the address proto to resolve.
- * @return pointer to the Instance or an error status
+ * @return pointer to the Instance.
  */
-absl::StatusOr<Address::InstanceConstSharedPtr>
+Address::InstanceConstSharedPtr
 resolveProtoAddress(const envoy::config::core::v3::Address& address);
 
 /**
  * Create an Instance from a envoy::config::core::v3::SocketAddress.
  * @param address supplies the socket address proto to resolve.
- * @return pointer to the Instance or an error status.
+ * @return pointer to the Instance.
  */
-absl::StatusOr<Address::InstanceConstSharedPtr>
+Address::InstanceConstSharedPtr
 resolveProtoSocketAddress(const envoy::config::core::v3::SocketAddress& address);
 
 DECLARE_FACTORY(IpResolver);

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -371,11 +371,10 @@ HdsCluster::HdsCluster(Server::Configuration::ServerFactoryContext& server_conte
     for (const auto& host : locality_endpoints.lb_endpoints()) {
       const LocalityEndpointTuple endpoint_key = {locality_endpoints.locality(), host};
       // Initialize an endpoint host object.
-      auto address_or_error = Network::Address::resolveProtoAddress(host.endpoint().address());
-      THROW_IF_STATUS_NOT_OK(address_or_error, throw);
       HostSharedPtr endpoint = std::make_shared<HostImpl>(
-          info_, "", std::move(address_or_error.value()), nullptr, 1, locality_endpoints.locality(),
-          host.endpoint().health_check_config(), 0, envoy::config::core::v3::UNKNOWN, time_source_);
+          info_, "", Network::Address::resolveProtoAddress(host.endpoint().address()), nullptr, 1,
+          locality_endpoints.locality(), host.endpoint().health_check_config(), 0,
+          envoy::config::core::v3::UNKNOWN, time_source_);
       // Add this host/endpoint pointer to our flat list of endpoints for health checking.
       hosts_->push_back(endpoint);
       // Add this host/endpoint pointer to our structured list by locality so results can be
@@ -484,13 +483,10 @@ void HdsCluster::updateHosts(
         host = host_pair->second;
       } else {
         // We do not have this endpoint saved, so create a new one.
-        auto address_or_error =
-            Network::Address::resolveProtoAddress(endpoint.endpoint().address());
-        THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-        host = std::make_shared<HostImpl>(info_, "", std::move(address_or_error.value()), nullptr,
-                                          1, endpoints.locality(),
-                                          endpoint.endpoint().health_check_config(), 0,
-                                          envoy::config::core::v3::UNKNOWN, time_source_);
+        host = std::make_shared<HostImpl>(
+            info_, "", Network::Address::resolveProtoAddress(endpoint.endpoint().address()),
+            nullptr, 1, endpoints.locality(), endpoint.endpoint().health_check_config(), 0,
+            envoy::config::core::v3::UNKNOWN, time_source_);
 
         // Set the initial health status as in HdsCluster::initialize.
         host->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -555,9 +555,7 @@ public:
       const auto& resolver_addrs = cares.resolvers();
       resolvers.reserve(resolver_addrs.size());
       for (const auto& resolver_addr : resolver_addrs) {
-        auto address_or_error = Network::Address::resolveProtoAddress(resolver_addr);
-        THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-        resolvers.push_back(std::move(address_or_error.value()));
+        resolvers.push_back(Network::Address::resolveProtoAddress(resolver_addr));
       }
     }
     return std::make_shared<Network::DnsResolverImpl>(cares, dispatcher, resolvers,

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -22,9 +22,8 @@ DogStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
   const auto& sink_config =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::DogStatsdSink&>(
           config, server.messageValidationContext().staticValidationVisitor());
-  auto address_or_error = Network::Address::resolveProtoAddress(sink_config.address());
-  THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-  Network::Address::InstanceConstSharedPtr address = address_or_error.value();
+  Network::Address::InstanceConstSharedPtr address =
+      Network::Address::resolveProtoAddress(sink_config.address());
   ENVOY_LOG(debug, "dog_statsd UDP ip address: {}", address->asString());
   absl::optional<uint64_t> max_bytes;
   if (sink_config.has_max_bytes_per_datagram()) {

--- a/source/extensions/stat_sinks/graphite_statsd/config.cc
+++ b/source/extensions/stat_sinks/graphite_statsd/config.cc
@@ -25,9 +25,8 @@ GraphiteStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
   switch (statsd_sink.statsd_specifier_case()) {
   case envoy::extensions::stat_sinks::graphite_statsd::v3::GraphiteStatsdSink::StatsdSpecifierCase::
       kAddress: {
-    auto address_or_error = Network::Address::resolveProtoAddress(statsd_sink.address());
-    THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-    Network::Address::InstanceConstSharedPtr address = address_or_error.value();
+    Network::Address::InstanceConstSharedPtr address =
+        Network::Address::resolveProtoAddress(statsd_sink.address());
     ENVOY_LOG(debug, "statsd UDP ip address: {}", address->asString());
     absl::optional<uint64_t> max_bytes;
     if (statsd_sink.has_max_bytes_per_datagram()) {

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -23,9 +23,8 @@ StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
           config, server.messageValidationContext().staticValidationVisitor());
   switch (statsd_sink.statsd_specifier_case()) {
   case envoy::config::metrics::v3::StatsdSink::StatsdSpecifierCase::kAddress: {
-    auto address_or_error = Network::Address::resolveProtoAddress(statsd_sink.address());
-    THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-    Network::Address::InstanceConstSharedPtr address = address_or_error.value();
+    Network::Address::InstanceConstSharedPtr address =
+        Network::Address::resolveProtoAddress(statsd_sink.address());
     ENVOY_LOG(debug, "statsd UDP ip address: {}", address->asString());
     return std::make_unique<Common::Statsd::UdpStatsdSink>(server.threadLocal(), std::move(address),
                                                            false, statsd_sink.prefix());

--- a/source/server/api_listener_impl.cc
+++ b/source/server/api_listener_impl.cc
@@ -13,10 +13,10 @@
 namespace Envoy {
 namespace Server {
 
-ApiListenerImplBase::ApiListenerImplBase(Network::Address::InstanceConstSharedPtr&& address,
-                                         const envoy::config::listener::v3::Listener& config,
+ApiListenerImplBase::ApiListenerImplBase(const envoy::config::listener::v3::Listener& config,
                                          Server::Instance& server, const std::string& name)
-    : config_(config), name_(name), address_(std::move(address)),
+    : config_(config), name_(name),
+      address_(Network::Address::resolveProtoAddress(config.address())),
       factory_context_(server, *this, server.stats().createScope(""),
                        server.stats().createScope(fmt::format("listener.api.{}.", name_)),
                        std::make_shared<ListenerInfoImpl>(config)) {}
@@ -41,19 +41,9 @@ HttpApiListener::ApiListenerWrapper::newStreamHandle(Http::ResponseEncoder& resp
   return http_connection_manager_->newStreamHandle(response_encoder, is_internally_created);
 }
 
-absl::StatusOr<std::unique_ptr<HttpApiListener>>
-HttpApiListener::create(const envoy::config::listener::v3::Listener& config,
-                        Server::Instance& server, const std::string& name) {
-  auto address_or_error = Network::Address::resolveProtoAddress(config.address());
-  RETURN_IF_STATUS_NOT_OK(address_or_error);
-  return std::unique_ptr<HttpApiListener>(
-      new HttpApiListener(std::move(address_or_error.value()), config, server, name));
-}
-
-HttpApiListener::HttpApiListener(Network::Address::InstanceConstSharedPtr&& address,
-                                 const envoy::config::listener::v3::Listener& config,
+HttpApiListener::HttpApiListener(const envoy::config::listener::v3::Listener& config,
                                  Server::Instance& server, const std::string& name)
-    : ApiListenerImplBase(std::move(address), config, server, name) {
+    : ApiListenerImplBase(config, server, name) {
   if (config.api_listener().api_listener().type_url() ==
       absl::StrCat(
           "type.googleapis.com/",

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -49,8 +49,7 @@ public:
   }
 
 protected:
-  ApiListenerImplBase(Network::Address::InstanceConstSharedPtr&& address,
-                      const envoy::config::listener::v3::Listener& config, Server::Instance& server,
+  ApiListenerImplBase(const envoy::config::listener::v3::Listener& config, Server::Instance& server,
                       const std::string& name);
 
   // Synthetic class that acts as a stub Network::ReadFilterCallbacks.
@@ -222,18 +221,14 @@ public:
     Http::ApiListenerPtr http_connection_manager_;
   };
 
+  HttpApiListener(const envoy::config::listener::v3::Listener& config, Server::Instance& server,
+                  const std::string& name);
+
   // ApiListener
   ApiListener::Type type() const override { return ApiListener::Type::HttpApiListener; }
   Http::ApiListenerPtr createHttpApiListener(Event::Dispatcher& dispatcher) override;
-  static absl::StatusOr<std::unique_ptr<HttpApiListener>>
-  create(const envoy::config::listener::v3::Listener& config, Server::Instance& server,
-         const std::string& name);
 
 private:
-  HttpApiListener(Network::Address::InstanceConstSharedPtr&& address,
-                  const envoy::config::listener::v3::Listener& config, Server::Instance& server,
-                  const std::string& name);
-
   // Need to store the factory due to the shared_ptrs that need to be kept alive: date provider,
   // route config manager, scoped route config manager.
   std::function<Http::ApiListenerPtr(Network::ReadFilterCallbacks&)>

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -231,9 +231,7 @@ InitialImpl::InitialImpl(const envoy::config::bootstrap::v3::Bootstrap& bootstra
   admin_.profile_path_ =
       admin.profile_path().empty() ? "/var/log/envoy/envoy.prof" : admin.profile_path();
   if (admin.has_address()) {
-    auto address_or_error = Network::Address::resolveProtoAddress(admin.address());
-    THROW_IF_STATUS_NOT_OK(address_or_error, throw);
-    admin_.address_ = std::move(address_or_error.value());
+    admin_.address_ = Network::Address::resolveProtoAddress(admin.address());
   }
   admin_.socket_options_ = std::make_shared<std::vector<Network::Socket::OptionConstSharedPtr>>();
   if (!admin.socket_options().empty()) {

--- a/test/common/network/resolver_impl_test.cc
+++ b/test/common/network/resolver_impl_test.cc
@@ -32,7 +32,7 @@ TEST_F(IpResolverTest, Basic) {
   envoy::config::core::v3::SocketAddress socket_address;
   socket_address.set_address("1.2.3.4");
   socket_address.set_port_value(443);
-  auto address = resolver_->resolve(socket_address).value();
+  auto address = resolver_->resolve(socket_address);
   EXPECT_EQ(address->ip()->addressAsString(), "1.2.3.4");
   EXPECT_EQ(address->ip()->port(), 443);
 }
@@ -41,25 +41,26 @@ TEST_F(IpResolverTest, DisallowsNamedPort) {
   envoy::config::core::v3::SocketAddress socket_address;
   socket_address.set_address("1.2.3.4");
   socket_address.set_named_port("http");
-  EXPECT_EQ(resolver_->resolve(socket_address).status().message(),
-            fmt::format("IP resolver can't handle port specifier type {}",
-                        envoy::config::core::v3::SocketAddress::PortSpecifierCase::kNamedPort));
+  EXPECT_THROW_WITH_MESSAGE(
+      resolver_->resolve(socket_address), EnvoyException,
+      fmt::format("IP resolver can't handle port specifier type {}",
+                  envoy::config::core::v3::SocketAddress::PortSpecifierCase::kNamedPort));
 }
 
 TEST(ResolverTest, FromProtoAddress) {
   envoy::config::core::v3::Address ipv4_address;
   ipv4_address.mutable_socket_address()->set_address("1.2.3.4");
   ipv4_address.mutable_socket_address()->set_port_value(5);
-  EXPECT_EQ("1.2.3.4:5", resolveProtoAddress(ipv4_address).value()->asString());
+  EXPECT_EQ("1.2.3.4:5", resolveProtoAddress(ipv4_address)->asString());
 
   envoy::config::core::v3::Address ipv6_address;
   ipv6_address.mutable_socket_address()->set_address("1::1");
   ipv6_address.mutable_socket_address()->set_port_value(2);
-  EXPECT_EQ("[1::1]:2", resolveProtoAddress(ipv6_address).value()->asString());
+  EXPECT_EQ("[1::1]:2", resolveProtoAddress(ipv6_address)->asString());
 
   envoy::config::core::v3::Address pipe_address;
   pipe_address.mutable_pipe()->set_path("/foo/bar");
-  EXPECT_EQ("/foo/bar", resolveProtoAddress(pipe_address).value()->asString());
+  EXPECT_EQ("/foo/bar", resolveProtoAddress(pipe_address)->asString());
 }
 
 TEST(ResolverTest, InternalListenerNameFromProtoAddress) {
@@ -67,14 +68,14 @@ TEST(ResolverTest, InternalListenerNameFromProtoAddress) {
   internal_listener_address.mutable_envoy_internal_address()->set_server_listener_name(
       "internal_listener_foo");
   EXPECT_EQ("envoy://internal_listener_foo/",
-            resolveProtoAddress(internal_listener_address).value()->asString());
+            resolveProtoAddress(internal_listener_address)->asString());
 }
 
 TEST(ResolverTest, UninitializedInternalAddressFromProtoAddress) {
   envoy::config::core::v3::Address internal_address;
   internal_address.mutable_envoy_internal_address();
   EXPECT_THROW_WITH_MESSAGE(
-      resolveProtoAddress(internal_address).IgnoreError(), EnvoyException,
+      resolveProtoAddress(internal_address), EnvoyException,
       fmt::format("Failed to resolve address:{}", internal_address.DebugString()));
 }
 
@@ -84,7 +85,7 @@ TEST(ResolverTest, FromProtoAddressV4Compat) {
     envoy::config::core::v3::Address ipv6_address;
     ipv6_address.mutable_socket_address()->set_address("1::1");
     ipv6_address.mutable_socket_address()->set_port_value(2);
-    auto resolved_addr = resolveProtoAddress(ipv6_address).value();
+    auto resolved_addr = resolveProtoAddress(ipv6_address);
     EXPECT_EQ("[1::1]:2", resolved_addr->asString());
   }
   {
@@ -92,14 +93,14 @@ TEST(ResolverTest, FromProtoAddressV4Compat) {
     ipv6_address.mutable_socket_address()->set_address("1::1");
     ipv6_address.mutable_socket_address()->set_port_value(2);
     ipv6_address.mutable_socket_address()->set_ipv4_compat(true);
-    auto resolved_addr = resolveProtoAddress(ipv6_address).value();
+    auto resolved_addr = resolveProtoAddress(ipv6_address);
     EXPECT_EQ("[1::1]:2", resolved_addr->asString());
   }
 }
 
 class TestResolver : public Resolver {
 public:
-  absl::StatusOr<InstanceConstSharedPtr>
+  InstanceConstSharedPtr
   resolve(const envoy::config::core::v3::SocketAddress& socket_address) override {
     const std::string& logical = socket_address.address();
     const std::string physical = getPhysicalName(logical);
@@ -153,7 +154,7 @@ TEST(ResolverTest, NonStandardResolver) {
     socket->set_address("foo");
     socket->set_port_value(5);
     socket->set_resolver_name("envoy.test.resolver");
-    auto instance = resolveProtoAddress(address).value();
+    auto instance = resolveProtoAddress(address);
     EXPECT_EQ("1.2.3.4:5", instance->asString());
     EXPECT_EQ("foo:5", instance->logicalName());
   }
@@ -163,7 +164,7 @@ TEST(ResolverTest, NonStandardResolver) {
     socket->set_address("bar");
     socket->set_named_port("http");
     socket->set_resolver_name("envoy.test.resolver");
-    auto instance = resolveProtoAddress(address).value();
+    auto instance = resolveProtoAddress(address);
     EXPECT_EQ("4.3.2.1:http", instance->asString());
     EXPECT_EQ("bar:http", instance->logicalName());
   }
@@ -171,8 +172,7 @@ TEST(ResolverTest, NonStandardResolver) {
 
 TEST(ResolverTest, UninitializedAddress) {
   envoy::config::core::v3::Address address;
-  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(address).IgnoreError(), EnvoyException,
-                            "Address must be set: ");
+  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(address), EnvoyException, "Address must be set: ");
 }
 
 TEST(ResolverTest, NoSuchResolver) {
@@ -181,7 +181,7 @@ TEST(ResolverTest, NoSuchResolver) {
   socket->set_address("foo");
   socket->set_port_value(5);
   socket->set_resolver_name("envoy.test.resolver");
-  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(address).IgnoreError(), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(resolveProtoAddress(address), EnvoyException,
                             "Unknown address resolver: envoy.test.resolver");
 }
 

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -170,7 +170,7 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
           replaceInvalidHostCharacters(
               stream_info.address().envoy_internal_address().server_listener_name()));
     } else {
-      address = Envoy::Network::Address::resolveProtoAddress(stream_info.address()).value();
+      address = Envoy::Network::Address::resolveProtoAddress(stream_info.address());
     }
   } else {
     address = Network::Utility::resolveUrl("tcp://10.0.0.1:443");
@@ -178,7 +178,6 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
   auto upstream_local_address =
       stream_info.has_upstream_local_address()
           ? Envoy::Network::Address::resolveProtoAddress(stream_info.upstream_local_address())
-                .value()
           : Network::Utility::resolveUrl("tcp://10.0.0.1:10000");
   test_stream_info->upstreamInfo()->setUpstreamLocalAddress(upstream_local_address);
   test_stream_info->downstream_connection_info_provider_ =

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -88,7 +88,7 @@ public:
   MockAddressResolver();
   ~MockAddressResolver() override;
 
-  MOCK_METHOD(absl::StatusOr<Address::InstanceConstSharedPtr>, resolve,
+  MOCK_METHOD(Address::InstanceConstSharedPtr, resolve,
               (const envoy::config::core::v3::SocketAddress&));
   MOCK_METHOD(std::string, name, (), (const));
 };

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -53,11 +53,11 @@ api_listener:
   const envoy::config::listener::v3::Listener config = parseListenerFromV3Yaml(yaml);
   server_.server_factory_context_->cluster_manager_.initializeClusters(
       {"dynamic_forward_proxy_cluster"}, {});
-  auto http_api_listener = HttpApiListener::create(config, server_, config.name()).value();
+  auto http_api_listener = HttpApiListener(config, server_, config.name());
 
-  ASSERT_EQ("test_api_listener", http_api_listener->name());
-  ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener->type());
-  ASSERT_NE(http_api_listener->createHttpApiListener(server_.dispatcher()), nullptr);
+  ASSERT_EQ("test_api_listener", http_api_listener.name());
+  ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener.type());
+  ASSERT_NE(http_api_listener.createHttpApiListener(server_.dispatcher()), nullptr);
 }
 
 TEST_F(ApiListenerTest, MobileApiListener) {
@@ -88,11 +88,11 @@ api_listener:
   const envoy::config::listener::v3::Listener config = parseListenerFromV3Yaml(yaml);
   server_.server_factory_context_->cluster_manager_.initializeClusters(
       {"dynamic_forward_proxy_cluster"}, {});
-  auto http_api_listener = HttpApiListener::create(config, server_, config.name()).value();
+  auto http_api_listener = HttpApiListener(config, server_, config.name());
 
-  ASSERT_EQ("test_api_listener", http_api_listener->name());
-  ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener->type());
-  ASSERT_NE(http_api_listener->createHttpApiListener(server_.dispatcher()), nullptr);
+  ASSERT_EQ("test_api_listener", http_api_listener.name());
+  ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener.type());
+  ASSERT_NE(http_api_listener.createHttpApiListener(server_.dispatcher()), nullptr);
 }
 
 TEST_F(ApiListenerTest, HttpApiListenerThrowsWithBadConfig) {
@@ -125,7 +125,7 @@ api_listener:
       ->set_path("eds path");
   expected_any_proto.PackFrom(expected_cluster_proto);
   EXPECT_THROW_WITH_MESSAGE(
-      HttpApiListener::create(config, server_, config.name()).IgnoreError(), EnvoyException,
+      HttpApiListener(config, server_, config.name()), EnvoyException,
       fmt::format("Unable to unpack as "
                   "envoy.extensions.filters.network.http_connection_manager.v3."
                   "HttpConnectionManager: {}",
@@ -159,11 +159,11 @@ api_listener:
   const envoy::config::listener::v3::Listener config = parseListenerFromV3Yaml(yaml);
   server_.server_factory_context_->cluster_manager_.initializeClusters(
       {"dynamic_forward_proxy_cluster"}, {});
-  auto http_api_listener = HttpApiListener::create(config, server_, config.name()).value();
+  auto http_api_listener = HttpApiListener(config, server_, config.name());
 
-  ASSERT_EQ("test_api_listener", http_api_listener->name());
-  ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener->type());
-  auto api_listener = http_api_listener->createHttpApiListener(server_.dispatcher());
+  ASSERT_EQ("test_api_listener", http_api_listener.name());
+  ASSERT_EQ(ApiListener::Type::HttpApiListener, http_api_listener.type());
+  auto api_listener = http_api_listener.createHttpApiListener(server_.dispatcher());
   ASSERT_NE(api_listener, nullptr);
 
   Network::MockConnectionCallbacks network_connection_callbacks;

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -109,6 +109,7 @@ paths:
     - source/common/network/address_impl.cc
     - source/common/network/utility.cc
     - source/common/network/dns_resolver/dns_factory_util.cc
+    - source/common/network/resolver_impl.cc
     - source/common/network/socket_impl.cc
     - source/common/ssl/tls_certificate_config_impl.cc
     - source/common/formatter/http_specific_formatter.cc


### PR DESCRIPTION
This reverts commit 7a1a883aed9dce124f449a82331228c055812356.

Most mobile ci has started permafailing since this landed

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
