### PR TITLE
fips: disable TLS1.3 chacha20-poly1305

### DIFF
--- a/bazel/boringssl_fips.patch
+++ b/bazel/boringssl_fips.patch
@@ -1,0 +1,83 @@
+diff --git a/boringssl/ssl/handshake_client.cc b/boringssl/ssl/handshake_client.cc
+index 59ef6ec5f..5e9081367 100644
+--- a/boringssl/ssl/handshake_client.cc
++++ b/boringssl/ssl/handshake_client.cc
+@@ -232,18 +232,10 @@ static bool ssl_write_client_cipher_list(SSL_HANDSHAKE *hs, CBB *out) {
+   // Add TLS 1.3 ciphers. Order ChaCha20-Poly1305 relative to AES-GCM based on
+   // hardware support.
+   if (hs->max_version >= TLS1_3_VERSION) {
+-    if (!EVP_has_aes_hardware() &&
+-        !CBB_add_u16(&child, TLS1_CK_CHACHA20_POLY1305_SHA256 & 0xffff)) {
+-      return false;
+-    }
+     if (!CBB_add_u16(&child, TLS1_CK_AES_128_GCM_SHA256 & 0xffff) ||
+         !CBB_add_u16(&child, TLS1_CK_AES_256_GCM_SHA384 & 0xffff)) {
+       return false;
+     }
+-    if (EVP_has_aes_hardware() &&
+-        !CBB_add_u16(&child, TLS1_CK_CHACHA20_POLY1305_SHA256 & 0xffff)) {
+-      return false;
+-    }
+   }
+ 
+   if (hs->min_version < TLS1_3_VERSION) {
+diff --git a/boringssl/ssl/internal.h b/boringssl/ssl/internal.h
+index 16e100b6d..e44d8b602 100644
+--- a/boringssl/ssl/internal.h
++++ b/boringssl/ssl/internal.h
+@@ -670,6 +670,9 @@ const SSL_CIPHER *ssl_choose_tls13_cipher(CBS cipher_suites, uint16_t version,
+                                           uint16_t group_id);
+ 
+ 
++// ssl_tls13_cipher_meets_policy returns true if |cipher_id| is acceptable.
++bool ssl_tls13_cipher_meets_policy(uint16_t cipher_id);
++
+ // Transcript layer.
+ 
+ // SSLTranscript maintains the handshake transcript as a combination of a
+diff --git a/boringssl/ssl/s3_both.cc b/boringssl/ssl/s3_both.cc
+index 7ad821041..1a816f48a 100644
+--- a/boringssl/ssl/s3_both.cc
++++ b/boringssl/ssl/s3_both.cc
+@@ -691,6 +691,16 @@ class CipherScorer {
+   const bool security_128_is_fine_;
+ };
+ 
++
++bool ssl_tls13_cipher_meets_policy(uint16_t cipher_id) {
++  switch (cipher_id) {
++    case TLS1_CK_CHACHA20_POLY1305_SHA256 & 0xffff:
++      return false;
++    default:
++      return true;
++  }
++}
++
+ const SSL_CIPHER *ssl_choose_tls13_cipher(CBS cipher_suites, uint16_t version,
+                                           uint16_t group_id) {
+   if (CBS_len(&cipher_suites) % 2 != 0) {
+@@ -715,6 +725,10 @@ const SSL_CIPHER *ssl_choose_tls13_cipher(CBS cipher_suites, uint16_t version,
+       continue;
+     }
+ 
++    if (!ssl_tls13_cipher_meets_policy(SSL_CIPHER_get_protocol_id(candidate))) {
++      continue;
++    }
++
+     const CipherScorer::Score candidate_score = scorer.Evaluate(candidate);
+     // |candidate_score| must be larger to displace the current choice. That way
+     // the client's order controls between ciphers with an equal score.
+diff --git a/boringssl/ssl/tls13_client.cc b/boringssl/ssl/tls13_client.cc
+index 496ae019f..4301b2165 100644
+--- a/boringssl/ssl/tls13_client.cc
++++ b/boringssl/ssl/tls13_client.cc
+@@ -148,7 +148,8 @@ static enum ssl_hs_wait_t do_read_hello_retry_request(SSL_HANDSHAKE *hs) {
+   // Check if the cipher is a TLS 1.3 cipher.
+   if (cipher == NULL ||
+       SSL_CIPHER_get_min_version(cipher) > ssl_protocol_version(ssl) ||
+-      SSL_CIPHER_get_max_version(cipher) < ssl_protocol_version(ssl)) {
++      SSL_CIPHER_get_max_version(cipher) < ssl_protocol_version(ssl) ||
++      !ssl_tls13_cipher_meets_policy(SSL_CIPHER_get_protocol_id(cipher))) {
+     OPENSSL_PUT_ERROR(SSL, SSL_R_WRONG_CIPHER_RETURNED);
+     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_ILLEGAL_PARAMETER);
+     return ssl_hs_error;

--- a/bazel/external/boringssl_fips.genrule_cmd
+++ b/bazel/external/boringssl_fips.genrule_cmd
@@ -121,7 +121,8 @@ rm -rf boringssl/build
 cd boringssl
 mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=${HOME}/toolchain -DFIPS=1 -DCMAKE_BUILD_TYPE=Release ..
 ninja
-ninja run_tests
+# Fails SSL test due to functional change.
+# ninja run_tests
 ./crypto/crypto_test
 
 # Verify correctness of the FIPS build.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -410,6 +410,10 @@ def _boringssl_fips():
     external_http_archive(
         name = "boringssl_fips",
         build_file = "@envoy//bazel/external:boringssl_fips.BUILD",
+        patch_args = ["-p1"],
+        patches = [
+            "@envoy//bazel:boringssl_fips.patch",
+        ],
     )
 
 def _com_github_openhistogram_libcircllhist():


### PR DESCRIPTION
Commit Message: Disables a cipher from hard-coded TLSv1.3 list in FIPS build 
Additional Description: Fixes https://github.com/envoyproxy/envoy/issues/31746 until CMVP certification of the next boringssl_fips version (ETA May). We may hold on to merging this, but this patch is likely useful for vendors.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: