### PR TITLE
mobile: Remove the no-remote-exec tag for most iOS tests

### DIFF
--- a/mobile/test/objective-c/BUILD
+++ b/mobile/test/objective-c/BUILD
@@ -11,7 +11,6 @@ envoy_mobile_objc_test(
         "EnvoyBridgeUtilityTest.m",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_objc_bridge_lib",
@@ -24,7 +23,6 @@ envoy_mobile_objc_test(
         "EnvoyKeyValueStoreBridgeImplTest.m",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_key_value_store_bridge_impl_lib",

--- a/mobile/test/swift/BUILD
+++ b/mobile/test/swift/BUILD
@@ -21,7 +21,6 @@ envoy_mobile_swift_test(
         "RetryPolicyTests.swift",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",

--- a/mobile/test/swift/RetryPolicyTests.swift
+++ b/mobile/test/swift/RetryPolicyTests.swift
@@ -1,9 +1,9 @@
 import Envoy
 import XCTest
 
-finl class RetryPolicyTests: XCTestCase {
+final class RetryPolicyTests: XCTestCase {
   func testRetryPoliciesAreEqualWhenPropertiesAreEqual() {
-    let policy1 = RetryPolicy(maxRetryCount: 123,
+    let policy1 = RetryPolicy(maxRetryCount: 124,
                               retryOn: [.connectFailure],
                               perRetryTimeoutMS: 8000)
     let policy2 = RetryPolicy(maxRetryCount: 123,

--- a/mobile/test/swift/RetryPolicyTests.swift
+++ b/mobile/test/swift/RetryPolicyTests.swift
@@ -1,7 +1,7 @@
 import Envoy
 import XCTest
 
-final class RetryPolicyTests: XCTestCase {
+finl class RetryPolicyTests: XCTestCase {
   func testRetryPoliciesAreEqualWhenPropertiesAreEqual() {
     let policy1 = RetryPolicy(maxRetryCount: 123,
                               retryOn: [.connectFailure],

--- a/mobile/test/swift/RetryPolicyTests.swift
+++ b/mobile/test/swift/RetryPolicyTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class RetryPolicyTests: XCTestCase {
   func testRetryPoliciesAreEqualWhenPropertiesAreEqual() {
-    let policy1 = RetryPolicy(maxRetryCount: 124,
+    let policy1 = RetryPolicy(maxRetryCount: 123,
                               retryOn: [.connectFailure],
                               perRetryTimeoutMS: 8000)
     let policy2 = RetryPolicy(maxRetryCount: 123,

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -10,6 +10,11 @@ envoy_mobile_swift_test(
     srcs = [
         "EndToEndNetworkingTest.swift",
     ],
+    # The test starts an Envoy server, which binds to a local socket. Binding to a local socket is
+    # not permitted on remote execution hosts, so we have to add the `no-remote-exec` tag.
+    tags = [
+        "no-remote-exec",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -70,6 +75,11 @@ envoy_mobile_swift_test(
     name = "idle_timeout_test",
     srcs = [
         "IdleTimeoutTest.swift",
+    ],
+    # The test starts an Envoy server, which binds to a local socket. Binding to a local socket is
+    # not permitted on remote execution hosts, so we have to add the `no-remote-exec` tag.
+    tags = [
+        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -12,9 +12,6 @@ envoy_mobile_swift_test(
     srcs = [
         "EndToEndNetworkingTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -28,9 +25,6 @@ envoy_mobile_swift_test(
     srcs = [
         "CancelStreamTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -42,9 +36,6 @@ envoy_mobile_swift_test(
     name = "engine_api_test",
     srcs = [
         "EngineApiTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -58,9 +49,6 @@ envoy_mobile_swift_test(
     srcs = [
         "FilterResetIdleTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -73,9 +61,6 @@ envoy_mobile_swift_test(
     srcs = [
         "GRPCReceiveErrorTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -87,9 +72,6 @@ envoy_mobile_swift_test(
     name = "idle_timeout_test",
     srcs = [
         "IdleTimeoutTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -104,9 +86,6 @@ envoy_mobile_swift_test(
     srcs = [
         "KeyValueStoreTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -118,9 +97,6 @@ envoy_mobile_swift_test(
     name = "receive_data_test",
     srcs = [
         "ReceiveDataTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -134,9 +110,6 @@ envoy_mobile_swift_test(
     srcs = [
         "ReceiveErrorTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -148,9 +121,6 @@ envoy_mobile_swift_test(
     name = "reset_connectivity_state_test",
     srcs = [
         "ResetConnectivityStateTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -164,9 +134,6 @@ envoy_mobile_swift_test(
     srcs = [
         "SendDataTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -178,9 +145,6 @@ envoy_mobile_swift_test(
     name = "send_headers_test",
     srcs = [
         "SendHeadersTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -194,9 +158,6 @@ envoy_mobile_swift_test(
     srcs = [
         "SendTrailersTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -208,9 +169,6 @@ envoy_mobile_swift_test(
     name = "set_event_tracker_test",
     srcs = [
         "SetEventTrackerTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -224,9 +182,6 @@ envoy_mobile_swift_test(
     srcs = [
         "SetEventTrackerTestNoTracker.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -239,9 +194,6 @@ envoy_mobile_swift_test(
     srcs = [
         "SetLoggerTest.swift",
     ],
-    tags = [
-        "no-remote-exec",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -253,9 +205,6 @@ envoy_mobile_swift_test(
     name = "cancel_grpc_stream_test",
     srcs = [
         "CancelGRPCStreamTest.swift",
-    ],
-    tags = [
-        "no-remote-exec",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -5,8 +5,6 @@ licenses(["notice"])  # Apache 2
 
 envoy_mobile_package()
 
-# TODO(jpsim): Fix remote execution for all the tests in this file.
-
 envoy_mobile_swift_test(
     name = "end_to_end_networking_test",
     srcs = [

--- a/mobile/test/swift/stats/BUILD
+++ b/mobile/test/swift/stats/BUILD
@@ -13,7 +13,6 @@ envoy_mobile_swift_test(
         "TagsBuilderTests.swift",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
-    tags = ["no-remote-exec"],  # TODO(jpsim): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",


### PR DESCRIPTION
This allows the test to run on RBE instead of the local CI machines, speeding up the CI run time (hopefully).

Tests that start an `EnvoyTestServer` must still have the `no-remote-exec` tag because they try to bind a 
local socket, which is not permitted on the remote environments (we get errors to this effect, e.g. https://github.com/envoyproxy/envoy/actions/runs/7893306052/job/21541684998#step:8:2268).