### PR TITLE
[ZK filter] Add missing operation supports for multi opcode

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -642,22 +642,34 @@ absl::Status DecoderImpl::parseMultiRequest(Buffer::Instance& data, uint64_t& of
       break;
     }
 
-    switch (static_cast<OpCodes>(opcode.value())) {
+    const auto op = static_cast<OpCodes>(opcode.value());
+    switch (op) {
     case OpCodes::Create:
-      status = parseCreateRequest(data, offset, len, OpCodes::Create);
-      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, OpCodes::Create);
+    case OpCodes::Create2:
+    case OpCodes::CreateContainer:
+    case OpCodes::CreateTtl:
+      status = parseCreateRequest(data, offset, len, op);
+      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);
       break;
     case OpCodes::SetData:
       status = parseSetRequest(data, offset, len);
-      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, OpCodes::SetData);
+      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);
       break;
     case OpCodes::Check:
       status = parseCheckRequest(data, offset, len);
-      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, OpCodes::Check);
+      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);
       break;
     case OpCodes::Delete:
       status = parseDeleteRequest(data, offset, len);
-      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, OpCodes::Delete);
+      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);
+      break;
+    case OpCodes::GetChildren:
+      status = parseGetChildrenRequest(data, offset, len, false);
+      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);
+      break;
+    case OpCodes::GetData:
+      status = parseGetDataRequest(data, offset, len);
+      EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);
       break;
     default:
       callbacks_.onDecodeError(absl::nullopt);

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -137,8 +137,11 @@ absl::StatusOr<absl::optional<OpCodes>> DecoderImpl::decodeOnData(Buffer::Instan
         status, fmt::format("parseGetDataRequest: {}", status.message()));
     break;
   case OpCodes::Create:
+    ABSL_FALLTHROUGH_INTENDED;
   case OpCodes::Create2:
+    ABSL_FALLTHROUGH_INTENDED;
   case OpCodes::CreateContainer:
+    ABSL_FALLTHROUGH_INTENDED;
   case OpCodes::CreateTtl:
     status = parseCreateRequest(data, offset, len.value(), opcode);
     RETURN_INVALID_ARG_ERR_IF_STATUS_NOT_OK(
@@ -645,8 +648,11 @@ absl::Status DecoderImpl::parseMultiRequest(Buffer::Instance& data, uint64_t& of
     const auto op = static_cast<OpCodes>(opcode.value());
     switch (op) {
     case OpCodes::Create:
+      ABSL_FALLTHROUGH_INTENDED;
     case OpCodes::Create2:
+      ABSL_FALLTHROUGH_INTENDED;
     case OpCodes::CreateContainer:
+      ABSL_FALLTHROUGH_INTENDED;
     case OpCodes::CreateTtl:
       status = parseCreateRequest(data, offset, len, op);
       EMIT_DECODER_ERR_AND_RETURN_IF_STATUS_NOT_OK(status, op);


### PR DESCRIPTION
Commit Message: [ZK filter] Add missing operation supports for multi opcode
Additional Description: The ZK filter did not support some operations for the multi opcode based on the [ZK source code](https://github.com/apache/zookeeper/blob/58eed9f5280be1c6a9ccacc47dd6afa65e916ae8/zookeeper-server/src/main/java/org/apache/zookeeper/MultiOperationRecord.java#L97-L105). This could lead to decode errors. This PR tries to fill this gap by adding the opcode support of `Create2`, `CreateContainer`, `CreateTtl`, `GetChildren`, and `GetData` for the `Multi` operation.
Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A