### PR TITLE
header_mutation: Remove redundant assert

### DIFF
--- a/source/extensions/filters/http/header_mutation/header_mutation.cc
+++ b/source/extensions/filters/http/header_mutation/header_mutation.cc
@@ -50,7 +50,6 @@ Http::FilterHeadersStatus HeaderMutation::decodeHeaders(Http::RequestHeaderMap& 
     }
   } else {
     for (const auto* route_config : route_configs_) {
-      ASSERT(route_config != nullptr);
       route_config->mutations().mutateRequestHeaders(headers, ctx,
                                                      decoder_callbacks_->streamInfo());
     }
@@ -75,7 +74,6 @@ Http::FilterHeadersStatus HeaderMutation::encodeHeaders(Http::ResponseHeaderMap&
     }
   } else {
     for (const auto* route_config : route_configs_) {
-      ASSERT(route_config != nullptr);
       route_config->mutations().mutateResponseHeaders(headers, ctx,
                                                       encoder_callbacks_->streamInfo());
     }


### PR DESCRIPTION
Assert here is redundant. [getAllPerFilterConfig](https://github.com/envoyproxy/envoy/blob/d5de0df4e2cbc452df9e89864ccc6410ea109197/source/common/http/utility.h#L645-L648)  will guarantee here would not be nullptr (i.e., would not crash).  

So clean up the leftover from last PR
