### PR TITLE
proxy status: add more mapping to proxystatus

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -47,6 +47,10 @@ minor_behavior_changes:
   change: |
     Enable obsolete line folding in BalsaParser (for behavior parity with http-parser, the
     previously used HTTP/1 parser).
+- area: proxy status
+  change: |
+    Add more conversion in the proxy status utility. It can be disabled by the runtime guard
+    ``envoy.reloadable_features.proxy_status_mapping_more_core_response_flags``.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -75,6 +75,7 @@ RUNTIME_GUARD(envoy_reloadable_features_oauth_make_token_cookie_httponly);
 RUNTIME_GUARD(envoy_reloadable_features_oauth_use_standard_max_age_value);
 RUNTIME_GUARD(envoy_reloadable_features_oauth_use_url_encoding);
 RUNTIME_GUARD(envoy_reloadable_features_original_dst_rely_on_idle_timeout);
+RUNTIME_GUARD(envoy_reloadable_features_proxy_status_mapping_more_core_response_flags);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_status_upstream_request_timeout);
 RUNTIME_GUARD(envoy_reloadable_features_quic_fix_filter_manager_uaf);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year. Confirm with

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -440,15 +440,44 @@ ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
       return ProxyStatusError::ConnectionTimeout;
     }
     return ProxyStatusError::HttpResponseTimeout;
