### PR TITLE
xds: Fix the resume_cds_ logic in ClusterManagerImpl

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1024,6 +1024,7 @@ void ClusterManagerImpl::updateClusterCounts() {
   if (all_clusters_initialized && ads_mux_) {
     const auto type_url = Config::getTypeUrl<envoy::config::cluster::v3::Cluster>();
     if (last_recorded_warming_clusters_count_ == 0 && !warming_clusters_.empty()) {
+      resume_cds_.reset();
       resume_cds_ = ads_mux_->pause(type_url);
     } else if (last_recorded_warming_clusters_count_ > 0 && warming_clusters_.empty()) {
       resume_cds_.reset();

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1023,16 +1023,14 @@ void ClusterManagerImpl::updateClusterCounts() {
       init_helper_.state() == ClusterManagerInitHelper::State::AllClustersInitialized;
   if (all_clusters_initialized && ads_mux_) {
     const auto type_url = Config::getTypeUrl<envoy::config::cluster::v3::Cluster>();
-    if (last_recorded_warming_clusters_count_ == 0 && !warming_clusters_.empty()) {
-      resume_cds_.reset();
+    if (resume_cds_ == nullptr && !warming_clusters_.empty()) {
       resume_cds_ = ads_mux_->pause(type_url);
-    } else if (last_recorded_warming_clusters_count_ > 0 && warming_clusters_.empty()) {
+    } else if (warming_clusters_.empty()) {
       resume_cds_.reset();
     }
   }
   cm_stats_.active_clusters_.set(active_clusters_.size());
   cm_stats_.warming_clusters_.set(warming_clusters_.size());
-  last_recorded_warming_clusters_count_ = warming_clusters_.size();
 }
 
 ThreadLocalCluster* ClusterManagerImpl::getThreadLocalCluster(absl::string_view cluster) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1026,7 +1026,6 @@ void ClusterManagerImpl::updateClusterCounts() {
     if (last_recorded_warming_clusters_count_ == 0 && !warming_clusters_.empty()) {
       resume_cds_ = ads_mux_->pause(type_url);
     } else if (last_recorded_warming_clusters_count_ > 0 && warming_clusters_.empty()) {
-      ASSERT(resume_cds_ != nullptr);
       resume_cds_.reset();
     }
   }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -936,15 +936,6 @@ private:
   bool initialized_{};
   bool ads_mux_initialized_{};
   std::atomic<bool> shutdown_{};
-
-  // Records the last `warming_clusters_` map size from updateClusterCounts(). This variable is
-  // used for bookkeeping to run the `resume_cds_` cleanup that decrements the pause count and
-  // enables the resumption of DiscoveryRequests for the Cluster type url.
-  //
-  // The `warming_clusters` gauge is not suitable for this purpose, because different environments
-  // (e.g. mobile) may have different stats enabled, leading to the gauge not having a reliable
-  // previous warming clusters size value.
-  std::size_t last_recorded_warming_clusters_count_{0};
 };
 
 } // namespace Upstream


### PR DESCRIPTION
We also remove an ASSERT that appears unneeded and was getting tripped in certain settings.
Calling `.reset()` on an already null unique_ptr is a no-op, so the ASSERT isn't needed.