### PR TITLE
break down local exception for thrift_proxy

### DIFF
--- a/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
@@ -50,6 +50,10 @@ Since these stats utilize the underlying cluster scope, we prefix with the ``thr
   thrift.upstream_cx_drain_close, Counter, Total upstream connections that were closed due to draining.
   thrift.downstream_cx_partial_response_close, Counter, Total downstream connections that were closed due to the partial response.
   thrift.downstream_cx_underflow_response_close, Counter, Total downstream connections that were closed due to the underflow response.
+  thrift.upstream_resp_exception_local.overflow, Counter, Total responses with the "Exception" message type generated locally by connection pool overflow.
+  thrift.upstream_resp_exception_local.local_connection_failure, Counter, Total responses with the "Exception" message type generated locally by local connection failure.
+  thrift.upstream_resp_exception_local.remote_connection_failure", Counter, Total responses with the "Exception" message type generated locally by remote connection failure.
+  thrift.upstream_resp_exception_local.timeout, Counter, Total responses with the "Exception" message type generated locally by timeout while creating a new connection.
 
 If the service zone is available for both the local service (via :option:`--service-zone`)
 and the :ref:`upstream cluster <arch_overview_service_discovery_types_eds>`,

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -149,7 +149,8 @@ public:
         upstream_resp_reply_error_(stat_name_set_->add("thrift.upstream_resp_error")),
         upstream_resp_exception_(stat_name_set_->add("thrift.upstream_resp_exception")),
         upstream_resp_exception_local_(stat_name_set_->add("thrift.upstream_resp_exception_local")),
-        upstream_resp_exception_local_overflow_(stat_name_set_->add("thrift.upstream_resp_exception_local_overflow")),
+        upstream_resp_exception_local_overflow_(
+            stat_name_set_->add("thrift.upstream_resp_exception_local_overflow")),
         upstream_resp_exception_local_local_connection_failure_(
             stat_name_set_->add("thrift.upstream_resp_exception_local_local_connection_failure")),
         upstream_resp_exception_local_remote_connection_failure_(
@@ -269,28 +270,31 @@ public:
    * upstream.
    * @param cluster Upstream::ClusterInfo& describing the upstream cluster
    */
-  void incResponseLocalException(const Upstream::ClusterInfo& cluster, LocalExceptionErrorType error_code) const {
+  void incResponseLocalException(const Upstream::ClusterInfo& cluster,
+                                 LocalExceptionErrorType error_code) const {
     incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_);
     incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_);
     switch (error_code) {
-      case LocalExceptionErrorType::Overflow:
-        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_overflow_);
-        break;
-      case LocalExceptionErrorType::LocalConnectionFailure:
-        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_local_connection_failure_);
-        break;
-      case LocalExceptionErrorType::RemoteConnectionFailure:
-        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_remote_connection_failure_);
-        break;
-      case LocalExceptionErrorType::Timeout:
-        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_timeout_);
-        break;
-      case LocalExceptionErrorType::MaintenanceMode:
-        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_maintenance_mode_);
-        break;
-      case LocalExceptionErrorType::NoHealthyUpstream:
-        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_no_healthy_upstream_);
-        break;
+    case LocalExceptionErrorType::Overflow:
+      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_overflow_);
+      break;
+    case LocalExceptionErrorType::LocalConnectionFailure:
+      incClusterScopeCounter(cluster, nullptr,
+                             upstream_resp_exception_local_local_connection_failure_);
+      break;
+    case LocalExceptionErrorType::RemoteConnectionFailure:
+      incClusterScopeCounter(cluster, nullptr,
+                             upstream_resp_exception_local_remote_connection_failure_);
+      break;
+    case LocalExceptionErrorType::Timeout:
+      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_timeout_);
+      break;
+    case LocalExceptionErrorType::MaintenanceMode:
+      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_maintenance_mode_);
+      break;
+    case LocalExceptionErrorType::NoHealthyUpstream:
+      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_no_healthy_upstream_);
+      break;
     }
   }
 

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -122,15 +122,6 @@ struct RouterNamedStats {
   }
 };
 
