### PR TITLE
http: keep `trailers` TE header instead of removing it

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -4,8 +4,8 @@ behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 - area: http
   change: |
-    Remove the hop by hop TE header from downstream request headers if it's not set to `trailers`. This change can be temporarily
-    reverted by setting ``envoy.reloadable_features.sanitize_te`` to false.
+    Remove the hop by hop TE header from downstream request headers if it's not set to `trailers`, else keep it. This change can be
+    temporarily reverted by setting ``envoy.reloadable_features.sanitize_te`` to false.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -2,6 +2,10 @@ date: Pending
 
 behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
+- area: http
+  change: |
+    Force the hop by hop TE header from downstream request headers to "trailers". This change can be temporarily reverted
+    by setting ``envoy.reloadable_features.sanitize_te`` to false.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -4,7 +4,7 @@ behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 - area: http
   change: |
-    Remove the hop by hop TE header from downstream request headers if it's not set to `trailers`, else keep it. This change can be
+    Remove the hop by hop TE header from downstream request headers if it's not set to ``trailers``, else keep it. This change can be
     temporarily reverted by setting ``envoy.reloadable_features.sanitize_te`` to false.
 
 minor_behavior_changes:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -4,8 +4,8 @@ behavior_changes:
 # *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 - area: http
   change: |
-    Force the hop by hop TE header from downstream request headers to "trailers". This change can be temporarily reverted
-    by setting ``envoy.reloadable_features.sanitize_te`` to false.
+    Remove the hop by hop TE header from downstream request headers if it's not set to `trailers`. This change can be temporarily
+    reverted by setting ``envoy.reloadable_features.sanitize_te`` to false.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -303,8 +303,8 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
 
   // If the TE header contains the "trailers" value, set the TE header to "trailers" only.
   std::vector<std::string> te_values = absl::StrSplit(te_header, ',');
