### PR TITLE
Remove fallback from accept4 to accept

### DIFF
--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -325,18 +325,15 @@ SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, sockl
 
 #if defined(__linux__)
   rc = ::accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
-  // If failed with EINVAL try without flags
-  if (rc >= 0 || errno != EINVAL) {
-    return {rc, rc != -1 ? 0 : errno};
-  }
-#endif
-
+  return {rc, rc != -1 ? 0 : errno};
+#else
   rc = ::accept(sockfd, addr, addrlen);
   if (rc >= 0) {
     setsocketblocking(rc, false);
   }
 
   return {rc, rc != -1 ? 0 : errno};
+#endif
 }
 
 SysCallBoolResult OsSysCallsImpl::socketTcpInfo([[maybe_unused]] os_fd_t sockfd,

--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -325,15 +325,13 @@ SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, sockl
 
 #if defined(__linux__)
   rc = ::accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
-  return {rc, rc != -1 ? 0 : errno};
 #else
   rc = ::accept(sockfd, addr, addrlen);
   if (rc >= 0) {
     setsocketblocking(rc, false);
   }
-
-  return {rc, rc != -1 ? 0 : errno};
 #endif
+  return {rc, rc != -1 ? 0 : errno};
 }
 
 SysCallBoolResult OsSysCallsImpl::socketTcpInfo([[maybe_unused]] os_fd_t sockfd,


### PR DESCRIPTION
Additional Description:
The fallback is pointless since accept will fail for the same reasons as accept4. However it creates coverage problem since the fallback code is not covered by tests.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
