### PR TITLE
stream_info: Add a move constructor the the ResponseFlag matcher

### DIFF
--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -20,6 +20,11 @@ class Matcher<Envoy::StreamInfo::ResponseFlag>
     : public internal::MatcherBase<Envoy::StreamInfo::ResponseFlag> {
 public:
   explicit Matcher() = default;
+
+  template <typename M, typename = typename std::remove_reference<M>::type::is_gtest_matcher>
+  Matcher(M&& m)
+      : internal::MatcherBase<Envoy::StreamInfo::ExtendedResponseFlag>(std::forward<M>(m)) {}
+
   Matcher(Envoy::StreamInfo::ResponseFlag value) { *this = Eq(value); }
   Matcher(Envoy::StreamInfo::CoreResponseFlag value) {
     *this = Eq(Envoy::StreamInfo::ResponseFlag(value));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -22,8 +22,7 @@ public:
   explicit Matcher() = default;
 
   template <typename M, typename = typename std::remove_reference<M>::type::is_gtest_matcher>
-  Matcher(M&& m)
-      : internal::MatcherBase<Envoy::StreamInfo::ResponseFlag>(std::forward<M>(m)) {}
+  Matcher(M&& m) : internal::MatcherBase<Envoy::StreamInfo::ResponseFlag>(std::forward<M>(m)) {}
 
   Matcher(Envoy::StreamInfo::ResponseFlag value) { *this = Eq(value); }
   Matcher(Envoy::StreamInfo::CoreResponseFlag value) {

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -23,7 +23,7 @@ public:
 
   template <typename M, typename = typename std::remove_reference<M>::type::is_gtest_matcher>
   Matcher(M&& m)
-      : internal::MatcherBase<Envoy::StreamInfo::ExtendedResponseFlag>(std::forward<M>(m)) {}
+      : internal::MatcherBase<Envoy::StreamInfo::ResponseFlag>(std::forward<M>(m)) {}
 
   Matcher(Envoy::StreamInfo::ResponseFlag value) { *this = Eq(value); }
   Matcher(Envoy::StreamInfo::CoreResponseFlag value) {


### PR DESCRIPTION
Without this move constructor, this mock does not build in newer versions of gtest.

Risk Level: low
Testing: existing
Docs Changes: N/A
Release Notes: N/A