### PR TITLE
test: Disable recently added AltSvcCachedH2Slow

### DIFF
--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -261,7 +261,8 @@ TEST_P(FilterIntegrationTest, AltSvcCachedH3Slow) {
                                100);
 }
 
-TEST_P(FilterIntegrationTest, AltSvcCachedH2Slow) {
+// TODO(32151): Deflake and re-enable.
+TEST_P(FilterIntegrationTest, DISABLED_AltSvcCachedH2Slow) {
 #ifdef WIN32
   // TODO: sort out what race only happens on windows and GCC.
   GTEST_SKIP() << "Skipping on Windows";

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -261,7 +261,7 @@ TEST_P(FilterIntegrationTest, AltSvcCachedH3Slow) {
                                100);
 }
 
-// TODO(32151): Deflake and re-enable.
+// TODO(32151): Figure out why it's flaky and re-enable.
 TEST_P(FilterIntegrationTest, DISABLED_AltSvcCachedH2Slow) {
 #ifdef WIN32
   // TODO: sort out what race only happens on windows and GCC.


### PR DESCRIPTION
It is causing test flakes and friction on CI. I was able to reproduce this, and the crash happens in
https://github.com/envoyproxy/envoy/blob/faec43168bb50028b4b4351f477dfef40e0fb227/test/integration/fake_upstream.h#L714.

But I'm not sure cause, so will disable it for now until we have deflaked it.

See https://github.com/envoyproxy/envoy/issues/32151 for details.