### PR TITLE
tests: don't always do tag extraction checks

### DIFF
--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -570,7 +570,7 @@ protected:
   bool use_real_stats_{};
 
   // If true, skip checking stats for missing tag-extraction rules.
-  bool skip_tag_extraction_rule_check_{};
+  bool skip_tag_extraction_rule_check_{true};
 
   // By default, node metadata (node name, cluster name, locality) for the test server gets set to
   // hard-coded values in the OptionsImpl ("node_name", "cluster_name", etc.). Set to true if your

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -28,6 +28,7 @@ class XdsIntegrationTest : public testing::TestWithParam<Network::Address::IpVer
                            public HttpIntegrationTest {
 public:
   XdsIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP2, GetParam()) {
+    skip_tag_extraction_rule_check_ = false;
     setUpstreamProtocol(Http::CodecType::HTTP2);
   }
 


### PR DESCRIPTION
Having an unexpected request makes debugging significantly harder.