### PR TITLE
Fix null node for list of struct in payload_to_metadaata filter

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.cc
@@ -102,6 +102,7 @@ bool Rule::matches(const ThriftProxy::MessageMetadata& metadata) const {
 }
 
 FilterStatus TrieMatchHandler::messageEnd() {
+  ASSERT(steps_ == 0);
   ENVOY_LOG(trace, "TrieMatchHandler messageEnd");
   parent_.handleOnMissing();
   complete_ = true;
@@ -110,13 +111,12 @@ FilterStatus TrieMatchHandler::messageEnd() {
 
 FilterStatus TrieMatchHandler::structBegin(absl::string_view) {
   ENVOY_LOG(trace, "TrieMatchHandler structBegin id: {}, steps: {}",
-            last_field_id_.has_value() ? std::to_string(last_field_id_.value())
-                                       : "top_level_struct",
-            steps_);
+            field_ids_.empty() ? "top_level_struct" : std::to_string(field_ids_.back()), steps_);
+  ASSERT(steps_ >= 0);
   assertNode();
-  if (last_field_id_.has_value()) {
-    if (steps_ == 0 && node_->children_.find(last_field_id_.value()) != node_->children_.end()) {
-      node_ = node_->children_[last_field_id_.value()];
+  if (!field_ids_.empty()) {
+    if (steps_ == 0 && node_->children_.find(field_ids_.back()) != node_->children_.end()) {
+      node_ = node_->children_[field_ids_.back()];
       ENVOY_LOG(trace, "name: {}", node_->name_);
     } else {
       steps_++;
@@ -136,37 +136,41 @@ FilterStatus TrieMatchHandler::structEnd() {
     // last decoder event
     node_ = nullptr;
   }
+  ASSERT(steps_ >= 0);
   return FilterStatus::Continue;
 }
 
 FilterStatus TrieMatchHandler::fieldBegin(absl::string_view, FieldType&, int16_t& field_id) {
-  last_field_id_ = field_id;
+  ENVOY_LOG(trace, "TrieMatchHandler fieldBegin id: {}", field_id);
+  field_ids_.push_back(field_id);
   return FilterStatus::Continue;
 }
 
 FilterStatus TrieMatchHandler::fieldEnd() {
-  last_field_id_.reset();
+  ENVOY_LOG(trace, "TrieMatchHandler fieldEnd");
+  field_ids_.pop_back();
   return FilterStatus::Continue;
 }
 
 FilterStatus TrieMatchHandler::stringValue(absl::string_view value) {
   assertLastFieldId();
-  ENVOY_LOG(trace, "TrieMatchHandler stringValue id:{} value:{}", last_field_id_.value(), value);
+  ENVOY_LOG(trace, "TrieMatchHandler stringValue id:{} value:{}", field_ids_.back(), value);
   return handleString(static_cast<std::string>(value));
 }
 
 template <typename NumberType> FilterStatus TrieMatchHandler::numberValue(NumberType value) {
   assertLastFieldId();
-  ENVOY_LOG(trace, "TrieMatchHandler numberValue id:{} value:{}", last_field_id_.value(), value);
+  ENVOY_LOG(trace, "TrieMatchHandler numberValue id:{} value:{}", field_ids_.back(), value);
   return handleString(std::to_string(value));
 }
 
 FilterStatus TrieMatchHandler::handleString(std::string value) {
+  ASSERT(steps_ >= 0);
   assertNode();
   assertLastFieldId();
-  if (steps_ == 0 && node_->children_.find(last_field_id_.value()) != node_->children_.end() &&
-      !node_->children_[last_field_id_.value()]->rule_ids_.empty()) {
-    auto on_present_node = node_->children_[last_field_id_.value()];
+  if (steps_ == 0 && node_->children_.find(field_ids_.back()) != node_->children_.end() &&
+      !node_->children_[field_ids_.back()]->rule_ids_.empty()) {
+    auto on_present_node = node_->children_[field_ids_.back()];
     ENVOY_LOG(trace, "name: {}", on_present_node->name_);
     parent_.handleOnPresent(std::move(value), on_present_node->rule_ids_);
   }
@@ -180,8 +184,8 @@ void TrieMatchHandler::assertNode() {
 }
 
 void TrieMatchHandler::assertLastFieldId() {
-  if (!last_field_id_.has_value()) {
-    throw EnvoyException("payload to metadata filter: invalid trie state, last_field_id is null");
+  if (field_ids_.empty()) {
+    throw EnvoyException("payload to metadata filter: invalid trie state, field_ids_ is null");
   }
 }
 

--- a/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h
@@ -135,6 +135,7 @@ private:
   }
 
   FilterStatus handleContainerEnd() {
+    ASSERT(steps_ > 0, "unmatched container end");
     steps_--;
     return FilterStatus::Continue;
   }
@@ -142,8 +143,8 @@ private:
   MetadataHandler& parent_;
   TrieSharedPtr node_;
   bool complete_{false};
-  absl::optional<int16_t> last_field_id_;
-  uint16_t steps_{0};
+  std::vector<int16_t> field_ids_;
+  int16_t steps_{0};
 };
 
 const uint32_t MAX_PAYLOAD_VALUE_LEN = 8 * 1024;


### PR DESCRIPTION
Commit Message:
Previously we rely on `fieldBegin` right before `structBegin` to determine this is not top-level struct.
i.e., `fieldBegin structBegin structEnd fieldEnd` sequence.

However, while we have a list of struct, this assumption doesn't hold since the structure inside a container inherits the field id of the container.
i.e., we had `fieldBegin listBegin (structBegin structEnd)*n listEnd fieldEnd` sequence.

Therefore, introduce a stack of field ids so could we track field id better.

In the added unit test, it hits assertion before fix.

Additional Description:
Risk Level: low
Testing: unit
