### PR TITLE
repo/windows: Enforce `lf` line endings for local checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 /generated_api_shadow/envoy/** linguist-generated=true
 /generated_api_shadow/bazel/** linguist-generated=true
 *.svg binary


### PR DESCRIPTION
This ensures that the files in the working tree always use `lf` line termination, even on Windows.

This should resolve various issues with tooling.

I believe this preserves the git conversion `lf` <> `crlf` - which is important for any new files added to repo in a windows env (i believe vscode will honour existing line termination for a file, but use the os default on new files)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
