### PR TITLE
quic: support multiple certs, selected by SNI

### DIFF
--- a/envoy/ssl/context_manager.h
+++ b/envoy/ssl/context_manager.h
@@ -12,6 +12,12 @@
 namespace Envoy {
 namespace Ssl {
 
+// Opaque type defined and used by the ``ServerContext``.
+struct TlsContext;
+
+using ContextAdditionalInitFunc =
+    std::function<void(Ssl::TlsContext& context, const Ssl::TlsCertificateConfig& cert)>;
+
 /**
  * Manages all of the SSL contexts in the process
  */
@@ -30,7 +36,8 @@ public:
    */
   virtual ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
-                         const std::vector<std::string>& server_names) PURE;
+                         const std::vector<std::string>& server_names,
+                         ContextAdditionalInitFunc additional_init) PURE;
 
   /**
    * @return the number of days until the next certificate being managed will expire, the value is

--- a/source/common/quic/envoy_quic_proof_source.cc
+++ b/source/common/quic/envoy_quic_proof_source.cc
@@ -18,67 +18,26 @@ quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain>
 EnvoyQuicProofSource::GetCertChain(const quic::QuicSocketAddress& server_address,
                                    const quic::QuicSocketAddress& client_address,
                                    const std::string& hostname, bool* cert_matched_sni) {
-  // TODO(DavidSchinazi) parse the certificate to correctly fill in |cert_matched_sni|.
-  *cert_matched_sni = false;
-
-  CertConfigWithFilterChain res =
-      getTlsCertConfigAndFilterChain(server_address, client_address, hostname);
-  absl::optional<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>> cert_config_ref =
-      res.cert_config_;
-  if (!cert_config_ref.has_value()) {
-    return nullptr;
-  }
-  auto& cert_config = cert_config_ref.value().get();
-  const std::string& chain_str = cert_config.certificateChain();
-  std::stringstream pem_stream(chain_str);
-  std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
-
-  quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain> cert_chain(
-      new quic::ProofSource::Chain(chain));
-  std::string error_details;
-  bssl::UniquePtr<X509> cert = parseDERCertificate(cert_chain->certs[0], &error_details);
-  if (cert == nullptr) {
-    ENVOY_LOG(warn, absl::StrCat("Invalid leaf cert: ", error_details));
-    return nullptr;
-  }
-
-  bssl::UniquePtr<EVP_PKEY> pub_key(X509_get_pubkey(cert.get()));
-  int sign_alg = deduceSignatureAlgorithmFromPublicKey(pub_key.get(), &error_details);
-  if (sign_alg == 0) {
-    ENVOY_LOG(warn, absl::StrCat("Failed to deduce signature algorithm from public key: ",
-                                 error_details));
-    return nullptr;
-  }
-  return cert_chain;
+  CertWithFilterChain res =
+      getTlsCertConfigAndFilterChain(server_address, client_address, hostname, cert_matched_sni);
+  return res.cert_;
 }
 
 void EnvoyQuicProofSource::signPayload(
     const quic::QuicSocketAddress& server_address, const quic::QuicSocketAddress& client_address,
     const std::string& hostname, uint16_t signature_algorithm, absl::string_view in,
     std::unique_ptr<quic::ProofSource::SignatureCallback> callback) {
-  CertConfigWithFilterChain res =
-      getTlsCertConfigAndFilterChain(server_address, client_address, hostname);
-  absl::optional<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>> cert_config_ref =
-      res.cert_config_;
-  if (!cert_config_ref.has_value()) {
+  CertWithFilterChain res = getTlsCertConfigAndFilterChain(server_address, client_address, hostname,
+                                                           nullptr /* cert_matched_sni */);
+  if (res.private_key_ == nullptr) {
     ENVOY_LOG(warn, "No matching filter chain found for handshake.");
-    callback->Run(false, "", nullptr);
-    return;
-  }
-  auto& cert_config = cert_config_ref.value().get();
-  // Load private key.
-  const std::string& pkey = cert_config.privateKey();
-  std::stringstream pem_str(pkey);
-  std::unique_ptr<quic::CertificatePrivateKey> pem_key =
-      quic::CertificatePrivateKey::LoadPemFromStream(&pem_str);
-  if (pem_key == nullptr) {
-    ENVOY_LOG(warn, "Failed to load private key.");
     callback->Run(false, "", nullptr);
     return;
   }
   // Verify the signature algorithm is as expected.
   std::string error_details;
