### PR TITLE
conn_pool_grid: Restructure the class layout to minimize padding

### DIFF
--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -213,15 +213,15 @@ ConnectivityGrid::ConnectivityGrid(
     HttpServerPropertiesCacheSharedPtr alternate_protocols,
     ConnectivityOptions connectivity_options, Quic::QuicStatNames& quic_stat_names,
     Stats::Scope& scope, Http::PersistentQuicInfo& quic_info)
-    : dispatcher_(dispatcher), random_generator_(random_generator), host_(host),
-      priority_(priority), options_(options), transport_socket_options_(transport_socket_options),
-      state_(state), next_attempt_duration_(std::chrono::milliseconds(kDefaultTimeoutMs)),
+    : dispatcher_(dispatcher), random_generator_(random_generator), host_(host), options_(options),
+      transport_socket_options_(transport_socket_options), state_(state),
+      next_attempt_duration_(std::chrono::milliseconds(kDefaultTimeoutMs)),
       time_source_(time_source), alternate_protocols_(alternate_protocols),
       quic_stat_names_(quic_stat_names), scope_(scope),
       // TODO(RyanTheOptimist): Figure out how scheme gets plumbed in here.
       origin_("https", getSni(transport_socket_options, host_->transportSocketFactory()),
               host_->address()->ip()->port()),
-      quic_info_(quic_info) {
+      quic_info_(quic_info), priority_(priority) {
   // ProdClusterManagerFactory::allocateConnPool verifies the protocols are HTTP/1, HTTP/2 and
   // HTTP/3.
   ASSERT(connectivity_options.protocols_.size() == 3);

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -205,17 +205,12 @@ private:
   Event::Dispatcher& dispatcher_;
   Random::RandomGenerator& random_generator_;
   Upstream::HostConstSharedPtr host_;
-  Upstream::ResourcePriority priority_;
   const Network::ConnectionSocket::OptionsSharedPtr options_;
   const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   Upstream::ClusterConnectivityState& state_;
   std::chrono::milliseconds next_attempt_duration_;
   TimeSource& time_source_;
   HttpServerPropertiesCacheSharedPtr alternate_protocols_;
-
-  // True iff this pool is draining. No new streams or connections should be created
-  // in this state.
-  bool draining_{false};
 
   // Tracks the callbacks to be called on drain completion.
   std::list<Instance::IdleCb> idle_callbacks_;
@@ -224,23 +219,31 @@ private:
   // desired use.
   std::list<ConnectionPool::InstancePtr> pools_;
 
-  // True iff under the stack of the destructor, to avoid calling drain
-  // callbacks on deletion.
-  bool destroying_{};
-
-  // True iff this pool is being being defer deleted.
-  bool deferred_deleting_{};
-
   // Wrapped callbacks are stashed in the wrapped_callbacks_ for ownership.
   std::list<WrapperCallbacksPtr> wrapped_callbacks_;
 
   Quic::QuicStatNames& quic_stat_names_;
+
   Stats::Scope& scope_;
+
   // The origin for this pool.
   // Note the host name here is based off of the host name used for SNI, which
   // may be from the cluster config, or the request headers for auto-sni.
   HttpServerPropertiesCache::Origin origin_;
+
   Http::PersistentQuicInfo& quic_info_;
+  Upstream::ResourcePriority priority_;
+
+  // True iff this pool is draining. No new streams or connections should be created
+  // in this state.
+  bool draining_{false};
+
+  // True iff under the stack of the destructor, to avoid calling drain
+  // callbacks on deletion.
+  bool destroying_{};
+
+  // True iff this pool is being deferred deleted.
+  bool deferred_deleting_{};
 };
 
 } // namespace Http


### PR DESCRIPTION
class `Envoy::Http::ConnectivityGrid` needs 20 bytes of padding,
 non-tail padding is 20 (fields: 20 padded fields: 3) total_size: 304

```
Padding	Size	Alignment	| Field name
	8	8		| dispatcher_
	8	8		| random_generator_
	16	8		| host_
7	1	1		| priority_
	16	8		| options_
	16	8		| transport_socket_options_
	8	8		| state_
	8	8		| next_attempt_duration_
	8	8		| time_source_
	16	8		| alternate_protocols_
7	1	1		| draining_
	24	8		| idle_callbacks_
	24	8		| pools_
	1	1		| destroying_
6	1	1		| deferred_deleting_
	24	8		| wrapped_callbacks_
	8	8		| quic_stat_names_
	8	8		| scope_
	56	8		| origin_
	8	8		| quic_info_
```

The new class layout structure will save 16 bytes by minimizing padding.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
