### PR TITLE
use createScope to guruantee longer lifetime than shadow writer

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -129,9 +129,10 @@ class RouterStats {
 public:
   RouterStats(const std::string& stat_prefix, Stats::Scope& scope,
               const LocalInfo::LocalInfo& local_info)
-      : named_(RouterNamedStats::generateStats(stat_prefix, scope)),
-        stat_name_set_(scope.symbolTable().makeSet("thrift_proxy")),
-        symbol_table_(scope.symbolTable()),
+      : stats_scope_(scope.createScope("")),
+        named_(RouterNamedStats::generateStats(stat_prefix, *stats_scope_)),
+        stat_name_set_(stats_scope_->symbolTable().makeSet("thrift_proxy")),
+        symbol_table_(stats_scope_->symbolTable()),
         upstream_rq_call_(stat_name_set_->add("thrift.upstream_rq_call")),
         upstream_rq_oneway_(stat_name_set_->add("thrift.upstream_rq_oneway")),
         upstream_rq_invalid_type_(stat_name_set_->add("thrift.upstream_rq_invalid_type")),
@@ -340,8 +341,6 @@ public:
                                 Stats::Histogram::Unit::Milliseconds, value);
   }
 
-  const RouterNamedStats named_;
-
 private:
   void incClusterScopeCounter(const Upstream::ClusterInfo& cluster,
                               Upstream::HostDescriptionConstSharedPtr upstream_host,
@@ -385,6 +384,12 @@ private:
     return symbol_table_.join({zone_, local_zone_name_, upstream_zone_name, stat_name});
   }
 
+  Stats::ScopeSharedPtr stats_scope_;
+
+public:
+  const RouterNamedStats named_;
+
+private:
   Stats::StatNameSetPtr stat_name_set_;
   Stats::SymbolTable& symbol_table_;
   const Stats::StatName upstream_rq_call_;

--- a/source/extensions/filters/network/thrift_proxy/router/router.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router.h
@@ -341,6 +341,8 @@ public:
                                 Stats::Histogram::Unit::Milliseconds, value);
   }
 
+  const RouterNamedStats& routerStats() const { return named_; }
+
 private:
   void incClusterScopeCounter(const Upstream::ClusterInfo& cluster,
                               Upstream::HostDescriptionConstSharedPtr upstream_host,
@@ -385,11 +387,7 @@ private:
   }
 
   Stats::ScopeSharedPtr stats_scope_;
-
-public:
   const RouterNamedStats named_;
-
-private:
   Stats::StatNameSetPtr stat_name_set_;
   Stats::SymbolTable& symbol_table_;
   const Stats::StatName upstream_rq_call_;
@@ -511,7 +509,7 @@ protected:
     Upstream::ThreadLocalCluster* cluster = clusterManager().getThreadLocalCluster(cluster_name);
     if (!cluster) {
       ENVOY_LOG(debug, "unknown cluster '{}'", cluster_name);
-      stats().named_.unknown_cluster_.inc();
+      stats().routerStats().unknown_cluster_.inc();
       return {AppException(AppExceptionType::InternalError,
                            fmt::format("unknown cluster '{}'", cluster_name)),
               absl::nullopt};
@@ -535,7 +533,7 @@ protected:
     }
 
     if (cluster_->maintenanceMode()) {
-      stats().named_.upstream_rq_maintenance_mode_.inc();
+      stats().routerStats().upstream_rq_maintenance_mode_.inc();
       if (metadata->messageType() == MessageType::Call) {
         stats().incResponseLocalException(*cluster_);
       }
@@ -556,7 +554,7 @@ protected:
 
     auto conn_pool_data = cluster->tcpConnPool(Upstream::ResourcePriority::Default, lb_context);
     if (!conn_pool_data) {
-      stats().named_.no_healthy_upstream_.inc();
+      stats().routerStats().no_healthy_upstream_.inc();
       if (metadata->messageType() == MessageType::Call) {
         stats().incResponseLocalException(*cluster_);
       }

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -278,7 +278,7 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
   route_ = callbacks_->route();
   if (!route_) {
     ENVOY_STREAM_LOG(debug, "no route match for method '{}'", *callbacks_, metadata->methodName());
-    stats().named_.route_missing_.inc();
+    stats().routerStats().route_missing_.inc();
     callbacks_->sendLocalReply(
         AppException(AppExceptionType::UnknownMethod,
                      fmt::format("no route for method '{}'", metadata->methodName())),

--- a/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/shadow_writer_impl.cc
@@ -22,7 +22,7 @@ OptRef<ShadowRouterHandle> ShadowWriterImpl::submit(const std::string& cluster_n
                                                           original_transport, original_protocol);
   const bool created = shadow_router->createUpstreamRequest();
   if (!created || !tls_.get().has_value()) {
-    stats_.named_.shadow_request_submit_failure_.inc();
+    stats_.routerStats().shadow_request_submit_failure_.inc();
     return absl::nullopt;
   }
 


### PR DESCRIPTION
Commit Message:
own our scope by `createScope` as shadow request could have as long as the lifecycle of thread local storage
Additional Description:
Risk Level: mid
Testing: unit

[Optional Fixes #Issue] #32234
