### PR TITLE
[1.27] google_grpc: add a runtime flag to disable TLSv1.3 (#32532)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -13,5 +13,10 @@ removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 new_features:
+- area: google_grpc
+  change: |
+    Added an off-by-default runtime flag
+    ``envoy.reloadable_features.google_grpc_disable_tls_13`` to disable TLSv1.3
+    usage by gRPC SDK for ``google_grpc`` services.
 
 deprecated:

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -210,6 +210,7 @@ envoy_cc_library(
         "//envoy/grpc:google_grpc_creds_interface",
         "//envoy/registry",
         "//source/common/config:datasource_lib",
+        "//source/common/runtime:runtime_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
     alwayslink = LEGACY_ALWAYSLINK,

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -122,6 +122,10 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_refresh_rtt_after_request);
 // TODO(danzh) false deprecate it once QUICHE has its own enable/disable flag.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 
+// A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
+// compliance restrictions.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_google_grpc_disable_tls_13);
+
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT
 ABSL_FLAG(uint64_t, re2_max_program_size_warn_level,            // NOLINT

--- a/test/common/grpc/BUILD
+++ b/test/common/grpc/BUILD
@@ -176,6 +176,7 @@ envoy_cc_test(
         ":grpc_client_integration_test_harness_lib",
         "//source/common/grpc:async_client_lib",
         "//source/extensions/grpc_credentials/example:config",
+        "//test/test_common:test_runtime_lib",
     ] + envoy_select_google_grpc(["//source/common/grpc:google_async_client_lib"]),
 )
 

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -5,6 +5,7 @@
 
 #endif
 
+#include "test/test_common/test_runtime.h"
 #include "test/common/grpc/grpc_client_integration_test_harness.h"
 
 using testing::Eq;
@@ -407,6 +408,29 @@ TEST_P(GrpcSslClientIntegrationTest, BasicSslRequestWithClientCert) {
   auto request = createRequest(empty_metadata_);
   request->sendReply();
   dispatcher_helper_.runDispatcher();
+}
+
+// Validate TLS version mismatch between the client and the server.
+TEST_P(GrpcSslClientIntegrationTest, BasicSslRequestHandshakeFailure) {
+  SKIP_IF_GRPC_CLIENT(ClientType::EnvoyGrpc);
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.google_grpc_disable_tls_13", "true"}});
+  use_server_tls_13_ = true;
+  initialize();
+  auto request = createRequest(empty_metadata_, false);
+  EXPECT_CALL(*request->child_span_, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("13")));
+  EXPECT_CALL(*request->child_span_,
+              setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
+  EXPECT_CALL(*request, onFailure(Status::Internal, "", _)).WillOnce(InvokeWithoutArgs([this]() {
+    dispatcher_helper_.dispatcher_.exit();
+  }));
+  EXPECT_CALL(*request->child_span_, finishSpan());
+  FakeRawConnectionPtr fake_connection;
+  ASSERT_TRUE(fake_upstream_->waitForRawConnection(fake_connection));
+  if (fake_connection->connected()) {
+    ASSERT_TRUE(fake_connection->waitForDisconnect());
+  }
+  dispatcher_helper_.dispatcher_.run(Event::Dispatcher::RunType::Block);
 }
 
 #ifdef ENVOY_GOOGLE_GRPC

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -365,7 +365,8 @@ public:
 
   virtual void expectExtraHeaders(FakeStream&) {}
 
-  HelloworldRequestPtr createRequest(const TestMetadata& initial_metadata) {
+  HelloworldRequestPtr createRequest(const TestMetadata& initial_metadata,
+                                     bool expect_upstream_request = true) {
     auto request = std::make_unique<HelloworldRequest>(dispatcher_helper_);
     EXPECT_CALL(*request, onCreateInitialMetadata(_))
         .WillOnce(Invoke([&initial_metadata](Http::HeaderMap& headers) {
@@ -391,6 +392,10 @@ public:
     request->grpc_request_ = grpc_client_->send(*method_descriptor_, request_msg, *request,
                                                 active_span, Http::AsyncClient::RequestOptions());
     EXPECT_NE(request->grpc_request_, nullptr);
+
+    if (!expect_upstream_request) {
+      return request;
+    }
 
     if (!fake_connection_) {
       AssertionResult result =
@@ -526,6 +531,7 @@ public:
       tls_cert->mutable_private_key()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
     }
+
     auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
         tls_context, factory_context_);
 
@@ -557,6 +563,13 @@ public:
       validation_context->mutable_trusted_ca()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/cacert.pem"));
     }
+    if (use_server_tls_13_) {
+      auto* tls_params = common_tls_context->mutable_tls_params();
+      tls_params->set_tls_minimum_protocol_version(
+          envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3);
+      tls_params->set_tls_maximum_protocol_version(
+          envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3);
+    }
 
     auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
         tls_context, factory_context_);
@@ -568,6 +581,7 @@ public:
   }
 
   bool use_client_cert_{};
+  bool use_server_tls_13_{false};
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
 };
 


### PR DESCRIPTION
Backport of https://github.com/envoyproxy/envoy/pull/32315