### PR TITLE
Use protobuf's DynamicCastToGenerated instead of dynamic_cast<>

### DIFF
--- a/source/extensions/http/early_header_mutation/header_mutation/config.cc
+++ b/source/extensions/http/early_header_mutation/header_mutation/config.cc
@@ -12,7 +12,8 @@ Envoy::Http::EarlyHeaderMutationPtr
 Factory::createExtension(const Protobuf::Message& message,
                          Server::Configuration::FactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const ProtobufWkt::Any&>(message), context.messageValidationVisitor(), *this);
+      *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::Any>(&message),
+      context.messageValidationVisitor(), *this);
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::http::early_header_mutation::header_mutation::v3::HeaderMutation&>(
       *mptr, context.messageValidationVisitor());

--- a/source/extensions/http/original_ip_detection/custom_header/config.cc
+++ b/source/extensions/http/original_ip_detection/custom_header/config.cc
@@ -17,7 +17,8 @@ Envoy::Http::OriginalIPDetectionSharedPtr
 CustomHeaderIPDetectionFactory::createExtension(const Protobuf::Message& message,
                                                 Server::Configuration::FactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const ProtobufWkt::Any&>(message), context.messageValidationVisitor(), *this);
+      *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::Any>(&message),
+      context.messageValidationVisitor(), *this);
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::http::original_ip_detection::custom_header::v3::CustomHeaderConfig&>(
       *mptr, context.messageValidationVisitor());

--- a/test/common/formatter/command_extension.cc
+++ b/test/common/formatter/command_extension.cc
@@ -29,7 +29,8 @@ CommandParserPtr
 TestCommandFactory::createCommandParserFromProto(const Protobuf::Message& message,
                                                  Server::Configuration::GenericFactoryContext&) {
   // Cast the config message to the actual type to test that it was constructed properly.
-  [[maybe_unused]] const auto config = dynamic_cast<const ProtobufWkt::StringValue&>(message);
+  [[maybe_unused]] const auto& config =
+      *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::StringValue>(&message);
   return std::make_unique<TestCommandParser>();
 }
 
