### PR TITLE
mobile: Fix narrowing conversion issue

### DIFF
--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -220,7 +220,7 @@ void Client::DirectStreamCallbacks::sendTrailersToBridge(const ResponseTrailerMa
   onComplete();
 }
 
-void Client::DirectStreamCallbacks::resumeData(int32_t bytes_to_send) {
+void Client::DirectStreamCallbacks::resumeData(size_t bytes_to_send) {
   ASSERT(explicit_flow_control_);
   ASSERT(bytes_to_send > 0);
 

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -186,7 +186,7 @@ private:
     //
     // Bytes will only be sent up once, even if the bytes available are fewer
     // than bytes_to_send.
-    void resumeData(int32_t bytes_to_send);
+    void resumeData(size_t bytes_to_send);
 
     void setFinalStreamIntel(StreamInfo::StreamInfo& stream_info);
 
@@ -219,7 +219,7 @@ private:
     bool remote_end_stream_received_{};
     // Set true when the end stream has been forwarded to the bridge.
     bool remote_end_stream_forwarded_{};
-    uint32_t bytes_to_send_{};
+    size_t bytes_to_send_{};
   };
 
   using DirectStreamCallbacksPtr = std::unique_ptr<DirectStreamCallbacks>;


### PR DESCRIPTION
This PR changes the `bytes_to_send_` to `size_t` instead of `int32_t`, so that there is no longer a narrowing conversion issue.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
