### PR TITLE
http2: more cleanup in preparation for removing nghttp2 callbacks

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1494,8 +1494,7 @@ int ConnectionImpl::onMetadataFrameComplete(int32_t stream_id, bool end_metadata
   return result ? 0 : NGHTTP2_ERR_CALLBACK_FAILURE;
 }
 
-int ConnectionImpl::saveHeader(int32_t stream_id, HeaderString&& name,
-                               HeaderString&& value) {
+int ConnectionImpl::saveHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) {
   StreamImpl* stream = getStreamUnchecked(stream_id);
   if (!stream) {
     // We have seen 1 or 2 crashes where we get a headers callback but there is no associated
@@ -1708,8 +1707,8 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
         name.setCopy(reinterpret_cast<const char*>(raw_name), name_length);
         HeaderString value;
         value.setCopy(reinterpret_cast<const char*>(raw_value), value_length);
-        return static_cast<ConnectionImpl*>(user_data)->onHeader(frame->hd.stream_id, std::move(name),
-                                                                 std::move(value));
+        return static_cast<ConnectionImpl*>(user_data)->onHeader(frame->hd.stream_id,
+                                                                 std::move(name), std::move(value));
       });
 
   nghttp2_session_callbacks_set_on_data_chunk_recv_callback(
@@ -2044,8 +2043,7 @@ Status ClientConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   return okStatus();
 }
 
-int ClientConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name,
-                                   HeaderString&& value) {
+int ClientConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) {
   ASSERT(connection_.state() == Network::Connection::State::Open);
   return saveHeader(stream_id, std::move(name), std::move(value));
 }
@@ -2145,8 +2143,7 @@ Status ServerConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   return okStatus();
 }
 
-int ServerConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name,
-                                   HeaderString&& value) {
+int ServerConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) {
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http2_discard_host_header")) {
     StreamImpl* stream = getStreamUnchecked(stream_id);
     if (stream && name == static_cast<absl::string_view>(Http::Headers::get().HostLegacy)) {

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1494,9 +1494,9 @@ int ConnectionImpl::onMetadataFrameComplete(int32_t stream_id, bool end_metadata
   return result ? 0 : NGHTTP2_ERR_CALLBACK_FAILURE;
 }
 
-int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
+int ConnectionImpl::saveHeader(int32_t stream_id, HeaderString&& name,
                                HeaderString&& value) {
-  StreamImpl* stream = getStreamUnchecked(frame->hd.stream_id);
+  StreamImpl* stream = getStreamUnchecked(stream_id);
   if (!stream) {
     // We have seen 1 or 2 crashes where we get a headers callback but there is no associated
     // stream data. I honestly am not sure how this can happen. However, from reading the nghttp2
@@ -1708,7 +1708,7 @@ ConnectionImpl::Http2Callbacks::Http2Callbacks() {
         name.setCopy(reinterpret_cast<const char*>(raw_name), name_length);
         HeaderString value;
         value.setCopy(reinterpret_cast<const char*>(raw_value), value_length);
-        return static_cast<ConnectionImpl*>(user_data)->onHeader(frame, std::move(name),
+        return static_cast<ConnectionImpl*>(user_data)->onHeader(frame->hd.stream_id, std::move(name),
                                                                  std::move(value));
       });
 
@@ -2044,13 +2044,10 @@ Status ClientConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   return okStatus();
 }
 
-int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& name,
+int ClientConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name,
                                    HeaderString&& value) {
-  // The client code explicitly does not currently support push promise.
-  ASSERT(frame->hd.type == NGHTTP2_HEADERS);
-  ASSERT(frame->headers.cat == NGHTTP2_HCAT_RESPONSE || frame->headers.cat == NGHTTP2_HCAT_HEADERS);
   ASSERT(connection_.state() == Network::Connection::State::Open);
-  return saveHeader(frame, std::move(name), std::move(value));
+  return saveHeader(stream_id, std::move(name), std::move(value));
 }
 
 // TODO(yanavlasov): move to the base class once the runtime flag is removed.
@@ -2148,13 +2145,10 @@ Status ServerConnectionImpl::onBeginHeaders(const nghttp2_frame* frame) {
   return okStatus();
 }
 
-int ServerConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& name,
+int ServerConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name,
                                    HeaderString&& value) {
-  // For a server connection, we should never get push promise frames.
-  ASSERT(frame->hd.type == NGHTTP2_HEADERS);
-  ASSERT(frame->headers.cat == NGHTTP2_HCAT_REQUEST || frame->headers.cat == NGHTTP2_HCAT_HEADERS);
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http2_discard_host_header")) {
-    StreamImpl* stream = getStreamUnchecked(frame->hd.stream_id);
+    StreamImpl* stream = getStreamUnchecked(stream_id);
     if (stream && name == static_cast<absl::string_view>(Http::Headers::get().HostLegacy)) {
       // Check if there is already the :authority header
       const auto result = stream->headers().get(Http::Headers::get().Host);
@@ -2165,7 +2159,7 @@ int ServerConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
       // Otherwise use host value as :authority
     }
   }
-  return saveHeader(frame, std::move(name), std::move(value));
+  return saveHeader(stream_id, std::move(name), std::move(value));
 }
 
 Status ServerConnectionImpl::trackInboundFrames(int32_t stream_id, size_t length, uint8_t type,

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -567,7 +567,7 @@ protected:
   // Same as getStream, but without the ASSERT.
   const StreamImpl* getStreamUnchecked(int32_t stream_id) const;
   StreamImpl* getStreamUnchecked(int32_t stream_id);
-  int saveHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value);
+  int saveHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value);
 
   /**
    * Copies any frames pending internally by nghttp2 into outbound buffer.
@@ -700,7 +700,7 @@ private:
   int onFrameSend(int32_t stream_id, size_t length, uint8_t type, uint8_t flags,
                   uint32_t error_code);
   int onError(absl::string_view error);
-  virtual int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) PURE;
+  virtual int onHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) PURE;
   int onInvalidFrame(int32_t stream_id, int error_code);
   // Pass through invoking with the actual stream.
   Status onStreamClose(int32_t stream_id, uint32_t error_code);
@@ -758,7 +758,7 @@ private:
   // ConnectionImpl
   ConnectionCallbacks& callbacks() override { return callbacks_; }
   Status onBeginHeaders(const nghttp2_frame* frame) override;
-  int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) override;
+  int onHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) override;
   Status trackInboundFrames(int32_t stream_id, size_t length, uint8_t type, uint8_t flags,
                             uint32_t) override;
   void dumpStreams(std::ostream& os, int indent_level) const override;
@@ -785,7 +785,7 @@ private:
   // ConnectionImpl
   ConnectionCallbacks& callbacks() override { return callbacks_; }
   Status onBeginHeaders(const nghttp2_frame* frame) override;
-  int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) override;
+  int onHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) override;
   Status trackInboundFrames(int32_t stream_id, size_t length, uint8_t type, uint8_t flags,
                             uint32_t padding_length) override;
   absl::optional<int> checkHeaderNameForUnderscores(absl::string_view header_name) override;


### PR DESCRIPTION
This PR removes a few references to the `nghttp2_frame` type in codec API methods.

Commit Message: http2: more cleanup in preparation for removing nghttp2 callbacks
Additional Description:
Risk Level: low; refactoring, no functional change intended
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
