### PR TITLE
add unit tests for uint32_accessor

### DIFF
--- a/test/common/stream_info/uint32_accessor_impl_test.cc
+++ b/test/common/stream_info/uint32_accessor_impl_test.cc
@@ -19,6 +19,25 @@ TEST(UInt32AccessorImplTest, IncrementValue) {
   EXPECT_EQ(0xdeadbef0, accessor.value());
 }
 
+TEST(UInt32AccessorImplTest, TestProto) {
+  uint32_t init_value = 0xdeadbeef;
+  UInt32AccessorImpl accessor(init_value);
+  auto message = accessor.serializeAsProto();
+  EXPECT_NE(nullptr, message);
+
+  auto* uint32_struct = dynamic_cast<ProtobufWkt::UInt32Value*>(message.get());
+  EXPECT_NE(nullptr, uint32_struct);
+  EXPECT_EQ(init_value, uint32_struct->value());
+}
+
+TEST(UInt32AccessorImplTest, TestString) {
+  uint32_t init_value = 0xdeadbeef;
+  UInt32AccessorImpl accessor(init_value);
+  absl::optional<std::string> value = accessor.serializeAsString();
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(value, std::to_string(init_value));
+}
+
 } // namespace
 } // namespace StreamInfo
 } // namespace Envoy


### PR DESCRIPTION
Additional Description: found some non-tested functions in UInt32AccessorImpl
Risk Level: low
Testing: unit tests