### PR TITLE
mobile: Set --define=signal_trace=disabled to be the default

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -40,6 +40,7 @@ build --define cxxopts=-std=c++17
 build --features=-per_object_debug_info
 # Suppress deprecated declaration warnings due to extensive transitive noise from protobuf.
 build --copt -Wno-deprecated-declarations
+build --define=signal_trace=disabled
 
 build:rules_xcodeproj --config=ios
 build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0
@@ -255,7 +256,6 @@ build:mobile-remote-ci-android --config=mobile-remote-ci
 test:mobile-remote-ci-android --build_tests_only
 test:mobile-remote-ci-android --config=mobile-test-android
 test:mobile-remote-ci-android --config=mobile-remote-ci
-test:mobile-remote-ci-android --define=signal_trace=disabled
 
 build:mobile-remote-ci-cc --config=mobile-remote-ci
 test:mobile-remote-ci-cc --action_env=LD_LIBRARY_PATH
@@ -277,7 +277,6 @@ build:mobile-remote-ci-cc-no-exceptions --define=envoy_mobile_xds=disabled
 build:mobile-remote-ci-cc-test --config=mobile-remote-ci
 test:mobile-remote-ci-cc-test --test_output=all
 test:mobile-remote-ci-cc-test --config=mobile-remote-ci
-test:mobile-remote-ci-cc-test --define=signal_trace=disabled
 test:mobile-remote-ci-cc-test --define=google_grpc=disabled
 test:mobile-remote-ci-cc-test --define=envoy_mobile_xds=disabled
 test:mobile-remote-ci-cc-test --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=
@@ -285,7 +284,6 @@ test:mobile-remote-ci-cc-test --define=envoy_yaml=disabled
 
 build:mobile-remote-ci-macos-kotlin --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-kotlin --fat_apk_cpu=x86_64
-build:mobile-remote-ci-macos-kotlin --define=signal_trace=disabled
 build:mobile-remote-ci-macos-kotlin --define=envoy_mobile_request_compression=disabled
 build:mobile-remote-ci-macos-kotlin --define=envoy_enable_http_datagrams=disabled
 build:mobile-remote-ci-macos-kotlin --define=google_grpc=disabled
@@ -296,7 +294,6 @@ build:mobile-remote-ci-macos-kotlin --@com_envoyproxy_protoc_gen_validate//bazel
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --config=mobile-test-ios
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
-build:mobile-remote-ci-macos-swift --define=signal_trace=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_request_compression=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_swift_cxx_interop=disabled
 build:mobile-remote-ci-macos-swift --define=google_grpc=disabled


### PR DESCRIPTION
Envoy Mobile requires `--define=signal_trace=disabled`. This PR makes `--define=signal_trace=disabled` to be the default and removes a lot of `--define=signal_trace=disabled` in the Envoy Mobile Bazel configs.

Risk Level: low (clean up)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a