### PR TITLE
http compressor filter should skipped when response has content-range header

### DIFF
--- a/docs/root/configuration/http/http_filters/compressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/compressor_filter.rst
@@ -80,7 +80,7 @@ By *default* response compression is enabled, but it will be *skipped* when:
 - A response does **not** contain a ``content-length`` or ``transfer-encoding`` headers.
 - Response size is smaller than 30 bytes (only applicable when ``transfer-encoding``
   is not chunked).
-- A request contains a ``content-range`` header.
+- A response status code is 206 Partial Content.
 
 Please note that in case the filter is configured to use a compression library extension
 other than gzip it looks for content encoding in the ``accept-encoding`` header provided by

--- a/docs/root/configuration/http/http_filters/compressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/compressor_filter.rst
@@ -80,6 +80,7 @@ By *default* response compression is enabled, but it will be *skipped* when:
 - A response does **not** contain a ``content-length`` or ``transfer-encoding`` headers.
 - Response size is smaller than 30 bytes (only applicable when ``transfer-encoding``
   is not chunked).
+- A request contains a ``content-range`` header.
 
 Please note that in case the filter is configured to use a compression library extension
 other than gzip it looks for content encoding in the ``accept-encoding`` header provided by

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -286,7 +286,7 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
       isEnabledAndContentLengthBigEnough && !Http::Utility::isUpgrade(headers) &&
       config.isContentTypeAllowed(headers) && !hasCacheControlNoTransform(headers) &&
       isEtagAllowed(headers) && !headers.getInline(response_content_encoding_handle.handle()) &&
