### PR TITLE
Update changelogs/current.yaml for PR#31762

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -13,7 +13,8 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 - area: postgres proxy
   change: |
-    Fix a race condition that may result from upstream servers refusing to switch to TLS/SSL. This fix first appeared in ``v1.29.0`` release.
+    Fix a race condition that may result from upstream servers refusing to switch to TLS/SSL.
+    This fix first appeared in ``v1.29.0`` release.
 
 new_features:
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,9 @@ bug_fixes:
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+- area: postgres proxy
+  change: |
+    Fix a race condition that may result from upstream servers refusing to switch to TLS/SSl.
 
 new_features:
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -13,7 +13,7 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 - area: postgres proxy
   change: |
-    Fix a race condition that may result from upstream servers refusing to switch to TLS/SSl.
+    Fix a race condition that may result from upstream servers refusing to switch to TLS/SSL. This fix first appeared in ``v1.29.0`` release.
 
 new_features:
 


### PR DESCRIPTION
#31762 solves a potential bug of postgres proxy that was not mentioned in the changelogs of _v1.29.0_ though the PR appeared in this release. This PR updates `changelogs/current.yaml ` file to cover the change.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes: 
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]

