### PR TITLE
stream info: rename the extended response flag and response flag

### DIFF
--- a/contrib/client_ssl_auth/filters/network/source/client_ssl_auth.cc
+++ b/contrib/client_ssl_auth/filters/network/source/client_ssl_auth.cc
@@ -127,7 +127,7 @@ void ClientSslAuthFilter::onEvent(Network::ConnectionEvent event) {
   if (!config_->allowedPrincipals().allowed(
           read_callbacks_->connection().ssl()->sha256PeerCertificateDigest())) {
     read_callbacks_->connection().streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UpstreamProtocolError);
+        StreamInfo::CoreResponseFlag::UpstreamProtocolError);
     read_callbacks_->connection().streamInfo().setResponseCodeDetails(AuthDigestNoMatch);
     config_->stats().auth_digest_no_match_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);

--- a/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
+++ b/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
@@ -164,7 +164,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   std::string expected_sha_1("digest");
   EXPECT_CALL(*ssl_, sha256PeerCertificateDigest()).WillOnce(ReturnRef(expected_sha_1));
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError));
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
               setResponseCodeDetails("auth_digest_no_match"));
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -31,15 +31,15 @@ Tracing::Decision tracingDecision(const Tracing::ConnectionManagerTracingConfig&
   return {Tracing::Reason::NotTraceable, false};
 }
 
-StreamInfo::ResponseFlag
+StreamInfo::CoreResponseFlag
 responseFlagFromDownstreamReasonReason(DownstreamStreamResetReason reason) {
   switch (reason) {
   case DownstreamStreamResetReason::ConnectionTermination:
-    return StreamInfo::ResponseFlag::DownstreamConnectionTermination;
+    return StreamInfo::CoreResponseFlag::DownstreamConnectionTermination;
   case DownstreamStreamResetReason::LocalConnectionTermination:
-    return StreamInfo::ResponseFlag::LocalReset;
+    return StreamInfo::CoreResponseFlag::LocalReset;
   case DownstreamStreamResetReason::ProtocolError:
-    return StreamInfo::ResponseFlag::DownstreamProtocolError;
+    return StreamInfo::CoreResponseFlag::DownstreamProtocolError;
   }
   PANIC("Unknown reset reason");
 }

--- a/contrib/generic_proxy/filters/network/source/router/router.cc
+++ b/contrib/generic_proxy/filters/network/source/router/router.cc
@@ -555,20 +555,21 @@ void RouterFilter::resetStream(StreamResetReason reason) {
     callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, resetReasonToStringView(reason)));
     break;
   case StreamResetReason::ProtocolError:
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError);
     callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, resetReasonToStringView(reason)));
     break;
   case StreamResetReason::ConnectionFailure:
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
+    callbacks_->streamInfo().setResponseFlag(
+        StreamInfo::CoreResponseFlag::UpstreamConnectionFailure);
     callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, resetReasonToStringView(reason)));
     break;
   case StreamResetReason::ConnectionTermination:
     callbacks_->streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UpstreamConnectionTermination);
+        StreamInfo::CoreResponseFlag::UpstreamConnectionTermination);
     callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, resetReasonToStringView(reason)));
     break;
   case StreamResetReason::Overflow:
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow);
     callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, resetReasonToStringView(reason)));
     break;
   }
@@ -580,7 +581,7 @@ void RouterFilter::kickOffNewUpstreamRequest() {
   auto thread_local_cluster = cluster_manager_.getThreadLocalCluster(cluster_name);
   if (thread_local_cluster == nullptr) {
     filter_complete_ = true;
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoClusterFound);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoClusterFound);
     callbacks_->sendLocalReply(Status(StatusCode::kNotFound, "cluster_not_found"));
     return;
   }
@@ -612,7 +613,7 @@ void RouterFilter::kickOffNewUpstreamRequest() {
       auto pool_data = thread_local_cluster->tcpConnPool(Upstream::ResourcePriority::Default, this);
       if (!pool_data.has_value()) {
         filter_complete_ = true;
-        callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream);
+        callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream);
         callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, "no_healthy_upstream"));
         return;
       }
@@ -632,7 +633,7 @@ void RouterFilter::kickOffNewUpstreamRequest() {
     auto pool_data = thread_local_cluster->tcpConnPool(Upstream::ResourcePriority::Default, this);
     if (!pool_data.has_value()) {
       filter_complete_ = true;
-      callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream);
+      callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream);
       callbacks_->sendLocalReply(Status(StatusCode::kUnavailable, "no_healthy_upstream"));
       return;
     }
@@ -671,7 +672,7 @@ FilterStatus RouterFilter::onStreamDecoded(StreamRequest& request) {
 
   ENVOY_LOG(debug, "No route for current request and send local reply");
   filter_complete_ = true;
-  callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+  callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound);
   callbacks_->sendLocalReply(Status(StatusCode::kNotFound, "route_not_found"));
   return FilterStatus::StopIteration;
 }

--- a/contrib/generic_proxy/filters/network/source/stats.cc
+++ b/contrib/generic_proxy/filters/network/source/stats.cc
@@ -35,11 +35,10 @@ Stats::StatName CodeOrFlags::statNameFromCode(uint32_t code) const {
 }
 
 Stats::StatName CodeOrFlags::statNameFromFlag(StreamInfo::ResponseFlag flag) const {
+  // Any flag value should be less than the size of flag_stat_names_. Because flag_stat_names_
+  // is initialized with all possible flags.
   ASSERT(flag.value() < flag_stat_names_.size());
-  if (flag.value() < flag_stat_names_.size()) {
-    return flag_stat_names_[flag.value()];
-  }
-  return unknown_code_or_flag_;
+  return flag_stat_names_[flag.value()];
 }
 
 void GenericFilterStatsHelper::onRequestReset() { stats_.downstream_rq_reset_.inc(); }

--- a/contrib/generic_proxy/filters/network/source/stats.h
+++ b/contrib/generic_proxy/filters/network/source/stats.h
@@ -28,6 +28,9 @@ private:
   Stats::StatNamePool pool_;
 
   std::vector<Stats::StatName> code_stat_names_;
+  // The flag_stat_names_ contains stat names of all response flags. The index of each flag
+  // is the same as the value of the flag. Size of this vector is the same as the size of
+  // StreamInfo::ResponseFlagUtils::responseFlagsVec().
   std::vector<Stats::StatName> flag_stat_names_;
 
   Stats::StatName unknown_code_or_flag_;

--- a/contrib/generic_proxy/filters/network/source/stats.h
+++ b/contrib/generic_proxy/filters/network/source/stats.h
@@ -28,7 +28,7 @@ private:
   Stats::StatNamePool pool_;
 
   std::vector<Stats::StatName> code_stat_names_;
