### PR TITLE
test: increases a test timeout to avoid flaky failures

### DIFF
--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2597,7 +2597,7 @@ TEST_P(Http2FrameIntegrationTest, CloseConnectionWithDeferredStreams) {
   // Test that Envoy can clean-up deferred streams
   // Make the timeout longer to accommodate non optimized builds
   test_server_->waitForCounterEq("http.config_test.downstream_rq_rx_reset", kRequestsSentPerIOCycle,
-                                 TestUtility::DefaultTimeout * 3);
+                                 TestUtility::DefaultTimeout * 10);
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, Http2FrameIntegrationTest,


### PR DESCRIPTION
In my repro attempts, I saw failures with both the `nghttp2` and `oghttp2` codecs.

Addresses the bulk of the failures from https://github.com/envoyproxy/envoy/issues/32132.

Tested via:
```
$ baze test --config=clang-tsan --config=remote test/integration:multiplexed_integration_test \
  --runs_per_test=1000 --test_filter='IpVersions/Http2FrameIntegrationTest.CloseConnectionWithDeferredStreams/*' \
  --test_sharding_strategy=disabled
```

With the timeout extension, I saw 1 failure in 1000 runs, which is significantly better than before.

Commit Message: Increases a test timeout to avoid flaky failures
Additional Description:
Risk Level: none, tests only
Testing: ran 1000 iterations of the suspicious test case
Docs Changes:
Release Notes:
Platform Specific Features:

