### PR TITLE
[qatzip] Use boringssl alias for consistent fips

### DIFF
--- a/contrib/qat/compression/qatzip/compressor/source/BUILD
+++ b/contrib/qat/compression/qatzip/compressor/source/BUILD
@@ -39,7 +39,8 @@ configure_make(
         "//bazel/foreign_cc:lz4",
         "//bazel/foreign_cc:zlib",
         "//contrib/qat:qatlib",
-        "@boringssl//:ssl",
+        # Use boringssl alias to select fips vs non-fips version.
+        "//bazel:boringssl",
     ],
     alwayslink = False,
 )


### PR DESCRIPTION
Commit Message: [qatzip] Use boringssl alias for consistent fips
Additional Description: This addresses the most immediate issue of #31874. There remains another issue where it still fails to build, and it's still an issue in boringssl, but it's no longer caused by inconsistent boringssl versions, so this is a step in the right direction.
Risk Level: Near-zero.
Testing: Manually; `bazel build --define boringssl=fips //contrib/exe:envoy-static` fails later after the change.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
