### PR TITLE
Check createFilterFactoryFromProto is ok before accessing its value

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_corpus/create_filter_factory_from_proto_not_ok
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/create_filter_factory_from_proto_not_ok
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.decompressor"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.decompressor.v3.Decompressor"
+    value: "\nU\n\001t\022P\nNtype.googleapis.com/envoy.extensions.filters.http.decompressor.v3.Decompressor"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -74,10 +74,8 @@ void UberFilterFuzzer::fuzz(
     // Clean-up config with filter-specific logic before it runs through validations.
     cleanFuzzedConfig(proto_config.name(), message.get());
     auto cb_or = factory.createFilterFactoryFromProto(*message, "stats", factory_context_);
-    if (!cb_or.ok()) {
-      return;
-    }
-    cb_ = *cb_or;
+    THROW_IF_STATUS_NOT_OK(cb_or, throw);
+    cb_ = cb_or.value();
     cb_(filter_callback_);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Controlled exception {}", e.what());

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -73,7 +73,11 @@ void UberFilterFuzzer::fuzz(
         proto_config, factory_context_.messageValidationVisitor(), factory);
     // Clean-up config with filter-specific logic before it runs through validations.
     cleanFuzzedConfig(proto_config.name(), message.get());
-    cb_ = factory.createFilterFactoryFromProto(*message, "stats", factory_context_).value();
+    auto cb_or = factory.createFilterFactoryFromProto(*message, "stats", factory_context_);
+    if (!cb_or.ok()) {
+      return;
+    }
+    cb_ = *cb_or;
     cb_(filter_callback_);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Controlled exception {}", e.what());


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Check createFilterFactoryFromProto is ok before accessing its value
Additional Description: This was causing the following fuzz error: https://oss-fuzz.com/testcase-detail/5123115348721664
Risk Level: low
Testing: Added fuzz test case
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
