### PR TITLE
Docs: include the hot-restart example as a link

### DIFF
--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -27,7 +27,7 @@ following general architecture:
   process and the old Envoy process are running inside different containers. Communication between
   the processes takes place only using unix domain sockets.
 * An example restarter/parent process written in Python is included in the source distribution at
-  `restarter/hot-restarter.py <https://github.com/envoyproxy/envoy/blob/main/restarter/hot-restarter.py>`_.
+  :repo:`restarter/hot-restarter.py <restarter/hot-restarter.py>`.
   This parent process is usable with standard process control utilities such as monit/runit/etc.
 
 Envoy's default command line options assume that only a single set of Envoy processes is running on

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -26,8 +26,9 @@ following general architecture:
 * Envoy’s hot restart support was designed so that it will work correctly even if the new Envoy
   process and the old Envoy process are running inside different containers. Communication between
   the processes takes place only using unix domain sockets.
-* An example restarter/parent process written in Python is included in the source distribution. This
-  parent process is usable with standard process control utilities such as monit/runit/etc.
+* An example restarter/parent process written in Python is included in the source distribution at
+  `restarter/hot-restarter.py <https://github.com/envoyproxy/envoy/blob/main/restarter/hot-restarter.py>`_.
+  This parent process is usable with standard process control utilities such as monit/runit/etc.
 
 Envoy's default command line options assume that only a single set of Envoy processes is running on
 a given host: an active Envoy server process and, potentially, a draining Envoy server process that


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: docs(hot_restart): include the example as a link
Additional Description: The hot-restart documentation was mentioning that the repository contains an example but it was not being linked for quick access.
Risk Level: Low
Testing: N/A
Docs Changes: docs/root/intro/arch_overview/operations/hot_restart.rst
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
