### PR TITLE
Remove assertions for DrainManagerImpl to be run on main thread.

### DIFF
--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -86,7 +86,6 @@ bool DrainManagerImpl::drainClose() const {
 }
 
 Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(DrainCloseCb cb) const {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
   ASSERT(dispatcher_.isThreadSafe());
 
   if (draining_) {
@@ -117,7 +116,7 @@ Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(DrainCloseCb cb) c
 }
 
 void DrainManagerImpl::addDrainCompleteCallback(std::function<void()> cb) {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  ASSERT(dispatcher_.isThreadSafe());
   ASSERT(draining_);
 
   // If the drain-tick-timer is active, add the callback to the queue. If not defined
@@ -130,7 +129,7 @@ void DrainManagerImpl::addDrainCompleteCallback(std::function<void()> cb) {
 }
 
 void DrainManagerImpl::startDrainSequence(std::function<void()> drain_complete_cb) {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  ASSERT(dispatcher_.isThreadSafe());
   ASSERT(drain_complete_cb);
 
   // If we've already started draining (either through direct invocation or through


### PR DESCRIPTION
Remove assertions for DrainManagerImpl to be run on main thread. These callbacks can be run on the worker thread so we must only check that the dispatcher is thread safe

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
