### PR TITLE
Adding runtime guard to protect drop overload  feature

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -2026,6 +2026,9 @@ uint32_t Filter::numRequestsAwaitingHeaders() {
 
 bool Filter::checkDropOverload(Upstream::ThreadLocalCluster& cluster,
                                std::function<void(Http::ResponseHeaderMap&)>& modify_headers) {
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_drop_overload")) {
+    return false;
+  }
   if (cluster.dropOverload().value()) {
     ENVOY_STREAM_LOG(debug, "Router filter: cluster DROP_OVERLOAD configuration: {}", *callbacks_,
                      cluster.dropOverload().value());

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -2032,9 +2032,9 @@ bool Filter::checkDropOverload(Upstream::ThreadLocalCluster& cluster,
     if (config_.random_.bernoulli(cluster.dropOverload())) {
       ENVOY_STREAM_LOG(debug, "The request is dropped by DROP_OVERLOAD", *callbacks_);
       callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DropOverLoad);
-      chargeUpstreamCode(Http::Code::ServiceUnavailable, nullptr, true);
+      chargeUpstreamCode(Http::Code::BadGateway, nullptr, true);
       callbacks_->sendLocalReply(
-          Http::Code::ServiceUnavailable, "drop overload",
+          Http::Code::BadGateway, "drop overload",
           [modify_headers, this](Http::ResponseHeaderMap& headers) {
             if (!config_.suppress_envoy_headers_) {
               headers.addReference(Http::Headers::get().EnvoyDropOverload,

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -98,6 +98,8 @@ RUNTIME_GUARD(envoy_reloadable_features_validate_upstream_headers);
 RUNTIME_GUARD(envoy_restart_features_send_goaway_for_premature_rst_streams);
 RUNTIME_GUARD(envoy_restart_features_udp_read_normalize_addresses);
 
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_drop_overload);
+
 // Begin false flags. These should come with a TODO to flip true.
 // Sentinel and test flag.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_test_feature_false);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -811,7 +811,7 @@ TEST_F(RouterTest, DropOverloadDropped) {
   EXPECT_CALL(random_, random())
       .WillRepeatedly(Return(0.2 * float(std::numeric_limits<uint64_t>::max())));
 
-  Http::TestResponseHeaderMapImpl response_headers{{":status", "503"},
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "502"},
                                                    {"content-length", "13"},
                                                    {"content-type", "text/plain"},
                                                    {"x-envoy-drop-overload", "true"}};

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -930,7 +930,7 @@ TEST_P(EdsIntegrationTest, DataplaneTrafficAfterEdsUpdateOfInitializedCluster) {
 // Test EDS cluster DROP_OVERLOAD configuration.
 TEST_P(EdsIntegrationTest, DropOverloadTestForEdsClusterNoDrop) { dropOverloadTest(0, "200"); }
 
-TEST_P(EdsIntegrationTest, DropOverloadTestForEdsClusterAllDrop) { dropOverloadTest(100, "503"); }
+TEST_P(EdsIntegrationTest, DropOverloadTestForEdsClusterAllDrop) { dropOverloadTest(100, "502"); }
 
 } // namespace
 } // namespace Envoy

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -207,6 +207,9 @@ public:
   void initializeTest(bool http_active_hc) { initializeTest(http_active_hc, nullptr); }
 
   void dropOverloadTest(uint32_t numerator, const std::string& status) {
+    TestScopedRuntime scoped_runtime;
+    scoped_runtime.mergeValues(
+        {{"envoy.reloadable_features.enable_drop_overload", "true"}});
     autonomous_upstream_ = true;
 
     initializeTest(false);

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -691,7 +691,7 @@ TEST_P(LoadStatsIntegrationTest, DropOverloadDropped) {
   initiateClientConnection();
   ASSERT_TRUE(response_->waitForEndStream());
   ASSERT_TRUE(response_->complete());
-  EXPECT_EQ("503", response_->headers().getStatusValue());
+  EXPECT_EQ("502", response_->headers().getStatusValue());
   cleanupUpstreamAndDownstream();
 
   ASSERT_TRUE(waitForLoadStatsRequest({}, 1, true));


### PR DESCRIPTION
The runtime guard is default to be false.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
