### PR TITLE
ci: fix typo in vtprotobuf disable logic

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -310,8 +310,10 @@ case $CI_TARGET in
                 fi
                 # TODO(https://github.com/planetscale/vtprotobuf/pull/122) do this directly in the generator.
                 # Make vtprotobuf opt-in as it has some impact on binary sizes
-                if [[ "$GO_FILE" = *.vtproto.pb.go ]]; then
-                    sed -i '1s;^;//go:build vtprotobuf\n;' "$OUTPUT_DIR/$(basename "$GO_FILE")"
+                if [[ "$GO_FILE" = *_vtproto.pb.go ]]; then
+                    if ! grep -q 'package ignore' "$GO_FILE"; then
+                        sed -i '1s;^;//go:build vtprotobuf\n// +build vtprotobuf\n;' "$OUTPUT_DIR/$(basename "$GO_FILE")"
+                    fi
                 fi
             done <<< "$(find "$INPUT_DIR" -name "*.go")"
         done


### PR DESCRIPTION
Without this fix, vtprotobuf is accidentally enabled for everyone instead of just opt-in.

Fixing https://github.com/envoyproxy/envoy/pull/31172


Commit Message: `ci: fix typo in vtprotobuf disable logic`
Additional Description:
    Without this fix, vtprotobuf is accidentally enabled for everyone
    instead of just opt-in.

    Fixing https://github.com/envoyproxy/envoy/pull/31172

Risk Level: Low
Testing: Manually ran
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
