### PR TITLE
mobile: Set the socket receive buffer size to 1MB for QUIC

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -769,6 +769,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 
     // Set the upstream connections UDP socket receive buffer size. The operating system defaults
     // are usually too small for QUIC.
+    // NOTE: An H3 cluster can also establish H2 connections (for example, if the H3 connection is
+    // marked as broken in the ConnectivityGrid). This option would apply to all connections in the
+    // cluster, meaning H2 TCP connections buffer size would also be set to 1MB.
     envoy::config::core::v3::SocketOption* sock_opt =
         base_cluster->mutable_upstream_bind_config()->add_socket_options();
     sock_opt->set_name(SO_RCVBUF);

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -769,6 +769,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 
     // Set the upstream connections socket receive buffer size. The operating system defaults are
     // usually too small for QUIC.
+    // TODO(32304): We can remove this once core Envoy has better receive buffer defaults.
     // NOTE: An H3 cluster can also establish H2 connections (for example, if the H3 connection is
     // marked as broken in the ConnectivityGrid). This option would apply to all connections in the
     // cluster, meaning H2 TCP connections buffer size would also be set to 1MB. On the platforms

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -772,7 +772,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     envoy::config::core::v3::SocketOption* sock_opt =
         base_cluster->mutable_upstream_bind_config()->add_socket_options();
     sock_opt->set_name(SO_RCVBUF);
-    sock_opt->set_level(IPPROTO_UDP);
+    sock_opt->set_level(SOL_SOCKET);
     sock_opt->set_int_value(QuicSocketReceiveBufferSize);
     sock_opt->set_description(
         absl::StrCat("UDP SO_RCVBUF = ", QuicSocketReceiveBufferSize, " bytes"));

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -42,7 +42,7 @@ namespace {
 
 // This is the same value Cronet uses:
 // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.h;drc=ccfe61524368c94b138ddf96ae8121d7eb7096cf;l=87
-const int32_t QuicSocketReceiveBufferSize = 1024 * 1024; // 1MB
+constexpr int32_t QuicSocketReceiveBufferSize = 1024 * 1024; // 1MB
 
 } // namespace
 

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -771,7 +771,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     // usually too small for QUIC.
     // NOTE: An H3 cluster can also establish H2 connections (for example, if the H3 connection is
     // marked as broken in the ConnectivityGrid). This option would apply to all connections in the
-    // cluster, meaning H2 TCP connections buffer size would also be set to 1MB.
+    // cluster, meaning H2 TCP connections buffer size would also be set to 1MB. On the platforms
+    // we've tested, IPPROTO_UDP cannot be used as a level for the SO_RCVBUF option.
     envoy::config::core::v3::SocketOption* sock_opt =
         base_cluster->mutable_upstream_bind_config()->add_socket_options();
     sock_opt->set_name(SO_RCVBUF);

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -776,7 +776,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     envoy::config::core::v3::SocketOption* sock_opt =
         base_cluster->mutable_upstream_bind_config()->add_socket_options();
     sock_opt->set_name(SO_RCVBUF);
