### PR TITLE
quic: remove duplicate code in QUIC encodeData(), encodeMetadata() and encodeTrailers() implementations

### DIFF
--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -651,7 +651,9 @@ envoy_cc_library(
     tags = ["nofips"],
     deps = [
         "//envoy/access_log:access_log_interface",
+        "//envoy/formatter:http_formatter_context_interface",
         "//envoy/http:codec_interface",
+        "//source/common/formatter:substitution_formatter_lib",
         "//source/common/http:header_map_lib",
         "@com_github_google_quiche//:quic_core_ack_listener_interface_lib",
     ],

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -145,19 +145,25 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "envoy_quic_stream_lib",
+    srcs = ["envoy_quic_stream.cc"],
     hdrs = ["envoy_quic_stream.h"],
     tags = ["nofips"],
     deps = [
         ":envoy_quic_simulated_watermark_buffer_lib",
         ":envoy_quic_utils_lib",
         ":quic_filter_manager_connection_lib",
+        ":quic_stats_gatherer",
         ":send_buffer_monitor_lib",
         "//envoy/event:dispatcher_interface",
         "//envoy/http:codec_interface",
         "//source/common/http:codec_helper_lib",
         "@com_github_google_quiche//:http2_adapter",
+        "@com_github_google_quiche//:quic_core_http_client_lib",
+        "@com_github_google_quiche//:quic_core_http_http_encoder_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
-    ],
+    ] + envoy_select_enable_http_datagrams([
+        ":http_datagram_handler",
+    ]),
 )
 
 envoy_cc_library(

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -138,12 +138,6 @@ void EnvoyQuicClientStream::encodeTrailers(const Http::RequestTrailerMap& traile
   onLocalEndStream();
 }
 
-void EnvoyQuicClientStream::encodeMetadata(const Http::MetadataMapVector& /*metadata_map_vector*/) {
-  // Metadata Frame is not supported in QUICHE.
-  ENVOY_STREAM_LOG(debug, "METADATA is not supported in Http3.", *this);
-  stats_.metadata_not_supported_error_.inc();
-}
-
 void EnvoyQuicClientStream::resetStream(Http::StreamResetReason reason) {
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
   if (http_datagram_handler_) {

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -23,6 +23,7 @@ EnvoyQuicClientStream::EnvoyQuicClientStream(
     const envoy::config::core::v3::Http3ProtocolOptions& http3_options)
     : quic::QuicSpdyClientStream(id, client_session, type),
       EnvoyQuicStream(
+          *this,
           // Flow control receive window should be larger than 8k so that the send buffer can fully
           // utilize congestion control window before it reaches the high watermark.
           static_cast<uint32_t>(GetReceiveWindow().value()), *filterManagerConnection(),
@@ -113,77 +114,6 @@ Http::Status EnvoyQuicClientStream::encodeHeaders(const Http::RequestHeaderMap& 
     onLocalEndStream();
   }
   return Http::okStatus();
-}
-
-void EnvoyQuicClientStream::encodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_STREAM_LOG(debug, "encodeData (end_stream={}) of {} bytes.", *this, end_stream,
-                   data.length());
-  const bool has_data = data.length() > 0;
-  if (!has_data && !end_stream) {
-    return;
-  }
-  if (write_side_closed()) {
-    IS_ENVOY_BUG("encodeData is called on write-closed stream.");
-    return;
-  }
-  ASSERT(!local_end_stream_);
-  local_end_stream_ = end_stream;
-  SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);
-#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
-  if (http_datagram_handler_) {
-    IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), false);
-    if (!http_datagram_handler_->encodeCapsuleFragment(data.toString(), end_stream)) {
-      Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
-      return;
-    }
-  } else {
-#endif
-    Buffer::RawSliceVector raw_slices = data.getRawSlices();
-    absl::InlinedVector<quiche::QuicheMemSlice, 4> quic_slices;
-    quic_slices.reserve(raw_slices.size());
-    for (auto& slice : raw_slices) {
-      ASSERT(slice.len_ != 0);
-      // Move each slice into a stand-alone buffer.
-      // TODO(danzh): investigate the cost of allocating one buffer per slice.
-      // If it turns out to be expensive, add a new function to free data in the middle in buffer
-      // interface and re-design QuicheMemSliceImpl.
-      if (!Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.quiche_use_mem_slice_releasor_api")) {
-        quic_slices.emplace_back(quiche::QuicheMemSlice::InPlace(), data, slice.len_);
-      } else {
-        auto single_slice_buffer = std::make_unique<Buffer::OwnedImpl>();
-        single_slice_buffer->move(data, slice.len_);
-        quic_slices.emplace_back(
-            reinterpret_cast<char*>(slice.mem_), slice.len_,
-            [single_slice_buffer = std::move(single_slice_buffer)](const char*) mutable {
-              // Free this memory explicitly when the callback is invoked.
-              single_slice_buffer = nullptr;
-            });
-      }
-    }
-    quic::QuicConsumedData result{0, false};
-    absl::Span<quiche::QuicheMemSlice> span(quic_slices);
-    {
-      IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), false);
-      result = WriteBodySlices(span, end_stream);
-    }
-    // QUIC stream must take all.
-    if (result.bytes_consumed == 0 && has_data) {
-      IS_ENVOY_BUG(fmt::format("Send buffer didn't take all the data. Stream is write {} with {} "
-                               "bytes in send buffer. Current write was rejected.",
-                               write_side_closed() ? "closed" : "open", BufferedDataBytes()));
-      Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
-      return;
-    }
-#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
-  }
-#endif
-  if (local_end_stream_) {
-    if (codec_callbacks_) {
-      codec_callbacks_->onCodecEncodeComplete();
-    }
-    onLocalEndStream();
-  }
 }
 
 void EnvoyQuicClientStream::encodeTrailers(const Http::RequestTrailerMap& trailers) {

--- a/source/common/quic/envoy_quic_client_stream.h
+++ b/source/common/quic/envoy_quic_client_stream.h
@@ -25,7 +25,6 @@ public:
   void setResponseDecoder(Http::ResponseDecoder& decoder) { response_decoder_ = &decoder; }
 
   // Http::StreamEncoder
-  void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector) override;
   Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
     return absl::nullopt;
   }

