### PR TITLE
mobile/ci: Tag the Swift tests with `no-remote-exec`

### DIFF
--- a/mobile/test/swift/BUILD
+++ b/mobile/test/swift/BUILD
@@ -21,6 +21,7 @@ envoy_mobile_swift_test(
         "RetryPolicyTests.swift",
     ],
     flaky = True,  # TODO(jpsim): Fix timeouts when running these tests on CI
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",

--- a/mobile/test/swift/cxx/BUILD
+++ b/mobile/test/swift/cxx/BUILD
@@ -10,6 +10,7 @@ envoy_mobile_swift_test(
     srcs = [
         "LogLevelCxxTests.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         "//library/swift/EnvoyCxxSwiftInterop",

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -28,6 +28,7 @@ envoy_mobile_swift_test(
     srcs = [
         "CancelStreamTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -40,6 +41,7 @@ envoy_mobile_swift_test(
     srcs = [
         "EngineApiTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -52,6 +54,7 @@ envoy_mobile_swift_test(
     srcs = [
         "FilterResetIdleTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -64,6 +67,7 @@ envoy_mobile_swift_test(
     srcs = [
         "GRPCReceiveErrorTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -94,6 +98,7 @@ envoy_mobile_swift_test(
     srcs = [
         "KeyValueStoreTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -106,6 +111,7 @@ envoy_mobile_swift_test(
     srcs = [
         "ReceiveDataTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -118,6 +124,7 @@ envoy_mobile_swift_test(
     srcs = [
         "ReceiveErrorTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -130,6 +137,7 @@ envoy_mobile_swift_test(
     srcs = [
         "ResetConnectivityStateTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -142,6 +150,7 @@ envoy_mobile_swift_test(
     srcs = [
         "SendDataTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -154,6 +163,7 @@ envoy_mobile_swift_test(
     srcs = [
         "SendHeadersTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -166,6 +176,7 @@ envoy_mobile_swift_test(
     srcs = [
         "SendTrailersTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -178,6 +189,7 @@ envoy_mobile_swift_test(
     srcs = [
         "SetEventTrackerTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -190,6 +202,7 @@ envoy_mobile_swift_test(
     srcs = [
         "SetEventTrackerTestNoTracker.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -202,6 +215,7 @@ envoy_mobile_swift_test(
     srcs = [
         "SetLoggerTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
@@ -214,6 +228,7 @@ envoy_mobile_swift_test(
     srcs = [
         "CancelGRPCStreamTest.swift",
     ],
+    tags = ["no-remote-exec"],  # TODO(32551): Re-enable remote exec
     visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",


### PR DESCRIPTION
This will turn off RBE for the Swift tests.  This will make the Swift tests go slower, but right now they are timing out at a regular rate on CI, seemingly due to DNS timeouts on the MacOS machines.

See https://github.com/envoyproxy/envoy/issues/31957 for details.

Opened https://github.com/envoyproxy/envoy/issues/32551 to find a fix that allows us to use RBE with the Swift tests.