### PR TITLE
mobile/ci: Fix iOS build failures

### DIFF
--- a/.github/workflows/envoy-macos.yml
+++ b/.github/workflows/envoy-macos.yml
@@ -60,7 +60,10 @@ jobs:
         - target: ci/mac_ci_steps.sh
           name: macOS
           steps-pre: |
-            - run: ./ci/mac_ci_setup.sh
+            # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
+            # and the GitHub Action runner image no longer includes Android SDK 30:
+            # https://github.com/actions/runner-images/issues/8952
+            - run: ./ci/mac_ci_setup.sh --android
               shell: bash
               name: Setup macos
           source: |

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -103,7 +103,10 @@ jobs:
             --config=mobile-remote-ci-macos-swift
             //library/swift:ios_framework
           source: |
-            ./ci/mac_ci_setup.sh
+            # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
+            # and the GitHub Action runner image no longer includes Android SDK 30:
+            # https://github.com/actions/runner-images/issues/8952
+            ./ci/mac_ci_setup.sh --android
             ./bazelw shutdown
 
   request:

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -44,7 +44,10 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
+        # and the GitHub Action runner image no longer includes Android SDK 30:
+        # https://github.com/actions/runner-images/issues/8952
+        ./ci/mac_ci_setup.sh --android
         ./bazelw shutdown
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}
@@ -83,7 +86,10 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
+        # and the GitHub Action runner image no longer includes Android SDK 30:
+        # https://github.com/actions/runner-images/issues/8952
+        ./ci/mac_ci_setup.sh --android
         ./bazelw shutdown
       steps-post: |
         - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
@@ -125,7 +131,10 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
+        # and the GitHub Action runner image no longer includes Android SDK 30:
+        # https://github.com/actions/runner-images/issues/8952
+        ./ci/mac_ci_setup.sh --android
       steps-post: |
         - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@2b4b266dbf6e410f2e8a05abf0dcd8ad13e6ecac  # actions-v0.2.23
           with:

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -44,7 +44,10 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
+        # and the GitHub Action runner image no longer includes Android SDK 30:
+        # https://github.com/actions/runner-images/issues/8952
+        ./ci/mac_ci_setup.sh --android
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}
       timeout-minutes: ${{ matrix.timeout-minutes }}

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -51,7 +51,10 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        # TODO(fredyw): A workaround since mobile/WORKSPACE always requires Android SDK to be available
+        # and the GitHub Action runner image no longer includes Android SDK 30:
+        # https://github.com/actions/runner-images/issues/8952
+        ./ci/mac_ci_setup.sh --android
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
       steps-post: |
         - run: |


### PR DESCRIPTION
The error:

```
ERROR: /Users/runner/work/envoy/envoy/mobile/WORKSPACE:98:18: fetching android_sdk_repository rule //external:androidsdk: Android SDK api level 30 was requested but it is not installed in the Android SDK at /Users/runner/Library/Android/sdk. The api levels found were [34, 33, 32, 31]. Please choose an available api level or install api level 30 from the Android SDK Manager.
```

This PR is a workaround to install Android SDK 30 even though it's not used for building iOS apps, that's because `mobile/WORKSPACE` expects the Android SDK 30 to be available and GitHub Runner image no longer includes Android SDK 30. See https://github.com/actions/runner-images/issues/8952. Passing `--android` in the `./ci/mac_ci_setup.sh` will install the Android SDK 30.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
