### PR TITLE
Fix a MSAN issue in ext_authz due to max_request_bytes_ change

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -152,16 +152,16 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
                  !(end_stream || Http::Utility::isWebSocketUpgradeRequest(headers) ||
                    Http::Utility::isH2UpgradeRequest(headers));
 
+  max_request_bytes_ = config_->maxRequestBytes();
   if (buffer_data_) {
     ENVOY_STREAM_LOG(debug, "ext_authz filter is buffering the request", *decoder_callbacks_);
 
     allow_partial_message_ = check_settings.has_with_request_body()
                                  ? check_settings.with_request_body().allow_partial_message()
                                  : config_->allowPartialMessage();
-    max_request_bytes_ = check_settings.has_with_request_body()
-                             ? check_settings.with_request_body().max_request_bytes()
-                             : config_->maxRequestBytes();
-
+    if (check_settings.has_with_request_body()) {
+      max_request_bytes_ = check_settings.with_request_body().max_request_bytes();
+    }
     if (!allow_partial_message_) {
       decoder_callbacks_->setDecoderBufferLimit(max_request_bytes_);
     }


### PR DESCRIPTION
There is a MSAN issue in ext_authz due to recently commit: #31437.
The error indicates use-of-uniniialized value of max_request_bytes_.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