-  absl::flat_hash_map<StreamInfo::ResponseFlag, Stats::StatName> flag_stat_names_;
+  std::vector<Stats::StatName> flag_stat_names_;
 
   Stats::StatName unknown_code_or_flag_;
 };

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -906,7 +906,7 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithDrainClose) {
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
   response->status_ = {234, false}; // Response non-OK.
-  active_stream->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
+  active_stream->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError);
   active_stream->onResponseStart(std::move(response));
 
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 1);

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -36,7 +36,7 @@ using ClusterInfoConstSharedPtr = std::shared_ptr<const ClusterInfo>;
 
 namespace StreamInfo {
 
-enum ResponseFlag : uint16_t {
+enum CoreResponseFlag : uint16_t {
   // Local server healthcheck failed.
   FailedLocalHealthCheck,
   // No healthy upstream.
@@ -99,28 +99,24 @@ enum ResponseFlag : uint16_t {
 
 class ResponseFlagUtils;
 
-// TODO(wbpcode): rename the ExtendedResponseFlag to ResponseFlag and legacy
-// ResponseFlag to CoreResponseFlag.
-class ExtendedResponseFlag {
+class ResponseFlag {
 public:
-  ExtendedResponseFlag() = default;
+  constexpr ResponseFlag() = default;
 
   /**
    * Construct a response flag from the core response flag enum. The integer
    * value of the enum is used as the raw integer value of the flag.
    * @param flag the core response flag enum.
    */
-  ExtendedResponseFlag(ResponseFlag flag) : raw_value_(flag) {}
+  constexpr ResponseFlag(CoreResponseFlag flag) : value_(flag) {}
 
   /**
    * Get the raw integer value of the flag.
    * @return uint16_t the raw integer value.
    */
-  uint16_t value() const { return raw_value_; }
+  uint16_t value() const { return value_; }
 
-  bool operator==(const ExtendedResponseFlag& other) const {
-    return raw_value_ == other.raw_value_;
-  }
+  bool operator==(const ResponseFlag& other) const { return value_ == other.value_; }
 
 private:
   friend class ResponseFlagUtils;
@@ -128,9 +124,9 @@ private:
   // This private constructor is used to create extended response flags from
   // uint16_t values. This can only be used by ResponseFlagUtils to ensure
   // only validated values are used.
-  ExtendedResponseFlag(uint16_t value) : raw_value_(value) {}
+  ResponseFlag(uint16_t value) : value_(value) {}
 
-  uint16_t raw_value_{};
+  uint16_t value_{};
 };
 
 /**
@@ -632,7 +628,7 @@ public:
    * @param response_flag the response flag. Each filter can set independent response flags. The
    * flags are accumulated.
    */
-  virtual void setResponseFlag(ExtendedResponseFlag response_flag) PURE;
+  virtual void setResponseFlag(ResponseFlag response_flag) PURE;
 
   /**
    * @param code the HTTP response code to set for this request.
@@ -787,7 +783,7 @@ public:
   /**
    * @return whether response flag is set or not.
    */
-  virtual bool hasResponseFlag(ExtendedResponseFlag response_flag) const PURE;
+  virtual bool hasResponseFlag(ResponseFlag response_flag) const PURE;
 
   /**
    * @return whether any response flag is set or not.
@@ -797,11 +793,11 @@ public:
   /**
    * @return all response flags that are set.
    */
-  virtual absl::Span<const ExtendedResponseFlag> responseFlags() const PURE;
+  virtual absl::Span<const ResponseFlag> responseFlags() const PURE;
 
   /**
    * @return response flags encoded as an integer. Every bit of the integer is used to represent a
-   * flag. Only flags that are declared in the enum ResponseFlag type are supported.
+   * flag. Only flags that are declared in the enum CoreResponseFlag type are supported.
    */
   virtual uint64_t legacyResponseFlags() const PURE;
 

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -211,7 +211,7 @@ typedef struct {
   uint64_t received_byte_count;
   // The final response flags for the stream. See
   // https://github.com/envoyproxy/envoy/blob/main/envoy/stream_info/stream_info.h
-  // for the ResponseFlag enum.
+  // for the CoreResponseFlag enum.
   uint64_t response_flags;
   // The upstream protocol, if an upstream connection was established. Field
   // entries are based off of Envoy's Http::Protocol

--- a/mobile/test/common/http/filters/test_read/filter.cc
+++ b/mobile/test/common/http/filters/test_read/filter.cc
@@ -34,7 +34,7 @@ Http::FilterHeadersStatus TestReadFilter::decodeHeaders(Http::RequestHeaderMap& 
   return Http::FilterHeadersStatus::Continue;
 }
 
-StreamInfo::ResponseFlag TestReadFilter::mapErrorToResponseFlag(uint64_t errorCode) {
+StreamInfo::CoreResponseFlag TestReadFilter::mapErrorToResponseFlag(uint64_t errorCode) {
   switch (errorCode) {
   case 0x4000000:
     return StreamInfo::DnsResolutionFailed;

--- a/mobile/test/common/http/filters/test_read/filter.h
+++ b/mobile/test/common/http/filters/test_read/filter.h
@@ -27,7 +27,7 @@ private:
   /* A mapping of the envoymobile errors we care about for testing
    * From https://github.com/envoyproxy/envoy/blob/main/envoy/stream_info/stream_info.h
    */
-  StreamInfo::ResponseFlag mapErrorToResponseFlag(uint64_t errorCode);
+  StreamInfo::CoreResponseFlag mapErrorToResponseFlag(uint64_t errorCode);
 };
 
 } // namespace TestRead

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -114,7 +114,8 @@ void CodecClient::onEvent(Network::ConnectionEvent event) {
       reason = StreamResetReason::ConnectionTermination;
       if (protocol_error_) {
         reason = StreamResetReason::ProtocolError;
-        connection_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
+        connection_->streamInfo().setResponseFlag(
+            StreamInfo::CoreResponseFlag::UpstreamProtocolError);
       }
     }
     while (!active_requests_.empty()) {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -582,7 +582,7 @@ private:
    */
   void doEndStream(ActiveStream& stream, bool check_for_deferred_close = true);
 
-  void resetAllStreams(absl::optional<StreamInfo::ResponseFlag> response_flag,
+  void resetAllStreams(absl::optional<StreamInfo::CoreResponseFlag> response_flag,
                        absl::string_view details);
   void onIdleTimeout();
   void onConnectionDurationTimeout();
@@ -590,11 +590,11 @@ private:
   void startDrainSequence();
   Tracing::Tracer& tracer() { return *config_.tracer(); }
   void handleCodecErrorImpl(absl::string_view error, absl::string_view details,
-                            StreamInfo::ResponseFlag response_flag);
+                            StreamInfo::CoreResponseFlag response_flag);
   void handleCodecError(absl::string_view error);
   void handleCodecOverloadError(absl::string_view error);
   void doConnectionClose(absl::optional<Network::ConnectionCloseType> close_type,
-                         absl::optional<StreamInfo::ResponseFlag> response_flag,
+                         absl::optional<StreamInfo::CoreResponseFlag> response_flag,
                          absl::string_view details);
   // Returns true if a RST_STREAM for the given stream is premature. Premature
   // means the RST_STREAM arrived before response headers were sent and than

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -26,7 +26,8 @@ using UpstreamFilterConfigProviderManager =
 class MissingConfigFilter : public Http::PassThroughDecoderFilter {
 public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
-    decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoFilterConfigFound);
+    decoder_callbacks_->streamInfo().setResponseFlag(
+        StreamInfo::CoreResponseFlag::NoFilterConfigFound);
     decoder_callbacks_->sendLocalReply(Http::Code::InternalServerError, EMPTY_STRING, nullptr,
                                        absl::nullopt, EMPTY_STRING);
     return Http::FilterHeadersStatus::StopIteration;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -2096,7 +2096,7 @@ int ClientConnectionImpl::onHeader(int32_t stream_id, HeaderString&& name, Heade
 }
 
 StreamResetReason ClientConnectionImpl::getMessagingErrorResetReason() const {
-  connection_.streamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError);
+  connection_.streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError);
 
   return StreamResetReason::ProtocolError;
 }

--- a/source/common/listener_manager/active_stream_listener_base.cc
+++ b/source/common/listener_manager/active_stream_listener_base.cc
@@ -44,7 +44,7 @@ void ActiveStreamListenerBase::newConnection(Network::ConnectionSocketPtr&& sock
     ENVOY_LOG(debug, "closing connection from {}: no matching filter chain found",
               socket->connectionInfoProvider().remoteAddress()->asString());
     stats_.no_filter_chain_match_.inc();
-    stream_info->setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+    stream_info->setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound);
     stream_info->setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().FilterChainNotFound);
     emitLogs(*config_, *stream_info);
     socket->close();

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -305,7 +305,7 @@ public:
 
   ~Filter() override;
 
-  static StreamInfo::ResponseFlag
+  static StreamInfo::CoreResponseFlag
   streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason);
 
   // Http::StreamFilterBase
@@ -520,11 +520,12 @@ private:
   // Handle an upstream request aborted due to a local timeout.
   void onSoftPerTryTimeout();
   void onSoftPerTryTimeout(UpstreamRequest& upstream_request);
-  void onUpstreamTimeoutAbort(StreamInfo::ResponseFlag response_flag, absl::string_view details);
+  void onUpstreamTimeoutAbort(StreamInfo::CoreResponseFlag response_flag,
+                              absl::string_view details);
   // Handle an "aborted" upstream request, meaning we didn't see response
   // headers (e.g. due to a reset). Handles recording stats and responding
   // downstream if appropriate.
-  void onUpstreamAbort(Http::Code code, StreamInfo::ResponseFlag response_flag,
+  void onUpstreamAbort(Http::Code code, StreamInfo::CoreResponseFlag response_flag,
                        absl::string_view body, bool dropped, absl::string_view details);
   void onUpstreamComplete(UpstreamRequest& upstream_request);
   // Reset all in-flight upstream requests.

--- a/source/common/router/upstream_codec_filter.cc
+++ b/source/common/router/upstream_codec_filter.cc
@@ -68,7 +68,7 @@ Http::FilterHeadersStatus UpstreamCodecFilter::decodeHeaders(Http::RequestHeader
     deferred_reset_ = false;
     // It is possible that encodeHeaders() fails. This can happen if filters or other extensions
     // erroneously remove required headers.
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DownstreamProtocolError);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::DownstreamProtocolError);
     const std::string details =
         absl::StrCat(StreamInfo::ResponseCodeDetails::get().FilterRemovedRequiredRequestHeaders,
                      "{", StringUtil::replaceAllEmptySpace(status.message()), "}");

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -510,7 +510,7 @@ void UpstreamRequest::setupPerTryTimeout() {
 
 void UpstreamRequest::onPerTryIdleTimeout() {
   ENVOY_STREAM_LOG(debug, "upstream per try idle timeout", *parent_.callbacks());
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::StreamIdleTimeout);
   parent_.onPerTryIdleTimeout(*this);
 }
 
@@ -520,7 +520,7 @@ void UpstreamRequest::onPerTryTimeout() {
   if (!parent_.downstreamResponseStarted()) {
     ENVOY_STREAM_LOG(debug, "upstream per try timeout", *parent_.callbacks());
 
-    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout);
+    stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout);
     parent_.onPerTryTimeout(*this);
   } else {
     ENVOY_STREAM_LOG(debug,

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -232,25 +232,25 @@ struct StreamInfoImpl : public StreamInfo {
 
   uint64_t bytesSent() const override { return bytes_sent_; }
 
-  void setResponseFlag(ExtendedResponseFlag flag) override {
+  void setResponseFlag(ResponseFlag flag) override {
     ASSERT(flag.value() < ResponseFlagUtils::responseFlagsVec().size());
     if (!hasResponseFlag(flag)) {
       response_flags_.push_back(flag);
     }
   }
 
-  bool hasResponseFlag(ExtendedResponseFlag flag) const override {
+  bool hasResponseFlag(ResponseFlag flag) const override {
     return std::find(response_flags_.begin(), response_flags_.end(), flag) != response_flags_.end();
   }
 
   bool hasAnyResponseFlag() const override { return !response_flags_.empty(); }
 
-  absl::Span<const ExtendedResponseFlag> responseFlags() const override { return response_flags_; }
+  absl::Span<const ResponseFlag> responseFlags() const override { return response_flags_; }
 
   uint64_t legacyResponseFlags() const override {
     uint64_t legacy_flags = 0;
-    for (ExtendedResponseFlag flag : response_flags_) {
-      if (flag.value() <= static_cast<uint16_t>(ResponseFlag::LastFlag)) {
+    for (ResponseFlag flag : response_flags_) {
+      if (flag.value() <= static_cast<uint16_t>(CoreResponseFlag::LastFlag)) {
         ASSERT(flag.value() < 64, "Legacy response flag out of range");
         legacy_flags |= (1UL << flag.value());
       }
@@ -441,7 +441,7 @@ private:
 public:
   absl::optional<std::string> response_code_details_;
   absl::optional<std::string> connection_termination_details_;
-  absl::InlinedVector<ExtendedResponseFlag, 4> response_flags_{};
+  absl::InlinedVector<ResponseFlag, 4> response_flags_{};
   bool health_check_request_{};
   Router::RouteConstSharedPtr route_;
   envoy::config::core::v3::Metadata metadata_{};

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -52,13 +52,12 @@ ResponseFlagUtils::ResponseFlagsMapType& ResponseFlagUtils::mutableResponseFlags
     ResponseFlagsMapType map;
     // Initialize the map with the all core flags first to ensure no custom flags
     // conflict with them.
-    RELEASE_ASSERT(CORE_RESPONSE_FLAGS.size() == ResponseFlag::LastFlag + 1,
+    RELEASE_ASSERT(CORE_RESPONSE_FLAGS.size() == CoreResponseFlag::LastFlag + 1,
                    "Not all inlined flags are contained by CORE_RESPONSE_FLAGS.");
 
     map.reserve(CORE_RESPONSE_FLAGS.size());
     for (const auto& flag : CORE_RESPONSE_FLAGS) {
-      map.emplace(flag.first.short_string_,
-                  FlagLongString{flag.second, std::string(flag.first.long_string_)});
+      map.emplace(flag.short_string_, FlagLongString{flag.flag_, std::string(flag.long_string_)});
     }
     RELEASE_ASSERT(map.size() == CORE_RESPONSE_FLAGS.size(),
                    "Duplicate flags in CORE_RESPONSE_FLAGS");
@@ -66,8 +65,8 @@ ResponseFlagUtils::ResponseFlagsMapType& ResponseFlagUtils::mutableResponseFlags
   }());
 }
 
-ExtendedResponseFlag ResponseFlagUtils::registerCustomFlag(absl::string_view custom_flag,
-                                                           absl::string_view custom_flag_long) {
+ResponseFlag ResponseFlagUtils::registerCustomFlag(absl::string_view custom_flag,
+                                                   absl::string_view custom_flag_long) {
   auto& mutable_flags = mutableResponseFlagsMap();
 
   RELEASE_ASSERT(!responseFlagsVecInitialized(),
@@ -85,14 +84,14 @@ ExtendedResponseFlag ResponseFlagUtils::registerCustomFlag(absl::string_view cus
 
 const ResponseFlagUtils::ResponseFlagsVecType& ResponseFlagUtils::responseFlagsVec() {
   CONSTRUCT_ON_FIRST_USE(ResponseFlagsVecType, []() {
-    static_assert(ResponseFlag::LastFlag == 27,
+    static_assert(CoreResponseFlag::LastFlag == 27,
                   "A flag has been added. Add the new flag to CORE_RESPONSE_FLAGS.");
 
     responseFlagsVecInitialized() = true;
 
     ResponseFlagsVecType res;
 
-    uint16_t max_flag = ResponseFlag::LastFlag;
+    uint16_t max_flag = CoreResponseFlag::LastFlag;
     for (const auto& flag : responseFlagsMap()) {
       if (flag.second.flag_.value() > max_flag) {
         max_flag = flag.second.flag_.value();
@@ -103,7 +102,8 @@ const ResponseFlagUtils::ResponseFlagsVecType& ResponseFlagUtils::responseFlagsV
 
     for (const auto& flag : responseFlagsMap()) {
       res[flag.second.flag_.value()] = {absl::string_view(flag.first),
-                                        absl::string_view(flag.second.long_string_)};
+                                        absl::string_view(flag.second.long_string_),
+                                        flag.second.flag_};
     }
 
     return res;
@@ -114,7 +114,7 @@ const ResponseFlagUtils::ResponseFlagsMapType& ResponseFlagUtils::responseFlagsM
   return mutableResponseFlagsMap();
 }
 
-absl::optional<ExtendedResponseFlag> ResponseFlagUtils::toResponseFlag(absl::string_view flag) {
+absl::optional<ResponseFlag> ResponseFlagUtils::toResponseFlag(absl::string_view flag) {
   const auto iter = responseFlagsMap().find(flag);
   if (iter != responseFlagsMap().end()) {
     return iter->second.flag_;
@@ -424,53 +424,53 @@ ProxyStatusUtils::proxyStatusErrorToString(const ProxyStatusError proxy_status) 
 
 const absl::optional<ProxyStatusError>
 ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
-  // NB: This mapping from Envoy-specific ResponseFlag enum to Proxy-Status
-  // error enum is lossy, since ResponseFlag is really a bitset of many
-  // ResponseFlag enums. Here, we search the list of all known ResponseFlag values in
+  // NB: This mapping from Envoy-specific CoreResponseFlag enum to Proxy-Status
+  // error enum is lossy, since CoreResponseFlag is really a bitset of many
+  // CoreResponseFlag enums. Here, we search the list of all known CoreResponseFlag values in
   // enum order, returning the first matching ProxyStatusError.
-  if (stream_info.hasResponseFlag(ResponseFlag::FailedLocalHealthCheck)) {
+  if (stream_info.hasResponseFlag(CoreResponseFlag::FailedLocalHealthCheck)) {
     return ProxyStatusError::DestinationUnavailable;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::NoHealthyUpstream)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::NoHealthyUpstream)) {
     return ProxyStatusError::DestinationUnavailable;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRequestTimeout)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRequestTimeout)) {
     if (!Runtime::runtimeFeatureEnabled(
             "envoy.reloadable_features.proxy_status_upstream_request_timeout")) {
       return ProxyStatusError::ConnectionTimeout;
     }
     return ProxyStatusError::HttpResponseTimeout;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::LocalReset)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::LocalReset)) {
     return ProxyStatusError::ConnectionTimeout;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRemoteReset)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRemoteReset)) {
     return ProxyStatusError::ConnectionTerminated;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamConnectionFailure)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionFailure)) {
     return ProxyStatusError::ConnectionRefused;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamConnectionTermination)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionTermination)) {
     return ProxyStatusError::ConnectionTerminated;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamOverflow)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamOverflow)) {
     return ProxyStatusError::ConnectionLimitReached;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::NoRouteFound)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::NoRouteFound)) {
     return ProxyStatusError::DestinationNotFound;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::RateLimited)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::RateLimited)) {
     return ProxyStatusError::ConnectionLimitReached;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::RateLimitServiceError)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::RateLimitServiceError)) {
     return ProxyStatusError::ConnectionLimitReached;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamRetryLimitExceeded)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRetryLimitExceeded)) {
     return ProxyStatusError::DestinationUnavailable;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::StreamIdleTimeout)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::StreamIdleTimeout)) {
     return ProxyStatusError::HttpResponseTimeout;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::InvalidEnvoyRequestHeaders)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::InvalidEnvoyRequestHeaders)) {
     return ProxyStatusError::HttpRequestError;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::DownstreamProtocolError)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::DownstreamProtocolError)) {
     return ProxyStatusError::HttpRequestError;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamMaxStreamDurationReached)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamMaxStreamDurationReached)) {
     return ProxyStatusError::HttpResponseTimeout;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::NoFilterConfigFound)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::NoFilterConfigFound)) {
     return ProxyStatusError::ProxyConfigurationError;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::UpstreamProtocolError)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamProtocolError)) {
     return ProxyStatusError::HttpProtocolError;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::NoClusterFound)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::NoClusterFound)) {
     return ProxyStatusError::DestinationUnavailable;
-  } else if (stream_info.hasResponseFlag(ResponseFlag::DnsResolutionFailed)) {
+  } else if (stream_info.hasResponseFlag(CoreResponseFlag::DnsResolutionFailed)) {
     return ProxyStatusError::DnsError;
   } else {
     return absl::nullopt;

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -16,6 +16,8 @@ namespace {
 
 // This flag is used to ensure that the responseFlagsVec() contains all the flags and no
 // any new custom flags are registered after the responseFlagsVec() is initialized.
+// NOTE: we expect all registrations of custom flags to happen during static initialization
+// before the first use of responseFlagsVec(). So no thread safety is needed here.
 bool& responseFlagsVecInitialized() { MUTABLE_CONSTRUCT_ON_FIRST_USE(bool, false); }
 
 } // namespace

--- a/source/common/stream_info/utility.h
+++ b/source/common/stream_info/utility.h
@@ -23,9 +23,9 @@ private:
 
 // Register a custom response flag by specifying the flag and the long name of the flag.
 // This macro should only be used in source files to register a flag.
-#define REGISTER_CUSTOM_RESPONSE_FLAG(short, long)                                                 \
+#define REGISTER_CUSTOM_RESPONSE_FLAG(flag_short_string, flag_long_string)                         \
   static CustomResponseFlag /* NOLINT(fuchsia-statically-constructed-objects) */                   \
-      registered_##short{#short, #long};
+      registered_##flag_short_string{#flag_short_string, #flag_long_string};
 
 // Get the registered flag value. This macro should only be used when calling the
 // 'setResponseFlag' method in the StreamInfo class.
@@ -40,9 +40,9 @@ private:
 // // header.h
 // ResponseFlag getRegisteredFlag();
 // // source.cc
-// REGISTER_CUSTOM_RESPONSE_FLAG(short, long);
-// ResponseFlag getRegisteredFlag() { return CUSTOM_RESPONSE_FLAG(short); }
-#define CUSTOM_RESPONSE_FLAG(short) registered_##short.flag()
+// REGISTER_CUSTOM_RESPONSE_FLAG(CF, CustomFlag);
+// ResponseFlag getRegisteredFlag() { return CUSTOM_RESPONSE_FLAG(CF); }
+#define CUSTOM_RESPONSE_FLAG(flag_short_string) registered_##flag_short_string.flag()
 
 /**
  * Util class for ResponseFlags.

--- a/source/common/stream_info/utility.h
+++ b/source/common/stream_info/utility.h
@@ -15,10 +15,10 @@ namespace StreamInfo {
 class CustomResponseFlag {
 public:
   CustomResponseFlag(absl::string_view flag, absl::string_view flag_long);
-  ExtendedResponseFlag flag() const { return flag_; }
+  ResponseFlag flag() const { return flag_; }
 
 private:
-  ExtendedResponseFlag flag_;
+  ResponseFlag flag_;
 };
 
 // Register a custom response flag by specifying the flag and the long name of the flag.
@@ -38,10 +38,10 @@ private:
 // macro and cannot be used to initialize another static variable):
 //
 // // header.h
-// ExtendedResponseFlag getRegisteredFlag();
+// ResponseFlag getRegisteredFlag();
 // // source.cc
 // REGISTER_CUSTOM_RESPONSE_FLAG(short, long);
-// ExtendedResponseFlag getRegisteredFlag() { return CUSTOM_RESPONSE_FLAG(short); }
+// ResponseFlag getRegisteredFlag() { return CUSTOM_RESPONSE_FLAG(short); }
 #define CUSTOM_RESPONSE_FLAG(short) registered_##short.flag()
 
 /**
@@ -51,15 +51,16 @@ class ResponseFlagUtils {
 public:
   static const std::string toString(const StreamInfo& stream_info);
   static const std::string toShortString(const StreamInfo& stream_info);
-  static absl::optional<ExtendedResponseFlag> toResponseFlag(absl::string_view response_flag);
+  static absl::optional<ResponseFlag> toResponseFlag(absl::string_view response_flag);
 
   struct FlagStrings {
     absl::string_view short_string_;
     absl::string_view long_string_; // PascalCase string
+    ResponseFlag flag_;
   };
 
   struct FlagLongString {
-    ExtendedResponseFlag flag_;
+    ResponseFlag flag_;
     std::string long_string_; // PascalCase string
   };
 
@@ -70,8 +71,6 @@ public:
   using ResponseFlagsMapType = absl::node_hash_map<std::string, FlagLongString>;
   static const ResponseFlagsVecType& responseFlagsVec();
   static const ResponseFlagsMapType& responseFlagsMap();
-
-  using FlagStringsAndEnum = std::pair<const FlagStrings, ResponseFlag>;
 
   // When adding a new flag, it's required to update the access log docs and the string
   // mapping below - ``CORE_RESPONSE_FLAGS``.
@@ -141,54 +140,51 @@ public:
   constexpr static absl::string_view DROP_OVERLOAD_LONG = "DropOverload";
 
   static constexpr std::array CORE_RESPONSE_FLAGS{
-      FlagStringsAndEnum{{FAILED_LOCAL_HEALTH_CHECK, FAILED_LOCAL_HEALTH_CHECK_LONG},
-                         ResponseFlag::FailedLocalHealthCheck},
-      FlagStringsAndEnum{{NO_HEALTHY_UPSTREAM, NO_HEALTHY_UPSTREAM_LONG},
-                         ResponseFlag::NoHealthyUpstream},
-      FlagStringsAndEnum{{UPSTREAM_REQUEST_TIMEOUT, UPSTREAM_REQUEST_TIMEOUT_LONG},
-                         ResponseFlag::UpstreamRequestTimeout},
-      FlagStringsAndEnum{{LOCAL_RESET, LOCAL_RESET_LONG}, ResponseFlag::LocalReset},
-      FlagStringsAndEnum{{UPSTREAM_REMOTE_RESET, UPSTREAM_REMOTE_RESET_LONG},
-                         ResponseFlag::UpstreamRemoteReset},
-      FlagStringsAndEnum{{UPSTREAM_CONNECTION_FAILURE, UPSTREAM_CONNECTION_FAILURE_LONG},
-                         ResponseFlag::UpstreamConnectionFailure},
-      FlagStringsAndEnum{{UPSTREAM_CONNECTION_TERMINATION, UPSTREAM_CONNECTION_TERMINATION_LONG},
-                         ResponseFlag::UpstreamConnectionTermination},
-      FlagStringsAndEnum{{UPSTREAM_OVERFLOW, UPSTREAM_OVERFLOW_LONG},
-                         ResponseFlag::UpstreamOverflow},
-      FlagStringsAndEnum{{NO_ROUTE_FOUND, NO_ROUTE_FOUND_LONG}, ResponseFlag::NoRouteFound},
-      FlagStringsAndEnum{{DELAY_INJECTED, DELAY_INJECTED_LONG}, ResponseFlag::DelayInjected},
-      FlagStringsAndEnum{{FAULT_INJECTED, FAULT_INJECTED_LONG}, ResponseFlag::FaultInjected},
-      FlagStringsAndEnum{{RATE_LIMITED, RATE_LIMITED_LONG}, ResponseFlag::RateLimited},
-      FlagStringsAndEnum{{UNAUTHORIZED_EXTERNAL_SERVICE, UNAUTHORIZED_EXTERNAL_SERVICE_LONG},
-                         ResponseFlag::UnauthorizedExternalService},
-      FlagStringsAndEnum{{RATELIMIT_SERVICE_ERROR, RATELIMIT_SERVICE_ERROR_LONG},
-                         ResponseFlag::RateLimitServiceError},
-      FlagStringsAndEnum{
-          {DOWNSTREAM_CONNECTION_TERMINATION, DOWNSTREAM_CONNECTION_TERMINATION_LONG},
-          ResponseFlag::DownstreamConnectionTermination},
-      FlagStringsAndEnum{{UPSTREAM_RETRY_LIMIT_EXCEEDED, UPSTREAM_RETRY_LIMIT_EXCEEDED_LONG},
-                         ResponseFlag::UpstreamRetryLimitExceeded},
-      FlagStringsAndEnum{{STREAM_IDLE_TIMEOUT, STREAM_IDLE_TIMEOUT_LONG},
-                         ResponseFlag::StreamIdleTimeout},
-      FlagStringsAndEnum{{INVALID_ENVOY_REQUEST_HEADERS, INVALID_ENVOY_REQUEST_HEADERS_LONG},
-                         ResponseFlag::InvalidEnvoyRequestHeaders},
-      FlagStringsAndEnum{{DOWNSTREAM_PROTOCOL_ERROR, DOWNSTREAM_PROTOCOL_ERROR_LONG},
-                         ResponseFlag::DownstreamProtocolError},
-      FlagStringsAndEnum{
-          {UPSTREAM_MAX_STREAM_DURATION_REACHED, UPSTREAM_MAX_STREAM_DURATION_REACHED_LONG},
-          ResponseFlag::UpstreamMaxStreamDurationReached},
-      FlagStringsAndEnum{{RESPONSE_FROM_CACHE_FILTER, RESPONSE_FROM_CACHE_FILTER_LONG},
-                         ResponseFlag::ResponseFromCacheFilter},
-      FlagStringsAndEnum{{NO_FILTER_CONFIG_FOUND, NO_FILTER_CONFIG_FOUND_LONG},
-                         ResponseFlag::NoFilterConfigFound},
-      FlagStringsAndEnum{{DURATION_TIMEOUT, DURATION_TIMEOUT_LONG}, ResponseFlag::DurationTimeout},
-      FlagStringsAndEnum{{UPSTREAM_PROTOCOL_ERROR, UPSTREAM_PROTOCOL_ERROR_LONG},
-                         ResponseFlag::UpstreamProtocolError},
-      FlagStringsAndEnum{{NO_CLUSTER_FOUND, NO_CLUSTER_FOUND_LONG}, ResponseFlag::NoClusterFound},
-      FlagStringsAndEnum{{OVERLOAD_MANAGER, OVERLOAD_MANAGER_LONG}, ResponseFlag::OverloadManager},
-      FlagStringsAndEnum{{DNS_FAIL, DNS_FAIL_LONG}, ResponseFlag::DnsResolutionFailed},
-      FlagStringsAndEnum{{DROP_OVERLOAD, DROP_OVERLOAD_LONG}, ResponseFlag::DropOverLoad},
+      FlagStrings{FAILED_LOCAL_HEALTH_CHECK, FAILED_LOCAL_HEALTH_CHECK_LONG,
+                  CoreResponseFlag::FailedLocalHealthCheck},
+      FlagStrings{NO_HEALTHY_UPSTREAM, NO_HEALTHY_UPSTREAM_LONG,
+                  CoreResponseFlag::NoHealthyUpstream},
+      FlagStrings{UPSTREAM_REQUEST_TIMEOUT, UPSTREAM_REQUEST_TIMEOUT_LONG,
+                  CoreResponseFlag::UpstreamRequestTimeout},
+      FlagStrings{LOCAL_RESET, LOCAL_RESET_LONG, CoreResponseFlag::LocalReset},
+      FlagStrings{UPSTREAM_REMOTE_RESET, UPSTREAM_REMOTE_RESET_LONG,
+                  CoreResponseFlag::UpstreamRemoteReset},
+      FlagStrings{UPSTREAM_CONNECTION_FAILURE, UPSTREAM_CONNECTION_FAILURE_LONG,
+                  CoreResponseFlag::UpstreamConnectionFailure},
+      FlagStrings{UPSTREAM_CONNECTION_TERMINATION, UPSTREAM_CONNECTION_TERMINATION_LONG,
+                  CoreResponseFlag::UpstreamConnectionTermination},
+      FlagStrings{UPSTREAM_OVERFLOW, UPSTREAM_OVERFLOW_LONG, CoreResponseFlag::UpstreamOverflow},
+      FlagStrings{NO_ROUTE_FOUND, NO_ROUTE_FOUND_LONG, CoreResponseFlag::NoRouteFound},
+      FlagStrings{DELAY_INJECTED, DELAY_INJECTED_LONG, CoreResponseFlag::DelayInjected},
+      FlagStrings{FAULT_INJECTED, FAULT_INJECTED_LONG, CoreResponseFlag::FaultInjected},
+      FlagStrings{RATE_LIMITED, RATE_LIMITED_LONG, CoreResponseFlag::RateLimited},
+      FlagStrings{UNAUTHORIZED_EXTERNAL_SERVICE, UNAUTHORIZED_EXTERNAL_SERVICE_LONG,
+                  CoreResponseFlag::UnauthorizedExternalService},
+      FlagStrings{RATELIMIT_SERVICE_ERROR, RATELIMIT_SERVICE_ERROR_LONG,
+                  CoreResponseFlag::RateLimitServiceError},
+      FlagStrings{DOWNSTREAM_CONNECTION_TERMINATION, DOWNSTREAM_CONNECTION_TERMINATION_LONG,
+                  CoreResponseFlag::DownstreamConnectionTermination},
+      FlagStrings{UPSTREAM_RETRY_LIMIT_EXCEEDED, UPSTREAM_RETRY_LIMIT_EXCEEDED_LONG,
+                  CoreResponseFlag::UpstreamRetryLimitExceeded},
+      FlagStrings{STREAM_IDLE_TIMEOUT, STREAM_IDLE_TIMEOUT_LONG,
+                  CoreResponseFlag::StreamIdleTimeout},
+      FlagStrings{INVALID_ENVOY_REQUEST_HEADERS, INVALID_ENVOY_REQUEST_HEADERS_LONG,
+                  CoreResponseFlag::InvalidEnvoyRequestHeaders},
+      FlagStrings{DOWNSTREAM_PROTOCOL_ERROR, DOWNSTREAM_PROTOCOL_ERROR_LONG,
+                  CoreResponseFlag::DownstreamProtocolError},
+      FlagStrings{UPSTREAM_MAX_STREAM_DURATION_REACHED, UPSTREAM_MAX_STREAM_DURATION_REACHED_LONG,
+                  CoreResponseFlag::UpstreamMaxStreamDurationReached},
+      FlagStrings{RESPONSE_FROM_CACHE_FILTER, RESPONSE_FROM_CACHE_FILTER_LONG,
+                  CoreResponseFlag::ResponseFromCacheFilter},
+      FlagStrings{NO_FILTER_CONFIG_FOUND, NO_FILTER_CONFIG_FOUND_LONG,
+                  CoreResponseFlag::NoFilterConfigFound},
+      FlagStrings{DURATION_TIMEOUT, DURATION_TIMEOUT_LONG, CoreResponseFlag::DurationTimeout},
+      FlagStrings{UPSTREAM_PROTOCOL_ERROR, UPSTREAM_PROTOCOL_ERROR_LONG,
+                  CoreResponseFlag::UpstreamProtocolError},
+      FlagStrings{NO_CLUSTER_FOUND, NO_CLUSTER_FOUND_LONG, CoreResponseFlag::NoClusterFound},
+      FlagStrings{OVERLOAD_MANAGER, OVERLOAD_MANAGER_LONG, CoreResponseFlag::OverloadManager},
+      FlagStrings{DNS_FAIL, DNS_FAIL_LONG, CoreResponseFlag::DnsResolutionFailed},
+      FlagStrings{DROP_OVERLOAD, DROP_OVERLOAD_LONG, CoreResponseFlag::DropOverLoad},
   };
 
 private:
@@ -204,8 +200,7 @@ private:
    * string.
    * @return uint16_t the flag value.
    */
-  static ExtendedResponseFlag registerCustomFlag(absl::string_view flag,
-                                                 absl::string_view flag_long);
+  static ResponseFlag registerCustomFlag(absl::string_view flag, absl::string_view flag_long);
   static ResponseFlagsMapType& mutableResponseFlagsMap();
 };
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -417,7 +417,7 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
       ENVOY_CONN_LOG(debug, "Cluster not found {} and no on demand cluster set.",
                      read_callbacks_->connection(), cluster_name);
       config_->stats().downstream_cx_no_route_.inc();
