### PR TITLE
optref: supporting nullopt conversion

### DIFF
--- a/envoy/common/optref.h
+++ b/envoy/common/optref.h
@@ -41,7 +41,9 @@ template <class T> struct OptRef {
    *
    * @return a ref to the converted object.
    */
-  template <class U> operator OptRef<U>() { return OptRef<U>(*ptr_); }
+  template <class U> operator OptRef<U>() {
+    return ptr_ == nullptr ? absl::nullopt : OptRef<U>(*ptr_);
+  }
 
   /**
    * Helper to call a const method on T. The caller is responsible for ensuring

--- a/test/common/common/optref_test.cc
+++ b/test/common/common/optref_test.cc
@@ -98,6 +98,11 @@ TEST(OptRefTest, Conversion) {
   // Ref conversion on construction from non-const to const.
   OptRef<const Bar> const_ref_to_bar = bar_ref;
   EXPECT_EQ(&(*const_ref_to_bar), &bar);
+
+  // Ref conversion on construction from derived class of null value.
+  OptRef<Bar> bar_null_ref(absl::nullopt);
+  OptRef<Foo> foo_ref_to_bar_null = bar_null_ref;
+  EXPECT_EQ(foo_ref_to_bar_null, absl::nullopt);
 }
 
 TEST(OptRefTest, Size) {


### PR DESCRIPTION
Commit Message: optref: supporting nullopt conversion
Additional Description:
Followup to #32256 addressing a case where the conversion is for nullopt.

Risk Level: low - new code
Testing: Added unit test.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
