### PR TITLE
ext_proc: Refactor the management of sidestream response in stream mode.

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -397,10 +397,12 @@ FilterDataStatus Filter::onData(ProcessorState& state, Buffer::Instance& data, b
     // may request a watermark if the queue is higher than the buffer limit to prevent running
     // out of memory.
     // 2) As a result, filters farther down the chain see empty buffers in some data callbacks.
-    // 3) When a response comes back from the external processor, it injects the processor's result
-    // into the filter chain using "inject**codedData". (The processor may respond indicating that
-    // there is no change, which means that the original buffer stored in the queue is what gets
-    // injected.)
+    // 3) When a response comes back from the external processor, it is buffered in HCM's buffered
+    // data and will be propagated to further filters in the chain altogether later (The processor
+    // may respond indicating that there is no change, which means that the original buffer stored
+    // in the queue is what gets propagated.)
+    // 4) If the response from the external processor is too large, watermark and then local reply
+    // will be triggered.
     //
     // This way, we pipeline data from the proxy to the external processor, and give the processor
     // the ability to modify each chunk, in order. Doing this any other way would have required

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -273,7 +273,7 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
       should_continue = chunk->end_stream;
       if (chunk_data.length() > 0) {
         ENVOY_LOG(trace, "Injecting {} bytes of data to filter stream", chunk_data.length());
-        injectDataToFilterChain(chunk_data, chunk->end_stream);
+        addBufferedData(chunk_data);
       }
 
       if (queueBelowLowLimit()) {

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -272,7 +272,7 @@ absl::Status ProcessorState::handleBodyResponse(const BodyResponse& response) {
       }
       should_continue = chunk->end_stream;
       if (chunk_data.length() > 0) {
-        ENVOY_LOG(trace, "Injecting {} bytes of data to filter stream", chunk_data.length());
+        ENVOY_LOG(trace, "Adding {} bytes of buffered data to filter stream", chunk_data.length());
         addBufferedData(chunk_data);
       }
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -3446,7 +3446,7 @@ TEST_P(ExtProcIntegrationTest, ResponseFromSidestreamTooLarge) {
   processRequestBodyMessage(
       *grpc_upstreams_[0], true, [&body_str](const HttpBody& body, BodyResponse& body_resp) {
         EXPECT_TRUE(body.end_of_stream());
-        // Sned huge body muation back to ext_proc.
+        // Send huge body mutation back to ext_proc.
         auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
         body_mut->set_body(body_str);
         return true;
@@ -3454,7 +3454,7 @@ TEST_P(ExtProcIntegrationTest, ResponseFromSidestreamTooLarge) {
 
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
-  // The response from sidestream is too large and triggers local reply with code 413
+  // The response from side stream is too large and triggers local reply with code 413
   // (PayloadTooLarge).
   EXPECT_EQ(response->headers().getStatusValue(), std::to_string(413));
 }

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -496,7 +496,7 @@ protected:
 
     Buffer::OwnedImpl want_response_body;
     Buffer::OwnedImpl got_response_body;
-    EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, _))
+    EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
         .WillRepeatedly(Invoke([&got_response_body](Buffer::Instance& data, Unused) {
           got_response_body.move(data);
         }));
@@ -1760,7 +1760,7 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
 
   Buffer::OwnedImpl want_request_body;
   Buffer::OwnedImpl got_request_body;
-  EXPECT_CALL(decoder_callbacks_, injectDecodedDataToFilterChain(_, true))
+  EXPECT_CALL(decoder_callbacks_, addDecodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_request_body](Buffer::Instance& data, Unused) { got_request_body.move(data); }));
 
@@ -1787,7 +1787,8 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
 
   Buffer::OwnedImpl want_response_body;
   Buffer::OwnedImpl got_response_body;
-  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, _))
+
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
 
@@ -1856,7 +1857,7 @@ TEST_F(HttpFilterTest, PostStreamingBodiesDifferentOrder) {
 
   Buffer::OwnedImpl want_request_body;
   Buffer::OwnedImpl got_request_body;
-  EXPECT_CALL(decoder_callbacks_, injectDecodedDataToFilterChain(_, true))
+  EXPECT_CALL(decoder_callbacks_, addDecodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_request_body](Buffer::Instance& data, Unused) { got_request_body.move(data); }));
 
