### PR TITLE
Revert "deps: Bump toolshed actions -> 0.2.23 (#31725)"

### DIFF
--- a/.github/workflows/_cache.yml
+++ b/.github/workflows/_cache.yml
@@ -29,7 +29,7 @@ on:
 # For a job that does, you can restore with something like:
 #
 #    steps:
-#    - uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+#    - uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
 #      with:
 #        key: "${{ needs.env.outputs.build-image }}"
 #
@@ -39,20 +39,20 @@ jobs:
   docker:
     runs-on: ubuntu-22.04
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: appauth
       name: Appauth (mutex lock)
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/docker/cache/prime@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: docker
       name: Prime Docker cache (${{ inputs.image-tag }})
       with:
         image-tag: ${{ inputs.image-tag }}
         lock-token: ${{ steps.appauth.outputs.token }}
         lock-repository: ${{ inputs.lock-repository }}
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: data
       name: Cache data
       with:
@@ -60,7 +60,7 @@ jobs:
         input: |
           cached: ${{ steps.docker.outputs.cached }}
           key: ${{ inputs.image-tag }}
-    - uses: envoyproxy/toolshed/gh-actions/json/table@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/json/table@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Summary
       with:
         json: ${{ steps.data.outputs.value }}

--- a/.github/workflows/_finish.yml
+++ b/.github/workflows/_finish.yml
@@ -36,7 +36,7 @@ jobs:
       actions: read
       contents: read
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Incoming data
       id: needs
       with:
@@ -87,7 +87,7 @@ jobs:
                    summary: "Check has finished",
                    text: $text}}}}
 
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Print summary
       with:
         input: ${{ toJSON(steps.needs.outputs.value).summary-title }}
@@ -95,13 +95,13 @@ jobs:
           "## \(.)"
         options: -Rr
         output-path: GITHUB_STEP_SUMMARY
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checks@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checks@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Update check
       with:
         action: update

--- a/.github/workflows/_load.yml
+++ b/.github/workflows/_load.yml
@@ -91,7 +91,7 @@ jobs:
     # Handle any failure in triggering job
     # Remove any `checks` we dont care about
     # Prepare a check request
-    - uses: envoyproxy/toolshed/gh-actions/github/env/load@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/env/load@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Load env
       id: data
       with:
@@ -102,13 +102,13 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     #  Update the check
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checks@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checks@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Update check
       if: ${{ fromJSON(steps.data.outputs.data).data.check.action == 'RUN' }}
       with:
@@ -116,7 +116,7 @@ jobs:
         checks: ${{ toJSON(fromJSON(steps.data.outputs.data).checks) }}
         token: ${{ steps.appauth.outputs.token }}
 
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Print request summary
       with:
         input: |
@@ -136,7 +136,7 @@ jobs:
           | $summary.summary as $summary
           | "${{ inputs.template-request-summary }}"
 
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: request-output
       name: Load request
       with:

--- a/.github/workflows/_load_env.yml
+++ b/.github/workflows/_load_env.yml
@@ -63,18 +63,18 @@ jobs:
       request: ${{ steps.env.outputs.data }}
       trusted: true
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: started
       name: Create timestamp
       with:
         options: -r
         filter: |
           now
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: checkout
       name: Checkout Envoy repository
     - name: Generate environment variables
-      uses: envoyproxy/toolshed/gh-actions/envoy/ci/env@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/envoy/ci/env@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: env
       with:
         branch-name: ${{ inputs.branch-name }}
@@ -86,7 +86,7 @@ jobs:
 
     - name: Request summary
       id: summary
-      uses: envoyproxy/toolshed/gh-actions/github/env/summary@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/env/summary@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         actor: ${{ toJSON(fromJSON(steps.env.outputs.data).request.actor) }}
         base-sha: ${{ fromJSON(steps.env.outputs.data).request.base-sha }}

