### PR TITLE
[bp/1.29] Not crash envoy when env resource detector can't detect attributes

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: tracing
+  change: |
+    Added support for configuring resource detectors on the OpenTelemetry tracer.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/test/extensions/tracers/opentelemetry/resource_detectors/environment/BUILD
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/environment/BUILD
@@ -35,3 +35,19 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/tracers/opentelemetry/resource_detectors/v3:pkg_cc_proto",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "environment_resource_detector_integration_test",
+    srcs = [
+        "environment_resource_detector_integration_test.cc",
+    ],
+    extension_names = ["envoy.tracers.opentelemetry.resource_detectors.environment"],
+    deps = [
+        "//source/exe:main_common_lib",
+        "//source/extensions/tracers/opentelemetry:config",
+        "//source/extensions/tracers/opentelemetry/resource_detectors/environment:config",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector_integration_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/environment/environment_resource_detector_integration_test.cc
@@ -1,0 +1,76 @@
+#include <memory>
+#include <string>
+
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+namespace {
+
+class EnvironmentResourceDetectorIntegrationTest
+    : public Envoy::HttpIntegrationTest,
+      public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  EnvironmentResourceDetectorIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
+
+    const std::string yaml_string = R"EOF(
+  provider:
+    name: envoy.tracers.opentelemetry
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+      grpc_service:
+        envoy_grpc:
+          cluster_name: opentelemetry_collector
+        timeout: 0.250s
+      service_name: "a_service_name"
+      resource_detectors:
+        - name: envoy.tracers.opentelemetry.resource_detectors.environment
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.resource_detectors.v3.EnvironmentResourceDetectorConfig
+  )EOF";
+
+    auto tracing_config =
+        std::make_unique<::envoy::extensions::filters::network::http_connection_manager::v3::
+                             HttpConnectionManager_Tracing>();
+    TestUtility::loadFromYaml(yaml_string, *tracing_config.get());
+    config_helper_.addConfigModifier(
+        [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) -> void { hcm.set_allocated_tracing(tracing_config.release()); });
+
+    initialize();
+    codec_client_ = makeHttpConnection(lookupPort("http"));
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, EnvironmentResourceDetectorIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+// Verify Envoy starts even when the Environment resource detector wasn't able to detect any
+// attributes (env variable OTEL_RESOURCE_ATTRIBUTES not set)
+TEST_P(EnvironmentResourceDetectorIntegrationTest, TestWithNoEnvVariableSet) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ(response->headers().getStatusValue(), "200");
+}
+
+} // namespace
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
As discussed with @wbpcode I'm creating this backport to 1.29 for this bug. We just merged this feature in Istio and would be great if this can be ported, so maybe the current to be release Istio version can have this. 

Commit Message: Backport from https://github.com/envoyproxy/envoy/pull/32229
Additional Description:
Risk Level: Low
Testing: Unit, Integration and Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]