### PR TITLE
tcp_proxy: increase stat on upstream request retry

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -457,6 +457,8 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
     cluster->trafficStats()->upstream_cx_connect_attempts_exceeded_.inc();
     onInitFailure(UpstreamFailureReason::ConnectFailed);
     return Network::FilterStatus::StopIteration;
+  } else if (connect_attempts_ >= 1) {
+    cluster->trafficStats()->upstream_rq_retry_.inc();
   }
 
   auto& downstream_connection = read_callbacks_->connection();

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -1243,6 +1243,8 @@ TEST_P(TcpTunnelingIntegrationTest, CopyInvalidResponseHeadersWithRetry) {
     ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   }
 
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_rq_retry", 1);
+
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
   upstream_request_->encodeHeaders(default_response_headers_, true);


### PR DESCRIPTION
Additional Description: increasing the ``upstream_rq_retry`` on retry in the ``tcp_proxy``
Risk Level: low
Testing: integration tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none