-      headers->get(Http::Headers::get().ContentRange).empty();
+      headers.get(Http::Headers::get().ContentRange).empty();
   if (!end_stream && isAcceptEncodingAllowed(isEnabledAndContentLengthBigEnough, headers) &&
       isCompressible && isTransferEncodingAllowed(headers)) {
     sanitizeEtagHeader(headers);

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -285,7 +285,8 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
   const bool isCompressible =
       isEnabledAndContentLengthBigEnough && !Http::Utility::isUpgrade(headers) &&
       config.isContentTypeAllowed(headers) && !hasCacheControlNoTransform(headers) &&
-      isEtagAllowed(headers) && !headers.getInline(response_content_encoding_handle.handle());
+      isEtagAllowed(headers) && !headers.getInline(response_content_encoding_handle.handle()) &&
+      headers->get(Http::Headers::get().ContentRange).empty();
   if (!end_stream && isAcceptEncodingAllowed(isEnabledAndContentLengthBigEnough, headers) &&
       isCompressible && isTransferEncodingAllowed(headers)) {
     sanitizeEtagHeader(headers);

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -286,7 +286,7 @@ Http::FilterHeadersStatus CompressorFilter::encodeHeaders(Http::ResponseHeaderMa
       isEnabledAndContentLengthBigEnough && !Http::Utility::isUpgrade(headers) &&
       config.isContentTypeAllowed(headers) && !hasCacheControlNoTransform(headers) &&
       isEtagAllowed(headers) && !headers.getInline(response_content_encoding_handle.handle()) &&
-      headers.get(Http::Headers::get().ContentRange).empty();
+      headers.getStatusValue() != "206";
   if (!end_stream && isAcceptEncodingAllowed(isEnabledAndContentLengthBigEnough, headers) &&
       isCompressible && isTransferEncodingAllowed(headers)) {
     sanitizeEtagHeader(headers);

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -421,10 +421,10 @@ TEST_F(CompressorFilterTest, ContentEncodingAlreadyEncoded) {
 
 // Content-Range: upstream response is range content.
 TEST_F(CompressorFilterTest, ContentRangeHeaderExists) {
-  doRequestNoCompression({{":method", "get"}, {"range" : "bytes=0-255"}});
+  doRequestNoCompression({{":method", "get"}, {"range", "bytes=0-255"}});
   Http::TestResponseHeaderMapImpl response_headers{
       {":method", "get"}, {"content-length", "256"}, {"content-range", "bytes 0-255/1024"}};
-  doResponseNoCompression(headers);
+  doResponseNoCompression(response_headers);
 }
 
 // No compression when upstream response is empty.

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -420,23 +420,24 @@ TEST_F(CompressorFilterTest, ContentEncodingAlreadyEncoded) {
 }
 
 // No compression when upstream response status code is 206 Partial Content.
-TEST_F(CompressorFilterTest, PartialContentResponse) {
-  // single part
-  {
-    doRequestNoCompression({{":method", "get"}, {"range", "bytes=0-255"}});
-    Http::TestResponseHeaderMapImpl response_headers{
-        {"content-length", "256"}, {"content-range", "bytes 0-255/1024"}, {":status", "206"}};
-    doResponseNoCompression(response_headers);
-  }
-  // multi parts
-  {
-    doRequestNoCompression({{":method", "get"}, {"range", "bytes=500-999, 7000-7999"}});
-    Http::TestResponseHeaderMapImpl response_headers{
-        {"content-length", "1741"},
-        {"content-type", "multipart/byteranges; boundary=THIS_STRING_SEPARATES"},
-        {":status", "206"}};
-    doResponseNoCompression(response_headers);
-  }
+// single part
+TEST_F(CompressorFilterTest, PartialContentSinglePartResponse) {
+
+  doRequestNoCompression({{":method", "get"}, {"range", "bytes=0-255"}});
+  Http::TestResponseHeaderMapImpl response_headers{
+      {"content-length", "256"}, {"content-range", "bytes 0-255/1024"}, {":status", "206"}};
+  doResponseNoCompression(response_headers);
+}
+
+// No compression when upstream response status code is 206 Partial Content.
+// multi parts
+TEST_F(CompressorFilterTest, PartialContentMultiPartsResponse) {
+  doRequestNoCompression({{":method", "get"}, {"range", "bytes=500-999, 7000-7999"}});
+  Http::TestResponseHeaderMapImpl response_headers{
+      {"content-length", "1741"},
+      {"content-type", "multipart/byteranges; boundary=THIS_STRING_SEPARATES"},
+      {":status", "206"}};
+  doResponseNoCompression(response_headers);
 }
 
 // No compression when upstream response is empty.

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -419,6 +419,14 @@ TEST_F(CompressorFilterTest, ContentEncodingAlreadyEncoded) {
   EXPECT_EQ(1U, stats_.counter("test.compressor.test.test.not_compressed").value());
 }
 
+// Content-Range: upstream response is range content.
+TEST_F(CompressorFilterTest, ContentRangeHeaderExists) {
+  doRequestNoCompression({{":method", "get"}, {"range" : "bytes=0-255"}});
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-range", "bytes 0-255/1024"}};
+  doResponseNoCompression(headers);
+}
+
 // No compression when upstream response is empty.
 TEST_F(CompressorFilterTest, EmptyResponse) {
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {":status", "204"}};

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -422,7 +422,6 @@ TEST_F(CompressorFilterTest, ContentEncodingAlreadyEncoded) {
 // No compression when upstream response status code is 206 Partial Content.
 // single part
 TEST_F(CompressorFilterTest, PartialContentSinglePartResponse) {
-
   doRequestNoCompression({{":method", "get"}, {"range", "bytes=0-255"}});
   Http::TestResponseHeaderMapImpl response_headers{
       {"content-length", "256"}, {"content-range", "bytes 0-255/1024"}, {":status", "206"}};


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
http range protocol says that if a 206 (Partial Content) response contains a Content-Range header field with a range unit (Section 2) that the recipient does not understand, the recipient MUST NOT attempt to recombine it with a stored representation. A proxy that receives such a message SHOULD forward it downstream.

Additional Description:
ref: [content-range](https://httpwg.org/specs/rfc7233.html#header.content-range)

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #31956]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
