### PR TITLE
coverage: lower coverage for source/common/io/

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -11,7 +11,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/event:95.0" # Emulated edge events guards don't report LCOV
 "source/common/filesystem/posix:96.2" # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
 "source/common/http/http2:95.2"
-"source/common/io:57.9 # TODO(#32149): CI has stopped executing this code.
+"source/common/io:57.9" # TODO(#32149): CI has stopped executing this code.
 "source/common/json:94.6"
 "source/common/matcher:94.6"
 "source/common/network:94.4" # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -11,6 +11,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/event:95.0" # Emulated edge events guards don't report LCOV
 "source/common/filesystem/posix:96.2" # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
 "source/common/http/http2:95.2"
+"source/common/io:57.9 # TODO(#32149): CI has stopped executing this code.
 "source/common/json:94.6"
 "source/common/matcher:94.6"
 "source/common/network:94.4" # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -3,7 +3,7 @@
 # directory:coverage_percent
 # for existing directories with low coverage.
 declare -a KNOWN_LOW_COVERAGE=(
-"source/common:96.2"
+"source/common:96.0" # TODO(#32149): increase this once io_uring is tested.
 "source/common/api:84.5" # flaky due to posix: be careful adjusting
 "source/common/api/posix:83.8" # flaky (accept failover non-deterministic): be careful adjusting
 "source/common/config:95.4"


### PR DESCRIPTION
Coverage CI is failing because coverage is too low in source/common/io because CI is not executing io_uring code. #32149 