### PR TITLE
mobile: Switch to Truth from AssertJ

### DIFF
--- a/mobile/bazel/envoy_mobile_dependencies.bzl
+++ b/mobile/bazel/envoy_mobile_dependencies.bzl
@@ -72,7 +72,7 @@ def kotlin_dependencies(extra_maven_dependencies = []):
             "org.jetbrains.dokka:dokka-cli:1.5.31",
             "org.jetbrains.dokka:javadoc-plugin:1.5.31",
             # Test artifacts
-            "org.assertj:assertj-core:3.23.1",
+            "com.google.truth:truth:1.4.0",
             "junit:junit:4.13",
             "org.mockito:mockito-inline:4.8.0",
             "org.mockito:mockito-core:4.8.0",
@@ -88,7 +88,6 @@ def kotlin_dependencies(extra_maven_dependencies = []):
             "androidx.test.ext:junit:1.1.3",
             "org.robolectric:robolectric:4.8.2",
             "org.hamcrest:hamcrest:2.2",
-            "com.google.truth:truth:1.1.3",
         ] + extra_maven_dependencies,
         version_conflict_policy = "pinned",
         repositories = [

--- a/mobile/bazel/kotlin_test.bzl
+++ b/mobile/bazel/kotlin_test.bzl
@@ -20,7 +20,7 @@ def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], reposito
         srcs = srcs + dep_srcs,
         deps = [
             repository + "//bazel:envoy_mobile_test_suite",
-            "@maven//:org_assertj_assertj_core",
+            "@maven//:com_google_truth_truth",
             "@maven//:junit_junit",
             "@maven//:org_mockito_mockito_inline",
             "@maven//:org_mockito_mockito_core",
@@ -102,7 +102,6 @@ def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_dep
             "@maven//:androidx_test_rules",
             "@maven//:org_robolectric_robolectric",
             "@robolectric//bazel:android-all",
-            "@maven//:org_assertj_assertj_core",
             "@maven//:junit_junit",
             "@maven//:org_mockito_mockito_inline",
             "@maven//:org_mockito_mockito_core",

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -11,7 +11,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor
 /**
  * Mock implementation of `EnvoyEngine`. Used internally for testing the bridging layer & mocking.
  */
-internal class MockEnvoyEngine : EnvoyEngine {
+class MockEnvoyEngine : EnvoyEngine {
   override fun runWithConfig(
     envoyConfiguration: EnvoyConfiguration?,
     logLevel: String?

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
@@ -9,10 +9,8 @@ import java.nio.ByteBuffer
  *
  * @param callbacks Callbacks associated with the stream.
  */
-internal class MockEnvoyHTTPStream(
-  val callbacks: EnvoyHTTPCallbacks,
-  val explicitFlowControl: Boolean
-) : EnvoyHTTPStream(0, 0, callbacks, explicitFlowControl) {
+class MockEnvoyHTTPStream(val callbacks: EnvoyHTTPCallbacks, val explicitFlowControl: Boolean) :
+  EnvoyHTTPStream(0, 0, callbacks, explicitFlowControl) {
   override fun sendHeaders(headers: MutableMap<String, MutableList<String>>?, endStream: Boolean) {}
 
   override fun sendData(data: ByteBuffer?, endStream: Boolean) {}

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
@@ -8,7 +8,7 @@ import java.nio.ByteBuffer
  * Mock implementation of `Stream` that also provides an interface for sending mocked responses
  * through to the stream's callbacks. Created via `MockStreamPrototype`.
  */
-class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) :
+class MockStream(underlyingStream: MockEnvoyHTTPStream) :
   Stream(underlyingStream, useByteBufferPosition = false) {
   private val mockStream: MockEnvoyHTTPStream = underlyingStream
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamPrototype.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamPrototype.kt
@@ -7,8 +7,7 @@ import java.util.concurrent.Executor
  *
  * @param onStart Closure that will be called each time a new stream is started from the prototype.
  */
-class MockStreamPrototype
-internal constructor(private val onStart: ((stream: MockStream) -> Unit)?) :
+class MockStreamPrototype(private val onStart: ((stream: MockStream) -> Unit)?) :
   StreamPrototype(MockEnvoyEngine()) {
   override fun start(executor: Executor): Stream {
     val callbacks = createCallbacks(executor)

--- a/mobile/test/java/integration/AndroidEngineSocketTagTest.java
+++ b/mobile/test/java/integration/AndroidEngineSocketTagTest.java
@@ -1,6 +1,6 @@
 package test.kotlin.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;

--- a/mobile/test/java/integration/AndroidEnvoyEngineStartUpTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyEngineStartUpTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 // NOLINT(namespace-envoy)
 

--- a/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
@@ -1,6 +1,6 @@
 package test.kotlin.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
@@ -204,7 +204,7 @@ public class AndroidEnvoyExplicitFlowTest {
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
     assertThat(response.getBodyAsString()).isEmpty();
     assertThat(response.getEnvoyError()).isNull();
-    assertThat(response.getNbResponseChunks()).isZero();
+    assertThat(response.getNbResponseChunks()).isEqualTo(0);
   }
 
   @Test
@@ -400,7 +400,7 @@ public class AndroidEnvoyExplicitFlowTest {
     Response response = sendRequest(requestScenario);
 
     assertThat(response.isCancelled()).isTrue();
-    assertThat(response.getRequestChunkSent()).isZero();
+    assertThat(response.getRequestChunkSent()).isEqualTo(0);
     assertThat(response.getEnvoyError()).isNull();
   }
 
@@ -416,7 +416,7 @@ public class AndroidEnvoyExplicitFlowTest {
     Response response = sendRequest(requestScenario);
 
     assertThat(response.isCancelled()).isTrue();
-    assertThat(response.getRequestChunkSent()).isOne();
+    assertThat(response.getRequestChunkSent()).isEqualTo(1);
     assertThat(response.getEnvoyError()).isNull();
   }
 

--- a/mobile/test/java/integration/AndroidEnvoyFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyFlowTest.java
@@ -1,6 +1,6 @@
 package test.kotlin.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
@@ -101,7 +101,7 @@ public class AndroidEnvoyFlowTest {
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
     assertThat(response.getBodyAsString()).isEmpty();
     assertThat(response.getEnvoyError()).isNull();
-    assertThat(response.getNbResponseChunks()).isZero();
+    assertThat(response.getNbResponseChunks()).isEqualTo(0);
   }
 
   @Test

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -10,7 +10,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyFinalStreamIntel
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterCallbacks
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.nio.ByteBuffer
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.util.regex.Pattern
 

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyNativeResourceRegistryTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyNativeResourceRegistryTest.kt
@@ -2,11 +2,10 @@ package io.envoyproxy.envoymobile.engine
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class EnvoyNativeResourceRegistryTest {
-
   @Test
   fun `release callbacks are invoked when EnvoyNativeResourceWrappers are flagged as unreachable`() {
     val latch = CountDownLatch(1)

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtilityTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtilityTest.kt
@@ -1,10 +1,9 @@
 package io.envoyproxy.envoymobile.engine
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class JvmBridgeUtilityTest {
-
   @Test
   fun `retrieveHeaders produces a Map with all headers provided via passHeaders`() {
     val utility = JvmBridgeUtility()
@@ -18,9 +17,7 @@ class JvmBridgeUtilityTest {
       "test-1" to listOf("value-1", "value-2")
     )
 
-    assertThat(headers)
-      .hasSize(2) // Two keys / header name
-      .usingRecursiveComparison().isEqualTo(expectedHeaders)
+    assertThat(headers).isEqualTo(expectedHeaders)
   }
 
   @Test
@@ -58,9 +55,7 @@ class JvmBridgeUtilityTest {
       "test-2" to listOf("value-3")
     )
 
-    assertThat(nextHeaders)
-      .hasSize(1) // One key / header name
-      .usingRecursiveComparison().isEqualTo(expectedHeaders)
+    assertThat(nextHeaders).isEqualTo(expectedHeaders)
   }
 
   @Test(expected = AssertionError::class)

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile.engine.testing;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/JniHelperTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/JniHelperTest.java
@@ -1,7 +1,7 @@
 package io.envoyproxy.envoymobile.jni;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -143,9 +143,9 @@ public class JniHelperTest {
 
   @Test
   public void testThrowNew() {
-    assertThatThrownBy(() -> throwNew("java/lang/RuntimeException", "Test"))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("Test");
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> throwNew("java/lang/RuntimeException", "Test"));
+    assertThat(exception).hasMessageThat().contains("Test");
   }
 
   @Test

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile.jni;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;

--- a/mobile/test/java/org/chromium/net/impl/AtomicCombinatoryStateTest.java
+++ b/mobile/test/java/org/chromium/net/impl/AtomicCombinatoryStateTest.java
@@ -1,6 +1,6 @@
 package org.chromium.net.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/mobile/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
@@ -1,7 +1,8 @@
 package org.chromium.net.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.google.common.truth.Truth.assertThat;
+
+import static org.junit.Assert.assertThrows;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -69,7 +70,7 @@ public class CancelProofEnvoyStreamTest {
   public void setStream() {
     cancelProofEnvoyStream.setStream(mMockedStream);
 
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
@@ -78,15 +79,14 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.setStream(mMockedStream);
 
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
   public void setStream_twice() {
     cancelProofEnvoyStream.setStream(mMockedStream);
 
-    assertThatThrownBy(() -> cancelProofEnvoyStream.setStream(mMockedStream))
-        .isInstanceOf(AssertionError.class);
+    assertThrows(AssertionError.class, () -> cancelProofEnvoyStream.setStream(mMockedStream));
   }
 
   @Test
@@ -95,14 +95,14 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.sendHeaders(HEADERS, false);
 
-    assertThat(mSendHeadersInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mSendHeadersInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
   public void sendHeaders_withoutStreamSet() {
-    assertThatThrownBy(() -> cancelProofEnvoyStream.sendHeaders(HEADERS, false))
-        .isInstanceOf(NullPointerException.class);
+    assertThrows(NullPointerException.class,
+                 () -> cancelProofEnvoyStream.sendHeaders(HEADERS, false));
   }
 
   @Test
@@ -112,8 +112,8 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.sendHeaders(HEADERS, false);
 
-    assertThat(mSendHeadersInvocationCount.get()).isZero();
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mSendHeadersInvocationCount.get()).isEqualTo(0);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -128,8 +128,8 @@ public class CancelProofEnvoyStreamTest {
     mSendHeadersBlock.open();
     thread.join(); // Wait for the Thread to die.
 
-    assertThat(mSendHeadersInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mSendHeadersInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -138,14 +138,14 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
 
-    assertThat(mSendDataInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mSendDataInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
   public void sendData_withoutStreamSet() {
-    assertThatThrownBy(() -> cancelProofEnvoyStream.sendData(BYTE_BUFFER, false))
-        .isInstanceOf(NullPointerException.class);
+    assertThrows(NullPointerException.class,
+                 () -> cancelProofEnvoyStream.sendData(BYTE_BUFFER, false));
   }
 
   @Test
@@ -155,8 +155,8 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
 
-    assertThat(mSendDataInvocationCount.get()).isZero();
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mSendDataInvocationCount.get()).isEqualTo(0);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -171,8 +171,8 @@ public class CancelProofEnvoyStreamTest {
     mSendDataBlock.open();
     thread.join(); // Wait for the Thread to die.
 
-    assertThat(mSendDataInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mSendDataInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -181,14 +181,13 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.readData(1);
 
-    assertThat(mReadDataInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mReadDataInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
   public void readData_withoutStreamSet() {
-    assertThatThrownBy(() -> cancelProofEnvoyStream.readData(1))
-        .isInstanceOf(NullPointerException.class);
+    assertThrows(NullPointerException.class, () -> cancelProofEnvoyStream.readData(1));
   }
 
   @Test
@@ -198,8 +197,8 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.readData(1);
 
-    assertThat(mReadDataInvocationCount.get()).isZero();
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mReadDataInvocationCount.get()).isEqualTo(0);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -214,8 +213,8 @@ public class CancelProofEnvoyStreamTest {
     mReadDataBlock.open();
     thread.join(); // Wait for the Thread to die.
 
-    assertThat(mReadDataInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mReadDataInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -224,7 +223,7 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.cancel();
 
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -234,7 +233,7 @@ public class CancelProofEnvoyStreamTest {
     cancelProofEnvoyStream.cancel();
     cancelProofEnvoyStream.cancel();
 
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -252,7 +251,7 @@ public class CancelProofEnvoyStreamTest {
       thread.join();
     }
 
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   @Test
@@ -275,8 +274,8 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.cancel();
 
-    assertThat(mSendHeadersInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mSendHeadersInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
@@ -289,8 +288,8 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.cancel();
 
-    assertThat(mSendDataInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mSendDataInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
@@ -303,8 +302,8 @@ public class CancelProofEnvoyStreamTest {
 
     cancelProofEnvoyStream.cancel();
 
-    assertThat(mReadDataInvocationCount.get()).isOne();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mReadDataInvocationCount.get()).isEqualTo(1);
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
   }
 
   @Test
@@ -342,7 +341,7 @@ public class CancelProofEnvoyStreamTest {
     assertThat(mReadDataInvocationCount.get()).isEqualTo(threads.length / 3);
 
     cancelProofEnvoyStream.cancel();
-    assertThat(mCancelInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(0);
 
     // Let all the Threads to finish executing the cancelProofEnvoyStream's methods.
     mSendHeadersBlock.open();
@@ -352,7 +351,7 @@ public class CancelProofEnvoyStreamTest {
     for (Thread thread : threads) {
       thread.join();
     }
-    assertThat(mCancelInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isEqualTo(1);
   }
 
   private class MockedStream extends EnvoyHTTPStream {

--- a/mobile/test/java/org/chromium/net/impl/CronetBidirectionalStateTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CronetBidirectionalStateTest.java
@@ -1,7 +1,7 @@
 package org.chromium.net.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -53,9 +53,9 @@ public class CronetBidirectionalStateTest {
   @Test
   public void userStart_twice() {
     mCronetBidirectionalState.nextAction(Event.USER_START);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_START))
-        .isExactlyInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("already started");
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class, () -> mCronetBidirectionalState.nextAction(Event.USER_START));
+    assertThat(exception).hasMessageThat().contains("already started");
   }
 
   // ================= STREAM_READY_CALLBACK_DONE =================
@@ -100,26 +100,29 @@ public class CronetBidirectionalStateTest {
   @Test
   public void userWrite_afterStartReadOnly() {
     mCronetBidirectionalState.nextAction(Event.USER_START_READ_ONLY);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_WRITE))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Write after writing end of stream");
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+                     () -> mCronetBidirectionalState.nextAction(Event.USER_WRITE));
+    assertThat(exception).hasMessageThat().contains("Write after writing end of stream");
   }
 
   @Test
   public void userWrite_afterStartWithHeadersReadOnly() {
     mCronetBidirectionalState.nextAction(Event.USER_START_WITH_HEADERS_READ_ONLY);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_WRITE))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Write after writing end of stream");
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+                     () -> mCronetBidirectionalState.nextAction(Event.USER_WRITE));
+    assertThat(exception).hasMessageThat().contains("Write after writing end of stream");
   }
 
   @Test
   public void userWrite_afterLastWrite() {
     mCronetBidirectionalState.nextAction(Event.USER_START);
     mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_WRITE))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Write after writing end of stream");
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+                     () -> mCronetBidirectionalState.nextAction(Event.USER_WRITE));
+    assertThat(exception).hasMessageThat().contains("Write after writing end of stream");
   }
 
   @Test
@@ -158,17 +161,19 @@ public class CronetBidirectionalStateTest {
   @Test
   public void userLastWrite_afterStartReadOnly() {
     mCronetBidirectionalState.nextAction(Event.USER_START_READ_ONLY);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Write after writing end of stream");
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+                     () -> mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE));
+    assertThat(exception).hasMessageThat().contains("Write after writing end of stream");
   }
 
   @Test
   public void userLastWrite_afterStartWithHeadersReadOnly() {
     mCronetBidirectionalState.nextAction(Event.USER_START_WITH_HEADERS_READ_ONLY);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Write after writing end of stream");
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+                     () -> mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE));
+    assertThat(exception).hasMessageThat().contains("Write after writing end of stream");
   }
 
   @Test
@@ -182,9 +187,10 @@ public class CronetBidirectionalStateTest {
   public void userLastWrite_afterLastWrite() {
     mCronetBidirectionalState.nextAction(Event.USER_START);
     mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Write after writing end of stream");
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class,
+                     () -> mCronetBidirectionalState.nextAction(Event.USER_LAST_WRITE));
+    assertThat(exception).hasMessageThat().contains("Write after writing end of stream");
   }
 
   @Test
@@ -264,9 +270,9 @@ public class CronetBidirectionalStateTest {
   public void userRead_beforeOnHeaders_afterAnotherRead() {
     mCronetBidirectionalState.nextAction(Event.USER_START_WITH_HEADERS_READ_ONLY);
     mCronetBidirectionalState.nextAction(Event.USER_READ);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_READ))
-        .isExactlyInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Unexpected read");
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class, () -> mCronetBidirectionalState.nextAction(Event.USER_READ));
+    assertThat(exception).hasMessageThat().contains("Unexpected read");
   }
 
   @Test
@@ -281,9 +287,9 @@ public class CronetBidirectionalStateTest {
     mCronetBidirectionalState.nextAction(Event.USER_START_WITH_HEADERS_READ_ONLY);
     mCronetBidirectionalState.nextAction(Event.ON_HEADERS);
     mCronetBidirectionalState.nextAction(Event.USER_READ);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_READ))
-        .isExactlyInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Unexpected read");
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class, () -> mCronetBidirectionalState.nextAction(Event.USER_READ));
+    assertThat(exception).hasMessageThat().contains("Unexpected read");
   }
 
   @Test
@@ -305,16 +311,16 @@ public class CronetBidirectionalStateTest {
     mCronetBidirectionalState.nextAction(Event.READY_TO_START_POSTPONED_READ_IF_ANY);
     mCronetBidirectionalState.nextAction(Event.ON_COMPLETE);
     mCronetBidirectionalState.nextAction(Event.USER_READ);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_READ))
-        .isExactlyInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Unexpected read");
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class, () -> mCronetBidirectionalState.nextAction(Event.USER_READ));
+    assertThat(exception).hasMessageThat().contains("Unexpected read");
   }
 
   @Test
   public void userRead_beforeUserStart() {
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_READ))
-        .isExactlyInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Unexpected read");
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class, () -> mCronetBidirectionalState.nextAction(Event.USER_READ));
+    assertThat(exception).hasMessageThat().contains("Unexpected read");
   }
 
   @Test