-      getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoClusterFound);
+      getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoClusterFound);
       onInitFailure(UpstreamFailureReason::NoRoute);
     } else {
       ASSERT(!cluster_discovery_handle_);
@@ -445,7 +445,7 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
   // Check this here because the TCP conn pool will queue our request waiting for a connection that
   // will never be released.
   if (!cluster->resourceManager(Upstream::ResourcePriority::Default).connections().canCreate()) {
-    getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
+    getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow);
     cluster->trafficStats()->upstream_cx_overflow_.inc();
     onInitFailure(UpstreamFailureReason::ResourceLimitExceeded);
     return Network::FilterStatus::StopIteration;
@@ -453,7 +453,7 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
 
   const uint32_t max_connect_attempts = config_->maxConnectAttempts();
   if (connect_attempts_ >= max_connect_attempts) {
-    getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded);
+    getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRetryLimitExceeded);
     cluster->trafficStats()->upstream_cx_connect_attempts_exceeded_.inc();
     onInitFailure(UpstreamFailureReason::ConnectFailed);
     return Network::FilterStatus::StopIteration;
@@ -487,7 +487,7 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
   if (!maybeTunnel(*thread_local_cluster)) {
     // Either cluster is unknown or there are no healthy hosts. tcpConnPool() increments
     // cluster->trafficStats()->upstream_cx_none_healthy in the latter case.
-    getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream);
+    getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream);
     onInitFailure(UpstreamFailureReason::NoHealthyUpstream);
   }
   return Network::FilterStatus::StopIteration;
