### PR TITLE
jwt: do not concatenate duplicated headers

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -71,6 +71,9 @@ bug_fixes:
     Fix crash due to uncaught exception when the operating system does not support an address type (such as IPv6) that is
     received in an mTLS client cert IP SAN. These SANs will be ignored. This applies only when using formatter
     ``%DOWNSTREAM_PEER_IP_SAN%``.
+- area: jwt_authn
+  change: |
+    Fixed JWT extractor, which concatenated headers with a comma, resultig in invalid tokens.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -265,10 +265,10 @@ ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
           }
           auto header_value = extractJWT(value_str, pos + location_spec->value_prefix_.length());
           tokens.push_back(std::make_unique<const JwtHeaderLocation>(
-            std::string(header_value), location_spec->issuer_checker_, location_spec->header_));
+              std::string(header_value), location_spec->issuer_checker_, location_spec->header_));
         } else {
           tokens.push_back(std::make_unique<const JwtHeaderLocation>(
-            std::string(value_str), location_spec->issuer_checker_, location_spec->header_));
+              std::string(value_str), location_spec->issuer_checker_, location_spec->header_));
         }
       }
     }

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -265,7 +265,7 @@ ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
           }
           auto header_value = extractJWT(value_str, pos + location_spec->value_prefix_.length());
           tokens.push_back(std::make_unique<const JwtHeaderLocation>(
-              std::string(header_value), location_spec->issuer_checker_, location_spec->header_));
+            std::string(header_value), location_spec->issuer_checker_, location_spec->header_));
         } else {
           tokens.push_back(std::make_unique<const JwtHeaderLocation>(
             std::string(value_str), location_spec->issuer_checker_, location_spec->header_));

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -263,13 +263,10 @@ ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
             // value_prefix not found anywhere in value_str, so skip
             continue;
           }
-          auto header_value = extractJWT(value_str, pos + location_spec->value_prefix_.length());
-          tokens.push_back(std::make_unique<const JwtHeaderLocation>(
-              std::string(header_value), location_spec->issuer_checker_, location_spec->header_));
-        } else {
-          tokens.push_back(std::make_unique<const JwtHeaderLocation>(
-              std::string(value_str), location_spec->issuer_checker_, location_spec->header_));
+          value_str = extractJWT(value_str, pos + location_spec->value_prefix_.length());
         }
+        tokens.push_back(std::make_unique<const JwtHeaderLocation>(
+            std::string(value_str), location_spec->issuer_checker_, location_spec->header_));
       }
     }
   }

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -143,7 +143,7 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocationWithValidJWT) {
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
 }
 
