### PR TITLE
mobile/ci: Adds a `mobile-test-ios` Bazel build option

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -75,13 +75,13 @@ build:mobile-dbg-ios --config=ios
 # Default flags for Android tests
 # TODO(jpsim): Explicitly register test extensions for Android tests
 # https://github.com/envoyproxy/envoy/issues/24977
-build:test-android --define=static_extension_registration=enabled
+build:mobile-test-android --define=static_extension_registration=enabled
 
 # Default flags for iOS tests.
-build:test-ios --config=ios
+build:mobile-test-ios --config=ios
 # Needed for running test Envoy servers as HTTP(S) proxies.
-build:test-ios --define=envoy_mobile_listener=enabled
-build:test-ios --define=static_extension_registration=enabled
+build:mobile-test-ios --define=envoy_mobile_listener=enabled
+build:mobile-test-ios --define=static_extension_registration=enabled
 
 # Locally-runnable ASAN config for MacOS & Linux with standard dev environment
 # See also:
@@ -258,7 +258,7 @@ build:mobile-remote-ci --config=remote-ci
 
 build:mobile-remote-ci-android --config=mobile-remote-ci
 test:mobile-remote-ci-android --build_tests_only
-test:mobile-remote-ci-android --config=test-android
+test:mobile-remote-ci-android --config=mobile-test-android
 test:mobile-remote-ci-android --config=mobile-remote-ci
 test:mobile-remote-ci-android --define=signal_trace=disabled
 
@@ -300,7 +300,7 @@ build:mobile-remote-ci-macos-kotlin --define=envoy_yaml=disabled
 build:mobile-remote-ci-macos-kotlin --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=
 
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
-build:mobile-remote-ci-macos-swift --config=test-ios
+build:mobile-remote-ci-macos-swift --config=mobile-test-ios
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --define=signal_trace=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_request_compression=disabled
@@ -317,7 +317,7 @@ test:mobile-remote-ci-core --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 test:mobile-remote-ci-core --define=envoy_yaml=disabled
 
 build:mobile-remote-ci-macos-ios --config=mobile-remote-ci-macos
-build:mobile-remote-ci-macos-ios --config=test-ios
+build:mobile-remote-ci-macos-ios --config=mobile-test-ios
 
 build:mobile-remote-ci-macos-ios-admin --config=mobile-remote-ci-macos-ios
 build:mobile-remote-ci-macos-ios-admin --define=admin_functionality=enabled

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -77,6 +77,12 @@ build:mobile-dbg-ios --config=ios
 # https://github.com/envoyproxy/envoy/issues/24977
 build:test-android --define=static_extension_registration=enabled
 
+# Default flags for iOS tests.
+build:test-ios --config=ios
+# Needed for running test Envoy servers as HTTP(S) proxies.
+build:test-ios --define=envoy_mobile_listener=enabled
+build:test-ios --define=static_extension_registration=enabled
+
 # Locally-runnable ASAN config for MacOS & Linux with standard dev environment
 # See also:
 # https://github.com/bazelbuild/bazel/issues/6932
@@ -294,7 +300,7 @@ build:mobile-remote-ci-macos-kotlin --define=envoy_yaml=disabled
 build:mobile-remote-ci-macos-kotlin --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=
 
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
-build:mobile-remote-ci-macos-swift --config=ios
+build:mobile-remote-ci-macos-swift --config=test-ios
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --define=signal_trace=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_request_compression=disabled
@@ -311,7 +317,7 @@ test:mobile-remote-ci-core --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 test:mobile-remote-ci-core --define=envoy_yaml=disabled
 
 build:mobile-remote-ci-macos-ios --config=mobile-remote-ci-macos
-build:mobile-remote-ci-macos-ios --config=ios
+build:mobile-remote-ci-macos-ios --config=test-ios
 
 build:mobile-remote-ci-macos-ios-admin --config=mobile-remote-ci-macos-ios
 build:mobile-remote-ci-macos-ios-admin --define=admin_functionality=enabled

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -79,9 +79,6 @@ build:mobile-test-android --define=static_extension_registration=enabled
 
 # Default flags for iOS tests.
 build:mobile-test-ios --config=ios
-# Needed for running test Envoy servers as HTTP(S) proxies.
-build:mobile-test-ios --define=envoy_mobile_listener=enabled
-build:mobile-test-ios --define=static_extension_registration=enabled
 
 # Locally-runnable ASAN config for MacOS & Linux with standard dev environment
 # See also:


### PR DESCRIPTION
Also, we rename `test-android` to `mobile-test-android` for consistency.