@@ -520,7 +520,7 @@ void Filter::onClusterDiscoveryCompletion(Upstream::ClusterDiscoveryStatus clust
   }
   // Failure path.
   config_->stats().downstream_cx_no_route_.inc();
-  getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoClusterFound);
+  getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoClusterFound);
   onInitFailure(UpstreamFailureReason::NoRoute);
 }
 
@@ -685,7 +685,7 @@ void Filter::onConnectTimeout() {
   ENVOY_CONN_LOG(debug, "connect timeout", read_callbacks_->connection());
   read_callbacks_->upstreamHost()->outlierDetector().putResult(
       Upstream::Outlier::Result::LocalOriginTimeout);
-  getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
+  getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure);
 
   // Raise LocalClose, which will trigger a reconnect if needed/configured.
   upstream_callbacks_->onEvent(Network::ConnectionEvent::LocalClose);
@@ -799,7 +799,7 @@ void Filter::onUpstreamEvent(Network::ConnectionEvent event) {
 
     if (connecting) {
       if (event == Network::ConnectionEvent::RemoteClose) {
-        getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
+        getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure);
         read_callbacks_->upstreamHost()->outlierDetector().putResult(
             Upstream::Outlier::Result::LocalOriginConnectFailed);
       }
@@ -864,7 +864,7 @@ void Filter::onIdleTimeout() {
 
 void Filter::onMaxDownstreamConnectionDuration() {
   ENVOY_CONN_LOG(debug, "max connection duration reached", read_callbacks_->connection());
-  getStreamInfo().setResponseFlag(StreamInfo::ResponseFlag::DurationTimeout);
+  getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::DurationTimeout);
   config_->stats().max_downstream_connection_duration_.inc();
   read_callbacks_->connection().close(
       Network::ConnectionCloseType::NoFlush,

--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
@@ -41,114 +41,115 @@ void Utility::responseFlagsToAccessLogResponseFlags(
     envoy::data::accesslog::v3::AccessLogCommon& common_access_log,
     const StreamInfo::StreamInfo& stream_info) {
 
-  static_assert(StreamInfo::ResponseFlag::LastFlag == 27, "A flag has been added. Fix this code.");
+  static_assert(StreamInfo::CoreResponseFlag::LastFlag == 27,
+                "A flag has been added. Fix this code.");
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::FailedLocalHealthCheck)) {
     common_access_log.mutable_response_flags()->set_failed_local_healthcheck(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream)) {
     common_access_log.mutable_response_flags()->set_no_healthy_upstream(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout)) {
     common_access_log.mutable_response_flags()->set_upstream_request_timeout(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::LocalReset)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::LocalReset)) {
     common_access_log.mutable_response_flags()->set_local_reset(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamRemoteReset)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRemoteReset)) {
     common_access_log.mutable_response_flags()->set_upstream_remote_reset(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure)) {
     common_access_log.mutable_response_flags()->set_upstream_connection_failure(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionTermination)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionTermination)) {
     common_access_log.mutable_response_flags()->set_upstream_connection_termination(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow)) {
     common_access_log.mutable_response_flags()->set_upstream_overflow(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::NoRouteFound)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound)) {
     common_access_log.mutable_response_flags()->set_no_route_found(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::DelayInjected)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected)) {
     common_access_log.mutable_response_flags()->set_delay_injected(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::FaultInjected)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected)) {
     common_access_log.mutable_response_flags()->set_fault_injected(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::RateLimited)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::RateLimited)) {
     common_access_log.mutable_response_flags()->set_rate_limited(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UnauthorizedExternalService)) {
     common_access_log.mutable_response_flags()->mutable_unauthorized_details()->set_reason(
         envoy::data::accesslog::v3::ResponseFlags::Unauthorized::EXTERNAL_SERVICE);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::RateLimitServiceError)) {
     common_access_log.mutable_response_flags()->set_rate_limit_service_error(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::DownstreamConnectionTermination)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::DownstreamConnectionTermination)) {
     common_access_log.mutable_response_flags()->set_downstream_connection_termination(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRetryLimitExceeded)) {
     common_access_log.mutable_response_flags()->set_upstream_retry_limit_exceeded(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::StreamIdleTimeout)) {
     common_access_log.mutable_response_flags()->set_stream_idle_timeout(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::InvalidEnvoyRequestHeaders)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::InvalidEnvoyRequestHeaders)) {
     common_access_log.mutable_response_flags()->set_invalid_envoy_request_headers(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::DownstreamProtocolError)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::DownstreamProtocolError)) {
     common_access_log.mutable_response_flags()->set_downstream_protocol_error(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamMaxStreamDurationReached)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamMaxStreamDurationReached)) {
     common_access_log.mutable_response_flags()->set_upstream_max_stream_duration_reached(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::ResponseFromCacheFilter)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::ResponseFromCacheFilter)) {
     common_access_log.mutable_response_flags()->set_response_from_cache_filter(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::NoFilterConfigFound)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::NoFilterConfigFound)) {
     common_access_log.mutable_response_flags()->set_no_filter_config_found(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::DurationTimeout)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::DurationTimeout)) {
     common_access_log.mutable_response_flags()->set_duration_timeout(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::UpstreamProtocolError)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError)) {
     common_access_log.mutable_response_flags()->set_upstream_protocol_error(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::NoClusterFound)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::NoClusterFound)) {
     common_access_log.mutable_response_flags()->set_no_cluster_found(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::OverloadManager)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::OverloadManager)) {
     common_access_log.mutable_response_flags()->set_overload_manager(true);
   }
 
