### PR TITLE
tools: fix python regex warnings for newer python

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -257,7 +257,7 @@ class FormatChecker:
 
     @cached_property
     def namespace_re(self):
-        return re.compile("^\s*namespace\s+%s\s*{" % self.namespace_check, re.MULTILINE)
+        return re.compile(r"^\s*namespace\s+%s\s*{" % self.namespace_check, re.MULTILINE)
 
     # Map a line transformation function across each line of a file,
     # writing the result lines as requested.

--- a/tools/code_format/envoy_build_fixer.py
+++ b/tools/code_format/envoy_build_fixer.py
@@ -33,18 +33,18 @@ OLD_LICENSES_REGEX = re.compile(r'^licenses\(.*\n+', re.MULTILINE)
 ENVOY_RULE_REGEX = re.compile(r'envoy[_\w]+\(')
 
 # Match a load() statement for the envoy_package macros.
-PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_package".*?\)\n)', re.DOTALL)
-EXTENSION_PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_extension_package".*?\)\n)', re.DOTALL)
-CONTRIB_PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_contrib_package".*?\)\n)', re.DOTALL)
-MOBILE_PACKAGE_LOAD_BLOCK_REGEX = re.compile('("envoy_mobile_package".*?\)\n)', re.DOTALL)
+PACKAGE_LOAD_BLOCK_REGEX = re.compile(r'("envoy_package".*?\)\n)', re.DOTALL)
+EXTENSION_PACKAGE_LOAD_BLOCK_REGEX = re.compile(r'("envoy_extension_package".*?\)\n)', re.DOTALL)
+CONTRIB_PACKAGE_LOAD_BLOCK_REGEX = re.compile(r'("envoy_contrib_package".*?\)\n)', re.DOTALL)
+MOBILE_PACKAGE_LOAD_BLOCK_REGEX = re.compile(r'("envoy_mobile_package".*?\)\n)', re.DOTALL)
 
 # Match Buildozer 'print' output. Example of Buildozer print output:
 # cc_library json_transcoder_filter_lib [json_transcoder_filter.cc] (missing) (missing)
 BUILDOZER_PRINT_REGEX = re.compile(
-    '\s*([\w_]+)\s+([\w_]+)\s+[(\[](.*?)[)\]]\s+[(\[](.*?)[)\]]\s+[(\[](.*?)[)\]]')
+    r'\s*([\w_]+)\s+([\w_]+)\s+[(\[](.*?)[)\]]\s+[(\[](.*?)[)\]]\s+[(\[](.*?)[)\]]')
 
 # Match API header include in Envoy source file?
-API_INCLUDE_REGEX = re.compile('#include "(contrib/envoy/.*|envoy/.*)/[^/]+\.pb\.(validate\.)?h"')
+API_INCLUDE_REGEX = re.compile(r'#include "(contrib/envoy/.*|envoy/.*)/[^/]+\.pb\.(validate\.)?h"')
 
 
 class EnvoyBuildFixerError(Exception):

--- a/tools/code_format/header_order.py
+++ b/tools/code_format/header_order.py
@@ -65,11 +65,11 @@ def reorder_headers(path):
     # Filters that define the #include blocks
     block_filters = [
         file_header_filter(),
-        regex_filter('<.*\.h>'),
-        regex_filter('<.*>'),
+        regex_filter(r'<.*\.h>'),
+        regex_filter(r'<.*>'),
     ]
     for subdir in include_dir_order:
-        block_filters.append(regex_filter('"' + subdir + '/.*"'))
+        block_filters.append(regex_filter(r'"' + subdir + r'/.*"'))
 
     blocks = []
     already_included = set([])


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix warnings/errors after upgrading to python3.12.2.
example error:
./tools/code_format/check_format.py:260: SyntaxWarning: invalid escape sequence '\s'  return re.compile("^\s*namespace\s+%s\s*{" % self.namespace_check, re.MULTILINE)

Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
