### PR TITLE
mobile: Fix a flake in the ClientIntegrationTest

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -939,10 +939,8 @@ TEST_P(ClientIntegrationTest, ResetWithBidiTrafficExplicitData) {
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(1, false);
   upstream_request_->encodeResetStream();
-  if (getCodecType() != Http::CodecType::HTTP3) {
-    // Make sure the headers are sent up.
-    headers_callback.waitReady();
-  }
+  // Make sure the headers are sent up.
+  headers_callback.waitReady();
 
   // Encoding data should not be problematic.
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");


### PR DESCRIPTION
The `ResetWithBidiTrafficExplicitData` was crashing sporadically with memory errors when run for HTTP3. Running with msan showed that the crashes were caused in `headers_callback.setReady()` being called after the test finished and member variables of the test were already destroyed.

I noticed that in the test, we didn't call `headers_callback.waitReady()` when the test was running for HTTP3.  It wasn't clear to me why, but that seemed like the cause.  I removed the if-guard so we always call `headers_callback.waitReady()`, and the test seems to pass now (over 500 runs).

Fixes #32024 