### PR TITLE
redis-proxy: support echo command

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -162,5 +162,8 @@ new_features:
     Envoy will select the host with the fewest active requests from the entire host set rather than
     :ref:`choice_count <envoy_v3_api_msg_extensions.load_balancing_policies.least_request.v3.LeastRequest>`
     random choices.
+- area: redis
+  change: |
+    Added support for the ``ECHO`` command.
 
 deprecated:

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -127,13 +127,14 @@ Supported commands
 At the protocol level, pipelines are supported.
 Use pipelining wherever possible for the best performance.
 
-At the command level, Envoy only supports commands that can be reliably hashed to a server. AUTH and PING
+At the command level, Envoy only supports commands that can be reliably hashed to a server. AUTH, PING and ECHO
 are the only exceptions. AUTH is processed locally by Envoy if a downstream password has been configured,
 and no other commands will be processed until authentication is successful when a password has been
 configured. Envoy will transparently issue AUTH commands upon connecting to upstream servers, if upstream
 authentication passwords are configured for the cluster. Envoy responds to PING immediately with PONG.
-Arguments to PING are not allowed. All other supported commands must contain a key. Supported commands are
-functionally identical to the original Redis command except possibly in failure scenarios.
+Arguments to PING are not allowed. Envoy responds to ECHO immediately with the command argument.
+All other supported commands must contain a key. Supported commands are functionally identical to the
+original Redis command except possibly in failure scenarios.
 
 For details on each command's usage see the official
 `Redis command reference <https://redis.io/commands>`_.
@@ -143,6 +144,7 @@ For details on each command's usage see the official
   :widths: 1, 1
 
   AUTH, Authentication
+  ECHO, Connection
   PING, Connection
   QUIT, Connection
   DEL, Generic

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -62,6 +62,11 @@ struct SupportedCommands {
   static const std::string& auth() { CONSTRUCT_ON_FIRST_USE(std::string, "auth"); }
 
   /**
+   * @return auth command
+   */
+  static const std::string& echo() { CONSTRUCT_ON_FIRST_USE(std::string, "echo"); }
+
+  /**
    * @return mget command
    */
   static const std::string& mget() { CONSTRUCT_ON_FIRST_USE(std::string, "mget"); }

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -636,7 +636,7 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
       return nullptr;
     }
     Common::Redis::RespValuePtr echo_resp(new Common::Redis::RespValue());
-    echo_resp->type(Common::Redis::RespType::SimpleString);
+    echo_resp->type(Common::Redis::RespType::BulkString);
     echo_resp->asString() = request->asArray()[1].asString();
     callbacks.onResponse(std::move(echo_resp));
     return nullptr;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -629,6 +629,19 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
     return nullptr;
   }
 
+  if (command_name == Common::Redis::SupportedCommands::echo()) {
+    // Respond to ECHO locally.
+    if (request->asArray().size() != 2) {
+      onInvalidRequest(callbacks);
+      return nullptr;
+    }
+    Common::Redis::RespValuePtr echo_resp(new Common::Redis::RespValue());
+    echo_resp->type(Common::Redis::RespType::SimpleString);
+    echo_resp->asString() = request->asArray()[1].asString();
+    callbacks.onResponse(std::move(echo_resp));
+    return nullptr;
+  }
+
   if (command_name == Common::Redis::SupportedCommands::time()) {
     // Respond to TIME locally.
     Common::Redis::RespValuePtr time_resp(new Common::Redis::RespValue());

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -413,7 +413,7 @@ TEST_F(RedisSingleServerRequestTest, EchoSuccess) {
   makeBulkStringArray(*request, {"echo", "foobar"});
 
   Common::Redis::RespValue response;
-  response.type(Common::Redis::RespType::SimpleString);
+  response.type(Common::Redis::RespType::BulkString);
   response.asString() = "foobar";
 
   EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -406,6 +406,22 @@ TEST_F(RedisSingleServerRequestTest, PingSuccess) {
   EXPECT_EQ(nullptr, handle_);
 };
 
+TEST_F(RedisSingleServerRequestTest, EchoSuccess) {
+  InSequence s;
+
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"echo", "foobar"});
+
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::SimpleString);
+  response.asString() = "foobar";
+
+  EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
+  handle_ = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+  EXPECT_EQ(nullptr, handle_);
+};
+
 TEST_F(RedisSingleServerRequestTest, Time) {
   InSequence s;
 


### PR DESCRIPTION
Commit Message: redis proxy: add support for echo command
Additional Description: 
Risk Level: Low
Testing: Unit test added
Docs Changes: Added
Release Notes: Added
Platform Specific Features: None
Fixes #31459
