### PR TITLE
generic proxy: change the status code type to int

### DIFF
--- a/contrib/generic_proxy/filters/network/source/interface/stream.h
+++ b/contrib/generic_proxy/filters/network/source/interface/stream.h
@@ -247,7 +247,7 @@ using StatusCode = absl::StatusCode;
 struct StreamStatus {
 public:
   StreamStatus() = default;
-  StreamStatus(uint32_t code, bool ok) : code_(code), ok_(ok) {}
+  StreamStatus(int code, bool ok) : code_(code), ok_(ok) {}
 
   // Returns true if the status indicates success. This will be used for tracing, logging
   // or stats purposes.
@@ -255,10 +255,10 @@ public:
 
   // Returns the status code value. The code will be used for tracing, logging or stats
   // purposes. The specific code value is application protocol specific.
-  ABSL_MUST_USE_RESULT uint32_t code() const { return code_; }
+  ABSL_MUST_USE_RESULT int code() const { return code_; }
 
 private:
-  uint32_t code_{};
+  int code_{};
   bool ok_{true};
 };
 

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -186,7 +186,7 @@ void ActiveStream::sendLocalReply(Status status, absl::string_view data,
   // status message will be used as response code details.
   stream_info_.setResponseCodeDetails(status.message());
   // Set the response code to the stream info.
-  stream_info_.setResponseCode(response_stream_->status().code());
+  stream_info_.setResponseCode(static_cast<uint32_t>(response_stream_->status().code()));
 
   sendResponseStartToDownstream();
 }

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -186,7 +186,7 @@ void ActiveStream::sendLocalReply(Status status, absl::string_view data,
   // status message will be used as response code details.
   stream_info_.setResponseCodeDetails(status.message());
   // Set the response code to the stream info.
-  stream_info_.setResponseCode(static_cast<uint32_t>(response_stream_->status().code()));
+  stream_info_.setResponseCode(response_stream_->status().code());
 
   sendResponseStartToDownstream();
 }

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -152,7 +152,7 @@ public:
       }
       // Additional 4 bytes for status.
       encoding_buffer_.writeBEInt<uint32_t>(body.size() + 4);
-      encoding_buffer_.writeBEInt<uint32_t>(static_cast<int32_t>(typed_response->status_.code()));
+      encoding_buffer_.writeBEInt<int>(typed_response->status_.code());
       encoding_buffer_.add(body);
 
       callback.onEncodingSuccess(encoding_buffer_, response.frameFlags().endStream());
@@ -160,8 +160,7 @@ public:
 
     ResponsePtr respond(Status status, absl::string_view, const Request&) override {
       auto response = std::make_unique<FakeResponse>();
-      response->status_ = {static_cast<uint32_t>(status.code()),
-                           status.code() == absl::StatusCode::kOk};
+      response->status_ = {status.raw_code(), status.code() == absl::StatusCode::kOk};
       response->message_ = status.message();
       response->protocol_ = "fake_protocol_for_test";
       return response;
@@ -192,7 +191,7 @@ public:
       }
 
       auto response = std::make_unique<FakeResponse>();
-      response->status_ = {static_cast<uint32_t>(status_code),
+      response->status_ = {status_code,
                            static_cast<absl::StatusCode>(status_code) == absl::StatusCode::kOk};
       response->protocol_ = std::string(result[0]);
       for (absl::string_view pair_str : absl::StrSplit(result[2], ';', absl::SkipEmpty())) {

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -160,7 +160,7 @@ public:
 
     ResponsePtr respond(Status status, absl::string_view, const Request&) override {
       auto response = std::make_unique<FakeResponse>();
-      response->status_ = {status.raw_code(), status.code() == absl::StatusCode::kOk};
+      response->status_ = {status.raw_code(), status.ok()};
       response->message_ = status.message();
       response->protocol_ = "fake_protocol_for_test";
       return response;

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -658,8 +658,7 @@ TEST_F(FilterTest, ActiveStreamSendLocalReply) {
   EXPECT_CALL(*server_codec_, respond(_, _, _))
       .WillOnce(Invoke([&](Status status, absl::string_view, const Request&) -> ResponsePtr {
         auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-        response->status_ = {static_cast<uint32_t>(status.code()),
-                             status.code() == StatusCode::kOk};
+        response->status_ = {static_cast<int>(status.code()), status.code() == StatusCode::kOk};
         response->message_ = status.message();
         return response;
       }));


### PR DESCRIPTION
Commit Message: generic proxy: change the status code type to int
Additional Description:

To support minus response code and output.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
