### PR TITLE
TcpAsyncClient: enhance reconnect robustness

### DIFF
--- a/envoy/tcp/async_tcp_client.h
+++ b/envoy/tcp/async_tcp_client.h
@@ -42,6 +42,8 @@ public:
    * Connect to a remote host. Errors or connection events are reported via the
    * event callback registered via setAsyncTcpClientCallbacks(). We need to set the
    * callbacks again to call connect() after the connection is disconnected.
+   * @returns true if a new client has created and the connection is in progress.
+   * @returns false if an underlying client exists and is connected or connecting.
    */
   virtual bool connect() PURE;
 

--- a/envoy/tcp/async_tcp_client.h
+++ b/envoy/tcp/async_tcp_client.h
@@ -40,8 +40,9 @@ public:
 
   /**
    * Connect to a remote host. Errors or connection events are reported via the
-   * event callback registered via setAsyncTcpClientCallbacks(). We need to set the
-   * callbacks again to call connect() after the connection is disconnected.
+   * event callback registered via setAsyncTcpClientCallbacks(). If the callbacks
+   * needs to be changed before reconnecting, it is required to set the callbacks
+   * again, before calling to connect() to attempting to reconnect.
    * @returns true if a new client has created and the connection is in progress.
    * @returns false if an underlying client exists and is connected or connecting.
    */

