### PR TITLE
Exclude //test/tools/router_check/test:router_tool_test from coverage builds

### DIFF
--- a/test/tools/router_check/test/BUILD
+++ b/test/tools/router_check/test/BUILD
@@ -17,6 +17,7 @@ envoy_sh_test(
     data = [
         ":configs",
     ],
+    tags = ["nocoverage"],
 )
 
 envoy_cc_test(


### PR DESCRIPTION
Additional Description:
Running this test does not produce useful coverage and disabling it does not affect coverage numbers.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
