### PR TITLE
wasm: fix xds node during configuration

### DIFF
--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -357,48 +357,53 @@ absl::optional<CelValue> XDSWrapper::operator[](CelValue key) const {
     return {};
   }
   auto value = key.StringOrDie().value();
+  if (value == Node) {
+    if (local_info_) {
+      return CelProtoWrapper::CreateMessage(&local_info_->node(), &arena_);
+    }
+    return {};
+  }
+  if (info_ == nullptr) {
+    return {};
+  }
   if (value == ClusterName) {
-    const auto cluster_info = info_.upstreamClusterInfo();
+    const auto cluster_info = info_->upstreamClusterInfo();
     if (cluster_info && cluster_info.value()) {
       return CelValue::CreateString(&cluster_info.value()->name());
     }
   } else if (value == ClusterMetadata) {
-    const auto cluster_info = info_.upstreamClusterInfo();
+    const auto cluster_info = info_->upstreamClusterInfo();
     if (cluster_info && cluster_info.value()) {
       return CelProtoWrapper::CreateMessage(&cluster_info.value()->metadata(), &arena_);
     }
   } else if (value == RouteName) {
-    if (info_.route()) {
-      return CelValue::CreateString(&info_.route()->routeName());
+    if (info_->route()) {
+      return CelValue::CreateString(&info_->route()->routeName());
     }
   } else if (value == RouteMetadata) {
-    if (info_.route()) {
-      return CelProtoWrapper::CreateMessage(&info_.route()->metadata(), &arena_);
+    if (info_->route()) {
+      return CelProtoWrapper::CreateMessage(&info_->route()->metadata(), &arena_);
     }
   } else if (value == UpstreamHostMetadata) {
-    const auto upstream_info = info_.upstreamInfo();
+    const auto upstream_info = info_->upstreamInfo();
     if (upstream_info && upstream_info->upstreamHost()) {
       return CelProtoWrapper::CreateMessage(upstream_info->upstreamHost()->metadata().get(),
                                             &arena_);
     }
   } else if (value == FilterChainName) {
-    const auto filter_chain_info = info_.downstreamAddressProvider().filterChainInfo();
+    const auto filter_chain_info = info_->downstreamAddressProvider().filterChainInfo();
     const absl::string_view filter_chain_name =
         filter_chain_info.has_value() ? filter_chain_info->name() : absl::string_view{};
     return CelValue::CreateStringView(filter_chain_name);
   } else if (value == ListenerMetadata) {
-    const auto listener_info = info_.downstreamAddressProvider().listenerInfo();
+    const auto listener_info = info_->downstreamAddressProvider().listenerInfo();
     if (listener_info) {
       return CelProtoWrapper::CreateMessage(&listener_info->metadata(), &arena_);
     }
   } else if (value == ListenerDirection) {
-    const auto listener_info = info_.downstreamAddressProvider().listenerInfo();
+    const auto listener_info = info_->downstreamAddressProvider().listenerInfo();
     if (listener_info) {
       return CelValue::CreateInt64(listener_info->direction());
-    }
-  } else if (value == Node) {
-    if (local_info_) {
-      return CelProtoWrapper::CreateMessage(&local_info_->node(), &arena_);
     }
   }
   return {};

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -237,13 +237,13 @@ private:
 
 class XDSWrapper : public BaseWrapper {
 public:
-  XDSWrapper(Protobuf::Arena& arena, const StreamInfo::StreamInfo& info,
+  XDSWrapper(Protobuf::Arena& arena, const StreamInfo::StreamInfo* info,
              const LocalInfo::LocalInfo* local_info)
       : BaseWrapper(arena), info_(info), local_info_(local_info) {}
   absl::optional<CelValue> operator[](CelValue key) const override;
 
 private:
-  const StreamInfo::StreamInfo& info_;
+  const StreamInfo::StreamInfo* info_;
   const LocalInfo::LocalInfo* local_info_;
 };
 

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -34,15 +34,19 @@ const ActivationLookupTable& getActivationTokens() {
 
 absl::optional<CelValue> StreamActivation::FindValue(absl::string_view name,
                                                      Protobuf::Arena* arena) const {
-  if (activation_info_ == nullptr) {
-    return {};
-  }
-  const StreamInfo::StreamInfo& info = *activation_info_;
   const auto& tokens = getActivationTokens();
   const auto token = tokens.find(name);
   if (token == tokens.end()) {
     return {};
   }
+  if (token->second == ActivationToken::XDS) {
+    return CelValue::CreateMap(
+        Protobuf::Arena::Create<XDSWrapper>(arena, *arena, activation_info_, local_info_));
+  }
+  if (activation_info_ == nullptr) {
+    return {};
+  }
+  const StreamInfo::StreamInfo& info = *activation_info_;
   switch (token->second) {
   case ActivationToken::Request:
     return CelValue::CreateMap(
@@ -64,10 +68,8 @@ absl::optional<CelValue> StreamActivation::FindValue(absl::string_view name,
     return CelValue::CreateMap(
         Protobuf::Arena::Create<FilterStateWrapper>(arena, *arena, info.filterState()));
   case ActivationToken::XDS:
-    return CelValue::CreateMap(
-        Protobuf::Arena::Create<XDSWrapper>(arena, *arena, info, local_info_));
+    return {};
   }
-  return {};
 }
 
 void StreamActivation::resetActivation() const {

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -70,6 +70,7 @@ absl::optional<CelValue> StreamActivation::FindValue(absl::string_view name,
   case ActivationToken::XDS:
     return {};
   }
+  return {};
 }
 
 void StreamActivation::resetActivation() const {

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -856,7 +856,7 @@ TEST(Context, XDSAttributes) {
   info.downstream_connection_info_provider_->setListenerInfo(listener_info);
 
   Protobuf::Arena arena;
-  XDSWrapper wrapper(arena, info, &local_info);
+  XDSWrapper wrapper(arena, &info, &local_info);
 
   {
     const auto value = wrapper[CelValue::CreateStringView(ClusterName)];

--- a/test/extensions/filters/http/wasm/test_data/metadata_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/metadata_rust.rs
@@ -15,7 +15,7 @@ impl Context for TestRoot {}
 
 impl RootContext for TestRoot {
     fn on_tick(&mut self) {
-        if let Some(value) = self.get_property(vec!["node", "metadata", "wasm_node_get_key"]) {
+        if let Some(value) = self.get_property(vec!["xds", "node", "metadata", "wasm_node_get_key"]) {
             debug!("onTick {}", String::from_utf8(value).unwrap());
         } else {
             debug!("missing node metadata");

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -81,6 +81,7 @@ bool TestRootContext::onConfigure(size_t size) {
           {{"plugin_vm_id"}, "vm_id"},
           {{"listener_direction"}, std::string("\x1\0\0\0\0\0\0\0\0", 8)}, // INBOUND
           {{"listener_metadata"}, ""},
+          {{"xds", "node", "metadata", "istio.io/metadata"}, "sample_data"},
       };
       for (const auto& property : properties) {
         std::string value;

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1775,14 +1775,13 @@ TEST_P(WasmHttpFilterTest, Property) {
     // TODO(PiotrSikora): test not yet implemented using Rust SDK.
     return;
   }
-  setupTest("", "property");
-  setupFilter();
   envoy::config::core::v3::Node node_data;
   ProtobufWkt::Value node_val;
   node_val.set_string_value("sample_data");
   (*node_data.mutable_metadata()->mutable_fields())["istio.io/metadata"] = node_val;
   EXPECT_CALL(local_info_, node()).WillRepeatedly(ReturnRef(node_data));
-
+  setupTest("", "property");
+  setupFilter();
   request_stream_info_.metadata_.mutable_filter_metadata()->insert(
       Protobuf::MapPair<std::string, ProtobufWkt::Struct>(
           "envoy.filters.http.wasm",


### PR DESCRIPTION
Commit Message: fixes an early exit due to empty stream info when calling xds attributes during configuration
Additional Description:
Risk Level: low
Testing: added
Docs Changes:
Release Notes: none