### PR TITLE
[1.28] google_grpc: add a runtime flag to disable TLSv1.3 (#32532)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -20,5 +20,10 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: google_grpc
+  change: |
+    Added an off-by-default runtime flag
+    ``envoy.reloadable_features.google_grpc_disable_tls_13`` to disable TLSv1.3
+    usage by gRPC SDK for ``google_grpc`` services.
 
 deprecated:

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -210,6 +210,7 @@ envoy_cc_library(
         "//envoy/grpc:google_grpc_creds_interface",
         "//envoy/registry",
         "//source/common/config:datasource_lib",
+        "//source/common/runtime:runtime_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
     alwayslink = LEGACY_ALWAYSLINK,

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -132,6 +132,10 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_no_downgrade_to_canonical_name);
 // TODO(pksohn): enable after fixing https://github.com/envoyproxy/envoy/issues/29930
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_defer_logging_to_ack_listener);
 
+// A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
+// compliance restrictions.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_google_grpc_disable_tls_13);
+
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT
 ABSL_FLAG(uint64_t, re2_max_program_size_warn_level,            // NOLINT

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -178,6 +178,7 @@ envoy_cc_test(
         ":grpc_client_integration_test_harness_lib",
         "//source/common/grpc:async_client_lib",
         "//source/extensions/grpc_credentials/example:config",
+        "//test/test_common:test_runtime_lib",
     ] + envoy_select_google_grpc(["//source/common/grpc:google_async_client_lib"]),
 )
 


### PR DESCRIPTION
Backport of https://github.com/envoyproxy/envoy/pull/32315