### PR TITLE
datadog: restore previous behavior of `Span::setSampled`

### DIFF
--- a/source/extensions/tracers/datadog/span.cc
+++ b/source/extensions/tracers/datadog/span.cc
@@ -122,9 +122,13 @@ void Span::setSampled(bool sampled) {
     return;
   }
 
-  auto priority = static_cast<int>(sampled ? datadog::tracing::SamplingPriority::USER_KEEP
-                                           : datadog::tracing::SamplingPriority::USER_DROP);
-  span_->trace_segment().override_sampling_priority(priority);
+  // Ignore the override if a sampling decision has already been made.
+  // Otherwise, treat the override as a user-specified sampling decision.
+  if (!span_->trace_segment().sampling_decision().has_value()) {
+    auto priority = static_cast<int>(sampled ? datadog::tracing::SamplingPriority::USER_KEEP
+                                             : datadog::tracing::SamplingPriority::USER_DROP);
+    span_->trace_segment().override_sampling_priority(priority);
+  }
 }
 
 std::string Span::getBaggage(absl::string_view) {


### PR DESCRIPTION
# The Problem and Its Fix
@Smeb reported a Datadog tracing related [issue][2] with an Istio setup that recently had been upgraded to an Envoy at least as recent as v1.27. These newer Envoy versions contain a [rewrite][1] of the Datadog tracing extension.

The symptom was that the sampling decision for the Istio traces was 100% even when configured to be 10%.

In our investigation to find the root cause, we identified a mismatch between the contract of [Envoy::Tracing::Span::setSampled(bool)][3] and how it is [sometimes used][4].

The problem can be thought of as a bug that I introduced during my rewrite of the Datadog tracing extension, but it reveals what might be a latent issue in how trace sampling is performed by Envoy, or at least by the [lua filter extension][5].

## The Problem
The rewritten Datadog tracing extension performs an unconditional sampling decision override whenever [Span::setSampled(bool)][6] is called.

Before the rewrite, the older OpenTracing-based Datadog tracing extension sometimes did _not_ override an existing sampling decision when `Span::setSampled(bool)` was called. The different call stacks are explained in my [comment][7] on the parent issue.

When the lua filter extension is used, it always specifies a sampling decision for requests that it makes. There are two possibilities:

1. The user specifies a boolean ["trace_sampled" property][8] of the table-valued argument to `httpCall` in Lua code, which is bound to this [C++ function][9]. There is no way to specify null (`nil`), which would indicate "use existing decision."
2. The user does not specify the "trace_sampled" property. A [default-constructed HttpCallOptions][10] is used for the underlying  HTTP call. [HttpCallOptions][11] contains a [RequestOptions][12], which contains an [absl::optional\<bool\> sampled_][13] that defaults to `true` (not null!).

As a result, any HTTP call made by the lua filter extension always results is a non-null sampling decision being specified in `RequestOptions`, which results in `Span::setSampled(bool)` always being [invoked][4]. `Span::setSampled(bool)` is [documented][3] as overriding any existing sampling decision:

> This method overrides any previous sampling decision associated with the trace instance.
> If the sampled parameter is false, this span and any subsequent child spans
> are not reported to the tracing system.

So, even if Envoy is configured to sample only 10% of traces, any trace that involves an HTTP call made by the lua filter extension will override the sampling decision to "keep," thus increasing the actual sampling rate.

The old behavior of the Datadog tracing extension, which violated the contract of `Span::setSampled(bool)`, prevented this issue by ignoring the specified override whenever a sampling decision had been made previously, such as when a decision had been extracted from the downstream request or when a decision was made per the tracer's configuration.

## The Fix
We have a few options for how to correct the offending behavior encountered by @Smeb:

1. We could modify the [lua filter extension][10] to call `options.request_options_.setSampled(absl::nullopt)` immediately after constructing `options`, thus changing the effective default value of `RequestOptions::sampled_` to null. This could change the trace sampling behavior for all users of the lua filter extension.
2. We could modify [RequestOptions::sampled_][13] to have a default value of _null_ instead of `true`. This could change the trace sampling behavior for all Envoy users (relevant [usage][4]).
3. We could modify the contract of [Span::setSampled(bool)][3] to permit tracer implementations to ignore the override, and restore the old behavior in the Datadog tracing extension. This would require that we revisit how `setSampled` is used (for example, in the [healthcheck filter][14]).
4. We could restore the old behavior of the Datadog tracing extension, thus putting it out of spec with respect to `Span::setSampled(bool)`, and defer what else to do, if anything, for later.

This pull request implements option (4). I modify the implementation of Datadog's `Span::setSampled(bool)` so that it honors the specified sampling decision only if a decision has not already been made. This makes `setSampled` behave as it did before the Datadog tracing extension rewrite introduced with release v1.27.

# Testing
See the included changes to `Span`'s unit test.

**Note**: I still need to verify that these modifications fix @Smeb's precise use case. It could be that the sampling decision made by the lua filter extension is the _first_ decision encountered, in which case I don't think this fix would be effective. If that turns out to be true, then deeper revision of the Datadog tracing extension will be necessary (or, we could go with one of the other three fixes proposed above). 

# Other Info
Please label this pull request for backport review. It fixes a bug that affects the `v1.27`, `v1.28`, and `v1.29` release branches. I'm happy to propose those backports once this pull request is reviewed.

[1]: https://github.com/envoyproxy/envoy/pull/26284
[2]: https://github.com/DataDog/dd-trace-cpp/issues/92
[3]: https://github.com/envoyproxy/envoy/blob/1b55caefd88cc9860a65166ccf72c28b15c08a77/envoy/tracing/trace_driver.h#L68-L74
[4]: https://github.com/envoyproxy/envoy/blob/1b55caefd88cc9860a65166ccf72c28b15c08a77/source/common/http/async_client_impl.cc#L275-L279
[5]: https://github.com/envoyproxy/envoy/blob/faa1be31e1fee74227b7a45005c84b280d26e4e6/source/extensions/filters/http/lua/lua_filter.cc#L355C24-L355C39
[6]: https://github.com/envoyproxy/envoy/blob/faa1be31e1fee74227b7a45005c84b280d26e4e6/source/extensions/tracers/datadog/span.cc#L120-L128
[7]: https://github.com/DataDog/dd-trace-cpp/issues/92#issuecomment-1915086625
[8]: https://github.com/envoyproxy/envoy/blob/faa1be31e1fee74227b7a45005c84b280d26e4e6/source/extensions/filters/http/lua/lua_filter.cc#L54
[9]: https://github.com/envoyproxy/envoy/blob/faa1be31e1fee74227b7a45005c84b280d26e4e6/source/extensions/filters/http/lua/lua_filter.cc#L156
[10]: https://github.com/envoyproxy/envoy/blob/faa1be31e1fee74227b7a45005c84b280d26e4e6/source/extensions/filters/http/lua/lua_filter.cc#L355
[11]: https://github.com/envoyproxy/envoy/blob/1b55caefd88cc9860a65166ccf72c28b15c08a77/source/extensions/filters/http/lua/lua_filter.h#L146
[12]: https://github.com/envoyproxy/envoy/blob/1b55caefd88cc9860a65166ccf72c28b15c08a77/envoy/http/async_client.h#L336
[13]: https://github.com/envoyproxy/envoy/blob/1b55caefd88cc9860a65166ccf72c28b15c08a77/envoy/http/async_client.h#L408-L409
[14]: https://github.com/envoyproxy/envoy/blob/d14ce54e2d9eff732520fe6b4db598726f86f18d/source/extensions/filters/http/health_check/health_check.cc#L59-L63