@@ -336,9 +342,9 @@ public class CronetBidirectionalStateTest {
     mCronetBidirectionalState.nextAction(Event.USER_READ);
     mCronetBidirectionalState.nextAction(Event.ON_DATA_END_STREAM);
     mCronetBidirectionalState.nextAction(Event.LAST_READ_COMPLETED);
-    assertThatThrownBy(() -> mCronetBidirectionalState.nextAction(Event.USER_READ))
-        .isExactlyInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Unexpected read");
+    IllegalStateException exception = assertThrows(
+        IllegalStateException.class, () -> mCronetBidirectionalState.nextAction(Event.USER_READ));
+    assertThat(exception).hasMessageThat().contains("Unexpected read");
   }
 
   // ================= USER_CANCEL =================

--- a/mobile/test/java/org/chromium/net/impl/CronvoyEngineTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CronvoyEngineTest.java
@@ -3,8 +3,10 @@ package org.chromium.net.impl;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import static org.junit.Assert.assertThrows;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
@@ -88,7 +90,7 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEqualTo("hello, world");
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
 
     // Do some basic stats accounting.
     String stats = cronvoyEngine.getEnvoyEngine().dumpStats();
@@ -110,7 +112,7 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEmpty();
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
   }
 
   @Test
@@ -131,7 +133,8 @@ public class CronvoyEngineTest {
     RequestScenario requestScenario = new RequestScenario().addResponseBuffers(11);
 
     // Message comes from Preconditions.checkHasRemaining()
-    assertThatThrownBy(() -> sendRequest(requestScenario)).hasMessageContaining("already full");
+    Exception exception = assertThrows(Exception.class, () -> sendRequest(requestScenario));
+    assertThat(exception).hasMessageThat().contains("already full");
   }
 
   @Test
