### PR TITLE
[balsa] Backport line folding support to 1.28

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,6 +5,10 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: http
+  change: |
+    Enable obsolete line folding in BalsaParser (for behavior parity with http-parser, the
+    previously used HTTP/1 parser).
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -150,7 +150,7 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   ASSERT(connection_ != nullptr);
 
   quiche::HttpValidationPolicy http_validation_policy;
-  http_validation_policy.disallow_header_continuation_lines = true;
+  http_validation_policy.disallow_header_continuation_lines = false;
   http_validation_policy.require_header_colon = true;
   http_validation_policy.disallow_multiple_content_length = true;
   http_validation_policy.disallow_transfer_encoding_with_content_length = false;
@@ -393,12 +393,11 @@ void BalsaParser::HandleWarning(BalsaFrameEnums::ErrorCode error_code) {
 
 void BalsaParser::validateAndProcessHeadersOrTrailersImpl(const quiche::BalsaHeaders& headers,
                                                           bool trailers) {
-  for (const std::pair<absl::string_view, absl::string_view>& key_value : headers.lines()) {
+  for (const auto& [key, value] : headers.lines()) {
     if (status_ == ParserStatus::Error) {
       return;
     }
 
-    absl::string_view key = key_value.first;
     if (!isHeaderNameValid(key)) {
       status_ = ParserStatus::Error;
       error_message_ = "HPE_INVALID_HEADER_TOKEN";
@@ -414,8 +413,22 @@ void BalsaParser::validateAndProcessHeadersOrTrailersImpl(const quiche::BalsaHea
       return;
     }
 
-    absl::string_view value = key_value.second;
-    status_ = convertResult(connection_->onHeaderValue(value.data(), value.length()));
+    // Remove CR and LF characters to match http-parser behavior.
+    auto is_cr_or_lf = [](char c) { return c == '\r' || c == '\n'; };
+    if (std::any_of(value.begin(), value.end(), is_cr_or_lf)) {
+      std::string value_without_cr_or_lf;
+      value_without_cr_or_lf.reserve(value.size());
+      for (char c : value) {
+        if (!is_cr_or_lf(c)) {
+          value_without_cr_or_lf.push_back(c);
+        }
+      }
+      status_ = convertResult(connection_->onHeaderValue(value_without_cr_or_lf.data(),
+                                                         value_without_cr_or_lf.length()));
+    } else {
+      // No need to copy if header value does not contain CR or LF.
+      status_ = convertResult(connection_->onHeaderValue(value.data(), value.length()));
+    }
   }
 }
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4473,43 +4473,6 @@ TEST_P(Http1ClientConnectionImplTest, NoContentLengthResponse) {
   }
 }
 
-// Line folding (also called continuation line) is disallowed per RFC9112 Section 5.2.
-TEST_P(Http1ServerConnectionImplTest, LineFolding) {
-  initialize();
-  InSequence s;
-
-  StrictMock<MockRequestDecoder> decoder;
-  Http::ResponseEncoder* response_encoder = nullptr;
-  EXPECT_CALL(callbacks_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder = &encoder;
-        return decoder;
-      }));
-
-  TestRequestHeaderMapImpl expected_headers{
-      {":path", "/"}, {":method", "GET"}, {"foo", "folded value"}};
-  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    EXPECT_CALL(decoder,
-                sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
-  } else {
-    EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
-  }
-
-  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n"
-                           "foo: \r\n"
-                           " folded value\r\n\r\n");
-  auto status = codec_->dispatch(buffer);
-
-  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    EXPECT_TRUE(isCodecProtocolError(status));
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(status.message(), "http/1.1 protocol error: INVALID_HEADER_FORMAT");
-    EXPECT_EQ("http1.codec_error", response_encoder->getStream().responseDetails());
-  } else {
-    EXPECT_TRUE(status.ok());
-  }
-}
-
 // Regression test for https://github.com/envoyproxy/envoy/issues/25458.
 TEST_P(Http1ServerConnectionImplTest, EmptyFieldName) {
   initialize();
@@ -4869,6 +4832,7 @@ TEST_P(Http1ClientConnectionImplTest, InvalidCharacterInTrailerName) {
 // such messages (also permitted by the specification). See RFC9110 Section 5.5:
 // https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values.
 TEST_P(Http1ServerConnectionImplTest, ObsFold) {
+  // SPELLCHECKER(off)
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
@@ -4877,28 +4841,20 @@ TEST_P(Http1ServerConnectionImplTest, ObsFold) {
   TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "GET"},
-      {"multi-line-header", "foo  bar"},
+      {"multi-line-header", "foo  bar\t\tbaz"},
   };
-  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    EXPECT_CALL(decoder,
-                sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
-  } else {
-    EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
-  }
+  EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n"
-                           "Multi-Line-Header: foo\r\n  bar\r\n"
+                           "Multi-Line-Header: \r\n  foo\r\n  bar\r\n\t\tbaz\r\n"
                            "\r\n");
   auto status = codec_->dispatch(buffer);
-  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(status.message(), "http/1.1 protocol error: INVALID_HEADER_FORMAT");
-  } else {
-    EXPECT_TRUE(status.ok());
-  }
+  EXPECT_TRUE(status.ok());
+  // SPELLCHECKER(on)
 }
 
 TEST_P(Http1ClientConnectionImplTest, ObsFold) {
+  // SPELLCHECKER(off)
   initialize();
 
   NiceMock<MockResponseDecoder> response_decoder;
@@ -4908,25 +4864,19 @@ TEST_P(Http1ClientConnectionImplTest, ObsFold) {
 
   TestRequestHeaderMapImpl expected_headers{
       {":status", "200"},
-      {"multi-line-header", "foo  bar"},
+      {"multi-line-header", "foo  bar\t\tbaz"},
       {"content-length", "0"},
   };
-  if (parser_impl_ == Http1ParserImpl::HttpParser) {
-    EXPECT_CALL(response_decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
-  }
+  EXPECT_CALL(response_decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
 
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\n"
-                             "Multi-Line-Header: foo\r\n  bar\r\n"
+                             "Multi-Line-Header: \r\n  foo\r\n  bar\r\n\t\tbaz\r\n"
                              "Content-Length: 0\r\n"
                              "\r\n");
 
   auto status = codec_->dispatch(response);
-  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(status.message(), "http/1.1 protocol error: INVALID_HEADER_FORMAT");
-  } else {
-    EXPECT_TRUE(status.ok());
-  }
+  EXPECT_TRUE(status.ok());
+  // SPELLCHECKER(on)
 }
 
 } // namespace Http


### PR DESCRIPTION
Commit Message: [balsa] Backport line folding support to 1.28
Additional Description: Backport #31080 (test-only) and #31168 to release 1.28 to support obsolete line folding in BalsaParser
Risk Level: low
Testing: test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: Enable obsolete line folding in BalsaParser.
Platform Specific Features: n/a

Balsa implementation tracking issue: #21245