### PR TITLE
Adding runtime guard to protect drop_overload feature

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -2026,6 +2026,9 @@ uint32_t Filter::numRequestsAwaitingHeaders() {
 
 bool Filter::checkDropOverload(Upstream::ThreadLocalCluster& cluster,
                                std::function<void(Http::ResponseHeaderMap&)>& modify_headers) {
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_drop_overload")) {
+    return false;
+  }
   if (cluster.dropOverload().value()) {
     ENVOY_STREAM_LOG(debug, "Router filter: cluster DROP_OVERLOAD configuration: {}", *callbacks_,
                      cluster.dropOverload().value());

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -98,6 +98,8 @@ RUNTIME_GUARD(envoy_reloadable_features_validate_upstream_headers);
 RUNTIME_GUARD(envoy_restart_features_send_goaway_for_premature_rst_streams);
 RUNTIME_GUARD(envoy_restart_features_udp_read_normalize_addresses);
 
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_drop_overload);
+
 // Begin false flags. These should come with a TODO to flip true.
 // Sentinel and test flag.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_test_feature_false);

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -790,8 +790,7 @@ TEST_F(RouterTest, MaintenanceMode) {
 // DropOverload pass test
 TEST_F(RouterTest, DropOverloadPassed) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-        {{"envoy.reloadable_features.enable_drop_overload", "true"}});
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_drop_overload", "true"}});
 
   EXPECT_CALL(cm_.thread_local_cluster_, dropOverload()).WillRepeatedly(Return(UnitFloat(0.3)));
   EXPECT_CALL(random_, random())
@@ -812,8 +811,7 @@ TEST_F(RouterTest, DropOverloadPassed) {
 // DropOverload drop test
 TEST_F(RouterTest, DropOverloadDropped) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-        {{"envoy.reloadable_features.enable_drop_overload", "true"}});
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_drop_overload", "true"}});
 
   EXPECT_CALL(cm_.thread_local_cluster_, dropOverload()).WillRepeatedly(Return(UnitFloat(0.3)));
   EXPECT_CALL(random_, random())
@@ -845,8 +843,7 @@ TEST_F(RouterTest, DropOverloadDropped) {
 // DropOverload runtime flag disable test
 TEST_F(RouterTest, DropOverloadDroppedDisableRuntime) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-        {{"envoy.reloadable_features.enable_drop_overload", "false"}});
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_drop_overload", "false"}});
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1481,6 +1481,7 @@ envoy_cc_test(
         "//test/config:utility_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:resources_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -207,6 +207,10 @@ public:
   void initializeTest(bool http_active_hc) { initializeTest(http_active_hc, nullptr); }
 
   void dropOverloadTest(uint32_t numerator, const std::string& status) {
+    TestScopedRuntime scoped_runtime;
+    scoped_runtime.mergeValues(
+        {{"envoy.reloadable_features.enable_drop_overload", "true"}});
+
     autonomous_upstream_ = true;
 
     initializeTest(false);

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -208,8 +208,7 @@ public:
 
   void dropOverloadTest(uint32_t numerator, const std::string& status) {
     TestScopedRuntime scoped_runtime;
-    scoped_runtime.mergeValues(
-        {{"envoy.reloadable_features.enable_drop_overload", "true"}});
+    scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_drop_overload", "true"}});
 
     autonomous_upstream_ = true;
 

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -10,6 +10,7 @@
 #include "test/integration/http_integration.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/resources.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -680,6 +681,8 @@ TEST_P(LoadStatsIntegrationTest, Dropped) {
 
 // Validate the load reports for dropped requests due to drop_overload make sense.
 TEST_P(LoadStatsIntegrationTest, DropOverloadDropped) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.enable_drop_overload", "true"}});
   initialize();
   waitForLoadStatsStream();
   ASSERT_TRUE(waitForLoadStatsRequest({}));


### PR DESCRIPTION
The runtime guard is default to be false.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
