### PR TITLE
test: hopefully deflaking tag extraction test

### DIFF
--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -436,6 +436,9 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
   });
   initialize();
 
+  // Make sure worker threads are established (#32237).
+  sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
   // Commented sample code to regenerate the map literals used below in the test log if necessary:
 
   // std::cout << "tag_extracted_counter_map = {";

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -437,7 +437,9 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
   initialize();
 
   // Make sure worker threads are established (#32237).
-  sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
+      test_server_->adminAddress(), "GET", "/config_dump", "", Http::CodecType::HTTP1);
+  EXPECT_TRUE(response->complete());
 
   // Commented sample code to regenerate the map literals used below in the test log if necessary:
 


### PR DESCRIPTION
Given it's a worker thread related stat, this makes sure the worker threads are up and registered.

hopefully fixes https://github.com/envoyproxy/envoy/issues/32237
