### PR TITLE
mobile: Fix build error target name

### DIFF
--- a/mobile/test/non_hermetic/BUILD
+++ b/mobile/test/non_hermetic/BUILD
@@ -25,7 +25,7 @@ envoy_cc_test_binary(
     ],
     repository = "@envoy",
     deps = [
-        "//library/common:envoy_lib_no_stamp",
+        "//library/common:engine_lib_no_stamp",
         "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
         "//test/common/integration:base_client_integration_test_lib",


### PR DESCRIPTION
This build target does not run as part of CI, that's why we didn't catch this issue.

Risk Level: n/a
Testing: manual
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
