### PR TITLE
ext_proc: Validate route re-pick and routing/path header mutation

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -117,7 +117,6 @@ protected:
       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter ext_proc_filter;
       std::string ext_proc_filter_name = "envoy.filters.http.ext_proc";
       ext_proc_filter.set_name(ext_proc_filter_name);
-
       ext_proc_filter.mutable_typed_config()->PackFrom(proto_config_);
       config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(ext_proc_filter));
 


### PR DESCRIPTION
`SetHostHeaderRoutingSucceeded` : ext_proc triggers route re-pick and set host header to match the domain of virtual host in routing configuration.  This makes routing to upstream successful.

`SetHostHeaderRoutingFailed`:  ext_proc triggers route re-pick but set host header to wrong header that doesn't match the  virtual host domain in routing configuration.  This makes routing to upstream failed since no route is found.

`GetAndSetPathHeader`: when `allow_all_routing` is false, path header is updated successfully but routing header mutation(e.g., host, method, scheme) are failed