### PR TITLE
Link test binaries dynamically for coverage builds

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -25,7 +25,8 @@ def envoy_cc_binary(
         deps = [],
         linkopts = [],
         tags = [],
-        features = []):
+        features = [],
+        linkstatic = True):
     linker_inputs = envoy_exported_symbols_input()
 
     if not linkopts:
@@ -43,7 +44,7 @@ def envoy_cc_binary(
         copts = envoy_copts(repository),
         linkopts = linkopts,
         testonly = testonly,
-        linkstatic = 1,
+        linkstatic = linkstatic,
         visibility = visibility,
         malloc = tcmalloc_external_dep(repository),
         stamp = stamp,

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -54,6 +54,10 @@ load(
     _envoy_sh_test = "envoy_sh_test",
 )
 load(
+    ":envoy_internal.bzl",
+    _envoy_linkstatic = "envoy_linkstatic",
+)
+load(
     ":envoy_mobile_defines.bzl",
     _envoy_mobile_defines = "envoy_mobile_defines",
 )
@@ -250,6 +254,7 @@ envoy_select_wasm_v8 = _envoy_select_wasm_v8
 envoy_select_wasm_wamr = _envoy_select_wasm_wamr
 envoy_select_wasm_wavm = _envoy_select_wasm_wavm
 envoy_select_wasm_wasmtime = _envoy_select_wasm_wasmtime
+envoy_select_linkstatic = _envoy_linkstatic
 
 # Binary wrappers (from envoy_binary.bzl)
 envoy_cc_binary = _envoy_cc_binary

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -228,6 +228,7 @@ def envoy_cc_test_binary(
         tags = [],
         deps = [],
         stamp = 0,
+        linkstatic = True,
         **kargs):
     envoy_cc_binary(
         name,
@@ -238,6 +239,7 @@ def envoy_cc_test_binary(
             "@envoy//test/test_common:test_version_linkstamp",
         ],
         stamp = stamp,
+        linkstatic = linkstatic,
         **kargs
     )
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -11,6 +11,7 @@ load(
     "envoy_select_enable_http3",
     "envoy_select_enable_yaml",
     "envoy_select_envoy_mobile_listener",
+    "envoy_select_linkstatic",
     "envoy_sh_test",
 )
 
@@ -364,6 +365,7 @@ envoy_cc_test_binary(
     external_deps = [
         "abseil_symbolize",
     ],
+    linkstatic = envoy_select_linkstatic(),
     deps = [
         "//source/exe:main_common_lib",
         "//source/exe:platform_impl_lib",

--- a/test/integration/run_envoy_test.sh
+++ b/test/integration/run_envoy_test.sh
@@ -52,6 +52,6 @@ expect_ok -c "${TEST_SRCDIR}/envoy/test/config/integration/empty.yaml" --mode va
 
 start_test "Launching envoy with empty config."
 run_in_background_saving_pid "${ENVOY_BIN}" -c "${TEST_SRCDIR}/envoy/test/config/integration/empty.yaml" --use-dynamic-base-id
-sleep 3
+sleep 120
 kill "${BACKGROUND_PID}"
 wait "${BACKGROUND_PID}"

--- a/test/tools/router_check/BUILD
+++ b/test/tools/router_check/BUILD
@@ -4,6 +4,7 @@ load(
     "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
+    "envoy_select_linkstatic",
 )
 load("//bazel:repositories.bzl", "PPC_SKIP_TARGETS", "WINDOWS_SKIP_TARGETS")
 load("//source/extensions:all_extensions.bzl", "envoy_all_extensions")
@@ -15,6 +16,7 @@ envoy_package()
 envoy_cc_test_binary(
     name = "router_check_tool",
     srcs = ["router_check.cc"],
+    linkstatic = envoy_select_linkstatic(),
     deps = [":router_check_main_lib"] + select({
         "//bazel:coverage_build": [],
         "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),


### PR DESCRIPTION
Commit Message:
Dynamic linking prevents build failure due to size of coverage instrumentation.

Additional Description:
This PR changed two known problematic binaries.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
