### PR TITLE
mobile: main_interface BUILD clean up

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -107,7 +107,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//library/common:envoy_main_interface_lib_no_stamp",
+        "//library/common:engine_lib_no_stamp",
         "//library/common/api:c_types",
         "//library/common/data:utility_lib",
         "//library/common/extensions/key_value/platform:config",

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -5,16 +5,16 @@ licenses(["notice"])  # Apache 2
 envoy_mobile_package()
 
 envoy_cc_library(
-    name = "envoy_main_interface_lib",
+    name = "engine_lib",
     repository = "@envoy",
     deps = [
         ":engine_common_lib_stamped",
-        ":envoy_main_interface_lib_no_stamp",
+        ":engine_lib_no_stamp",
     ],
 )
 
 envoy_cc_library(
-    name = "envoy_main_interface_lib_no_stamp",
+    name = "engine_lib_no_stamp",
     srcs = [
         "engine.cc",
     ],

--- a/mobile/library/common/jni/BUILD
+++ b/mobile/library/common/jni/BUILD
@@ -75,7 +75,7 @@ envoy_cc_library(
         ":android_network_utility_lib",
         ":jni_utility_lib",
         "//library/cc:engine_builder_lib",
-        "//library/common:envoy_main_interface_lib",
+        "//library/common:engine_lib",
         "//library/common/api:c_types",
         "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
         "//library/common/extensions/key_value/platform:config",
@@ -123,7 +123,7 @@ envoy_cc_library(
         ":jni_impl_lib",
         ":jni_support_lib",
         ":jni_utility_lib",
-        "//library/common:envoy_main_interface_lib",
+        "//library/common:engine_lib",
         "//library/common/jni/import:jni_import_lib",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.

--- a/mobile/library/objective-c/BUILD
+++ b/mobile/library/objective-c/BUILD
@@ -57,7 +57,7 @@ envoy_objc_library(
         ":envoy_key_value_store_lib",
         ":envoy_objc_bridge_lib",
         "//library/cc:engine_builder_lib",
-        "//library/common:envoy_main_interface_lib",
+        "//library/common:engine_lib",
         "//library/common/api:c_types",
         "//library/common/network:apple_platform_cert_verifier",
     ],

--- a/mobile/test/common/BUILD
+++ b/mobile/test/common/BUILD
@@ -25,7 +25,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
-        "//library/common:envoy_main_interface_lib_no_stamp",
+        "//library/common:engine_lib_no_stamp",
         "//library/common/types:c_types_lib",
         "@envoy//test/common/http:common_lib",
     ],
@@ -39,7 +39,7 @@ envoy_cc_test(
     ),
     repository = "@envoy",
     deps = [
-        "//library/common:envoy_main_interface_lib_no_stamp",
+        "//library/common:engine_lib_no_stamp",
         "//library/common/data:utility_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",

--- a/mobile/test/common/stats/BUILD
+++ b/mobile/test/common/stats/BUILD
@@ -9,7 +9,7 @@ envoy_cc_test(
     srcs = ["utility_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/common:envoy_main_interface_lib_no_stamp",
+        "//library/common:engine_lib_no_stamp",
         "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//test/common/stats:stat_test_utility_lib",

--- a/mobile/test/non_hermetic/BUILD
+++ b/mobile/test/non_hermetic/BUILD
@@ -25,7 +25,7 @@ envoy_cc_test_binary(
     ],
     repository = "@envoy",
     deps = [
-        "//library/common:envoy_main_interface_lib_no_stamp",
+        "//library/common:envoy_lib_no_stamp",
         "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
         "//test/common/integration:base_client_integration_test_lib",

--- a/mobile/test/performance/BUILD
+++ b/mobile/test/performance/BUILD
@@ -9,5 +9,5 @@ envoy_cc_binary(
     srcs = ["test_binary_size.cc"],
     repository = "@envoy",
     stamped = True,
-    deps = ["//library/common:envoy_main_interface_lib"],
+    deps = ["//library/common:engine_lib"],
 )


### PR DESCRIPTION
`main_interface.(h|cc)` has been removed in https://github.com/envoyproxy/envoy/pull/32018. This PR updates the build target names to not have `main_interface` in the  name.

Risk Level: low (cosmetic changes)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