@@ -1879,9 +1880,6 @@ TEST_F(HttpFilterTest, PostStreamingBodiesDifferentOrder) {
 
   Buffer::OwnedImpl want_response_body;
   Buffer::OwnedImpl got_response_body;
-  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, false))
-      .WillRepeatedly(Invoke(
-          [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
   Buffer::OwnedImpl response_buffer;
   setUpEncodingBuffering(response_buffer, true);
 
@@ -1897,6 +1895,10 @@ TEST_F(HttpFilterTest, PostStreamingBodiesDifferentOrder) {
   EXPECT_EQ(0, response_buffer.length());
   EXPECT_FALSE(encoding_watermarked);
   got_response_body.move(response_buffer);
+
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
+      .WillRepeatedly(Invoke(
+          [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
 
   for (int i = 0; i < 5; i++) {
     Buffer::OwnedImpl resp_chunk;
@@ -1966,7 +1968,7 @@ TEST_F(HttpFilterTest, GetStreamingBodyAndChangeMode) {
 
   Buffer::OwnedImpl want_response_body;
   Buffer::OwnedImpl got_response_body;
-  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, false))
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
 
@@ -2000,7 +2002,7 @@ TEST_F(HttpFilterTest, GetStreamingBodyAndChangeMode) {
     processResponseBody(absl::nullopt, false);
   }
 
-  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, true))
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
 
@@ -2058,7 +2060,7 @@ TEST_F(HttpFilterTest, GetStreamingBodyAndChangeModeDifferentOrder) {
 
   Buffer::OwnedImpl want_response_body;
   Buffer::OwnedImpl got_response_body;
-  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, false))
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
 
@@ -2084,7 +2086,7 @@ TEST_F(HttpFilterTest, GetStreamingBodyAndChangeModeDifferentOrder) {
   TestUtility::feedBufferWithRandomCharacters(resp_chunk, 100);
   want_response_body.add(resp_chunk.toString());
 
-  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, true))
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, _))
       .WillRepeatedly(Invoke(
           [&got_response_body](Buffer::Instance& data, Unused) { got_response_body.move(data); }));
 

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -273,9 +273,57 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBody) {
         // them all.
         uint32_t received_size = 0;
         ProcessingRequest body_req;
+        while (stream->Read(&body_req)) {
+          received_size += body_req.request_body().body().size();
+          ProcessingResponse body_resp;
+          body_resp.mutable_request_body();
+          stream->Write(body_resp);
+        }
+
+        EXPECT_EQ(received_size, total_size);
+      });
+
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  sendPostRequest(num_chunks, chunk_size, [total_size](Http::HeaderMap& headers) {
+    // This header tells the "autonomous upstream" that will respond to our
+    // request to throw an error if it doesn't get the right number of bytes.
+    headers.addCopy(LowerCaseString("expect_request_size_bytes"), total_size);
+  });
+
+  ASSERT_TRUE(client_response_->waitForEndStream());
+  EXPECT_TRUE(client_response_->complete());
+  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
+}
+
+TEST_P(StreamingIntegrationTest, UnderWaterMarkStreamedRequestBody) {
+  const uint32_t num_chunks = 152;
+  const uint32_t chunk_size = 10;
+
+  uint32_t total_size = num_chunks * chunk_size;
+  std::string req_body_str;
+  test_processor_.start(
+      ipVersion(), [total_size, &req_body_str](
+                       grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+        // Expect a request_headers message as the first message on the stream,
+        // and send back an empty response.
+        ProcessingRequest header_req;
+        ASSERT_TRUE(stream->Read(&header_req));
+        ASSERT_TRUE(header_req.has_request_headers());
+        ProcessingResponse header_resp;
+        header_resp.mutable_request_headers();
+        stream->Write(header_resp);
+
+        // Now, expect a bunch of request_body messages and respond to each.
+        // Count up the number of bytes we receive and make sure that we get
+        // them all.
+        uint32_t received_size = 0;
+        ProcessingRequest body_req;
         do {
           ASSERT_TRUE(stream->Read(&body_req));
           ASSERT_TRUE(body_req.has_request_body());
+          req_body_str += body_req.request_body().body();
           received_size += body_req.request_body().body().size();
           ProcessingResponse body_resp;
           body_resp.mutable_request_body();
@@ -355,7 +403,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyPartially) {
 
   ASSERT_TRUE(client_response_->waitForEndStream());
   EXPECT_TRUE(client_response_->complete());
-  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
+  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
 }
 
 // Send a body that's larger than the buffer limit in streamed mode, and close
@@ -399,7 +447,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyAndClose) {
 
   ASSERT_TRUE(client_response_->waitForEndStream());
   EXPECT_TRUE(client_response_->complete());
-  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
+  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
 }
 
 // Do an HTTP GET that will return a body smaller than the buffer limit, which we process

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -249,57 +249,9 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedRequestBody) {
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
 }
 
-// Send a downstream client request body that's larger than the buffer limit in streamed mode, it
-// triggers high watermark and 413 will be returned with local reply.
-TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBody) {
-  const uint32_t num_chunks = 152;
-  const uint32_t chunk_size = 1000;
-  uint32_t total_size = num_chunks * chunk_size;
-
-  test_processor_.start(
-      ipVersion(),
-      [total_size](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
-        // Expect a request_headers message as the first message on the stream,
-        // and send back an empty response.
-        ProcessingRequest header_req;
-        ASSERT_TRUE(stream->Read(&header_req));
-        ASSERT_TRUE(header_req.has_request_headers());
-        ProcessingResponse header_resp;
-        header_resp.mutable_request_headers();
-        stream->Write(header_resp);
-
-        // Now, expect a bunch of request_body messages and respond to each.
-        // Count up the number of bytes we receive and make sure that we get
-        // them all.
-        uint32_t received_size = 0;
-        ProcessingRequest body_req;
-        while (stream->Read(&body_req)) {
-          received_size += body_req.request_body().body().size();
-          ProcessingResponse body_resp;
-          body_resp.mutable_request_body();
-          stream->Write(body_resp);
-        }
-
-        EXPECT_EQ(received_size, total_size);
-      });
-
-  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
-  initializeConfig();
-  HttpIntegrationTest::initialize();
-  sendPostRequest(num_chunks, chunk_size, [total_size](Http::HeaderMap& headers) {
-    // This header tells the "autonomous upstream" that will respond to our
-    // request to throw an error if it doesn't get the right number of bytes.
-    headers.addCopy(LowerCaseString("expect_request_size_bytes"), total_size);
-  });
-
-  ASSERT_TRUE(client_response_->waitForEndStream());
-  EXPECT_TRUE(client_response_->complete());
-  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
-}
-
 // Send a body that's smaller than the buffer limit in streamed mode, and ensure
 // that the processor gets the right number of bytes.
