### PR TITLE
mobile: Set the allow_client_socket_creation_failure runtime guard

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -845,12 +845,20 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   ProtobufWkt::Struct envoy_layer;
   ProtobufWkt::Struct& runtime_values =
       *(*envoy_layer.mutable_fields())["envoy"].mutable_struct_value();
-  ProtobufWkt::Struct& flags =
+  ProtobufWkt::Struct& reloadable_features =
       *(*runtime_values.mutable_fields())["reloadable_features"].mutable_struct_value();
   for (auto& guard_and_value : runtime_guards_) {
-    (*flags.mutable_fields())[guard_and_value.first].set_bool_value(guard_and_value.second);
+    (*reloadable_features.mutable_fields())[guard_and_value.first].set_bool_value(
+        guard_and_value.second);
   }
-  (*flags.mutable_fields())["always_use_v6"].set_bool_value(always_use_v6_);
+  (*reloadable_features.mutable_fields())["always_use_v6"].set_bool_value(always_use_v6_);
+  ProtobufWkt::Struct& restart_features =
+      *(*runtime_values.mutable_fields())["restart_features"].mutable_struct_value();
+  // TODO(abeyad): This runtime flag is set because https://github.com/envoyproxy/envoy/pull/32370
+  // needed to be merged with the default off due to unresolved test issues. Once those are fixed,
+  // and the default for `allow_client_socket_creation_failure` is true, we can remove this.
+  (*restart_features.mutable_fields())["allow_client_socket_creation_failure"].set_bool_value(true);
+
   (*runtime_values.mutable_fields())["disallow_global_stats"].set_bool_value(true);
   ProtobufWkt::Struct& overload_values =
       *(*envoy_layer.mutable_fields())["overload"].mutable_struct_value();

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -99,6 +99,7 @@ TEST(TestConfig, ConfigIsApplied) {
       "key: \"dns_persistent_cache\" save_interval { seconds: 101 }",
       "key: \"always_use_v6\" value { bool_value: true }",
       "key: \"test_feature_false\" value { bool_value: true }",
+      "key: \"allow_client_socket_creation_failure\" value { bool_value: true }",
       "key: \"device_os\" value { string_value: \"probably-ubuntu-on-CI\" } }",
       "key: \"app_version\" value { string_value: \"1.2.3\" } }",
       "key: \"app_id\" value { string_value: \"1234-1234-1234\" } }",


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/32370 introduced the allow_client_socket_creation_failure runtime guard, but had to default it to off due to test failures.

In Envoy Mobile, we are turning it on as it's been the source of assert failures.