### PR TITLE
clear-text logging of sensitive information {patch}

### DIFF
--- a/test/integration/python/hotrestart_handoff_test.py
+++ b/test/integration/python/hotrestart_handoff_test.py
@@ -353,7 +353,7 @@ class IntegrationTest(unittest.IsolatedAsyncioTestCase):
             "-c",
             self.slow_config_path,
         )
-        log.info(f"cert path = {IntegrationTest.server_cert}")
+       log.info("Handling certificate information in the test. Certificate path: {IntegrationTest.server_cert}")
         log.info("waiting for envoy ready")
         await _wait_for_envoy_epoch(0)
         log.info("making requests")


### PR DESCRIPTION

To address the clear-text logging of sensitive information in the given code, I had modify it to avoid exposing the sensitive data directly. Instead, i had log a more generic message without including the sensitive value  
patch for issue: https://issuetracker.google.com/issues/324681523
In this way convey that the certificate information is involved without explicitly logging the sensitive data. It's essential to log in a way that does not expose sensitive details, especially in environments where logs might be accessible to unauthorized parties.





