### PR TITLE
sockets: flipping graceful client socket creation failure

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -17,7 +17,7 @@ minor_behavior_changes:
 - area: sockets
   change: |
     Failure to create an upstream socket should now result in clean connection failure rather than failing a release assert. This behavior
-    can be temporarily reverted by setting runtime feature ``envoy.restart_features_.llow_client_socket_creation_failure`` to false.
+    can be temporarily reverted by setting runtime feature ``envoy.restart_features_.allow_client_socket_creation_failure`` to false.
 - area: adaptive concurrency filter stats
   change: |
     Multiply the gradient value stat by 1000 to make it more granular (values will range between 500 and 2000).

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -14,6 +14,10 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: sockets
+  change: |
+    Failure to create an upstream socket should now result in clean connection failure rather than failing a release assert. This behavior
+    can be temporarily reverted by setting runtime feature ``envoy.restart_features_.llow_client_socket_creation_failure`` to false.
 - area: adaptive concurrency filter stats
   change: |
     Multiply the gradient value stat by 1000 to make it more granular (values will range between 500 and 2000).

--- a/source/common/network/listen_socket_impl.cc
+++ b/source/common/network/listen_socket_impl.cc
@@ -46,7 +46,7 @@ void ListenSocketImpl::setupSocket(const Network::Socket::OptionsSharedPtr& opti
 
 UdsListenSocket::UdsListenSocket(const Address::InstanceConstSharedPtr& address)
     : ListenSocketImpl(ioHandleForAddr(Socket::Type::Stream, address, {}), address) {
-  RELEASE_ASSERT(io_handle_->isOpen(), "");
+  RELEASE_ASSERT(io_handle_ && io_handle_->isOpen(), "");
   bind(connection_info_provider_->localAddress());
 }
 

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -53,7 +53,7 @@ public:
                          address) {
     // Prebind is applied if the socket is bind to port.
     if (bind_to_port) {
-      RELEASE_ASSERT(io_handle_->isOpen(), "");
+      RELEASE_ASSERT(io_handle_ && io_handle_->isOpen(), "");
       setPrebindSocketOptions();
       setupSocket(options);
     } else {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -100,13 +100,12 @@ RUNTIME_GUARD(envoy_reloadable_features_use_http3_header_normalisation);
 RUNTIME_GUARD(envoy_reloadable_features_validate_connect);
 RUNTIME_GUARD(envoy_reloadable_features_validate_grpc_header_before_log_grpc_status);
 RUNTIME_GUARD(envoy_reloadable_features_validate_upstream_headers);
+RUNTIME_GUARD(envoy_restart_features_allow_client_socket_creation_failure);
 RUNTIME_GUARD(envoy_restart_features_send_goaway_for_premature_rst_streams);
 RUNTIME_GUARD(envoy_restart_features_udp_read_normalize_addresses);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
 
-// TODO(alyssawilk) flip true after server side is handled.
-FALSE_RUNTIME_GUARD(envoy_restart_features_allow_client_socket_creation_failure);
 // Execution context is optional and must be enabled explicitly.
 // See https://github.com/envoyproxy/envoy/issues/32012.
 FALSE_RUNTIME_GUARD(envoy_restart_features_enable_execution_context);


### PR DESCRIPTION
Allowing graceful client socket creation failure by default in Envoy

Risk Level: medium
Testing: yes
Docs Changes: n/a
Release Notes: inline
[Optional Runtime guard:] yes.