### PR TITLE
Increase dns timeout and no. of tries

### DIFF
--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -87,6 +87,9 @@ DnsResolverImpl::AresOptions DnsResolverImpl::defaultAresOptions() {
     options.optmask_ |= ARES_OPT_FLAGS;
     options.options_.flags |= ARES_FLAG_NOSEARCH;
   }
+  options.optmask_ |= ARES_OPT_FLAGS;
+  options.options_.timeout = 10000;
+  options.options_.tries = 10;
 
   return options;
 }


### PR DESCRIPTION
Note: This is for giving more opportunities to envoy to succeed doing DNS resolutions for STRICT DNS clusters before calling itself ready.

Goal: Increase dns timeout from 5 seconds, to 10 seconds, and increase tries from the default 3 (excluding the first attempt) to 10.