--- a/source/common/quic/envoy_quic_client_stream.h
+++ b/source/common/quic/envoy_quic_client_stream.h
@@ -25,7 +25,6 @@ public:
   void setResponseDecoder(Http::ResponseDecoder& decoder) { response_decoder_ = &decoder; }
 
   // Http::StreamEncoder
-  void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector) override;
   Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
     return absl::nullopt;
@@ -89,10 +88,6 @@ private:
 
   Http::ResponseDecoder* response_decoder_{nullptr};
   bool decoded_1xx_{false};
-#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
-  // Setting |http_datagram_handler_| enables HTTP Datagram support.
-  std::unique_ptr<HttpDatagramHandler> http_datagram_handler_;
-#endif
 
   // When an HTTP Upgrade is requested, this contains the protocol upgrade type, e.g. "websocket".
   // It will be empty, when no such request is active.

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -113,12 +113,6 @@ void EnvoyQuicServerStream::encodeTrailers(const Http::ResponseTrailerMap& trail
   onLocalEndStream();
 }
 
-void EnvoyQuicServerStream::encodeMetadata(const Http::MetadataMapVector& /*metadata_map_vector*/) {
-  // Metadata Frame is not supported in QUIC.
-  ENVOY_STREAM_LOG(debug, "METADATA is not supported in Http3.", *this);
-  stats_.metadata_not_supported_error_.inc();
-}
-
 void EnvoyQuicServerStream::resetStream(Http::StreamResetReason reason) {
   if (buffer_memory_account_) {
     buffer_memory_account_->clearDownstream();

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -30,6 +30,7 @@ EnvoyQuicServerStream::EnvoyQuicServerStream(
         headers_with_underscores_action)
     : quic::QuicSpdyServerStreamBase(id, session, type),
       EnvoyQuicStream(
+          *this,
           // Flow control receive window should be larger than 8k to fully utilize congestion
           // control window before it reaches the high watermark.
           static_cast<uint32_t>(GetReceiveWindow().value()), *filterManagerConnection(),
@@ -81,78 +82,6 @@ void EnvoyQuicServerStream::encodeHeaders(const Http::ResponseHeaderMap& headers
     ENVOY_BUG(bytes_sent != 0, "Failed to encode headers.");
   }
 
-  if (local_end_stream_) {
-    if (codec_callbacks_) {
-      codec_callbacks_->onCodecEncodeComplete();
-    }
-    onLocalEndStream();
-  }
-}
-
-void EnvoyQuicServerStream::encodeData(Buffer::Instance& data, bool end_stream) {
-  ENVOY_STREAM_LOG(debug, "encodeData (end_stream={}) of {} bytes.", *this, end_stream,
-                   data.length());
-  const bool has_data = data.length() > 0;
-  if (!has_data && !end_stream) {
-    return;
-  }
-  if (write_side_closed()) {
-    IS_ENVOY_BUG("encodeData is called on write-closed stream.");
-    return;
-  }
-  ASSERT(!local_end_stream_);
-  local_end_stream_ = end_stream;
-  SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);
-#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
-  if (http_datagram_handler_) {
-    IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), false);
-    if (!http_datagram_handler_->encodeCapsuleFragment(data.toString(), end_stream)) {
-      Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
-      return;
-    }
-  } else {
-#endif
-    Buffer::RawSliceVector raw_slices = data.getRawSlices();
-    absl::InlinedVector<quiche::QuicheMemSlice, 4> quic_slices;
-    quic_slices.reserve(raw_slices.size());
-    for (auto& slice : raw_slices) {
-      ASSERT(slice.len_ != 0);
-      // Move each slice into a stand-alone buffer.
-      // TODO(danzh): investigate the cost of allocating one buffer per slice.
-      // If it turns out to be expensive, add a new function to free data in the middle in buffer
-      // interface and re-design QuicheMemSliceImpl.
-      if (!Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.quiche_use_mem_slice_releasor_api")) {
-        quic_slices.emplace_back(quiche::QuicheMemSlice::InPlace(), data, slice.len_);
-      } else {
-        auto single_slice_buffer = std::make_unique<Buffer::OwnedImpl>();
-        single_slice_buffer->move(data, slice.len_);
-        quic_slices.emplace_back(
-            reinterpret_cast<char*>(slice.mem_), slice.len_,
-            [single_slice_buffer = std::move(single_slice_buffer)](const char*) mutable {
-              // Free this memory explicitly when the callback is invoked.
-              single_slice_buffer = nullptr;
-            });
-      }
-    }
-    quic::QuicConsumedData result{0, false};
-    absl::Span<quiche::QuicheMemSlice> span(quic_slices);
-    {
-      IncrementalBytesSentTracker tracker(*this, *mutableBytesMeter(), false);
-      result = WriteBodySlices(span, end_stream);
-      stats_gatherer_->addBytesSent(result.bytes_consumed, end_stream);
-    }
-    // QUIC stream must take all.
-    if (result.bytes_consumed == 0 && has_data) {
-      IS_ENVOY_BUG(fmt::format("Send buffer didn't take all the data. Stream is write {} with {} "
-                               "bytes in send buffer. Current write was rejected.",
-                               write_side_closed() ? "closed" : "open", BufferedDataBytes()));
-      Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
-      return;
-    }
-#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
-  }
-#endif
   if (local_end_stream_) {
     if (codec_callbacks_) {
       codec_callbacks_->onCodecEncodeComplete();

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -118,11 +118,6 @@ private:
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_;
 
-  quiche::QuicheReferenceCountedPointer<QuicStatsGatherer> stats_gatherer_;
-#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
-  // Setting |http_datagram_handler_| enables HTTP Datagram support.
-  std::unique_ptr<HttpDatagramHandler> http_datagram_handler_;
-#endif
   // True if a :path header has been seen before.
   bool saw_path_{false};
 };

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -5,7 +5,6 @@
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
 #include "source/common/quic/http_datagram_handler.h"
 #endif
-#include "source/common/quic/quic_stats_gatherer.h"
 
 #include "quiche/common/platform/api/quiche_reference_counted.h"
 #include "quiche/quic/core/http/quic_spdy_server_stream_base.h"
@@ -28,12 +27,10 @@ public:
     request_decoder_ = &decoder;
     stats_gatherer_->setAccessLogHandlers(request_decoder_->accessLogHandlers());
   }
