### PR TITLE
mobile: Consolidate dumpStats and terminate implementations to common/engine.cc

### DIFF
--- a/mobile/library/cc/engine.cc
+++ b/mobile/library/cc/engine.cc
@@ -1,16 +1,15 @@
 #include "engine.h"
 
-#include "library/common/data/utility.h"
 #include "library/common/engine.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
 namespace Platform {
 
-Engine::Engine(::Envoy::Engine* engine) : engine_(engine), terminated_(false) {}
+Engine::Engine(::Envoy::Engine* engine) : engine_(engine) {}
 
 Engine::~Engine() {
-  if (!terminated_) {
+  if (!engine_->isTerminated()) {
     terminate();
   }
 }
@@ -23,26 +22,9 @@ StreamClientSharedPtr Engine::streamClient() {
   return std::make_shared<StreamClient>(shared_from_this());
 }
 
-std::string Engine::dumpStats() {
-  envoy_data data;
-  if (engine_->dumpStats(&data) == ENVOY_FAILURE) {
-    return "";
-  }
-  const std::string to_return = Data::Utility::copyToString(data);
-  release_envoy_data(data);
+std::string Engine::dumpStats() { return engine_->dumpStats(); }
 
-  return to_return;
-}
-
-envoy_status_t Engine::terminate() {
-  if (terminated_) {
-    IS_ENVOY_BUG("attempted to double terminate engine");
-    return ENVOY_FAILURE;
-  }
-  envoy_status_t ret = engine_->terminate();
-  terminated_ = true;
-  return ret;
-}
+envoy_status_t Engine::terminate() { return engine_->terminate(); }
 
 } // namespace Platform
 } // namespace Envoy

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -37,7 +37,6 @@ private:
 
   Envoy::Engine* engine_;
   StreamClientSharedPtr stream_client_;
-  bool terminated_;
 };
 
 using EngineSharedPtr = std::shared_ptr<Engine>;

--- a/mobile/library/common/engine.h
+++ b/mobile/library/common/engine.h
@@ -39,9 +39,13 @@ public:
   envoy_status_t run(std::unique_ptr<Envoy::OptionsImplBase>&& options);
 
   /**
-   * Immediately terminate the engine, if running.
+   * Immediately terminate the engine, if running. Calling this function when
+   * the engine has been terminated will result in `ENVOY_FAILURE`.
    */
   envoy_status_t terminate();
+
+  /** Returns true if the Engine has been terminated; false otherwise. */
+  bool isTerminated() const;
 
   /**
    * Accessor for the provisional event dispatcher.
@@ -98,13 +102,9 @@ public:
                                   uint64_t count);
 
   /**
-   * Dump Envoy stats into the provided envoy_data
-   * @params envoy_data which will be filed with referenced stats dumped in Envoy's standard text
-   * format.
-   * @return failure status if the engine is no longer running.
-   * This can be called from any thread, but will block on engine-thread processing.
+   * Dumps Envoy stats into string. Returns an empty string when an error occurred.
    */
-  envoy_status_t dumpStats(envoy_data* out);
+  std::string dumpStats();
 
   /**
    * Get cluster manager from the Engine.
@@ -118,6 +118,14 @@ public:
 
 private:
   envoy_status_t main(std::unique_ptr<Envoy::OptionsImplBase>&& options);
+  /**
+   * Dump Envoy stats into the provided envoy_data
+   * @params envoy_data which will be filed with referenced stats dumped in Envoy's standard text
+   * format.
+   * @return failure status if the engine is no longer running.
+   * This can be called from any thread, but will block on engine-thread processing.
+   */
+  envoy_status_t dumpStats(envoy_data* out);
   static void logInterfaces(absl::string_view event,
                             std::vector<Network::InterfacePair>& interfaces);
 
@@ -142,6 +150,7 @@ private:
   // main_thread_ should be destroyed first, hence it is the last member variable. Objects with
   // instructions scheduled on the main_thread_ need to have a longer lifetime.
   std::thread main_thread_{}; // Empty placeholder to be populated later.
+  bool terminated_{false};
 };
 
 using EngineSharedPtr = std::shared_ptr<Engine>;

--- a/mobile/library/common/engine.h
+++ b/mobile/library/common/engine.h
@@ -118,14 +118,6 @@ public:
 
 private:
   envoy_status_t main(std::unique_ptr<Envoy::OptionsImplBase>&& options);