@@ -65,7 +66,8 @@ FormatterProviderPtr AdditionalCommandParser::parse(const std::string& command, 
 CommandParserPtr AdditionalCommandFactory::createCommandParserFromProto(
     const Protobuf::Message& message, Server::Configuration::GenericFactoryContext&) {
   // Cast the config message to the actual type to test that it was constructed properly.
-  [[maybe_unused]] const auto config = dynamic_cast<const ProtobufWkt::UInt32Value&>(message);
+  [[maybe_unused]] const auto& config =
+      *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::UInt32Value>(&message);
   return std::make_unique<AdditionalCommandParser>();
 }
 
@@ -83,7 +85,8 @@ CommandParserPtr
 FailCommandFactory::createCommandParserFromProto(const Protobuf::Message& message,
                                                  Server::Configuration::GenericFactoryContext&) {
   // Cast the config message to the actual type to test that it was constructed properly.
-  [[maybe_unused]] const auto config = dynamic_cast<const ProtobufWkt::UInt64Value&>(message);
+  [[maybe_unused]] const auto& config =
+      *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::UInt64Value>(&message);
   return nullptr;
 }
 

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -38,8 +38,8 @@ void addFileDescriptorsRecursively(const Protobuf::FileDescriptor& descriptor,
 
 void addBookstoreProtoDescriptor(Protobuf::Message* message) {
   envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder& config =
-      dynamic_cast<envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&>(
-          *message);
+      *Envoy::Protobuf::DynamicCastToGenerated<
+          envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder>(message);
   config.clear_services();
   config.add_services("bookstore.Bookstore");
 
@@ -82,7 +82,8 @@ void UberFilterFuzzer::guideAnyProtoType(test::fuzz::HttpData* mutable_data, uin
 
 void cleanTapConfig(Protobuf::Message* message) {
   envoy::extensions::filters::http::tap::v3::Tap& config =
-      dynamic_cast<envoy::extensions::filters::http::tap::v3::Tap&>(*message);
+      *Envoy::Protobuf::DynamicCastToGenerated<envoy::extensions::filters::http::tap::v3::Tap>(
+          message);
   if (config.common_config().config_type_case() ==
       envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::kStaticConfig) {
     auto const& output_config = config.common_config().static_config().output_config();
@@ -110,9 +111,9 @@ void cleanTapConfig(Protobuf::Message* message) {
 
 void cleanFileSystemBufferConfig(Protobuf::Message* message) {
   envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig& config =
-      dynamic_cast<
-          envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&>(
-          *message);
+      *Envoy::Protobuf::DynamicCastToGenerated<
+          envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig>(
+          message);
   if (config.manager_config().thread_pool().thread_count() > kMaxAsyncFileManagerThreadCount) {
     throw EnvoyException(fmt::format(
         "received input exceeding the allowed number of threads ({} > {}) for "

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -103,8 +103,8 @@ void UberFilterFuzzer::checkInvalidInputForFuzzer(const std::string& filter_name
   // HttpConnectionManager} on which we have constraints.
   if (filter_name == NetworkFilterNames::get().DirectResponse) {
     envoy::extensions::filters::network::direct_response::v3::Config& config =
-        dynamic_cast<envoy::extensions::filters::network::direct_response::v3::Config&>(
-            *config_message);
+        *Envoy::Protobuf::DynamicCastToGenerated<
+            envoy::extensions::filters::network::direct_response::v3::Config>(config_message);
     if (config.response().specifier_case() ==
         envoy::config::core::v3::DataSource::SpecifierCase::kFilename) {
       throw EnvoyException(
@@ -112,8 +112,9 @@ void UberFilterFuzzer::checkInvalidInputForFuzzer(const std::string& filter_name
     }
   } else if (filter_name == NetworkFilterNames::get().LocalRateLimit) {
     envoy::extensions::filters::network::local_ratelimit::v3::LocalRateLimit& config =
-        dynamic_cast<envoy::extensions::filters::network::local_ratelimit::v3::LocalRateLimit&>(
-            *config_message);
+        *Envoy::Protobuf::DynamicCastToGenerated<
+            envoy::extensions::filters::network::local_ratelimit::v3::LocalRateLimit>(
+            config_message);
     if (config.token_bucket().fill_interval().seconds() > SecondsPerDay) {
       // Too large fill_interval may cause "c++/v1/chrono" overflow when simulated_time_system_ is
       // converting it to a smaller unit. Constraining fill_interval to no greater than one day is
@@ -124,8 +125,9 @@ void UberFilterFuzzer::checkInvalidInputForFuzzer(const std::string& filter_name
     }
   } else if (filter_name == NetworkFilterNames::get().HttpConnectionManager) {
     envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-        config = dynamic_cast<envoy::extensions::filters::network::http_connection_manager::v3::
-                                  HttpConnectionManager&>(*config_message);
+        config = *Envoy::Protobuf::DynamicCastToGenerated<
+            envoy::extensions::filters::network::http_connection_manager::v3::
+                HttpConnectionManager>(config_message);
     if (config.codec_type() == envoy::extensions::filters::network::http_connection_manager::v3::
                                    HttpConnectionManager::HTTP3) {
       // Quiche is still in progress and http_conn_manager has a dedicated fuzzer.
@@ -156,9 +158,9 @@ void UberFilterFuzzer::checkInvalidInputForFuzzer(const std::string& filter_name
     }
   } else if (filter_name == NetworkFilterNames::get().EnvoyMobileHttpConnectionManager) {
     envoy::extensions::filters::network::http_connection_manager::v3::
-        EnvoyMobileHttpConnectionManager& config =
-            dynamic_cast<envoy::extensions::filters::network::http_connection_manager::v3::
-                             EnvoyMobileHttpConnectionManager&>(*config_message);
+        EnvoyMobileHttpConnectionManager& config = *Envoy::Protobuf::DynamicCastToGenerated<
+            envoy::extensions::filters::network::http_connection_manager::v3::
+                EnvoyMobileHttpConnectionManager>(config_message);
     if (config.config().codec_type() ==
         envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
             HTTP3) {


### PR DESCRIPTION
Commit Message:
Replace dynamic_cast with a protobuf method that can work even when RTTI is disabled.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