-  QuicStatsGatherer* statsGatherer() { return stats_gatherer_.get(); }
 
   // Http::StreamEncoder
   void encode1xxHeaders(const Http::ResponseHeaderMap& headers) override;
   void encodeHeaders(const Http::ResponseHeaderMap& headers, bool end_stream) override;
-  void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(const Http::ResponseTrailerMap& trailers) override;
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector) override;
   Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -32,7 +32,6 @@ public:
   void encode1xxHeaders(const Http::ResponseHeaderMap& headers) override;
   void encodeHeaders(const Http::ResponseHeaderMap& headers, bool end_stream) override;
   void encodeTrailers(const Http::ResponseTrailerMap& trailers) override;
-  void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector) override;
   Http::Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
     return absl::nullopt;
   }

--- a/source/common/quic/envoy_quic_stream.cc
+++ b/source/common/quic/envoy_quic_stream.cc
@@ -79,5 +79,11 @@ void EnvoyQuicStream::encodeData(Buffer::Instance& data, bool end_stream) {
   }
 }
 
+void EnvoyQuicStream::encodeMetadata(const Http::MetadataMapVector& /*metadata_map_vector*/) {
+  // Metadata Frame is not supported in QUICHE.
+  ENVOY_STREAM_LOG(debug, "METADATA is not supported in Http3.", *this);
+  stats_.metadata_not_supported_error_.inc();
+}
+
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_stream.cc
+++ b/source/common/quic/envoy_quic_stream.cc
@@ -1,0 +1,83 @@
+#include "source/common/quic/envoy_quic_stream.h"
+
+#include "source/common/http/utility.h"
+
+#include "quiche/quic/core/http/http_encoder.h"
+#include "quiche/quic/core/qpack/qpack_encoder.h"
+#include "quiche/quic/core/qpack/qpack_instruction_encoder.h"
+
+namespace Envoy {
+namespace Quic {
+
+void EnvoyQuicStream::encodeData(Buffer::Instance& data, bool end_stream) {
+  ENVOY_STREAM_LOG(debug, "encodeData (end_stream={}) of {} bytes.", *this, end_stream,
+                   data.length());
+  const bool has_data = data.length() > 0;
+  if (!has_data && !end_stream) {
+    return;
+  }
+  if (quic_stream_.write_side_closed()) {
+    IS_ENVOY_BUG("encodeData is called on write-closed stream.");
+    return;
+  }
+  ASSERT(!local_end_stream_);
+  local_end_stream_ = end_stream;
+  SendBufferMonitor::ScopedWatermarkBufferUpdater updater(&quic_stream_, this);
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  if (http_datagram_handler_) {
+    IncrementalBytesSentTracker tracker(quic_stream_, *mutableBytesMeter(), false);
+    if (!http_datagram_handler_->encodeCapsuleFragment(data.toString(), end_stream)) {
+      quic_stream_.Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
+      return;
+    }
+  } else {
+#endif
+    Buffer::RawSliceVector raw_slices = data.getRawSlices();
+    absl::InlinedVector<quiche::QuicheMemSlice, 4> quic_slices;
+    quic_slices.reserve(raw_slices.size());
+    for (auto& slice : raw_slices) {
+      ASSERT(slice.len_ != 0);
+      // Move each slice into a stand-alone buffer.
+      // TODO(danzh): investigate the cost of allocating one buffer per slice.
+      // If it turns out to be expensive, add a new function to free data in the middle in buffer
+      // interface and re-design QuicheMemSliceImpl.
+      auto single_slice_buffer = std::make_unique<Buffer::OwnedImpl>();
+      single_slice_buffer->move(data, slice.len_);
+      quic_slices.emplace_back(
+          reinterpret_cast<char*>(slice.mem_), slice.len_,
+          [single_slice_buffer = std::move(single_slice_buffer)](const char*) mutable {
+            // Free this memory explicitly when the callback is invoked.
+            single_slice_buffer = nullptr;
+          });
+    }
+    quic::QuicConsumedData result{0, false};
+    absl::Span<quiche::QuicheMemSlice> span(quic_slices);
+    {
+      IncrementalBytesSentTracker tracker(quic_stream_, *mutableBytesMeter(), false);
+      result = quic_stream_.WriteBodySlices(span, end_stream);
+      if (stats_gatherer_ != nullptr) {
+        stats_gatherer_->addBytesSent(result.bytes_consumed, end_stream);
+      }
+    }
+    // QUIC stream must take all.
+    if (result.bytes_consumed == 0 && has_data) {
+      IS_ENVOY_BUG(fmt::format("Send buffer didn't take all the data. Stream is write {} with {} "
+                               "bytes in send buffer. Current write was rejected.",
+                               quic_stream_.write_side_closed() ? "closed" : "open",
+                               quic_stream_.BufferedDataBytes()));
+      quic_stream_.Reset(quic::QUIC_BAD_APPLICATION_PAYLOAD);
+      return;
+    }
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  }
+#endif
+  if (local_end_stream_) {
+    if (codec_callbacks_) {
+      codec_callbacks_->onCodecEncodeComplete();
+    }
+    onLocalEndStream();
+  }
+}
+
+} // namespace Quic
+} // namespace Envoy

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -10,10 +10,13 @@
 #include "source/common/http/codec_helper.h"
 #include "source/common/quic/envoy_quic_simulated_watermark_buffer.h"
 #include "source/common/quic/envoy_quic_utils.h"
