### PR TITLE
generic proxy: only create child span if the spawnUpstreamSpan return true

### DIFF
--- a/contrib/generic_proxy/filters/network/source/router/router.cc
+++ b/contrib/generic_proxy/filters/network/source/router/router.cc
@@ -286,7 +286,8 @@ UpstreamRequest::UpstreamRequest(RouterFilter& parent, GenericUpstreamSharedPtr 
   expects_response_ = !options.oneWayStream();
 
   // Set tracing config.
-  if (tracing_config_ = parent_.callbacks_->tracingConfig(); tracing_config_.has_value()) {
+  tracing_config_ = parent_.callbacks_->tracingConfig();
+  if (tracing_config_.has_value() && tracing_config_->spawnUpstreamSpan()) {
     span_ = parent_.callbacks_->activeSpan().spawnChild(
         tracing_config_.value().get(),
         absl::StrCat("router ", parent_.cluster_->observabilityName(), " egress"),

--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -251,6 +251,7 @@ public:
     if (with_tracing_) {
       EXPECT_CALL(mock_filter_callback_, tracingConfig())
           .WillOnce(Return(OptRef<const Tracing::Config>{tracing_config_}));
+      EXPECT_CALL(tracing_config_, spawnUpstreamSpan()).WillOnce(Return(true));
       EXPECT_CALL(active_span_, spawnChild_(_, "router observability_name egress", _))
           .WillOnce(Invoke([this](const Tracing::Config&, const std::string&, SystemTime) {
             child_span_ = new NiceMock<Tracing::MockSpan>();


### PR DESCRIPTION
Commit Message: generic proxy: only create child span if the spawnUpstreamSpan return true
Additional Description:

Not all tracers require dual-spans. This patch fix a minor bug of generic proxy tracing where always create the upstream span for the upstream request.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.