### PR TITLE
golang filter: change register configFactory to filterFactory

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -13,6 +13,9 @@ minor_behavior_changes:
     Upstream now excludes hosts set to ``DRAINING`` state via EDS from load balancing and panic routing
     threshold calculation. This feature can be disabled by setting
     ``envoy.reloadable_features.exclude_host_in_eds_status_draining`` to false.
+- area: golang
+  change: |
+    Change ``RegisterHttpFilterConfigFactoryAndParser`` to ``RegisterHttpFilterFactoryAndConfigParser``.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/contrib/golang/common/go/api/filter.go
+++ b/contrib/golang/common/go/api/filter.go
@@ -103,12 +103,17 @@ func (*PassThroughStreamFilter) OnDestroy(DestroyReason) {
 }
 
 type StreamFilterConfigParser interface {
+	// Parse the proto message to any Go value, and return error to reject the config.
+	// This is called when Envoy receives the config from the control plane.
+	// Also, you can define Metrics through the callbacks, and the callbacks will be nil when parsing the route config.
 	Parse(any *anypb.Any, callbacks ConfigCallbackHandler) (interface{}, error)
+	// Merge the two configs(filter level config or route level config) into one.
+	// May merge multi-level configurations, i.e. filter level, virtualhost level, router level and weighted cluster level,
+	// into a single one recursively, by invoking this method multiple times.
 	Merge(parentConfig interface{}, childConfig interface{}) interface{}
 }
 
-type StreamFilterConfigFactory func(config interface{}) StreamFilterFactory
-type StreamFilterFactory func(callbacks FilterCallbackHandler) StreamFilter
+type StreamFilterFactory func(config interface{}, callbacks FilterCallbackHandler) StreamFilter
 
 // stream info
 // refer https://github.com/envoyproxy/envoy/blob/main/envoy/stream_info/stream_info.h

