### PR TITLE
uri_template: pre compile regex in uri template matcher

### DIFF
--- a/source/extensions/path/match/uri_template/uri_template_match.cc
+++ b/source/extensions/path/match/uri_template/uri_template_match.cc
@@ -18,8 +18,7 @@ namespace UriTemplate {
 namespace Match {
 
 bool UriTemplateMatcher::match(absl::string_view path) const {
-  RE2 matching_pattern_regex = RE2(convertPathPatternSyntaxToRegex(path_template_).value());
-  return RE2::FullMatch(Http::PathUtil::removeQueryAndFragment(path), matching_pattern_regex);
+  return RE2::FullMatch(Http::PathUtil::removeQueryAndFragment(path), matching_pattern_regex_);
 }
 
 absl::string_view UriTemplateMatcher::uriTemplate() const { return path_template_; }

--- a/source/extensions/path/match/uri_template/uri_template_match.h
+++ b/source/extensions/path/match/uri_template/uri_template_match.h
@@ -9,6 +9,7 @@
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "re2/re2.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -29,7 +30,8 @@ class UriTemplateMatcher : public Router::PathMatcher {
 public:
   explicit UriTemplateMatcher(
       const envoy::extensions::path::match::uri_template::v3::UriTemplateMatchConfig& config)
-      : path_template_(config.path_template()) {}
+      : path_template_(config.path_template()),
+        matching_pattern_regex_(convertPathPatternSyntaxToRegex(path_template_).value()) {}
 
   // Router::PathMatcher
   bool match(absl::string_view path) const override;
@@ -38,6 +40,7 @@ public:
 
 private:
   const std::string path_template_;
+  const RE2 matching_pattern_regex_;
 };
 
 } // namespace Match


### PR DESCRIPTION
Commit Message: Avoid compiling regex in every match, instead pre-compile regex on constructor
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