@@ -155,7 +158,7 @@ public class CronvoyEngineTest {
     // The response will come in 3 chunks. The 4th read is the final read and shouldn't trigger
     // OnReadComplete() as no data is read.
     assertThat(testCallback.getNumOnReadCompleteCalled()).isEqualTo(3);
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
     assertThat(response.getBodyAsString()).isEqualTo("hello, world");
     assertThat(response.getNbResponseChunks()).isEqualTo(3); // 5 bytes, 5 bytes, and 2 bytes
   }
@@ -169,7 +172,7 @@ public class CronvoyEngineTest {
     Response response = sendRequest(requestScenario);
 
     assertThat(response.isCancelled()).isTrue();
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
     assertThat(response.getBodyAsString()).isEmpty();
   }
 
@@ -194,7 +197,7 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEqualTo("This is the response Body");
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
   }
 
   @Test
@@ -221,7 +224,7 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEqualTo("This is the response Body");
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
   }
 
   @Test
@@ -252,10 +255,10 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEqualTo("Everything is awesome");
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
     assertThat(response.getUrlResponseInfo().getUrlChain())
-        .contains(mockWebServer.url("/get/flowers").toString(),
-                  mockWebServer.url("/get/chocolates").toString());
+        .containsExactly(mockWebServer.url("/get/flowers").toString(),
+                         mockWebServer.url("/get/chocolates").toString());
   }
 
   @Test
