### PR TITLE
Add integration tests for ext_authz timeout

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -32,11 +32,11 @@ struct GrpcInitializeConfigOpts {
 
 struct WaitForSuccessfulUpstreamResponseOpts {
   // Fields of type Headers must be set at initialization.
-  const Headers headers_to_add;
-  const Headers headers_to_append;
-  const Headers headers_to_remove;
-  const Http::TestRequestHeaderMapImpl new_headers_from_upstream;
-  const Http::TestRequestHeaderMapImpl headers_to_append_multiple;
+  const Headers headers_to_add = {};
+  const Headers headers_to_append = {};
+  const Headers headers_to_remove = {};
+  const Http::TestRequestHeaderMapImpl new_headers_from_upstream = {};
+  const Http::TestRequestHeaderMapImpl headers_to_append_multiple = {};
   bool failure_mode_allowed_header = false;
 };
 
@@ -943,7 +943,7 @@ TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailOpen) {
 
   // Do not sendExtAuthzResponse(). Envoy should eventually proxy the request upstream as if the
   // authz service approved the request.
-  WaitForSuccessfulUpstreamResponseOpts upstream_opts{};
+  WaitForSuccessfulUpstreamResponseOpts upstream_opts;
   upstream_opts.failure_mode_allowed_header = true;
   waitForSuccessfulUpstreamResponse("200", upstream_opts);
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add integration tests for ext_authz timeout
Additional Description: This PR adds integration tests for the http and grpc implementations of ext_authz. For each, it tests the fail open and fail closed modes. It also tests that ext_authz's `failure_mode_allow_header_add` config works as expected for the fail open cases.
Risk Level: none
Testing: test-only PR
Docs Changes: none
Release Notes: none
Platform Specific Features: none
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
