### PR TITLE
tls: Fix Envoy reaching into private structures in io_handle_bio.cc

### DIFF
--- a/source/extensions/transport_sockets/tls/io_handle_bio.cc
+++ b/source/extensions/transport_sockets/tls/io_handle_bio.cc
@@ -65,18 +65,6 @@ long io_handle_ctrl(BIO*, int cmd, long, void*) {
   long ret = 1;
 
   switch (cmd) {
-  case BIO_C_SET_FD:
-    RELEASE_ASSERT(false, "should not be called");
-    break;
-  case BIO_C_GET_FD:
-    RELEASE_ASSERT(false, "should not be called");
-    break;
-  case BIO_CTRL_GET_CLOSE:
-    RELEASE_ASSERT(false, "should not be called");
-    break;
-  case BIO_CTRL_SET_CLOSE:
-    RELEASE_ASSERT(false, "should not be called");
-    break;
   case BIO_CTRL_FLUSH:
     ret = 1;
     break;

--- a/source/extensions/transport_sockets/tls/io_handle_bio.h
+++ b/source/extensions/transport_sockets/tls/io_handle_bio.h
@@ -11,7 +11,8 @@ namespace Tls {
 
 /**
  * Creates a custom BIO that can read from/write to an IoHandle. It's equivalent to a socket BIO
- * but instead of relying on access to an fd, it relies on IoHandle APIs for all interactions.
+ * but instead of relying on access to an fd, it relies on IoHandle APIs for all interactions. The
+ * IoHandle must remain valid for the lifetime of the BIO.
  */
 // NOLINTNEXTLINE(readability-identifier-naming)
 BIO* BIO_new_io_handle(Envoy::Network::IoHandle* io_handle);

--- a/test/extensions/transport_sockets/tls/io_handle_bio_test.cc
+++ b/test/extensions/transport_sockets/tls/io_handle_bio_test.cc
@@ -38,9 +38,6 @@ TEST_F(IoHandleBioTest, WriteError) {
 TEST_F(IoHandleBioTest, TestMiscApis) {
   EXPECT_EQ(BIO_read(bio_, nullptr, 0), 0);
 
-  EXPECT_DEATH(BIO_ctrl(bio_, BIO_C_GET_FD, 0, nullptr), "should not be called");
-  EXPECT_DEATH(BIO_ctrl(bio_, BIO_C_SET_FD, 0, nullptr), "should not be called");
-
   int ret = BIO_ctrl(bio_, BIO_CTRL_RESET, 0, nullptr);
   EXPECT_EQ(ret, 0);
 

--- a/test/extensions/transport_sockets/tls/io_handle_bio_test.cc
+++ b/test/extensions/transport_sockets/tls/io_handle_bio_test.cc
@@ -38,10 +38,10 @@ TEST_F(IoHandleBioTest, WriteError) {
 TEST_F(IoHandleBioTest, TestMiscApis) {
   EXPECT_EQ(BIO_read(bio_, nullptr, 0), 0);
 
-  int ret = BIO_ctrl(bio_, BIO_CTRL_RESET, 0, nullptr);
+  int ret = BIO_reset(bio_);
   EXPECT_EQ(ret, 0);
 
-  ret = BIO_ctrl(bio_, BIO_CTRL_FLUSH, 0, nullptr);
+  ret = BIO_flush(bio_);
   EXPECT_EQ(ret, 1);
 }
 

--- a/test/extensions/transport_sockets/tls/io_handle_bio_test.cc
+++ b/test/extensions/transport_sockets/tls/io_handle_bio_test.cc
@@ -29,34 +29,23 @@ TEST_F(IoHandleBioTest, WriteError) {
   EXPECT_CALL(io_handle_, writev(_, 1))
       .WillOnce(
           Return(testing::ByMove(Api::IoCallUint64Result(0, Network::IoSocketError::create(100)))));
-  EXPECT_EQ(-1, bio_->method->bwrite(bio_, nullptr, 10));
+  EXPECT_EQ(-1, BIO_write(bio_, nullptr, 10));
   const int err = ERR_get_error();
   EXPECT_EQ(ERR_GET_LIB(err), ERR_LIB_SYS);
   EXPECT_EQ(ERR_GET_REASON(err), 100);
 }
 
 TEST_F(IoHandleBioTest, TestMiscApis) {
-  EXPECT_EQ(bio_->method->destroy(nullptr), 0);
-  EXPECT_EQ(bio_->method->bread(nullptr, nullptr, 0), 0);
+  EXPECT_EQ(BIO_read(bio_, nullptr, 0), 0);
 
-  EXPECT_DEATH(bio_->method->ctrl(bio_, BIO_C_GET_FD, 0, nullptr), "should not be called");
-  EXPECT_DEATH(bio_->method->ctrl(bio_, BIO_C_SET_FD, 0, nullptr), "should not be called");
+  EXPECT_DEATH(BIO_ctrl(bio_, BIO_C_GET_FD, 0, nullptr), "should not be called");
+  EXPECT_DEATH(BIO_ctrl(bio_, BIO_C_SET_FD, 0, nullptr), "should not be called");
 
-  int ret = bio_->method->ctrl(bio_, BIO_CTRL_RESET, 0, nullptr);
+  int ret = BIO_ctrl(bio_, BIO_CTRL_RESET, 0, nullptr);
   EXPECT_EQ(ret, 0);
 
-  ret = bio_->method->ctrl(bio_, BIO_CTRL_FLUSH, 0, nullptr);
+  ret = BIO_ctrl(bio_, BIO_CTRL_FLUSH, 0, nullptr);
   EXPECT_EQ(ret, 1);
-
-  ret = bio_->method->ctrl(bio_, BIO_CTRL_SET_CLOSE, 1, nullptr);
-  EXPECT_EQ(ret, 1);
-
-  ret = bio_->method->ctrl(bio_, BIO_CTRL_GET_CLOSE, 0, nullptr);
-  EXPECT_EQ(ret, 1);
-
-  EXPECT_CALL(io_handle_, close())
-      .WillOnce(Return(testing::ByMove(Api::IoCallUint64Result{0, Api::IoError::none()})));
-  bio_->init = 1;
 }
 
 } // namespace Tls


### PR DESCRIPTION
Commit Message:
Rather than reaching into private structures, Envoy should stick to supported public APIs. This covers both the implementation and the tests. I did my best to salvage io_handle_bio_test.cc, as it was previously testing mostly incoherent things. However, it warrants another pass by Envoy folks.

What you all should be testing is that *public* BIO APIs correctly call the underlying io_handle operations.  Instead, the old tests mostly forcibly called the underlying function pointers with cases that will never be called in the first place. (E.g. the destroy callback will never be called with a null BIO.)

I've also removed the BIO_CTRL_SET_CLOSE (BIO_set_close) bits as it seems to be entirely dead code. Envoy never actually configures the BIO to close the io_handle when destroyed. If you all don't actually need this, there's no point in bothering. That seems to have been copy-pasted from the built-in BIOs, which have BIO_CLOSE and BIO_NOCLOSE modes that allow the caller to optionally pass ownership of the io_handle. From what I can tell, Envoy never wants to pass ownership.

Additional Description:
Risk Level: Low
Testing: `bazelisk test test/extensions/transport_sockets/tls/...`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
