### PR TITLE
Disable test/common/router:route_fuzz_test under fuzz-coverage

### DIFF
--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -276,6 +276,8 @@ envoy_cc_fuzz_test(
     size = "large",
     srcs = ["route_fuzz_test.cc"],
     corpus = ":route_corpus",
+    # The :config_impl_test_static target does not build with coverage
+    tags = ["nocoverage"],
     deps = [
         ":route_fuzz_proto_cc_proto",
         "//source/common/router:config_lib",


### PR DESCRIPTION
Additional Description:
Disable a fuzz test under fuzz-coverage that uses a statically linked binary that can no longer link with coverage instrumentation due to size.

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
