### PR TITLE
contrib: Fix build for fips arm

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -481,6 +481,14 @@ config_setting(
     values = {"define": "boringssl=disabled"},
 )
 
+selects.config_setting_group(
+    name = "boringssl_fips_x86",
+    match_all = [
+        ":boringssl_fips",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 config_setting(
     name = "zlib_ng",
     constraint_values = [

--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -28,7 +28,7 @@ PPC_SKIP_CONTRIB_TARGETS = [
     "envoy.compression.qatzip.compressor",
 ]
 
-FIPS_SKIP_CONTRIB_TARGETS = [
+FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS = [
     "envoy.compression.qatzip.compressor",
 ]
 

--- a/contrib/exe/BUILD
+++ b/contrib/exe/BUILD
@@ -7,7 +7,7 @@ load(
 load(
     "//contrib:all_contrib_extensions.bzl",
     "ARM64_SKIP_CONTRIB_TARGETS",
-    "FIPS_SKIP_CONTRIB_TARGETS",
+    "FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS",
     "PPC_SKIP_CONTRIB_TARGETS",
     "envoy_all_contrib_extensions",
 )
@@ -24,7 +24,7 @@ alias(
 SELECTED_CONTRIB_EXTENSIONS = select({
     "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
     "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
-    "//bazel:boringssl_fips": envoy_all_contrib_extensions(FIPS_SKIP_CONTRIB_TARGETS),
+    "//bazel:boringssl_fips_x86": envoy_all_contrib_extensions(FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS),
     "//conditions:default": envoy_all_contrib_extensions(),
 })
 


### PR DESCRIPTION
Previously, the ARM build with FIPS enabled was failing when building on main with this commit https://github.com/envoyproxy/envoy/commit/92bc83698450258650a2b7d20216abbb819ad1be

```
ERROR: /go/src/github.com/DataDog/envoy/contrib/exe/BUILD:31:16: Illegal ambiguous match on configurable attribute "deps" in //contrib/exe:envoy-static:
//bazel:linux_aarch64
//bazel:boringssl_fips
```

This adds `config_setting_group` to make the match explicit - that is, we will skip the `qatzip` extension
for FIPS + AMD or ARM.

This relates to https://github.com/envoyproxy/envoy/pull/31910, which added a fix for the v1.29.0 build with FIPS + AMD.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing: built an image in our CI with FIPS enabled and targeting aarch64, `bazel build --compilation_mode=opt --define boringssl=fips //distribution/binary:release`
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #31874]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
