### PR TITLE
Promote downstream connections monitor extension to stable

### DIFF
--- a/api/envoy/extensions/resource_monitors/downstream_connections/v3/BUILD
+++ b/api/envoy/extensions/resource_monitors/downstream_connections/v3/BUILD
@@ -5,8 +5,5 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = [
-        "@com_github_cncf_xds//udpa/annotations:pkg",
-        "@com_github_cncf_xds//xds/annotations/v3:pkg",
-    ],
+    deps = ["@com_github_cncf_xds//udpa/annotations:pkg"],
 )

--- a/api/envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto
+++ b/api/envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.resource_monitors.downstream_connections.v3;
 
-import "xds/annotations/v3/status.proto";
-
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto
+++ b/api/envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto
@@ -12,7 +12,6 @@ option java_outer_classname = "DownstreamConnectionsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/resource_monitors/downstream_connections/v3;downstream_connectionsv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
-option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // [#protodoc-title: Downstream connections]
 // [#extension: envoy.resource_monitors.downstream_connections]

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1021,7 +1021,7 @@ envoy.resource_monitors.downstream_connections:
   categories:
   - envoy.resource_monitors
   security_posture: data_plane_agnostic
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
 envoy.resource_monitors.fixed_heap:


### PR DESCRIPTION
Since [downstream connections monitor](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto#extensions-resource-monitors-downstream-connections-v3-downstreamconnectionsconfig) has been [enabled](https://github.com/envoyproxy/envoy/pull/28202) in the hot request path in tcp listener in the beginning of October 2023, it has been deployed into high scale prod env at Spotify and has been running with no observed issues for 2.5 month. This patch suggests to promote this extension to stable.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes: TBD
Platform Specific Features:

