### PR TITLE
tap: rejecting invalid config that requires an admin

### DIFF
--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -64,7 +64,10 @@ TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& pr
 
   switch (sink_type_) {
   case ProtoOutputSink::OutputSinkTypeCase::kBufferedAdmin:
-    ASSERT(admin_streamer != nullptr, "admin output must be configured via admin");
+    if (admin_streamer == nullptr) {
+      throw EnvoyException(fmt::format("Output sink type BufferedAdmin requires that the admin "
+                                       "output will be configured via admin"));
+    }
     // TODO(mattklein123): Graceful failure, error message, and test if someone specifies an
     // admin stream output with the wrong format.
     RELEASE_ASSERT(
@@ -75,7 +78,10 @@ TapConfigBaseImpl::TapConfigBaseImpl(const envoy::config::tap::v3::TapConfig& pr
     sink_to_use_ = admin_streamer;
     break;
   case ProtoOutputSink::OutputSinkTypeCase::kStreamingAdmin:
-    ASSERT(admin_streamer != nullptr, "admin output must be configured via admin");
+    if (admin_streamer == nullptr) {
+      throw EnvoyException(fmt::format("Output sink type StreamingAdmin requires that the admin "
+                                       "output will be configured via admin"));
+    }
     // TODO(mattklein123): Graceful failure, error message, and test if someone specifies an
     // admin stream output with the wrong format.
     // TODO(davidpeet8): Simple change to enable PROTO_BINARY_LENGTH_DELIMITED format -

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/tap_filter_admin
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/tap_filter_admin
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.match_delegate"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher"
+    value: "\022\213\002\n\001:\022\205\002\nLtype.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher\022\264\001\022\261\001\n\001:\022\253\001\nLtype.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher\022[\022Y\n\001:\022T\n<type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap\022\024\n\022\022\020\022\016\n\014*\n\010\200\200\200\200\200\200\200\2002"
+  }
+}


### PR DESCRIPTION
Commit Message: tap: rejecting invalid config that requires an admin
Additional Description:
Rejecting a config that requires TAP to output to an admin-based output when the admin isn't configured.
Risk Level: low.
Testing: Added corpus.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Fixes fuzz issue [55142](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55142)