### PR TITLE
grid: fixing a teardown bug

### DIFF
--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -96,6 +96,12 @@ public:
                                   StreamInfo::StreamInfo& info,
                                   absl::optional<Http::Protocol> protocol);
 
+    // Called by onConnectionAttemptFailed and on grid deletion destruction to let wrapper
+    // callback subscribers know the connect attempt failed.
+    void signalFailureAndDeleteSelf(ConnectionPool::PoolFailureReason reason,
+                                    absl::string_view transport_failure_reason,
+                                    Upstream::HostDescriptionConstSharedPtr host);
+
   private:
     // Removes this from the owning list, deleting it.
     void deleteThis();

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -560,6 +560,22 @@ TEST_F(ConnectivityGridTest, TestCancel) {
   cancel->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
 }
 
+// Test tearing down the grid with active connections.
+TEST_F(ConnectivityGridTest, TestTeardown) {
+  initialize();
+  addHttp3AlternateProtocol();
+  EXPECT_EQ(grid_->first(), nullptr);
+
+  grid_->newStream(decoder_, callbacks_,
+                   {/*can_send_early_data_=*/false,
+                    /*can_use_http3_=*/true});
+  EXPECT_NE(grid_->first(), nullptr);
+
+  // When the grid is reset, pool failure should be called.
+  EXPECT_CALL(callbacks_.pool_failure_, ready());
+  grid_.reset();
+}
+
 // Make sure drains get sent to all active pools.
 TEST_F(ConnectivityGridTest, Drain) {
   initialize();


### PR DESCRIPTION
Fixing an issue where the grid didn't always inform newStream subscribers of stream creation fail on teardown.
Fixing a second issue where on teardown, we might try to fail from UDP to TCP.

Risk Level: low
Testing: fixes a mobile RTDS flake, new unit test
Docs Changes: n/a
Release Notes: n/a