### PR TITLE
opentelemetry tracer: Add TraceState types from OTel C++ SDK

### DIFF
--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -73,3 +73,13 @@ envoy_cc_library(
         "@opentelemetry_proto//:trace_cc_proto",
     ],
 )
+
+envoy_cc_library(
+    name = "trace_state_lib",
+    hdrs = [
+        "kv_properties.h",
+        "trace_state.h",
+    ],
+    deps = [
+    ],
+)

--- a/source/extensions/tracers/opentelemetry/kv_properties.h
+++ b/source/extensions/tracers/opentelemetry/kv_properties.h
@@ -1,0 +1,241 @@
+#pragma once
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Originally taken from the official OpenTelemetry C++ API/SDK
+// https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.13.0/api/include/opentelemetry/common/kv_properties.h
+
+#include <memory>
+#include <string>
+
+#include "source/common/common/utility.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+namespace {
+
+absl::string_view trim(absl::string_view str, size_t left, size_t right) {
+  while (left <= right && str[static_cast<std::size_t>(left)] == ' ') {
+    left++;
+  }
+  while (left <= right && str[static_cast<std::size_t>(right)] == ' ') {
+    right--;
+  }
+  return str.substr(left, 1 + right - left);
+}
+
+} // namespace
+
+// Constructor parameter for KeyValueStringTokenizer
+struct KeyValueStringTokenizerOptions {
+  char member_separator = ',';
+  char key_value_separator = '=';
+  bool ignore_empty_members = true;
+};
+
+// Tokenizer for key-value headers
+class KeyValueStringTokenizer {
+public:
+  KeyValueStringTokenizer(absl::string_view str, const KeyValueStringTokenizerOptions& opts =
+                                                     KeyValueStringTokenizerOptions()) noexcept
+      : str_(str), opts_(opts) {}
+
+  static absl::string_view getDefaultKeyOrValue() {
+    static std::string default_str = "";
+    return default_str;
+  }
+
+  // Returns next key value in the string header
+  // @param valid_kv : if the found kv pair is valid or not
+  // @param key : key in kv pair
+  // @param key : value in kv pair
+  // @returns true if next kv pair was found, false otherwise.
+  bool next(bool& valid_kv, absl::string_view& key, absl::string_view& value) noexcept {
+    valid_kv = true;
+    while (index_ < str_.size()) {
+      bool is_empty_pair = false;
+      size_t end = str_.find(opts_.member_separator, index_);
+      if (end == std::string::npos) {
+        end = str_.size() - 1;
+      } else if (end == index_) // empty pair. do not update end
+      {
+        is_empty_pair = true;
+      } else {
+        end--;
+      }
+
+      auto list_member = trim(str_, index_, end);
+      if (list_member.empty() || is_empty_pair) {
+        // empty list member
+        index_ = end + 2 - is_empty_pair;
+        if (opts_.ignore_empty_members) {
+          continue;
+        }
+
+        valid_kv = true;
+        key = getDefaultKeyOrValue();
+        value = getDefaultKeyOrValue();
+        return true;
+      }
+
+      auto key_end_pos = list_member.find(opts_.key_value_separator);
+      if (key_end_pos == std::string::npos) {
+        // invalid member
+        valid_kv = false;
+      } else {
+        key = list_member.substr(0, key_end_pos);
+        value = list_member.substr(key_end_pos + 1);
+      }
+
+      index_ = end + 2;
+
+      return true;
+    }
+
+    // no more entries remaining
+    return false;
+  }
+
+  // Returns total number of tokens in header string
+  size_t numTokens() const noexcept {
+    size_t cnt = 0, begin = 0;
+    while (begin < str_.size()) {
+      ++cnt;
+      size_t end = str_.find(opts_.member_separator, begin);
+      if (end == std::string::npos) {
+        break;
+      }
+
+      begin = end + 1;
+    }
+
+    return cnt;
+  }
+
+  // Resets the iterator
+  void reset() noexcept { index_ = 0; }
+
+private:
+  absl::string_view str_;
+  KeyValueStringTokenizerOptions opts_;
+  size_t index_{};
+};
+
+// Class to store fixed size array of key-value pairs of string type
+class KeyValueProperties {
+  // Class to store key-value pairs of string types
+public:
+  class Entry {
+  public:
+    Entry() : key_(nullptr), value_(nullptr) {}
+
+    // Copy constructor
+    Entry(const Entry& copy) {
+      key_ = copyStringToPointer(copy.key_.get());
+      value_ = copyStringToPointer(copy.value_.get());
+    }
+
+    // Copy assignment operator
+    Entry& operator=(Entry& other) {
+      key_ = copyStringToPointer(other.key_.get());
+      value_ = copyStringToPointer(other.value_.get());
+      return *this;
+    }
+
+    // Move contructor and assignment operator
+    Entry(Entry&& other) = default;
+    Entry& operator=(Entry&& other) = default;
+
+    // Creates an Entry for a given key-value pair.
+    Entry(absl::string_view key, absl::string_view value) {
+      key_ = copyStringToPointer(key);
+      value_ = copyStringToPointer(value);
+    }
+
+    // Gets the key associated with this entry.
+    absl::string_view getKey() const noexcept { return key_.get(); }
+
+    // Gets the value associated with this entry.
+    absl::string_view getValue() const noexcept { return value_.get(); }
+
+    // Sets the value for this entry. This overrides the previous value.
+    void setValue(absl::string_view value) noexcept { value_ = copyStringToPointer(value); }
+
+  private:
+    // Store key and value as raw char pointers to avoid using std::string.
+    std::unique_ptr<const char[]> key_;
+    std::unique_ptr<const char[]> value_;
+
+    // Copies string into a buffer and returns a unique_ptr to the buffer.
+    // This is a workaround for the fact that memcpy doesn't accept a const destination.
+    std::unique_ptr<const char[]> copyStringToPointer(absl::string_view str) {
+      char* temp = new char[str.size() + 1];
+      memcpy(temp, str.data(), str.size()); // NOLINT(safe-memcpy)
+      temp[str.size()] = '\0';
+      return std::unique_ptr<const char[]>(temp);
+    }
+  };
+
+  // Maintain the number of entries in entries_.
+  size_t num_entries_;
+
+  // Max size of allocated array
+  size_t max_num_entries_;
+
+  // Store entries in a C-style array to avoid using std::array or std::vector.
+  std::unique_ptr<Entry[]> entries_;
+
+public:
+  // Create Key-value list of given size
+  // @param size : Size of list.
+  KeyValueProperties(size_t size) noexcept
+      : num_entries_(0), max_num_entries_(size), entries_(new Entry[size]) {}
+
+  // Create Empty Key-Value list
+  KeyValueProperties() noexcept : num_entries_(0), max_num_entries_(0), entries_(nullptr) {}
+
+  // Adds new kv pair into kv properties
+  void addEntry(absl::string_view key, absl::string_view value) noexcept {
+    if (num_entries_ < max_num_entries_) {
+      Entry entry(key, value);
+      (entries_.get())[num_entries_++] = std::move(entry);
+    }
+  }
+
+  // Returns all kv pair entries
+  bool
+  getAllEntries(std::function<bool(absl::string_view, absl::string_view)> callback) const noexcept {
+    for (size_t i = 0; i < num_entries_; i++) {
+      auto& entry = (entries_.get())[i];
+      if (!callback(entry.getKey(), entry.getValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Return value for key if exists, return false otherwise
+  bool getValue(absl::string_view key, std::string& value) const noexcept {
+    for (size_t i = 0; i < num_entries_; i++) {
+      auto& entry = (entries_.get())[i];
+      if (entry.getKey() == key) {
+        const auto& entry_value = entry.getValue();
+        value = std::string(entry_value.data(), entry_value.size());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  size_t size() const noexcept { return num_entries_; }
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/samplers/sampler.h
+++ b/source/extensions/tracers/opentelemetry/samplers/sampler.h
@@ -23,11 +23,11 @@ class SpanContext;
 enum class Decision {
   // IsRecording will be false, the Span will not be recorded and all events and attributes will be
   // dropped.
-  DROP,
+  Drop,
   // IsRecording will be true, but the Sampled flag MUST NOT be set.
-  RECORD_ONLY,
+  RecordOnly,
   // IsRecording will be true and the Sampled flag MUST be set.
-  RECORD_AND_SAMPLE
+  RecordAndSample
 };
 
 /**
@@ -48,10 +48,10 @@ struct SamplingResult {
   std::string tracestate;
 
   inline bool isRecording() const {
-    return decision == Decision::RECORD_ONLY || decision == Decision::RECORD_AND_SAMPLE;
+    return decision == Decision::RecordOnly || decision == Decision::RecordAndSample;
   }
 
-  inline bool isSampled() const { return decision == Decision::RECORD_AND_SAMPLE; }
+  inline bool isSampled() const { return decision == Decision::RecordAndSample; }
 };
 
 /**

--- a/source/extensions/tracers/opentelemetry/trace_state.h
+++ b/source/extensions/tracers/opentelemetry/trace_state.h
@@ -1,0 +1,233 @@
+#pragma once
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Originally taken from the official OpenTelemetry C++ API/SDK
+// https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.13.0/api/include/opentelemetry/trace/trace_state.h
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "source/extensions/tracers/opentelemetry/kv_properties.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * TraceState carries tracing-system specific context in a list of key-value pairs. TraceState
+ * allows different vendors to propagate additional information and inter-operate with their legacy
+ * id formats.
+ *
+ * For more information, see the W3C Trace Context specification:
+ * https://www.w3.org/TR/trace-context
+ */
+class TraceState {
+public:
+  static constexpr int kKeyMaxSize = 256;
+  static constexpr int kValueMaxSize = 256;
+  static constexpr int kMaxKeyValuePairs = 32;
+  static constexpr auto kKeyValueSeparator = '=';
+  static constexpr auto kMembersSeparator = ',';
+
+  static std::shared_ptr<TraceState> getDefault() {
+    static std::shared_ptr<TraceState> ts{new TraceState()};
+    return ts;
+  }
+
+  /**
+   * Returns shared_ptr to a newly created TraceState parsed from the header provided.
+   * @param header Encoding of the tracestate header defined by
+   * the W3C Trace Context specification https://www.w3.org/TR/trace-context/
+   * @return TraceState A new TraceState instance or DEFAULT
+   */
+  static std::shared_ptr<TraceState> fromHeader(absl::string_view header) noexcept {
+
+    KeyValueStringTokenizer kv_str_tokenizer(header);
+    size_t cnt = kv_str_tokenizer.numTokens(); // upper bound on number of kv pairs
+    if (cnt > kMaxKeyValuePairs) {
+      cnt = kMaxKeyValuePairs;
+    }
+
+    std::shared_ptr<TraceState> ts(new TraceState(cnt));
+    bool kv_valid;
+    absl::string_view key, value;
+    while (kv_str_tokenizer.next(kv_valid, key, value) && ts->kv_properties_->size() < cnt) {
+      if (kv_valid == false) {
+        return getDefault();
+      }
+
+      if (!isValidKey(key) || !isValidValue(value)) {
+        // invalid header. return empty TraceState
+        ts->kv_properties_ = std::make_unique<KeyValueProperties>();
+        break;
+      }
+
+      ts->kv_properties_->addEntry(key, value);
+    }
+
+    return ts;
+  }
+
+  /**
+   * Creates a w3c tracestate header from TraceState object
+   */
+  std::string toHeader() const noexcept {
+    std::string header_s;
+    bool first = true;
+    kv_properties_->getAllEntries(
+        [&header_s, &first](absl::string_view key, absl::string_view value) noexcept {
+          if (!first) {
+            header_s.append(",");
+          } else {
+            first = false;
+          }
+          header_s.append(std::string(key.data(), key.size()));
+          header_s.append(1, kKeyValueSeparator);
+          header_s.append(std::string(value.data(), value.size()));
+          return true;
+        });
+    return header_s;
+  }
+
+  /**
+   *  Returns `value` associated with `key` passed as argument
+   *  Returns empty string if key is invalid  or not found
+   */
+  bool get(absl::string_view key, std::string& value) const noexcept {
+    if (!isValidKey(key)) {
+      return false;
+    }
+
+    return kv_properties_->getValue(key, value);
+  }
+
+  /**
+   * Returns shared_ptr of `new` TraceState object with following mutations applied to the existing
+   * instance: Update Key value: The updated value must be moved to beginning of List Add : The new
+   * key-value pair SHOULD be added to beginning of List
+   *
+   * If the provided key-value pair is invalid, or results in transtate that violates the
+   * tracecontext specification, empty TraceState instance will be returned.
+   *
+   * If the existing object has maximum list members, it's copy is returned.
+   */
+  std::shared_ptr<TraceState> set(const absl::string_view& key,
+                                  const absl::string_view& value) noexcept {
+    auto curr_size = kv_properties_->size();
+    if (!isValidKey(key) || !isValidValue(value)) {
+      // max size reached or invalid key/value. Returning empty TraceState
+      return TraceState::getDefault();
+    }
+    auto allocate_size = curr_size;
+    if (curr_size < kMaxKeyValuePairs) {
+      allocate_size += 1;
+    }
+    std::shared_ptr<TraceState> ts(new TraceState(allocate_size));
+    if (curr_size < kMaxKeyValuePairs) {
+      // add new field first
+      ts->kv_properties_->addEntry(key, value);
+    }
+    // add rest of the fields.
+    kv_properties_->getAllEntries([&ts](absl::string_view key, absl::string_view value) {
+      ts->kv_properties_->addEntry(key, value);
+      return true;
+    });
+    return ts;
+  }
+
+  /**
+   * Returns shared_ptr to a `new` TraceState object after removing the attribute with given key (
+   * if present )
+   * @returns empty TraceState object if key is invalid
+   * @returns copy of original TraceState object if key is not present (??)
+   */
+  std::shared_ptr<TraceState> remove(const absl::string_view& key) noexcept {
+    if (!isValidKey(key)) {
+      return TraceState::getDefault();
+    }
+    auto curr_size = kv_properties_->size();
+    auto allocate_size = curr_size;
+    std::string unused;
+    if (kv_properties_->getValue(key, unused)) {
+      allocate_size -= 1;
+    }
+    std::shared_ptr<TraceState> ts(new TraceState(allocate_size));
+    kv_properties_->getAllEntries([&ts, &key](absl::string_view e_key, absl::string_view e_value) {
+      if (key != e_key) {
+        ts->kv_properties_->addEntry(e_key, e_value);
+      }
+      return true;
+    });
+    return ts;
+  }
+
+  // Returns true if there are no keys, false otherwise.
+  bool empty() const noexcept { return kv_properties_->size() == 0; }
+
+  // @return all key-values entris by repeatedly invoking the function reference passed as argument
+  // for each entry
+  bool
+  getAllEntries(std::function<bool(absl::string_view, absl::string_view)> callback) const noexcept {
+    return kv_properties_->getAllEntries(callback);
+  }
+
+  /** Returns whether key is a valid key. See https://www.w3.org/TR/trace-context/#key
+   * Identifiers MUST begin with a lowercase letter or a digit, and can only contain
+   * lowercase letters (a-z), digits (0-9), underscores (_), dashes (-), asterisks (*),
+   * and forward slashes (/).
+   * For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the vendor name.
+   *
+   */
+  static bool isValidKey(absl::string_view key) {
+    if (key.empty() || key.size() > kKeyMaxSize || !isLowerCaseAlphaOrDigit(key[0])) {
+      return false;
+    }
+
+    int ats = 0;
+
+    for (const char c : key) {
+      if (!isLowerCaseAlphaOrDigit(c) && c != '_' && c != '-' && c != '@' && c != '*' && c != '/') {
+        return false;
+      }
+      if ((c == '@') && (++ats > 1)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Returns whether value is a valid value. See https://www.w3.org/TR/trace-context/#value
+   * The value is an opaque string containing up to 256 printable ASCII (RFC0020)
+   *  characters ((i.e., the range 0x20 to 0x7E) except comma , and equal =)
+   */
+  static bool isValidValue(absl::string_view value) {
+    if (value.empty() || value.size() > kValueMaxSize) {
+      return false;
+    }
+
+    for (const char c : value) {
+      if (c < ' ' || c > '~' || c == ',' || c == '=') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+private:
+  TraceState() : kv_properties_(new KeyValueProperties()) {}
+  TraceState(size_t size) : kv_properties_(new KeyValueProperties(size)) {}
+  static bool isLowerCaseAlphaOrDigit(char c) { return isdigit(c) || islower(c); }
+
+private:
+  // Store entries in a C-style array to avoid using std::array or std::vector.
+  std::unique_ptr<KeyValueProperties> kv_properties_;
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/BUILD
+++ b/test/extensions/tracers/opentelemetry/BUILD
@@ -93,3 +93,16 @@ envoy_extension_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "tracestate_test",
+    srcs = [
+        "kv_properties_test.cc",
+        "trace_state_test.cc",
+    ],
+    extension_names = ["envoy.tracers.opentelemetry"],
+    deps = [
+        "//source/extensions/tracers/opentelemetry:trace_state_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/kv_properties_test.cc
+++ b/test/extensions/tracers/opentelemetry/kv_properties_test.cc
@@ -1,0 +1,220 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Originally taken from the official OpenTelemetry C++ API/SDK
+// https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.13.0/api/test/common/kv_properties_test.cc
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "source/extensions/tracers/opentelemetry/kv_properties.h"
+
+#include "gtest/gtest.h"
+
+// ------------------------- Entry class tests ---------------------------------
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+// Test constructor that takes a key-value pair
+TEST(EntryTest, KeyValueConstruction) {
+  absl::string_view key = "test_key";
+  absl::string_view val = "test_value";
+  KeyValueProperties::Entry e(key, val);
+
+  EXPECT_EQ(key.size(), e.getKey().size());
+  EXPECT_EQ(key, e.getKey());
+
+  EXPECT_EQ(val.size(), e.getValue().size());
+  EXPECT_EQ(val, e.getValue());
+}
+
+// Test copy constructor
+TEST(EntryTest, Copy) {
+  KeyValueProperties::Entry e("test_key", "test_value");
+  KeyValueProperties::Entry copy(e);
+  EXPECT_EQ(copy.getKey(), e.getKey());
+  EXPECT_EQ(copy.getValue(), e.getValue());
+
+  e.setValue("changed_value");
+  EXPECT_NE(copy.getValue(), e.getValue());
+}
+
+// Test assignment operator
+TEST(EntryTest, Assignment) {
+  KeyValueProperties::Entry e("test_key", "test_value");
+  KeyValueProperties::Entry empty;
+  empty = e;
+  EXPECT_EQ(empty.getKey(), e.getKey());
+  EXPECT_EQ(empty.getValue(), e.getValue());
+}
+
+TEST(EntryTest, SetValue) {
+  KeyValueProperties::Entry e("test_key", "test_value");
+  absl::string_view new_val = "new_value";
+  e.setValue(new_val);
+
+  EXPECT_EQ(new_val.size(), e.getValue().size());
+  EXPECT_EQ(new_val, e.getValue());
+}
+
+// // ------------------------- KeyValueStringTokenizer tests ---------------------------------
+
+TEST(KVStringTokenizer, SinglePair) {
+  bool valid_kv;
+  absl::string_view key, value;
+  absl::string_view str = "k1=v1";
+  KeyValueStringTokenizerOptions opts;
+  KeyValueStringTokenizer tk(str, opts);
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, AcceptEmptyEntries) {
+  bool valid_kv;
+  absl::string_view key, value;
+  absl::string_view str = ":k1=v1::k2=v2: ";
+  KeyValueStringTokenizerOptions opts;
+  opts.member_separator = ':';
+  opts.ignore_empty_members = false;
+
+  KeyValueStringTokenizer tk(str, opts);
+  EXPECT_TRUE(tk.next(valid_kv, key, value)); // empty pair
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+  EXPECT_TRUE(tk.next(valid_kv, key, value)); // empty pair
+  EXPECT_EQ(key, "");
+  EXPECT_EQ(value, "");
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_EQ(key, "k2");
+  EXPECT_EQ(value, "v2");
+  EXPECT_TRUE(tk.next(valid_kv, key, value)); // empty pair
+  EXPECT_EQ(key, "");
+  EXPECT_EQ(value, "");
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, ValidPairsWithEmptyEntries) {
+  absl::string_view str = "k1:v1===k2:v2==";
+  bool valid_kv;
+  absl::string_view key, value;
+  KeyValueStringTokenizerOptions opts;
+  opts.member_separator = '=';
+  opts.key_value_separator = ':';
+
+  KeyValueStringTokenizer tk(str, opts);
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k2");
+  EXPECT_EQ(value, "v2");
+
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, InvalidPairs) {
+  absl::string_view str = "k1=v1,invalid  ,,  k2=v2   ,invalid";
+  KeyValueStringTokenizer tk(str);
+  bool valid_kv;
+  absl::string_view key, value;
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k1");
+  EXPECT_EQ(value, "v1");
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_FALSE(valid_kv);
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_TRUE(valid_kv);
+  EXPECT_EQ(key, "k2");
+  EXPECT_EQ(value, "v2");
+
+  EXPECT_TRUE(tk.next(valid_kv, key, value));
+  EXPECT_FALSE(valid_kv);
+
+  EXPECT_FALSE(tk.next(valid_kv, key, value));
+}
+
+TEST(KVStringTokenizer, NumTokens) {
+  struct {
+    const char* input;
+    size_t expected;
+  } testcases[] = {{"k1=v1", 1},
+                   {" ", 1},
+                   {"k1=v1,k2=v2,k3=v3", 3},
+                   {"k1=v1,", 1},
+                   {"k1=v1,k2=v2,invalidmember", 3},
+                   {"", 0}};
+  for (auto& testcase : testcases) {
+    KeyValueStringTokenizer tk(testcase.input);
+    EXPECT_EQ(tk.numTokens(), testcase.expected);
+  }
+}
+
+// //------------------------- KeyValueProperties tests ---------------------------------
+
+TEST(KeyValueProperties, addEntry) {
+  auto kv_properties = KeyValueProperties(1);
+  kv_properties.addEntry("k1", "v1");
+  std::string value;
+  bool present = kv_properties.getValue("k1", value);
+  EXPECT_TRUE(present);
+  EXPECT_EQ(value, "v1");
+
+  kv_properties.addEntry("k2", "v2"); // entry will not be added as max size reached.
+  EXPECT_EQ(kv_properties.size(), 1);
+  present = kv_properties.getValue("k2", value);
+  EXPECT_FALSE(present);
+}
+
+TEST(KeyValueProperties, getValue) {
+  auto kv_properties = KeyValueProperties(1);
+  kv_properties.addEntry("k1", "v1");
+  std::string value;
+  bool present = kv_properties.getValue("k1", value);
+  EXPECT_TRUE(present);
+  EXPECT_EQ(value, "v1");
+
+  present = kv_properties.getValue("k3", value);
+  EXPECT_FALSE(present);
+}
+
+TEST(KeyValueProperties, GetAllEntries) {
+  const size_t kNumPairs = 3;
+  absl::string_view keys[kNumPairs] = {"k1", "k2", "k3"};
+  absl::string_view values[kNumPairs] = {"v1", "v2", "v3"};
+
+  auto kv_properties = KeyValueProperties(kNumPairs);
+  kv_properties.addEntry("k1", "v1");
+  kv_properties.addEntry("k2", "v2");
+  kv_properties.addEntry("k3", "v3");
+
+  size_t index = 0;
+  kv_properties.getAllEntries(
+      [&keys, &values, &index](absl::string_view key, absl::string_view value) {
+        EXPECT_EQ(key, keys[index]);
+        EXPECT_EQ(value, values[index]);
+        index++;
+        return true;
+      });
+
+  EXPECT_EQ(index, kNumPairs);
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/tracers/opentelemetry/trace_state_test.cc
+++ b/test/extensions/tracers/opentelemetry/trace_state_test.cc
@@ -1,0 +1,186 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Originally taken from the official OpenTelemetry C++ API/SDK
+// https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.13.0/api/test/trace/trace_state_test.cc
+
+#include <gtest/gtest.h>
+
+#include "source/extensions/tracers/opentelemetry/trace_state.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+// Random string of length 257. Used for testing strings with max length 256.
+const char* kLongString =
+    "4aekid3he76zgytjavudqqeltyvu5zqio2lx7d92dlxlf0z4883irvxuwelsq27sx1mlrjg3r7ad3jeq09rjppyd9veorg"
+    "2nmihy4vilabfts8bsxruih0urusmjnglzl3iwpjinmo835dbojcrd73p56nw80v4xxrkye59ytmu5v84ysfa24d58ovv9"
+    "w1n54n0mhhf4z0mpv6oudywrp9vfoks6lrvxv3uihvbi2ihazf237kvt1nbsjn3kdvfdb";
+
+// -------------------------- TraceState class tests ---------------------------
+
+std::string createTsReturnHeader(std::string header) {
+  auto ts = TraceState::fromHeader(header);
+  return ts->toHeader();
+}
+
+std::string headerWithMaxMembers() {
+  std::string header = "";
+  auto max_members = TraceState::kMaxKeyValuePairs;
+  for (int i = 0; i < max_members; i++) {
+    std::string key = "key" + std::to_string(i);
+    std::string value = "value" + std::to_string(i);
+    header += key + "=" + value;
+    if (i != max_members - 1) {
+      header += ",";
+    }
+  }
+  return header;
+}
+
+TEST(TraceStateTest, ValidateHeaderParsing) {
+  auto max_trace_state_header = headerWithMaxMembers();
+
+  struct {
+    const char* input;
+    const char* expected;
+  } testcases[] = {{"k1=v1", "k1=v1"},
+                   {"K1=V1", ""},
+                   {"k1=v1,k2=v2,k3=v3", "k1=v1,k2=v2,k3=v3"},
+                   {"k1=v1,k2=v2,,", "k1=v1,k2=v2"},
+                   {"k1=v1,k2=v2,invalidmember", ""},
+                   {"1a-2f@foo=bar1,a*/foo-_/bar=bar4", "1a-2f@foo=bar1,a*/foo-_/bar=bar4"},
+                   {"1a-2f@foo=bar1,*/foo-_/bar=bar4", ""},
+                   {",k1=v1", "k1=v1"},
+                   {",", ""},
+                   {",=,", ""},
+                   {"", ""},
+                   {max_trace_state_header.data(), max_trace_state_header.data()}};
+  for (auto& testcase : testcases) {
+    EXPECT_EQ(createTsReturnHeader(testcase.input), testcase.expected);
+  }
+}
+
+TEST(TraceStateTest, TraceStateGet) {
+  std::string trace_state_header = headerWithMaxMembers();
+  auto ts = TraceState::fromHeader(trace_state_header);
+
+  std::string value;
+  EXPECT_TRUE(ts->get("key0", value));
+  EXPECT_EQ(value, "value0");
+  EXPECT_TRUE(ts->get("key16", value));
+  EXPECT_EQ(value, "value16");
+  EXPECT_TRUE(ts->get("key31", value));
+  EXPECT_EQ(value, "value31");
+  EXPECT_FALSE(ts->get("key32", value));
+}
+
+TEST(TraceStateTest, TraceStateSet) {
+  std::string trace_state_header = "k1=v1,k2=v2";
+  auto ts1 = TraceState::fromHeader(trace_state_header);
+  auto ts1_new = ts1->set("k3", "v3");
+  EXPECT_EQ(ts1_new->toHeader(), "k3=v3,k1=v1,k2=v2");
+
+  trace_state_header = headerWithMaxMembers();
+  auto ts2 = TraceState::fromHeader(trace_state_header);
+
+  // adding to max list, should return copy of existing list
+  auto ts2_new = ts2->set("n_k1", "n_v1");
+  EXPECT_EQ(ts2_new->toHeader(), trace_state_header);
+
+  trace_state_header = "k1=v1,k2=v2";
+  auto ts3 = TraceState::fromHeader(trace_state_header);
+  auto ts3_new = ts3->set("*n_k1", "n_v1"); // adding invalid key, should return empty
+  EXPECT_EQ(ts3_new->toHeader(), "");
+}
+
+TEST(TraceStateTest, TraceStateDelete) {
+  std::string trace_state_header = "k1=v1,k2=v2,k3=v3";
+  auto ts1 = TraceState::fromHeader(trace_state_header);
+  auto ts1_new = ts1->remove(std::string("k1"));
+  EXPECT_EQ(ts1_new->toHeader(), "k2=v2,k3=v3");
+
+  trace_state_header = "k1=v1"; // single list member
+  auto ts2 = TraceState::fromHeader(trace_state_header);
+  auto ts2_new = ts2->remove(std::string("k1"));
+  EXPECT_EQ(ts2_new->toHeader(), "");
+
+  trace_state_header = "k1=v1"; // single list member, delete invalid entry
+  auto ts3 = TraceState::fromHeader(trace_state_header);
+  auto ts3_new = ts3->remove(std::string("InvalidKey"));
+  EXPECT_EQ(ts3_new->toHeader(), "");
+}
+
+TEST(TraceStateTest, Empty) {
+  std::string trace_state_header = "";
+  auto ts = TraceState::fromHeader(trace_state_header);
+  EXPECT_TRUE(ts->empty());
+
+  trace_state_header = "k1=v1,k2=v2";
+  auto ts1 = TraceState::fromHeader(trace_state_header);
+  EXPECT_FALSE(ts1->empty());
+}
+
+TEST(TraceStateTest, GetAllEntries) {
+  std::string trace_state_header = "k1=v1,k2=v2,k3=v3";
+  auto ts1 = TraceState::fromHeader(trace_state_header);
+  const int kNumPairs = 3;
+  absl::string_view keys[kNumPairs] = {"k1", "k2", "k3"};
+  absl::string_view values[kNumPairs] = {"v1", "v2", "v3"};
+  size_t index = 0;
+  ts1->getAllEntries([&keys, &values, &index](absl::string_view key, absl::string_view value) {
+    EXPECT_EQ(key, keys[index]);
+    EXPECT_EQ(value, values[index]);
+    index++;
+    return true;
+  });
+}
+
+TEST(TraceStateTest, isValidKey) {
+  EXPECT_TRUE(TraceState::isValidKey("valid-key23/*"));
+  EXPECT_FALSE(TraceState::isValidKey("Invalid_key"));
+  EXPECT_FALSE(TraceState::isValidKey("invalid$Key&"));
+  EXPECT_FALSE(TraceState::isValidKey(""));
+  EXPECT_FALSE(TraceState::isValidKey(kLongString));
+}
+
+TEST(TraceStateTest, isValidValue) {
+  EXPECT_TRUE(TraceState::isValidValue("valid-val$%&~"));
+  EXPECT_FALSE(TraceState::isValidValue("\tinvalid"));
+  EXPECT_FALSE(TraceState::isValidValue("invalid="));
+  EXPECT_FALSE(TraceState::isValidValue("invalid,val"));
+  EXPECT_FALSE(TraceState::isValidValue(""));
+  EXPECT_FALSE(TraceState::isValidValue(kLongString));
+}
+
+// Tests that keys and values don't depend on null terminators
+TEST(TraceStateTest, MemorySafe) {
+  std::string trace_state_header = "";
+  auto ts = TraceState::fromHeader(trace_state_header);
+  const int kNumPairs = 3;
+  absl::string_view key_string = "test_key_1test_key_2test_key_3";
+  absl::string_view val_string = "test_val_1test_val_2test_val_3";
+  absl::string_view keys[kNumPairs] = {key_string.substr(0, 10), key_string.substr(10, 10),
+                                       key_string.substr(20, 10)};
+  absl::string_view values[kNumPairs] = {val_string.substr(0, 10), val_string.substr(10, 10),
+                                         val_string.substr(20, 10)};
+
+  auto ts1 = ts->set(keys[2], values[2]);
+  auto ts2 = ts1->set(keys[1], values[1]);
+  auto ts3 = ts2->set(keys[0], values[0]);
+  size_t index = 0;
+
+  ts3->getAllEntries([&keys, &values, &index](absl::string_view key, absl::string_view value) {
+    EXPECT_EQ(key, keys[index]);
+    EXPECT_EQ(value, values[index]);
+    index++;
+    return true;
+  });
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: Add TraceState type following the OTel/W3C specs
Additional Description: TraceState is a type that is used to manipulate the trace state of a traced request. One of the many uses for TraceState is propagation of sampling information, such as sampling [probability and randomness](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/tracestate-probability-sampling.md#tracestate-probability-sampling).
Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

This is a continuation of the initial Sampling PR #30259. We will be sending another follow up PR for a Dynatrace sampler, and we will need to manipulate the `TraceState` there. Note that the types here can be used by any other sampler, which may be added in the future, such as the [Probability Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/tracestate-probability-sampling.md#tracestate-probability-sampling). This sets the base for it.

**Note:**  I did not want to re-invent the wheel, and simply "port" the code from the OTel C++ API/SDK repository that already does all of the `TraceState` handling. The reason is that is compliant with the OTel/W3C specs and have extensive tests. I'm not sure how such things are handled in Envoy, but that is Apache 2.0 license, and I kept the license heading and added links to the original source files. 

It is mostly the same, I just adapted it to use `absl` types instead of the ones they use in the OTel C++ SDK repo. 

CC @wbpcode 
