### PR TITLE
http2: restores some log statements, simplifies onBeginData()

### DIFF
--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -708,7 +708,7 @@ private:
   int onData(int32_t stream_id, const uint8_t* data, size_t len);
   Status onBeforeFrameReceived(int32_t stream_id, size_t length, uint8_t type, uint8_t flags);
   Status onPing(uint64_t opaque_data, bool is_ack);
-  Status onBeginData(int32_t stream_id, size_t length, uint8_t type, uint8_t flags, size_t padding);
+  Status onBeginData(int32_t stream_id, size_t length, uint8_t flags, size_t padding);
   Status onGoAway(uint32_t error_code);
   Status onHeaders(int32_t stream_id, size_t length, uint8_t flags);
   Status onRstStream(int32_t stream_id, uint32_t error_code);


### PR DESCRIPTION
These log statements were accidentally omitted in the refactoring performed in https://github.com/envoyproxy/envoy/pull/31878.

This change also removes the redundant frame type argument from `ConnectionImpl::onBeginData()`.

```
$ bazel test //test/common/http/http2/... //test/integration/...
INFO: Invocation ID: 2516e9a0-c488-4630-93d9-a01e0e81d5c3
INFO: Analyzed 397 targets (0 packages loaded, 0 targets configured).
INFO: Found 295 targets and 102 test targets...
INFO: Elapsed time: 752.367s, Critical Path: 750.91s
INFO: 399 processes: 1 remote cache hit, 399 remote.
INFO: Build completed successfully, 399 total actions

Executed 102 out of 102 tests: 102 tests pass.
```

Commit Message: http2: restores some log statements, simplifies onBeginData()
Additional Description:
Risk Level: low
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