-  if (stream_info.hasResponseFlag(StreamInfo::ResponseFlag::DnsResolutionFailed)) {
+  if (stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::DnsResolutionFailed)) {
     common_access_log.mutable_response_flags()->set_dns_resolution_failure(true);
   }
 }

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -641,7 +641,7 @@ void CacheFilter::encodeCachedResponse() {
           ? static_cast<Http::StreamFilterCallbacks*>(decoder_callbacks_)
           : static_cast<Http::StreamFilterCallbacks*>(encoder_callbacks_);
 
-  callbacks->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::ResponseFromCacheFilter);
+  callbacks->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::ResponseFromCacheFilter);
   callbacks->streamInfo().setResponseCodeDetails(
       CacheResponseCodeDetails::get().ResponseFromCacheFilter);
 

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -379,7 +379,8 @@ void ProxyFilter::onDnsResolutionFail() {
     return;
   }
 
-  decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DnsResolutionFailed);
+  decoder_callbacks_->streamInfo().setResponseFlag(
+      StreamInfo::CoreResponseFlag::DnsResolutionFailed);
   decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable,
                                      ResponseStrings::get().DnsResolutionFailure, nullptr,
                                      absl::nullopt, RcDetails::get().DnsResolutionFailure);

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -136,7 +136,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
       ENVOY_STREAM_LOG(trace, "ext_authz filter is disabled. Deny the request.",
                        *decoder_callbacks_);
       decoder_callbacks_->streamInfo().setResponseFlag(
-          StreamInfo::ResponseFlag::UnauthorizedExternalService);
+          StreamInfo::CoreResponseFlag::UnauthorizedExternalService);
       decoder_callbacks_->sendLocalReply(
           config_->statusOnError(), EMPTY_STRING, nullptr, absl::nullopt,
           Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzError);
@@ -422,7 +422,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
 
     // setResponseFlag must be called before sendLocalReply
     decoder_callbacks_->streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UnauthorizedExternalService);
+        StreamInfo::CoreResponseFlag::UnauthorizedExternalService);
     decoder_callbacks_->sendLocalReply(
         response->status_code, response->body,
         [&headers = response->headers_to_set,
@@ -467,7 +467,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
           trace, "ext_authz filter rejected the request with an error. Response status code: {}",
           *decoder_callbacks_, enumToInt(config_->statusOnError()));
       decoder_callbacks_->streamInfo().setResponseFlag(
-          StreamInfo::ResponseFlag::UnauthorizedExternalService);
+          StreamInfo::CoreResponseFlag::UnauthorizedExternalService);
       decoder_callbacks_->sendLocalReply(
           config_->statusOnError(), EMPTY_STRING, nullptr, absl::nullopt,
           Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzError);

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -169,7 +169,7 @@ bool FaultFilter::maybeSetupDelay(const Http::RequestHeaderMap& request_headers)
     ENVOY_LOG(debug, "fault: delaying request {}ms", duration.value().count());
     delay_timer_->enableTimer(duration.value(), &decoder_callbacks_->scope());
     recordDelaysInjectedStats();
-    decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DelayInjected);
+    decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected);
     auto& dynamic_metadata = decoder_callbacks_->streamInfo().dynamicMetadata();
     (*dynamic_metadata.mutable_filter_metadata())[decoder_callbacks_->filterConfigName()] =
         fault_settings_->filterMetadata();
@@ -470,7 +470,7 @@ void FaultFilter::postDelayInjection(const Http::RequestHeaderMap& request_heade
 void FaultFilter::abortWithStatus(Http::Code http_status_code,
                                   absl::optional<Grpc::Status::GrpcStatus> grpc_status) {
   recordAbortsInjectedStats();
-  decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FaultInjected);
+  decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected);
   auto& dynamic_metadata = decoder_callbacks_->streamInfo().dynamicMetadata();
   (*dynamic_metadata.mutable_filter_metadata())[decoder_callbacks_->filterConfigName()] =
       fault_settings_->filterMetadata();

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -120,7 +120,7 @@ void HealthCheckFilter::onComplete() {
   const std::string* details = &RcDetails::get().HealthCheckOk;
   bool degraded = false;
   if (context_.healthCheckFailed()) {
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::FailedLocalHealthCheck);
     final_status = Http::Code::ServiceUnavailable;
     details = &RcDetails::get().HealthCheckFailed;
   } else {
@@ -171,7 +171,8 @@ void HealthCheckFilter::onComplete() {
     }
 
     if (!Http::CodeUtility::is2xx(enumToInt(final_status))) {
-      callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck);
+      callbacks_->streamInfo().setResponseFlag(
+          StreamInfo::CoreResponseFlag::FailedLocalHealthCheck);
     }
   }
 

--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
@@ -152,7 +152,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         config->responseHeadersParser().evaluateHeaders(headers, decoder_callbacks_->streamInfo());
       },
       config->rateLimitedGrpcStatus(), "local_rate_limited");
-  decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
+  decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited);
 
   return Http::FilterHeadersStatus::StopIteration;
 }

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -194,7 +194,7 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::processCachedBucket(size_t bucke
         // configured.
         callbacks_->sendLocalReply(Envoy::Http::Code::TooManyRequests, "", nullptr, absl::nullopt,
                                    "");
-        callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
+        callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited);
         return Envoy::Http::FilterHeadersStatus::StopIteration;
       }
     }

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -199,7 +199,7 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
   if (status == Filters::Common::RateLimit::LimitStatus::OverLimit &&
       config_->runtime().snapshot().featureEnabled("ratelimit.http_filter_enforcing", 100)) {
     state_ = State::Responded;
-    callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
+    callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited);
     callbacks_->sendLocalReply(
         config_->rateLimitedStatus(), response_body,
         [this](Http::HeaderMap& headers) {
@@ -218,7 +218,7 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
       }
     } else {
       state_ = State::Responded;
-      callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError);
+      callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::RateLimitServiceError);
       callbacks_->sendLocalReply(config_->statusOnError(), response_body, nullptr, absl::nullopt,
                                  RcDetails::get().RateLimitError);
     }

--- a/source/extensions/filters/network/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/network/ext_authz/ext_authz.cc
@@ -108,7 +108,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     config_->stats().cx_closed_.inc();
     filter_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush, "ext_authz_close");
     filter_callbacks_->connection().streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UnauthorizedExternalService);
