### PR TITLE
quic: add Private Key Provider support

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -198,6 +198,10 @@ new_features:
     Add ``Envoy::ExecutionContext``, which is notified by ``ScopeTrackerScopeState``'s constructor and destructor. This feature is
     disabled by default, it can be enabled by runtime feature flag ``envoy.restart_features.enable_execution_context``. For more details,
     please see https://github.com/envoyproxy/envoy/issues/32012.
+- area: quic
+  change: |
+    Added private key provider :ref:`private_key_provider <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>`
+    support for the quic over TLS 1.3 protocol.
 - area: rbac
   change: |
     Added :ref:`uri_template<envoy_v3_api_field_config.rbac.v3.Permission.uri_template>` which uses existing

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -200,7 +200,8 @@ new_features:
     please see https://github.com/envoyproxy/envoy/issues/32012.
 - area: quic
   change: |
-    Added private key provider :ref:`private_key_provider <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>`
+    Added private key provider
+    :ref:`private_key_provider<envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.private_key_provider>`
     support for the quic over TLS 1.3 protocol.
 - area: rbac
   change: |

--- a/source/extensions/quic/crypto_stream/BUILD
+++ b/source/extensions/quic/crypto_stream/BUILD
@@ -17,8 +17,14 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "envoy_quic_crypto_server_stream_lib",
-    srcs = ["envoy_quic_crypto_server_stream.cc"],
-    hdrs = ["envoy_quic_crypto_server_stream.h"],
+    srcs = [
+        "envoy_quic_crypto_server_stream.cc",
+        "envoy_tls_server_handshaker.cc",
+    ],
+    hdrs = [
+        "envoy_quic_crypto_server_stream.h",
+        "envoy_tls_server_handshaker.h",
+    ],
     tags = ["nofips"],
     visibility = [
         "//source/common/quic:__subpackages__",
@@ -27,6 +33,8 @@ envoy_cc_library(
     deps = [
         "//envoy/registry",
         "//source/common/quic:envoy_quic_server_crypto_stream_factory_lib",
+        "//source/common/quic:quic_server_transport_socket_factory_lib",
+        "@com_github_google_quiche//:quic_server_session_lib",
         "@envoy_api//envoy/extensions/quic/crypto_stream/v3:pkg_cc_proto",
     ],
     alwayslink = LEGACY_ALWAYSLINK,

--- a/source/extensions/quic/crypto_stream/envoy_quic_crypto_server_stream.cc
+++ b/source/extensions/quic/crypto_stream/envoy_quic_crypto_server_stream.cc
@@ -11,23 +11,13 @@ EnvoyQuicCryptoServerStreamFactoryImpl::createEnvoyQuicCryptoServerStream(
     const quic::QuicCryptoServerConfig* crypto_config,
     quic::QuicCompressedCertsCache* compressed_certs_cache, quic::QuicSession* session,
     quic::QuicCryptoServerStreamBase::Helper* helper,
-    // Though this extension doesn't use the two parameters below, they might be used by
-    // downstreams. Do not remove them.
     OptRef<const Network::DownstreamTransportSocketFactory> transport_socket_factory,
     Envoy::Event::Dispatcher& dispatcher) {
-  switch (session->connection()->version().handshake_protocol) {
-  case quic::PROTOCOL_QUIC_CRYPTO:
-    return quic::CreateCryptoServerStream(crypto_config, compressed_certs_cache, session, helper);
-  case quic::PROTOCOL_TLS1_3:
+  if (session->connection()->version().handshake_protocol == quic::PROTOCOL_TLS1_3) {
     return std::unique_ptr<EnvoyTlsServerHandshaker>(
         new EnvoyTlsServerHandshaker(session, crypto_config, transport_socket_factory, dispatcher));
-  case quic::PROTOCOL_UNSUPPORTED:
-    break;
   }
-  QUIC_BUG(quic_bug_10492_1) << "Unknown handshake protocol: "
-                             << static_cast<int>(
-                                    session->connection()->version().handshake_protocol);
-  return nullptr;
+  return quic::CreateCryptoServerStream(crypto_config, compressed_certs_cache, session, helper);
 }
 
 REGISTER_FACTORY(EnvoyQuicCryptoServerStreamFactoryImpl,

--- a/source/extensions/quic/crypto_stream/envoy_quic_crypto_server_stream.cc
+++ b/source/extensions/quic/crypto_stream/envoy_quic_crypto_server_stream.cc
@@ -1,5 +1,8 @@
 #include "source/extensions/quic/crypto_stream/envoy_quic_crypto_server_stream.h"
 
+#include "envoy_tls_server_handshaker.h"
+#include "quiche/quic/core/tls_server_handshaker.h"
+
 namespace Envoy {
 namespace Quic {
 
@@ -10,9 +13,21 @@ EnvoyQuicCryptoServerStreamFactoryImpl::createEnvoyQuicCryptoServerStream(
     quic::QuicCryptoServerStreamBase::Helper* helper,
     // Though this extension doesn't use the two parameters below, they might be used by
     // downstreams. Do not remove them.
-    OptRef<const Network::DownstreamTransportSocketFactory> /*transport_socket_factory*/,
-    Envoy::Event::Dispatcher& /*dispatcher*/) {
-  return quic::CreateCryptoServerStream(crypto_config, compressed_certs_cache, session, helper);
+    OptRef<const Network::DownstreamTransportSocketFactory> transport_socket_factory,
+    Envoy::Event::Dispatcher& dispatcher) {
+  switch (session->connection()->version().handshake_protocol) {
+  case quic::PROTOCOL_QUIC_CRYPTO:
+    return quic::CreateCryptoServerStream(crypto_config, compressed_certs_cache, session, helper);
+  case quic::PROTOCOL_TLS1_3:
+    return std::unique_ptr<EnvoyTlsServerHandshaker>(
+        new EnvoyTlsServerHandshaker(session, crypto_config, transport_socket_factory, dispatcher));
+  case quic::PROTOCOL_UNSUPPORTED:
+    break;
+  }
+  QUIC_BUG(quic_bug_10492_1) << "Unknown handshake protocol: "
+                             << static_cast<int>(
+                                    session->connection()->version().handshake_protocol);
+  return nullptr;
 }
 
 REGISTER_FACTORY(EnvoyQuicCryptoServerStreamFactoryImpl,

--- a/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.cc
+++ b/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.cc
@@ -23,7 +23,7 @@ ssl_private_key_result_t EnvoyTlsServerHandshaker::PrivateKeySign(uint8_t* out, 
                                                                   size_t max_out, uint16_t sig_alg,
                                                                   absl::string_view in) {
   if (transport_socket_factory_->getTlsCertificates().size() > 0) {
-    // TODO(soulxu): Currently the QUIC transport socket only support one certficate. After
+    // TODO(soulxu): Currently the QUIC transport socket only support one certificate. After
     // QUIC transport socket with multiple certificates, we will figure out how to support
     // multiple certificates for private key provider also.
     auto private_key_method =

--- a/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.cc
+++ b/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.cc
@@ -1,0 +1,72 @@
+#include "envoy_tls_server_handshaker.h"
+
+namespace Envoy {
+namespace Quic {
+
+EnvoyTlsServerHandshaker::EnvoyTlsServerHandshaker(
+    quic::QuicSession* session, const quic::QuicCryptoServerConfig* crypto_config,
+    OptRef<const Network::DownstreamTransportSocketFactory> transport_socket_factory,
+    Envoy::Event::Dispatcher& dispatcher)
+    : quic::TlsServerHandshaker(session, crypto_config) {
+  if (transport_socket_factory != absl::nullopt) {
+    transport_socket_factory_.emplace(
+        dynamic_cast<const QuicServerTransportSocketFactory&>(transport_socket_factory.ref()));
+    for (auto cert_config : transport_socket_factory_->getTlsCertificates()) {
+      if (cert_config.get().privateKeyMethod()) {
+        cert_config.get().privateKeyMethod()->registerPrivateKeyMethod(GetSsl(), *this, dispatcher);
+      }
+    }
+  }
+}
+
+ssl_private_key_result_t EnvoyTlsServerHandshaker::PrivateKeySign(uint8_t* out, size_t* out_len,
+                                                                  size_t max_out, uint16_t sig_alg,
+                                                                  absl::string_view in) {
+  if (transport_socket_factory_->getTlsCertificates().size() > 0) {
+    auto private_key_method =
+        transport_socket_factory_->getTlsCertificates()[0].get().privateKeyMethod();
+    if (private_key_method != nullptr) {
+      auto ret = private_key_method->getBoringSslPrivateKeyMethod()->sign(
+          GetSsl(), out, out_len, max_out, sig_alg, reinterpret_cast<const uint8_t*>(in.data()),
+          in.size());
+      if (ret == ssl_private_key_retry) {
+        set_expected_ssl_error(SSL_ERROR_WANT_PRIVATE_KEY_OPERATION);
+      }
+      return ret;
+    }
+  }
+  return quic::TlsServerHandshaker::PrivateKeySign(out, out_len, max_out, sig_alg, in);
+}
+
+ssl_private_key_result_t EnvoyTlsServerHandshaker::PrivateKeyComplete(uint8_t* out, size_t* out_len,
+                                                                      size_t max_out) {
+  if (transport_socket_factory_->getTlsCertificates().size() > 0) {
+    auto private_key_method =
+        transport_socket_factory_->getTlsCertificates()[0].get().privateKeyMethod();
+    if (private_key_method != nullptr) {
+      auto ret = private_key_method->getBoringSslPrivateKeyMethod()->complete(GetSsl(), out,
+                                                                              out_len, max_out);
+      if (ret == ssl_private_key_success) {
+        set_expected_ssl_error(SSL_ERROR_WANT_READ);
+      }
+      return ret;
+    }
+  }
+  return quic::TlsServerHandshaker::PrivateKeyComplete(out, out_len, max_out);
+}
+
+void EnvoyTlsServerHandshaker::onPrivateKeyMethodComplete() { AdvanceHandshakeFromCallback(); }
+
+void EnvoyTlsServerHandshaker::FinishHandshake() {
+  quic::TlsServerHandshaker::FinishHandshake();
+  if (transport_socket_factory_ != absl::nullopt) {
+    for (auto cert_config : transport_socket_factory_->getTlsCertificates()) {
+      if (cert_config.get().privateKeyMethod()) {
+        cert_config.get().privateKeyMethod()->unregisterPrivateKeyMethod(GetSsl());
+      }
+    }
+  }
+}
+
+} // namespace Quic
+} // namespace Envoy

--- a/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.cc
+++ b/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.cc
@@ -23,6 +23,9 @@ ssl_private_key_result_t EnvoyTlsServerHandshaker::PrivateKeySign(uint8_t* out, 
                                                                   size_t max_out, uint16_t sig_alg,
                                                                   absl::string_view in) {
   if (transport_socket_factory_->getTlsCertificates().size() > 0) {
+    // TODO(soulxu): Currently the QUIC transport socket only support one certficate. After
+    // QUIC transport socket with multiple certificates, we will figure out how to support
+    // multiple certificates for private key provider also.
     auto private_key_method =
         transport_socket_factory_->getTlsCertificates()[0].get().privateKeyMethod();
     if (private_key_method != nullptr) {

--- a/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.h
+++ b/source/extensions/quic/crypto_stream/envoy_tls_server_handshaker.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "envoy/ssl/private_key/private_key_callbacks.h"
+
+#include "source/common/quic/quic_server_transport_socket_factory.h"
+
+#include "quiche/quic/core/tls_server_handshaker.h"
+
+namespace Envoy {
+namespace Quic {
+
+class EnvoyTlsServerHandshaker : public quic::TlsServerHandshaker,
+                                 public Envoy::Ssl::PrivateKeyConnectionCallbacks {
+public:
+  EnvoyTlsServerHandshaker(
+      quic::QuicSession* session, const quic::QuicCryptoServerConfig* crypto_config,
+      OptRef<const Network::DownstreamTransportSocketFactory> transport_socket_factory,
+      Envoy::Event::Dispatcher& dispatcher);
+
+  ssl_private_key_result_t PrivateKeySign(uint8_t* out, size_t* out_len, size_t max_out,
+                                          uint16_t sig_alg, absl::string_view in) override;
+  ssl_private_key_result_t PrivateKeyComplete(uint8_t* out, size_t* out_len,
+                                              size_t max_out) override;
+  void onPrivateKeyMethodComplete() override;
+
+protected:
+  void FinishHandshake() override;
+
+private:
+  OptRef<const QuicServerTransportSocketFactory> transport_socket_factory_;
+};
+
+} // namespace Quic
+} // namespace Envoy

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -169,6 +169,7 @@ envoy_cc_test(
         "//source/common/quic:envoy_quic_server_connection_lib",
         "//source/common/quic:envoy_quic_server_session_lib",
         "//source/common/quic:server_codec_lib",
+        "//source/extensions/quic/crypto_stream:envoy_quic_crypto_server_stream_lib",
         "//source/server:configuration_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/http:http_mocks",

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1518,7 +1518,7 @@ void ConfigHelper::initializeTls(
       tls_certificate->mutable_private_key_provider()->set_provider_name("test");
       ProtobufWkt::Struct message;
       std::string sync_mode = test_private_key_provider_sync_mode ? "true" : "false";
-      MessageUtil::loadFromJson(
+      TestUtility::loadFromJson(
           "{\"private_key_file\":\"" +
               TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem") +
               "\", \"expected_operation\":\"sign\", \"mode\":\"rsa\", \"sync_mode\":" + sync_mode +

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1519,16 +1519,16 @@ void ConfigHelper::initializeTls(
       ProtobufWkt::Struct message;
       std::string sync_mode = test_private_key_provider_sync_mode ? "true" : "false";
 #ifdef ENVOY_ENABLE_YAML
-          TestUtility::loadFromJson(
-            "{\"private_key_file\":\"" +
-                TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem") +
-                "\", \"expected_operation\":\"sign\", \"mode\":\"rsa\", \"sync_mode\":" + sync_mode +
-                "}",
-            message);
+      TestUtility::loadFromJson(
+          "{\"private_key_file\":\"" +
+              TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem") +
+              "\", \"expected_operation\":\"sign\", \"mode\":\"rsa\", \"sync_mode\":" + sync_mode +
+              "}",
+          message);
 #else
-          UNREFERENCED_PARAMETER(message);
-          UNREFERENCED_PARAMETER(sync_mode);
-          PANIC("YAML support compiled out");
+      UNREFERENCED_PARAMETER(message);
+      UNREFERENCED_PARAMETER(sync_mode);
+      PANIC("YAML support compiled out");
 #endif
       tls_certificate->mutable_private_key_provider()->mutable_typed_config()->PackFrom(message);
     }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1518,12 +1518,18 @@ void ConfigHelper::initializeTls(
       tls_certificate->mutable_private_key_provider()->set_provider_name("test");
       ProtobufWkt::Struct message;
       std::string sync_mode = test_private_key_provider_sync_mode ? "true" : "false";
-      TestUtility::loadFromJson(
-          "{\"private_key_file\":\"" +
-              TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem") +
-              "\", \"expected_operation\":\"sign\", \"mode\":\"rsa\", \"sync_mode\":" + sync_mode +
-              "}",
-          message);
+#ifdef ENVOY_ENABLE_YAML
+          TestUtility::loadFromJson(
+            "{\"private_key_file\":\"" +
+                TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem") +
+                "\", \"expected_operation\":\"sign\", \"mode\":\"rsa\", \"sync_mode\":" + sync_mode +
+                "}",
+            message);
+#else
+          UNREFERENCED_PARAMETER(config);
+          UNREFERENCED_PARAMETER(filter_list_back);
+          PANIC("YAML support compiled out");
+#endif
       tls_certificate->mutable_private_key_provider()->mutable_typed_config()->PackFrom(message);
     }
     if (options.rsa_cert_ocsp_staple_) {

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1321,8 +1321,7 @@ void ConfigHelper::addSslConfig(const ServerSslOptions& options) {
 
 void ConfigHelper::addQuicDownstreamTransportSocketConfig(
     bool enable_early_data, std::vector<absl::string_view> custom_alpns,
-    bool with_test_private_key_provider,
-    bool test_private_key_provider_sync_mode) {
+    bool with_test_private_key_provider, bool test_private_key_provider_sync_mode) {
   for (auto& listener : *bootstrap_.mutable_static_resources()->mutable_listeners()) {
     if (listener.udp_listener_config().has_quic_options()) {
       // Disable SO_REUSEPORT, because it undesirably allows parallel test jobs to use the same
@@ -1333,8 +1332,8 @@ void ConfigHelper::addQuicDownstreamTransportSocketConfig(
   configDownstreamTransportSocketWithTls(
       bootstrap_,
       [&](envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& common_tls_context) {
-        initializeTls(ServerSslOptions().setRsaCert(true).setTlsV13(true), common_tls_context,
-                      true, with_test_private_key_provider, test_private_key_provider_sync_mode);
+        initializeTls(ServerSslOptions().setRsaCert(true).setTlsV13(true), common_tls_context, true,
+                      with_test_private_key_provider, test_private_key_provider_sync_mode);
         for (absl::string_view alpn : custom_alpns) {
           common_tls_context.add_alpn_protocols(alpn);
         }
@@ -1454,8 +1453,8 @@ void ConfigHelper::initializeTlsKeyLog(
 
 void ConfigHelper::initializeTls(
     const ServerSslOptions& options,
-    envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& common_tls_context,
-    bool http3, bool with_test_private_key_provider, bool test_private_key_provider_sync_mode) {
+    envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& common_tls_context, bool http3,
+    bool with_test_private_key_provider, bool test_private_key_provider_sync_mode) {
   if (!http3) {
     // If it's HTTP/3, leave it empty as QUIC will derive the supported ALPNs from QUIC version by
     // default.

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1526,8 +1526,8 @@ void ConfigHelper::initializeTls(
                 "}",
             message);
 #else
-          UNREFERENCED_PARAMETER(config);
-          UNREFERENCED_PARAMETER(filter_list_back);
+          UNREFERENCED_PARAMETER(message);
+          UNREFERENCED_PARAMETER(sync_mode);
           PANIC("YAML support compiled out");
 #endif
       tls_certificate->mutable_private_key_provider()->mutable_typed_config()->PackFrom(message);

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -160,8 +160,7 @@ public:
   static void
   initializeTls(const ServerSslOptions& options,
                 envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& common_context,
-                bool http3,
-                bool with_test_private_key_provider = false,
+                bool http3, bool with_test_private_key_provider = false,
                 bool test_private_key_provider_sync_mode = false);
 
   static void initializeTlsKeyLog(

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -160,7 +160,9 @@ public:
   static void
   initializeTls(const ServerSslOptions& options,
                 envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& common_context,
-                bool http3);
+                bool http3,
+                bool with_test_private_key_provider = false,
+                bool test_private_key_provider_sync_mode = false);
 
   static void initializeTlsKeyLog(
       envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& common_tls_context,
@@ -338,7 +340,9 @@ public:
 
   // Add the default SSL configuration for QUIC downstream.
   void addQuicDownstreamTransportSocketConfig(bool enable_early_data,
-                                              std::vector<absl::string_view> custom_alpns);
+                                              std::vector<absl::string_view> custom_alpns,
+                                              bool with_test_private_key_provider = false,
+                                              bool test_private_key_provider_sync_mode = false);
 
   // Set the HTTP access log for the first HCM (if present) to a given file. The default is
   // the platform's null device.

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
@@ -395,6 +395,8 @@ TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
   pkey_ = std::move(pkey);
 }
 
+REGISTER_FACTORY(TestPrivateKeyMethodFactory, Ssl::PrivateKeyMethodProviderInstanceFactory);
+
 } // namespace PrivateKeyMethodProvider
 } // namespace Extensions
 } // namespace Envoy

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -2401,6 +2401,7 @@ envoy_cc_test(
         "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
         "//test/common/config:dummy_config_proto_cc_proto",
         "//test/extensions/transport_sockets/tls/cert_validator:timed_cert_validator",
+        "//test/extensions/transport_sockets/tls:test_private_key_method_provider_test_lib",
         ":http_integration_lib",
         ":socket_interface_swap_lib",
         "//source/common/quic:client_connection_factory_lib",

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -372,7 +372,8 @@ void HttpIntegrationTest::initialize() {
 
   // Needed to config QUIC transport socket factory, and needs to be added before base class calls
   // initialize().
-  config_helper_.addQuicDownstreamTransportSocketConfig(enable_quic_early_data_, custom_alpns_);
+  config_helper_.addQuicDownstreamTransportSocketConfig(enable_quic_early_data_, custom_alpns_,
+                                                        enable_test_private_key_provider_);
 
   BaseIntegrationTest::initialize();
   registerTestServerPorts({"http"}, test_server_);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -369,6 +369,8 @@ protected:
   quic::DeterministicConnectionIdGenerator connection_id_generator_{
       quic::kQuicDefaultConnectionIdLength};
 #endif
+  bool enable_test_private_key_provider_{false};
+  bool test_private_key_provider_sync_mode_{false};
 };
 
 // Helper class for integration tests using raw HTTP/2 frames

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -417,6 +417,34 @@ public:
       : QuicHttpIntegrationTestBase(GetParam(), ConfigHelper::quicHttpProxyConfig()) {}
 };
 
+class QuicHttpPrivateKeyProviderAsyncIntegrationTest
+    : public QuicHttpIntegrationTestBase,
+      public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  QuicHttpPrivateKeyProviderAsyncIntegrationTest()
+      : QuicHttpIntegrationTestBase(GetParam(), ConfigHelper::quicHttpProxyConfig()) {}
+
+  void initialize() override {
+    enable_test_private_key_provider_ = true;
+    test_private_key_provider_sync_mode_ = false;
+    QuicHttpIntegrationTestBase::initialize();
+  }
+};
+
+class QuicHttpPrivateKeyProviderSyncIntegrationTest
+    : public QuicHttpIntegrationTestBase,
+      public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  QuicHttpPrivateKeyProviderSyncIntegrationTest()
+      : QuicHttpIntegrationTestBase(GetParam(), ConfigHelper::quicHttpProxyConfig()) {}
+
+  void initialize() override {
+    enable_test_private_key_provider_ = true;
+    test_private_key_provider_sync_mode_ = true;
+    QuicHttpIntegrationTestBase::initialize();
+  }
+};
+
 class QuicHttpMultiAddressesIntegrationTest
     : public QuicHttpIntegrationTestBase,
       public testing::TestWithParam<Network::Address::IpVersion> {
@@ -526,7 +554,14 @@ public:
 INSTANTIATE_TEST_SUITE_P(QuicHttpIntegrationTests, QuicHttpIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
-
+INSTANTIATE_TEST_SUITE_P(QuicHttpPrivateKeyProviderSyncIntegrationTest,
+                         QuicHttpPrivateKeyProviderSyncIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(QuicHttpPrivateKeyProviderAsyncIntegrationTest,
+                         QuicHttpPrivateKeyProviderAsyncIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 INSTANTIATE_TEST_SUITE_P(QuicHttpMultiAddressesIntegrationTest,
                          QuicHttpMultiAddressesIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
@@ -695,6 +730,16 @@ TEST_P(QuicHttpIntegrationTest, EarlyDataDisabled) {
 
 // Ensure multiple quic connections work, regardless of platform BPF support
 TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsDefaultMode) {
+  testMultipleQuicConnections();
+}
+
+// Ensure multiple quic connections work, regardless of platform BPF support
+TEST_P(QuicHttpPrivateKeyProviderSyncIntegrationTest, MultipleQuicConnectionsDefaultMode) {
+  testMultipleQuicConnections();
+}
+
+// Ensure multiple quic connections work, regardless of platform BPF support
+TEST_P(QuicHttpPrivateKeyProviderAsyncIntegrationTest, MultipleQuicConnectionsDefaultMode) {
   testMultipleQuicConnections();
 }
 


### PR DESCRIPTION
Commit Message: quic: add Private Key Provider support
Additional Description:

This PR adds private key provider support to the QUIC over TLS 1.3

Risk Level: low
Testing: unittest and integration test
Docs Changes: api
Release Notes: new feature
Platform Specific Features: n/a

