### PR TITLE
mobile: Remove -fno-unwind-tables

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -119,7 +119,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:uhv_enabled": ["-DENVOY_ENABLE_UHV"],
                "//conditions:default": [],
            }) + envoy_select_hot_restart(["-DENVOY_HOT_RESTART"], repository) + \
-           envoy_select_disable_exceptions(["-fno-unwind-tables", "-fno-exceptions"], repository) + \
+           envoy_select_disable_exceptions(["-fno-exceptions"], repository) + \
            envoy_select_admin_html(["-DENVOY_ADMIN_HTML"], repository) + \
            envoy_select_static_extension_registration(["-DENVOY_STATIC_EXTENSION_REGISTRATION"], repository) + \
            envoy_select_disable_logging(["-DENVOY_DISABLE_LOGGING"], repository) + \

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -269,7 +269,6 @@ build:mobile-remote-ci-cc-no-yaml --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 build:mobile-remote-ci-cc-no-exceptions --config=mobile-remote-ci
 build:mobile-remote-ci-cc-no-exceptions --define=envoy_yaml=disabled
 build:mobile-remote-ci-cc-no-exceptions --define envoy_exceptions=disabled
-build:mobile-remote-ci-cc-no-exceptions --copt=-fno-unwind-tables
 build:mobile-remote-ci-cc-no-exceptions --copt=-fno-exceptions
 build:mobile-remote-ci-cc-no-exceptions --define=google_grpc=disabled
 build:mobile-remote-ci-cc-no-exceptions --define=envoy_mobile_xds=disabled


### PR DESCRIPTION
Having `-fno-unwind-tables` will cause the crashes to not have any useful backtrace information. This PR removes `-fno-unwind-tables` when exceptions are disabled.

Risk Level: low (only Envoy Mobile has exceptions disabled)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobkle
