### PR TITLE
mobile/ci: Remove kotlin-build from mobile-compile-time-options

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -97,22 +97,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: kotlin-build
-          args: >-
-            build
-            --config=mobile-remote-ci-macos-kotlin
-            //:android_dist
-          source: |
-            . ./ci/mac_ci_setup.sh --android
-            echo "ANDROID_NDK_HOME=${ANDROID_NDK_HOME}" >> $GITHUB_ENV
-            export ANDROID_NDK_HOME
-          steps-pre: |
-            - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0  # v3.13.0
-              with:
-                java-version: '8'
-                java-package: jdk
-                architecture: x64
-                distribution: zulu
         - name: swift-build
           args: >-
             build


### PR DESCRIPTION
That specific job has been covered in [mobile-android_build.yml](https://github.com/envoyproxy/envoy/blob/234dcc646cbfc1cd512742fc92ad704f514b5948/.github/workflows/mobile-android_build.yml#L45-L47).

This fixes #31726.

Risk Level: low (has already been covered by another job)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
