### PR TITLE
docs: add missing typed_config for tls_inspector

### DIFF
--- a/docs/root/faq/configuration/sni.rst
+++ b/docs/root/faq/configuration/sni.rst
@@ -19,6 +19,8 @@ The following is a YAML example of the above requirement.
     socket_address: { address: 127.0.0.1, port_value: 1234 }
   listener_filters:
   - name: "envoy.filters.listener.tls_inspector"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
   filter_chains:
   - filter_chain_match:
       server_names: ["example.com", "www.example.com"]


### PR DESCRIPTION
Commit Message: docs: add missing typed_config for tls_inspector
Additional Description: Without typed_config, the following error is returned: "Didn't find a registered implementation for 'envoy.filters.listener.tls_inspector' with type URL: ''
Risk Level: none
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
