### PR TITLE
mobile: Fully qualify C++ includes

### DIFF
--- a/mobile/library/cc/bridge_utility.h
+++ b/mobile/library/cc/bridge_utility.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#include "headers.h"
+#include "library/cc/headers.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -2,9 +2,9 @@
 
 #include <functional>
 
+#include "library/cc/log_level.h"
+#include "library/cc/stream_client.h"
 #include "library/common/types/c_types.h"
-#include "log_level.h"
-#include "stream_client.h"
 
 namespace Envoy {
 class Engine;

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -13,12 +13,12 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "direct_response_testing.h"
-#include "engine.h"
-#include "engine_callbacks.h"
-#include "key_value_store.h"
+#include "library/cc/engine.h"
+#include "library/cc/engine_callbacks.h"
+#include "library/cc/key_value_store.h"
+#include "library/cc/log_level.h"
+#include "library/cc/string_accessor.h"
 #include "library/common/types/matcher_data.h"
-#include "log_level.h"
-#include "string_accessor.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/engine_callbacks.cc
+++ b/mobile/library/cc/engine_callbacks.cc
@@ -1,4 +1,4 @@
-#include "engine_callbacks.h"
+#include "library/cc/engine_callbacks.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/engine_callbacks.h
+++ b/mobile/library/cc/engine_callbacks.h
@@ -3,7 +3,7 @@
 #include <functional>
 #include <memory>
 
-#include "engine.h"
+#include "library/cc/engine.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {

--- a/mobile/library/cc/headers.cc
+++ b/mobile/library/cc/headers.cc
@@ -1,4 +1,4 @@
-#include "headers.h"
+#include "library/cc/headers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/headers_builder.cc
+++ b/mobile/library/cc/headers_builder.cc
@@ -1,4 +1,4 @@
-#include "headers_builder.h"
+#include "library/cc/headers_builder.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/request_headers.cc
+++ b/mobile/library/cc/request_headers.cc
@@ -1,4 +1,4 @@
-#include "request_headers.h"
+#include "library/cc/request_headers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/request_headers.h
+++ b/mobile/library/cc/request_headers.h
@@ -3,10 +3,10 @@
 #include <optional>
 
 #include "absl/types/optional.h"
-#include "headers.h"
-#include "request_headers_builder.h"
-#include "request_method.h"
-#include "retry_policy.h"
+#include "library/cc/headers.h"
+#include "library/cc/request_headers_builder.h"
+#include "library/cc/request_method.h"
+#include "library/cc/retry_policy.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/request_headers_builder.h
+++ b/mobile/library/cc/request_headers_builder.h
@@ -2,9 +2,9 @@
 
 #include <string>
 
-#include "headers_builder.h"
-#include "request_headers.h"
-#include "request_method.h"
+#include "library/cc/headers_builder.h"
+#include "library/cc/request_headers.h"
+#include "library/cc/request_method.h"
 #include "retry_policy.h"
 
 namespace Envoy {

--- a/mobile/library/cc/request_trailers.h
+++ b/mobile/library/cc/request_trailers.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "request_trailers_builder.h"
-#include "trailers.h"
+#include "library/cc/request_trailers_builder.h"
+#include "library/cc/trailers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/request_trailers_builder.cc
+++ b/mobile/library/cc/request_trailers_builder.cc
@@ -1,4 +1,4 @@
-#include "request_trailers_builder.h"
+#include "library/cc/request_trailers_builder.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/request_trailers_builder.h
+++ b/mobile/library/cc/request_trailers_builder.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "headers_builder.h"
-#include "request_trailers.h"
+#include "library/cc/headers_builder.h"
+#include "library/cc/request_trailers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_headers.cc
+++ b/mobile/library/cc/response_headers.cc
@@ -1,4 +1,4 @@
-#include "response_headers.h"
+#include "library/cc/response_headers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_headers.h
+++ b/mobile/library/cc/response_headers.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "headers.h"
-#include "response_headers_builder.h"
+#include "library/cc/headers.h"
+#include "library/cc/response_headers_builder.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_headers_builder.cc
+++ b/mobile/library/cc/response_headers_builder.cc
@@ -1,4 +1,4 @@
-#include "response_headers_builder.h"
+#include "library/cc/response_headers_builder.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_headers_builder.h
+++ b/mobile/library/cc/response_headers_builder.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "headers_builder.h"
-#include "response_headers.h"
+#include "library/cc/headers_builder.h"
+#include "library/cc/response_headers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_trailers.cc
+++ b/mobile/library/cc/response_trailers.cc
@@ -1,4 +1,4 @@
-#include "response_trailers.h"
+#include "library/cc/response_trailers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_trailers.h
+++ b/mobile/library/cc/response_trailers.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "response_trailers_builder.h"
-#include "trailers.h"
+#include "library/cc/response_trailers_builder.h"
+#include "library/cc/trailers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_trailers_builder.cc
+++ b/mobile/library/cc/response_trailers_builder.cc
@@ -1,4 +1,4 @@
-#include "response_trailers_builder.h"
+#include "library/cc/response_trailers_builder.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/response_trailers_builder.h
+++ b/mobile/library/cc/response_trailers_builder.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "headers_builder.h"
-#include "response_trailers.h"
+#include "library/cc/headers_builder.h"
+#include "library/cc/response_trailers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/retry_policy.cc
+++ b/mobile/library/cc/retry_policy.cc
@@ -1,4 +1,4 @@
-#include "retry_policy.h"
+#include "library/cc/retry_policy.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/retry_policy.h
+++ b/mobile/library/cc/retry_policy.h
@@ -4,8 +4,8 @@
 #include <vector>
 
 #include "absl/types/optional.h"
-#include "headers.h"
-#include "request_headers.h"
+#include "library/cc/headers.h"
+#include "library/cc/request_headers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/stream.cc
+++ b/mobile/library/cc/stream.cc
@@ -1,6 +1,6 @@
 #include "stream.h"
 
-#include "bridge_utility.h"
+#include "library/cc/bridge_utility.h"
 #include "library/common/engine.h"
 #include "library/common/types/c_types.h"
 

--- a/mobile/library/cc/stream.h
+++ b/mobile/library/cc/stream.h
@@ -2,10 +2,10 @@
 
 #include <vector>
 
+#include "library/cc/request_headers.h"
+#include "library/cc/request_trailers.h"
+#include "library/cc/stream_callbacks.h"
 #include "library/common/types/c_types.h"
-#include "request_headers.h"
-#include "request_trailers.h"
-#include "stream_callbacks.h"
 
 namespace Envoy {
 class Engine;

--- a/mobile/library/cc/stream_callbacks.cc
+++ b/mobile/library/cc/stream_callbacks.cc
@@ -1,9 +1,9 @@
 #include "stream_callbacks.h"
 
-#include "bridge_utility.h"
+#include "library/cc/bridge_utility.h"
+#include "library/cc/response_headers_builder.h"
+#include "library/cc/response_trailers_builder.h"
 #include "library/common/data/utility.h"
-#include "response_headers_builder.h"
-#include "response_trailers_builder.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/stream_callbacks.h
+++ b/mobile/library/cc/stream_callbacks.h
@@ -5,11 +5,11 @@
 #include <vector>
 
 #include "absl/types/optional.h"
-#include "envoy_error.h"
+#include "library/cc/envoy_error.h"
+#include "library/cc/response_headers.h"
+#include "library/cc/response_trailers.h"
+#include "library/cc/stream.h"
 #include "library/common/types/c_types.h"
-#include "response_headers.h"
-#include "response_trailers.h"
-#include "stream.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/stream_client.cc
+++ b/mobile/library/cc/stream_client.cc
@@ -1,4 +1,4 @@
-#include "stream_client.h"
+#include "library/cc/stream_client.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/stream_client.h
+++ b/mobile/library/cc/stream_client.h
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include "engine.h"
-#include "stream_prototype.h"
+#include "library/cc/engine.h"
+#include "library/cc/stream_prototype.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/stream_prototype.h
+++ b/mobile/library/cc/stream_prototype.h
@@ -2,13 +2,13 @@
 
 #include <memory>
 
-#include "engine.h"
-#include "envoy_error.h"
+#include "library/cc/engine.h"
+#include "library/cc/envoy_error.h"
+#include "library/cc/response_headers.h"
+#include "library/cc/response_trailers.h"
+#include "library/cc/stream.h"
+#include "library/cc/stream_callbacks.h"
 #include "library/common/types/c_types.h"
-#include "response_headers.h"
-#include "response_trailers.h"
-#include "stream.h"
-#include "stream_callbacks.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/library/cc/trailers.h
+++ b/mobile/library/cc/trailers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "headers.h"
+#include "library/cc/headers.h"
 
 namespace Envoy {
 namespace Platform {

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -442,7 +442,7 @@ TEST(TestConfig, DISABLED_StringAccessors) {
   std::string data_string = "envoy string";
   auto accessor = std::make_shared<TestStringAccessor>(data_string);
   engine_builder.addStringAccessor(name, accessor);
-  EngineSharedPtr engine = engine_builder.build();
+  Platform::EngineSharedPtr engine = engine_builder.build();
   auto c_accessor = static_cast<envoy_string_accessor*>(Envoy::Api::External::retrieveApi(name));
   ASSERT_TRUE(c_accessor != nullptr);
   EXPECT_EQ(0, accessor->count());


### PR DESCRIPTION
This PR cleans up the includes by updating the include paths to start from the Bazel workspace.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
