### PR TITLE
mobile: Fix send_headers_test ASAN failure for not releasing a memory

### DIFF
--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -38,7 +38,10 @@ TEST(SendHeadersTest, CanSendHeaders) {
                 status.status_code = headers->httpStatus();
                 status.end_stream = end_stream;
               })
-          .setOnData([&](envoy_data, bool end_stream) { status.end_stream = end_stream; })
+          .setOnData([&](envoy_data data, bool end_stream) {
+            status.end_stream = end_stream;
+            data.release(data.context);
+          })
           .setOnComplete(
               [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
           .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,


### PR DESCRIPTION
This fixes the ASAN test failure by releasing the `envoy_data` after use.

Risk Level: low (test only)
Testing: unit tests with ASAN
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
