### PR TITLE
Fix accidental --android on non-mobile ci/mac_ci_setup.sh

### DIFF
--- a/.github/workflows/envoy-macos.yml
+++ b/.github/workflows/envoy-macos.yml
@@ -60,10 +60,7 @@ jobs:
         - target: ci/mac_ci_steps.sh
           name: macOS
           steps-pre: |
-            # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
-            # and the GitHub Action runner image no longer includes Android SDK 30:
-            # https://github.com/actions/runner-images/issues/8952
-            - run: ./ci/mac_ci_setup.sh --android
+            - run: ./ci/mac_ci_setup.sh
               shell: bash
               name: Setup macos
           source: |


### PR DESCRIPTION
Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