+        StreamInfo::CoreResponseFlag::UnauthorizedExternalService);
     filter_callbacks_->connection().streamInfo().setResponseCodeDetails(
         response->status == Filters::Common::ExtAuthz::CheckStatus::Denied
             ? Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzDenied

--- a/source/extensions/filters/network/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/network/local_ratelimit/local_ratelimit.cc
@@ -107,7 +107,7 @@ Network::FilterStatus Filter::onNewConnection() {
     ENVOY_CONN_LOG(trace, "local_rate_limit: rate limiting connection",
                    read_callbacks_->connection());
     read_callbacks_->connection().streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded);
+        StreamInfo::CoreResponseFlag::UpstreamRetryLimitExceeded);
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush,
                                         "local_ratelimit_close_over_limit");
     return Network::FilterStatus::StopIteration;

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -90,7 +90,7 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
           ThriftProxy::AppException(ThriftProxy::AppExceptionType::InternalError, "limiter error"),
           false);
       decoder_callbacks_->streamInfo().setResponseFlag(
-          StreamInfo::ResponseFlag::RateLimitServiceError);
+          StreamInfo::CoreResponseFlag::RateLimitServiceError);
       return;
     }
     cluster_->statsScope().counterFromStatName(stat_names.failure_mode_allowed_).inc();
@@ -102,7 +102,7 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
       decoder_callbacks_->sendLocalReply(
           ThriftProxy::AppException(ThriftProxy::AppExceptionType::InternalError, "over limit"),
           false);
-      decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::RateLimited);
+      decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited);
       return;
     }
     break;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -91,7 +91,7 @@ typed_config:
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
   EXPECT_CALL(*file_, write(_));
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure);
   request_headers_.addCopy(Http::Headers::get().UserAgent, "user-agent-set");
   request_headers_.addCopy(Http::Headers::get().RequestId, "id");
   request_headers_.addCopy(Http::Headers::get().Host, "host");
@@ -118,7 +118,7 @@ typed_config:
   auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
   stream_info_.upstreamInfo()->setUpstreamHost(
       Upstream::makeTestHostDescription(cluster, "tcp://10.0.0.5:1234", simTime()));
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamConnectionTermination);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::DownstreamConnectionTermination);
 
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
   EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET / HTTP/1.1\" 0 DC 1 2 3 - \"-\" \"-\" \"-\" \"-\" "
@@ -135,7 +135,7 @@ void AccessLogImplTest::routeNameTest(std::string yaml, bool omit_empty) {
   route->route_name_ = "route-test-name";
 
   stream_info_.route_ = route;
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure);
   request_headers_.addCopy(Http::Headers::get().UserAgent, "user-agent-set");
   request_headers_.addCopy(Http::Headers::get().RequestId, "id");
   request_headers_.addCopy(Http::Headers::get().Host, "host");
@@ -977,7 +977,7 @@ typed_config:
   EXPECT_CALL(*file_, write(_)).Times(0);
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound);
   EXPECT_CALL(*file_, write(_));
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 }
@@ -999,11 +999,11 @@ typed_config:
   EXPECT_CALL(*file_, write(_)).Times(0);
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound);
   EXPECT_CALL(*file_, write(_)).Times(0);
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow);
   EXPECT_CALL(*file_, write(_));
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 }
@@ -1026,11 +1026,11 @@ typed_config:
   EXPECT_CALL(*file_, write(_)).Times(0);
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound);
   EXPECT_CALL(*file_, write(_)).Times(0);
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 
-  stream_info_.setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow);
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow);
   EXPECT_CALL(*file_, write(_));
   log->log({&request_headers_, &response_headers_, &response_trailers_}, stream_info_);
 }
@@ -1076,9 +1076,10 @@ typed_config:
 
   InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
-  for (const auto& [flag_strings, response_flag] :
+  for (const auto& [short_string, long_string, response_flag] :
        StreamInfo::ResponseFlagUtils::CORE_RESPONSE_FLAGS) {
-    UNREFERENCED_PARAMETER(flag_strings);
+    UNREFERENCED_PARAMETER(short_string);
+    UNREFERENCED_PARAMETER(long_string);
 
     TestStreamInfo stream_info(time_source_);
     stream_info.setResponseFlag(response_flag);

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -540,7 +540,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
 
   {
     StreamInfoFormatter response_flags_format("RESPONSE_FLAGS");
-    stream_info.setResponseFlag(StreamInfo::ResponseFlag::LocalReset);
+    stream_info.setResponseFlag(StreamInfo::CoreResponseFlag::LocalReset);
     EXPECT_EQ("LR", response_flags_format.formatWithContext({}, stream_info));
     EXPECT_THAT(response_flags_format.formatValueWithContext({}, stream_info),
                 ProtoEq(ValueUtil::stringValue("LR")));
@@ -548,7 +548,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
 
   {
     StreamInfoFormatter response_flags_format("RESPONSE_FLAGS_LONG");
-    stream_info.setResponseFlag(StreamInfo::ResponseFlag::LocalReset);
+    stream_info.setResponseFlag(StreamInfo::CoreResponseFlag::LocalReset);
     EXPECT_EQ("LocalReset", response_flags_format.formatWithContext({}, stream_info));
     EXPECT_THAT(response_flags_format.formatValueWithContext({}, stream_info),
                 ProtoEq(ValueUtil::stringValue("LocalReset")));

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -231,8 +231,8 @@ void HttpConnectionManagerImplMixin::sendRequestHeadersAndData() {
 }
 
 ResponseHeaderMap* HttpConnectionManagerImplMixin::sendResponseHeaders(
-    ResponseHeaderMapPtr&& response_headers, absl::optional<StreamInfo::ResponseFlag> response_flag,
-    std::string response_code_details) {
+    ResponseHeaderMapPtr&& response_headers,
+    absl::optional<StreamInfo::CoreResponseFlag> response_flag, std::string response_code_details) {
   ResponseHeaderMap* altered_response_headers = nullptr;
 
   EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, _))

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -53,7 +53,7 @@ public:
   void sendRequestHeadersAndData();
   ResponseHeaderMap*
   sendResponseHeaders(ResponseHeaderMapPtr&& response_headers,
-                      absl::optional<StreamInfo::ResponseFlag> response_flag = absl::nullopt,
+                      absl::optional<StreamInfo::CoreResponseFlag> response_flag = absl::nullopt,
                       std::string response_code_details = "details");
   void expectOnDestroy(bool deferred = true);
   void doRemoteClose(bool deferred = true);

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -204,7 +204,7 @@ TEST(HeaderParserTest, TestParse) {
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
   ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
 
-  stream_info.setResponseFlag(StreamInfo::ResponseFlag::LocalReset);
+  stream_info.setResponseFlag(StreamInfo::CoreResponseFlag::LocalReset);
 
   absl::optional<std::string> rc_details{"via_upstream"};
   ON_CALL(stream_info, responseCodeDetails()).WillByDefault(ReturnRef(rc_details));

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -50,7 +50,8 @@ TEST_F(RouterTestSuppressEnvoyHeaders, MaintenanceMode) {
       {":status", "503"}, {"content-length", "16"}, {"content-type", "text/plain"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow));
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -98,7 +99,8 @@ TEST_F(RouterTestSuppressEnvoyHeaders, EnvoyAttemptCountInResponseNotPresent) {
       {":status", "503"}, {"content-length", "16"}, {"content-type", "text/plain"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow));
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -371,7 +373,7 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
   expectNewStreamWithImmediateEncoder(encoder1, &response_decoder, Http::Protocol::Http10);
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRemoteReset));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRemoteReset));
 
   Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
   HttpTestUtility::addDefaultHeaders(headers);
@@ -731,7 +733,7 @@ TEST_P(RouterTestStrictCheckOneHeader, SingleInvalidHeader) {
   auto checked_header = GetParam();
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::InvalidEnvoyRequestHeaders));
+              setResponseFlag(StreamInfo::CoreResponseFlag::InvalidEnvoyRequestHeaders));
 
   EXPECT_CALL(callbacks_, encodeHeaders_(_, _))
       .WillOnce(Invoke([&](Http::ResponseHeaderMap& response_headers, bool end_stream) -> void {
@@ -808,7 +810,7 @@ TEST_P(RouterTestStrictCheckAllHeaders, MultipleInvalidHeaders) {
   HttpTestUtility::addDefaultHeaders(headers);
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::InvalidEnvoyRequestHeaders));
+              setResponseFlag(StreamInfo::CoreResponseFlag::InvalidEnvoyRequestHeaders));
 
   EXPECT_CALL(callbacks_, encodeHeaders_(_, _))
       .WillOnce(Invoke([&](Http::ResponseHeaderMap& response_headers, bool end_stream) -> void {
@@ -892,7 +894,7 @@ TEST_F(RouterTestSupressGRPCStatsEnabled, ExcludeTimeoutHttpStats) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -945,7 +947,7 @@ TEST_F(RouterTestSupressGRPCStatsDisabled, IncludeHttpTimeoutStats) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -316,7 +316,7 @@ TEST_F(RouterTest, UpdateSubjectAltNamesFilterStateWithIpHeaderOverride) {
 }
 
 TEST_F(RouterTest, RouteNotFound) {
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound));
+  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -355,7 +355,8 @@ TEST_F(RouterTest, MissingRequiredHeaders) {
 }
 
 TEST_F(RouterTest, ClusterNotFound) {
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::NoClusterFound));
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::NoClusterFound));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -387,7 +388,7 @@ TEST_F(RouterTest, PoolFailureWithPriority) {
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -420,7 +421,7 @@ TEST_F(RouterTest, PoolFailureDueToConnectTimeout) {
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -747,7 +748,7 @@ TEST_F(RouterTest, NoHost) {
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream));
+              setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -770,7 +771,8 @@ TEST_F(RouterTest, MaintenanceMode) {
                                                    {"x-envoy-overloaded", "true"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow));
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -817,7 +819,7 @@ TEST_F(RouterTest, DropOverloadDropped) {
                                                    {"x-envoy-drop-overload", "true"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::DropOverLoad));
+  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::CoreResponseFlag::DropOverLoad));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -1035,7 +1037,7 @@ TEST_F(RouterTest, EnvoyAttemptCountInResponsePresentWithLocalReply) {
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamConnectionFailure));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure));
 
   Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
