### PR TITLE
http: abort filter chain after reset stream was called

### DIFF
--- a/changelogs/1.28.0.yaml
+++ b/changelogs/1.28.0.yaml
@@ -132,6 +132,11 @@ minor_behavior_changes:
   change: |
     When emitting grpc logs, only downstream HTTP filter state was used. Now, both downstream and upstream HTTP filter states
     will be tried to find the keys configured in filter_state_objects_to_log.
+- area: http
+  change: |
+    Abort the HTTP filter chain iteration when the stream is reset by ``resetStream()`` of filter callbacks.
+    This behavior can be reverted by setting
+    runtime flag ``envoy.reloadable_features.abort_filter_chain_on_stream_reset`` to ``false``.
 
 bug_fixes:
 - area: connection limit

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1777,9 +1777,22 @@ void ActiveStreamEncoderFilter::responseDataDrained() {
   onEncoderFilterBelowWriteBufferLowWatermark();
 }
 
+void FilterManager::resetStream(StreamResetReason reason,
+                                absl::string_view transport_failure_reason) {
+  // Stop filter chain iteration if stream is reset while filter decoding or encoding callbacks
+  // are running.
+  if (state_.filter_call_state_ & FilterCallState::IsDecodingMask) {
+    state_.decoder_filter_chain_aborted_ = true;
+  } else if (state_.filter_call_state_ & FilterCallState::IsEncodingMask) {
+    state_.encoder_filter_chain_aborted_ = true;
+  }
+
+  filter_manager_callbacks_.resetStream(reason, transport_failure_reason);
+}
+
 void ActiveStreamFilterBase::resetStream(Http::StreamResetReason reset_reason,
                                          absl::string_view transport_failure_reason) {
-  parent_.filter_manager_callbacks_.resetStream(reset_reason, transport_failure_reason);
+  parent_.resetStream(reset_reason, transport_failure_reason);
 }
 
 uint64_t ActiveStreamFilterBase::streamId() const { return parent_.streamId(); }

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1779,12 +1779,15 @@ void ActiveStreamEncoderFilter::responseDataDrained() {
 
 void FilterManager::resetStream(StreamResetReason reason,
                                 absl::string_view transport_failure_reason) {
-  // Stop filter chain iteration if stream is reset while filter decoding or encoding callbacks
-  // are running.
-  if (state_.filter_call_state_ & FilterCallState::IsDecodingMask) {
-    state_.decoder_filter_chain_aborted_ = true;
-  } else if (state_.filter_call_state_ & FilterCallState::IsEncodingMask) {
-    state_.encoder_filter_chain_aborted_ = true;
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.abort_filter_chain_on_stream_reset")) {
+    // Stop filter chain iteration if stream is reset while filter decoding or encoding callbacks
+    // are running.
+    if (state_.filter_call_state_ & FilterCallState::IsDecodingMask) {
+      state_.decoder_filter_chain_aborted_ = true;
+    } else if (state_.filter_call_state_ & FilterCallState::IsEncodingMask) {
+      state_.encoder_filter_chain_aborted_ = true;
+    }
   }
 
   filter_manager_callbacks_.resetStream(reason, transport_failure_reason);

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -780,6 +780,9 @@ public:
                               const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                               const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                               absl::string_view details) PURE;
+
+  void resetStream(StreamResetReason reason, absl::string_view transport_failure_reason);
+
   /**
    * Executes a prepared, but not yet propagated, local reply.
    * Prepared local replies can occur in the decoder filter chain iteration.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -29,6 +29,7 @@
 // If issues are found that require a runtime feature to be disabled, it should be reported
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
+RUNTIME_GUARD(envoy_reloadable_features_abort_filter_chain_on_stream_reset);
 RUNTIME_GUARD(envoy_reloadable_features_allow_absolute_url_with_mixed_scheme);
 RUNTIME_GUARD(envoy_reloadable_features_append_xfh_idempotent);
 RUNTIME_GUARD(envoy_reloadable_features_avoid_zombie_streams);

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -1279,6 +1279,50 @@ TEST_P(FilterIntegrationTest, ResetFilter) {
   EXPECT_FALSE(response->complete());
 }
 
+// Verify filters can reset the stream
+TEST_P(FilterIntegrationTest, EncoderResetFilter) {
+  // Make the add-body-filter stop iteration from encodeData. Headers should be sent to the client.
+  prependFilter(R"EOF(
+  name: encoder-reset-stream-filter
+  )EOF");
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  // Accept request and send response.
+  waitForNextUpstreamRequest(0);
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  upstream_request_->encodeHeaders(response_headers, true);
+
+  // The stream will be in the response path.
+  ASSERT_TRUE(response->waitForReset());
+  EXPECT_FALSE(response->complete());
+}
+
+TEST_P(FilterIntegrationTest, EncoderResetFilterAndContinue) {
+  // Make the add-body-filter stop iteration from encodeData. Headers should be sent to the client.
+  prependFilter(R"EOF(
+  name: encoder-reset-stream-filter
+  )EOF");
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  default_request_headers_.addCopy("continue-after-reset", "true");
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  // Accept request and send response.
+  waitForNextUpstreamRequest(0);
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  upstream_request_->encodeHeaders(response_headers, true);
+
+  // The stream will be in the response path.
+  ASSERT_TRUE(response->waitForReset());
+  EXPECT_FALSE(response->complete());
+}
+
 TEST_P(FilterIntegrationTest, LocalReplyViaFilterChainDoesNotConcurrentlyInvokeFilter) {
   prependFilter(R"EOF(
   name: assert-non-reentrant-filter

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -1280,7 +1280,50 @@ TEST_P(FilterIntegrationTest, ResetFilter) {
 }
 
 // Verify filters can reset the stream
+TEST_P(FilterIntegrationTest, ResetFilterWithRuntimeFlagFalse) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.abort_filter_chain_on_stream_reset",
+                                    "false");
+
+  // Make the add-body-filter stop iteration from encodeData. Headers should be sent to the client.
+  prependFilter(R"EOF(
+  name: reset-stream-filter
+  )EOF");
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForReset());
+  EXPECT_FALSE(response->complete());
+}
+
+// Verify filters can reset the stream
 TEST_P(FilterIntegrationTest, EncoderResetFilter) {
+  // Make the add-body-filter stop iteration from encodeData. Headers should be sent to the client.
+  prependFilter(R"EOF(
+  name: encoder-reset-stream-filter
+  )EOF");
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  IntegrationStreamDecoderPtr response =
+      codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  // Accept request and send response.
+  waitForNextUpstreamRequest(0);
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  upstream_request_->encodeHeaders(response_headers, true);
+
+  // The stream will be in the response path.
+  ASSERT_TRUE(response->waitForReset());
+  EXPECT_FALSE(response->complete());
+}
+
+TEST_P(FilterIntegrationTest, EncoderResetFilterWithRuntimeFlagFalse) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.abort_filter_chain_on_stream_reset",
+                                    "false");
+
   // Make the add-body-filter stop iteration from encodeData. Headers should be sent to the client.
   prependFilter(R"EOF(
   name: encoder-reset-stream-filter

--- a/test/integration/filters/reset_stream_filter.cc
+++ b/test/integration/filters/reset_stream_filter.cc
@@ -38,4 +38,40 @@ static Registry::RegisterFactory<ResetFilterConfig,
                                  Server::Configuration::UpstreamHttpFilterConfigFactory>
     register_upstream_;
 
+class EncoderResetFilter : public Http::PassThroughFilter {
+public:
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& request_headers, bool) override {
+    if (!request_headers.get(Http::LowerCaseString("continue-after-reset")).empty()) {
+      continue_after_reset_ = true;
+    }
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
+    encoder_callbacks_->resetStream();
+    if (continue_after_reset_) {
+      return Http::FilterHeadersStatus::Continue;
+    }
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+
+private:
+  bool continue_after_reset_{false};
+};
+
+class EncoderResetFilterConfig : public Extensions::HttpFilters::Common::EmptyHttpDualFilterConfig {
+public:
+  EncoderResetFilterConfig() : EmptyHttpDualFilterConfig("encoder-reset-stream-filter") {}
+  absl::StatusOr<Http::FilterFactoryCb>
+  createDualFilter(const std::string&, Server::Configuration::ServerFactoryContext&) override {
+    return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamFilter(std::make_shared<::Envoy::EncoderResetFilter>());
+    };
+  }
+};
+
+static Registry::RegisterFactory<EncoderResetFilterConfig,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    encoder_register_;
+
 } // namespace Envoy

--- a/test/integration/filters/reset_stream_filter.cc
+++ b/test/integration/filters/reset_stream_filter.cc
@@ -73,5 +73,8 @@ public:
 static Registry::RegisterFactory<EncoderResetFilterConfig,
                                  Server::Configuration::NamedHttpFilterConfigFactory>
     encoder_register_;
+static Registry::RegisterFactory<EncoderResetFilterConfig,
+                                 Server::Configuration::UpstreamHttpFilterConfigFactory>
+    encoder_register_upstream_;
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: http: abort filter chain after reset stream was called
Additional Description:

To close https://github.com/envoyproxy/envoy/issues/26994. The #26994 is caused by that the filter chain still continue and try to send reply after the whole stream is closed. We should abort the filter chain to avoid any possible further logic after the stream is reset.

Also see https://github.com/envoyproxy/envoy/pull/30835 for more context.

Risk Level: low.
Testing: integration.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.