### PR TITLE
generic proxy: get filter factory by type for route config

### DIFF
--- a/contrib/generic_proxy/filters/network/source/interface/config.h
+++ b/contrib/generic_proxy/filters/network/source/interface/config.h
@@ -51,6 +51,16 @@ public:
   virtual absl::Status validateCodec(const TypedExtensionConfig& /*config*/) {
     return absl::OkStatus();
   }
+
+  std::set<std::string> configTypes() override {
+    auto config_types = TypedFactory::configTypes();
+
+    if (auto message = createEmptyRouteConfigProto(); message != nullptr) {
+      config_types.insert(createReflectableMessage(*message)->GetDescriptor()->full_name());
+    }
+
+    return config_types;
+  }
 };
 
 } // namespace GenericProxy

--- a/contrib/generic_proxy/filters/network/source/route.h
+++ b/contrib/generic_proxy/filters/network/source/route.h
@@ -46,6 +46,11 @@ public:
 
   const Envoy::Config::TypedMetadata& typedMetadata() const override { return typed_metadata_; };
 
+  RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfig(const std::string& name, const ProtobufWkt::Any& typed_config,
+                                  Server::Configuration::ServerFactoryContext& factory_context,
+                                  ProtobufMessage::ValidationVisitor& validator);
+
 private:
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;
 

--- a/contrib/generic_proxy/filters/network/test/BUILD
+++ b/contrib/generic_proxy/filters/network/test/BUILD
@@ -34,6 +34,7 @@ envoy_cc_test(
         "//source/common/buffer:buffer_lib",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -72,6 +73,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/generic_proxy/v3:pkg_cc_proto",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",

--- a/contrib/generic_proxy/filters/network/test/mocks/filter.cc
+++ b/contrib/generic_proxy/filters/network/test/mocks/filter.cc
@@ -22,7 +22,9 @@ MockStreamFilterConfig::MockStreamFilterConfig() {
   ON_CALL(*this, createFilterFactoryFromProto(_, _, _))
       .WillByDefault(Return([](FilterChainFactoryCallbacks&) {}));
   ON_CALL(*this, name()).WillByDefault(Return("envoy.filters.generic.mock_filter"));
-  ON_CALL(*this, configTypes()).WillByDefault(Return(std::set<std::string>{}));
+  ON_CALL(*this, configTypes()).WillByDefault(Invoke([this]() {
+    return NamedFilterConfigFactory::configTypes();
+  }));
 }
 
 MockFilterChainManager::MockFilterChainManager() {


### PR DESCRIPTION
Commit Message: generic proxy: get filter factory by type for route config
Additional Description:

The type should be used first to find the filter factory. This patch fixed previous logic problem. And the
runtime guard `envoy.reloadable_features.no_extension_lookup_by_name` could be used to ensure the legacy name searching still could works.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.