### PR TITLE
[http-cache-filter] limit cache read chunk size to buffer size

### DIFF
--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -490,6 +490,69 @@ TEST_F(CacheFilterTest, FilterDestroyedWhileWatermarkedSendsLowWatermarkEvent) {
   }
 }
 
+MATCHER_P2(RangeMatcher, begin, end, "") {
+  return testing::ExplainMatchResult(begin, arg.begin(), result_listener) &&
+         testing::ExplainMatchResult(end, arg.end(), result_listener);
+}
+
+TEST_F(CacheFilterTest, BodyReadFromCacheLimitedToBufferSizeChunks) {
+  request_headers_.setHost("CacheHitWithBody");
+  // Set the buffer limit to 5 bytes, and we will have the file be of size
+  // 8 bytes.
+  EXPECT_CALL(encoder_callbacks_, encoderBufferLimit()).WillRepeatedly(::testing::Return(5));
+  auto mock_http_cache = std::make_shared<MockHttpCache>();
+  auto mock_lookup_context = std::make_unique<MockLookupContext>();
+  EXPECT_CALL(*mock_http_cache, makeLookupContext(_, _))
+      .WillOnce([&](LookupRequest&&,
+                    Http::StreamDecoderFilterCallbacks&) -> std::unique_ptr<LookupContext> {
+        return std::move(mock_lookup_context);
+      });
+  EXPECT_CALL(*mock_lookup_context, getHeaders(_)).WillOnce([&](LookupHeadersCallback&& cb) {
+    std::unique_ptr<Http::ResponseHeaderMap> response_headers =
+        std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_);
+    cb(LookupResult{CacheEntryStatus::Ok, std::move(response_headers), 8, absl::nullopt});
+  });
+  EXPECT_CALL(*mock_lookup_context, getBody(RangeMatcher(0, 5), _))
+      .WillOnce([&](const AdjustedByteRange&, LookupBodyCallback&& cb) {
+        cb(std::make_unique<Buffer::OwnedImpl>("abcde"));
+      });
+  EXPECT_CALL(*mock_lookup_context, getBody(RangeMatcher(5, 8), _))
+      .WillOnce([&](const AdjustedByteRange&, LookupBodyCallback&& cb) {
+        cb(std::make_unique<Buffer::OwnedImpl>("fgh"));
+      });
+  EXPECT_CALL(*mock_lookup_context, onDestroy());
+
+  CacheFilterSharedPtr filter = makeFilter(mock_http_cache, false);
+
+  // The filter should encode cached headers.
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(IsSupersetOfHeaders(response_headers_), false));
+
+  // The filter should encode cached data in two pieces.
+  EXPECT_CALL(
+      decoder_callbacks_,
+      encodeData(testing::Property(&Buffer::Instance::toString, testing::Eq("abcde")), false));
+  EXPECT_CALL(decoder_callbacks_,
+              encodeData(testing::Property(&Buffer::Instance::toString, testing::Eq("fgh")), true));
+
+  // The filter should stop decoding iteration when decodeHeaders is called as a cache lookup is
+  // in progress.
+  EXPECT_EQ(filter->decodeHeaders(request_headers_, true),
+            Http::FilterHeadersStatus::StopAllIterationAndWatermark);
+
+  // The filter should not continue decoding when the cache lookup result is ready, as the
+  // expected result is a hit.
+  EXPECT_CALL(decoder_callbacks_, continueDecoding).Times(0);
+
+  // The cache lookup callback should be posted to the dispatcher.
+  // Run events on the dispatcher so that the callback is invoked.
+  // The posted lookup callback will cause another callback to be posted (when getBody() is
+  // called) which should also be invoked.
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  filter->onDestroy();
+  filter.reset();
+}
+
 TEST_F(CacheFilterTest, CacheInsertAbortedByCache) {
   request_headers_.setHost("CacheHitWithBody");
   const std::string body = "abc";


### PR DESCRIPTION
Commit Message: [http-cache-filter] limit cache read chunk size to buffer size
Additional Description: Before this change, the cache filter will request the entire body of a cache entry in a single request from its associated cache extension, and both existing cache extensions would try to simply fulfill the request. When a file is very large, this results in trying to load an entire very large file into memory, which typically leads to a crash.

This change makes the cache filter request only the amount of data that would fill the streaming buffer per chunk, which should make it more tolerant of very large cache entries. If there is no buffer limit, an arbitrary 64MB limit is imposed.
Risk Level: Very small; change is to a WIP filter and addresses an existing crash.
Testing: Added unit test, and tested as a patch in production, where it fixed the reproducible OOM that provoked this change.
Docs Changes: n/a
Release Notes: n/a (the API between filter and cache is unchanged, this change is within the promised behavior)
Platform Specific Features: n/a
