### PR TITLE
quic: loosen transport socket factory downcast type

### DIFF
--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -91,7 +91,7 @@ EnvoyQuicClientSession::EnvoyQuicClientSession(
       quic_stat_names_(quic_stat_names), rtt_cache_(rtt_cache), scope_(scope),
       transport_socket_options_(transport_socket_options),
       transport_socket_factory_(makeOptRefFromPtr(
-          dynamic_cast<QuicClientTransportSocketFactory*>(transport_socket_factory.ptr()))) {
+          dynamic_cast<QuicTransportSocketFactoryBase*>(transport_socket_factory.ptr()))) {
   streamInfo().setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
   if (transport_socket_options_ != nullptr &&
       !transport_socket_options_->applicationProtocolListOverride().empty()) {

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -5,7 +5,7 @@
 #include "source/common/quic/envoy_quic_client_connection.h"
 #include "source/common/quic/envoy_quic_client_crypto_stream_factory.h"
 #include "source/common/quic/envoy_quic_client_stream.h"
-#include "source/common/quic/quic_client_transport_socket_factory.h"
+#include "source/common/quic/quic_transport_socket_factory.h"
 #include "source/common/quic/quic_filter_manager_connection_impl.h"
 #include "source/common/quic/quic_stat_names.h"
 
@@ -130,7 +130,7 @@ private:
   Stats::Scope& scope_;
   bool disable_keepalive_{false};
   Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
-  OptRef<QuicClientTransportSocketFactory> transport_socket_factory_;
+  OptRef<QuicTransportSocketFactoryBase> transport_socket_factory_;
   std::vector<std::string> configured_alpns_;
 };
 

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -5,9 +5,9 @@
 #include "source/common/quic/envoy_quic_client_connection.h"
 #include "source/common/quic/envoy_quic_client_crypto_stream_factory.h"
 #include "source/common/quic/envoy_quic_client_stream.h"
-#include "source/common/quic/quic_transport_socket_factory.h"
 #include "source/common/quic/quic_filter_manager_connection_impl.h"
 #include "source/common/quic/quic_stat_names.h"
+#include "source/common/quic/quic_transport_socket_factory.h"
 
 #include "quiche/quic/core/http/quic_spdy_client_session.h"
 


### PR DESCRIPTION
Commit Message: change EnvoyQuicClientSession to downcast transport socket factory to QuicTransportSocketFactoryBase instead of QuicClientTransportSocketFactory. 

Additional Description: this will enable the usage of other upstream transport socket extensions for QUIC.
Risk Level: low
Testing: existing test passed
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
