### PR TITLE
Handling undefined 1xx responses from upstream

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -234,7 +234,8 @@ bool HeaderUtility::authorityIsValid(const absl::string_view header_value) {
 }
 
 bool HeaderUtility::isSpecial1xx(const ResponseHeaderMap& response_headers) {
-    return (Utility::getResponseStatus(response_headers) >= 100 &&
+  // All 1xx responses from upstream except with 101 status code
+  return (Utility::getResponseStatus(response_headers) >= 100 &&
           Utility::getResponseStatus(response_headers) < 200 &&
           Utility::getResponseStatus(response_headers) != 101);
 }

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -234,8 +234,9 @@ bool HeaderUtility::authorityIsValid(const absl::string_view header_value) {
 }
 
 bool HeaderUtility::isSpecial1xx(const ResponseHeaderMap& response_headers) {
-  return response_headers.Status()->value() == "100" ||
-         response_headers.Status()->value() == "102" || response_headers.Status()->value() == "103";
+    return (Utility::getResponseStatus(response_headers) >= 100 &&
+          Utility::getResponseStatus(response_headers) < 200 &&
+          Utility::getResponseStatus(response_headers) != 101);
 }
 
 bool HeaderUtility::isConnect(const RequestHeaderMap& headers) {


### PR DESCRIPTION
Commit Message: If there is an [undefined 1xx response ](https://umbraco.com/knowledge-base/http-status-codes/#1xx)returned by upstream, it will cause as ASSERT to happen as such a response is not supposed to be processed by encodeHeaders() but by encode1xxHeaders() similar to responses with status codes 100/102/103.
Risk Level: Low
Testing: Fuzz Test passing with problematic input where response status code for 1xx is other than [100,102,103] and not 101. Remaining 1xx response status (if sent from upstream) should be processed by special 1xx headers.