### PR TITLE
http2: removes an unnecessary ASSERT

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1488,7 +1488,6 @@ Status ConnectionImpl::onStreamClose(StreamImpl* stream, uint32_t error_code) {
 
     } else if (stream->defer_processing_backedup_streams_ && !stream->reset_reason_.has_value() &&
                stream->stream_manager_.hasBufferedBodyOrTrailers()) {
-      ASSERT(error_code == NGHTTP2_NO_ERROR);
       ENVOY_CONN_LOG(debug, "buffered onStreamClose for stream: {}", connection_, stream_id);
       // Buffer the call, rely on the stream->process_buffered_data_callback_
       // to end up invoking.

--- a/test/common/http/codec_impl_corpus/content_length_mismatch-5806467830579200
+++ b/test/common/http/codec_impl_corpus/content_length_mismatch-5806467830579200
@@ -1,0 +1,206 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "K"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "ckie"
+        value: "/"
+      }
+      headers {
+        key: "cookie"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 54
+    request {
+      data: 3000000
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  mutate {
+    value: 989855744
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    response {
+      headers {
+        headers {
+          key: "content-length"
+          value: "5"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      read_disable: true
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      read_disable: false
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 5
+      end_stream: true
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      trailers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 67108864
+    request {
+      read_disable: true
+      end_stream: true
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      trailers {
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "http"
+        value: "foo=bar"
+      }
+      headers {
+        key: "cookie"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    request {
+      data: 54
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    response {
+      headers {
+        headers {
+          key: ":status"
+          value: "200"
+        }
+        headers {
+          key: "content-length"
+          value: "5"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 1
+    response {
+      data: 5
+      end_stream: true
+    }
+  }
+}


### PR DESCRIPTION
This ASSERT triggers with a specific `codec_impl_fuzz_test.cc` input, but the condition itself appears arbitrary. For the purpose of code correctness, it doesn't matter whether the error code passed in is NO_ERROR or something else.

All unit and integration tests continue to pass without the ASSERT in place.

```
$ bazel test --config=remote test/integration/... test/common/http/...
Starting local Bazel server and connecting to it...
INFO: Invocation ID: a59c05fc-a314-4957-8e1c-188bfbec3704
INFO: Analyzed 507 targets (714 packages loaded, 37077 targets configured).
INFO: Found 361 targets and 146 test targets...
INFO: Elapsed time: 920.573s, Critical Path: 849.49s
INFO: 4318 processes: 2722 remote cache hit, 158 internal, 1438 remote.
INFO: Build completed successfully, 4318 total actions

Executed 146 out of 146 tests: 146 tests pass.
```

Commit Message: removes an unnecessary ASSERT
Additional Description:
Risk Level: low
Testing: ran all unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