-enum class LocalExceptionErrorType {
-  Overflow,
-  LocalConnectionFailure,
-  RemoteConnectionFailure,
-  Timeout,
-  MaintenanceMode,
-  NoHealthyUpstream,
-};
-
 /**
  * Stats for use in the router.
  */
@@ -150,17 +141,13 @@ public:
         upstream_resp_exception_(stat_name_set_->add("thrift.upstream_resp_exception")),
         upstream_resp_exception_local_(stat_name_set_->add("thrift.upstream_resp_exception_local")),
         upstream_resp_exception_local_overflow_(
-            stat_name_set_->add("thrift.upstream_resp_exception_local_overflow")),
+            stat_name_set_->add("thrift.upstream_resp_exception_local.overflow")),
         upstream_resp_exception_local_local_connection_failure_(
-            stat_name_set_->add("thrift.upstream_resp_exception_local_local_connection_failure")),
+            stat_name_set_->add("thrift.upstream_resp_exception_local.local_connection_failure")),
         upstream_resp_exception_local_remote_connection_failure_(
-            stat_name_set_->add("thrift.upstream_resp_exception_local_remote_connection_failure")),
+            stat_name_set_->add("thrift.upstream_resp_exception_local.remote_connection_failure")),
         upstream_resp_exception_local_timeout_(
-            stat_name_set_->add("thrift.upstream_resp_exception_local_timeout")),
-        upstream_resp_exception_local_maintenance_mode_(
-            stat_name_set_->add("thrift.upstream_resp_exception_local_maintenance_mode")),
-        upstream_resp_exception_local_no_healthy_upstream_(
-            stat_name_set_->add("thrift.upstream_resp_exception_local_no_healthy_upstream")),
+            stat_name_set_->add("thrift.upstream_resp_exception_local.timeout")),
         upstream_resp_exception_remote_(
             stat_name_set_->add("thrift.upstream_resp_exception_remote")),
         upstream_resp_invalid_type_(stat_name_set_->add("thrift.upstream_resp_invalid_type")),
@@ -270,31 +257,29 @@ public:
    * upstream.
    * @param cluster Upstream::ClusterInfo& describing the upstream cluster
    */
-  void incResponseLocalException(const Upstream::ClusterInfo& cluster,
-                                 LocalExceptionErrorType error_code) const {
+  void incResponseLocalException(
+      const Upstream::ClusterInfo& cluster,
+      absl::optional<ConnectionPool::PoolFailureReason> reason = absl::nullopt) const {
     incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_);
     incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_);
-    switch (error_code) {
-    case LocalExceptionErrorType::Overflow:
-      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_overflow_);
-      break;
-    case LocalExceptionErrorType::LocalConnectionFailure:
-      incClusterScopeCounter(cluster, nullptr,
-                             upstream_resp_exception_local_local_connection_failure_);
-      break;
-    case LocalExceptionErrorType::RemoteConnectionFailure:
-      incClusterScopeCounter(cluster, nullptr,
-                             upstream_resp_exception_local_remote_connection_failure_);
-      break;
-    case LocalExceptionErrorType::Timeout:
-      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_timeout_);
-      break;
-    case LocalExceptionErrorType::MaintenanceMode:
-      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_maintenance_mode_);
-      break;
-    case LocalExceptionErrorType::NoHealthyUpstream:
-      incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_no_healthy_upstream_);
-      break;
+
+    if (reason.has_value()) {
+      switch (reason.value()) {
+      case ConnectionPool::PoolFailureReason::Overflow:
+        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_overflow_);
+        break;
+      case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
+        incClusterScopeCounter(cluster, nullptr,
+                               upstream_resp_exception_local_local_connection_failure_);
+        break;
+      case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
+        incClusterScopeCounter(cluster, nullptr,
+                               upstream_resp_exception_local_remote_connection_failure_);
+        break;
+      case ConnectionPool::PoolFailureReason::Timeout:
+        incClusterScopeCounter(cluster, nullptr, upstream_resp_exception_local_timeout_);
+        break;
+      }
     }
   }
 
