### PR TITLE
grid: fixing a inline newStream bug with H3 recently broken

### DIFF
--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -90,7 +90,7 @@ void ConnectivityGrid::WrapperCallbacks::onConnectionAttemptFailed(
   }
 
   // If the next connection attempt does not immediately fail, let it proceed.
-  if (tryAnotherConnection()) {
+  if (tryAnotherConnection().first) {
     return;
   }
 
@@ -189,19 +189,19 @@ void ConnectivityGrid::WrapperCallbacks::cancelAllPendingAttempts(
   connection_attempts_.clear();
 }
 
-bool ConnectivityGrid::WrapperCallbacks::tryAnotherConnection() {
+std::pair<bool, ConnectivityGrid::StreamCreationResult> ConnectivityGrid::WrapperCallbacks::tryAnotherConnection() {
   absl::optional<PoolIterator> next_pool = grid_.nextPool(current_);
   if (!next_pool.has_value()) {
     // If there are no other pools to try, return false.
-    return false;
+    return {false, StreamCreationResult::ImmediateResult};
   }
   // Create a new connection attempt for the next pool. If we reach this point
   // return true regardless of if newStream resulted in an immediate result or
   // an async call, as either way the attempt will result in success/failure
   // callbacks.
   current_ = next_pool.value();
-  newStream();
-  return true;
+  auto ret = newStream();
+  return {true, ret};
 }
 
 ConnectivityGrid::ConnectivityGrid(
@@ -327,7 +327,11 @@ ConnectionPool::Cancellable* ConnectivityGrid::newStream(Http::ResponseDecoder& 
   }
   if (!delay_tcp_attempt) {
     // Immediately start TCP attempt if HTTP/3 failed recently.
-    wrapped_callbacks_.front()->tryAnotherConnection();
+    auto try_and_status = wrapped_callbacks_.front()->tryAnotherConnection();
+    if (try_and_status.first && try_and_status.second == StreamCreationResult::ImmediateResult) {
+      // As above, if we have an immediate success, return nullptr.
+      return nullptr;
+    }
   }
   return ret;
 }

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -80,9 +80,10 @@ public:
     StreamCreationResult newStream();
 
     // Called on pool failure or timeout to kick off another connection attempt.
-    // Returns true if there is a failover pool and a connection has been
-    // attempted, false if all pools have been tried.
-    bool tryAnotherConnection();
+    // Returns true and the StreamCreationResult if there is a failover pool and a
+    // connection has been attempted, false and a StreamCreationResult which
+    // should be ignored if all pools have been tried.
+    std::pair<bool, StreamCreationResult> tryAnotherConnection();
 
     // Called by a ConnectionAttempt when the underlying pool fails.
     void onConnectionAttemptFailed(ConnectionAttemptCallbacks* attempt,

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -67,8 +67,12 @@ public:
                                         "reason", host());
                 return nullptr;
               }
+              if (second_pool_immediate_success_) {
+                second_pool_immediate_success_ = false;
+                immediate_success_ = true;
+              }
               callbacks_.push_back(&callbacks);
-              return &cancel_;
+              return cancel_;
             }));
     if (pools_.size() == 1) {
       EXPECT_CALL(*first(), protocolDescription())
@@ -111,9 +115,10 @@ public:
   NiceMock<MockRequestEncoder>* encoder_;
   void setDestroying() { destroying_ = true; }
   std::vector<ConnectionPool::Callbacks*> callbacks_;
-  NiceMock<Envoy::ConnectionPool::MockCancellable> cancel_;
+  NiceMock<Envoy::ConnectionPool::MockCancellable>* cancel_;
   bool immediate_success_{};
   bool immediate_failure_{};
+  bool second_pool_immediate_success_{};
 };
 
 namespace {
@@ -142,6 +147,7 @@ public:
         Upstream::ResourcePriority::Default, socket_options_, transport_socket_options_, state_,
         simTime(), alternate_protocols_, options_, quic_stat_names_, *store_.rootScope(),
         *quic_connection_persistent_info_);
+    grid_->cancel_ = &cancel_;
     host_ = grid_->host();
     grid_->info_ = &info_;
     grid_->encoder_ = &encoder_;
@@ -179,6 +185,7 @@ public:
   Stats::IsolatedStoreImpl store_;
   Quic::QuicStatNames quic_stat_names_;
   PersistentQuicInfoPtr quic_connection_persistent_info_;
+  NiceMock<Envoy::ConnectionPool::MockCancellable> cancel_;
   std::unique_ptr<ConnectivityGridForTest> grid_;
   Upstream::HostDescriptionConstSharedPtr host_;
 
@@ -549,7 +556,7 @@ TEST_F(ConnectivityGridTest, TestCancel) {
   EXPECT_NE(grid_->first(), nullptr);
 
   // cancel should be passed through the WrapperCallbacks to the connection pool.
-  EXPECT_CALL(grid_->cancel_, cancel(_));
+  EXPECT_CALL(*grid_->cancel_, cancel(_));
   cancel->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
 }
 
@@ -868,7 +875,7 @@ TEST_F(ConnectivityGridTest, Http3FailedRecentlyThenSucceeds) {
   ASSERT_NE(grid_->callbacks(0), nullptr);
   ASSERT_NE(grid_->callbacks(1), nullptr);
   EXPECT_CALL(callbacks_.pool_ready_, ready());
-  EXPECT_CALL(grid_->cancel_, cancel(_));
+  EXPECT_CALL(*grid_->cancel_, cancel(_));
   grid_->callbacks(0)->onPoolReady(encoder_, host_, info_, absl::nullopt);
   // Getting onPoolReady() from HTTP/3 pool doesn't change H3 status.
   EXPECT_TRUE(ConnectivityGridForTest::hasHttp3FailedRecently(*grid_));
@@ -900,6 +907,22 @@ TEST_F(ConnectivityGridTest, Http3FailedRecentlyThenFailsAgain) {
   grid_->callbacks(0)->onPoolFailure(ConnectionPool::PoolFailureReason::LocalConnectionFailure,
                                      "reason", host_);
   EXPECT_TRUE(grid_->isHttp3Broken());
+}
+
+TEST_F(ConnectivityGridTest, Http3FailedH2SuceedsInline) {
+  initialize();
+  addHttp3AlternateProtocol();
+  grid_->onZeroRttHandshakeFailed();
+  EXPECT_TRUE(ConnectivityGridForTest::hasHttp3FailedRecently(*grid_));
+  EXPECT_EQ(grid_->first(), nullptr);
+
+  // Force H3 to have no immediate change, but H2 to immediately succeed.
+  grid_->second_pool_immediate_success_ = true;
+  // Because the second pool immediately succeeded, newStream should return nullptr.
+  EXPECT_EQ(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/true,
+                               /*can_use_http3_=*/true}),
+            nullptr);
 }
 
 #ifdef ENVOY_ENABLE_QUIC


### PR DESCRIPTION
Fixing a bug in the grid where if H3 was recently broken and an H2 connection was established, the grid would both synchronously call pool success callbacks and return a cancelable.

Risk Level: low
Testing: new unit tests, manual e2e
Docs Changes: n/a
Release Notes:  n/a