-  for (const auto& teValue : te_values) {
-    bool has_trailers_te = absl::StripAsciiWhitespace(teValue) == Http::Headers::get().TEValues.Trailers;
+  for (const auto& te_value : te_values) {
+    bool has_trailers_te = absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
 
     if (has_trailers_te) {
       request_headers.setTE(Http::Headers::get().TEValues.Trailers);

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -94,9 +94,7 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     request_headers.removeUpgrade();
 
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
-      if (Grpc::Common::isGrpcRequestHeaders(request_headers)) {
-        request_headers.setTE(Http::Headers::get().TEValues.Trailers);
-      } else {
+      if (request_headers.TE() != Http::Headers::get().TEValues.Trailers) {
         request_headers.removeTE();
       }
     }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -93,7 +93,7 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     request_headers.removeConnection();
     request_headers.removeUpgrade();
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
-      request_headers.removeTE();
+      request_headers.setTE(Http::Headers::get().TEValues.Trailers);
     }
   }
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -92,8 +92,13 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
   if (!Utility::isUpgrade(request_headers)) {
     request_headers.removeConnection();
     request_headers.removeUpgrade();
+
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
-      request_headers.setTE(Http::Headers::get().TEValues.Trailers);
+      if (Grpc::Common::isGrpcRequestHeaders(request_headers)) {
+        request_headers.setTE(Http::Headers::get().TEValues.Trailers);
+      } else {
+        request_headers.removeTE();
+      }
     }
   }
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -304,9 +304,9 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
   // If the TE header contains the "trailers" value, set the TE header to "trailers" only.
   std::vector<std::string> te_values = absl::StrSplit(te_header, ',');
   for (const std::string& te_value : te_values) {
-    bool has_trailers_te = absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
+    bool is_trailers = absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
 
-    if (has_trailers_te) {
+    if (is_trailers) {
       request_headers.setTE(Http::Headers::get().TEValues.Trailers);
       return;
     }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -296,14 +296,14 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
     return;
   }
 
-  std::string te_header = request_headers.getTEValue();
+  absl::string_view te_header = request_headers.getTEValue();
   if (te_header.empty()) {
     return;
   }
 
   // If the TE header contains the "trailers" value, set the TE header to "trailers" only.
-  std::vector<std::string> te_values = absl::StrSplit(te_header, ',');
-  for (const std::string& te_value : te_values) {
+  std::vector<absl::string_view> te_values = absl::StrSplit(te_header, ',');
+  for (const absl::string_view& te_value : te_values) {
     bool is_trailers = absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
 
     if (is_trailers) {

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -94,23 +94,23 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     request_headers.removeUpgrade();
 
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
-      auto teHeader = request_headers.getTEValue();
+      std::string te_header = request_headers.getTEValue();
 
-      if (!teHeader.empty()) {
-        auto hasTrailersTE = false;
+      if (!te_header.empty()) {
+        bool has_trailers_te = false;
 
-        auto teValues = absl::StrSplit(, ",");
-        for (const auto& teValue : teValues) {
-          auto parts = absl::StrSplit(teValue, ";"); // Handles cases like "chunked, trailers;q=0.5"
-          auto value = absl::StripAsciiWhitespace(parts[0]);
+        std::vector<std::string> te_values = absl::StrSplit(, ",");
+        for (const auto& teValue : te_values) {
+          std::vector<std::string> parts = absl::StrSplit(teValue, ";"); // Handles cases like "chunked, trailers;q=0.5"
+          std::string value = absl::StripAsciiWhitespace(parts[0]);
 
           if (value == Http::Headers::get().TEValues.Trailers) {
-            hasTrailersTE = true;
+            has_trailers_te = true;
             break;
           }
         }
 
-        if (hasTrailersTE) {
+        if (has_trailers_te) {
           request_headers.setTE(Http::Headers::get().TEValues.Trailers);
         } else {
           request_headers.removeTE();

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -301,21 +301,19 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
     return;
   }
 
-  bool has_trailers_te = false;
-
+  // If the TE header contains the "trailers" value, set the TE header to "trailers" only.
   std::vector<std::string> te_values = absl::StrSplit(te_header, ',');
   for (const auto& teValue : te_values) {
-    if (absl::StripAsciiWhitespace(teValue) == Http::Headers::get().TEValues.Trailers) {
-      has_trailers_te = true;
-      break;
+    bool has_trailers_te = absl::StripAsciiWhitespace(teValue) == Http::Headers::get().TEValues.Trailers;
+
+    if (has_trailers_te) {
+      request_headers.setTE(Http::Headers::get().TEValues.Trailers);
+      return;
     }
   }
 
-  if (has_trailers_te) {
-    request_headers.setTE(Http::Headers::get().TEValues.Trailers);
-  } else {
-    request_headers.removeTE();
-  }
+  // If the TE header does not contain the "trailers" value, remove the TE header.
+  request_headers.removeTE();
 }
 
 void ConnectionManagerUtility::cleanInternalHeaders(

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -303,7 +303,7 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
 
   // If the TE header contains the "trailers" value, set the TE header to "trailers" only.
   std::vector<std::string> te_values = absl::StrSplit(te_header, ',');
-  for (const auto& te_value : te_values) {
+  for (const std::string& te_value : te_values) {
     bool has_trailers_te = absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
 
     if (has_trailers_te) {

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -304,7 +304,8 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
   // If the TE header contains the "trailers" value, set the TE header to "trailers" only.
   std::vector<absl::string_view> te_values = absl::StrSplit(te_header, ',');
   for (const absl::string_view& te_value : te_values) {
-    bool is_trailers = absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
+    bool is_trailers =
+        absl::StripAsciiWhitespace(te_value) == Http::Headers::get().TEValues.Trailers;
 
     if (is_trailers) {
       request_headers.setTE(Http::Headers::get().TEValues.Trailers);

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -94,7 +94,7 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     request_headers.removeUpgrade();
 
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
-      if (request_headers.TE() != Http::Headers::get().TEValues.Trailers) {
+      if (request_headers.getTEValue() != Http::Headers::get().TEValues.Trailers) {
         request_headers.removeTE();
       }
     }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -292,7 +292,7 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
 }
 
 void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_headers) {
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.sanitize_te")) {
     return;
   }
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -303,13 +303,9 @@ void ConnectionManagerUtility::sanitizeTEHeader(RequestHeaderMap& request_header
 
   bool has_trailers_te = false;
 
-  std::vector<std::string> te_values = absl::StrSplit(, ",");
+  std::vector<std::string> te_values = absl::StrSplit(te_header, ',');
   for (const auto& teValue : te_values) {
-    std::vector<std::string> parts =
-        absl::StrSplit(teValue, ";"); // Handles cases like "chunked, trailers;q=0.5"
-    std::string value = absl::StripAsciiWhitespace(parts[0]);
-
-    if (value == Http::Headers::get().TEValues.Trailers) {
+    if (absl::StripAsciiWhitespace(teValue) == Http::Headers::get().TEValues.Trailers) {
       has_trailers_te = true;
       break;
     }

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -141,6 +141,7 @@ private:
   static void mutateXfccRequestHeader(RequestHeaderMap& request_headers,
                                       Network::Connection& connection,
                                       ConnectionManagerConfig& config);
+  static void sanitizeTEHeader(RequestHeaderMap& request_headers);
   static void cleanInternalHeaders(RequestHeaderMap& request_headers, bool edge_request,
                                    const std::list<Http::LowerCaseString>& internal_only_headers);
 };

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2237,5 +2237,39 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverwriteXForwardedPortFromUntrustedHo
   EXPECT_EQ("80", headers.getForwardedPortValue());
 }
 
+// Verify when TE header is present, the value should be preserved only if it's equal to "trailers".
+TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderSimple) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
+
+  TestRequestHeaderMapImpl headers{{"te", "trailers"}};
+  callMutateRequestHeaders(headers, Protocol::Http2);
+
+  EXPECT_EQ("trailers", headers.getTEValue());
+}
+
+// Verify when TE header is present, the value should be preserved only if it contains "trailers".
+TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderMultipleValuesAndWeigthted) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
+
+  TestRequestHeaderMapImpl headers{{"te", "chunked;q=0.8  ,  trailers  ;q=0.5,deflate  "}};
+  callMutateRequestHeaders(headers, Protocol::Http2);
+
+  EXPECT_EQ("trailers", headers.getTEValue());
+}
+
+// Verify when TE header is present, the value should be discarded if it doesn't contains
+// "trailers".
+TEST_F(ConnectionManagerUtilityTest, DiscardTEHeaderWithoutTrailers) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
+
+  TestRequestHeaderMapImpl headers{{"te", "gzip"}};
+  callMutateRequestHeaders(headers, Protocol::Http2);
+
+  EXPECT_EQ("", headers.getTEValue());
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2239,9 +2239,6 @@ TEST_F(ConnectionManagerUtilityTest, DoNotOverwriteXForwardedPortFromUntrustedHo
 
 // Verify when TE header is present, the value should be preserved only if it's equal to "trailers".
 TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderSimple) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
-
   TestRequestHeaderMapImpl headers{{"te", "trailers"}};
   callMutateRequestHeaders(headers, Protocol::Http2);
 
@@ -2250,9 +2247,6 @@ TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderSimple) {
 
 // Verify when TE header is present, the value should be preserved only if it contains "trailers".
 TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderMultipleValuesAndWeigthted) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
-
   TestRequestHeaderMapImpl headers{{"te", "chunked;q=0.8  ,  trailers  ,deflate  "}};
   callMutateRequestHeaders(headers, Protocol::Http2);
 
@@ -2262,9 +2256,6 @@ TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderMultipleValuesAndWeigth
 // Verify when TE header is present, the value should be discarded if it doesn't contains
 // "trailers".
 TEST_F(ConnectionManagerUtilityTest, DiscardTEHeaderWithoutTrailers) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
-
   TestRequestHeaderMapImpl headers{{"te", "gzip"}};
   callMutateRequestHeaders(headers, Protocol::Http2);
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2264,7 +2264,7 @@ TEST_F(ConnectionManagerUtilityTest, DiscardTEHeaderWithoutTrailers) {
 
 // Verify when TE header is present, the value should be kept if the reloadable feature
 // "sanitize_te" is enabled.
-TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderSimple) {
+TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderReloadableFeatureDisabled) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "false"}});
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2262,5 +2262,17 @@ TEST_F(ConnectionManagerUtilityTest, DiscardTEHeaderWithoutTrailers) {
   EXPECT_EQ("", headers.getTEValue());
 }
 
+// Verify when TE header is present, the value should be kept if the reloadable feature
+// "sanitize_te" is enabled.
+TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderSimple) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "false"}});
+
+  TestRequestHeaderMapImpl headers{{"te", "gzip"}};
+  callMutateRequestHeaders(headers, Protocol::Http2);
+
+  EXPECT_EQ("gzip", headers.getTEValue());
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2253,7 +2253,7 @@ TEST_F(ConnectionManagerUtilityTest, KeepTrailersTEHeaderMultipleValuesAndWeigth
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues({{"envoy.reloadable_features.sanitize_te", "true"}});
 
-  TestRequestHeaderMapImpl headers{{"te", "chunked;q=0.8  ,  trailers  ;q=0.5,deflate  "}};
+  TestRequestHeaderMapImpl headers{{"te", "chunked;q=0.8  ,  trailers  ,deflate  "}};
   callMutateRequestHeaders(headers, Protocol::Http2);
 
   EXPECT_EQ("trailers", headers.getTEValue());

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -832,6 +832,29 @@ TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationTrailers) {
   EXPECT_EQ("trailers", upstream_headers->getTEValue());
 }
 
+TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationTrailersMultipleValuesAndWeigthted) {
+  if (downstreamProtocol() != Http::CodecType::HTTP1) {
+    return;
+  }
+
+  autonomous_upstream_ = true;
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.sanitize_te", "true");
+
+  default_request_headers_.setTE("chunked;q=0.8  ,  trailers  ;q=0.5,deflate  ");
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  auto upstream_headers =
+      reinterpret_cast<AutonomousUpstream*>(fake_upstreams_[0].get())->lastRequestHeaders();
+  EXPECT_TRUE(upstream_headers != nullptr);
+  EXPECT_EQ("trailers", upstream_headers->getTEValue());
+}
+
 // Regression test for https://github.com/envoyproxy/envoy/issues/10270
 TEST_P(ProtocolIntegrationTest, LongHeaderValueWithSpaces) {
   // Header with at least 20kb of spaces surrounded by non-whitespace characters to ensure that

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -809,7 +809,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TeSanitization) {
   EXPECT_EQ("", upstream_headers->getTEValue());
 }
 
-TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationGrpc) {
+TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationTrailers) {
   if (downstreamProtocol() != Http::CodecType::HTTP1) {
     return;
   }
@@ -817,8 +817,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationGrpc) {
   autonomous_upstream_ = true;
   config_helper_.addRuntimeOverride("envoy.reloadable_features.sanitize_te", "true");
 
-  default_request_headers_.setTE("gzip");
-  default_request_headers_.setContentType("application/grpc");
+  default_request_headers_.setTE("trailers");
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -806,6 +806,30 @@ TEST_P(DownstreamProtocolIntegrationTest, TeSanitization) {
   auto upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_[0].get())->lastRequestHeaders();
   EXPECT_TRUE(upstream_headers != nullptr);
+  EXPECT_EQ("", upstream_headers->getTEValue());
+}
+
+TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationGrpc) {
+  if (downstreamProtocol() != Http::CodecType::HTTP1) {
+    return;
+  }
+
+  autonomous_upstream_ = true;
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.sanitize_te", "true");
+
+  default_request_headers_.setTE("gzip");
+  default_request_headers_.setContentType("application/grpc");
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  auto upstream_headers =
+      reinterpret_cast<AutonomousUpstream*>(fake_upstreams_[0].get())->lastRequestHeaders();
+  EXPECT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ("trailers", upstream_headers->getTEValue());
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -840,7 +840,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TeSanitizationTrailersMultipleValuesAn
   autonomous_upstream_ = true;
   config_helper_.addRuntimeOverride("envoy.reloadable_features.sanitize_te", "true");
 
-  default_request_headers_.setTE("chunked;q=0.8  ,  trailers  ;q=0.5,deflate  ");
+  default_request_headers_.setTE("chunked;q=0.8  ,  trailers  ,deflate  ");
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -806,7 +806,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TeSanitization) {
   auto upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_[0].get())->lastRequestHeaders();
   EXPECT_TRUE(upstream_headers != nullptr);
-  EXPECT_EQ("", upstream_headers->getTEValue());
+  EXPECT_EQ("trailers", upstream_headers->getTEValue());
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/10270


### PR DESCRIPTION
Official grpc library [does not allow empty TE header](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/http/server/http_server_filter.cc#L102). This causes an issue when proxying requests through Envoy which currently deletes the TE header since https://github.com/envoyproxy/envoy/pull/30535.

I opened a related MR on the grpc library to allow this header to be empty as the HTTP/2 RFC allows it but it might cause issues with other libraries.

Risk Level: medium (behavioral change)
Testing: modified an existing test
Docs Changes: n/a
Release Notes: inline
Platform Specific Features:
Runtime guard: keep the previous one
