### PR TITLE
grpc: Add support for max frame length in gPRC frame decoding

### DIFF
--- a/source/common/grpc/codec.h
+++ b/source/common/grpc/codec.h
@@ -82,6 +82,8 @@ enum class State {
 
 class FrameInspector {
 public:
+  FrameInspector() = default;
+  FrameInspector(uint32_t max_frame_length) : max_frame_length_(max_frame_length) {}
   // Inspects the given buffer with GRPC data frame and updates the frame count.
   // Invokes visitor callbacks for each frame in the following sequence:
   //   "frameStart frameDataStart frameData* frameDataEnd"
@@ -113,10 +115,17 @@ protected:
     uint8_t length_as_bytes_[4];
   };
   uint64_t count_{0};
+  // Default value 0 means there is no limitation on maximum frame length.
+  uint32_t max_frame_length_{0};
+  // When `max_frame_length_` is configured, this flag will be true if frame length is larger than
+  // `max_frame_length_`.
+  bool is_frame_oversized_{false};
 };
 
 class Decoder : public FrameInspector {
 public:
+  Decoder() = default;
+  Decoder(uint32_t max_frame_length) : FrameInspector(max_frame_length) {}
   // Decodes the given buffer with GRPC data frame. Drains the input buffer when
   // decoding succeeded (returns true). If the input is not sufficient to make a
   // complete GRPC data frame, it will be buffered in the decoder. If a decoding

--- a/source/common/grpc/codec.h
+++ b/source/common/grpc/codec.h
@@ -82,8 +82,6 @@ enum class State {
 
 class FrameInspector {
 public:
-  FrameInspector() = default;
-  FrameInspector(uint32_t max_frame_length) : max_frame_length_(max_frame_length) {}
   // Inspects the given buffer with GRPC data frame and updates the frame count.
   // Invokes visitor callbacks for each frame in the following sequence:
   //   "frameStart frameDataStart frameData* frameDataEnd"
@@ -124,8 +122,6 @@ protected:
 
 class Decoder : public FrameInspector {
 public:
-  Decoder() = default;
-  Decoder(uint32_t max_frame_length) : FrameInspector(max_frame_length) {}
   // Decodes the given buffer with GRPC data frame. Drains the input buffer when
   // decoding succeeded (returns true). If the input is not sufficient to make a
   // complete GRPC data frame, it will be buffered in the decoder. If a decoding
@@ -142,6 +138,9 @@ public:
 
   // Indicates whether it has buffered any partial data.
   bool hasBufferedData() const { return state_ != State::FhFlag; }
+
+  // Configures the maximum frame length.
+  void setMaxFrameLength(uint32_t max_frame_length) { max_frame_length_ = max_frame_length; }
 
 protected:
   bool frameStart(uint8_t) override;

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -239,7 +239,7 @@ TEST(GrpcCodecTest, decodeSingleFrameOverLimit) {
   Decoder decoder = Decoder(32 * 1024);
   // The decoder doesn't successfully decode due to oversized frame.
   EXPECT_FALSE(decoder.decode(buffer, frames));
-  EXPECT_EQ(size, buffer.length());
+  EXPECT_EQ(buffer.length(), size);
 }
 
 TEST(GrpcCodecTest, decodeMultipleFramesOverLimit) {
@@ -270,12 +270,14 @@ TEST(GrpcCodecTest, decodeMultipleFramesOverLimit) {
   EXPECT_FALSE(decoder.decode(buffer, frames));
   // When the decoder doesn't successfully decode, it puts valid frames up until
   // an oversized frame into output frame vector.
-  EXPECT_EQ(1, frames.size());
+  ASSERT_EQ(frames.size(), 1);
+  // First frame is successfully decoded.
+  EXPECT_EQ(frames[0].length_, request.ByteSize());
   // Buffer does not get drained due to it returning false.
-  EXPECT_EQ(size, buffer.length());
+  EXPECT_EQ(buffer.length(), size);
   // Only part of the buffer represented a valid frame. Thus, the frame length should not equal the
   // buffer length.
-  EXPECT_NE(size, frames[0].length_);
+  EXPECT_NE(frames[0].length_, size);
 }
 
 TEST(GrpcCodecTest, FrameInspectorTest) {

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -236,7 +236,9 @@ TEST(GrpcCodecTest, decodeSingleFrameOverLimit) {
 
   std::vector<Frame> frames;
   // Configure decoder with 32kb max_frame_length.
-  Decoder decoder = Decoder(32 * 1024);
+  Decoder decoder;
+  decoder.setMaxFrameLength(32 * 1024);
+
   // The decoder doesn't successfully decode due to oversized frame.
   EXPECT_FALSE(decoder.decode(buffer, frames));
   EXPECT_EQ(buffer.length(), size);
@@ -265,7 +267,9 @@ TEST(GrpcCodecTest, decodeMultipleFramesOverLimit) {
   size_t size = buffer.length();
 
   std::vector<Frame> frames;
-  Decoder decoder = Decoder(32 * 1024);
+  Decoder decoder;
+  decoder.setMaxFrameLength(32 * 1024);
+
   EXPECT_FALSE(decoder.decode(buffer, frames));
   // When the decoder doesn't successfully decode, it puts valid frames up until
   // an oversized frame into output frame vector.

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -243,7 +243,6 @@ TEST(GrpcCodecTest, decodeSingleFrameOverLimit) {
 }
 
 TEST(GrpcCodecTest, decodeMultipleFramesOverLimit) {
-
   Buffer::OwnedImpl buffer;
   std::array<uint8_t, 5> header;
   Encoder encoder;

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -250,7 +250,7 @@ TEST(GrpcCodecTest, decodeSingleFrameWithMultiBuffersOverLimit) {
   Encoder encoder;
 
   uint32_t max_length = 32 * 1024;
-  uint32_t single_buffer_length = 24 * 1024;
+  uint32_t single_buffer_length = 18 * 1024;
   std::string req_str = std::string(single_buffer_length, 'a');
 
   // First buffer is valid (i.e. within total_frame_length limit).
@@ -269,13 +269,13 @@ TEST(GrpcCodecTest, decodeSingleFrameWithMultiBuffersOverLimit) {
   encoder.newFrame(GRPC_FH_DEFAULT, request.ByteSize() + request_2.ByteSize(), header);
 
   size_t size = buffer.length();
-  std::vector<Frame> frames;
+  std::vector<Frame> frames = {};
   Decoder decoder;
   decoder.setMaxFrameLength(max_length);
 
   // The decoder doesn't successfully decode due to oversized frame.
   EXPECT_FALSE(decoder.decode(buffer, frames));
-  ASSERT_EQ(frames.size(), 0);
+  EXPECT_EQ(frames.size(), 0);
   // Buffer does not get drained due to it returning false.
   EXPECT_EQ(buffer.length(), size);
 }

--- a/test/common/grpc/codec_test.cc
+++ b/test/common/grpc/codec_test.cc
@@ -250,7 +250,7 @@ TEST(GrpcCodecTest, decodeSingleFrameWithMultiBuffersOverLimit) {
   Encoder encoder;
 
   uint32_t max_length = 32 * 1024;
-  uint32_t single_buffer_length = 18 * 1024;
+  uint32_t single_buffer_length = 24 * 1024;
   std::string req_str = std::string(single_buffer_length, 'a');
 
   // First buffer is valid (i.e. within total_frame_length limit).


### PR DESCRIPTION
**The workflow:**
-  Client of gRPC decoder configure the  `max_frame_length`  via `setMaxFrameLength()`
-  If `max_frame_length`  is configured and total length exceeds the limit, the future decoding process will be skipped and returned

**The use case/ motivation**: Enable `max_receive_message_length` in Envoy-gRPC (which use gRPC decoder) . 
-  When the message is over limit, it can be rejected  before frame data [is fully decoded (i.e. expanded](https://github.com/envoyproxy/envoy/blob/ffbf1889ef788ccb4b1d0e402ed2c3976d7204fd/source/common/grpc/async_client_impl.cc#L144)). 
- This can prevent malicious attack , for example, unbounded and huge message is sent over channel and is injected and buffered in Envoy over Envoy-gRPC.

**Next step**:  

- Refactor `bool Decoder::decode` method: Change the return type from `bool` to absl:status so that the caller can identify whether it is decoding error or over-limit error. 
