### PR TITLE
Fix h3_request to work with delays

### DIFF
--- a/tools/h3_request/h3_request.py
+++ b/tools/h3_request/h3_request.py
@@ -92,10 +92,13 @@ class Http3Client(QuicConnectionProtocol):
             ],
             end_stream=not post_stdin,
         )
+        self.transmit()
         if post_stdin:
             async for data in _stream_stdin_generator():
                 self._http.send_data(stream_id=stream_id, data=data, end_stream=False)
+                self.transmit()
             self._http.send_data(stream_id=stream_id, data=b'', end_stream=True)
+            self.transmit()
 
         await future
 


### PR DESCRIPTION
Commit Message: fix h3_request to work with delays
Additional Description: It turns out the aiohttp functions named with the prefix `send_` only *sometimes* send, and would be more accurately prefixed `queue_`, or more accurately still `queue_or_send_`. This fixes the tool to always send.
Risk Level: None, test-tool only.
Testing: Tested manually with the call that wasn't working right before, and it does now.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
