### PR TITLE
build: Add the CFNetwork framework to the Apple linkopts

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -59,7 +59,7 @@ def _envoy_linkopts():
         "@envoy//bazel:apple": [
             # https://github.com/envoyproxy/envoy/issues/24782
             "-Wl,-framework,CoreFoundation",
-	    # Required for iOS proxy support.
+	    # Required for Apple proxy support.
 	    # (see https://github.com/envoyproxy/envoy/pull/30903)
             "-Wl,-framework,CFNetwork",
             # https://github.com/bazelbuild/bazel/pull/16414

--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -59,6 +59,9 @@ def _envoy_linkopts():
         "@envoy//bazel:apple": [
             # https://github.com/envoyproxy/envoy/issues/24782
             "-Wl,-framework,CoreFoundation",
+	    # Required for iOS proxy support.
+	    # (see https://github.com/envoyproxy/envoy/pull/30903)
+            "-Wl,-framework,CFNetwork",
             # https://github.com/bazelbuild/bazel/pull/16414
             "-Wl,-undefined,error",
         ],


### PR DESCRIPTION
iOS proxy support, which is being introduced in
https://github.com/envoyproxy/envoy/pull/30903, requires the CFNetwork framework to be linked in.

Since https://github.com/envoyproxy/envoy/pull/30903 is a long, mobile-specific PR, we're adding this option in a separate PR to reduce review burden on Envoy reviewers.