### PR TITLE
mobile: Move mocks from library to test

### DIFF
--- a/mobile/bazel/kotlin_lib.bzl
+++ b/mobile/bazel/kotlin_lib.bzl
@@ -20,7 +20,7 @@ def native_lib_name(native_dep):
         lib_name = native_dep.split(".so")[0]
     return lib_name
 
-def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = [], exports = []):
+def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = [], exports = [], associates = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion. This is used to work around testing visibility.
     native.filegroup(
@@ -34,6 +34,7 @@ def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = [], expor
         srcs = srcs,
         deps = deps,
         exports = exports,
+        associates = associates,
         visibility = visibility,
     )
 

--- a/mobile/bazel/kotlin_test.bzl
+++ b/mobile/bazel/kotlin_test.bzl
@@ -3,7 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_local_test")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//bazel:kotlin_lib.bzl", "native_lib_name")
 
-def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], repository = "", exec_properties = {}):
+def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], repository = "", exec_properties = {}, associates = []):
     # This is to work around the issue where we have specific implementation functionality which
     # we want to avoid consumers to use but we want to unit test
     dep_srcs = []
@@ -28,6 +28,7 @@ def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], reposito
         data = data,
         jvm_flags = jvm_flags,
         exec_properties = exec_properties,
+        associates = associates,
     )
 
 # A simple macro to define the JVM flags that are common for envoy_mobile_jni_kt_test and
@@ -47,7 +48,7 @@ def jvm_flags(lib_name):
 
 # A basic macro to make it easier to declare and run kotlin tests which depend on a JNI lib
 # This will create the native .so binary (for linux) and a .jnilib (for macOS) look up
-def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps = [], repository = "", exec_properties = {}):
+def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps = [], repository = "", exec_properties = {}, associates = []):
     _internal_kt_test(
         name,
         srcs,
@@ -56,6 +57,7 @@ def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps
         jvm_flags = jvm_flags(native_lib_name),
         repository = repository,
         exec_properties = exec_properties,
+        associates = associates,
     )
 
 # A basic macro to make it easier to declare and run kotlin tests
@@ -74,11 +76,11 @@ def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps
 #         "ExampleTest.kt",
 #     ],
 # )
-def envoy_mobile_kt_test(name, srcs, deps = [], repository = "", exec_properties = {}):
-    _internal_kt_test(name, srcs, deps, repository = repository, exec_properties = exec_properties)
+def envoy_mobile_kt_test(name, srcs, deps = [], repository = "", exec_properties = {}, associates = []):
+    _internal_kt_test(name, srcs, deps, repository = repository, exec_properties = exec_properties, associates = associates)
 
 # A basic macro to run android based (robolectric) tests with native dependencies
-def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_deps = [], repository = "", exec_properties = {}):
+def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_deps = [], repository = "", exec_properties = {}, associates = []):
     android_library(
         name = name + "_test_lib",
         custom_package = "io.envoyproxy.envoymobile.test",
@@ -116,4 +118,5 @@ def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_dep
         test_class = "io.envoyproxy.envoymobile.bazel.EnvoyMobileTestSuite",
         jvm_flags = jvm_flags(native_lib_name),
         exec_properties = exec_properties,
+        associates = associates,
     )

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -101,7 +101,6 @@ envoy_mobile_kt_library(
         "Trailers.kt",
         "filters/*.kt",
         "grpc/*.kt",
-        "mocks/*.kt",
         "stats/*.kt",
     ]),
     visibility = ["//visibility:public"],

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitorTest.java
@@ -11,8 +11,8 @@ import androidx.test.filters.MediumTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.annotation.UiThreadTest;
-import io.envoyproxy.envoymobile.MockEnvoyEngine;
-import org.junit.After;
+import io.envoyproxy.envoymobile.mocks.MockEnvoyEngine;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -51,6 +51,7 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidNetworkMonitorTest.java",
     ],
+    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -63,6 +64,6 @@ envoy_mobile_android_test(
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
-        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/kotlin/io/envoyproxy/envoymobile/mocks:mocks_lib",
     ],
 )

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -43,8 +43,9 @@ envoy_mobile_kt_test(
     srcs = [
         "GRPCStreamTest.kt",
     ],
+    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
     deps = [
-        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/kotlin/io/envoyproxy/envoymobile/mocks:mocks_lib",
     ],
 )
 

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
@@ -1,6 +1,8 @@
 package io.envoyproxy.envoymobile
 
 import com.google.common.truth.Truth.assertThat
+import io.envoyproxy.envoymobile.mocks.MockStream
+import io.envoyproxy.envoymobile.mocks.MockStreamClient
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/BUILD
@@ -1,0 +1,19 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+load("@envoy_mobile//bazel:kotlin_lib.bzl", "envoy_mobile_kt_library")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
+
+envoy_mobile_kt_library(
+    name = "mocks_lib",
+    srcs = [
+        "MockEnvoyEngine.kt",
+        "MockEnvoyHTTPStream.kt",
+        "MockStream.kt",
+        "MockStreamClient.kt",
+        "MockStreamPrototype.kt",
+    ],
+    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile.mocks
 
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile.mocks
 
 import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
@@ -1,5 +1,11 @@
-package io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile.mocks
 
+import io.envoyproxy.envoymobile.EnvoyError
+import io.envoyproxy.envoymobile.RequestHeaders
+import io.envoyproxy.envoymobile.RequestTrailers
+import io.envoyproxy.envoymobile.ResponseHeaders
+import io.envoyproxy.envoymobile.ResponseTrailers
+import io.envoyproxy.envoymobile.Stream
 import io.envoyproxy.envoymobile.engine.types.EnvoyFinalStreamIntel
 import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel
 import java.nio.ByteBuffer

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamClient.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamClient.kt
@@ -1,4 +1,7 @@
-package io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile.mocks
+
+import io.envoyproxy.envoymobile.StreamClient
+import io.envoyproxy.envoymobile.StreamPrototype
 
 /**
  * Mock implementation of `StreamClient` which produces `MockStreamPrototype` values.

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamPrototype.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamPrototype.kt
@@ -1,5 +1,7 @@
-package io.envoyproxy.envoymobile
+package io.envoyproxy.envoymobile.mocks
 
+import io.envoyproxy.envoymobile.Stream
+import io.envoyproxy.envoymobile.StreamPrototype
 import java.util.concurrent.Executor
 
 /**


### PR DESCRIPTION
Prior to this PR, building `//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib` would also include the mocks, which is not ideal. This PR moves the mocks from `library` to `test` and uses Bazel `associates` attribute in `kt_jvm_library` to allow accessing `internal` code without having to include the mocks into the `library` JAR.

Risk Level: low (tests only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