@@ -288,10 +291,10 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEqualTo("Everything is awesome");
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
     assertThat(response.getUrlResponseInfo().getUrlChain())
-        .contains(mockWebServer.url("/get/flowers").toString(),
-                  mockWebServer.url("/get/chocolates").toString());
+        .containsExactly(mockWebServer.url("/get/flowers").toString(),
+                         mockWebServer.url("/get/chocolates").toString());
   }
 
   @Test
@@ -329,10 +332,10 @@ public class CronvoyEngineTest {
 
     assertThat(response.getResponseCode()).isEqualTo(HTTP_OK);
     assertThat(response.getBodyAsString()).isEqualTo("Everything is awesome");
-    assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
+    assertWithMessage(response.getErrorMessage()).that(response.getCronetException()).isNull();
     assertThat(response.getUrlResponseInfo().getUrlChain())
-        .contains(mockWebServer.url("/get/flowers").toString(),
-                  mockWebServer.url("/get/chocolates").toString());
+        .containsExactly(mockWebServer.url("/get/flowers").toString(),
+                         mockWebServer.url("/get/chocolates").toString());
   }
 
   private Response sendRequest(RequestScenario requestScenario) {

--- a/mobile/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
+++ b/mobile/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
@@ -1,7 +1,7 @@
 package org.chromium.net.testing;
 
 import static io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.chromium.net.testing.CronetTestRule.SERVER_CERT_PEM;
 import static org.chromium.net.testing.CronetTestRule.SERVER_KEY_PKCS8_PEM;
 

--- a/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -1,7 +1,7 @@
 package org.chromium.net.testing;
 
 import static io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.chromium.net.testing.CronetTestRule.SERVER_CERT_PEM;
 import static org.chromium.net.testing.CronetTestRule.SERVER_KEY_PKCS8_PEM;
 

--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -18,7 +19,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 private const val FILTER_NAME = "cancel_validation_filter"

--- a/mobile/test/kotlin/integration/CancelStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelStreamTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -18,7 +19,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/EngineApiTest.kt
+++ b/mobile/test/kotlin/integration/EngineApiTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.NullValue
 import com.google.protobuf.Struct
 import com.google.protobuf.Value
@@ -9,7 +10,6 @@ import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class EngineApiTest {

--- a/mobile/test/kotlin/integration/EnvoyEngineSimpleIntegrationTest.kt
+++ b/mobile/test/kotlin/integration/EnvoyEngineSimpleIntegrationTest.kt
@@ -1,12 +1,11 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class EnvoyEngineSimpleIntegrationTest {
-
   init {
     JniLibrary.loadTestLibrary()
   }

--- a/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
+++ b/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
@@ -2,6 +2,7 @@ package test.kotlin.integration
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -23,7 +24,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertWithMessage
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -17,8 +18,7 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val PBF_TYPE =
@@ -107,16 +107,16 @@ class GRPCReceiveErrorTest {
     callbackReceivedError.await(10, TimeUnit.SECONDS)
     engine.terminate()
 
-    assertThat(filterReceivedError.count)
-      .withFailMessage("Missing call to onError filter callback")
+    assertWithMessage("Missing call to onError filter callback")
+      .that(filterReceivedError.count)
       .isEqualTo(0)
 
-    assertThat(filterNotCancelled.count)
-      .withFailMessage("Unexpected call to onCancel filter callback")
+    assertWithMessage("Unexpected call to onCancel filter callback")
+      .that(filterNotCancelled.count)
       .isEqualTo(1)
 
-    assertThat(callbackReceivedError.count)
-      .withFailMessage("Missing call to onError response callback")
+    assertWithMessage("Missing call to onError response callback")
+      .that(callbackReceivedError.count)
       .isEqualTo(0)
   }
 }

--- a/mobile/test/kotlin/integration/KeyValueStoreTest.kt
+++ b/mobile/test/kotlin/integration/KeyValueStoreTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.KeyValueStore
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -8,8 +9,7 @@ import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/ReceiveDataTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveDataTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -8,8 +9,7 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/ReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveErrorTest.kt
@@ -1,5 +1,7 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -16,8 +18,7 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val PBF_TYPE =
@@ -118,16 +119,16 @@ class ReceiveErrorTest {
     callbackReceivedError.await(10, TimeUnit.SECONDS)
     engine.terminate()
 
-    assertThat(filterReceivedError.count)
-      .withFailMessage("Missing call to onError filter callback")
+    assertWithMessage("Missing call to onError filter callback")
+      .that(filterReceivedError.count)
       .isEqualTo(0)
 
-    assertThat(filterNotCancelled.count)
-      .withFailMessage("Unexpected call to onCancel filter callback")
+    assertWithMessage("Unexpected call to onCancel filter callback")
+      .that(filterNotCancelled.count)
       .isEqualTo(1)
 
-    assertThat(callbackReceivedError.count)
-      .withFailMessage("Missing call to onError response callback")
+    assertWithMessage("Missing call to onError response callback")
+      .that(callbackReceivedError.count)
       .isEqualTo(0)
 
     assertThat(errorCode).isEqualTo(2) // 503/Connection Failure

--- a/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -18,8 +19,7 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
+++ b/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -8,8 +9,7 @@ import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -11,8 +12,7 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val ASSERTION_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/SendHeadersTest.kt
+++ b/mobile/test/kotlin/integration/SendHeadersTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -8,8 +9,7 @@ import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/SendTrailersTest.kt
+++ b/mobile/test/kotlin/integration/SendTrailersTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -9,8 +10,7 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/mobile/test/kotlin/integration/SetEventTrackerTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
@@ -7,7 +8,6 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class SetEventTrackerTest {

--- a/mobile/test/kotlin/integration/SetLoggerTest.kt
+++ b/mobile/test/kotlin/integration/SetLoggerTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
@@ -9,11 +10,9 @@ import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class SetLoggerTest {
-
   init {
     JniLibrary.loadTestLibrary()
   }

--- a/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
+++ b/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
@@ -1,5 +1,6 @@
 package test.kotlin.integration
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -18,8 +19,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 private const val TEST_RESPONSE_FILTER_TYPE =
@@ -67,7 +67,7 @@ class StreamIdleTimeoutTest {
     override fun onComplete(finalStreamIntel: FinalStreamIntel) {}
 
     override fun onCancel(finalStreamIntel: FinalStreamIntel) {
-      fail<StreamIdleTimeoutTest>("Unexpected call to onCancel filter callback")
+      fail("Unexpected call to onCancel filter callback")
     }
   }
 

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -15,7 +16,6 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -15,7 +16,6 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -15,7 +16,6 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -15,7 +16,6 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -14,7 +15,6 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.ProxyInfo
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -14,7 +15,6 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -1,8 +1,8 @@
 package io.envoyproxy.envoymobile
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.Mockito.mock
 

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCRequestHeadersBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCRequestHeadersBuilderTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class GRPCRequestHeadersBuilderTest {

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
@@ -1,12 +1,12 @@
 package io.envoyproxy.envoymobile
 
+import com.google.common.truth.Truth.assertThat
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class GRPCStreamTest {
@@ -204,7 +204,7 @@ class GRPCStreamTest {
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
       .setOnResponseMessage { message, _ ->
-        assertThat(message.array()).hasSize(0)
+        assertThat(message.array()).hasLength(0)
         countDownLatch.countDown()
       }
       .start(Executor {})
@@ -257,7 +257,7 @@ class GRPCStreamTest {
       .newGRPCStreamPrototype()
       .setOnResponseMessage { message, _ ->
         if (countDownLatch.count == 2L) {
-          assertThat(message.array()).hasSize(0)
+          assertThat(message.array()).hasLength(0)
         } else {
           assertThat(message.array()).isEqualTo(secondMessage)
         }

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/HeadersBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/HeadersBuilderTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class HeadersBuilderTest {

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/HeadersContainerTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/HeadersContainerTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class HeadersContainerest {

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/PulseClientImplTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/PulseClientImplTest.kt
@@ -1,13 +1,12 @@
 package io.envoyproxy.envoymobile
 
+import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/RequestHeadersBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/RequestHeadersBuilderTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class RequestHeadersBuilderTest {
@@ -170,7 +170,7 @@ class RequestHeadersBuilderTest {
         .addRetryPolicy(retryPolicy)
         .build()
 
-    assertThat(headers.caseSensitiveHeaders()).containsAllEntriesOf(retryPolicyHeaders)
+    assertThat(headers.caseSensitiveHeaders()).containsAtLeastEntriesIn(retryPolicyHeaders)
   }
 
   @Test

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/ResponseHeadersTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/ResponseHeadersTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class ResponseHeadersTest {

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class RetryPolicyMapperTest {

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/stats/TagsBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/stats/TagsBuilderTest.kt
@@ -1,6 +1,6 @@
 package io.envoyproxy.envoymobile
 
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class TagsBuilderTest {


### PR DESCRIPTION
Having multiple assertion libraries can be confusing. This PR switches the Java and Kotlin tests to use Google's Truth instead of AssertJ since that is what's used at Google, which makes rebasing Cronet for example easier. Google's Truth has also better failure messages. For comparison between the two, see [this](https://truth.dev/comparison.html).

Risk Level: low (tests only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