--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -40,14 +40,14 @@ jobs:
       env: ${{ steps.data.outputs.value }}
       config: ${{ steps.config.outputs.config }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: started
       name: Create timestamp
       with:
         options: -r
         filter: |
           now
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -60,7 +60,7 @@ jobs:
     # *ALL* variables collected should be treated as untrusted and should be sanitized before
     # use
     - name: Generate environment variables from commit
-      uses: envoyproxy/toolshed/gh-actions/envoy/ci/request@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/envoy/ci/request@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: env
       with:
         branch-name: ${{ steps.checkout.outputs.branch-name }}
@@ -71,7 +71,7 @@ jobs:
         vars: ${{ toJSON(vars) }}
     - name: Request summary
       id: summary
-      uses: envoyproxy/toolshed/gh-actions/github/env/summary@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/env/summary@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         actor: ${{ toJSON(fromJSON(steps.env.outputs.data).request.actor) }}
         base-sha: ${{ fromJSON(steps.env.outputs.data).request.base-sha }}
@@ -87,7 +87,7 @@ jobs:
         target-branch: ${{ fromJSON(steps.env.outputs.data).request.target-branch }}
 
     - name: Environment data
-      uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: data
       with:
         input: |

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -94,7 +94,7 @@ on:
       summary-post:
         type: string
         default: |
-          - uses: envoyproxy/toolshed/gh-actions/envoy/run/summary@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+          - uses: envoyproxy/toolshed/gh-actions/envoy/run/summary@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
             with:
               context: %{{ inputs.context }}
       steps-pre:
@@ -155,7 +155,7 @@ jobs:
     name: ${{ inputs.command }} ${{ inputs.target }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: started
       name: Create timestamp
       with:
@@ -163,7 +163,7 @@ jobs:
         filter: |
           now
     # This controls which input vars are exposed to the run action (and related steps)
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Context
       id: context
       with:
@@ -184,11 +184,11 @@ jobs:
           | . * {$config, $check}
     - if: ${{ inputs.cache-build-image }}
       name: Restore Docker cache ${{ inputs.cache-build-image && format('({0})', inputs.cache-build-image) || '' }}
-      uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/docker/cache/restore@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         image_tag: ${{ inputs.cache-build-image }}
 
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: appauth
       name: Appauth
       if: ${{ inputs.trusted }}
@@ -199,7 +199,7 @@ jobs:
         # - the workaround is to allow the token to be passed through.
         token: ${{ github.token }}
         token-ok: true
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -216,7 +216,7 @@ jobs:
         token: ${{ inputs.trusted && steps.appauth.outputs.token || github.token }}
 
     # This is currently only use by mobile-docs and can be removed once they are updated to the newer website
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: checkout-extra
       name: Checkout extra repository (for publishing)
       if: ${{ inputs.checkout-extra }}
@@ -224,7 +224,7 @@ jobs:
         config: ${{ inputs.checkout-extra }}
         ssh-key: ${{ inputs.trusted && inputs.ssh-key-extra || '' }}
 
-    - uses: envoyproxy/toolshed/gh-actions/github/run@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/run@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Run CI ${{ inputs.command }} ${{ inputs.target }}
       with:
         args: ${{ inputs.args != '--' && inputs.args || inputs.target }}

--- a/.github/workflows/_stage_publish.yml
+++ b/.github/workflows/_stage_publish.yml
@@ -63,7 +63,7 @@ jobs:
             export ENVOY_PUBLISH_DRY_RUN=${{ (fromJSON(inputs.request).request.version.dev || ! inputs.trusted) && 1 || '' }}
           steps-pre: |
             - id: url
-              uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+              uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 options: -Rr
                 input: >-
@@ -80,7 +80,7 @@ jobs:
                     end
                   | . as $bucket
                   | "https://storage.googleapis.com/\($bucket)/\($sha)/\($path)"
-            - uses: envoyproxy/toolshed/gh-actions/fetch@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/fetch@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 url: %{{ steps.url.outputs.value }}
                 path: %{{ runner.temp }}/release.signed
@@ -98,12 +98,12 @@ jobs:
     needs:
     - publish
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         ref: main
         repository: ${{ fromJSON(inputs.request).request.version.dev && 'envoyproxy/envoy-website' || 'envoyproxy/archive' }}

--- a/.github/workflows/_stage_verify.yml
+++ b/.github/workflows/_stage_verify.yml
@@ -50,7 +50,7 @@ jobs:
           rbe: false
           steps-pre: |
             - id: url
-              uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+              uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 options: -Rr
                 input: >-
@@ -66,15 +66,15 @@ jobs:
                     end
                   | . as $bucket
                   | "https://storage.googleapis.com/\($bucket)/\($sha)"
-            - uses: envoyproxy/toolshed/gh-actions/docker/fetch@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/docker/fetch@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 url: %{{ steps.url.outputs.value }}/docker/envoy.tar
                 variant: dev
-            - uses: envoyproxy/toolshed/gh-actions/docker/fetch@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/docker/fetch@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 url: %{{ steps.url.outputs.value }}/docker/envoy-contrib.tar
                 variant: contrib-dev
-            - uses: envoyproxy/toolshed/gh-actions/docker/fetch@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/docker/fetch@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 url: %{{ steps.url.outputs.value }}/docker/envoy-google-vrp.tar
                 variant: google-vrp-dev

--- a/.github/workflows/_start.yml
+++ b/.github/workflows/_start.yml
@@ -54,7 +54,7 @@ jobs:
   start:
     runs-on: ubuntu-22.04
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/jq@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/jq@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: check-config
       name: Prepare check data
       with:
@@ -77,13 +77,13 @@ jobs:
           | .skipped.output.summary = "${{ inputs.skipped-summary }}"
           | .skipped.output.text = ""
 
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checks@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checks@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Start checks
       id: checks
       with:
@@ -94,7 +94,7 @@ jobs:
 
           ${{ fromJSON(inputs.env).summary.summary }}
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/gh-actions/json/table@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/json/table@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Summary
       with:
         collapse-open: true
@@ -118,7 +118,7 @@ jobs:
         output-path: GITHUB_STEP_SUMMARY
         title: Checks started/skipped
 
-    - uses: envoyproxy/toolshed/gh-actions/github/env/save@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/env/save@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Save env
       id: data
       with:

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Free disk space
       if: ${{ env.BUILD_TARGETS != '' }}
-      uses: envoyproxy/toolshed/gh-actions/diskspace@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/diskspace@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         to_remove: |
           /usr/local/lib/android

--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -28,7 +28,7 @@ jobs:
          && github.actor != 'dependabot[bot]'
       }}
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/github/command@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/command@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Parse command from comment
       id: command
       with:
