### PR TITLE
tcp: add platform check to avoid RST setting spam

### DIFF
--- a/envoy/common/platform.h
+++ b/envoy/common/platform.h
@@ -329,3 +329,9 @@ struct mmsghdr {
 // On non-Linux platforms use 128 which is libevent listener default
 #define ENVOY_TCP_BACKLOG_SIZE 128
 #endif
+
+#if defined(__linux__)
+#define ENVOY_PLATFORM_ENABLE_SEND_RST 1
+#else
+#define ENVOY_PLATFORM_ENABLE_SEND_RST 0
+#endif

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -292,14 +292,14 @@ void ConnectionImpl::closeSocket(ConnectionEvent close_type) {
 
   if (enable_rst_detect_send_ && (detected_close_type_ == DetectedCloseType::RemoteReset ||
                                   detected_close_type_ == DetectedCloseType::LocalReset)) {
-    #if ENVOY_PLATFORM_ENABLE_SEND_RST
-      const bool ok = Network::Socket::applyOptions(
-          Network::SocketOptionFactory::buildZeroSoLingerOptions(), *socket_,
-          envoy::config::core::v3::SocketOption::STATE_LISTENING);
-      if (!ok) {
-        ENVOY_LOG_EVERY_POW_2(error, "rst setting so_linger=0 failed on connection {}", id());
-      }
-    #endif
+#if ENVOY_PLATFORM_ENABLE_SEND_RST
+    const bool ok = Network::Socket::applyOptions(
+        Network::SocketOptionFactory::buildZeroSoLingerOptions(), *socket_,
+        envoy::config::core::v3::SocketOption::STATE_LISTENING);
+    if (!ok) {
+      ENVOY_LOG_EVERY_POW_2(error, "rst setting so_linger=0 failed on connection {}", id());
+    }
+#endif
   }
 
   // It is safe to call close() since there is an IO handle check.

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -85,9 +85,13 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
       write_end_stream_(false), current_write_end_stream_(false), dispatch_buffered_data_(false),
       transport_wants_read_(false) {
 
+#if defined(__linux__) || defined(__APPLE__)
   // Keep it as a bool flag to reduce the times calling runtime method..
   enable_rst_detect_send_ = Runtime::runtimeFeatureEnabled(
       "envoy.reloadable_features.detect_and_raise_rst_tcp_connection");
+#else
+  enable_rst_detect_send_ = false;
+#endif
 
   if (!connected) {
     connecting_ = true;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -640,6 +640,7 @@ TEST_P(ConnectionImplTest, SocketOptionsFailureTest) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
+#if ENVOY_PLATFORM_ENABLE_SEND_RST
 // Test that connection is AbortReset closed during callback.
 TEST_P(ConnectionImplTest, ClientAbortResetDuringCallback) {
   Network::ClientConnectionPtr upstream_connection_;
@@ -786,6 +787,7 @@ TEST_P(ConnectionImplTest, ServerResetCloseRuntimeDisabled) {
   server_connection_->close(ConnectionCloseType::AbortReset);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
+#endif
 
 struct MockConnectionStats {
   Connection::ConnectionStats toBufferStats() {
@@ -1111,6 +1113,7 @@ TEST_P(ConnectionImplTest, CloseOnReadDisableWithoutCloseDetection) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
+#if ENVOY_PLATFORM_ENABLE_SEND_RST
 // Test normal RST close without readDisable.
 TEST_P(ConnectionImplTest, RstCloseOnNotReadDisabledConnection) {
   setUpBasicConnection();
@@ -1188,6 +1191,7 @@ TEST_P(ConnectionImplTest, RstCloseOnReadEarlyCloseDisabledThenWrite) {
   client_connection_->write(buffer, false);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
+#endif
 
 // Test that connection half-close is sent and received properly.
 TEST_P(ConnectionImplTest, HalfClose) {
@@ -1229,6 +1233,7 @@ TEST_P(ConnectionImplTest, HalfClose) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
+#if ENVOY_PLATFORM_ENABLE_SEND_RST
 // Test that connection is immediately closed when RST is detected even
 // half-close is enabled
 TEST_P(ConnectionImplTest, HalfCloseResetClose) {
@@ -1346,7 +1351,6 @@ TEST_P(ConnectionImplTest, HalfCloseThenResetClose) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
 
-#if !defined(WIN32)
 // Test that no remote close event will be propagated back to peer, when a connection is
 // half-closed and then the connection is RST closed. Writing data to the half closed and then
 // reset connection will lead to broken pipe error rather than reset error.

--- a/test/integration/tcp_async_client_integration_test.cc
+++ b/test/integration/tcp_async_client_integration_test.cc
@@ -111,6 +111,7 @@ TEST_P(TcpAsyncClientIntegrationTest, MultipleResponseFrames) {
   tcp_client->close();
 }
 
+#if ENVOY_PLATFORM_ENABLE_SEND_RST
 // Test if RST close can be detected from downstream and upstream is closed by RST.
 TEST_P(TcpAsyncClientIntegrationTest, TestClientCloseRST) {
   enableHalfClose(true);
@@ -175,7 +176,6 @@ TEST_P(TcpAsyncClientIntegrationTest, TestUpstreamCloseRST) {
   tcp_client->waitForDisconnect();
 }
 
-#if !defined(WIN32)
 // Test the behaviour when the connection is half closed and then the connection is reset by
 // the client. The behavior is different for windows, since RST support is literally supported for
 // unix like system, disabled the test for windows.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Only limit the RST send and detect feature to linux.
There is already a release note before.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes #31564
