### PR TITLE
mobile: Pass by const reference instead of value in Engine::run

### DIFF
--- a/mobile/library/common/engine.cc
+++ b/mobile/library/common/engine.cc
@@ -32,7 +32,7 @@ Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
   Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.dfp_mixed_scheme", true);
 }
 
-envoy_status_t Engine::run(const std::string config, const std::string log_level) {
+envoy_status_t Engine::run(const std::string& config, const std::string& log_level) {
   // Start the Envoy on the dedicated thread. Note: due to how the assignment operator works with
   // std::thread, main_thread_ is the same object after this call, but its state is replaced with
   // that of the temporary. The temporary object's state becomes the default state, which does
@@ -40,7 +40,7 @@ envoy_status_t Engine::run(const std::string config, const std::string log_level
   auto options = std::make_unique<Envoy::OptionsImplBase>();
   options->setConfigYaml(config);
   if (!log_level.empty()) {
-    ENVOY_BUG(options->setLogLevel(log_level.c_str()).ok(), "invalid log level");
+    ENVOY_BUG(options->setLogLevel(log_level).ok(), "invalid log level");
   }
   options->setConcurrency(1);
   return run(std::move(options));

--- a/mobile/library/common/engine.h
+++ b/mobile/library/common/engine.h
@@ -35,7 +35,7 @@ public:
    * @param config, the Envoy bootstrap configuration to use.
    * @param log_level, the log level.
    */
-  envoy_status_t run(std::string config, std::string log_level);
+  envoy_status_t run(const std::string& config, const std::string& log_level);
   envoy_status_t run(std::unique_ptr<Envoy::OptionsImplBase>&& options);
 
   /**


### PR DESCRIPTION
The YAML `config` can be pretty big, so passing by const reference is more efficient than passing by value.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
