### PR TITLE
devcontainer: Use libc++ when building Envoy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ARG USER_UID=501
 ARG USER_GID=$USER_UID
 
 ENV BUILD_DIR=/build
-ENV ENVOY_STDLIB=libstdc++
+ENV ENVOY_STDLIB=libc++
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update \

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,7 +5,7 @@ BAZELRC_FILE=~/.bazelrc bazel/setup_clang.sh /opt/llvm
 # TODO(phlax): use user.bazelrc
 # Use generated toolchain config because we know the base container is the one we're using in RBE.
 # Not using libc++ here because clangd will raise some tidy issue in libc++ header as of version 9.
-echo "build --config=rbe-toolchain-clang" >> ~/.bazelrc
+echo "build --config=rbe-toolchain-clang-libc++" >> ~/.bazelrc
 echo "build ${BAZEL_BUILD_EXTRA_OPTIONS}" | tee -a ~/.bazelrc
 
 # Ideally we want this line so bazel doesn't pollute things outside of the devcontainer, but some of


### PR DESCRIPTION
Fixes #31856

Risk Level: low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
