### PR TITLE
ci/coverage: revise regex for extracting clang and LLVM versions

### DIFF
--- a/test/run_envoy_bazel_coverage.sh
+++ b/test/run_envoy_bazel_coverage.sh
@@ -3,8 +3,8 @@
 set -e -o pipefail
 
 LLVM_VERSION=${LLVM_VERSION:-"14.0.0"}
-CLANG_VERSION=$(clang --version | grep version | sed -e 's/\ *clang version \(.*\)\ */\1/')
-LLVM_COV_VERSION=$(llvm-cov --version | grep version | sed -e 's/\ *LLVM version \(.*\)/\1/')
+CLANG_VERSION=$(clang --version | grep version | sed -e 's/\ *clang version \([0-9.]*\).*/\1/')
+LLVM_COV_VERSION=$(llvm-cov --version | grep version | sed -e 's/\ *LLVM version \([0-9.]*\).*/\1/')
 LLVM_PROFDATA_VERSION=$(llvm-profdata show --version | grep version | sed -e 's/\ *LLVM version \(.*\)/\1/')
 
 if [ "${CLANG_VERSION}" != "${LLVM_VERSION}" ]


### PR DESCRIPTION
Commit Message:
The regular expressions currently used to extract clang and LLVM versions in `run_envoy_bazel_coverage.sh` can include spurious non-version characters which can result in an accidental mismatch.

This change revises the expressions assuming that clang and LLVM versions will always match `[0-9.]*`, the characters expected in semantic versioning, which should be a reasonable assumption.

Testing:
`./ci/run_envoy_docker.sh ./ci/do_ci.sh coverage` should succeed