### PR TITLE
mobile: Change the return type to void from void* in the callbacks

### DIFF
--- a/mobile/library/cc/stream_callbacks.cc
+++ b/mobile/library/cc/stream_callbacks.cc
@@ -10,8 +10,7 @@ namespace Platform {
 
 namespace {
 
-void* c_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel intel,
-                   void* context) {
+void c_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel intel, void* context) {
   auto stream_callbacks = *static_cast<StreamCallbacksSharedPtr*>(context);
   if (stream_callbacks->on_headers.has_value()) {
     auto raw_headers = envoyHeadersAsRawHeaderMap(headers);
@@ -27,10 +26,9 @@ void* c_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel in
   } else {
     release_envoy_headers(headers);
   }
-  return context;
 }
 
-void* c_on_data(envoy_data data, bool end_stream, envoy_stream_intel, void* context) {
+void c_on_data(envoy_data data, bool end_stream, envoy_stream_intel, void* context) {
   auto stream_callbacks = *static_cast<StreamCallbacksSharedPtr*>(context);
   if (stream_callbacks->on_data.has_value()) {
     auto on_data = stream_callbacks->on_data.value();
@@ -38,10 +36,9 @@ void* c_on_data(envoy_data data, bool end_stream, envoy_stream_intel, void* cont
   } else {
     release_envoy_data(data);
   }
-  return context;
 }
 
-void* c_on_trailers(envoy_headers metadata, envoy_stream_intel intel, void* context) {
+void c_on_trailers(envoy_headers metadata, envoy_stream_intel intel, void* context) {
   auto stream_callbacks = *static_cast<StreamCallbacksSharedPtr*>(context);
   if (stream_callbacks->on_trailers.has_value()) {
     auto raw_headers = envoyHeadersAsRawHeaderMap(metadata);
@@ -54,11 +51,10 @@ void* c_on_trailers(envoy_headers metadata, envoy_stream_intel intel, void* cont
   } else {
     release_envoy_headers(metadata);
   }
-  return context;
 }
 
-void* c_on_error(envoy_error raw_error, envoy_stream_intel intel,
-                 envoy_final_stream_intel final_intel, void* context) {
+void c_on_error(envoy_error raw_error, envoy_stream_intel intel,
+                envoy_final_stream_intel final_intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_error.has_value()) {
@@ -71,10 +67,9 @@ void* c_on_error(envoy_error raw_error, envoy_stream_intel intel,
   }
   release_envoy_error(raw_error);
   delete stream_callbacks_ptr;
-  return nullptr;
 }
 
-void* c_on_complete(envoy_stream_intel intel, envoy_final_stream_intel final_intel, void* context) {
+void c_on_complete(envoy_stream_intel intel, envoy_final_stream_intel final_intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_complete.has_value()) {
@@ -82,10 +77,9 @@ void* c_on_complete(envoy_stream_intel intel, envoy_final_stream_intel final_int
     on_complete(intel, final_intel);
   }
   delete stream_callbacks_ptr;
-  return nullptr;
 }
 
-void* c_on_cancel(envoy_stream_intel intel, envoy_final_stream_intel final_intel, void* context) {
+void c_on_cancel(envoy_stream_intel intel, envoy_final_stream_intel final_intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_cancel.has_value()) {
@@ -93,17 +87,15 @@ void* c_on_cancel(envoy_stream_intel intel, envoy_final_stream_intel final_intel
     on_cancel(intel, final_intel);
   }
   delete stream_callbacks_ptr;
-  return nullptr;
 }
 
-void* c_on_send_window_available(envoy_stream_intel intel, void* context) {
+void c_on_send_window_available(envoy_stream_intel intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_send_window_available.has_value()) {
     auto on_send_window_available = stream_callbacks->on_send_window_available.value();
     on_send_window_available(intel);
   }
-  return nullptr;
 }
 
 } // namespace

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -322,10 +322,9 @@ extern "C" { // function pointers
  * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream,
-                                    envoy_stream_intel stream_intel, void* context);
+typedef void (*envoy_on_headers_f)(envoy_headers headers, bool end_stream,
+                                   envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for data on an HTTP stream.
@@ -337,10 +336,9 @@ typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream,
  * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
-                                 void* context);
+typedef void (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
+                                void* context);
 
 /**
  * Callback signature for metadata on an HTTP stream.
@@ -353,8 +351,8 @@ typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel stream_intel,
-                                     void* context);
+typedef void (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel stream_intel,
+                                    void* context);
 
 /**
  * Callback signature for trailers on an HTTP stream.
@@ -365,10 +363,9 @@ typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel 
  * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel stream_intel,
-                                     void* context);
+typedef void (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel stream_intel,
+                                    void* context);
 
 /**
  * Callback signature for errors with an HTTP stream.
@@ -380,10 +377,9 @@ typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel 
  * @param final_stream_intel, contains final internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_error_f)(envoy_error error, envoy_stream_intel stream_intel,
-                                  envoy_final_stream_intel final_stream_intel, void* context);
+typedef void (*envoy_on_error_f)(envoy_error error, envoy_stream_intel stream_intel,
+                                 envoy_final_stream_intel final_stream_intel, void* context);
 
 /**
  * Callback signature for when an HTTP stream bi-directionally completes without error.
@@ -394,10 +390,9 @@ typedef void* (*envoy_on_error_f)(envoy_error error, envoy_stream_intel stream_i
  * @param final_stream_intel, contains final internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_complete_f)(envoy_stream_intel stream_intel,
-                                     envoy_final_stream_intel final_stream_intel, void* context);
+typedef void (*envoy_on_complete_f)(envoy_stream_intel stream_intel,
+                                    envoy_final_stream_intel final_stream_intel, void* context);
 
 /**
  * Callback signature for when an HTTP stream is cancelled.
@@ -408,10 +403,9 @@ typedef void* (*envoy_on_complete_f)(envoy_stream_intel stream_intel,
  * @param final_stream_intel, contains final internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_cancel_f)(envoy_stream_intel stream_intel,
-                                   envoy_final_stream_intel final_stream_intel, void* context);
+typedef void (*envoy_on_cancel_f)(envoy_stream_intel stream_intel,
+                                  envoy_final_stream_intel final_stream_intel, void* context);
 
 /**
  * Called when the envoy engine is exiting.
@@ -456,9 +450,8 @@ typedef void (*envoy_logger_release_f)(const void* context);
  * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
- * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_send_window_available_f)(envoy_stream_intel stream_intel, void* context);
+typedef void (*envoy_on_send_window_available_f)(envoy_stream_intel stream_intel, void* context);
 
 /**
  * Called when envoy's event tracker tracks an event.

--- a/mobile/library/objective-c/EnvoyHTTPStreamImpl.mm
+++ b/mobile/library/objective-c/EnvoyHTTPStreamImpl.mm
@@ -21,8 +21,8 @@ typedef struct {
 
 #pragma mark - C callbacks
 
-static void *ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel,
-                            void *context) {
+static void ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel,
+                           void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -30,11 +30,10 @@ static void *ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream
       callbacks.onHeaders(to_ios_headers(headers), end_stream, stream_intel);
     }
   });
-  return NULL;
 }
 
-static void *ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
-                         void *context) {
+static void ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
+                        void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -42,16 +41,13 @@ static void *ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel st
       callbacks.onData(to_ios_data(data), end_stream, stream_intel);
     }
   });
-  return NULL;
 }
 
-static void *ios_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel,
-                             void *context) {
-  return NULL;
-}
+static void ios_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel,
+                            void *context) {}
 
-static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_intel,
-                             void *context) {
+static void ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_intel,
+                            void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -59,10 +55,9 @@ static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_i
       callbacks.onTrailers(to_ios_headers(trailers), stream_intel);
     }
   });
-  return NULL;
 }
 
-static void *ios_on_send_window_available(envoy_stream_intel stream_intel, void *context) {
+static void ios_on_send_window_available(envoy_stream_intel stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -70,11 +65,10 @@ static void *ios_on_send_window_available(envoy_stream_intel stream_intel, void 
       callbacks.onSendWindowAvailable(stream_intel);
     }
   });
-  return NULL;
 }
 
-static void *ios_on_complete(envoy_stream_intel stream_intel,
-                             envoy_final_stream_intel final_stream_intel, void *context) {
+static void ios_on_complete(envoy_stream_intel stream_intel,
+                            envoy_final_stream_intel final_stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -86,11 +80,10 @@ static void *ios_on_complete(envoy_stream_intel stream_intel,
     assert(stream);
     [stream cleanUp];
   });
-  return NULL;
 }
 
-static void *ios_on_cancel(envoy_stream_intel stream_intel,
-                           envoy_final_stream_intel final_stream_intel, void *context) {
+static void ios_on_cancel(envoy_stream_intel stream_intel,
+                          envoy_final_stream_intel final_stream_intel, void *context) {
   // This call is atomically gated at the call-site and will only happen once. It may still fire
   // after a complete response or error callback, but no other callbacks for the stream will ever
   // fire AFTER the cancellation callback.
@@ -106,11 +99,10 @@ static void *ios_on_cancel(envoy_stream_intel stream_intel,
     assert(stream);
     [stream cleanUp];
   });
-  return NULL;
 }
 
-static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
-                          envoy_final_stream_intel final_stream_intel, void *context) {
+static void ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
+                         envoy_final_stream_intel final_stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -128,7 +120,6 @@ static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
     assert(stream);
     [stream cleanUp];
   });
-  return NULL;
 }
 
 #pragma mark - EnvoyHTTPStreamImpl

--- a/mobile/test/common/main_interface_test.cc
+++ b/mobile/test/common/main_interface_test.cc
@@ -167,20 +167,18 @@ TEST_F(MainInterfaceTest, BasicStream) {
 
   absl::Notification on_complete_notification;
   envoy_http_callbacks stream_cbs{
-      [](envoy_headers c_headers, bool end_stream, envoy_stream_intel, void*) -> void* {
+      [](envoy_headers c_headers, bool end_stream, envoy_stream_intel, void*) -> void {
         auto response_headers = toResponseHeaders(c_headers);
         EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
         EXPECT_TRUE(end_stream);
-        return nullptr;
       } /* on_headers */,
       nullptr /* on_data */,
       nullptr /* on_metadata */,
       nullptr /* on_trailers */,
       nullptr /* on_error */,
-      [](envoy_stream_intel, envoy_final_stream_intel, void* context) -> void* {
+      [](envoy_stream_intel, envoy_final_stream_intel, void* context) -> void {
         auto* on_complete_notification = static_cast<absl::Notification*>(context);
         on_complete_notification->Notify();
-        return nullptr;
       } /* on_complete */,
       nullptr /* on_cancel */,
       nullptr /* on_send_window_available*/,
@@ -239,10 +237,9 @@ TEST_F(MainInterfaceTest, ResetStream) {
       nullptr /* on_trailers */,
       nullptr /* on_error */,
       nullptr /* on_complete */,
-      [](envoy_stream_intel, envoy_final_stream_intel, void* context) -> void* {
+      [](envoy_stream_intel, envoy_final_stream_intel, void* context) -> void {
         auto* on_cancel_notification = static_cast<absl::Notification*>(context);
         on_cancel_notification->Notify();
-        return nullptr;
       } /* on_cancel */,
       nullptr /* on_send_window_available */,
       &on_cancel_notification /* context */};


### PR DESCRIPTION
Remove the Envoy callbacks to return `void` instead of `void *` since we never care about the return values. Prior to this PR, in an implementation like JNI, we would return a raw JNI local reference, which would not be automatically deleted causing the number of JNI local references to go up.

Risk Level: low (the return values are never used)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a