### PR TITLE
protos: for Go, allow *opt-out* of PGV

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -305,6 +305,9 @@ case $CI_TARGET in
             # echo "Copying go files ${INPUT_DIR} -> ${OUTPUT_DIR}"
             while read -r GO_FILE; do
                 cp -a "$GO_FILE" "$OUTPUT_DIR"
+                if [[ "$GO_FILE" = *.validate.go ]]; then
+                    sed -i '1s;^;//go:build !disable_pgv\n;' "$OUTPUT_DIR/$(basename "$GO_FILE")"
+                fi
             done <<< "$(find "$INPUT_DIR" -name "*.go")"
         done
         ;;


### PR DESCRIPTION


Commit Message: protos: for Go, allow *opt-out* of PGV
Additional Description:

PGV is extremely expensive in terms of binary size. This directly feeds into memory usage, storage and transmission costs, etc. For our binary, disable PGV (which we don't use) trims our binaries by a whopping 15MB!

This PR has no negative impact on any users unless they explicitly opt out of PGV (with `-tags=disable_pgv`). All existing users are un-impacted. This change only impacts Go via the go-control-plane repo.

This change is do as a post-processing step rather than in PGV upstream as PGV has moved to v1.0 and totally rewritten the repo, so the old PGV is frozen AFAIK. Since moving to v1.0 is a major effort (possibly not planned), the simple approach here was taken.

This mirrors https://github.com/envoyproxy/envoy/pull/31172, where similar proto additions are currently on hold due to the binary size increase. There we are also planning to take a similar opt-in to the binary size increase. In this case, we use an opt-out for backwards compatibility, as PGV has been around longer.


Risk Level: None, opt-in
Testing: Manual
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
