### PR TITLE
quic: fix client session test

### DIFF
--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -16,6 +16,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/simulated_time_system.h"
 
 #include "gmock/gmock.h"
@@ -67,9 +68,10 @@ public:
         dispatcher_(api_->allocateDispatcher("test_thread")), connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_({GetParam()}),
         peer_addr_(
-            Network::Utility::getAddressWithPort(*Network::Utility::getIpv6LoopbackAddress(), 0)),
-        self_addr_(Network::Utility::getAddressWithPort(*Network::Utility::getIpv6LoopbackAddress(),
-                                                        54321)),
+            Network::Test::getCanonicalLoopbackAddress(TestEnvironment::getIpVersionsForTest()[0])),
+        self_addr_(Network::Utility::getAddressWithPort(
+            *Network::Test::getCanonicalLoopbackAddress(TestEnvironment::getIpVersionsForTest()[0]),
+            54321)),
         peer_socket_(createConnectionSocket(self_addr_, peer_addr_, nullptr)),
         quic_connection_(new TestEnvoyQuicClientConnection(
             quic::test::TestConnectionId(), connection_helper_, alarm_factory_, writer_,


### PR DESCRIPTION
Commit Message: the unit test hard coded ip version to be v6 and hasn't needed to use real I/O on the socket util recent. Test `StatelessResetOnProbingSocket` needs to call sendmsg() on the socket, so if the environment doesn't support v6, the sys call will fail.

Risk Level: low, test only
Testing: verified StatelessResetOnProbingSocket passes on v4 environment.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
