### PR TITLE
Go HTTP Filter: Expose envoy concurrency and request worker_id in public API

### DIFF
--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -139,7 +139,8 @@ type StreamInfo interface {
 	FilterState() FilterState
 	// VirtualClusterName returns the name of the virtual cluster which got matched
 	VirtualClusterName() (string, bool)
-
+	// WorkerID returns the ID of the Envoy worker thread
+	WorkerID() uint32
 	// Some fields in stream info can be fetched via GetProperty
 	// For example, startTime() is equal to GetProperty("request.time")
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/filter.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filter.go
@@ -281,6 +281,10 @@ func (s *streamInfo) VirtualClusterName() (string, bool) {
 	return cAPI.HttpGetStringValue(unsafe.Pointer(s.request), ValueVirtualClusterName)
 }
 
+func (s *streamInfo) WorkerID() uint32 {
+	return uint32(s.request.req.worker_id)
+}
+
 type filterState struct {
 	request *httpRequest
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -46,7 +46,7 @@ var ErrDupRequestKey = errors.New("dup request key")
 var Requests = &requestMap{}
 
 var (
-	initialized = false
+	initialized      = false
 	envoyConcurrency uint32
 )
 

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -45,6 +45,14 @@ var ErrDupRequestKey = errors.New("dup request key")
 
 var Requests = &requestMap{}
 
+var envoyConcurrency uint32
+
+// EnvoyConcurrency returns the concurrency Envoy was set to run at. This can be used to optimize HTTP filters that need
+// memory per worker thread to avoid locks.
+func EnvoyConcurrency() uint32 {
+	return envoyConcurrency
+}
+
 type requestMap struct {
 	initOnce sync.Once
 	requests []map[*C.httpRequest]*httpRequest
@@ -52,6 +60,7 @@ type requestMap struct {
 
 func (f *requestMap) initialize(concurrency uint32) {
 	f.initOnce.Do(func() {
+		envoyConcurrency = concurrency
 		f.requests = make([]map[*C.httpRequest]*httpRequest, concurrency)
 		for i := uint32(0); i < concurrency; i++ {
 			f.requests[i] = map[*C.httpRequest]*httpRequest{}

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -45,11 +45,20 @@ var ErrDupRequestKey = errors.New("dup request key")
 
 var Requests = &requestMap{}
 
-var envoyConcurrency uint32
+var (
+	initialized = false
+	envoyConcurrency uint32
+)
 
 // EnvoyConcurrency returns the concurrency Envoy was set to run at. This can be used to optimize HTTP filters that need
 // memory per worker thread to avoid locks.
+//
+// Note: Do not use inside of an `init()` function, the value will not be populated yet. Use within the filters
+// `StreamFilterConfigFactory` or `StreamFilterConfigParser`
 func EnvoyConcurrency() uint32 {
+	if !initialized {
+		panic("concurrency has not yet been initialized, do not access within an init()")
+	}
 	return envoyConcurrency
 }
 
@@ -60,6 +69,7 @@ type requestMap struct {
 
 func (f *requestMap) initialize(concurrency uint32) {
 	f.initOnce.Do(func() {
+		initialized = true
 		envoyConcurrency = concurrency
 		f.requests = make([]map[*C.httpRequest]*httpRequest, concurrency)
 		for i := uint32(0); i < concurrency; i++ {

--- a/contrib/golang/filters/network/source/go/pkg/network/filter.go
+++ b/contrib/golang/filters/network/source/go/pkg/network/filter.go
@@ -113,6 +113,10 @@ func (n *connectionCallback) VirtualClusterName() (string, bool) {
 	panic("implement me")
 }
 
+func (n *connectionCallback) WorkerID() uint32 {
+	panic("implement me")
+}
+
 type filterState struct {
 	wrapper unsafe.Pointer
 	setFunc func(envoyFilter unsafe.Pointer, key string, value string, stateType api.StateType, lifeSpan api.LifeSpan, streamSharing api.StreamSharing)


### PR DESCRIPTION
Adds new functions to the Go SDK `EnvoyConcurrency()` and `StreamInfo.WorkerID()`. This information will allow Go HTTP plugins to optimize their performance in certain use cases. Follow up from #31987

cc @doujiang24  

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