--- a/source/common/tcp/async_tcp_client_impl.cc
+++ b/source/common/tcp/async_tcp_client_impl.cc
@@ -22,20 +22,19 @@ AsyncTcpClientImpl::AsyncTcpClientImpl(Event::Dispatcher& dispatcher,
     : dispatcher_(dispatcher), thread_local_cluster_(thread_local_cluster),
       cluster_info_(thread_local_cluster_.info()), context_(context),
       connect_timer_(dispatcher.createTimer([this]() { onConnectTimeout(); })),
-      enable_half_close_(enable_half_close) {
-  cluster_info_->trafficStats()->upstream_cx_active_.inc();
-  cluster_info_->trafficStats()->upstream_cx_total_.inc();
-}
-
-AsyncTcpClientImpl::~AsyncTcpClientImpl() {
-  cluster_info_->trafficStats()->upstream_cx_active_.dec();
-}
+      enable_half_close_(enable_half_close) {}
 
 bool AsyncTcpClientImpl::connect() {
+  if (connection_) {
+    return false;
+  }
+
   connection_ = std::move(thread_local_cluster_.tcpConn(context_).connection_);
   if (!connection_) {
     return false;
   }
+
+  cluster_info_->trafficStats()->upstream_cx_total_.inc();
   connection_->enableHalfClose(enable_half_close_);
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(std::make_shared<NetworkReadFilter>(*this));
@@ -109,17 +108,21 @@ void AsyncTcpClientImpl::reportConnectionDestroy(Network::ConnectionEvent event)
 void AsyncTcpClientImpl::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-    if (disconnected_) {
+    if (connected_) {
+      cluster_info_->trafficStats()->upstream_cx_active_.dec();
+    } else {
       cluster_info_->trafficStats()->upstream_cx_connect_fail_.inc();
     }
 
-    if (!disconnected_ && conn_length_ms_ != nullptr) {
+    if (connected_ && conn_length_ms_ != nullptr) {
       conn_length_ms_->complete();
       conn_length_ms_.reset();
     }
+
     disableConnectTimeout();
     reportConnectionDestroy(event);
-    disconnected_ = true;
+
+    connected_ = false;
     if (connection_) {
       detected_close_ = connection_->detectedCloseType();
     }
@@ -127,10 +130,11 @@ void AsyncTcpClientImpl::onEvent(Network::ConnectionEvent event) {
     dispatcher_.deferredDelete(std::move(connection_));
     if (callbacks_) {
       callbacks_->onEvent(event);
-      callbacks_ = nullptr;
     }
   } else {
-    disconnected_ = false;
+    cluster_info_->trafficStats()->upstream_cx_active_.inc();
+
+    connected_ = true;
     conn_connect_ms_->complete();
     conn_connect_ms_.reset();
     disableConnectTimeout();

--- a/source/common/tcp/async_tcp_client_impl.cc
+++ b/source/common/tcp/async_tcp_client_impl.cc
@@ -109,9 +109,8 @@ void AsyncTcpClientImpl::reportConnectionDestroy(Network::ConnectionEvent event)
 void AsyncTcpClientImpl::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
-    if (connected_) {
-      cluster_info_->trafficStats()->upstream_cx_active_.dec();
-    } else {
+    cluster_info_->trafficStats()->upstream_cx_active_.dec();
+    if (!connected_) {
       cluster_info_->trafficStats()->upstream_cx_connect_fail_.inc();
     }
 

--- a/source/common/tcp/async_tcp_client_impl.cc
+++ b/source/common/tcp/async_tcp_client_impl.cc
@@ -35,6 +35,7 @@ bool AsyncTcpClientImpl::connect() {
   }
 
   cluster_info_->trafficStats()->upstream_cx_total_.inc();
+  cluster_info_->trafficStats()->upstream_cx_active_.inc();
   connection_->enableHalfClose(enable_half_close_);
   connection_->addConnectionCallbacks(*this);
   connection_->addReadFilter(std::make_shared<NetworkReadFilter>(*this));
@@ -132,8 +133,6 @@ void AsyncTcpClientImpl::onEvent(Network::ConnectionEvent event) {
       callbacks_->onEvent(event);
     }
   } else {
-    cluster_info_->trafficStats()->upstream_cx_active_.inc();
-
     connected_ = true;
     conn_connect_ms_->complete();
     conn_connect_ms_.reset();

--- a/source/common/tcp/async_tcp_client_impl.h
+++ b/source/common/tcp/async_tcp_client_impl.h
@@ -29,8 +29,6 @@ public:
                      Upstream::ThreadLocalCluster& thread_local_cluster,
                      Upstream::LoadBalancerContext* context, bool enable_half_close);
 
-  ~AsyncTcpClientImpl() override;
-
   void close(Network::ConnectionCloseType type) override;
 
   Network::DetectedCloseType detectedCloseType() const override { return detected_close_; }
@@ -56,7 +54,7 @@ public:
   /**
    * @return if the client connects to a peer host.
    */
-  bool connected() override { return !disconnected_; }
+  bool connected() override { return connected_; }
 
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
 
@@ -108,7 +106,7 @@ private:
   Event::TimerPtr connect_timer_;
   AsyncTcpClientCallbacks* callbacks_{};
   Network::DetectedCloseType detected_close_{Network::DetectedCloseType::Normal};
-  bool disconnected_{true};
+  bool connected_{false};
   bool enable_half_close_{false};
 };
 

--- a/test/common/tcp/async_tcp_client_impl_test.cc
+++ b/test/common/tcp/async_tcp_client_impl_test.cc
@@ -273,7 +273,7 @@ TEST_F(AsyncTcpClientImplTest, ReconnectAfterClientDisconnected) {
   expectCreateConnection();
 
   EXPECT_EQ(2UL, cluster_manager_.thread_local_cluster_.cluster_.info_->traffic_stats_
-                    ->upstream_cx_total_.value());
+                     ->upstream_cx_total_.value());
 }
 
 } // namespace Tcp

--- a/test/common/tcp/async_tcp_client_impl_test.cc
+++ b/test/common/tcp/async_tcp_client_impl_test.cc
@@ -245,9 +245,35 @@ TEST_F(AsyncTcpClientImplTest, TestActiveCx) {
   expectCreateConnection();
   EXPECT_EQ(1UL, cluster_manager_.thread_local_cluster_.cluster_.info_->traffic_stats_
                      ->upstream_cx_active_.value());
-  client_.reset();
+  EXPECT_CALL(callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
   EXPECT_EQ(0UL, cluster_manager_.thread_local_cluster_.cluster_.info_->traffic_stats_
                      ->upstream_cx_active_.value());
+}
+
+TEST_F(AsyncTcpClientImplTest, ReconnectWhileClientConnected) {
+  setUpClient();
+  expectCreateConnection();
+  EXPECT_FALSE(client_->connect());
+}
+
+TEST_F(AsyncTcpClientImplTest, ReconnectWhileClientConnecting) {
+  setUpClient();
+  expectCreateConnection(false);
+  EXPECT_FALSE(client_->connect());
+}
+
+TEST_F(AsyncTcpClientImplTest, ReconnectAfterClientDisconnected) {
+  setUpClient();
+  expectCreateConnection();
+
+  EXPECT_CALL(callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+  connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
+  expectCreateConnection();
+
+  EXPECT_EQ(2UL, cluster_manager_.thread_local_cluster_.cluster_.info_->traffic_stats_
+                    ->upstream_cx_total_.value());
 }
 
 } // namespace Tcp

--- a/test/common/tcp/async_tcp_client_impl_test.cc
+++ b/test/common/tcp/async_tcp_client_impl_test.cc
@@ -251,6 +251,17 @@ TEST_F(AsyncTcpClientImplTest, TestActiveCx) {
                      ->upstream_cx_active_.value());
 }
 
+TEST_F(AsyncTcpClientImplTest, TestActiveCxWhileNotConnected) {
+  setUpClient();
+  expectCreateConnection(false);
+  EXPECT_EQ(1UL, cluster_manager_.thread_local_cluster_.cluster_.info_->traffic_stats_
+                     ->upstream_cx_active_.value());
+  EXPECT_CALL(callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+  EXPECT_EQ(0UL, cluster_manager_.thread_local_cluster_.cluster_.info_->traffic_stats_
+                     ->upstream_cx_active_.value());
+}
+
 TEST_F(AsyncTcpClientImplTest, ReconnectWhileClientConnected) {
   setUpClient();
   expectCreateConnection();

--- a/test/integration/filters/test_network_async_tcp_filter.cc
+++ b/test/integration/filters/test_network_async_tcp_filter.cc
@@ -50,6 +50,11 @@ public:
   }
 
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override {
+    if (require_reconnect_ && !client_->connect()) {
+      ENVOY_LOG_MISC(debug, "Unable to reconnect to cluster");
+      return Network::FilterStatus::StopIteration;
+    }
+
     stats_.on_data_.inc();
     ENVOY_LOG_MISC(debug, "Downstream onData: {}, length: {} sending to upstream", data.toString(),
                    data.length());
@@ -75,6 +80,8 @@ public:
     read_callbacks_->connection().enableHalfClose(true);
     read_callbacks_->connection().addConnectionCallbacks(*downstream_callbacks_);
   }
+
+  bool require_reconnect_{false};
 
 private:
   struct DownstreamCallbacks : public Envoy::Network::ConnectionCallbacks {
@@ -121,6 +128,12 @@ private:
     void onEvent(Network::ConnectionEvent event) override {
       ENVOY_LOG_MISC(debug, "tcp client test filter upstream callback onEvent: {}",
                      static_cast<int>(event));
+
+      if (event == Network::ConnectionEvent::RemoteClose
+          || event == Network::ConnectionEvent::LocalClose) {
+        parent_.require_reconnect_ = true;
+      }
+
       if (event != Network::ConnectionEvent::RemoteClose) {
         return;
       }

--- a/test/integration/filters/test_network_async_tcp_filter.cc
+++ b/test/integration/filters/test_network_async_tcp_filter.cc
@@ -129,8 +129,8 @@ private:
       ENVOY_LOG_MISC(debug, "tcp client test filter upstream callback onEvent: {}",
                      static_cast<int>(event));
 
-      if (event == Network::ConnectionEvent::RemoteClose
-          || event == Network::ConnectionEvent::LocalClose) {
+      if (event == Network::ConnectionEvent::RemoteClose ||
+          event == Network::ConnectionEvent::LocalClose) {
         parent_.require_reconnect_ = true;
       }
 

--- a/test/integration/tcp_async_client_integration_test.cc
+++ b/test/integration/tcp_async_client_integration_test.cc
@@ -111,6 +111,40 @@ TEST_P(TcpAsyncClientIntegrationTest, MultipleResponseFrames) {
   tcp_client->close();
 }
 
+TEST_P(TcpAsyncClientIntegrationTest, Reconnect) {
+  if (GetParam() == Network::Address::IpVersion::v6) {
+    return;
+  }
+
+  enableHalfClose(true);
+  initialize();
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write("hello1", false));
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_total", 1);
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 1);
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(fake_upstream_connection->waitForData([&](const std::string& data) -> bool {
+    return data == "hello1";
+  }));
+  ASSERT_TRUE(fake_upstream_connection->close());
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 0);
+
+  // We use the same tcp_client to ensure that a new upstream connection is created.
+  ASSERT_TRUE(tcp_client->write("hello2", false));
+  test_server_->waitForCounterEq("cluster.cluster_0.upstream_cx_total", 2);
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 1);
+  FakeRawConnectionPtr fake_upstream_connection2;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
+  ASSERT_TRUE(fake_upstream_connection2->waitForData([&](const std::string& data) -> bool {
+    return data == "hello2";
+  }));
+
+  tcp_client->close();
+  test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 0);
+}
+
 #if ENVOY_PLATFORM_ENABLE_SEND_RST
 // Test if RST close can be detected from downstream and upstream is closed by RST.
 TEST_P(TcpAsyncClientIntegrationTest, TestClientCloseRST) {

--- a/test/integration/tcp_async_client_integration_test.cc
+++ b/test/integration/tcp_async_client_integration_test.cc
@@ -125,9 +125,8 @@ TEST_P(TcpAsyncClientIntegrationTest, Reconnect) {
   test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 1);
   FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
-  ASSERT_TRUE(fake_upstream_connection->waitForData([&](const std::string& data) -> bool {
-    return data == "hello1";
-  }));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(
+      [&](const std::string& data) -> bool { return data == "hello1"; }));
   ASSERT_TRUE(fake_upstream_connection->close());
   test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 0);
 
@@ -137,9 +136,8 @@ TEST_P(TcpAsyncClientIntegrationTest, Reconnect) {
   test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 1);
   FakeRawConnectionPtr fake_upstream_connection2;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
-  ASSERT_TRUE(fake_upstream_connection2->waitForData([&](const std::string& data) -> bool {
-    return data == "hello2";
-  }));
+  ASSERT_TRUE(fake_upstream_connection2->waitForData(
+      [&](const std::string& data) -> bool { return data == "hello2"; }));
 
   tcp_client->close();
   test_server_->waitForGaugeEq("cluster.cluster_0.upstream_cx_active", 0);


### PR DESCRIPTION
Additional Description: small modifications to allow reconnecting in ``TcpAsyncClient`` along with tests
Risk Level: low
Testing: unit tests, integration tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None
