### PR TITLE
Contrib builds actually excluding skipped targets

### DIFF
--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -28,5 +28,9 @@ PPC_SKIP_CONTRIB_TARGETS = [
     "envoy.compression.qatzip.compressor",
 ]
 
+FIPS_SKIP_CONTRIB_TARGETS = [
+    "envoy.compression.qatzip.compressor",
+]
+
 def envoy_all_contrib_extensions(denylist = []):
     return [v + "_envoy_extension" for k, v in CONTRIB_EXTENSIONS.items() if not k in denylist]

--- a/contrib/exe/BUILD
+++ b/contrib/exe/BUILD
@@ -7,6 +7,7 @@ load(
 load(
     "//contrib:all_contrib_extensions.bzl",
     "ARM64_SKIP_CONTRIB_TARGETS",
+    "FIPS_SKIP_CONTRIB_TARGETS",
     "PPC_SKIP_CONTRIB_TARGETS",
     "envoy_all_contrib_extensions",
 )
@@ -20,11 +21,18 @@ alias(
     actual = ":envoy-static",
 )
 
+SELECTED_CONTRIB_EXTENSIONS = select({
+    "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
+    "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
+    "//bazel:boringssl_fips": envoy_all_contrib_extensions(FIPS_SKIP_CONTRIB_TARGETS),
+    "//conditions:default": envoy_all_contrib_extensions(),
+})
+
 envoy_cc_binary(
     name = "envoy-static",
     stamped = True,
     visibility = ["//visibility:public"],
-    deps = ["//source/exe:envoy_main_entry_lib"] + envoy_all_contrib_extensions(),
+    deps = ["//source/exe:envoy_main_entry_lib"] + SELECTED_CONTRIB_EXTENSIONS,
 )
 
 envoy_cc_test(
@@ -41,9 +49,5 @@ envoy_cc_test(
     },
     deps = [
         "//test/config_test:example_configs_test_lib",
-    ] + select({
-        "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
-        "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
-        "//conditions:default": envoy_all_contrib_extensions(),
-    }),
+    ] + SELECTED_CONTRIB_EXTENSIONS,
 )


### PR DESCRIPTION
Commit Message: Contrib builds excluding skipped targets
Additional Description: Previously the contrib static binary did not exclude targets that were tagged for skipping, which seems like it was a mistake.
This also adds a target skip for `boringssl=fips` configuration, because the qatzip extension currently breaks the FIPS build.
This is imperfect, in that an aarch64 build with boringssl=fips will still not work, but should repair the majority of currently surprise-broken cases.
Fixes #31874 
Risk Level: Small risk of surprising aarch64 and ppc builds by actually excluding extensions that were nominally excluded all along.
Testing: `bazel build --define boringssl=fips //contrib/exe:envoy-static` in the devcontainer works after and does not work before.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