-TEST_P(StreamingIntegrationTest, UnderWaterMarkStreamedRequestBody) {
+TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyUnderWatermark) {
   const uint32_t num_chunks = 152;
   const uint32_t chunk_size = 10;
 
@@ -349,13 +301,48 @@ TEST_P(StreamingIntegrationTest, UnderWaterMarkStreamedRequestBody) {
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
 }
 
+// Send a downstream client request body that's larger than the buffer limit in streamed mode, it
+// triggers high watermark and 413 will be returned with local reply.
+TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyOverWatermark) {
+  const uint32_t num_chunks = 152;
+  const uint32_t chunk_size = 1000;
+
+  test_processor_.start(
+      ipVersion(), [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+        // Expect a request_headers message as the first message on the stream,
+        // and send back an empty response.
+        ProcessingRequest header_req;
+        ASSERT_TRUE(stream->Read(&header_req));
+        ASSERT_TRUE(header_req.has_request_headers());
+        ProcessingResponse header_resp;
+        header_resp.mutable_request_headers();
+        stream->Write(header_resp);
+
+        ProcessingRequest body_req;
+        while (stream->Read(&body_req)) {
+          ProcessingResponse body_resp;
+          body_resp.mutable_request_body();
+          stream->Write(body_resp);
+        }
+      });
+
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  sendPostRequest(num_chunks, chunk_size, absl::nullopt);
+
+  ASSERT_TRUE(client_response_->waitForEndStream());
+  EXPECT_TRUE(client_response_->complete());
+  EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
+}
+
 // Send a body that's larger than the buffer limit in streamed mode, and change the processing mode
 // after receiving some of the body. It triggers high watermark and 413 will be returned with local
 // reply.
 TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyPartially) {
   const uint32_t num_chunks = 19;
   const uint32_t chunk_size = 10000;
-  uint32_t total_size = num_chunks * chunk_size;
 
   test_processor_.start(
       ipVersion(), [](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
@@ -398,9 +385,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyPartially) {
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
   initializeConfig();
   HttpIntegrationTest::initialize();
-  sendPostRequest(num_chunks, chunk_size, [total_size](Http::HeaderMap& headers) {
-    headers.addCopy(LowerCaseString("expect_request_size_bytes"), total_size);
-  });
+  sendPostRequest(num_chunks, chunk_size, absl::nullopt);
 
   ASSERT_TRUE(client_response_->waitForEndStream());
   EXPECT_TRUE(client_response_->complete());
@@ -441,9 +426,7 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyAndClose) {
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
   initializeConfig();
   HttpIntegrationTest::initialize();
-  sendPostRequest(num_chunks, chunk_size, [total_size](Http::HeaderMap& headers) {
-    headers.addCopy(LowerCaseString("expect_request_size_bytes"), total_size);
-  });
+  sendPostRequest(num_chunks, chunk_size, absl::nullopt);
 
   ASSERT_TRUE(client_response_->waitForEndStream());
   EXPECT_TRUE(client_response_->complete());

--- a/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/streaming_integration_test.cc
@@ -249,8 +249,8 @@ TEST_P(StreamingIntegrationTest, PostAndProcessBufferedRequestBody) {
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
 }
 
-// Send a body that's larger than the buffer limit in streamed mode, and ensure
-// that the processor gets the right number of bytes.
+// Send a downstream client request body that's larger than the buffer limit in streamed mode, it
+// triggers high watermark and 413 will be returned with local reply.
 TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBody) {
   const uint32_t num_chunks = 152;
   const uint32_t chunk_size = 1000;
@@ -297,6 +297,8 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBody) {
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
 }
 
+// Send a body that's smaller than the buffer limit in streamed mode, and ensure
+// that the processor gets the right number of bytes.
 TEST_P(StreamingIntegrationTest, UnderWaterMarkStreamedRequestBody) {
   const uint32_t num_chunks = 152;
   const uint32_t chunk_size = 10;
@@ -347,10 +349,9 @@ TEST_P(StreamingIntegrationTest, UnderWaterMarkStreamedRequestBody) {
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("200"));
 }
 
-// Send a body that's larger than the buffer limit in streamed mode, and change
-// the processing mode after receiving some of the body. We might continue to
-// receive streamed messages after this point, but the whole message should
-// make it upstream regardless.
+// Send a body that's larger than the buffer limit in streamed mode, and change the processing mode
+// after receiving some of the body. It triggers high watermark and 413 will be returned with local
+// reply.
 TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyPartially) {
   const uint32_t num_chunks = 19;
   const uint32_t chunk_size = 10000;
@@ -406,9 +407,8 @@ TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyPartially) {
   EXPECT_THAT(client_response_->headers(), Http::HttpStatusIs("413"));
 }
 
-// Send a body that's larger than the buffer limit in streamed mode, and close
-// the stream before we've received all the chunks. The whole message should
-// be received by the upstream regardless.
+// Send a downstream client request body that's larger than the buffer limit in streamed mode, and
+// close the stream. It triggers high watermark and 413 will be returned with local reply.
 TEST_P(StreamingIntegrationTest, PostAndProcessStreamedRequestBodyAndClose) {
   const uint32_t num_chunks = 25;
   const uint32_t chunk_size = 10000;


### PR DESCRIPTION
Huge response(either single large response or large amount of smaller responses in short period) from ext_proc server could lead to OOM risk. 

A simple and safe solution proposed here : Leveraging the HCM buffering/watermark to handle the ext_proc server response. When the response cause high watermark, local reply will be triggered to avoid OOM. Note: the request to ext_proc server is still being streamed out.

The optimal solution and next step : upstream/downstream applies back pressure to sidestream(that connects to ext_proc server). It is being actively explored and developed but it is a complex solution demands significant effort/validation.