### PR TITLE
mobile: Remove the envoy_mobile_stats_reporting build option

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -298,7 +298,6 @@ build:mobile-remote-ci-macos-swift --config=ios
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --define=signal_trace=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_request_compression=disabled
-build:mobile-remote-ci-macos-swift --define=envoy_mobile_stats_reporting=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_swift_cxx_interop=disabled
 build:mobile-remote-ci-macos-swift --define=google_grpc=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_xds=disabled

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -52,7 +52,6 @@ Features:
 - api: removed ``enableHappyEyeballs`` turning up happy eyeballs by default.
 - build: Add a build feature ``exclude_certificates`` to disable inclusion of the Envoy Mobile certificate list, for use when using platform certificate validation.
 - build: Add a build feature ``envoy_http_datagrams`` to allow disabling HTTP Datagram support. (:issue:`#23564 <23564>`)
-- build: Add a build feature ``envoy_mobile_stats_reporting`` to allow disabling stats reporting. (:issue:`26086 <26086>`)
 - swift: Add a new Swift implementation of generating the Envoy bootstrap that replaces the previous Objective-C implementation.
   This can be enabled by setting ``useSwiftBootstrap(true)`` and requires building with ``--define=envoy_mobile_swift_cxx_interop=enabled``. (:issue:`#26111 <26111>`)
 - android: log cleared JNI exceptions to platform layer as `jni_cleared_pending_exception` events (:issue:`#26133 <26133>`).


### PR DESCRIPTION
It is no longer in use anywhere.