### PR TITLE
mobile: Update Cronvoy API to allow setting log level and logger

### DIFF
--- a/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyEngineBuilderImpl.java
@@ -20,6 +20,8 @@ import org.chromium.net.CronetEngine;
 import org.chromium.net.ICronetEngineBuilder;
 import org.chromium.net.impl.Annotations.HttpCacheType;
 
+import io.envoyproxy.envoymobile.engine.EnvoyEngine;
+
 /** Implementation of {@link ICronetEngineBuilder} that builds Envoy-Mobile based Cronet engine. */
 public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
 
@@ -66,6 +68,8 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
   private String mExperimentalOptions;
   private boolean mNetworkQualityEstimatorEnabled;
   private int mThreadPriority = INVALID_THREAD_PRIORITY;
+  private EnvoyEngine.LogLevel mLogLevel = EnvoyEngine.LogLevel.OFF;
+  private CronvoyLogger mCronvoyLogger = new CronvoyLogger();
 
   /**
    * Default config enables SPDY and QUIC, disables SDCH and HTTP cache.
@@ -357,4 +361,22 @@ public abstract class CronvoyEngineBuilderImpl extends ICronetEngineBuilder {
    * @return {@link Context} for builder.
    */
   Context getContext() { return mApplicationContext; }
+
+  /** Sets the log level. */
+  public CronvoyEngineBuilderImpl setLogLevel(EnvoyEngine.LogLevel logLevel) {
+    this.mLogLevel = logLevel;
+    return this;
+  }
+
+  /** Gets the log level. It defaults to `OFF` when not set. */
+  public EnvoyEngine.LogLevel getLogLevel() { return mLogLevel; }
+
+  /** Sets the {@link io.envoyproxy.envoymobile.engine.types.EnvoyLogger}. */
+  public CronvoyEngineBuilderImpl setLogger(CronvoyLogger cronvoyLogger) {
+    this.mCronvoyLogger = cronvoyLogger;
+    return this;
+  }
+
+  /** Gets the {@link org.chromium.net.impl.CronvoyLogger} implementation. */
+  public CronvoyLogger getLogger() { return mCronvoyLogger; }
 }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyLogger.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyLogger.java
@@ -22,7 +22,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
  * the desired file until CronvoyUrlRequestContext.stopNetLog disables Envoy logging.
  *
  */
-final class CronvoyLogger implements EnvoyLogger {
+public class CronvoyLogger implements EnvoyLogger {
   private int mFilesize = 0;
   private String mFileName = null;
   private FileWriter mWriter = null;

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
@@ -47,7 +47,7 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
   private final Object mLock = new Object();
   private final ConditionVariable mInitCompleted = new ConditionVariable(false);
   private final AtomicInteger mActiveRequestCount = new AtomicInteger(0);
-  private EnvoyEngine.LogLevel mLogLevel = EnvoyEngine.LogLevel.OFF;
+  private EnvoyEngine.LogLevel mLogLevel;
 
   @GuardedBy("mLock") private EnvoyEngine mEngine;
   /**
@@ -61,7 +61,7 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
 
   private final String mUserAgent;
   private final AtomicReference<Runnable> mInitializationCompleter = new AtomicReference<>();
-  private final CronvoyLogger mCronvoyLogger = new CronvoyLogger();
+  private final CronvoyLogger mCronvoyLogger;
 
   /**
    * Locks operations on the list of RequestFinishedInfo.Listeners, because operations can happen
@@ -84,8 +84,9 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
     final int threadPriority =
         builder.threadPriority(THREAD_PRIORITY_BACKGROUND + THREAD_PRIORITY_MORE_FAVORABLE);
     mUserAgent = builder.getUserAgent();
+    mLogLevel = builder.getLogLevel();
+    mCronvoyLogger = builder.getLogger();
     synchronized (mLock) {
-
       mEngine = builder.createEngine(() -> {
         mNetworkThread = Thread.currentThread();
         android.os.Process.setThreadPriority(threadPriority);


### PR DESCRIPTION
This PR updates the Cronvoy's `EngineBuilder` API to allow setting the log level and custom logger implementation similar to the standard `EngineBuilder` API. For backward compatibility, the log level will be set to `OFF` and the custom logger will be set to the default `CronvoyLogger` implementation.

Risk Level: low
Testing: tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