@@ -1201,7 +1203,8 @@ TEST_F(RouterTest, NoRetriesOverflow) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   // RetryOverflow kicks in.
-  EXPECT_CALL(callbacks_.stream_info_, setResponseFlag(StreamInfo::ResponseFlag::UpstreamOverflow));
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamOverflow));
   EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _, _))
       .WillOnce(Return(RetryStatus::NoOverflow));
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->health_checker_, setUnhealthy(_))
@@ -1259,7 +1262,7 @@ TEST_F(RouterTest, UpstreamTimeoutAllStatsEmission) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "503"}});
@@ -1291,7 +1294,7 @@ TEST_F(RouterTest, UpstreamTimeout) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -1481,7 +1484,7 @@ TEST_F(RouterTest, TimeoutBudgetHistogramStatDuringRetries) {
 
   // Trigger second request failure.
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder2.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -1564,7 +1567,7 @@ TEST_F(RouterTest, TimeoutBudgetHistogramStatDuringGlobalTimeout) {
 
   // Trigger global timeout.
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder2.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -1800,7 +1803,7 @@ TEST_F(RouterTest, UpstreamTimeoutWithAltResponse) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{{":status", "204"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
@@ -1829,7 +1832,7 @@ TEST_F(RouterTest, UpstreamPerTryIdleTimeout) {
   router_->config().upstream_logs_.push_back(
       std::make_shared<TestAccessLog>([&](const auto& stream_info) {
         filter_state_verified =
-            stream_info.hasResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout);
+            stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::StreamIdleTimeout);
       }));
 
   NiceMock<Http::MockRequestEncoder> encoder;
@@ -1871,7 +1874,7 @@ TEST_F(RouterTest, UpstreamPerTryIdleTimeout) {
               putResult(Upstream::Outlier::Result::LocalOriginTimeout, _));
   EXPECT_CALL(*per_try_idle_timeout_, disableTimer());
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(*response_timeout_, disableTimer());
   EXPECT_CALL(callbacks_.stream_info_, setResponseCodeDetails("upstream_per_try_idle_timeout"));
   Http::TestResponseHeaderMapImpl response_headers{
@@ -1964,7 +1967,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeout) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -2018,7 +2021,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutDelayedPoolReady) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(encoder.stream_, resetStream(Http::StreamResetReason::LocalReset));
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -2077,7 +2080,7 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
               putResult(Upstream::Outlier::Result::LocalOriginTimeout, _));
   EXPECT_CALL(*per_try_timeout_, disableTimer());
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
   EXPECT_CALL(*response_timeout_, disableTimer());
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
@@ -3214,7 +3217,7 @@ TEST_F(RouterTest, RetryNoneHealthy) {
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::NoHealthyUpstream));
+              setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream));
   router_->retry_state_->callback_();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
   // Pool failure for the first try, so only 1 upstream request was made.
@@ -3666,7 +3669,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelay) {
 
   // Fire timeout.
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
 
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_, putResponseTime(_))
       .Times(0);
@@ -3815,7 +3818,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHost) {
   // Fire timeout.
   EXPECT_CALL(cancellable, cancel(_));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
 
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_, putResponseTime(_))
       .Times(0);
@@ -3868,7 +3871,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHostAltRespo
   // Fire timeout.
   EXPECT_CALL(cancellable, cancel(_));
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout));
 
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_, putResponseTime(_))
       .Times(0);

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -519,7 +519,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   absl::optional<uint32_t> response_code(503);
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(100));
-  stream_info.setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout);
+  stream_info.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRequestTimeout);
 
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("503")));

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -321,7 +321,7 @@ response: {}
     const std::string route_name("route-name-test");
     ON_CALL(stream_info, getRouteName()).WillByDefault(ReturnRef(route_name));
 
-    ON_CALL(stream_info, hasResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+    ON_CALL(stream_info, hasResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
         .WillByDefault(Return(true));
     stream_info.onRequestComplete();
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -949,7 +949,7 @@ TEST_F(HttpFilterTest, HeadersToRemoveRemovesHeadersExceptSpecialHeaders) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1004,7 +1004,7 @@ TEST_F(HttpFilterTest, ClearCache) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1051,7 +1051,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAppendOnly) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1095,7 +1095,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAddOnly) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1139,7 +1139,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToRemoveOnly) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1184,7 +1184,7 @@ TEST_F(HttpFilterTest, NoClearCacheRoute) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1222,7 +1222,7 @@ TEST_F(HttpFilterTest, NoClearCacheRouteConfig) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -2163,7 +2163,7 @@ TEST_P(HttpFilterTestParam, OkResponse) {
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
 
   Filters::Common::ExtAuthz::Response response{};
@@ -2525,7 +2525,7 @@ TEST_P(HttpFilterTestParam, DeniedResponseWith401) {
                      const StreamInfo::StreamInfo&) -> void { request_callbacks_ = &callbacks; }));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService));
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
@@ -2570,7 +2570,7 @@ TEST_P(HttpFilterTestParam, DeniedResponseWith401NoClusterResponseCodeStats) {
                      const StreamInfo::StreamInfo&) -> void { request_callbacks_ = &callbacks; }));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService));
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
@@ -2606,7 +2606,7 @@ TEST_P(HttpFilterTestParam, DeniedResponseWith403) {
                      const StreamInfo::StreamInfo&) -> void { request_callbacks_ = &callbacks; }));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService));
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
@@ -2817,7 +2817,7 @@ TEST_F(HttpFilterTest, EmitDynamicMetadata) {
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+              setResponseFlag(Envoy::StreamInfo::CoreResponseFlag::UnauthorizedExternalService))
       .Times(0);
   request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
 

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -246,7 +246,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected))
       .Times(0);
 
   // Abort related calls
@@ -266,7 +266,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -300,7 +300,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected))
       .Times(0);
 
   // Abort related calls
@@ -322,7 +322,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -356,7 +356,7 @@ TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected))
       .Times(0);
 
   // Abort related calls
@@ -377,7 +377,7 @@ TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
               encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -406,7 +406,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected))
       .Times(0);
 
   // Abort related calls
@@ -428,7 +428,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
               encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -457,7 +457,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpAndGrpcStatus) {
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected))
       .Times(0);
 
   // Abort related calls
@@ -479,7 +479,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpAndGrpcStatus) {
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -585,7 +585,7 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
@@ -593,7 +593,7 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
   EXPECT_EQ(1UL, config_->stats().active_faults_.value());
@@ -639,7 +639,7 @@ TEST_F(FaultFilterTest, ConsecutiveDelayFaults) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected))
       .Times(2);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_, dynamicMetadata())
       .WillOnce(ReturnRef(dynamic_metadata))
@@ -654,7 +654,7 @@ TEST_F(FaultFilterTest, ConsecutiveDelayFaults) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
   EXPECT_EQ(1UL, config_->stats().active_faults_.value());
@@ -720,7 +720,7 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
       .WillOnce(Return(500UL));
   expectDelayTimer(500UL);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -730,7 +730,7 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
@@ -769,7 +769,7 @@ TEST_F(FaultFilterTest, DelayForDownstreamClusterDisableTracing) {
       .WillOnce(Return(500UL));
   expectDelayTimer(500UL);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -779,7 +779,7 @@ TEST_F(FaultFilterTest, DelayForDownstreamClusterDisableTracing) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
@@ -828,7 +828,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   expectDelayTimer(500UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -854,7 +854,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   timer_->invokeCallback();
@@ -893,7 +893,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbort) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -915,7 +915,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbort) {
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
 
@@ -947,7 +947,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstreamNodes) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   request_headers_.addCopy("x-envoy-downstream-service-node", "canary");
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -969,7 +969,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstreamNodes) {
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
 
@@ -1011,7 +1011,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -1032,7 +1032,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
               encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected));
 
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
 
@@ -1095,7 +1095,7 @@ TEST_F(FaultFilterTest, TimerResetAfterStreamReset) {
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5000UL), _));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -1114,7 +1114,7 @@ TEST_F(FaultFilterTest, TimerResetAfterStreamReset) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
@@ -1149,7 +1149,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchSuccess) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
@@ -1157,7 +1157,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchSuccess) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   timer_->invokeCallback();
@@ -1254,7 +1254,7 @@ TEST_F(FaultFilterTest, RouteFaultOverridesListenerFault) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
 
@@ -1355,7 +1355,7 @@ TEST_F(FaultFilterRateLimitTest, DelayWithResponseRateLimitEnabled) {
   expectDelayTimer(5000UL);
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+              setResponseFlag(StreamInfo::CoreResponseFlag::DelayInjected));
 
   // Rate limiter related calls.
   ON_CALL(encoder_filter_callbacks_, encoderBufferLimit()).WillByDefault(Return(1100));
@@ -1369,7 +1369,7 @@ TEST_F(FaultFilterRateLimitTest, DelayWithResponseRateLimitEnabled) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+              setResponseFlag(StreamInfo::CoreResponseFlag::FaultInjected))
       .Times(0);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
   EXPECT_EQ(1UL, config_->stats().active_faults_.value());

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -241,7 +241,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, HealthCheckFailedCallbackCalled) {
       }));
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FailedLocalHealthCheck));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -311,7 +311,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedServiceUnavailableCallbackCalled) {
       }));
 
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FailedLocalHealthCheck));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, true));
@@ -351,7 +351,7 @@ TEST_F(HealthCheckFilterCachingTest, All) {
   // Verify that the next request uses the cached value without setting the degraded header.
   prepareFilter(true);
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FailedLocalHealthCheck));
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
       .Times(1)
       .WillRepeatedly(Invoke([&](Http::ResponseHeaderMap& headers, bool end_stream) {
@@ -385,7 +385,7 @@ TEST_F(HealthCheckFilterCachingTest, DegradedHeader) {
   // Verify that the next request uses the cached value and that the x-envoy-degraded header is set.
   prepareFilter(true);
   EXPECT_CALL(callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::FailedLocalHealthCheck));
+              setResponseFlag(StreamInfo::CoreResponseFlag::FailedLocalHealthCheck));
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true))
       .Times(1)
       .WillRepeatedly(Invoke([&](Http::ResponseHeaderMap& headers, bool end_stream) {

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -249,7 +249,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr,
                                nullptr, "", nullptr);
@@ -291,7 +291,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithHeaders) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
 
   Http::HeaderMapPtr request_headers_to_add{
@@ -347,7 +347,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithFilterHeaders) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
 
   auto descriptor_statuses = {
@@ -458,7 +458,7 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponse) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
 
   EXPECT_EQ(
@@ -486,7 +486,7 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimitServiceError));
 
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, true))
       .WillOnce(Invoke([&](const Http::ResponseHeaderMap& headers, bool) -> void {
@@ -523,7 +523,7 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponseWithFailureModeAllowOffAndCustomSta
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimitServiceError));
 
   EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, true))
       .WillOnce(Invoke([&](const Http::ResponseHeaderMap& headers, bool) -> void {
@@ -560,7 +560,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponse) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{
@@ -613,7 +613,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithDynamicMetadata) {
       }));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{
@@ -658,7 +658,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithHeaders) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::HeaderMapPtr rl_headers{new Http::TestResponseHeaderMapImpl{
       {"x-ratelimit-limit", "1000"}, {"x-ratelimit-remaining", "0"}, {"retry-after", "33"}}};
@@ -710,7 +710,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithBody) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   const std::string response_body = "this is a custom over limit response body.";
   const std::string content_length = std::to_string(response_body.length());
@@ -773,7 +773,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithBodyAndContentType) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   const std::string response_body = R"EOF(
   { "message": "this is a custom over limit response body as json.", "retry-after": "33" }
@@ -835,7 +835,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithFilterHeaders) {
           })));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -890,7 +890,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithoutEnvoyRateLimitedHeader) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{{":status", "429"}};