-    sock_opt->set_level(IPPROTO_UDP);
+    sock_opt->set_level(SOL_SOCKET);
     sock_opt->set_int_value(SocketReceiveBufferSize);
     sock_opt->set_description(absl::StrCat("SO_RCVBUF = ", SocketReceiveBufferSize, " bytes"));
   }

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -40,9 +40,9 @@ namespace Platform {
 
 namespace {
 
-// This is the same value Cronet uses:
+// This is the same value Cronet uses for QUIC:
 // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.h;drc=ccfe61524368c94b138ddf96ae8121d7eb7096cf;l=87
-constexpr int32_t QuicSocketReceiveBufferSize = 1024 * 1024; // 1MB
+constexpr int32_t SocketReceiveBufferSize = 1024 * 1024; // 1MB
 
 } // namespace
 
@@ -767,18 +767,17 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
         ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
             .PackFrom(alpn_options);
 
-    // Set the upstream connections UDP socket receive buffer size. The operating system defaults
-    // are usually too small for QUIC.
+    // Set the upstream connections socket receive buffer size. The operating system defaults are
+    // usually too small for QUIC.
     // NOTE: An H3 cluster can also establish H2 connections (for example, if the H3 connection is
     // marked as broken in the ConnectivityGrid). This option would apply to all connections in the
     // cluster, meaning H2 TCP connections buffer size would also be set to 1MB.
     envoy::config::core::v3::SocketOption* sock_opt =
         base_cluster->mutable_upstream_bind_config()->add_socket_options();
     sock_opt->set_name(SO_RCVBUF);
-    sock_opt->set_level(SOL_SOCKET);
-    sock_opt->set_int_value(QuicSocketReceiveBufferSize);
-    sock_opt->set_description(
-        absl::StrCat("UDP SO_RCVBUF = ", QuicSocketReceiveBufferSize, " bytes"));
+    sock_opt->set_level(IPPROTO_UDP);
+    sock_opt->set_int_value(SocketReceiveBufferSize);
+    sock_opt->set_description(absl::StrCat("SO_RCVBUF = ", SocketReceiveBufferSize, " bytes"));
   }
 
   // Set up stats.

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -15,6 +15,8 @@ envoy_cc_test(
     deps = [
         "//library/cc:engine_builder_lib",
         "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/dynamic_forward_proxy/v3:pkg_cc_proto",
         "@envoy_build_config//:extension_registry",
         "@envoy_build_config//:test_extensions",

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -1,6 +1,10 @@
+#include <sys/socket.h>
+
 #include <string>
 #include <vector>
 
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.pb.h"
 
 #include "test/test_common/utility.h"
@@ -24,10 +28,13 @@ namespace {
 using namespace Platform;
 
 using envoy::config::bootstrap::v3::Bootstrap;
+using envoy::config::cluster::v3::Cluster;
+using envoy::config::core::v3::SocketOption;
 using DfpClusterConfig = ::envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig;
 using testing::HasSubstr;
 using testing::IsEmpty;
 using testing::Not;
+using testing::NotNull;
 using testing::SizeIs;
 
 DfpClusterConfig getDfpClusterConfig(const Bootstrap& bootstrap) {
@@ -292,6 +299,38 @@ TEST(TestConfig, DisableHttp3) {
       Not(HasSubstr("envoy.extensions.filters.http.alternate_protocols_cache.v3.FilterConfig")));
 #endif
 }
+
+#ifdef ENVOY_ENABLE_QUIC
+TEST(TestConfig, QuicSocketReceiveBufferSize) {
+  EngineBuilder engine_builder;
+  engine_builder.enableHttp3(true);
+
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  Cluster const* base_cluster = nullptr;
+  for (const Cluster& cluster : bootstrap->static_resources().clusters()) {
+    if (cluster.name() == "base") {
+      base_cluster = &cluster;
+      break;
+    }
+  }
+
+  // The base H3 cluster should always be found.
+  ASSERT_THAT(base_cluster, NotNull());
+
+  SocketOption const* rcv_buf_option = nullptr;
+  for (const SocketOption& sock_opt : base_cluster->upstream_bind_config().socket_options()) {
+    if (sock_opt.name() == SO_RCVBUF) {
+      rcv_buf_option = &sock_opt;
+      break;
+    }
+  }
+
+  // When using an H3 cluster, the UDP receive buffer size option should always be set.
+  ASSERT_THAT(rcv_buf_option, NotNull());
+  EXPECT_EQ(rcv_buf_option->level(), IPPROTO_UDP);
+  EXPECT_EQ(rcv_buf_option->int_value(), 1024 * 1024 /* 1 MB */);
+}
+#endif
 
 #ifdef ENVOY_MOBILE_XDS
 TEST(TestConfig, XdsConfig) {

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -301,7 +301,7 @@ TEST(TestConfig, DisableHttp3) {
 }
 
 #ifdef ENVOY_ENABLE_QUIC
-TEST(TestConfig, QuicSocketReceiveBufferSize) {
+TEST(TestConfig, SocketReceiveBufferSize) {
   EngineBuilder engine_builder;
   engine_builder.enableHttp3(true);
 

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -327,7 +327,7 @@ TEST(TestConfig, QuicSocketReceiveBufferSize) {
 
   // When using an H3 cluster, the UDP receive buffer size option should always be set.
   ASSERT_THAT(rcv_buf_option, NotNull());
-  EXPECT_EQ(rcv_buf_option->level(), IPPROTO_UDP);
+  EXPECT_EQ(rcv_buf_option->level(), SOL_SOCKET);
   EXPECT_EQ(rcv_buf_option->int_value(), 1024 * 1024 /* 1 MB */);
 }
 #endif


### PR DESCRIPTION
Cronet sets the UDP receive buffer size to 1MB:
https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_session_pool.cc;l=839;drc=7dc3003765c74daa4bb49e4463e3a7963d8c7ea1

If we don't set the receive buffer size explicitely, the operating system defaults are used, which are typically too small for UDP.