-  } else if (stream_info.hasResponseFlag(CoreResponseFlag::LocalReset)) {
-    return ProxyStatusError::ConnectionTimeout;
-  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRemoteReset)) {
-    return ProxyStatusError::ConnectionTerminated;
-  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionFailure)) {
-    return ProxyStatusError::ConnectionRefused;
-  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionTermination)) {
-    return ProxyStatusError::ConnectionTerminated;
-  } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamOverflow)) {
+  }
+
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.proxy_status_mapping_more_core_response_flags")) {
+    if (stream_info.hasResponseFlag(CoreResponseFlag::DurationTimeout)) {
+      return ProxyStatusError::ConnectionTimeout;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::LocalReset)) {
+      return ProxyStatusError::ConnectionTimeout;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRemoteReset)) {
+      return ProxyStatusError::ConnectionTerminated;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionFailure)) {
+      return ProxyStatusError::ConnectionRefused;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UnauthorizedExternalService)) {
+      return ProxyStatusError::ConnectionRefused;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionTermination)) {
+      return ProxyStatusError::ConnectionTerminated;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::DownstreamConnectionTermination)) {
+      return ProxyStatusError::ConnectionTerminated;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::OverloadManager)) {
+      return ProxyStatusError::ConnectionLimitReached;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::DropOverLoad)) {
+      return ProxyStatusError::ConnectionLimitReached;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::FaultInjected)) {
+      return ProxyStatusError::HttpRequestError;
+    }
+  } else {
+    if (stream_info.hasResponseFlag(CoreResponseFlag::LocalReset)) {
+      return ProxyStatusError::ConnectionTimeout;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRemoteReset)) {
+      return ProxyStatusError::ConnectionTerminated;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionFailure)) {
+      return ProxyStatusError::ConnectionRefused;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionTermination)) {
+      return ProxyStatusError::ConnectionTerminated;
+    }
+  }
+
+  if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamOverflow)) {
     return ProxyStatusError::ConnectionLimitReached;
   } else if (stream_info.hasResponseFlag(CoreResponseFlag::NoRouteFound)) {
     return ProxyStatusError::DestinationNotFound;

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -456,14 +456,14 @@ ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
       return ProxyStatusError::ConnectionRefused;
     } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamConnectionTermination)) {
       return ProxyStatusError::ConnectionTerminated;
-    } else if (stream_info.hasResponseFlag(CoreResponseFlag::DownstreamConnectionTermination)) {
-      return ProxyStatusError::ConnectionTerminated;
     } else if (stream_info.hasResponseFlag(CoreResponseFlag::OverloadManager)) {
       return ProxyStatusError::ConnectionLimitReached;
     } else if (stream_info.hasResponseFlag(CoreResponseFlag::DropOverLoad)) {
       return ProxyStatusError::ConnectionLimitReached;
     } else if (stream_info.hasResponseFlag(CoreResponseFlag::FaultInjected)) {
       return ProxyStatusError::HttpRequestError;
+    } else if (stream_info.hasResponseFlag(CoreResponseFlag::DownstreamConnectionTermination)) {
+      return ProxyStatusError::ConnectionTerminated;
     }
   } else {
     if (stream_info.hasResponseFlag(CoreResponseFlag::LocalReset)) {

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -368,6 +368,8 @@ TEST(ProxyStatusFromStreamInfo, TestAll) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.proxy_status_mapping_more_core_response_flags", "false"}});
   for (const auto& [response_flag, proxy_status_error] :
        std::vector<std::pair<ResponseFlag, ProxyStatusError>>{
            {CoreResponseFlag::FailedLocalHealthCheck, ProxyStatusError::DestinationUnavailable},
@@ -378,6 +380,49 @@ TEST(ProxyStatusFromStreamInfo, TestAll) {
            {CoreResponseFlag::UpstreamConnectionFailure, ProxyStatusError::ConnectionRefused},
            {CoreResponseFlag::UpstreamConnectionTermination,
             ProxyStatusError::ConnectionTerminated},
+           {CoreResponseFlag::UpstreamOverflow, ProxyStatusError::ConnectionLimitReached},
+           {CoreResponseFlag::NoRouteFound, ProxyStatusError::DestinationNotFound},
+           {CoreResponseFlag::RateLimited, ProxyStatusError::ConnectionLimitReached},
+           {CoreResponseFlag::RateLimitServiceError, ProxyStatusError::ConnectionLimitReached},
+           {CoreResponseFlag::UpstreamRetryLimitExceeded, ProxyStatusError::DestinationUnavailable},
+           {CoreResponseFlag::StreamIdleTimeout, ProxyStatusError::HttpResponseTimeout},
+           {CoreResponseFlag::InvalidEnvoyRequestHeaders, ProxyStatusError::HttpRequestError},
+           {CoreResponseFlag::DownstreamProtocolError, ProxyStatusError::HttpRequestError},
+           {CoreResponseFlag::UpstreamMaxStreamDurationReached,
+            ProxyStatusError::HttpResponseTimeout},
+           {CoreResponseFlag::NoFilterConfigFound, ProxyStatusError::ProxyConfigurationError},
+           {CoreResponseFlag::UpstreamProtocolError, ProxyStatusError::HttpProtocolError},
+           {CoreResponseFlag::NoClusterFound, ProxyStatusError::DestinationUnavailable},
+           {CoreResponseFlag::DnsResolutionFailed, ProxyStatusError::DnsError}}) {
+    NiceMock<MockStreamInfo> stream_info;
+    ON_CALL(stream_info, hasResponseFlag(response_flag)).WillByDefault(Return(true));
+    EXPECT_THAT(ProxyStatusUtils::fromStreamInfo(stream_info), proxy_status_error);
+  }
+}
+
+TEST(ProxyStatusFromStreamInfo, TestNewAll) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.proxy_status_mapping_more_core_response_flags", "true"}});
+  for (const auto& [response_flag, proxy_status_error] :
+       std::vector<std::pair<ResponseFlag, ProxyStatusError>>{
+           {CoreResponseFlag::FailedLocalHealthCheck, ProxyStatusError::DestinationUnavailable},
+           {CoreResponseFlag::NoHealthyUpstream, ProxyStatusError::DestinationUnavailable},
+           {CoreResponseFlag::UpstreamRequestTimeout, ProxyStatusError::HttpResponseTimeout},
+           {CoreResponseFlag::DurationTimeout, ProxyStatusError::ConnectionTimeout},
+           {CoreResponseFlag::LocalReset, ProxyStatusError::ConnectionTimeout},
+           {CoreResponseFlag::UpstreamRemoteReset, ProxyStatusError::ConnectionTerminated},
+           {CoreResponseFlag::UpstreamConnectionFailure, ProxyStatusError::ConnectionRefused},
+           {CoreResponseFlag::UnauthorizedExternalService, ProxyStatusError::ConnectionRefused},
+           {CoreResponseFlag::UpstreamConnectionTermination,
+            ProxyStatusError::ConnectionTerminated},
+           {CoreResponseFlag::DownstreamConnectionTermination,
+            ProxyStatusError::ConnectionTerminated},
+           {CoreResponseFlag::OverloadManager, ProxyStatusError::ConnectionLimitReached},
+           {CoreResponseFlag::DropOverLoad, ProxyStatusError::ConnectionLimitReached},
+           {CoreResponseFlag::FaultInjected, ProxyStatusError::HttpRequestError},
            {CoreResponseFlag::UpstreamOverflow, ProxyStatusError::ConnectionLimitReached},
            {CoreResponseFlag::NoRouteFound, ProxyStatusError::DestinationNotFound},
            {CoreResponseFlag::RateLimited, ProxyStatusError::ConnectionLimitReached},


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

DurationTimeout -> ConnectionTimeout
UnauthorizedExternalService -> ConnectionRefused
DownstreamConnectionTermination -> ConnectionTerminated
OverloadManager -> ConnectionLimitReached
DropOverLoad -> ConnectionLimitReached
FaultInjected -> HttpRequestError


Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
