### PR TITLE
SlowStart: reject small aggression configs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -38,6 +38,10 @@ minor_behavior_changes:
     Port migration is default turned off. QUIC client connections will no longer attempt to migrate to a new port when connections
     is degrading. Can be manually turned on via
     :ref:`port_migration <envoy_v3_api_field_config.core.v3.QuicProtocolOptions.num_timeouts_to_trigger_port_migration>`.
+- area: load balancing
+  change: |
+    Rejecting configs that have SlowStartConfig (supported by Round-Robin and Least-Request) with a small (< 1e-30)
+    :ref:`aggresion <envoy_v3_api_field_config.cluster.v3.Cluster.SlowStartConfig.aggression>` value.
 - area: aws
   change: |
     AWS region string is now retrieved from environment and profile consistently within aws_request_signer and

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -63,6 +63,26 @@ public:
     return proto_config.slow_start_config();
   }
 
+  /**
+   * Validates a given config that supports SlowStartConfig (currently
+   * RoundRobin and LeastRequest LBs are supporting it) is valid.
+   */
+  template <class Proto> static absl::Status validateSlowStartConfig(const Proto& proto_config) {
+    if (!proto_config.has_slow_start_config()) {
+      return {};
+    }
+    // Validates the value of the Aggression field.
+    const auto& slow_start_config = proto_config.slow_start_config();
+    if (slow_start_config.has_aggression()) {
+      const auto& aggression = slow_start_config.aggression();
+      if (aggression.default_value() < 1e-30) {
+        return absl::InvalidArgumentError(fmt::format(
+            "Aggression value ({}) cannot be smaller than 1e-30", aggression.default_value()));
+      }
+    }
+    return absl::OkStatus();
+  }
+
   static absl::optional<envoy::extensions::load_balancing_policies::common::v3::LocalityLbConfig>
   localityLbConfigFromCommonLbConfig(
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);

--- a/source/extensions/load_balancing_policies/least_request/config.h
+++ b/source/extensions/load_balancing_policies/least_request/config.h
@@ -65,11 +65,20 @@ public:
     auto active_or_legacy = Common::ActiveOrLegacy<LeastRequestLbProto, ClusterProto>::get(&config);
     ASSERT(active_or_legacy.hasLegacy() || active_or_legacy.hasActive());
 
-    return active_or_legacy.hasLegacy()
-               ? Upstream::LoadBalancerConfigPtr{new LegacyLeastRequestLbConfig(
-                     *active_or_legacy.legacy())}
-               : Upstream::LoadBalancerConfigPtr{
-                     new TypedLeastRequestLbConfig(*active_or_legacy.active())};
+    if (active_or_legacy.hasLegacy()) {
+      auto legacy_config = std::make_unique<LegacyLeastRequestLbConfig>(*active_or_legacy.legacy());
+      if (legacy_config->lbConfig().has_value()) {
+        THROW_IF_NOT_OK(Upstream::LoadBalancerConfigHelper::validateSlowStartConfig(
+            legacy_config->lbConfig().ref()));
+      }
+      return Upstream::LoadBalancerConfigPtr{std::move(legacy_config)};
+    } else {
+      ASSERT(active_or_legacy.hasActive());
+      THROW_IF_NOT_OK(
+          Upstream::LoadBalancerConfigHelper::validateSlowStartConfig(*active_or_legacy.active()));
+      return Upstream::LoadBalancerConfigPtr{
+          new TypedLeastRequestLbConfig(*active_or_legacy.active())};
+    }
   }
 };
 

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -739,7 +739,9 @@ envoy_cc_fuzz_test(
         ":round_robin_load_balancer_fuzz_proto_cc_proto",
         ":utility_lib",
         ":zone_aware_load_balancer_fuzz_lib",
+        "//source/extensions/load_balancing_policies/round_robin:config",
         "//test/fuzz:utility_lib",
+        "//test/mocks/server:factory_context_mocks",
     ],
 )
 
@@ -760,6 +762,8 @@ envoy_cc_fuzz_test(
         ":least_request_load_balancer_fuzz_proto_cc_proto",
         ":utility_lib",
         ":zone_aware_load_balancer_fuzz_lib",
+        "//source/extensions/load_balancing_policies/least_request:config",
+        "//test/mocks/server:factory_context_mocks",
     ],
 )
 