@@ -37,14 +37,14 @@ jobs:
           ^/(retest)
 
     # /retest
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       if: ${{ steps.command.outputs.command == 'retest' }}
       id: appauth-retest
       name: Appauth (retest)
       with:
         key: ${{ secrets.ENVOY_CI_APP_KEY }}
         app_id: ${{ secrets.ENVOY_CI_APP_ID }}
-    - uses: envoyproxy/toolshed/gh-actions/retest@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/retest@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       if: ${{ steps.command.outputs.command == 'retest' }}
       name: Retest
       with:

--- a/.github/workflows/envoy-dependency.yml
+++ b/.github/workflows/envoy-dependency.yml
@@ -50,16 +50,16 @@ jobs:
     steps:
     - id: appauth
       name: Appauth
-      uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
         key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/gh-actions/bson@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/bson@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: update
       name: Update dependency (${{ inputs.dependency }})
       with:
@@ -94,13 +94,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: envoyproxy/toolshed/gh-actions/upload/diff@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/upload/diff@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Upload diff
       with:
         name: ${{ inputs.dependency }}-${{ steps.update.outputs.output }}
     - name: Create a PR
       if: ${{ inputs.pr }}
-      uses: envoyproxy/toolshed/gh-actions/github/pr@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/pr@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         base: main
         body: |
@@ -131,11 +131,11 @@ jobs:
     steps:
     - id: appauth
       name: Appauth
-      uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
         key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -177,7 +177,7 @@ jobs:
 
     - name: Check Docker SHAs
       id: build-images
-      uses: envoyproxy/toolshed/gh-actions/docker/shas@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/docker/shas@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         images: |
            sha: envoyproxy/envoy-build-ubuntu:${{ steps.build-tools.outputs.tag }}
@@ -206,7 +206,7 @@ jobs:
       name: Update SHAs
       working-directory: envoy
     - name: Create a PR
