### PR TITLE
mobile/ci: Update the binary size expectations

### DIFF
--- a/mobile/ci/test_size_regression.sh
+++ b/mobile/ci/test_size_regression.sh
@@ -4,10 +4,10 @@ set -o pipefail
 
 # Checks the absolute size and the relative size increase of a file.
 
-# As of Jan 10, 2024, the latest runs show that the test binary size is
-# 5906999 bytes:
-# https://github.com/envoyproxy/envoy/actions/runs/7464691863/job/20312749642
-MAX_SIZE=5950000 # 5.95MB
+# As of Jan 11, 2024, the latest runs show that the test binary size is
+# 4273716 bytes:
+# https://github.com/envoyproxy/envoy/actions/runs/7497709450/job/20411963750
+MAX_SIZE=4500000 # 4.5MB
 MAX_PERC=1.5
 
 if [ "$(uname)" == "Darwin" ]


### PR DESCRIPTION
Recent changes, including the removal of the Brotli compressor in Envoy Mobile, have brought the Envoy Mobile test binary size down to ~4.27MB, so we are updating the maximum allowed size in the regression check CI job.