### PR TITLE
socket: using error return

### DIFF
--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -68,9 +68,7 @@ Api::SysCallIntResult SocketImpl::bind(Network::Address::InstanceConstSharedPtr 
     if (pipe->mode() != 0 && !abstract_namespace && bind_result.return_value_ == 0) {
       auto set_permissions = Api::OsSysCallsSingleton::get().chmod(pipe_sa->sun_path, pipe->mode());
       if (set_permissions.return_value_ != 0) {
-        throwEnvoyExceptionOrPanic(fmt::format("Failed to create socket with mode {}: {}",
-                                               std::to_string(pipe->mode()),
-                                               errorDetails(set_permissions.errno_)));
+        return set_permissions;
       }
     }
     return bind_result;

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -408,7 +408,7 @@ TEST(PipeInstanceTest, PermissionFail) {
 
   EXPECT_CALL(os_sys_calls, bind(_, _, _)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
   EXPECT_CALL(os_sys_calls, chmod(_, _)).WillOnce(Return(Api::SysCallIntResult{-1, 0}));
-  EXPECT_THROW_WITH_REGEX(sock.bind(address), EnvoyException, "Failed to create socket with mode");
+  EXPECT_NE(sock.bind(address).return_value_, 0);
 }
 
 TEST(PipeInstanceTest, AbstractNamespacePermission) {

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -109,7 +109,6 @@ paths:
     - source/common/network/address_impl.cc
     - source/common/network/utility.cc
     - source/common/network/dns_resolver/dns_factory_util.cc
-    - source/common/network/socket_impl.cc
     - source/common/ssl/tls_certificate_config_impl.cc
     - source/common/formatter/http_specific_formatter.cc
     - source/common/formatter/stream_info_formatter.h


### PR DESCRIPTION
Replacing a (not exerted) data plane crash with error handling.

https://github.com/envoyproxy/envoy-mobile/issues/176
