### PR TITLE
mobile: Remove isQuicEnabled parameter

### DIFF
--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
@@ -535,12 +535,11 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
     mBytesReceivedFromRedirects += mBytesReceivedFromLastRedirect;
     mAdditionalStatusDetails = Status.CONNECTING;
     mUrlChain.add(mCurrentUrl);
-    Map<String, List<String>> envoyRequestHeaders =
-        buildEnvoyRequestHeaders(mInitialMethod, mRequestHeaders, mUploadDataStream, mUserAgent,
-                                 mCurrentUrl, mRequestContext.getBuilder().quicEnabled());
+    Map<String, List<String>> envoyRequestHeaders = buildEnvoyRequestHeaders(
+        mInitialMethod, mRequestHeaders, mUploadDataStream, mUserAgent, mCurrentUrl);
     mCronvoyCallbacks = new CronvoyHttpCallbacks();
     mStream.set(mRequestContext.getEnvoyEngine().startStream(mCronvoyCallbacks,
-                                                             /* explicitFlowCrontrol= */ true));
+                                                             /* explicitFlowControl= */ true));
     mStream.get().sendHeaders(envoyRequestHeaders, mUploadDataStream == null);
     if (mUploadDataStream != null && mUrlChain.size() == 1) {
       mUploadDataStream.initializeWithRequest();
@@ -550,7 +549,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
   private static Map<String, List<String>>
   buildEnvoyRequestHeaders(String initialMethod, HeadersList headersList,
                            CronvoyUploadDataStream mUploadDataStream, String userAgent,
-                           String currentUrl, boolean isQuicEnabled) {
+                           String currentUrl) {
     Map<String, List<String>> headers = new LinkedHashMap<>();
     final URL url;
     try {

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
@@ -30,7 +30,6 @@ import org.chromium.net.UrlRequest;
 import org.chromium.net.impl.CronvoyVersionSafeCallbacks.RequestFinishedInfoListener;
 import org.chromium.net.urlconnection.CronvoyHttpURLConnection;
 import org.chromium.net.urlconnection.CronvoyURLStreamHandlerFactory;
-import org.chromium.net.impl.CronvoyLogger;
 
 /**
  * Cronvoy engine shim.
@@ -61,7 +60,6 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
   private Thread mNetworkThread;
 
   private final String mUserAgent;
-  private final CronvoyEngineBuilderImpl mBuilder;
   private final AtomicReference<Runnable> mInitializationCompleter = new AtomicReference<>();
   private final CronvoyLogger mCronvoyLogger = new CronvoyLogger();
 
@@ -77,7 +75,6 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
       new HashMap<>();
 
   public CronvoyUrlRequestContext(NativeCronvoyEngineBuilderImpl builder) {
-    mBuilder = builder;
     // On android, all background threads (and all threads that are part
     // of background processes) are put in a cgroup that is allowed to
     // consume up to 5% of CPU - these worker threads spend the vast
@@ -112,8 +109,6 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
       return mEngine;
     }
   }
-
-  CronvoyEngineBuilderImpl getBuilder() { return mBuilder; }
 
   void setTaskToExecuteWhenInitializationIsCompleted(Runnable runnable) {
     if (!mInitializationCompleter.compareAndSet(null, runnable)) {


### PR DESCRIPTION
This PR removes the unused `isQuicEnabled` parameter that is no longer used since the protocol-based routing was removed in https://github.com/envoyproxy/envoy/pull/25893

Risk Level: low (unused code)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
