### PR TITLE
buffer_filter: allow to set the maximum size Without buffering data immediately

### DIFF
--- a/api/envoy/extensions/filters/http/buffer/v3/buffer.proto
+++ b/api/envoy/extensions/filters/http/buffer/v3/buffer.proto
@@ -28,6 +28,11 @@ message Buffer {
   // manager will stop buffering and return a 413 response.
   google.protobuf.UInt32Value max_request_bytes = 1
       [(validate.rules).uint32 = {gt: 0}, (validate.rules).message = {required: true}];
+
+  // Set the maximum request size but doesn't buffer the data immediately.
+  // It's useful when the following filters may do the buffer themselves conditionally, so
+  // we won't buffer the data too early.
+  bool set_limit_only = 3;
 }
 
 message BufferPerRoute {

--- a/api/envoy/extensions/filters/http/buffer/v3/buffer.proto
+++ b/api/envoy/extensions/filters/http/buffer/v3/buffer.proto
@@ -29,9 +29,9 @@ message Buffer {
   google.protobuf.UInt32Value max_request_bytes = 1
       [(validate.rules).uint32 = {gt: 0}, (validate.rules).message = {required: true}];
 
-  // Set the maximum request size but doesn't buffer the data immediately.
-  // It's useful when the following filters may do the buffer themselves conditionally, so
-  // we won't buffer the data too early.
+  // Set the maximum request size but doesn't buffer the data in the Buffer filter.
+  // It's useful when subsequent filters may do the buffering themselves conditionally,
+  // so the Buffer filter doesn't buffer prematurely.
   bool set_limit_only = 3;
 }
 

--- a/source/extensions/filters/http/buffer/buffer_filter.h
+++ b/source/extensions/filters/http/buffer/buffer_filter.h
@@ -21,10 +21,12 @@ public:
   BufferFilterSettings(const envoy::extensions::filters::http::buffer::v3::BufferPerRoute&);
 
   bool disabled() const { return disabled_; }
+  bool setLimitOnly() const { return set_limit_only_; }
   uint64_t maxRequestBytes() const { return max_request_bytes_; }
 
 private:
   bool disabled_;
+  bool set_limit_only_;
   uint64_t max_request_bytes_;
 };
 

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -329,6 +329,16 @@ typed_config:
 )EOF";
 }
 
+std::string ConfigHelper::smallSetLimitOnlyBufferFilter() {
+  return R"EOF(
+name: set_limit_only_buffer
+typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
+    max_request_bytes : 1024
+    set_limit_only : true
+)EOF";
+}
+
 std::string ConfigHelper::defaultHealthCheckFilter() {
   return R"EOF(
 name: health_check

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -195,6 +195,9 @@ public:
   static std::string defaultBufferFilter();
   // A string for a small buffer filter, which can be used with prependFilter()
   static std::string smallBufferFilter();
+  // A string for a small buffer filter with set_limit_only enabled, which can be used with
+  // prependFilter()
+  static std::string smallSetLimitOnlyBufferFilter();
   // A string for a health check filter which can be used with prependFilter()
   static std::string defaultHealthCheckFilter();
   // A string for a squash filter which can be used with prependFilter()

--- a/test/extensions/filters/http/buffer/BUILD
+++ b/test/extensions/filters/http/buffer/BUILD
@@ -42,6 +42,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/buffer:config",
         "//test/config:utility_lib",
         "//test/integration:http_protocol_integration_lib",
+        "//test/integration/filters:buffer_continue_filter_lib",
         "@envoy_api//envoy/extensions/filters/http/buffer/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/buffer/buffer_filter_test.cc
+++ b/test/extensions/filters/http/buffer/buffer_filter_test.cc
@@ -149,6 +149,22 @@ TEST_F(BufferFilterTest, PerFilterConfigDisabledConfigOverride) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data1, true));
 }
 
+TEST_F(BufferFilterTest, SetLimitOnly) {
+  envoy::extensions::filters::http::buffer::v3::BufferPerRoute per_route_cfg;
+  auto* buf = per_route_cfg.mutable_buffer();
+  buf->mutable_max_request_bytes()->set_value(123);
+  buf->set_set_limit_only(true);
+  BufferFilterSettings route_settings(per_route_cfg);
+
+  EXPECT_CALL(*callbacks_.route_, mostSpecificPerFilterConfig(_)).WillOnce(Return(&route_settings));
+  EXPECT_CALL(callbacks_, setDecoderBufferLimit(123ULL));
+
+  Http::TestRequestHeaderMapImpl headers;
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(headers, false));
+
+  filter_.onDestroy();
+}
+
 } // namespace BufferFilter
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: buffer_filter: allow to set the maximum size Without buffering data immediately
Additional Description:
Risk Level: Low, doesn't change the default behavior
Testing: Unit & Integration
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #32205
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
