### PR TITLE
Sending local reply with status code 502 for request dropped by drop_overload

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -2032,9 +2032,9 @@ bool Filter::checkDropOverload(Upstream::ThreadLocalCluster& cluster,
     if (config_.random_.bernoulli(cluster.dropOverload())) {
       ENVOY_STREAM_LOG(debug, "The request is dropped by DROP_OVERLOAD", *callbacks_);
       callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DropOverLoad);
-      chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, true);
+      chargeUpstreamCode(Http::Code::BadGateway, nullptr, true);
       callbacks_->sendLocalReply(
-          Http::Code::ServiceUnavailable, "drop overload",
+          Http::Code::BadGateway, "drop overload",
           [modify_headers, this](Http::ResponseHeaderMap& headers) {
             if (!config_.suppress_envoy_headers_) {
               headers.addReference(Http::Headers::get().EnvoyDropOverload,

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -811,7 +811,7 @@ TEST_F(RouterTest, DropOverloadDropped) {
   EXPECT_CALL(random_, random())
       .WillRepeatedly(Return(0.2 * float(std::numeric_limits<uint64_t>::max())));
 
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"},
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "502"},
                                                    {"content-length", "13"},
                                                    {"content-type", "text/plain"},
                                                    {"x-envoy-drop-overload", "true"}};

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -930,7 +930,7 @@ TEST_P(EdsIntegrationTest, DataplaneTrafficAfterEdsUpdateOfInitializedCluster) {
 // Test EDS cluster DROP_OVERLOAD configuration.
 TEST_P(EdsIntegrationTest, DropOverloadTestForEdsClusterNoDrop) { dropOverloadTest(0, "200"); }
 
-TEST_P(EdsIntegrationTest, DropOverloadTestForEdsClusterAllDrop) { dropOverloadTest(100, "503"); }
+TEST_P(EdsIntegrationTest, DropOverloadTestForEdsClusterAllDrop) { dropOverloadTest(100, "502"); }
 
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Sending local reply with status code 502 (BAD_GATEWAY) instead of 503(SERVICE_UNAVAILABLE)for request dropped by drop_overload.  

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
