### PR TITLE
[1.28] google_grpc: add a runtime flag to disable TLSv1.3

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -20,5 +20,10 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: google_grpc
+  change: |
+    Added an off-by-default runtime flag
+    ``envoy.reloadable_features.google_grpc_disable_tls_13`` to disable TLSv1.3
+    usage by gRPC SDK for ``google_grpc`` services.
 
 deprecated:

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -210,6 +210,7 @@ envoy_cc_library(
         "//envoy/grpc:google_grpc_creds_interface",
         "//envoy/registry",
         "//source/common/config:datasource_lib",
+        "//source/common/runtime:runtime_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
     alwayslink = LEGACY_ALWAYSLINK,

--- a/source/common/grpc/google_grpc_creds_impl.cc
+++ b/source/common/grpc/google_grpc_creds_impl.cc
@@ -4,6 +4,7 @@
 #include "envoy/grpc/google_grpc_creds.h"
 
 #include "source/common/config/datasource.h"
+#include "source/common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -15,12 +16,29 @@ std::shared_ptr<grpc::ChannelCredentials> CredsUtility::getChannelCredentials(
     case envoy::config::core::v3::GrpcService::GoogleGrpc::ChannelCredentials::
         CredentialSpecifierCase::kSslCredentials: {
       const auto& ssl_credentials = google_grpc.channel_credentials().ssl_credentials();
-      const grpc::SslCredentialsOptions ssl_credentials_options = {
-          Config::DataSource::read(ssl_credentials.root_certs(), true, api),
-          Config::DataSource::read(ssl_credentials.private_key(), true, api),
-          Config::DataSource::read(ssl_credentials.cert_chain(), true, api),
-      };
-      return grpc::SslCredentials(ssl_credentials_options);
+      const auto root_certs = Config::DataSource::read(ssl_credentials.root_certs(), true, api);
+      const auto private_key = Config::DataSource::read(ssl_credentials.private_key(), true, api);
+      const auto cert_chain = Config::DataSource::read(ssl_credentials.cert_chain(), true, api);
+      grpc::experimental::TlsChannelCredentialsOptions options;
+      if (!private_key.empty() || !cert_chain.empty()) {
+        options.set_certificate_provider(
+            std::make_shared<grpc::experimental::StaticDataCertificateProvider>(
+                root_certs,
+                std::vector<grpc::experimental::IdentityKeyCertPair>{{private_key, cert_chain}}));
+      } else if (!root_certs.empty()) {
+        options.set_certificate_provider(
+            std::make_shared<grpc::experimental::StaticDataCertificateProvider>(root_certs));
+      }
+      if (!root_certs.empty()) {
+        options.watch_root_certs();
+      }
+      if (!private_key.empty() || !cert_chain.empty()) {
+        options.watch_identity_key_cert_pairs();
+      }
+      if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.google_grpc_disable_tls_13")) {
+        options.set_max_tls_version(grpc_tls_version::TLS1_2);
+      }
+      return grpc::experimental::TlsCredentials(options);
     }
     case envoy::config::core::v3::GrpcService::GoogleGrpc::ChannelCredentials::
         CredentialSpecifierCase::kLocalCredentials: {


### PR DESCRIPTION
Backport of https://github.com/envoyproxy/envoy/pull/32315