### PR TITLE
macos: fix linker error from CEL library

### DIFF
--- a/bazel/cel-cpp.patch
+++ b/bazel/cel-cpp.patch
@@ -1,3 +1,24 @@
+diff --git a/eval/internal/interop.cc b/eval/internal/interop.cc
+index 3acde6c..20f8ea3 100644
+--- a/eval/internal/interop.cc
++++ b/eval/internal/interop.cc
+@@ -729,13 +729,14 @@ absl::StatusOr<CelValue> ToLegacyValue(google::protobuf::Arena* arena,
+         return CelValue::CreateMessageWrapper(
+             MessageWrapperAccess::Make(message, type_info));
+       }
+-      if (ProtoStructValueToMessageWrapper) {
++      // This weak symbol is never defined in Envoy, and checking it causes linker failures on macOS
++      /*if (ProtoStructValueToMessageWrapper) {
+         auto maybe_message_wrapper = ProtoStructValueToMessageWrapper(*value);
+         if (maybe_message_wrapper.has_value()) {
+           return CelValue::CreateMessageWrapper(
+               std::move(maybe_message_wrapper).value());
+         }
+-      }
++      }*/
+       return absl::UnimplementedError(
+           "only legacy struct types and values can be used for interop");
+     }
 diff --git a/eval/public/cel_value.cc b/eval/public/cel_value.cc
 index 6aeff6d..c43864c 100644
 --- a/eval/public/cel_value.cc


### PR DESCRIPTION
Commit Message:
Additional Description: As described in the linked issue, on macOS (at least in some OS/compiler combos) there is a linker error in CEL. The missing symbol is specified as a weak symbol. The definition of the function is in `cel-cpp/extensions/protobuf:data`. As far as I can tell, only a test in CEL actually builds that target; Envoy does not build that target, so this function will not ever be compiled into Envoy. So commenting out the block in this PR should not have behavior change to how Envoy uses CEL.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
Fixes #31932
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
