### PR TITLE
server: switch the assert to allow child threads.

### DIFF
--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -86,7 +86,6 @@ bool DrainManagerImpl::drainClose() const {
 }
 
 Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(DrainCloseCb cb) const {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
   ASSERT(dispatcher_.isThreadSafe());
 
   if (draining_) {
@@ -117,7 +116,7 @@ Common::CallbackHandlePtr DrainManagerImpl::addOnDrainCloseCb(DrainCloseCb cb) c
 }
 
 void DrainManagerImpl::addDrainCompleteCallback(std::function<void()> cb) {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  ASSERT(dispatcher_.isThreadSafe());
   ASSERT(draining_);
 
   // If the drain-tick-timer is active, add the callback to the queue. If not defined
@@ -130,7 +129,7 @@ void DrainManagerImpl::addDrainCompleteCallback(std::function<void()> cb) {
 }
 
 void DrainManagerImpl::startDrainSequence(std::function<void()> drain_complete_cb) {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  ASSERT(dispatcher_.isThreadSafe());
   ASSERT(drain_complete_cb);
 
   // If we've already started draining (either through direct invocation or through


### PR DESCRIPTION
Commit Message: The new asserts in #31452 don't allow child draining threads. Sadly there are no tests that catch this in OSS. This tweaks the asserts so this can work, and we have verified this with internal tests.
Additional Description:
Risk Level: low
Testing: just CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

