### PR TITLE
mobile: Fix possible inequality bug

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
@@ -81,7 +81,7 @@ class AndroidProxyMonitor extends BroadcastReceiver {
     // proxy is configured.
     //
     // See https://github.com/envoyproxy/envoy-mobile/issues/2531 for more details.
-    if (info.getPacFileUrl() != null && info.getPacFileUrl() != Uri.EMPTY) {
+    if (!Uri.EMPTY.equals(info.getPacFileUrl())) {
       if (intent == null) {
         // PAC proxies are supported only when Intent is present
         return null;


### PR DESCRIPTION
In Java, doing an equality comparison using `==` will only return true if the two instances are the same object. If they are not the same object, the `==` will return false. Using `equals()` is a safer way of doing an equality comparison.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
