### PR TITLE
Fix the wrong server response match for pg upstream tls

### DIFF
--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -440,7 +440,8 @@ Decoder::Result DecoderImpl::onDataInNegotiating(Buffer::Instance& data, bool fr
 
   // This should be reply from the server indicating if it accepted
   // request to use SSL. It is only one character long packet, where
-  // 'S' means use SSL, 'E' means do not use.
+  // 'S' means use SSL, 'N' means do not use.
+  // See details in https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-SSL
 
   // Indicate to the filter, the response and give the initial
   // packet temporarily buffered to be sent upstream.
@@ -451,7 +452,7 @@ Decoder::Result DecoderImpl::onDataInNegotiating(Buffer::Instance& data, bool fr
     if (c == 'S') {
       upstreamSSL = true;
     } else {
-      if (c != 'E') {
+      if (c != 'N') {
         state_ = State::OutOfSyncState;
       }
     }


### PR DESCRIPTION
In [this doc](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.6.7.12) of PostgreSQL, section [55.2.10.](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-SSL) outlines what is sent from server upon requesting for SSL- 

> The server then responds with a single byte containing S or N, indicating that it is willing or unwilling to perform SSL, respectively.

Current postgres filter matches 'E' instead of 'N' what was fixed in this PR. 

Commit Message:
Additional Description: 
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Fixes commit #23990 