### PR TITLE
api_listener: fixing a lifetime issue with the weak pointer wrapper

### DIFF
--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -427,8 +427,7 @@ void Client::DirectStreamCallbacks::latchError() {
   if (error_.has_value()) {
     return;  // Only latch error once.
   }
-  envoy_error error{};
-  error_ = error;
+  error_ = envoy_error();
 
   OptRef<RequestDecoder> request_decoder = direct_stream_.requestDecoder();
   if (!request_decoder) {

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -425,6 +425,7 @@ void Client::DirectStream::saveFinalStreamIntel() {
 
 void Client::DirectStreamCallbacks::latchError() {
   if (error_.has_value()) {
+    return;  // Only latch error once.
   }
   envoy_error error{};
   error_ = error;

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -425,7 +425,7 @@ void Client::DirectStream::saveFinalStreamIntel() {
 
 void Client::DirectStreamCallbacks::latchError() {
   if (error_.has_value()) {
-    return;  // Only latch error once.
+    return; // Only latch error once.
   }
   error_ = envoy_error();
 

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -190,6 +190,8 @@ private:
 
     void setFinalStreamIntel(StreamInfo::StreamInfo& stream_info);
 
+    void latchError();
+
   private:
     bool hasBufferedData() { return response_data_.get() && response_data_->length() != 0; }
 
@@ -198,7 +200,6 @@ private:
     void sendErrorToBridge();
     envoy_stream_intel streamIntel();
     envoy_final_stream_intel& finalStreamIntel();
-    envoy_error streamError();
 
     DirectStream& direct_stream_;
     const envoy_http_callbacks bridge_callbacks_;

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -240,11 +240,7 @@ private:
     // Stream
     void addCallbacks(StreamCallbacks& callbacks) override { addCallbacksHelper(callbacks); }
     void removeCallbacks(StreamCallbacks& callbacks) override { removeCallbacksHelper(callbacks); }
-    CodecEventCallbacks*
-    registerCodecEventCallbacks(CodecEventCallbacks* codec_callbacks) override {
-      std::swap(codec_callbacks, codec_callbacks_);
-      return codec_callbacks;
-    }
+    CodecEventCallbacks* registerCodecEventCallbacks(CodecEventCallbacks* codec_callbacks) override;
 
     void resetStream(StreamResetReason) override;
     Network::ConnectionInfoProvider& connectionInfoProvider() override {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -180,6 +180,13 @@ private:
                               public DownstreamStreamFilterCallbacks {
     ActiveStream(ConnectionManagerImpl& connection_manager, uint32_t buffer_limit,
                  Buffer::BufferMemoryAccountSharedPtr account);
+
+    // Event::DeferredDeletable
+    void deleteIsPending() override {
+      // The stream should not be accessed once deferred delete has been called.
+      still_alive_.reset();
+    }
+
     void completeRequest();
 
     const Network::Connection* connection();


### PR DESCRIPTION
Last time we tried to check this in it didn't run Envoy Mobile CI

Turns out we had several issues accessing the weak pointer, some of which look like they could be legitimate Envoy Mobile bugs in certain circumstances.  

Risk Level: low (Envoy changes should only affect Envoy Mobile or other API listener users)
Testing: new unit tests, existing tests enhanced by ENVOY_BUG
Docs Changes: n/a
Release Notes: n/a