### PR TITLE
cryptomb: support ECDSA

### DIFF
--- a/api/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto
+++ b/api/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto
@@ -21,10 +21,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // A CryptoMbPrivateKeyMethodConfig message specifies how the CryptoMb private
 // key provider is configured. The private key provider provides ``SIMD``
-// processing for RSA sign and decrypt operations (ECDSA signing uses regular
-// BoringSSL functions). The provider works by gathering the operations into a
-// worker-thread specific queue, and processing the queue using ``ipp-crypto``
-// library when the queue is full or when a timer expires.
+// processing for ECDSA sign operations and RSA sign and decrypt operations.
+// The provider works by gathering the operations into a worker-thread specific
+// queue, and processing the queue using ``ipp-crypto`` library when the queue
+// is full or when a timer expires.
 // [#extension-category: envoy.tls.key_providers]
 message CryptoMbPrivateKeyMethodConfig {
   // Private key to use in the private key provider. If set to inline_bytes or

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -56,6 +56,72 @@ bool CryptoMbRsaContext::rsaInit(const uint8_t* in, size_t in_len) {
   return true;
 }
 
+CryptoMbEcdsaContext::~CryptoMbEcdsaContext() {
+  if (s_) {
+    ECDSA_SIG_free(s_);
+  }
+  if (ctx_) {
+    BN_CTX_end(ctx_);
+    BN_CTX_free(ctx_);
+  }
+}
+
+bool CryptoMbEcdsaContext::ecdsaInit(const uint8_t* in, size_t in_len) {
+  if (ec_key_ == nullptr) {
+    return false;
+  }
+
+  const EC_GROUP* group = EC_KEY_get0_group(ec_key_.get());
+  const BIGNUM* priv_key_ = EC_KEY_get0_private_key(ec_key_.get());
+  const EC_POINT* pub_key = EC_KEY_get0_public_key(ec_key_.get());
+  if (group == nullptr || priv_key_ == nullptr || pub_key == nullptr) {
+    return false;
+  }
+
+  s_ = ECDSA_SIG_new();
+  if (s_ == nullptr) {
+    return false;
+  }
+  BIGNUM* sig_r = BN_new();
+  BIGNUM* sig_s = BN_new();
+  if (ECDSA_SIG_set0(s_, sig_r, sig_s) == 0) {
+    return false;
+  }
+
+  ctx_ = BN_CTX_new();
+  if (ctx_ == nullptr) {
+    return false;
+  }
+  BN_CTX_start(ctx_);
+  k_ = BN_CTX_get(ctx_);
+
+  const BIGNUM* order = EC_GROUP_get0_order(group);
+  if (order == nullptr) {
+    return false;
+  }
+
+  // Extent with zero paddings as CryptoMB expects in buf being sign length.
+  int len = BN_num_bits(order);
+  buf_len_ = (len + 7) / 8;
+  if (8 * in_len < static_cast<unsigned long>(len)) {
+    in_buf_ = std::make_unique<uint8_t[]>(buf_len_);
+    memcpy(in_buf_.get() + buf_len_ - in_len, in, in_len); // NOLINT(safe-memcpy)
+  } else {
+    in_buf_ = std::make_unique<uint8_t[]>(in_len);
+    memcpy(in_buf_.get(), in, in_len); // NOLINT(safe-memcpy)
+  }
+
+  do {
+    if (!BN_rand_range(k_, order)) {
+      return false;
+    }
+  } while (BN_is_zero(k_));
+
+  out_len_ = ECDSA_size(ec_key_.get());
+
+  return true;
+}
+
 namespace {
 
 int calculateDigest(const EVP_MD* md, const uint8_t* in, size_t in_len, unsigned char* hash,
@@ -70,13 +136,11 @@ int calculateDigest(const EVP_MD* md, const uint8_t* in, size_t in_len, unsigned
   return 1;
 }
 
-ssl_private_key_result_t ecdsaPrivateKeySignInternal(CryptoMbPrivateKeyConnection* ops,
-                                                     uint8_t* out, size_t* out_len, size_t max_out,
-                                                     uint16_t signature_algorithm,
+ssl_private_key_result_t ecdsaPrivateKeySignInternal(CryptoMbPrivateKeyConnection* ops, uint8_t*,
+                                                     size_t*, size_t, uint16_t signature_algorithm,
                                                      const uint8_t* in, size_t in_len) {
   unsigned char hash[EVP_MAX_MD_SIZE];
   unsigned int hash_len;
-  unsigned int out_len_unsigned;
 
   if (ops == nullptr) {
     return ssl_private_key_failure;
@@ -105,20 +169,17 @@ ssl_private_key_result_t ecdsaPrivateKeySignInternal(CryptoMbPrivateKeyConnectio
     return ssl_private_key_failure;
   }
 
-  if (max_out < ECDSA_size(ec_key.get())) {
+  // Create MB context which will be used for this particular
+  // signing/decryption.
+  CryptoMbEcdsaContextSharedPtr mb_ctx =
+      std::make_shared<CryptoMbEcdsaContext>(std::move(ec_key), ops->dispatcher_, ops->cb_);
+
+  if (!mb_ctx->ecdsaInit(hash, hash_len)) {
     return ssl_private_key_failure;
   }
 
-  // Borrow "out" because it has been already initialized to the max_out size.
-  if (!ECDSA_sign(0, hash, hash_len, out, &out_len_unsigned, ec_key.get())) {
-    return ssl_private_key_failure;
-  }
-
-  if (out_len_unsigned > max_out) {
-    return ssl_private_key_failure;
-  }
-  *out_len = out_len_unsigned;
-  return ssl_private_key_success;
+  ops->addToQueue(mb_ctx);
+  return ssl_private_key_retry;
 }
 
 ssl_private_key_result_t ecdsaPrivateKeySign(SSL* ssl, uint8_t* out, size_t* out_len,
@@ -386,10 +447,16 @@ void CryptoMbQueue::addAndProcessEightRequests(CryptoMbContextSharedPtr mb_ctx) 
 }
 
 void CryptoMbQueue::processRequests() {
-  if (type_ == KeyType::Rsa) {
+  switch (type_) {
+  case KeyType::Rsa:
     // Record queue size statistic value for histogram.
     stats_.rsa_queue_sizes_.recordValue(request_queue_.size());
     processRsaRequests();
+    break;
+  case KeyType::Ec:
+    // Record queue size statistic value for histogram.
+    stats_.ecdsa_queue_sizes_.recordValue(request_queue_.size());
+    processEcdsaRequests();
   }
   request_queue_.clear();
 }
@@ -458,6 +525,48 @@ void CryptoMbQueue::processRsaRequests() {
       }
       // else keep the previous status from the private key operation
     } else {
+      status[req_num] = RequestStatus::Error;
+    }
+
+    ctx_status = status[req_num];
+    mb_ctx->scheduleCallback(ctx_status);
+  }
+}
+
+void CryptoMbQueue::processEcdsaRequests() {
+  unsigned char* sign_r[MULTIBUFF_BATCH] = {nullptr};
+  unsigned char* sign_s[MULTIBUFF_BATCH] = {nullptr};
+  const unsigned char* digest[MULTIBUFF_BATCH] = {nullptr};
+  const BIGNUM* eph_key[MULTIBUFF_BATCH] = {nullptr};
+  const BIGNUM* priv_key[MULTIBUFF_BATCH] = {nullptr};
+
+  /* Build arrays of pointers for call */
+  for (unsigned req_num = 0; req_num < request_queue_.size(); req_num++) {
+    CryptoMbEcdsaContextSharedPtr mb_ctx =
+        std::static_pointer_cast<CryptoMbEcdsaContext>(request_queue_[req_num]);
+    sign_r[req_num] = mb_ctx->out_buf_;
+    sign_s[req_num] = mb_ctx->out_buf_ + mb_ctx->buf_len_;
+    digest[req_num] = mb_ctx->in_buf_.get();
+    eph_key[req_num] = mb_ctx->k_;
+    priv_key[req_num] = mb_ctx->priv_key_;
+  }
+
+  ENVOY_LOG(debug, "Multibuffer ECDSA process {} requests", request_queue_.size());
+
+  uint32_t ecdsa_sts =
+      ipp_->mbxNistp256EcdsaSignSslMb8(sign_r, sign_s, digest, eph_key, priv_key, nullptr);
+
+  enum RequestStatus status[MULTIBUFF_BATCH] = {RequestStatus::Retry};
+
+  for (unsigned req_num = 0; req_num < request_queue_.size(); req_num++) {
+    CryptoMbRsaContextSharedPtr mb_ctx =
+        std::static_pointer_cast<CryptoMbRsaContext>(request_queue_[req_num]);
+    enum RequestStatus ctx_status;
+    if (ipp_->mbxGetSts(ecdsa_sts, req_num)) {
+      ENVOY_LOG(debug, "Multibuffer RSA request {} success", req_num);
+      status[req_num] = RequestStatus::Success;
+    } else {
+      ENVOY_LOG(debug, "Multibuffer RSA request {} failure", req_num);
       status[req_num] = RequestStatus::Error;
     }
 

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -52,6 +52,9 @@ bool CryptoMbEcdsaContext::ecdsaInit(const uint8_t* in, size_t in_len) {
   }
   BN_CTX_start(ctx_.get());
   k_ = BN_CTX_get(ctx_.get());
+  if (!k_) {
+    return false;
+  }
   do {
     if (!BN_rand_range(k_, order)) {
       return false;

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -9,6 +9,12 @@
 
 #include "openssl/ssl.h"
 
+extern "C" {
+// NOLINTNEXTLINE(readability-identifier-naming)
+int BN_generate_dsa_nonce(BIGNUM* out, const BIGNUM* range, const BIGNUM* priv,
+                          const unsigned char* message, size_t message_len, BN_CTX* ctx);
+} // extern "C"
+
 namespace Envoy {
 namespace Extensions {
 namespace PrivateKeyMethodProvider {
@@ -52,8 +58,14 @@ bool CryptoMbEcdsaContext::ecdsaInit(const uint8_t* in, size_t in_len) {
   }
   BN_CTX_start(ctx_.get());
   k_ = BN_CTX_get(ctx_.get());
+  int ret = 0;
   do {
-    if (!BN_rand_range(k_, order)) {
+    if (in_len > 0) {
+      ret = BN_generate_dsa_nonce(k_, order, priv_key_, in, in_len, ctx_.get());
+    } else {
+      ret = BN_rand_range(k_, order);
+    }
+    if (!ret) {
       return false;
     }
   } while (BN_is_zero(k_));

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.cc
@@ -9,12 +9,6 @@
 
 #include "openssl/ssl.h"
 
-extern "C" {
-// NOLINTNEXTLINE(readability-identifier-naming)
-int BN_generate_dsa_nonce(BIGNUM* out, const BIGNUM* range, const BIGNUM* priv,
-                          const unsigned char* message, size_t message_len, BN_CTX* ctx);
-} // extern "C"
-
 namespace Envoy {
 namespace Extensions {
 namespace PrivateKeyMethodProvider {
@@ -58,14 +52,8 @@ bool CryptoMbEcdsaContext::ecdsaInit(const uint8_t* in, size_t in_len) {
   }
   BN_CTX_start(ctx_.get());
   k_ = BN_CTX_get(ctx_.get());
-  int ret = 0;
   do {
-    if (in_len > 0) {
-      ret = BN_generate_dsa_nonce(k_, order, priv_key_, in, in_len, ctx_.get());
-    } else {
-      ret = BN_rand_range(k_, order);
-    }
-    if (!ret) {
+    if (!BN_rand_range(k_, order)) {
       return false;
     }
   } while (BN_is_zero(k_));

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
@@ -64,14 +64,12 @@ public:
   CryptoMbEcdsaContext(bssl::UniquePtr<EC_KEY> ec_key, Event::Dispatcher& dispatcher,
                        Ssl::PrivateKeyConnectionCallbacks& cb)
       : CryptoMbContext(dispatcher, cb), ec_key_(std::move(ec_key)) {}
-  ~CryptoMbEcdsaContext() override;
   bool ecdsaInit(const uint8_t* in, size_t in_len);
 
   // ECDSA key.
   bssl::UniquePtr<EC_KEY> ec_key_{};
-  // ECDSA context to create the ephemeral key k_, which must be released manually after the using
-  // of k_.
-  BN_CTX* ctx_{};
+  // ECDSA context to create the ephemeral key k_.
+  bssl::UniquePtr<BN_CTX> ctx_{};
   BIGNUM* k_{};
   // ECDSA parameters, which will contain values whose memory is managed within
   // BoringSSL ECDSA key structure, so not wrapped in smart pointers.

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
@@ -101,8 +101,12 @@ public:
   // ECDSA parameters, which will contain values whose memory is managed within
   // BoringSSL ECDSA key structure, so not wrapped in smart pointers.
   const BIGNUM* priv_key_{};
+  BIGNUM* sig_r_{};
+  BIGNUM* sig_s_{};
   BIGNUM* k_{};
   size_t buf_len_{};
+  size_t sig_len_{};
+  std::unique_ptr<uint8_t[]> sig_buf_;
 };
 
 using CryptoMbContextSharedPtr = std::shared_ptr<CryptoMbContext>;

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
@@ -95,16 +95,14 @@ public:
 
   // ECDSA key.
   bssl::UniquePtr<EC_KEY> ec_key_{};
-  // ECDSA sig and context, which must be released manually.
-  ECDSA_SIG* s_{};
+  // ECDSA context, which must be released manually.
   BN_CTX* ctx_{};
   // ECDSA parameters, which will contain values whose memory is managed within
   // BoringSSL ECDSA key structure, so not wrapped in smart pointers.
-  const BIGNUM* priv_key_{};
-  BIGNUM* sig_r_{};
-  BIGNUM* sig_s_{};
-  BIGNUM* k_{};
   size_t buf_len_{};
+  BIGNUM* k_{};
+  const BIGNUM* priv_key_{};
+  // ECDSA intermediate buffer, which stores signature by CryptoMB.
   size_t sig_len_{};
   std::unique_ptr<uint8_t[]> sig_buf_;
 };
@@ -127,6 +125,7 @@ private:
   void processRequests();
   void processRsaRequests();
   void processEcdsaRequests();
+  bool postprocessEcdsaRequest(CryptoMbEcdsaContextSharedPtr mb_ctx);
   void startTimer();
   void stopTimer();
 

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_stats.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_stats.h
@@ -9,8 +9,8 @@ namespace PrivateKeyMethodProvider {
 namespace CryptoMb {
 
 #define ALL_CRYPTOMB_STATS(HISTOGRAM)                                                              \
-  HISTOGRAM(rsa_queue_sizes, Unspecified)                                                          \
-  HISTOGRAM(ecdsa_queue_sizes, Unspecified)
+  HISTOGRAM(ecdsa_queue_sizes, Unspecified)                                                        \
+  HISTOGRAM(rsa_queue_sizes, Unspecified)
 
 /**
  * CryptoMb stats struct definition. @see stats_macros.h

--- a/contrib/cryptomb/private_key_providers/source/cryptomb_stats.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_stats.h
@@ -8,7 +8,9 @@ namespace Extensions {
 namespace PrivateKeyMethodProvider {
 namespace CryptoMb {
 
-#define ALL_CRYPTOMB_STATS(HISTOGRAM) HISTOGRAM(rsa_queue_sizes, Unspecified)
+#define ALL_CRYPTOMB_STATS(HISTOGRAM)                                                              \
+  HISTOGRAM(rsa_queue_sizes, Unspecified)                                                          \
+  HISTOGRAM(ecdsa_queue_sizes, Unspecified)
 
 /**
  * CryptoMb stats struct definition. @see stats_macros.h

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
@@ -14,6 +14,11 @@ public:
   virtual ~IppCrypto() = default;
 
   virtual int mbxIsCryptoMbApplicable(uint64_t features) PURE;
+  virtual uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
+                                              const uint8_t* const pa_msg[8],
+                                              const BIGNUM* const pa_eph_skey[8],
+                                              const BIGNUM* const pa_reg_skey[8],
+                                              uint8_t* p_buffer) PURE;
   virtual uint32_t mbxRsaPrivateCrtSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                           const BIGNUM* const p_pa[8], const BIGNUM* const q_pa[8],
                                           const BIGNUM* const dp_pa[8],
@@ -23,11 +28,6 @@ public:
   virtual uint32_t mbxRsaPublicSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                       const BIGNUM* const e_pa[8], const BIGNUM* const n_pa[8],
                                       int expected_rsa_bitsize) PURE;
-  virtual uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
-                                              const uint8_t* const pa_msg[8],
-                                              const BIGNUM* const pa_eph_skey[8],
-                                              const BIGNUM* const pa_reg_skey[8],
-                                              uint8_t* p_buffer) PURE;
   virtual bool mbxGetSts(uint32_t status, unsigned req_num) PURE;
 };
 

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
@@ -23,6 +23,11 @@ public:
   virtual uint32_t mbxRsaPublicSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                       const BIGNUM* const e_pa[8], const BIGNUM* const n_pa[8],
                                       int expected_rsa_bitsize) PURE;
+  virtual uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
+                                              const uint8_t* const pa_msg[8],
+                                              const BIGNUM* const pa_eph_skey[8],
+                                              const BIGNUM* const pa_reg_skey[8],
+                                              uint8_t* p_buffer) PURE;
   virtual bool mbxGetSts(uint32_t status, unsigned req_num) PURE;
 };
 

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
@@ -17,8 +17,7 @@ public:
   virtual uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
                                               const uint8_t* const pa_msg[8],
                                               const BIGNUM* const pa_eph_skey[8],
-                                              const BIGNUM* const pa_reg_skey[8],
-                                              uint8_t* p_buffer) PURE;
+                                              const BIGNUM* const pa_reg_skey[8]) PURE;
   virtual uint32_t mbxRsaPrivateCrtSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                           const BIGNUM* const p_pa[8], const BIGNUM* const q_pa[8],
                                           const BIGNUM* const dp_pa[8],

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
@@ -15,6 +15,14 @@ public:
   int mbxIsCryptoMbApplicable(uint64_t features) override {
     return ::mbx_is_crypto_mb_applicable(features);
   }
+  uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
+                                      const uint8_t* const pa_msg[8],
+                                      const BIGNUM* const pa_eph_skey[8],
+                                      const BIGNUM* const pa_reg_skey[8],
+                                      uint8_t* p_buffer) override {
+    return ::mbx_nistp256_ecdsa_sign_ssl_mb8(pa_sign_r, pa_sign_s, pa_msg, pa_eph_skey, pa_reg_skey,
+                                             p_buffer);
+  }
   uint32_t mbxRsaPrivateCrtSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                   const BIGNUM* const p_pa[8], const BIGNUM* const q_pa[8],
                                   const BIGNUM* const dp_pa[8], const BIGNUM* const dq_pa[8],
@@ -26,14 +34,6 @@ public:
                               const BIGNUM* const e_pa[8], const BIGNUM* const n_pa[8],
                               int expected_rsa_bitsize) override {
     return ::mbx_rsa_public_ssl_mb8(from_pa, to_pa, e_pa, n_pa, expected_rsa_bitsize);
-  }
-  uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
-                                      const uint8_t* const pa_msg[8],
-                                      const BIGNUM* const pa_eph_skey[8],
-                                      const BIGNUM* const pa_reg_skey[8],
-                                      uint8_t* p_buffer) override {
-    return ::mbx_nistp256_ecdsa_sign_ssl_mb8(pa_sign_r, pa_sign_s, pa_msg, pa_eph_skey, pa_reg_skey,
-                                             p_buffer);
   }
   bool mbxGetSts(uint32_t status, unsigned req_num) override {
     if (MBX_GET_STS(status, req_num) == MBX_STATUS_OK) {

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
@@ -18,10 +18,9 @@ public:
   uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
                                       const uint8_t* const pa_msg[8],
                                       const BIGNUM* const pa_eph_skey[8],
-                                      const BIGNUM* const pa_reg_skey[8],
-                                      uint8_t* p_buffer) override {
+                                      const BIGNUM* const pa_reg_skey[8]) override {
     return ::mbx_nistp256_ecdsa_sign_ssl_mb8(pa_sign_r, pa_sign_s, pa_msg, pa_eph_skey, pa_reg_skey,
-                                             p_buffer);
+                                             nullptr);
   }
   uint32_t mbxRsaPrivateCrtSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                   const BIGNUM* const p_pa[8], const BIGNUM* const q_pa[8],

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
@@ -27,6 +27,14 @@ public:
                               int expected_rsa_bitsize) override {
     return ::mbx_rsa_public_ssl_mb8(from_pa, to_pa, e_pa, n_pa, expected_rsa_bitsize);
   }
+  uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
+                                      const uint8_t* const pa_msg[8],
+                                      const BIGNUM* const pa_eph_skey[8],
+                                      const BIGNUM* const pa_reg_skey[8],
+                                      uint8_t* p_buffer) override {
+    return ::mbx_nistp256_ecdsa_sign_ssl_mb8(pa_sign_r, pa_sign_s, pa_msg, pa_eph_skey, pa_reg_skey,
+                                             p_buffer);
+  }
   bool mbxGetSts(uint32_t status, unsigned req_num) override {
     if (MBX_GET_STS(status, req_num) == MBX_STATUS_OK) {
       return true;

--- a/contrib/cryptomb/private_key_providers/test/fake_factory.cc
+++ b/contrib/cryptomb/private_key_providers/test/fake_factory.cc
@@ -42,6 +42,40 @@ bool FakeIppCryptoImpl::mbxGetSts(uint32_t status, unsigned req_num) {
   return !((status >> req_num) & 1UL);
 }
 
+uint32_t FakeIppCryptoImpl::mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
+                                                       const uint8_t* const pa_msg[8],
+                                                       const BIGNUM* const pa_eph_skey[8],
+                                                       const BIGNUM* const pa_reg_skey[8],
+                                                       uint8_t*) {
+
+  uint32_t status = 0xff;
+
+  for (int i = 0; i < 8; i++) {
+    EC_KEY* key;
+    ECDSA_SIG* sig;
+
+    if (pa_eph_skey[i] == nullptr) {
+      break;
+    }
+
+    key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+    EC_KEY_set_private_key(key, pa_reg_skey[i]);
+
+    // Length of the message representative is equal to length of r (order of EC subgroup).
+    sig = ECDSA_do_sign(pa_msg[i], 32, key);
+
+    BN_bn2bin(sig->r, pa_sign_r[i]);
+    BN_bn2bin(sig->s, pa_sign_s[i]);
+
+    ECDSA_SIG_free(sig);
+    EC_KEY_free(key);
+
+    status = mbxSetSts(status, i, !inject_errors_);
+  }
+
+  return status;
+}
+
 uint32_t FakeIppCryptoImpl::mbxRsaPrivateCrtSslMb8(
     const uint8_t* const from_pa[8], uint8_t* const to_pa[8], const BIGNUM* const p_pa[8],
     const BIGNUM* const q_pa[8], const BIGNUM* const dp_pa[8], const BIGNUM* const dq_pa[8],

--- a/contrib/cryptomb/private_key_providers/test/fake_factory.cc
+++ b/contrib/cryptomb/private_key_providers/test/fake_factory.cc
@@ -45,8 +45,7 @@ bool FakeIppCryptoImpl::mbxGetSts(uint32_t status, unsigned req_num) {
 uint32_t FakeIppCryptoImpl::mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
                                                        const uint8_t* const pa_msg[8],
                                                        const BIGNUM* const pa_eph_skey[8],
-                                                       const BIGNUM* const pa_reg_skey[8],
-                                                       uint8_t*) {
+                                                       const BIGNUM* const pa_reg_skey[8]) {
 
   uint32_t status = 0xff;
 

--- a/contrib/cryptomb/private_key_providers/test/fake_factory.h
+++ b/contrib/cryptomb/private_key_providers/test/fake_factory.h
@@ -16,6 +16,11 @@ public:
   FakeIppCryptoImpl(bool supported_instruction_set);
 
   int mbxIsCryptoMbApplicable(uint64_t features) override;
+  uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
+                                      const uint8_t* const pa_msg[8],
+                                      const BIGNUM* const pa_eph_skey[8],
+                                      const BIGNUM* const pa_reg_skey[8],
+                                      uint8_t* p_buffer) override;
   uint32_t mbxRsaPrivateCrtSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                   const BIGNUM* const p_pa[8], const BIGNUM* const q_pa[8],
                                   const BIGNUM* const dp_pa[8], const BIGNUM* const dq_pa[8],

--- a/contrib/cryptomb/private_key_providers/test/fake_factory.h
+++ b/contrib/cryptomb/private_key_providers/test/fake_factory.h
@@ -19,8 +19,7 @@ public:
   uint32_t mbxNistp256EcdsaSignSslMb8(uint8_t* pa_sign_r[8], uint8_t* pa_sign_s[8],
                                       const uint8_t* const pa_msg[8],
                                       const BIGNUM* const pa_eph_skey[8],
-                                      const BIGNUM* const pa_reg_skey[8],
-                                      uint8_t* p_buffer) override;
+                                      const BIGNUM* const pa_reg_skey[8]) override;
   uint32_t mbxRsaPrivateCrtSslMb8(const uint8_t* const from_pa[8], uint8_t* const to_pa[8],
                                   const BIGNUM* const p_pa[8], const BIGNUM* const q_pa[8],
                                   const BIGNUM* const dp_pa[8], const BIGNUM* const dq_pa[8],

--- a/contrib/cryptomb/private_key_providers/test/ops_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/ops_test.cc
@@ -102,8 +102,6 @@ protected:
 
   // Size of output in out_ from an operation.
   size_t out_len_ = 0;
-
-  const std::string queue_size_histogram_name_ = "cryptomb.rsa_queue_sizes";
 };
 
 class CryptoMbProviderRsaTest : public CryptoMbProviderTest {
@@ -116,6 +114,8 @@ protected:
   }
   CryptoMbQueue queue_;
   bssl::UniquePtr<EVP_PKEY> pkey_;
+
+  const std::string queue_size_histogram_name_ = "cryptomb.rsa_queue_sizes";
 };
 
 class CryptoMbProviderEcdsaTest : public CryptoMbProviderTest {
@@ -125,14 +125,39 @@ protected:
         pkey_(makeEcdsaKey()) {}
   CryptoMbQueue queue_;
   bssl::UniquePtr<EVP_PKEY> pkey_;
+
+  const std::string queue_size_histogram_name_ = "cryptomb.ecdsa_queue_sizes";
 };
 
 TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaSigning) {
-  TestCallbacks cb;
-  CryptoMbPrivateKeyConnection op(cb, *dispatcher_, bssl::UpRef(pkey_), queue_);
-  res_ = ecdsaPrivateKeySignForTest(&op, out_, &out_len_, max_out_len_,
-                                    SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
+  // Initialize connections.
+  TestCallbacks cbs[CryptoMbQueue::MULTIBUFF_BATCH];
+  std::vector<std::unique_ptr<CryptoMbPrivateKeyConnection>> connections;
+  for (auto& cb : cbs) {
+    connections.push_back(std::make_unique<CryptoMbPrivateKeyConnection>(
+        cb, *dispatcher_, bssl::UpRef(pkey_), queue_));
+  }
+
+  // Create MULTIBUFF_BATCH amount of signing operations.
+  for (uint32_t i = 0; i < CryptoMbQueue::MULTIBUFF_BATCH; i++) {
+    // Create request.
+    res_ = ecdsaPrivateKeySignForTest(connections[i].get(), nullptr, nullptr, max_out_len_,
+                                      SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
+    EXPECT_EQ(res_, ssl_private_key_retry);
+
+    // No processing done after first requests.
+    // After the last request, the status is set only from the event loop which is not run. This
+    // should still be "retry", the cryptographic result is present anyway.
+    res_ = privateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
+    EXPECT_EQ(res_, ssl_private_key_retry);
+  }
+
+  // Timeout does not have to be triggered when queue is at maximum size.
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+
+  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
+  EXPECT_NE(out_len_, 0);
 }
 
 TEST_F(CryptoMbProviderRsaTest, TestRsaPkcs1Signing) {
@@ -299,7 +324,48 @@ TEST_F(CryptoMbProviderTest, TestErrors) {
   EXPECT_EQ(res_, ssl_private_key_failure);
 }
 
-TEST_F(CryptoMbProviderRsaTest, TestRSATimer) {
+TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaTimer) {
+  TestCallbacks cbs[2];
+
+  // Successful operation with timer.
+  CryptoMbPrivateKeyConnection op0(cbs[0], *dispatcher_, bssl::UpRef(pkey_), queue_);
+  res_ = ecdsaPrivateKeySignForTest(&op0, nullptr, nullptr, max_out_len_,
+                                    SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
+  EXPECT_EQ(res_, ssl_private_key_retry);
+
+  res_ = privateKeyCompleteForTest(&op0, nullptr, nullptr, max_out_len_);
+  // No processing done yet after first request
+  EXPECT_EQ(res_, ssl_private_key_retry);
+
+  time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
+                                 Event::Dispatcher::RunType::NonBlock);
+
+  res_ = privateKeyCompleteForTest(&op0, out_, &out_len_, max_out_len_);
+  EXPECT_EQ(res_, ssl_private_key_success);
+  EXPECT_NE(out_len_, 0);
+
+  // Unsuccessful operation with timer.
+  // Add crypto library errors
+  fakeIpp_->injectErrors(true);
+
+  CryptoMbPrivateKeyConnection op1(cbs[1], *dispatcher_, bssl::UpRef(pkey_), queue_);
+
+  res_ = ecdsaPrivateKeySignForTest(&op1, nullptr, nullptr, max_out_len_,
+                                    SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
+  EXPECT_EQ(res_, ssl_private_key_retry);
+
+  res_ = privateKeyCompleteForTest(&op1, nullptr, nullptr, max_out_len_);
+  // No processing done yet after first request
+  EXPECT_EQ(res_, ssl_private_key_retry);
+
+  time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
+                                 Event::Dispatcher::RunType::NonBlock);
+
+  res_ = privateKeyCompleteForTest(&op1, out_, &out_len_, max_out_len_);
+  EXPECT_EQ(res_, ssl_private_key_failure);
+}
+
+TEST_F(CryptoMbProviderRsaTest, TestRsaTimer) {
   TestCallbacks cbs[2];
 
   // Successful operation with timer.
@@ -340,7 +406,62 @@ TEST_F(CryptoMbProviderRsaTest, TestRSATimer) {
   EXPECT_EQ(res_, ssl_private_key_failure);
 }
 
-TEST_F(CryptoMbProviderRsaTest, TestRSAQueueSizeStatistics) {
+TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaQueueSizeStatistics) {
+  // Initialize connections.
+  TestCallbacks cbs[CryptoMbQueue::MULTIBUFF_BATCH];
+  std::vector<std::unique_ptr<CryptoMbPrivateKeyConnection>> connections;
+  for (auto& cb : cbs) {
+    connections.push_back(std::make_unique<CryptoMbPrivateKeyConnection>(
+        cb, *dispatcher_, bssl::UpRef(pkey_), queue_));
+  }
+
+  // Increment all but the last queue size once inside the loop.
+  for (uint32_t i = 1; i < CryptoMbQueue::MULTIBUFF_BATCH; i++) {
+    // Create correct amount of signing operations for current index.
+    for (uint32_t j = 0; j < i; j++) {
+      res_ = ecdsaPrivateKeySignForTest(connections[j].get(), nullptr, nullptr, max_out_len_,
+                                        SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
+      EXPECT_EQ(res_, ssl_private_key_retry);
+    }
+
+    time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
+                                   Event::Dispatcher::RunType::NonBlock);
+
+    out_len_ = 0;
+    res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+    EXPECT_EQ(res_, ssl_private_key_success);
+    EXPECT_NE(out_len_, 0);
+
+    // Check that current queue size is recorded.
+    std::vector<uint64_t> histogram_values(
+        store_.histogramValues(queue_size_histogram_name_, true));
+    EXPECT_EQ(histogram_values.size(), 1);
+    EXPECT_EQ(histogram_values[0], i);
+  }
+
+  // Increment last queue size once.
+  // Create an amount of signing operations equal to maximum queue size.
+  for (uint32_t j = 0; j < CryptoMbQueue::MULTIBUFF_BATCH; j++) {
+    res_ = ecdsaPrivateKeySignForTest(connections[j].get(), nullptr, nullptr, max_out_len_,
+                                      SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
+    EXPECT_EQ(res_, ssl_private_key_retry);
+  }
+
+  // Timeout does not have to be triggered when queue is at maximum size.
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+
+  out_len_ = 0;
+  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  EXPECT_EQ(res_, ssl_private_key_success);
+  EXPECT_NE(out_len_, 0);
+
+  // Check that last queue size is recorded.
+  std::vector<uint64_t> histogram_values(store_.histogramValues(queue_size_histogram_name_, true));
+  EXPECT_EQ(histogram_values.size(), 1);
+  EXPECT_EQ(histogram_values[0], CryptoMbQueue::MULTIBUFF_BATCH);
+}
+
+TEST_F(CryptoMbProviderRsaTest, TestRsaQueueSizeStatistics) {
   // Initialize connections.
   TestCallbacks cbs[CryptoMbQueue::MULTIBUFF_BATCH];
   std::vector<std::unique_ptr<CryptoMbPrivateKeyConnection>> connections;


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: cryptomb: support ECDSA
Additional Description: The CryptoMB private key provider only supports RSA at the time, the patch adds ECDSA support to it.
Risk Level: Low (as contrib extension)
Testing: Unit and integration tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: Requires AVX512 or equivalent CPU instruction set