--- a/contrib/golang/filters/http/source/go/pkg/http/filtermanager.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filtermanager.go
@@ -22,44 +22,68 @@ import (
 	"sync"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
-var httpFilterConfigFactoryAndParser = sync.Map{}
+var httpFilterFactoryAndParser = sync.Map{}
 
-type filterConfigFactoryAndParser struct {
-	configFactory api.StreamFilterConfigFactory
+type filterFactoryAndParser struct {
+	filterFactory api.StreamFilterFactory
 	configParser  api.StreamFilterConfigParser
 }
 
-// Register config factory and config parser for the specified plugin.
-// The "factory" parameter is required, should not be nil,
-// and the "parser" parameter is optional, could be nil.
-func RegisterHttpFilterConfigFactoryAndParser(name string, factory api.StreamFilterConfigFactory, parser api.StreamFilterConfigParser) {
-	if factory == nil {
-		panic("config factory should not be nil")
-	}
-	httpFilterConfigFactoryAndParser.Store(name, &filterConfigFactoryAndParser{factory, parser})
+// nullParser is a no-op implementation of the StreamFilterConfigParser interface.
+type nullParser struct{}
+
+// Parse do nothing, returns the input any as is.
+func (p *nullParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
+	return any, nil
 }
 
-func getOrCreateHttpFilterFactory(name string, configId uint64) api.StreamFilterFactory {
+// Merge only use the childConfig, ignore the parentConfig.
+func (p *nullParser) Merge(parentConfig interface{}, childConfig interface{}) interface{} {
+	return childConfig
+}
+
+var NullParser api.StreamFilterConfigParser = &nullParser{}
+
+// RegisterHttpFilterFactoryAndConfigParser register http filter factory and config parser for the specified plugin.
+// The factory and parser should not be nil.
+// Use the NullParser if the plugin does not care about config.
+func RegisterHttpFilterFactoryAndConfigParser(name string, factory api.StreamFilterFactory, parser api.StreamFilterConfigParser) {
+	if factory == nil {
+		panic("filter factory should not be nil")
+	}
+	if parser == nil {
+		panic("config parser should not be nil")
+	}
+	httpFilterFactoryAndParser.Store(name, &filterFactoryAndParser{factory, parser})
+}
+
+func getHttpFilterFactoryAndConfig(name string, configId uint64) (api.StreamFilterFactory, interface{}) {
 	config, ok := configCache.Load(configId)
 	if !ok {
 		panic(fmt.Sprintf("config not found, plugin: %s, configId: %d", name, configId))
 	}
 
-	if v, ok := httpFilterConfigFactoryAndParser.Load(name); ok {
-		return (v.(*filterConfigFactoryAndParser)).configFactory(config)
+	if v, ok := httpFilterFactoryAndParser.Load(name); ok {
+		return (v.(*filterFactoryAndParser)).filterFactory, config
 	}
 
 	api.LogErrorf("plugin %s not found, pass through by default", name)
 
-	// pass through by default
-	return PassThroughFactory(config)
+	// return PassThroughFactory when no factory found
+	return PassThroughFactory, config
 }
 
 func getHttpFilterConfigParser(name string) api.StreamFilterConfigParser {
-	if v, ok := httpFilterConfigFactoryAndParser.Load(name); ok {
-		return (v.(*filterConfigFactoryAndParser)).configParser
+	if v, ok := httpFilterFactoryAndParser.Load(name); ok {
+		parser := (v.(*filterFactoryAndParser)).configParser
+		if parser == nil {
+			panic(fmt.Sprintf("config parser not found, plugin: %s", name))
+		}
+		return parser
 	}
-	return nil
+	// return NullParser when no parser found
+	return NullParser
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/filtermanager.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/filtermanager.go
@@ -35,19 +35,19 @@ type filterFactoryAndParser struct {
 // nullParser is a no-op implementation of the StreamFilterConfigParser interface.
 type nullParser struct{}
 
-// Parse do nothing, returns the input any as is.
+// Parse does nothing, returns the input `any` as is.
 func (p *nullParser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
 	return any, nil
 }
 
-// Merge only use the childConfig, ignore the parentConfig.
+// Merge only uses the childConfig, ignore the parentConfig.
 func (p *nullParser) Merge(parentConfig interface{}, childConfig interface{}) interface{} {
 	return childConfig
 }
 
 var NullParser api.StreamFilterConfigParser = &nullParser{}
 
-// RegisterHttpFilterFactoryAndConfigParser register http filter factory and config parser for the specified plugin.
+// RegisterHttpFilterFactoryAndConfigParser registers the http filter factory and config parser for the specified plugin.
 // The factory and parser should not be nil.
 // Use the NullParser if the plugin does not care about config.
 func RegisterHttpFilterFactoryAndConfigParser(name string, factory api.StreamFilterFactory, parser api.StreamFilterConfigParser) {

--- a/contrib/golang/filters/http/source/go/pkg/http/passthrough.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/passthrough.go
@@ -26,10 +26,8 @@ type passThroughFilter struct {
 	callbacks api.FilterCallbackHandler
 }
 
-func PassThroughFactory(interface{}) api.StreamFilterFactory {
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &passThroughFilter{
-			callbacks: callbacks,
-		}
+func PassThroughFactory(config interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
+	return &passThroughFilter{
+		callbacks: callbacks,
 	}
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -54,7 +54,7 @@ var (
 // memory per worker thread to avoid locks.
 //
 // Note: Do not use inside of an `init()` function, the value will not be populated yet. Use within the filters
-// `StreamFilterConfigFactory` or `StreamFilterConfigParser`
+// `StreamFilterFactory` or `StreamFilterConfigParser`
 func EnvoyConcurrency() uint32 {
 	if !initialized {
 		panic("concurrency has not yet been initialized, do not access within an init()")
@@ -119,8 +119,8 @@ func createRequest(r *C.httpRequest) *httpRequest {
 	}
 
 	configId := uint64(r.configId)
-	filterFactory := getOrCreateHttpFilterFactory(req.pluginName(), configId)
-	f := filterFactory(req)
+	filterFactory, config := getHttpFilterFactoryAndConfig(req.pluginName(), configId)
+	f := filterFactory(config, req)
 	req.httpFilter = f
 
 	return req

--- a/contrib/golang/filters/http/test/test_data/access_log/config.go
+++ b/contrib/golang/filters/http/test/test_data/access_log/config.go
@@ -10,7 +10,7 @@ import (
 const Name = "access_log"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
 type config struct {
@@ -28,16 +28,14 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	return child
 }
 
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-			config:    conf,
-		}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/action/config.go
+++ b/contrib/golang/filters/http/test/test_data/action/config.go
@@ -8,18 +8,12 @@ import (
 const Name = "action"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, nil)
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, http.NullParser)
 }
 
-type config struct {
-	decodeHeadersRet api.StatusType
-}
-
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-		}
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
+	return &filter{
+		callbacks: callbacks,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/basic/config.go
+++ b/contrib/golang/filters/http/test/test_data/basic/config.go
@@ -11,14 +11,12 @@ func init() {
 	api.LogCritical("init")
 	api.LogCritical(api.GetLogLevel().String())
 
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, nil)
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, http.NullParser)
 }
 
-func ConfigFactory(interface{}) api.StreamFilterFactory {
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-		}
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
+	return &filter{
+		callbacks: callbacks,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/buffer/config.go
+++ b/contrib/golang/filters/http/test/test_data/buffer/config.go
@@ -10,7 +10,7 @@ import (
 const Name = "buffer"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
 type config struct {
@@ -28,16 +28,14 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	return child
 }
 
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-			config:    conf,
-		}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/dummy/plugin.go
+++ b/contrib/golang/filters/http/test/test_data/dummy/plugin.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser("", http.PassThroughFactory, nil)
+	http.RegisterHttpFilterFactoryAndConfigParser("", http.PassThroughFactory, http.NullParser)
 }
 
 func main() {

--- a/contrib/golang/filters/http/test/test_data/echo/config.go
+++ b/contrib/golang/filters/http/test/test_data/echo/config.go
@@ -11,7 +11,7 @@ import (
 const Name = "echo"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
 type config struct {
@@ -43,16 +43,14 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	panic("TODO")
 }
 
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-			config:    conf,
-		}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/metric/config.go
+++ b/contrib/golang/filters/http/test/test_data/metric/config.go
@@ -13,7 +13,7 @@ func init() {
 	api.LogCritical("init")
 	api.LogCritical(api.GetLogLevel().String())
 
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
 type config struct {
@@ -37,16 +37,14 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	panic("TODO")
 }
 
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-			config:    conf,
-		}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/passthrough/filter.go
+++ b/contrib/golang/filters/http/test/test_data/passthrough/filter.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser("passthrough", http.PassThroughFactory, nil)
+	http.RegisterHttpFilterFactoryAndConfigParser("passthrough", http.PassThroughFactory, http.NullParser)
 }
 
 func main() {

--- a/contrib/golang/filters/http/test/test_data/property/config.go
+++ b/contrib/golang/filters/http/test/test_data/property/config.go
@@ -10,7 +10,7 @@ import (
 const Name = "property"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
 type config struct {
@@ -28,16 +28,14 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	return child
 }
 
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-			config:    conf,
-		}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
 	}
 }
 

--- a/contrib/golang/filters/http/test/test_data/routeconfig/config.go
+++ b/contrib/golang/filters/http/test/test_data/routeconfig/config.go
@@ -13,19 +13,17 @@ import (
 const Name = "routeconfig"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, configFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
-func configFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			config:    conf,
-			callbacks: callbacks,
-		}
+	return &filter{
+		config:    conf,
+		callbacks: callbacks,
 	}
 }
 

--- a/examples/golang-http/simple/config.go
+++ b/examples/golang-http/simple/config.go
@@ -14,7 +14,7 @@ import (
 const Name = "simple"
 
 func init() {
-	http.RegisterHttpFilterConfigFactoryAndParser(Name, ConfigFactory, &parser{})
+	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
 }
 
 type config struct {
@@ -60,17 +60,14 @@ func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
 	return &newConfig
 }
 
-func ConfigFactory(c interface{}) api.StreamFilterFactory {
+func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
 	conf, ok := c.(*config)
 	if !ok {
 		panic("unexpected config type")
 	}
-
-	return func(callbacks api.FilterCallbackHandler) api.StreamFilter {
-		return &filter{
-			callbacks: callbacks,
-			config:    conf,
-		}
+	return &filter{
+		callbacks: callbacks,
+		config:    conf,
 	}
 }
 


### PR DESCRIPTION
We followed the C++ style to register configFactory, but it's not a proper choice for Golang filter.
Here is the Reasons:
1. Golang introduced the ConfigParser interface to Parse/validate a config, configFactory does not need to parse config.
2. better performance. By using fiterFactory, we could ommit generate a closure per http request, that may take ~1ns.

Yep, this is a breaking change, people need to change the register API.
So, I suggest we fix it earlier.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
