### PR TITLE
test: hopefully fixing a flake

### DIFF
--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -271,6 +271,7 @@ TEST_P(FilterIntegrationTest, AltSvcCachedH2Slow) {
 #endif
   // Start with the alt-svc header in the cache.
   write_alt_svc_to_file_ = true;
+  config_helper_.setConnectTimeout(std::chrono::seconds(1));
 
   const uint64_t request_size = 0;
   const uint64_t response_size = 0;


### PR DESCRIPTION
I think the connection idle timeout and stats timeout were too close, causing the flake. Shortening connect timeout and crossing fingers (since I couldn't repro locally)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
