### PR TITLE
network: Allow interfaceName() to gracefully handle getifaddrs failures

### DIFF
--- a/source/common/network/io_socket_handle_base_impl.cc
+++ b/source/common/network/io_socket_handle_base_impl.cc
@@ -135,7 +135,7 @@ absl::optional<std::string> IoSocketHandleBaseImpl::interfaceName() {
   Api::InterfaceAddressVector interface_addresses{};
   const Api::SysCallIntResult rc = os_syscalls_singleton.getifaddrs(interface_addresses);
   if (rc.return_value_ != 0) {
-    ENVOY_LOG(warn, "getifaddrs error: {}", rc.errno_);
+    ENVOY_LOG_EVERY_POW_2(warn, "getifaddrs error: {}", rc.errno_);
     return absl::nullopt;
   }
 

--- a/source/common/network/io_socket_handle_base_impl.cc
+++ b/source/common/network/io_socket_handle_base_impl.cc
@@ -134,7 +134,10 @@ absl::optional<std::string> IoSocketHandleBaseImpl::interfaceName() {
 
   Api::InterfaceAddressVector interface_addresses{};
   const Api::SysCallIntResult rc = os_syscalls_singleton.getifaddrs(interface_addresses);
-  RELEASE_ASSERT(!rc.return_value_, fmt::format("getifaddrs error: {}", rc.errno_));
+  if (rc.return_value_ != 0) {
+    ENVOY_LOG(warn, "getifaddrs error: {}", rc.errno_);
+    return absl::nullopt;
+  }
 
   absl::optional<std::string> selected_interface_name{};
   for (const auto& interface_address : interface_addresses) {


### PR DESCRIPTION
In the mobile world, `getifaddrs` sometimes returns ERRNO 19 (`ENODEV`). Given that `interfaceName()` is designed to return an optional anyway, release assert is not the right thing to do here and instead, we log a warning and return `nullopt`.

`interfaceName()` is mainly used for logging purposes, so this change seems low risk.

Risk Level: low
Testing: unit test