-  /**
-   * Dump Envoy stats into the provided envoy_data
-   * @params envoy_data which will be filed with referenced stats dumped in Envoy's standard text
-   * format.
-   * @return failure status if the engine is no longer running.
-   * This can be called from any thread, but will block on engine-thread processing.
-   */
-  envoy_status_t dumpStats(envoy_data* out);
   static void logInterfaces(absl::string_view event,
                             std::vector<Network::InterfacePair>& interfaces);
 

--- a/mobile/library/common/jni/jni_impl.cc
+++ b/mobile/library/common/jni/jni_impl.cc
@@ -181,17 +181,9 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_dumpStats(JNIEnv* env,
                                                            jlong engine_handle) {
   jni_log("[Envoy]", "dumpStats");
   auto engine = reinterpret_cast<Envoy::Engine*>(engine_handle);
-  envoy_data data;
-  jint result = engine->dumpStats(&data);
+  std::string stats = engine->dumpStats();
   Envoy::JNI::JniHelper jni_helper(env);
-  if (result != ENVOY_SUCCESS) {
-    return jni_helper.newStringUtf("").release();
-  }
-
-  Envoy::JNI::LocalRefUniquePtr<jstring> str = Envoy::JNI::envoyDataToJavaString(jni_helper, data);
-  release_envoy_data(data);
-
-  return str.release();
+  return jni_helper.newStringUtf(stats.c_str()).release();
 }
 
 // JvmCallbackContext

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -569,17 +569,12 @@ static void ios_track_event(envoy_map map, const void *context) {
 }
 
 - (NSString *)dumpStats {
-  envoy_data data;
-  envoy_status_t status = _engine->dumpStats(&data);
-  if (status != ENVOY_SUCCESS) {
+  std::string status = _engine->dumpStats();
+  if (status == "") {
     return @"";
   }
 
-  NSString *stringCopy = [[NSString alloc] initWithBytes:data.bytes
-                                                  length:data.length
-                                                encoding:NSUTF8StringEncoding];
-  release_envoy_data(data);
-  return stringCopy;
+  return @(status.c_str());
 }
 
 - (void)terminate {

--- a/mobile/test/common/engine_test.cc
+++ b/mobile/test/common/engine_test.cc
@@ -84,7 +84,7 @@ TEST_F(EngineTest, AccessEngineAfterInitialization) {
 
   absl::Notification getClusterManagerInvoked;
   // Running engine functions should work because the engine is running
-  EXPECT_NE("", engine_->engine_->dumpStats());
+  EXPECT_EQ("runtime.load_success: 1\n", engine_->engine_->dumpStats());
 
   engine_->terminate();
   ASSERT_TRUE(engine_->isTerminated());

--- a/mobile/test/common/engine_test.cc
+++ b/mobile/test/common/engine_test.cc
@@ -21,8 +21,13 @@ struct TestEngine {
   }
 
   envoy_status_t terminate() { return engine_->terminate(); }
+  bool isTerminated() const { return engine_->isTerminated(); }
 
-  ~TestEngine() { engine_->terminate(); }
+  ~TestEngine() {
+    if (!engine_->isTerminated()) {
+      engine_->terminate();
+    }
+  }
 };
 
 class EngineTest : public testing::Test {
@@ -54,6 +59,7 @@ TEST_F(EngineTest, EarlyExit) {
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
   ASSERT_EQ(engine_->terminate(), ENVOY_SUCCESS);
+  ASSERT_TRUE(engine_->isTerminated());
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
   engine_->engine_->startStream(0, {}, false);
@@ -77,15 +83,14 @@ TEST_F(EngineTest, AccessEngineAfterInitialization) {
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
   absl::Notification getClusterManagerInvoked;
-  envoy_data stats_data;
   // Running engine functions should work because the engine is running
-  EXPECT_EQ(ENVOY_SUCCESS, engine_->engine_->dumpStats(&stats_data));
-  release_envoy_data(stats_data);
+  EXPECT_NE("", engine_->engine_->dumpStats());
 
   engine_->terminate();
+  ASSERT_TRUE(engine_->isTerminated());
 
   // Now that the engine has been shut down, we no longer expect scheduling to work.
-  EXPECT_EQ(ENVOY_FAILURE, engine_->engine_->dumpStats(&stats_data));
+  EXPECT_EQ("", engine_->engine_->dumpStats());
 
   engine_.reset();
 }


### PR DESCRIPTION
This PR is needed as part of unifying the two `Engine` code. With this change, `Platform::Engine` will simply delegate its tasks to `Envoy::Engine`.

Risk Level: low (refactoring)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