+#include "source/common/quic/http_datagram_handler.h"
 #include "source/common/quic/quic_filter_manager_connection_impl.h"
 #include "source/common/quic/send_buffer_monitor.h"
 
+#include "source/common/quic/quic_stats_gatherer.h"
 #include "quiche/http2/adapter/header_validator.h"
+#include "quiche/quic/core/http/quic_spdy_stream.h"
 
 namespace Envoy {
 namespace Quic {
@@ -27,12 +30,12 @@ class EnvoyQuicStream : public virtual Http::StreamEncoder,
 public:
   // |buffer_limit| is the high watermark of the stream send buffer, and the low
   // watermark will be half of it.
-  EnvoyQuicStream(uint32_t buffer_limit, QuicFilterManagerConnectionImpl& filter_manager_connection,
+  EnvoyQuicStream(quic::QuicSpdyStream& quic_stream, uint32_t buffer_limit, QuicFilterManagerConnectionImpl& filter_manager_connection,
                   std::function<void()> below_low_watermark,
                   std::function<void()> above_high_watermark, Http::Http3::CodecStats& stats,
                   const envoy::config::core::v3::Http3ProtocolOptions& http3_options)
       : Http::MultiplexedStreamImplBase(filter_manager_connection.dispatcher()), stats_(stats),
-        http3_options_(http3_options),
+        http3_options_(http3_options), quic_stream_(quic_stream),
         send_buffer_simulation_(buffer_limit / 2, buffer_limit, std::move(below_low_watermark),
                                 std::move(above_high_watermark), ENVOY_LOGGER()),
         filter_manager_connection_(filter_manager_connection),
@@ -44,6 +47,7 @@ public:
 
   // Http::StreamEncoder
   Stream& getStream() override { return *this; }
+  void encodeData(Buffer::Instance& data, bool end_stream) override;
 
   // Http::Stream
   void readDisable(bool disable) override {
@@ -138,7 +142,10 @@ public:
 
   const StreamInfo::BytesMeterSharedPtr& bytesMeter() override { return bytes_meter_; }
 
+  QuicStatsGatherer* statsGatherer() { return stats_gatherer_.get(); }
+
 protected:
+  //virtual void useCapsuleProtocol() PURE;
   virtual void switchStreamBlockState() PURE;
 
   // Needed for ENVOY_STREAM_LOG.
@@ -167,6 +174,12 @@ protected:
 
   StreamInfo::BytesMeterSharedPtr& mutableBytesMeter() { return bytes_meter_; }
 
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  // Setting |http_datagram_handler_| enables HTTP Datagram support.
+  std::unique_ptr<HttpDatagramHandler> http_datagram_handler_;
+#endif
+  quiche::QuicheReferenceCountedPointer<QuicStatsGatherer> stats_gatherer_;
+
   // True once end of stream is propagated to Envoy. Envoy doesn't expect to be
   // notified more than once about end of stream. So once this is true, no need
   // to set it in the callback to Envoy stream any more.
@@ -191,7 +204,10 @@ protected:
   bool saw_regular_headers_{false};
 
 private:
-  // Keeps track of bytes buffered in the stream send buffer in QUICHE and reacts
+  // QUIC stream that this EnvoyQuicStream wraps.
+  quic::QuicSpdyStream& quic_stream_;
+
+    // Keeps track of bytes buffered in the stream send buffer in QUICHE and reacts
   // upon crossing high and low watermarks.
   // Its high watermark is also the buffer limit of stream read/write filters in
   // HCM.

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -10,6 +10,7 @@
 #include "source/common/http/codec_helper.h"
 #include "source/common/quic/envoy_quic_simulated_watermark_buffer.h"
 #include "source/common/quic/envoy_quic_utils.h"
+
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
 #include "source/common/quic/http_datagram_handler.h"
 #endif

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -178,6 +178,8 @@ protected:
 
   StreamInfo::BytesMeterSharedPtr& mutableBytesMeter() { return bytes_meter_; }
 
+  void encodeTrailersImpl(spdy::Http2HeaderBlock&& trailers);
+
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
   // Setting |http_datagram_handler_| enables HTTP Datagram support.
   std::unique_ptr<HttpDatagramHandler> http_datagram_handler_;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -52,6 +52,7 @@ public:
   // Http::StreamEncoder
   Stream& getStream() override { return *this; }
   void encodeData(Buffer::Instance& data, bool end_stream) override;
+  void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector) override;
 
   // Http::Stream
   void readDisable(bool disable) override {

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -145,7 +145,6 @@ public:
   QuicStatsGatherer* statsGatherer() { return stats_gatherer_.get(); }
 
 protected:
-  //virtual void useCapsuleProtocol() PURE;
   virtual void switchStreamBlockState() PURE;
 
   // Needed for ENVOY_STREAM_LOG.
@@ -207,7 +206,7 @@ private:
   // QUIC stream that this EnvoyQuicStream wraps.
   quic::QuicSpdyStream& quic_stream_;
 
-    // Keeps track of bytes buffered in the stream send buffer in QUICHE and reacts
+  // Keeps track of bytes buffered in the stream send buffer in QUICHE and reacts
   // upon crossing high and low watermarks.
   // Its high watermark is also the buffer limit of stream read/write filters in
   // HCM.

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -12,9 +12,9 @@
 #include "source/common/quic/envoy_quic_utils.h"
 #include "source/common/quic/http_datagram_handler.h"
 #include "source/common/quic/quic_filter_manager_connection_impl.h"
+#include "source/common/quic/quic_stats_gatherer.h"
 #include "source/common/quic/send_buffer_monitor.h"
 
-#include "source/common/quic/quic_stats_gatherer.h"
 #include "quiche/http2/adapter/header_validator.h"
 #include "quiche/quic/core/http/quic_spdy_stream.h"
 
@@ -30,7 +30,8 @@ class EnvoyQuicStream : public virtual Http::StreamEncoder,
 public:
   // |buffer_limit| is the high watermark of the stream send buffer, and the low
   // watermark will be half of it.
-  EnvoyQuicStream(quic::QuicSpdyStream& quic_stream, uint32_t buffer_limit, QuicFilterManagerConnectionImpl& filter_manager_connection,
+  EnvoyQuicStream(quic::QuicSpdyStream& quic_stream, uint32_t buffer_limit,
+                  QuicFilterManagerConnectionImpl& filter_manager_connection,
                   std::function<void()> below_low_watermark,
                   std::function<void()> above_high_watermark, Http::Http3::CodecStats& stats,
                   const envoy::config::core::v3::Http3ProtocolOptions& http3_options)

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -10,7 +10,9 @@
 #include "source/common/http/codec_helper.h"
 #include "source/common/quic/envoy_quic_simulated_watermark_buffer.h"
 #include "source/common/quic/envoy_quic_utils.h"
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
 #include "source/common/quic/http_datagram_handler.h"
+#endif
 #include "source/common/quic/quic_filter_manager_connection_impl.h"
 #include "source/common/quic/quic_stats_gatherer.h"
 #include "source/common/quic/send_buffer_monitor.h"

--- a/source/common/quic/quic_stats_gatherer.cc
+++ b/source/common/quic/quic_stats_gatherer.cc
@@ -1,8 +1,8 @@
 #include "source/common/quic/quic_stats_gatherer.h"
 
-#include "envoy/formatter/http_formatter_context.h"
-
 #include <cstdint>
+
+#include "envoy/formatter/http_formatter_context.h"
 
 namespace Envoy {
 namespace Quic {

--- a/source/common/quic/quic_stats_gatherer.cc
+++ b/source/common/quic/quic_stats_gatherer.cc
@@ -1,5 +1,7 @@
 #include "source/common/quic/quic_stats_gatherer.h"
 
+#include "envoy/formatter/http_formatter_context.h"
+
 #include <cstdint>
 
 namespace Envoy {


### PR DESCRIPTION
quic: remove duplicate code in QUIC `encodeData()`, `encodeMetadata()` and `encodeTrailers()` implementations

Add a `QuicSpdyStream&` member to `EnvoyQuicStream` so that the `encodeData()`, `encodeMetadata()` and `encodeTrailers()` implementation can be moved to EnvoyQuicStream and out of the subclasses.

Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A