-TEST_F(ExtractorTest, TestDuplicatedAuthorizationHeaderWithBearerTokens) {
+TEST_F(ExtractorTest, TestDuplicatedHeadersWithDuplicatedTokenPrefixes) {
   auto headers = TestRequestHeaderMapImpl{
     {"Authorization", absl::StrCat("Bearer ", GoodToken)},
     {"Authorization", absl::StrCat("Bearer ", GoodToken)}};
@@ -157,7 +157,7 @@ TEST_F(ExtractorTest, TestDuplicatedAuthorizationHeaderWithBearerTokens) {
   EXPECT_TRUE(tokens[1]->isIssuerAllowed("issuer1"));
 }
 
-TEST_F(ExtractorTest, TestDuplicatedAuthorizationHeaderWithBearerAndBasicTokens) {
+TEST_F(ExtractorTest, TestDuplicatedHeadersWithUniqueTokenPrefixes) {
   auto headers = TestRequestHeaderMapImpl{
     {"Authorization", absl::StrCat("Bearer ", GoodToken)},
     {"Authorization", absl::StrCat("Basic ", "basic")}};

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -143,6 +143,32 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocationWithValidJWT) {
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
 }
 
+TEST_F(ExtractorTest, TestDuplicatedAuthorizationHeaderWithBearerTokens) {
+  auto headers = TestRequestHeaderMapImpl{
+    {"Authorization", absl::StrCat("Bearer ", GoodToken)},
+    {"Authorization", absl::StrCat("Bearer ", GoodToken)}};
+  auto tokens = extractor_->extract(headers);
+  EXPECT_EQ(tokens.size(), 2);
+
+  // Only the issue1 is using default header location.
+  EXPECT_EQ(tokens[0]->token(), GoodToken);
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
+  EXPECT_EQ(tokens[1]->token(), GoodToken);
+  EXPECT_TRUE(tokens[1]->isIssuerAllowed("issuer1"));
+}
+
+TEST_F(ExtractorTest, TestDuplicatedAuthorizationHeaderWithBearerAndBasicTokens) {
+  auto headers = TestRequestHeaderMapImpl{
+    {"Authorization", absl::StrCat("Bearer ", GoodToken)},
+    {"Authorization", absl::StrCat("Basic ", "basic")}};
+  auto tokens = extractor_->extract(headers);
+  EXPECT_EQ(tokens.size(), 1);
+
+  // Only the issue1 is using default header location.
+  EXPECT_EQ(tokens[0]->token(), GoodToken);
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
+}
+
 // Test extracting JWT as Bearer token from the default header location: "Authorization" -
 // using an actual (correctly-formatted) JWT but token is invalid, like: GoodToken +
 // chars_after_space expected to get all token include characters after the space:
@@ -203,12 +229,13 @@ TEST_F(ExtractorTest, TestCustomHeaderToken) {
   EXPECT_FALSE(headers.has(Http::LowerCaseString("token-header")));
 }
 
-// Make sure a double custom header concatenates the token
+// Make sure a double custom header does not concatenate the token
 TEST_F(ExtractorTest, TestDoubleCustomHeaderToken) {
   auto headers = TestRequestHeaderMapImpl{{"token-header", "jwt_token"}, {"token-header", "foo"}};
   auto tokens = extractor_->extract(headers);
-  EXPECT_EQ(tokens.size(), 1);
-  EXPECT_EQ(tokens[0]->token(), "jwt_token,foo");
+  EXPECT_EQ(tokens.size(), 2);
+  EXPECT_EQ(tokens[0]->token(), "jwt_token");
+  EXPECT_EQ(tokens[1]->token(), "foo");
 }
 
 // Test extracting token from the custom header: "prefix-header"
@@ -249,7 +276,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch1) {
 
   // Match issuer 7 with map key as: prefix-header + 'CCCDDD'
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer7"));
-  EXPECT_EQ(tokens[0]->token(), "jwt_token,extra=more");
+  EXPECT_EQ(tokens[0]->token(), "jwt_token");
 }
 
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
@@ -260,7 +287,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
 
   // Match issuer 7 with map key as: prefix-header + AAA
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer7"));
-  EXPECT_EQ(tokens[0]->token(), "and0X3Rva2Vu\",comment=\"fish tag\"");
+  EXPECT_EQ(tokens[0]->token(), "and0X3Rva2Vu\"");
 }
 
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch3) {

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -276,7 +276,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch1) {
 
   // Match issuer 7 with map key as: prefix-header + 'CCCDDD'
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer7"));
-  EXPECT_EQ(tokens[0]->token(), "jwt_token");
+  EXPECT_EQ(tokens[0]->token(), "jwt_token,extra=more");
 }
 
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
@@ -287,7 +287,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
 
   // Match issuer 7 with map key as: prefix-header + AAA
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer7"));
-  EXPECT_EQ(tokens[0]->token(), "and0X3Rva2Vu\"");
+  EXPECT_EQ(tokens[0]->token(), "and0X3Rva2Vu\",comment=\"fish tag\"");
 }
 
 TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch3) {

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -144,9 +144,8 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocationWithValidJWT) {
 }
 
 TEST_F(ExtractorTest, TestDuplicatedHeadersWithDuplicatedTokenPrefixes) {
-  auto headers = TestRequestHeaderMapImpl{
-    {"Authorization", absl::StrCat("Bearer ", GoodToken)},
-    {"Authorization", absl::StrCat("Bearer ", GoodToken)}};
+  auto headers = TestRequestHeaderMapImpl{{"Authorization", absl::StrCat("Bearer ", GoodToken)},
+                                          {"Authorization", absl::StrCat("Bearer ", GoodToken)}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 2);
 
@@ -158,9 +157,8 @@ TEST_F(ExtractorTest, TestDuplicatedHeadersWithDuplicatedTokenPrefixes) {
 }
 
 TEST_F(ExtractorTest, TestDuplicatedHeadersWithUniqueTokenPrefixes) {
-  auto headers = TestRequestHeaderMapImpl{
-    {"Authorization", absl::StrCat("Bearer ", GoodToken)},
-    {"Authorization", absl::StrCat("Basic ", "basic")}};
+  auto headers = TestRequestHeaderMapImpl{{"Authorization", absl::StrCat("Bearer ", GoodToken)},
+                                          {"Authorization", absl::StrCat("Basic ", "basic")}};
   auto tokens = extractor_->extract(headers);
   EXPECT_EQ(tokens.size(), 1);
 


### PR DESCRIPTION
Commit Message: jwt: do not concatenate duplicated headers
Additional Description:
Duplicated headers should not be concatenated with a comma, because comma is not allowed in a JWT token, so concatenation invalidates tokens.
This PR fixes #31468. 

Risk Level:
Testing: unit tests
Docs Changes: none
Release Notes:
Platform Specific Features: none