@@ -414,8 +399,6 @@ private:
   const Stats::StatName upstream_resp_exception_local_local_connection_failure_;
   const Stats::StatName upstream_resp_exception_local_remote_connection_failure_;
   const Stats::StatName upstream_resp_exception_local_timeout_;
-  const Stats::StatName upstream_resp_exception_local_maintenance_mode_;
-  const Stats::StatName upstream_resp_exception_local_no_healthy_upstream_;
   const Stats::StatName upstream_resp_exception_remote_;
   const Stats::StatName upstream_resp_invalid_type_;
   const Stats::StatName upstream_resp_decoding_error_;
@@ -549,7 +532,7 @@ protected:
     if (cluster_->maintenanceMode()) {
       stats().named_.upstream_rq_maintenance_mode_.inc();
       if (metadata->messageType() == MessageType::Call) {
-        stats().incResponseLocalException(*cluster_, LocalExceptionErrorType::MaintenanceMode);
+        stats().incResponseLocalException(*cluster_);
       }
       return {AppException(AppExceptionType::InternalError,
                            fmt::format("maintenance mode for cluster '{}'", cluster_name)),
@@ -570,7 +553,7 @@ protected:
     if (!conn_pool_data) {
       stats().named_.no_healthy_upstream_.inc();
       if (metadata->messageType() == MessageType::Call) {
-        stats().incResponseLocalException(*cluster_, LocalExceptionErrorType::NoHealthyUpstream);
+        stats().incResponseLocalException(*cluster_);
       }
       return {AppException(AppExceptionType::InternalError,
                            fmt::format("no healthy upstream for '{}'", cluster_name)),

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -302,20 +302,21 @@ bool UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
   bool close_downstream = true;
 
   chargeResponseTiming();
-
+  LocalExceptionErrorType error_code = LocalExceptionErrorType::Overflow;
   switch (reason) {
   case ConnectionPool::PoolFailureReason::Overflow:
-    stats_.incResponseLocalException(parent_.cluster());
+    stats_.incResponseLocalException(parent_.cluster(), error_code);
     parent_.sendLocalReply(AppException(AppExceptionType::InternalError,
                                         "thrift upstream request: too many connections"),
                            false /* Don't close the downstream connection. */);
     close_downstream = false;
     break;
   case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
-    FALLTHRU;
+    error_code = LocalExceptionErrorType::LocalConnectionFailure;
   case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
-    FALLTHRU;
+    error_code = LocalExceptionErrorType::RemoteConnectionFailure;
   case ConnectionPool::PoolFailureReason::Timeout:
+    error_code = LocalExceptionErrorType::Timeout;
     upstream_host_->outlierDetector().putResult(poolFailureReasonToResult(reason));
 
     // Error occurred after an underflow response, propagate the reset to the downstream.
@@ -328,7 +329,7 @@ bool UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
       if (response_state_ == ResponseState::Started) {
         stats_.incClosePartialResponse(parent_.cluster());
       }
-      stats_.incResponseLocalException(parent_.cluster());
+      stats_.incResponseLocalException(parent_.cluster(), error_code);
       parent_.sendLocalReply(
           AppException(AppExceptionType::InternalError,
                        fmt::format("connection failure before response {}: {} '{}'",

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -766,7 +766,7 @@ TEST_P(ThriftRouterRainidayTest, PoolRemoteConnectionFailure) {
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
                 ->statsScope()
-                .counterFromString("thrift.upstream_resp_exception_local_timeout")
+                .counterFromString("thrift.upstream_resp_exception_local.remote_connection_failure")
                 .value());
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
@@ -798,6 +798,21 @@ TEST_P(ThriftRouterRainidayTest, PoolLocalConnectionFailure) {
   context_.server_factory_context_.cluster_manager_.thread_local_cluster_.tcp_conn_pool_
       .poolFailure(ConnectionPool::PoolFailureReason::LocalConnectionFailure);
 
+  EXPECT_EQ(1UL,
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
+                ->statsScope()
+                .counterFromString("thrift.upstream_resp_exception_local.local_connection_failure")
+                .value());
+  EXPECT_EQ(1UL,
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
+                ->statsScope()
+                .counterFromString("thrift.upstream_resp_exception_local")
+                .value());
+  EXPECT_EQ(1UL,
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
+                ->statsScope()
+                .counterFromString("thrift.upstream_resp_exception")
+                .value());
   EXPECT_EQ(0UL, context_.server_factory_context_.cluster_manager_.thread_local_cluster_
                      .tcp_conn_pool_.host_->stats_.rq_error_.value());
 }
@@ -830,7 +845,7 @@ TEST_P(ThriftRouterRainidayTest, PoolTimeout) {
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
                 ->statsScope()
-                .counterFromString("thrift.upstream_resp_exception_local_timeout")
+                .counterFromString("thrift.upstream_resp_exception_local.timeout")
                 .value());
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
@@ -870,7 +885,7 @@ TEST_P(ThriftRouterRainidayTest, PoolOverflowFailure) {
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
                 ->statsScope()
-                .counterFromString("thrift.upstream_resp_exception_local_overflow")
+                .counterFromString("thrift.upstream_resp_exception_local.overflow")
                 .value());
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
@@ -1438,7 +1453,7 @@ TEST_F(ThriftRouterTest, PoolTimeoutUpstreamTimeMeasurement) {
   dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(500));
   EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception"));
   EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception_local"));
-  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception_local_timeout"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception_local.timeout"));
   EXPECT_CALL(cluster_store,
               histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds))
       .Times(0);

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -766,6 +766,11 @@ TEST_P(ThriftRouterRainidayTest, PoolRemoteConnectionFailure) {
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
                 ->statsScope()
+                .counterFromString("thrift.upstream_resp_exception_local_timeout")
+                .value());
+  EXPECT_EQ(1UL,
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
+                ->statsScope()
                 .counterFromString("thrift.upstream_resp_exception_local")
                 .value());
   EXPECT_EQ(1UL,
@@ -825,6 +830,11 @@ TEST_P(ThriftRouterRainidayTest, PoolTimeout) {
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
                 ->statsScope()
+                .counterFromString("thrift.upstream_resp_exception_local_timeout")
+                .value());
+  EXPECT_EQ(1UL,
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
+                ->statsScope()
                 .counterFromString("thrift.upstream_resp_exception_local")
                 .value());
   EXPECT_EQ(1UL,
@@ -857,6 +867,11 @@ TEST_P(ThriftRouterRainidayTest, PoolOverflowFailure) {
   context_.server_factory_context_.cluster_manager_.thread_local_cluster_.tcp_conn_pool_
       .poolFailure(ConnectionPool::PoolFailureReason::Overflow, true);
 
+  EXPECT_EQ(1UL,
+            context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
+                ->statsScope()
+                .counterFromString("thrift.upstream_resp_exception_local_overflow")
+                .value());
   EXPECT_EQ(1UL,
             context_.server_factory_context_.cluster_manager_.thread_local_cluster_.cluster_.info_
                 ->statsScope()
@@ -1423,6 +1438,7 @@ TEST_F(ThriftRouterTest, PoolTimeoutUpstreamTimeMeasurement) {
   dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(500));
   EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception"));
   EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception_local"));
+  EXPECT_CALL(cluster_store, counter("thrift.upstream_resp_exception_local_timeout"));
   EXPECT_CALL(cluster_store,
               histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds))
       .Times(0);


### PR DESCRIPTION
Commit Message:
Currently `upstream_resp_exception_local` in thrift_proxy is not fine grain enough for debugging online services
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
