### PR TITLE
api: async mode in ext_proc

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -118,10 +118,10 @@ message ExternalProcessor {
   // If true, send each part of the HTTP request or response specified by ProcessingMode
   // asynchronously -- in other words, send the message on the gRPC stream and then continue
   // filter processing. In this mode:
-  // 1) only STREAMED body processing mode is supported for async processing and any other body
-  // processing mode will be treated as invalid mode and will be ignored.
-  // 2) ext_proc server is not expected to send back processing response. Any response will be
-  // simply ignored.
+  // 1) only STREAMED body processing mode is supported and any other body processing modes
+  // will be treated as invalid and will be ignored for async processing.
+  // 2) ext_proc server is not expected to send back processing response. Any response from
+  // ext_proc server will be simply ignored.
   //
   // If false, which is the default, suspend filter execution after
   // each message is sent to the remote service and wait up to "message_timeout"
@@ -131,8 +131,8 @@ message ExternalProcessor {
   //
   //    Flow control is necessary mechanism to prevent the fast sender (either downstream client or upstream server)
   //    from overwhelming the ext_proc server when its processing speed is slower.
-  //    This protective measure is being developed but has not been implemented yet so please use your own discretion
-  //    when enabling this feature.
+  //    This protective measure is being explored and developed but has not been ready yet, so please use your own
+  //    discretion when enabling this feature.
   //
   bool async_mode = 4;
 

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -118,8 +118,8 @@ message ExternalProcessor {
   // If true, send each part of the HTTP request or response specified by ProcessingMode
   // asynchronously -- in other words, send the message on the gRPC stream and then continue
   // filter processing. In this mode:
-  // 1) only STREAMED body processing mode is supported and any other body processing modes
-  // will be treated as invalid and will be ignored for async processing.
+  // 1) Only STREAMED body processing mode is supported and any other body processing modes
+  // will be ignored for asynchronous processing.
   // 2) ext_proc server is not expected to send back processing response. Any response from
   // ext_proc server will be simply ignored.
   //

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -115,12 +115,25 @@ message ExternalProcessor {
   // sent. See ProcessingMode for details.
   ProcessingMode processing_mode = 3;
 
-  // [#not-implemented-hide:]
   // If true, send each part of the HTTP request or response specified by ProcessingMode
   // asynchronously -- in other words, send the message on the gRPC stream and then continue
-  // filter processing. If false, which is the default, suspend filter execution after
+  // filter processing. In this mode:
+  // 1) only STREAMED body processing mode is supported for async processing and any other body
+  // processing mode will be treated as invalid mode and will be ignored.
+  // 2) ext_proc server is not expected to send back processing response. Any response will be
+  // simply ignored.
+  //
+  // If false, which is the default, suspend filter execution after
   // each message is sent to the remote service and wait up to "message_timeout"
   // for a reply.
+  //
+  // .. warning::
+  //
+  //    Flow control is necessary mechanism to prevent the fast sender (either downstream client or upstream server)
+  //    from overwhelming the ext_proc server when its processing speed is slower.
+  //    This protective measure is being developed but has not been implemented yet so please use your own discretion
+  //    when enabling this feature.
+  //
   bool async_mode = 4;
 
   // Envoy provides a number of :ref:`attributes <arch_overview_attributes>`


### PR DESCRIPTION
API changes   to ext_proc async mode. Implementation will be followed once consensus is reached on the api changes/design.

 **Highlighted Changes**:

1. For the body, async mode is restricted to [STREAMED](https://github.com/envoyproxy/envoy/blob/9a47bc9eff9c3283fbfaed9144313b7bda366aac/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto#L58-L60) processing mode only. Alternatively, we can add a new mode (e.g., ASYNC_STREAMED mode). I don't feel strong either way, please let me know your thoughts.
2. Specify that ext_proc server' response is not expected in this mode and will be ignored .
3. Add warning section to state that flow control is not ready yet.

 
