### PR TITLE
Update changelogs/1.29.0.yaml for PR#31762

### DIFF
--- a/changelogs/1.29.0.yaml
+++ b/changelogs/1.29.0.yaml
@@ -173,7 +173,10 @@ bug_fixes:
     setting. The OAuth spec does not dictate that an authorization server must respond with an expiry. Envoy currently
     fails any OAuth flow if the expiry is not set. This setting allows you to provide a default in this case to ensure
     the OAuth flow can succeed.
-
+- area: postgres proxy
+  change: |
+    Fix a race condition that may result from upstream servers refusing to switch to TLS.
+    
 removed_config_or_runtime:
 - area: http
   change: |

--- a/changelogs/1.29.0.yaml
+++ b/changelogs/1.29.0.yaml
@@ -176,7 +176,7 @@ bug_fixes:
 - area: postgres proxy
   change: |
     Fix a race condition that may result from upstream servers refusing to switch to TLS.
-    
+
 removed_config_or_runtime:
 - area: http
   change: |


### PR DESCRIPTION
#31762 solves a potential bug of postgres proxy that was not mentioned in the changelogs of _v1.29.0_ though the PR appeared in this release. This PR updates `changelogs/1.29.0.yaml ` file to cover the change.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes: 
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
