### PR TITLE
Revert "mobile/ci: Fix iOS build failures (#31756)"

### DIFF
--- a/.github/workflows/envoy-macos.yml
+++ b/.github/workflows/envoy-macos.yml
@@ -58,11 +58,8 @@ jobs:
         include:
         - target: ci/mac_ci_steps.sh
           name: macOS
-          steps-pre: |
-            - run: ./ci/mac_ci_setup.sh
-              shell: bash
-              name: Setup macos
           source: |
+            source ./ci/mac_ci_setup.sh
             _BAZEL_BUILD_EXTRA_OPTIONS=(
               --remote_download_toplevel
               --flaky_test_attempts=2

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -103,10 +103,7 @@ jobs:
             --config=mobile-remote-ci-macos-swift
             //library/swift:ios_framework
           source: |
-            # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
-            # and the GitHub Action runner image no longer includes Android SDK 30:
-            # https://github.com/actions/runner-images/issues/8952
-            ./ci/mac_ci_setup.sh --android
+            ./ci/mac_ci_setup.sh
             ./bazelw shutdown
 
   request:

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -103,7 +103,7 @@ jobs:
             --config=mobile-remote-ci-macos-swift
             //library/swift:ios_framework
           source: |
-            ./ci/mac_ci_setup.sh
+            source ./ci/mac_ci_setup.sh
             ./bazelw shutdown
 
   request:

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -44,10 +44,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
-        # and the GitHub Action runner image no longer includes Android SDK 30:
-        # https://github.com/actions/runner-images/issues/8952
-        ./ci/mac_ci_setup.sh --android
+        ./ci/mac_ci_setup.sh
         ./bazelw shutdown
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}
@@ -86,10 +83,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
-        # and the GitHub Action runner image no longer includes Android SDK 30:
-        # https://github.com/actions/runner-images/issues/8952
-        ./ci/mac_ci_setup.sh --android
+        ./ci/mac_ci_setup.sh
         ./bazelw shutdown
       steps-post: |
         - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@680d414be3f56cbb161dfdebebece85d81c3f686  # actions-v0.2.24
@@ -131,10 +125,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
-        # and the GitHub Action runner image no longer includes Android SDK 30:
-        # https://github.com/actions/runner-images/issues/8952
-        ./ci/mac_ci_setup.sh --android
+        ./ci/mac_ci_setup.sh
       steps-post: |
         - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@680d414be3f56cbb161dfdebebece85d81c3f686  # actions-v0.2.24
           with:

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -44,7 +44,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        source ./ci/mac_ci_setup.sh
         ./bazelw shutdown
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}
@@ -83,7 +83,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        source ./ci/mac_ci_setup.sh
         ./bazelw shutdown
       steps-post: |
         - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@680d414be3f56cbb161dfdebebece85d81c3f686  # actions-v0.2.24
@@ -125,7 +125,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        source ./ci/mac_ci_setup.sh
       steps-post: |
         - uses: envoyproxy/toolshed/gh-actions/envoy/ios/post@680d414be3f56cbb161dfdebebece85d81c3f686  # actions-v0.2.24
           with:

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -44,7 +44,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        source ./ci/mac_ci_setup.sh
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}
       timeout-minutes: ${{ matrix.timeout-minutes }}

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -44,10 +44,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        # TODO(fredyw): A workaround since mobile/WORKSPACE requires Android SDK to be available
-        # and the GitHub Action runner image no longer includes Android SDK 30:
-        # https://github.com/actions/runner-images/issues/8952
-        ./ci/mac_ci_setup.sh --android
+        ./ci/mac_ci_setup.sh
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}
       timeout-minutes: ${{ matrix.timeout-minutes }}

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -51,10 +51,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        # TODO(fredyw): A workaround since mobile/WORKSPACE always requires Android SDK to be available
-        # and the GitHub Action runner image no longer includes Android SDK 30:
-        # https://github.com/actions/runner-images/issues/8952
-        ./ci/mac_ci_setup.sh --android
+        ./ci/mac_ci_setup.sh
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
       steps-post: |
         - run: |

--- a/.github/workflows/mobile-release_validation.yml
+++ b/.github/workflows/mobile-release_validation.yml
@@ -51,7 +51,7 @@ jobs:
       request: ${{ needs.load.outputs.request }}
       runs-on: macos-12
       source: |
-        ./ci/mac_ci_setup.sh
+        source ./ci/mac_ci_setup.sh
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
       steps-post: |
         - run: |

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -56,6 +56,10 @@ sudo xcode-select --switch /Applications/Xcode_14.1.app
 
 retry ./bazelw version
 
+echo "ANDROID_HOME: ${ANDROID_HOME}"
+echo "ANDROID_NDK_HOME: ${ANDROID_NDK_HOME}"
+exit 1
+
 if [[ "${1:-}" == "--android" ]]; then
   # Download and set up ndk 21 after GitHub update
   # https://github.com/actions/virtual-environments/issues/5595

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -56,18 +56,6 @@ sudo xcode-select --switch /Applications/Xcode_14.1.app
 
 retry ./bazelw version
 
-if [[ "${1:-}" == "--android" ]]; then
-  # Download and set up ndk 21 after GitHub update
-  # https://github.com/actions/virtual-environments/issues/5595
-  ANDROID_HOME=$ANDROID_SDK_ROOT
-  SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
-  "${SDKMANAGER}" --install "platform-tools" "platforms;android-30"
-  "${SDKMANAGER}" --uninstall "ndk-bundle"
-  "${SDKMANAGER}" --install "ndk;21.4.7075529"
-  "${SDKMANAGER}" --install "build-tools;30.0.2"
-  ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/21.4.7075529"
-  export ANDROID_NDK_HOME
-else
-  unset ANDROID_HOME
-  unset ANDROID_NDK_HOME
-fi
+# Unset default variables so we don't have to install Android SDK/NDK.
+unset ANDROID_HOME
+unset ANDROID_NDK_HOME

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -56,10 +56,6 @@ sudo xcode-select --switch /Applications/Xcode_14.1.app
 
 retry ./bazelw version
 
-echo "ANDROID_HOME: ${ANDROID_HOME}"
-echo "ANDROID_NDK_HOME: ${ANDROID_NDK_HOME}"
-exit 1
-
 if [[ "${1:-}" == "--android" ]]; then
   # Download and set up ndk 21 after GitHub update
   # https://github.com/actions/virtual-environments/issues/5595
@@ -71,4 +67,7 @@ if [[ "${1:-}" == "--android" ]]; then
   "${SDKMANAGER}" --install "build-tools;30.0.2"
   ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/21.4.7075529"
   export ANDROID_NDK_HOME
+else
+  unset ANDROID_HOME
+  unset ANDROID_NDK_HOME
 fi


### PR DESCRIPTION
The default github action runners have ANDROID_HOME and ANDROID_NDK_HOME set automatically. Because of this our bazel logic requires android to be installed. For jobs that don't request android explicitly we now unset this to save that install CI time. This also changes the CI setup to actively source the mac_ci_setup script since previously those env vars would be ignored, since github actions sources the text listed there, but not each line

This reverts commit f37ef3ff03bb78035e80b65159c0ec35b7544e0d.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