@@ -970,7 +970,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithRateLimitedStatus) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{
@@ -1011,7 +1011,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithInvalidRateLimitedStatus) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{
@@ -1642,7 +1642,7 @@ TEST_F(HttpRateLimitFilterTest, StatsWithPrefix) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl()};
   Http::TestResponseHeaderMapImpl response_headers{

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -871,7 +871,7 @@ TEST_F(ConnectionManagerTest, OnDataWithFilterSendsLocalReply) {
   // First filter sends local reply.
   EXPECT_CALL(*first_filter, onMessageDecoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr, ContextSharedPtr) -> FilterStatus {
-        callbacks->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+        callbacks->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::NoRouteFound);
         callbacks->sendLocalReply(direct_response, false);
         return FilterStatus::AbortIteration;
       }));

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -216,7 +216,7 @@ TEST_F(ExtAuthzFilterTest, DeniedWithOnData) {
 
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush, _));
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UnauthorizedExternalService));
   EXPECT_CALL(
       filter_callbacks_.connection_.stream_info_,
       setResponseCodeDetails(Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzDenied));
@@ -291,7 +291,7 @@ TEST_F(ExtAuthzFilterTest, FailClose) {
   EXPECT_CALL(filter_callbacks_.connection_, close(_, _));
   EXPECT_CALL(filter_callbacks_, continueReading()).Times(0);
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UnauthorizedExternalService));
   EXPECT_CALL(
       filter_callbacks_.connection_.stream_info_,
       setResponseCodeDetails(Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzError));
@@ -463,7 +463,7 @@ TEST_F(ExtAuthzFilterTest, ImmediateNOK) {
         EXPECT_TRUE(TestUtility::protoEqual(returned_dynamic_metadata, dynamic_metadata));
       }));
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UnauthorizedExternalService));
   EXPECT_CALL(
       filter_callbacks_.connection_.stream_info_,
       setResponseCodeDetails(Filters::Common::ExtAuthz::ResponseCodeDetails::get().AuthzDenied));

--- a/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
@@ -172,7 +172,7 @@ http_filters:
   Http::TestRequestHeaderMapImpl headers;
   missing_config_filter->setDecoderFilterCallbacks(decoder_callbacks);
   missing_config_filter->decodeHeaders(headers, false);
-  EXPECT_TRUE(stream_info.hasResponseFlag(StreamInfo::ResponseFlag::NoFilterConfigFound));
+  EXPECT_TRUE(stream_info.hasResponseFlag(StreamInfo::CoreResponseFlag::NoFilterConfigFound));
 }
 
 // Tests where upgrades are configured on via the HCM.

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
@@ -93,7 +93,7 @@ token_bucket:
   // Second connection should be rate limited.
   ActiveFilter active_filter2(config_);
   EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::UpstreamRetryLimitExceeded));
+              setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamRetryLimitExceeded));
   EXPECT_CALL(active_filter2.read_filter_callbacks_.connection_,
               close(Network::ConnectionCloseType::NoFlush, "local_ratelimit_close_over_limit"));
   EXPECT_EQ(Network::FilterStatus::StopIteration, active_filter2.filter_.onNewConnection());

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -224,7 +224,7 @@ TEST_F(ThriftRateLimitFilterTest, OkResponse) {
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OK, nullptr, nullptr,
                                nullptr, "", nullptr);
@@ -305,7 +305,7 @@ TEST_F(ThriftRateLimitFilterTest, ErrorResponse) {
 
   EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageEnd());
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
 
   EXPECT_EQ(
@@ -348,7 +348,7 @@ TEST_F(ThriftRateLimitFilterTest, ErrorResponseWithDynamicMetadata) {
 
   EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageEnd());
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited))
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited))
       .Times(0);
 
   EXPECT_EQ(
@@ -380,7 +380,7 @@ TEST_F(ThriftRateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
         EXPECT_EQ(ThriftProxy::AppExceptionType::InternalError, app_ex.type_);
       }));
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimitServiceError));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimitServiceError));
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::Error, nullptr, nullptr,
                                nullptr, "", nullptr);
 
@@ -414,7 +414,7 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponse) {
       }));
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr, nullptr,
                                nullptr, "", nullptr);
 
@@ -445,7 +445,7 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponseWithHeaders) {
   // TODO(zuercher): Headers are currently ignored, but sendLocalReply is the place to pass them.
   EXPECT_CALL(filter_callbacks_, sendLocalReply(_, false));
   EXPECT_CALL(filter_callbacks_.stream_info_,
-              setResponseFlag(StreamInfo::ResponseFlag::RateLimited));
+              setResponseFlag(StreamInfo::CoreResponseFlag::RateLimited));
 
   Http::ResponseHeaderMapPtr h{new Http::TestResponseHeaderMapImpl(*rl_headers)};
   request_callbacks_->complete(Filters::Common::RateLimit::LimitStatus::OverLimit, nullptr,

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -85,13 +85,12 @@ MockStreamInfo::MockStreamInfo()
   downstream_connection_info_provider_->setDirectRemoteAddressForTest(
       downstream_direct_remote_address);
 
-  ON_CALL(*this, setResponseFlag(_))
-      .WillByDefault(Invoke([this](ExtendedResponseFlag response_flag) {
-        auto iter = std::find(response_flags_.begin(), response_flags_.end(), response_flag);
-        if (iter == response_flags_.end()) {
-          response_flags_.push_back(response_flag);
-        }
-      }));
+  ON_CALL(*this, setResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag response_flag) {
+    auto iter = std::find(response_flags_.begin(), response_flags_.end(), response_flag);
+    if (iter == response_flags_.end()) {
+      response_flags_.push_back(response_flag);
+    }
+  }));
   ON_CALL(*this, setResponseCode(_)).WillByDefault(Invoke([this](uint32_t code) {
     response_code_ = code;
   }));
@@ -141,20 +140,20 @@ MockStreamInfo::MockStreamInfo()
     bytes_sent_ += bytes_sent;
   }));
   ON_CALL(*this, bytesSent()).WillByDefault(ReturnPointee(&bytes_sent_));
-  ON_CALL(*this, hasResponseFlag(_)).WillByDefault(Invoke([this](ExtendedResponseFlag flag) {
+  ON_CALL(*this, hasResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag flag) {
     auto iter = std::find(response_flags_.begin(), response_flags_.end(), flag);
     return iter != response_flags_.end();
   }));
   ON_CALL(*this, hasAnyResponseFlag()).WillByDefault(Invoke([this]() {
     return !response_flags_.empty();
   }));
-  ON_CALL(*this, responseFlags())
-      .WillByDefault(
-          Invoke([this]() -> absl::Span<const ExtendedResponseFlag> { return response_flags_; }));
+  ON_CALL(*this, responseFlags()).WillByDefault(Invoke([this]() -> absl::Span<const ResponseFlag> {
+    return response_flags_;
+  }));
   ON_CALL(*this, legacyResponseFlags()).WillByDefault(Invoke([this]() -> uint64_t {
     uint64_t legacy_flags = 0;
-    for (ExtendedResponseFlag flag : response_flags_) {
-      if (flag.value() <= static_cast<uint16_t>(ResponseFlag::LastFlag)) {
+    for (ResponseFlag flag : response_flags_) {
+      if (flag.value() <= static_cast<uint16_t>(CoreResponseFlag::LastFlag)) {
         ASSERT(flag.value() < 64, "Legacy response flag out of range");
         legacy_flags |= (1UL << flag.value());
       }

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -16,22 +16,22 @@
 namespace testing {
 
 template <>
-class Matcher<Envoy::StreamInfo::ExtendedResponseFlag>
-    : public internal::MatcherBase<Envoy::StreamInfo::ExtendedResponseFlag> {
+class Matcher<Envoy::StreamInfo::ResponseFlag>
+    : public internal::MatcherBase<Envoy::StreamInfo::ResponseFlag> {
 public:
   explicit Matcher() = default;
-  Matcher(Envoy::StreamInfo::ExtendedResponseFlag value) { *this = Eq(value); }
-  Matcher(Envoy::StreamInfo::ResponseFlag value) {
-    *this = Eq(Envoy::StreamInfo::ExtendedResponseFlag(value));
+  Matcher(Envoy::StreamInfo::ResponseFlag value) { *this = Eq(value); }
+  Matcher(Envoy::StreamInfo::CoreResponseFlag value) {
+    *this = Eq(Envoy::StreamInfo::ResponseFlag(value));
   }
 
-  explicit Matcher(const MatcherInterface<const Envoy::StreamInfo::ExtendedResponseFlag&>* impl)
-      : internal::MatcherBase<Envoy::StreamInfo::ExtendedResponseFlag>(impl) {}
+  explicit Matcher(const MatcherInterface<const Envoy::StreamInfo::ResponseFlag&>* impl)
+      : internal::MatcherBase<Envoy::StreamInfo::ResponseFlag>(impl) {}
 
   template <typename U>
   explicit Matcher(const MatcherInterface<U>* impl,
                    typename std::enable_if<!std::is_same<U, const U&>::value>::type* = nullptr)
-      : internal::MatcherBase<Envoy::StreamInfo::ExtendedResponseFlag>(impl) {}
+      : internal::MatcherBase<Envoy::StreamInfo::ResponseFlag>(impl) {}
 };
 
 } // namespace testing
@@ -90,7 +90,7 @@ public:
   ~MockStreamInfo() override;
 
   // StreamInfo::StreamInfo
-  MOCK_METHOD(void, setResponseFlag, (ExtendedResponseFlag response_flag));
+  MOCK_METHOD(void, setResponseFlag, (ResponseFlag response_flag));
   MOCK_METHOD(void, setResponseCode, (uint32_t));
   MOCK_METHOD(void, setResponseCodeDetails, (absl::string_view));
   MOCK_METHOD(void, setConnectionTerminationDetails, (absl::string_view));
@@ -127,9 +127,9 @@ public:
   MOCK_METHOD(uint64_t, bytesSent, (), (const));
   MOCK_METHOD(void, addWireBytesSent, (uint64_t));
   MOCK_METHOD(uint64_t, wireBytesSent, (), (const));
-  MOCK_METHOD(bool, hasResponseFlag, (ExtendedResponseFlag), (const));
+  MOCK_METHOD(bool, hasResponseFlag, (ResponseFlag), (const));
   MOCK_METHOD(bool, hasAnyResponseFlag, (), (const));
-  MOCK_METHOD(absl::Span<const ExtendedResponseFlag>, responseFlags, (), (const));
+  MOCK_METHOD(absl::Span<const ResponseFlag>, responseFlags, (), (const));
   MOCK_METHOD(uint64_t, legacyResponseFlags, (), (const));
   MOCK_METHOD(bool, healthCheck, (), (const));
   MOCK_METHOD(void, healthCheck, (bool is_health_check));
@@ -176,7 +176,7 @@ public:
   absl::optional<std::string> connection_termination_details_;
   absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_;
   std::shared_ptr<UpstreamInfo> upstream_info_;
-  absl::InlinedVector<ExtendedResponseFlag, 4> response_flags_{};
+  absl::InlinedVector<ResponseFlag, 4> response_flags_{};
   envoy::config::core::v3::Metadata metadata_;
   FilterStateSharedPtr filter_state_;
   uint64_t bytes_received_{};


### PR DESCRIPTION
Commit Message: stream info: rename the extended response flag and response flag
Additional Description:

Further work of https://github.com/envoyproxy/envoy/pull/31719

1. Rename the `ResponseFlag` enum to `CoreResponseFlag`.
2. Rename the `ExendedResponseFlag` to `ResponseFlag`.
3. Add new test to ensure the `legacyResponseFlags()` method works as expected.
4. Minor update to the macro of registering new custom response flag. (short -> short_flag_string, long -> long_flag_string)

Risk Level: low. No new logic.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