-      uses: envoyproxy/toolshed/gh-actions/github/pr@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/pr@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         base: main
         body: Created by Envoy dependency bot

--- a/.github/workflows/envoy-release.yml
+++ b/.github/workflows/envoy-release.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         app_key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
@@ -77,10 +77,10 @@ jobs:
       name: Check changelog summary
     - if: ${{ inputs.author }}
       name: Validate signoff email
-      uses: envoyproxy/toolshed/gh-actions/email/validate@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/email/validate@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         email: ${{ inputs.author }}
-    - uses: envoyproxy/toolshed/gh-actions/github/run@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/run@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Create release
       with:
         source: |
@@ -105,7 +105,7 @@ jobs:
       name: Release version
       id: release
     - name: Create a PR
-      uses: envoyproxy/toolshed/gh-actions/github/pr@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/pr@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         base: ${{ github.ref_name }}
         commit: false
@@ -130,13 +130,13 @@ jobs:
     steps:
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         app_key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}
-    - uses: envoyproxy/toolshed/gh-actions/github/run@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/github/run@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       name: Sync version histories
       with:
         command: >-
@@ -146,7 +146,7 @@ jobs:
           --
           --signoff="${{ env.COMMITTER_NAME }} <${{ env.COMMITTER_EMAIL }}>"
     - name: Create a PR
-      uses: envoyproxy/toolshed/gh-actions/github/pr@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/pr@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         append-commit-message: true
         base: ${{ github.ref_name }}
@@ -176,7 +176,7 @@ jobs:
     name: Create release branch
     steps:
     - name: Checkout repository
-      uses: envoyproxy/toolshed/gh-actions/github/checkout@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+      uses: envoyproxy/toolshed/gh-actions/github/checkout@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         app_key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}

--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -31,12 +31,12 @@ jobs:
         - data-plane-api
         - mobile-website
     steps:
-    - uses: envoyproxy/toolshed/gh-actions/appauth@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/appauth@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/gh-actions/dispatch@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+    - uses: envoyproxy/toolshed/gh-actions/dispatch@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       with:
         repository: "envoyproxy/${{ matrix.downstream }}"
         ref: main

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -75,9 +75,9 @@ jobs:
       target: kotlin-hello-world
       runs-on: envoy-x64-small
       steps-pre: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+        - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
           with:
             apk: bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
             app: io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -104,7 +104,7 @@ jobs:
       target: ${{ matrix.target }}
       runs-on: envoy-x64-small
       steps-pre: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+        - uses: envoyproxy/toolshed/gh-actions/envoy/android/pre@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
       steps-post: ${{ matrix.steps-post }}
       timeout-minutes: 50
       trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
@@ -115,7 +115,7 @@ jobs:
         include:
         - name: java-hello-world
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 apk: bazel-bin/examples/java/hello_world/hello_envoy.apk
                 app: io.envoyproxy.envoymobile.helloenvoy/.MainActivity
@@ -134,7 +134,7 @@ jobs:
             --config=mobile-remote-release-clang-android
             //test/kotlin/apps/baseline:hello_envoy_kt
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 apk: bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
                 app: io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
@@ -149,7 +149,7 @@ jobs:
             --config=mobile-remote-release-clang-android
             //test/kotlin/apps/experimental:hello_envoy_kt
           steps-post: |
-            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+            - uses: envoyproxy/toolshed/gh-actions/envoy/android/post@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
               with:
                 apk: bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
                 app: io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -86,7 +86,7 @@ jobs:
         ./ci/mac_ci_setup.sh
         ./bazelw shutdown
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
           with:
             app: ${{ matrix.app }}
             args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}
@@ -127,7 +127,7 @@ jobs:
       source: |
         ./ci/mac_ci_setup.sh
       steps-post: |
-        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
+        - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@6b3ddd1e42c252d68fb98973760c0ee1943c9c21  # actions-v0.2.20
           with:
             app: ${{ matrix.app }}
             args: ${{ matrix.args || '--config=mobile-remote-ci-macos-ios' }}


### PR DESCRIPTION
This reverts commit 32d8e3bd9986864809b301b4c326bcaf7ccecef6.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
