### PR TITLE
mobile: Update the singleton instance to never call its destructor

### DIFF
--- a/mobile/library/common/common/system_helper.cc
+++ b/mobile/library/common/common/system_helper.cc
@@ -12,7 +12,7 @@
 
 namespace Envoy {
 
-std::unique_ptr<SystemHelper> SystemHelper::instance_ = std::make_unique<DefaultSystemHelper>();
+SystemHelper* SystemHelper::instance_ = new DefaultSystemHelper();
 
 SystemHelper& SystemHelper::getInstance() { return *instance_; }
 

--- a/mobile/library/common/common/system_helper.h
+++ b/mobile/library/common/common/system_helper.h
@@ -47,7 +47,7 @@ public:
 private:
   friend class test::SystemHelperPeer;
 
-  static std::unique_ptr<SystemHelper> instance_;
+  static SystemHelper* instance_;
 };
 
 } // namespace Envoy

--- a/mobile/test/common/mocks/common/mocks.h
+++ b/mobile/test/common/mocks/common/mocks.h
@@ -29,24 +29,27 @@ public:
   // Handle's `mock_helper()` accessor.
   static std::unique_ptr<Handle> replaceSystemHelper() { return std::make_unique<Handle>(); }
 
-  // RAII type for replacing the SystemHelper singleton with a the MockSystemHelper.
+  // RAII type for replacing the SystemHelper singleton with the MockSystemHelper.
   // When this object is destroyed, it resets the SystemHelper singleton back
   // to the previous state.
   class Handle {
   public:
     Handle() {
-      previous_ = std::make_unique<test::MockSystemHelper>();
-      SystemHelper::instance_.swap(previous_);
+      previous_ = new test::MockSystemHelper();
+      std::swap(SystemHelper::instance_, previous_);
     }
 
-    ~Handle() { SystemHelper::instance_ = std::move(previous_); }
+    ~Handle() {
+      delete SystemHelper::instance_;
+      SystemHelper::instance_ = previous_;
+    }
 
     test::MockSystemHelper& mock_helper() {
-      return *static_cast<test::MockSystemHelper*>(SystemHelper::instance_.get());
+      return *static_cast<test::MockSystemHelper*>(SystemHelper::instance_);
     }
 
   private:
-    std::unique_ptr<SystemHelper> previous_;
+    SystemHelper* previous_;
   };
 };
 


### PR DESCRIPTION
Prior to this PR, the `SystemHelper::instance_` was a `std::unique_ptr`, which means there could be a  possibility that the `SystemHelper::instance_`'s destructor gets called upon program termination while the cert verification thread is still running causing `SystemHelper::getInstance()` to return a destroyed instance. This PR fixes the issue by making the `SystemHelper::instance_` a raw pointer, such that the destructor is never called.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a