### PR TITLE
Add a `client_scope` field to `ClientConfig`

### DIFF
--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -189,7 +189,7 @@ message ClientConfig {
   // For xDS clients, the scope in which the data is used.
   // For example, gRPC indicates the data plane target or that the data is
   // associated with gRPC server(s).
-  string client_scope = 10;
+  string client_scope = 4;
 }
 
 message ClientStatusResponse {

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -185,6 +185,11 @@ message ClientConfig {
   // Represents generic xDS config and the exact config structure depends on
   // the type URL (like Cluster if it is CDS)
   repeated GenericXdsConfig generic_xds_configs = 3;
+
+  // For xDS clients, the scope in which the data is used.
+  // For example, gRPC indicates the data plane target or that the data is
+  // associated with gRPC server(s).
+  string client_scope = 10;
 }
 
 message ClientStatusResponse {


### PR DESCRIPTION
Commit Message:
Add a `client_scope` field to `ClientConfig`

Additional Description:
Extends an CSDS API with an additional field that includes extra information for implementations that can have multiple unrelated configs.

Risk Level:
Low

Testing:
Manual

Docs Changes:
None

Release Notes:
None

Platform Specific Features:
None