-  int sign_alg = deduceSignatureAlgorithmFromPublicKey(pem_key->private_key(), &error_details);
+  int sign_alg =
+      deduceSignatureAlgorithmFromPublicKey(res.private_key_->private_key(), &error_details);
   if (sign_alg != signature_algorithm) {
     ENVOY_LOG(warn,
               fmt::format("The signature algorithm {} from the private key is not expected: {}",
@@ -88,17 +47,16 @@ void EnvoyQuicProofSource::signPayload(
   }
 
   // Sign.
-  std::string sig = pem_key->Sign(in, signature_algorithm);
+  std::string sig = res.private_key_->Sign(in, signature_algorithm);
   bool success = !sig.empty();
   ASSERT(res.filter_chain_.has_value());
   callback->Run(success, sig,
                 std::make_unique<EnvoyQuicProofSourceDetails>(res.filter_chain_.value().get()));
 }
 
-EnvoyQuicProofSource::CertConfigWithFilterChain
-EnvoyQuicProofSource::getTlsCertConfigAndFilterChain(const quic::QuicSocketAddress& server_address,
-                                                     const quic::QuicSocketAddress& client_address,
-                                                     const std::string& hostname) {
+EnvoyQuicProofSource::CertWithFilterChain EnvoyQuicProofSource::getTlsCertConfigAndFilterChain(
+    const quic::QuicSocketAddress& server_address, const quic::QuicSocketAddress& client_address,
+    const std::string& hostname, bool* cert_matched_sni) {
   ENVOY_LOG(trace, "Getting cert chain for {}", hostname);
   // TODO(danzh) modify QUICHE to make quic session or ALPN accessible to avoid hard-coded ALPN.
   Network::ConnectionSocketPtr connection_socket = createServerConnectionSocket(
@@ -111,23 +69,19 @@ EnvoyQuicProofSource::getTlsCertConfigAndFilterChain(const quic::QuicSocketAddre
   if (filter_chain == nullptr) {
     listener_stats_.no_filter_chain_match_.inc();
     ENVOY_LOG(warn, "No matching filter chain found for handshake.");
-    return {absl::nullopt, absl::nullopt};
+    return {};
   }
   ENVOY_LOG(trace, "Got a matching cert chain {}", filter_chain->name());
 
   auto& transport_socket_factory =
       dynamic_cast<const QuicServerTransportSocketFactory&>(filter_chain->transportSocketFactory());
 
-  std::vector<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>> tls_cert_configs =
-      transport_socket_factory.getTlsCertificates();
-  if (tls_cert_configs.empty()) {
+  auto [cert, key] = transport_socket_factory.getTlsCertificateAndKey(hostname, cert_matched_sni);
+  if (cert == nullptr || key == nullptr) {
     ENVOY_LOG(warn, "No certificate is configured in transport socket config.");
-    return {absl::nullopt, absl::nullopt};
+    return {};
   }
-  // Only return the first TLS cert config.
-  // TODO(danzh) Choose based on supported cipher suites in TLS1.3 CHLO and prefer EC
-  // certs if supported.
-  return {tls_cert_configs[0].get(), *filter_chain};
+  return {std::move(cert), std::move(key), *filter_chain};
 }
 
 void EnvoyQuicProofSource::updateFilterChainManager(

--- a/source/common/quic/envoy_quic_proof_source.h
+++ b/source/common/quic/envoy_quic_proof_source.h
@@ -34,15 +34,16 @@ protected:
                    std::unique_ptr<quic::ProofSource::SignatureCallback> callback) override;
 
 private:
-  struct CertConfigWithFilterChain {
-    absl::optional<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>> cert_config_;
+  struct CertWithFilterChain {
+    quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain> cert_;
+    std::shared_ptr<quic::CertificatePrivateKey> private_key_;
     absl::optional<std::reference_wrapper<const Network::FilterChain>> filter_chain_;
   };
 
-  CertConfigWithFilterChain
-  getTlsCertConfigAndFilterChain(const quic::QuicSocketAddress& server_address,
-                                 const quic::QuicSocketAddress& client_address,
-                                 const std::string& hostname);
+  CertWithFilterChain getTlsCertConfigAndFilterChain(const quic::QuicSocketAddress& server_address,
+                                                     const quic::QuicSocketAddress& client_address,
+                                                     const std::string& hostname,
+                                                     bool* cert_matched_sni);
 
   Network::Socket& listen_socket_;
   Network::FilterChainManager* filter_chain_manager_{nullptr};

--- a/source/common/quic/quic_server_transport_socket_factory.cc
+++ b/source/common/quic/quic_server_transport_socket_factory.cc
@@ -5,6 +5,7 @@
 #include "envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.validate.h"
 
 #include "source/common/runtime/runtime_features.h"
+#include "source/common/quic/envoy_quic_utils.h"
 #include "source/extensions/transport_sockets/tls/context_config_impl.h"
 
 namespace Envoy {
@@ -13,7 +14,7 @@ namespace Quic {
 Network::DownstreamTransportSocketFactoryPtr
 QuicServerTransportSocketConfigFactory::createTransportSocketFactory(
     const Protobuf::Message& config, Server::Configuration::TransportSocketFactoryContext& context,
-    const std::vector<std::string>& /*server_names*/) {
+    const std::vector<std::string>& server_names) {
   auto quic_transport = MessageUtil::downcastAndValidate<
       const envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport&>(
       config, context.messageValidationVisitor());
@@ -26,9 +27,58 @@ QuicServerTransportSocketConfigFactory::createTransportSocketFactory(
 
   auto factory = std::make_unique<QuicServerTransportSocketFactory>(
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(quic_transport, enable_early_data, true),
-      context.statsScope(), std::move(server_config));
+      context.statsScope(), std::move(server_config), context.sslContextManager(), server_names);
   factory->initialize();
   return factory;
+}
+
+namespace {
+void initializeQuicCertAndKey(Ssl::TlsContext& context,
+                              const Ssl::TlsCertificateConfig& cert_config) {
+  const std::string& chain_str = cert_config.certificateChain();
+  std::stringstream pem_stream(chain_str);
+  std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
+
+  quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain> cert_chain(
+      new quic::ProofSource::Chain(chain));
+  std::string error_details;
+  bssl::UniquePtr<X509> cert = parseDERCertificate(cert_chain->certs[0], &error_details);
+  if (cert == nullptr) {
+    throwEnvoyExceptionOrPanic(absl::StrCat("Invalid leaf cert: ", error_details));
+  }
+
+  bssl::UniquePtr<EVP_PKEY> pub_key(X509_get_pubkey(cert.get()));
+  int sign_alg = deduceSignatureAlgorithmFromPublicKey(pub_key.get(), &error_details);
+  if (sign_alg == 0) {
+    throwEnvoyExceptionOrPanic(
+        absl::StrCat("Failed to deduce signature algorithm from public key: ", error_details));
+  }
+
+  context.quic_cert_ = std::move(cert_chain);
+
+  const std::string& pkey = cert_config.privateKey();
+  std::stringstream pem_str(pkey);
+  std::unique_ptr<quic::CertificatePrivateKey> pem_key =
+      quic::CertificatePrivateKey::LoadPemFromStream(&pem_str);
+  if (pem_key == nullptr) {
+    throwEnvoyExceptionOrPanic("Failed to load QUIC private key.");
+  }
+
+  context.quic_private_key_ = std::move(pem_key);
+}
+} // namespace
+
+QuicServerTransportSocketFactory::QuicServerTransportSocketFactory(
+    bool enable_early_data, Stats::Scope& scope, Ssl::ServerContextConfigPtr config,
+    Envoy::Ssl::ContextManager& manager, const std::vector<std::string>& server_names)
+    : QuicTransportSocketFactoryBase(scope, "server"), manager_(manager), stats_scope_(scope),
+      config_(std::move(config)), server_names_(server_names),
+      ssl_ctx_(manager_.createSslServerContext(stats_scope_, *config_, server_names_,
+                                               initializeQuicCertAndKey)),
+      enable_early_data_(enable_early_data) {}
+
+QuicServerTransportSocketFactory::~QuicServerTransportSocketFactory() {
+  manager_.removeContext(ssl_ctx_);
 }
 
 ProtobufTypes::MessagePtr QuicServerTransportSocketConfigFactory::createEmptyConfigProto() {
@@ -44,6 +94,47 @@ void QuicServerTransportSocketFactory::initialize() {
   if (!config_->alpnProtocols().empty()) {
     supported_alpns_ = absl::StrSplit(config_->alpnProtocols(), ',');
   }
+}
+
+std::pair<quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain>,
+          std::shared_ptr<quic::CertificatePrivateKey>>
+QuicServerTransportSocketFactory::getTlsCertificateAndKey(absl::string_view sni,
+                                                          bool* cert_matched_sni) const {
+  // onSecretUpdated() could be invoked in the middle of checking the existence of ssl_ctx and
+  // creating SslSocket using ssl_ctx. Capture ssl_ctx_ into a local variable so that we check and
+  // use the same ssl_ctx to create SslSocket.
+  Envoy::Ssl::ServerContextSharedPtr ssl_ctx;
+  {
+    absl::ReaderMutexLock l(&ssl_ctx_mu_);
+    ssl_ctx = ssl_ctx_;
+  }
+  if (!ssl_ctx) {
+    ENVOY_LOG(warn, "SDS hasn't finished updating Ssl context config yet.");
+    stats_.downstream_context_secrets_not_ready_.inc();
+    return {};
+  }
+  auto ctx =
+      std::dynamic_pointer_cast<Extensions::TransportSockets::Tls::ServerContextImpl>(ssl_ctx);
+  auto [tls_context, ocsp_staple_action] = ctx->findTlsContext(
+      sni, true /* TODO: ecdsa_capable */, false /* TODO: ocsp_capable */, cert_matched_sni);
+
+  // Thread safety note: accessing the tls_context requires holding a shared_ptr to the ``ssl_ctx``.
+  // Both of these members are themselves refcounted, so it is safe to use them after ``ssl_ctx``
+  // goes out of scope after the function returns.
+  return {tls_context.quic_cert_, tls_context.quic_private_key_};
+}
+
+void QuicServerTransportSocketFactory::onSecretUpdated() {
+  ENVOY_LOG(debug, "Secret is updated.");
+  auto ctx = manager_.createSslServerContext(stats_scope_, *config_, server_names_,
+                                             initializeQuicCertAndKey);
+  {
+    absl::WriterMutexLock l(&ssl_ctx_mu_);
+    std::swap(ctx, ssl_ctx_);
+  }
+  manager_.removeContext(ctx);
+
+  stats_.context_config_update_by_sds_.inc();
 }
 
 REGISTER_FACTORY(QuicServerTransportSocketConfigFactory,

--- a/source/common/quic/quic_server_transport_socket_factory.h
+++ b/source/common/quic/quic_server_transport_socket_factory.h
@@ -19,9 +19,10 @@ class QuicServerTransportSocketFactory : public Network::DownstreamTransportSock
                                          public QuicTransportSocketFactoryBase {
 public:
   QuicServerTransportSocketFactory(bool enable_early_data, Stats::Scope& store,
-                                   Ssl::ServerContextConfigPtr config)
-      : QuicTransportSocketFactoryBase(store, "server"), config_(std::move(config)),
-        enable_early_data_(enable_early_data) {}
+                                   Ssl::ServerContextConfigPtr config,
+                                   Envoy::Ssl::ContextManager& manager,
+                                   const std::vector<std::string>& server_names);
+  ~QuicServerTransportSocketFactory() override;
 
   // Network::DownstreamTransportSocketFactory
   Network::TransportSocketPtr createDownstreamTransportSocket() const override {
@@ -31,24 +32,22 @@ public:
 
   void initialize() override;
 
-  // Return TLS certificates if the context config is ready.
-  std::vector<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>>
-  getTlsCertificates() const {
-    if (!config_->isReady()) {
-      ENVOY_LOG(warn, "SDS hasn't finished updating Ssl context config yet.");
-      stats_.downstream_context_secrets_not_ready_.inc();
-      return {};
-    }
-    return config_->tlsCertificates();
-  }
+  std::pair<quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain>,
+            std::shared_ptr<quic::CertificatePrivateKey>>
+  getTlsCertificateAndKey(absl::string_view sni, bool* cert_matched_sni) const;
 
   bool earlyDataEnabled() const { return enable_early_data_; }
 
 protected:
-  void onSecretUpdated() override { stats_.context_config_update_by_sds_.inc(); }
+  void onSecretUpdated() override;
 
 private:
+  Envoy::Ssl::ContextManager& manager_;
+  Stats::Scope& stats_scope_;
   Ssl::ServerContextConfigPtr config_;
+  const std::vector<std::string> server_names_;
+  mutable absl::Mutex ssl_ctx_mu_;
+  Envoy::Ssl::ServerContextSharedPtr ssl_ctx_ ABSL_GUARDED_BY(ssl_ctx_mu_);
   bool enable_early_data_;
 };
 

--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -181,6 +181,7 @@ envoy_cc_library(
         "//source/extensions/transport_sockets/tls/private_key:private_key_manager_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",
+        "@com_github_google_quiche//:quic_core_crypto_proof_source_lib",
     ],
 )
 

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -40,10 +40,6 @@
 #include "openssl/rand.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace TransportSockets {
-namespace Tls {
-
 namespace {
 
 bool cbsContainsU16(CBS& cbs, uint16_t n) {
@@ -71,6 +67,10 @@ void logSslErrorChain() {
 
 } // namespace
 
+namespace Extensions {
+namespace TransportSockets {
+namespace Tls {
+
 int ContextImpl::sslExtendedSocketInfoIndex() {
   CONSTRUCT_ON_FIRST_USE(int, []() -> int {
     int ssl_context_index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
@@ -80,7 +80,7 @@ int ContextImpl::sslExtendedSocketInfoIndex() {
 }
 
 ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& config,
-                         TimeSource& time_source)
+                         TimeSource& time_source, Ssl::ContextAdditionalInitFunc additional_init)
     : scope_(scope), stats_(generateSslStats(scope)), time_source_(time_source),
       tls_max_version_(config.maxProtocolVersion()),
       stat_name_set_(scope.symbolTable().makeSet("TransportSockets::Tls")),
@@ -292,6 +292,10 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
         ctx.loadPrivateKey(tls_certificate.privateKey(), tls_certificate.privateKeyPath(),
                            tls_certificate.password());
       }
+
+      if (additional_init != nullptr) {
+        additional_init(ctx, tls_certificate);
+      }
     }
   }
 
@@ -372,7 +376,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
   // As late as possible, run the custom SSL_CTX configuration callback on each
   // SSL_CTX, if set.
   if (auto sslctx_cb = config.sslctxCb(); sslctx_cb) {
-    for (TlsContext& ctx : tls_contexts_) {
+    for (Ssl::TlsContext& ctx : tls_contexts_) {
       sslctx_cb(ctx.ssl_ctx_.get());
     }
   }
@@ -654,7 +658,7 @@ std::vector<Envoy::Ssl::CertificateDetailsPtr> ContextImpl::getCertChainInformat
 ClientContextImpl::ClientContextImpl(Stats::Scope& scope,
                                      const Envoy::Ssl::ClientContextConfig& config,
                                      TimeSource& time_source)
-    : ContextImpl(scope, config, time_source),
+    : ContextImpl(scope, config, time_source, nullptr /* additional_init */),
       server_name_indication_(config.serverNameIndication()),
       allow_renegotiation_(config.allowRenegotiation()),
       enforce_rsa_key_usage_(config.enforceRsaKeyUsage()),
@@ -783,8 +787,10 @@ int ClientContextImpl::newSessionKey(SSL_SESSION* session) {
 ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
                                      const Envoy::Ssl::ServerContextConfig& config,
                                      const std::vector<std::string>& server_names,
-                                     TimeSource& time_source)
-    : ContextImpl(scope, config, time_source), session_ticket_keys_(config.sessionTicketKeys()),
+                                     TimeSource& time_source,
+                                     Ssl::ContextAdditionalInitFunc additional_init)
+    : ContextImpl(scope, config, time_source, additional_init),
+      session_ticket_keys_(config.sessionTicketKeys()),
       ocsp_staple_policy_(config.ocspStaplePolicy()),
       full_scan_certs_on_sni_mismatch_(config.fullScanCertsOnSNIMismatch()) {
   if (config.tlsCertificates().empty() && !config.capabilities().provides_certificates) {
@@ -889,7 +895,7 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
   }
 }
 
-void ServerContextImpl::populateServerNamesMap(TlsContext& ctx, int pkey_id) {
+void ServerContextImpl::populateServerNamesMap(Ssl::TlsContext& ctx, int pkey_id) {
   if (ctx.cert_chain_ == nullptr) {
     return;
   }
@@ -911,7 +917,7 @@ void ServerContextImpl::populateServerNamesMap(TlsContext& ctx, int pkey_id) {
       // implemented.
       return;
     }
-    sn_match->second.emplace(std::pair<int, std::reference_wrapper<TlsContext>>(pkey_id, ctx));
+    sn_match->second.emplace(std::pair<int, std::reference_wrapper<Ssl::TlsContext>>(pkey_id, ctx));
   };
 
   bssl::UniquePtr<GENERAL_NAMES> san_names(static_cast<GENERAL_NAMES*>(
@@ -1191,7 +1197,7 @@ bool ServerContextImpl::isClientOcspCapable(const SSL_CLIENT_HELLO* ssl_client_h
   return false;
 }
 
-OcspStapleAction ServerContextImpl::ocspStapleAction(const TlsContext& ctx,
+OcspStapleAction ServerContextImpl::ocspStapleAction(const Ssl::TlsContext& ctx,
                                                      bool client_ocsp_capable) {
   if (!client_ocsp_capable) {
     return OcspStapleAction::ClientNotCapable;
@@ -1233,20 +1239,22 @@ OcspStapleAction ServerContextImpl::ocspStapleAction(const TlsContext& ctx,
   PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
-enum ssl_select_cert_result_t
-ServerContextImpl::selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
-  const bool client_ecdsa_capable = isClientEcdsaCapable(ssl_client_hello);
-  const bool client_ocsp_capable = isClientOcspCapable(ssl_client_hello);
-  absl::string_view sni = absl::NullSafeStringView(
-      SSL_get_servername(ssl_client_hello->ssl, TLSEXT_NAMETYPE_host_name));
+std::pair<const Ssl::TlsContext&, OcspStapleAction>
+ServerContextImpl::findTlsContext(absl::string_view sni, bool client_ecdsa_capable,
+                                  bool client_ocsp_capable, bool* cert_matched_sni) {
+  bool unused = false;
+  if (cert_matched_sni == nullptr) {
+    // Avoid need for nullptr checks when this is set.
+    cert_matched_sni = &unused;
+  }
 
   // selected_ctx represents the final selected certificate, it should meet all requirements or pick
-  // a candidate
-  const TlsContext* selected_ctx = nullptr;
-  const TlsContext* candidate_ctx = nullptr;
+  // a candidate.
+  const Ssl::TlsContext* selected_ctx = nullptr;
+  const Ssl::TlsContext* candidate_ctx = nullptr;
   OcspStapleAction ocsp_staple_action;
 
-  auto selected = [&](const TlsContext& ctx) -> bool {
+  auto selected = [&](const Ssl::TlsContext& ctx) -> bool {
     auto action = ocspStapleAction(ctx, client_ocsp_capable);
     if (action == OcspStapleAction::Fail) {
       // The selected ctx must adhere to OCSP policy
@@ -1309,6 +1317,7 @@ ServerContextImpl::selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
         select_from_map(wildcard);
       }
     }
+    *cert_matched_sni = (selected_ctx != nullptr || candidate_ctx != nullptr);
     tail_select(full_scan_certs_on_sni_mismatch_);
   }
   // Full scan certs if SNI is not provided by client;
@@ -1327,10 +1336,24 @@ ServerContextImpl::selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
     tail_select(false);
   }
 
+  ASSERT(selected_ctx != nullptr);
+  return {*selected_ctx, ocsp_staple_action};
+}
+
+enum ssl_select_cert_result_t
+ServerContextImpl::selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
+  absl::string_view sni = absl::NullSafeStringView(
+      SSL_get_servername(ssl_client_hello->ssl, TLSEXT_NAMETYPE_host_name));
+  const bool client_ecdsa_capable = isClientEcdsaCapable(ssl_client_hello);
+  const bool client_ocsp_capable = isClientOcspCapable(ssl_client_hello);
+
+  auto [selected_ctx, ocsp_staple_action] =
+      findTlsContext(sni, client_ecdsa_capable, client_ocsp_capable, nullptr);
+
   // Apply the selected context. This must be done before OCSP stapling below
   // since applying the context can remove the previously-set OCSP response.
   // This will only return NULL if memory allocation fails.
-  RELEASE_ASSERT(SSL_set_SSL_CTX(ssl_client_hello->ssl, selected_ctx->ssl_ctx_.get()) != nullptr,
+  RELEASE_ASSERT(SSL_set_SSL_CTX(ssl_client_hello->ssl, selected_ctx.ssl_ctx_.get()) != nullptr,
                  "");
 
   if (client_ocsp_capable) {
@@ -1340,9 +1363,9 @@ ServerContextImpl::selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
   switch (ocsp_staple_action) {
   case OcspStapleAction::Staple: {
     // We avoid setting the OCSP response if the client didn't request it, but doing so is safe.
-    RELEASE_ASSERT(selected_ctx->ocsp_response_,
+    RELEASE_ASSERT(selected_ctx.ocsp_response_,
                    "OCSP response must be present under OcspStapleAction::Staple");
-    auto& resp_bytes = selected_ctx->ocsp_response_->rawBytes();
+    auto& resp_bytes = selected_ctx.ocsp_response_->rawBytes();
     int rc = SSL_set_ocsp_response(ssl_client_hello->ssl, resp_bytes.data(), resp_bytes.size());
     RELEASE_ASSERT(rc != 0, "");
     stats_.ocsp_staple_responses_.inc();
@@ -1359,6 +1382,31 @@ ServerContextImpl::selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello) {
 
   return ssl_select_cert_success;
 }
+
+ValidationResults ContextImpl::customVerifyCertChainForQuic(
+    STACK_OF(X509) & cert_chain, Ssl::ValidateResultCallbackPtr callback, bool is_server,
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
+    const CertValidator::ExtraValidationContext& validation_context, const std::string& host_name) {
+  ASSERT(!tls_contexts_.empty());
+  // It doesn't matter which SSL context is used, because they share the same cert validation
+  // config.
+  SSL_CTX* ssl_ctx = tls_contexts_[0].ssl_ctx_.get();
+  if (SSL_CTX_get_verify_mode(ssl_ctx) == SSL_VERIFY_NONE) {
+    // Skip validation if the TLS is configured SSL_VERIFY_NONE.
+    return {ValidationResults::ValidationStatus::Successful,
+            Envoy::Ssl::ClientValidationStatus::NotValidated, absl::nullopt, absl::nullopt};
+  }
+  ValidationResults result =
+      cert_validator_->doVerifyCertChain(cert_chain, std::move(callback), transport_socket_options,
+                                         *ssl_ctx, validation_context, is_server, host_name);
+  return result;
+}
+
+} // namespace Tls
+} // namespace TransportSockets
+} // namespace Extensions
+
+namespace Ssl {
 
 bool TlsContext::isCipherEnabled(uint16_t cipher_id, uint16_t client_version) {
   const SSL_CIPHER* c = SSL_get_cipher_by_value(cipher_id);
@@ -1378,25 +1426,6 @@ bool TlsContext::isCipherEnabled(uint16_t cipher_id, uint16_t client_version) {
     }
   }
   return false;
-}
-
-ValidationResults ContextImpl::customVerifyCertChainForQuic(
-    STACK_OF(X509)& cert_chain, Ssl::ValidateResultCallbackPtr callback, bool is_server,
-    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
-    const CertValidator::ExtraValidationContext& validation_context, const std::string& host_name) {
-  ASSERT(!tls_contexts_.empty());
-  // It doesn't matter which SSL context is used, because they share the same cert validation
-  // config.
-  SSL_CTX* ssl_ctx = tls_contexts_[0].ssl_ctx_.get();
-  if (SSL_CTX_get_verify_mode(ssl_ctx) == SSL_VERIFY_NONE) {
-    // Skip validation if the TLS is configured SSL_VERIFY_NONE.
-    return {ValidationResults::ValidationStatus::Successful,
-            Envoy::Ssl::ClientValidationStatus::NotValidated, absl::nullopt, absl::nullopt};
-  }
-  ValidationResults result =
-      cert_validator_->doVerifyCertChain(cert_chain, std::move(callback), transport_socket_options,
-                                         *ssl_ctx, validation_context, is_server, host_name);
-  return result;
 }
 
 void TlsContext::loadCertificateChain(const std::string& data, const std::string& data_path) {
@@ -1441,9 +1470,9 @@ void TlsContext::loadPrivateKey(const std::string& data, const std::string& data
                               !password.empty() ? const_cast<char*>(password.c_str()) : nullptr));
 
   if (pkey == nullptr || !SSL_CTX_use_PrivateKey(ssl_ctx_.get(), pkey.get())) {
-    throwEnvoyExceptionOrPanic(fmt::format("Failed to load private key from {}, Cause: {}",
-                                           data_path,
-                                           Utility::getLastCryptoError().value_or("unknown")));
+    throwEnvoyExceptionOrPanic(fmt::format(
+        "Failed to load private key from {}, Cause: {}", data_path,
+        Extensions::TransportSockets::Tls::Utility::getLastCryptoError().value_or("unknown")));
   }
 
   checkPrivateKey(pkey, data_path);
@@ -1480,9 +1509,9 @@ void TlsContext::loadPkcs12(const std::string& data, const std::string& data_pat
     throwEnvoyExceptionOrPanic(absl::StrCat("Failed to load certificate from ", data_path));
   }
   if (temp_private_key == nullptr || !SSL_CTX_use_PrivateKey(ssl_ctx_.get(), pkey.get())) {
-    throwEnvoyExceptionOrPanic(fmt::format("Failed to load private key from {}, Cause: {}",
-                                           data_path,
-                                           Utility::getLastCryptoError().value_or("unknown")));
+    throwEnvoyExceptionOrPanic(fmt::format(
+        "Failed to load private key from {}, Cause: {}", data_path,
+        Extensions::TransportSockets::Tls::Utility::getLastCryptoError().value_or("unknown")));
   }
 
   checkPrivateKey(pkey, data_path);
@@ -1516,7 +1545,5 @@ void TlsContext::checkPrivateKey(const bssl::UniquePtr<EVP_PKEY>& pkey,
 #endif
 }
 
-} // namespace Tls
-} // namespace TransportSockets
-} // namespace Extensions
+} // namespace Ssl
 } // namespace Envoy

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -28,14 +28,16 @@
 #include "openssl/ssl.h"
 #include "openssl/x509v3.h"
 
+#ifdef ENVOY_ENABLE_QUIC
+#include "quiche/quic/core/crypto/proof_source.h"
+#endif
+
 namespace Envoy {
 #ifndef OPENSSL_IS_BORINGSSL
 #error Envoy requires BoringSSL
 #endif
 
-namespace Extensions {
-namespace TransportSockets {
-namespace Tls {
+namespace Ssl {
 
 struct TlsContext {
   // Each certificate specified for the context has its own SSL_CTX. `SSL_CTXs`
@@ -45,10 +47,15 @@ struct TlsContext {
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
   bssl::UniquePtr<X509> cert_chain_;
   std::string cert_chain_file_path_;
-  Ocsp::OcspResponseWrapperPtr ocsp_response_;
+  Extensions::TransportSockets::Tls::Ocsp::OcspResponseWrapperPtr ocsp_response_;
   bool is_ecdsa_{};
   bool is_must_staple_{};
   Ssl::PrivateKeyMethodProviderSharedPtr private_key_method_provider_{};
+
+#ifdef ENVOY_ENABLE_QUIC
+  quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain> quic_cert_;
+  std::shared_ptr<quic::CertificatePrivateKey> quic_private_key_;
+#endif
 
   std::string getCertChainFileName() const { return cert_chain_file_path_; };
   bool isCipherEnabled(uint16_t cipher_id, uint16_t client_version);
@@ -62,6 +69,11 @@ struct TlsContext {
                   const std::string& password);
   void checkPrivateKey(const bssl::UniquePtr<EVP_PKEY>& pkey, const std::string& key_path);
 };
+} // namespace Ssl
+
+namespace Extensions {
+namespace TransportSockets {
+namespace Tls {
 
 class ContextImpl : public virtual Envoy::Ssl::Context,
                     protected Logger::Loggable<Logger::Id::config> {
@@ -93,7 +105,7 @@ public:
 
   // Validate cert asynchronously for a QUIC connection.
   ValidationResults customVerifyCertChainForQuic(
-      STACK_OF(X509)& cert_chain, Ssl::ValidateResultCallbackPtr callback, bool is_server,
+      STACK_OF(X509) & cert_chain, Ssl::ValidateResultCallbackPtr callback, bool is_server,
       const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
       const CertValidator::ExtraValidationContext& validation_context,
       const std::string& host_name);
@@ -103,8 +115,8 @@ public:
 protected:
   friend class ContextImplPeer;
 
-  ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& config,
-              TimeSource& time_source);
+  ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& config, TimeSource& time_source,
+              Ssl::ContextAdditionalInitFunc additional_init);
 
   /**
    * The global SSL-library index used for storing a pointer to the context
@@ -126,13 +138,13 @@ protected:
       Envoy::Ssl::SslExtendedSocketInfo* extended_socket_info,
       const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options, SSL* ssl);
 
-  void populateServerNamesMap(TlsContext& ctx, const int pkey_id);
+  void populateServerNamesMap(Ssl::TlsContext& ctx, const int pkey_id);
 
   // This is always non-empty, with the first context used for all new SSL
   // objects. For server contexts, once we have ClientHello, we
   // potentially switch to a different CertificateContext based on certificate
   // selection.
-  std::vector<TlsContext> tls_contexts_;
+  std::vector<Ssl::TlsContext> tls_contexts_;
   CertValidatorPtr cert_validator_;
   Stats::Scope& scope_;
   SslStats stats_;
@@ -183,23 +195,31 @@ enum class OcspStapleAction { Staple, NoStaple, Fail, ClientNotCapable };
 class ServerContextImpl : public ContextImpl, public Envoy::Ssl::ServerContext {
 public:
   ServerContextImpl(Stats::Scope& scope, const Envoy::Ssl::ServerContextConfig& config,
-                    const std::vector<std::string>& server_names, TimeSource& time_source);
+                    const std::vector<std::string>& server_names, TimeSource& time_source,
+                    Ssl::ContextAdditionalInitFunc additional_init);
 
   // Select the TLS certificate context in SSL_CTX_set_select_certificate_cb() callback with
   // ClientHello details. This is made public for use by custom TLS extensions who want to
   // manually create and use this as a client hello callback.
   enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
 
+  // Finds the best matching context. The returned context will have the same lifetime as
+  // this ``ServerContextImpl``.
+  std::pair<const Ssl::TlsContext&, OcspStapleAction> findTlsContext(absl::string_view sni,
+                                                                     bool client_ecdsa_capable,
+                                                                     bool client_ocsp_capable,
+                                                                     bool* cert_matched_sni);
+
 private:
   // Currently, at most one certificate of a given key type may be specified for each exact
   // server name or wildcard domain name.
-  using PkeyTypesMap = absl::flat_hash_map<int, std::reference_wrapper<TlsContext>>;
+  using PkeyTypesMap = absl::flat_hash_map<int, std::reference_wrapper<Ssl::TlsContext>>;
   // Both exact server names and wildcard domains are part of the same map, in which wildcard
   // domains are prefixed with "." (i.e. ".example.com" for "*.example.com") to differentiate
   // between exact and wildcard entries.
   using ServerNamesMap = absl::flat_hash_map<std::string, PkeyTypesMap>;
 
-  void populateServerNamesMap(TlsContext& ctx, const int pkey_id);
+  void populateServerNamesMap(Ssl::TlsContext& ctx, const int pkey_id);
 
   using SessionContextID = std::array<uint8_t, SSL_MAX_SSL_SESSION_ID_LENGTH>;
 
@@ -209,7 +229,7 @@ private:
                            HMAC_CTX* hmac_ctx, int encrypt);
   bool isClientEcdsaCapable(const SSL_CLIENT_HELLO* ssl_client_hello);
   bool isClientOcspCapable(const SSL_CLIENT_HELLO* ssl_client_hello);
-  OcspStapleAction ocspStapleAction(const TlsContext& ctx, bool client_ocsp_capable);
+  OcspStapleAction ocspStapleAction(const Ssl::TlsContext& ctx, bool client_ocsp_capable);
 
   SessionContextID generateHashForSessionContextId(const std::vector<std::string>& server_names);
 

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -30,16 +30,15 @@ ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
   return context;
 }
 
-Envoy::Ssl::ServerContextSharedPtr
-ContextManagerImpl::createSslServerContext(Stats::Scope& scope,
-                                           const Envoy::Ssl::ServerContextConfig& config,
-                                           const std::vector<std::string>& server_names) {
+Envoy::Ssl::ServerContextSharedPtr ContextManagerImpl::createSslServerContext(
+    Stats::Scope& scope, const Envoy::Ssl::ServerContextConfig& config,
+    const std::vector<std::string>& server_names, Ssl::ContextAdditionalInitFunc additional_init) {
   if (!config.isReady()) {
     return nullptr;
   }
 
-  Envoy::Ssl::ServerContextSharedPtr context =
-      std::make_shared<ServerContextImpl>(scope, config, server_names, time_source_);
+  Envoy::Ssl::ServerContextSharedPtr context = std::make_shared<ServerContextImpl>(
+      scope, config, server_names, time_source_, std::move(additional_init));
   contexts_.insert(context);
   return context;
 }

--- a/source/extensions/transport_sockets/tls/context_manager_impl.h
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.h
@@ -34,7 +34,8 @@ public:
                          const Envoy::Ssl::ClientContextConfig& config) override;
   Ssl::ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const Envoy::Ssl::ServerContextConfig& config,
-                         const std::vector<std::string>& server_names) override;
+                         const std::vector<std::string>& server_names,
+                         Ssl::ContextAdditionalInitFunc additional_init) override;
   absl::optional<uint32_t> daysUntilFirstCertExpires() const override;
   absl::optional<uint64_t> secondsUntilFirstOcspResponseExpires() const override;
   void iterateContexts(std::function<void(const Envoy::Ssl::Context&)> callback) override;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -429,7 +429,7 @@ ServerSslSocketFactory::ServerSslSocketFactory(Envoy::Ssl::ServerContextConfigPt
                                                const std::vector<std::string>& server_names)
     : manager_(manager), stats_scope_(stats_scope), stats_(generateStats("server", stats_scope)),
       config_(std::move(config)), server_names_(server_names),
-      ssl_ctx_(manager_.createSslServerContext(stats_scope_, *config_, server_names_)) {
+      ssl_ctx_(manager_.createSslServerContext(stats_scope_, *config_, server_names_, nullptr)) {
   config_->setSecretUpdateCallback([this]() { onAddOrUpdateSecret(); });
 }
 
@@ -463,7 +463,7 @@ bool ServerSslSocketFactory::implementsSecureTransport() const { return true; }
 
 void ServerSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
-  auto ctx = manager_.createSslServerContext(stats_scope_, *config_, server_names_);
+  auto ctx = manager_.createSslServerContext(stats_scope_, *config_, server_names_, nullptr);
   {
     absl::WriterMutexLock l(&ssl_ctx_mu_);
     std::swap(ctx, ssl_ctx_);

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -20,10 +20,9 @@ class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
     throwException();
   }
 
-  Ssl::ServerContextSharedPtr
-  createSslServerContext(Stats::Scope& /* scope */,
-                         const Envoy::Ssl::ServerContextConfig& /* config */,
-                         const std::vector<std::string>& /* server_names */) override {
+  Ssl::ServerContextSharedPtr createSslServerContext(
+      Stats::Scope& /* scope */, const Envoy::Ssl::ServerContextConfig& /* config */,
+      const std::vector<std::string>& /* server_names */, Ssl::ContextAdditionalInitFunc) override {
     throwException();
   }
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -28,7 +28,8 @@ public:
               (Stats::Scope & scope, const ClientContextConfig& config));
   MOCK_METHOD(ServerContextSharedPtr, createSslServerContext,
               (Stats::Scope & stats, const ServerContextConfig& config,
-               const std::vector<std::string>& server_names));
+               const std::vector<std::string>& server_names,
+               ContextAdditionalInitFunc additional_init));
   MOCK_METHOD(absl::optional<uint32_t>, daysUntilFirstCertExpires, (), (const));
   MOCK_METHOD(absl::optional<uint64_t>, secondsUntilFirstOcspResponseExpires, (), (const));
   MOCK_METHOD(void, iterateContexts, (std::function<void(const Context&)> callback));


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: This brings feature parity between quic and non-quic TLS use for certificate selection.
Additional Description:
Risk Level: Medium
Testing: TODO
Docs Changes: TODO
Release Notes: TODO
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