--- a/test/common/upstream/least_request_load_balancer_corpus/small_agression
+++ b/test/common/upstream/least_request_load_balancer_corpus/small_agression
@@ -1,0 +1,85 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 28
+        zum_degraded_hosts: 1811939328
+        random_bytestring: 1870266368
+        random_bytestring: 8
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 33
+        random_bytestring: 4
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      choose_host {
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 1195853345
+        num_degraded_hosts: 95
+        num_excluded_hosts: 9
+        random_bytestring: 4
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 1195853345
+        num_degraded_hosts: 95
+        num_excluded_hosts: 9
+        random_bytestring: 4
+      }
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 8
+      num_hosts_locality_a: 4
+      random_bytestring: 2
+    }
+    seed_for_prng: 5
+  }
+  random_bytestring_for_weights: "$/"
+}
+least_request_lb_config {
+  active_requTrueest_bias {
+    runtime_key: "envoy_"
+  }
+  slow_start_config {
+    slow_start_window {
+      seconds: 2
+    }
+    aggression {
+      default_value: 5.05429155695595e-321
+      runtime_key: "envoy_"
+    }
+    min_weight_percent {
+      value: 5.05429155695595e-321
+    }
+  }
+}
+random_bytestring_for_requests: "@\275"

--- a/test/common/upstream/round_robin_load_balancer_corpus/small_aggression
+++ b/test/common/upstream/round_robin_load_balancer_corpus/small_aggression
@@ -1,0 +1,26 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 99
+      random_bytestring: 2
+    }
+    seed_for_prng: 8
+  }
+  need_local_priority_set: true
+  random_bytestring_for_weights: " "
+}
+round_robin_lb_config {
+  slow_start_config {
+    slow_start_window {
+      seconds: 2304
+    }
+    aggression {
+      default_value: 6.42285339593621e-322
+      runtime_key: "RRRRRRRRRRRRRRRRRRRRRRR"
+    }
+    min_weight_percent {
+    }
+  }
+}

--- a/test/common/upstream/round_robin_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/round_robin_load_balancer_fuzz_test.cc
@@ -2,9 +2,12 @@
 
 #include "envoy/common/optref.h"
 
+#include "source/extensions/load_balancing_policies/round_robin/config.h"
+
 #include "test/common/upstream/round_robin_load_balancer_fuzz.pb.validate.h"
 #include "test/common/upstream/zone_aware_load_balancer_fuzz_base.h"
 #include "test/fuzz/fuzz_runner.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
@@ -21,6 +24,20 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::RoundRobinLoadBalancerTestCase
   const test::common::upstream::ZoneAwareLoadBalancerTestCase& zone_aware_load_balancer_test_case =
       input.zone_aware_load_balancer_test_case();
 
+  // Load the config using the factory (does extra validation).
+  try {
+    envoy::config::cluster::v3::Cluster cluster;
+    cluster.mutable_common_lb_config()->CopyFrom(
+        zone_aware_load_balancer_test_case.load_balancer_test_case().common_lb_config());
+    cluster.mutable_round_robin_lb_config()->CopyFrom(input.round_robin_lb_config());
+    NiceMock<Server::Configuration::MockServerFactoryContext> context;
+    Envoy::Extensions::LoadBalancingPolices::RoundRobin::Factory factory;
+    auto lb_config = factory.loadConfig(cluster, context.messageValidationVisitor());
+  } catch (EnvoyException& e) {
+    ENVOY_LOG_MISC(debug, "EnvoyException while loading config; {}", e.what());
+    return;
+  }
+
   ZoneAwareLoadBalancerFuzzBase zone_aware_load_balancer_fuzz = ZoneAwareLoadBalancerFuzzBase(
       zone_aware_load_balancer_test_case.need_local_priority_set(),
       zone_aware_load_balancer_test_case.random_bytestring_for_weights());
@@ -28,6 +45,7 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::RoundRobinLoadBalancerTestCase
       zone_aware_load_balancer_test_case.load_balancer_test_case());
 
   try {
+
     zone_aware_load_balancer_fuzz.lb_ = std::make_unique<RoundRobinLoadBalancer>(
         zone_aware_load_balancer_fuzz.priority_set_,
         zone_aware_load_balancer_fuzz.local_priority_set_.get(),


### PR DESCRIPTION
Commit Message: SlowStart: reject small aggression configs
Additional Description:
The SlowStartConfig has an aggression field, that if set to too small may cause the weights to be very small.
In this PR we limit the aggression value to be GTE than 1e-30, which I think should be small enough for a reasonable value.

Risk Level: low
Testing: Added integration tests, and fuzz test cases.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A

Fixes fuzz issues: [66847](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66847) and [66837](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66837)