### PR TITLE
http3: fixing an upstream threading issue and bumping http3 upstream code back to alpha

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -50,6 +50,10 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: http3_upstream
+  change: |
+    Fixing a bug with HTTP/3 upstream using a non-threadsafe cache cross-thread. Bumping HTTP/3 support down
+    to alpha as the severity of this bug indicates it is both not in use and not GA quality code.
 - area: tracers
   change: |
     use unary RPC calls for OpenTelemetry trace exports, rather than client-side streaming connections.

--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -8,8 +8,7 @@ HTTP/3 overview
   While HTTP/3 **downstream support is deemed ready for production use**, improvements are ongoing,
   tracked in the `area-quic <https://github.com/envoyproxy/envoy/labels/area%2Fquic>`_ tag.
 
-  HTTP/3 **upstream support is fine for locally controlled networks**, but is alpha for
-  general internet use - key features are implemented but have not been tested at scale.
+  HTTP/3 support is alpha - key features are implemented but have not been tested at scale.
 
 .. _arch_overview_http3_downstream:
 

--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -8,7 +8,7 @@ HTTP/3 overview
   While HTTP/3 **downstream support is deemed ready for production use**, improvements are ongoing,
   tracked in the `area-quic <https://github.com/envoyproxy/envoy/labels/area%2Fquic>`_ tag.
 
-  HTTP/3 support is alpha - key features are implemented but have not been tested at scale.
+  HTTP/3 upstream support is alpha - key features are implemented but have not been tested at scale.
 
 .. _arch_overview_http3_downstream:
 

--- a/source/common/quic/quic_client_transport_socket_factory.cc
+++ b/source/common/quic/quic_client_transport_socket_factory.cc
@@ -34,11 +34,8 @@ QuicClientTransportSocketFactory::QuicClientTransportSocketFactory(
     : QuicTransportSocketFactoryBase(factory_context.statsScope(), "client"),
       fallback_factory_(std::make_unique<Extensions::TransportSockets::Tls::ClientSslSocketFactory>(
           std::move(config), factory_context.sslContextManager(), factory_context.statsScope())),
-           tls_slot_(factory_context.serverFactoryContext().threadLocal()) {
-    tls_slot_.set([](Event::Dispatcher &) {
-    ENVOY_LOG(warn, "Creating TLS config");
-      return std::make_shared<ThreadLocalQuicConfig>();
-    });
+      tls_slot_(factory_context.serverFactoryContext().threadLocal()) {
+  tls_slot_.set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalQuicConfig>(); });
 }
 
 void QuicClientTransportSocketFactory::initialize() {
@@ -62,7 +59,6 @@ std::shared_ptr<quic::QuicCryptoClientConfig> QuicClientTransportSocketFactory::
   }
 
   ASSERT(tls_slot_.currentThreadRegistered());
-    ENVOY_LOG(warn, "Getting TLS config");
   ThreadLocalQuicConfig& tls_config = *tls_slot_;
 
   if (tls_config.client_context_ != context) {

--- a/source/common/quic/quic_client_transport_socket_factory.cc
+++ b/source/common/quic/quic_client_transport_socket_factory.cc
@@ -33,7 +33,13 @@ QuicClientTransportSocketFactory::QuicClientTransportSocketFactory(
     Server::Configuration::TransportSocketFactoryContext& factory_context)
     : QuicTransportSocketFactoryBase(factory_context.statsScope(), "client"),
       fallback_factory_(std::make_unique<Extensions::TransportSockets::Tls::ClientSslSocketFactory>(
-          std::move(config), factory_context.sslContextManager(), factory_context.statsScope())) {}
+          std::move(config), factory_context.sslContextManager(), factory_context.statsScope())),
+           tls_slot_(factory_context.serverFactoryContext().threadLocal()) {
+    tls_slot_.set([](Event::Dispatcher &) {
+    ENVOY_LOG(warn, "Creating TLS config");
+      return std::make_shared<ThreadLocalQuicConfig>();
+    });
+}
 
 void QuicClientTransportSocketFactory::initialize() {
   if (!fallback_factory_->clientContextConfig()->alpnProtocols().empty()) {
@@ -55,15 +61,19 @@ std::shared_ptr<quic::QuicCryptoClientConfig> QuicClientTransportSocketFactory::
     return nullptr;
   }
 
-  if (client_context_ != context) {
+  ASSERT(tls_slot_.currentThreadRegistered());
+    ENVOY_LOG(warn, "Getting TLS config");
+  ThreadLocalQuicConfig& tls_config = *tls_slot_;
+
+  if (tls_config.client_context_ != context) {
     // If the context has been updated, update the crypto config.
-    client_context_ = context;
-    crypto_config_ = std::make_shared<quic::QuicCryptoClientConfig>(
+    tls_config.client_context_ = context;
+    tls_config.crypto_config_ = std::make_shared<quic::QuicCryptoClientConfig>(
         std::make_unique<Quic::EnvoyQuicProofVerifier>(std::move(context)),
         std::make_unique<quic::QuicClientSessionCache>());
   }
   // Return the latest crypto config.
-  return crypto_config_;
+  return tls_config.crypto_config_;
 }
 
 REGISTER_FACTORY(QuicClientTransportSocketConfigFactory,

--- a/source/common/quic/quic_client_transport_socket_factory.h
+++ b/source/common/quic/quic_client_transport_socket_factory.h
@@ -46,7 +46,7 @@ protected:
   void onSecretUpdated() override {}
 
   // The cache in the QuicCryptoClientConfig is not thread-safe, so crypto_config_ needs to
-  // be a tls object. client_context lets the TLS object determine if the crypto
+  // be a thread local object. client_context lets the thread local object determine if the crypto
   // config needs to be updated.
   struct ThreadLocalQuicConfig : public ThreadLocal::ThreadLocalObject {
     // Latch the latest client context, to determine if it has updated since last

--- a/source/common/quic/quic_client_transport_socket_factory.h
+++ b/source/common/quic/quic_client_transport_socket_factory.h
@@ -45,14 +45,22 @@ protected:
   // fallback_factory_ will update the context.
   void onSecretUpdated() override {}
 
+  // The cache in the QuicCryptoClientConfig is not thread-safe, so crypto_config_ needs to
+  // be a tls object. client_context lets the TLS object determine if the crypto
+  // config needs to be updated.
+  struct ThreadLocalQuicConfig : public ThreadLocal::ThreadLocalObject {
+    // Latch the latest client context, to determine if it has updated since last
+    // checked.
+    Envoy::Ssl::ClientContextSharedPtr client_context_;
+    // If client_context_ changes, client config will be updated as well.
+    std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config_;
+  };
+
 private:
   // The QUIC client transport socket can create TLS sockets for fallback to TCP.
   std::unique_ptr<Extensions::TransportSockets::Tls::ClientSslSocketFactory> fallback_factory_;
-  // Latch the latest client context, to determine if it has updated since last
-  // checked.
-  Envoy::Ssl::ClientContextSharedPtr client_context_;
-  // If client_context_ changes, client config will be updated as well.
-  std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config_;
+  // The storage for thread local quic config.
+  ThreadLocal::TypedSlot<ThreadLocalQuicConfig> tls_slot_;
 };
 
 class QuicClientTransportSocketConfigFactory

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -39,6 +39,7 @@ public:
 class Http3ConnPoolImplTest : public Event::TestUsingSimulatedTime, public testing::Test {
 public:
   Http3ConnPoolImplTest() {
+    ON_CALL(context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
     EXPECT_CALL(context_.context_manager_, createSslClientContext(_, _))
         .WillRepeatedly(Return(ssl_context_));
     factory_.emplace(std::unique_ptr<Envoy::Ssl::ClientContextConfig>(
@@ -86,6 +87,7 @@ public:
   std::unique_ptr<Http3ConnPoolImpl> pool_;
   MockPoolConnectResultCallback connect_result_callback_;
   std::shared_ptr<Network::MockSocketOption> socket_option_{new Network::MockSocketOption()};
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 class MockQuicClientTransportSocketFactory : public Quic::QuicClientTransportSocketFactory {

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -27,6 +27,7 @@ class QuicNetworkConnectionTest : public Event::TestUsingSimulatedTime,
                                   public testing::TestWithParam<Network::Address::IpVersion> {
 protected:
   void initialize() {
+    ON_CALL(context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
     EXPECT_CALL(*cluster_, perConnectionBufferLimitBytes()).WillOnce(Return(45));
     EXPECT_CALL(*cluster_, connectTimeout).WillOnce(Return(std::chrono::seconds(10)));
     auto* protocol_options = cluster_->http3_options_.mutable_quic_protocol_options();
@@ -88,6 +89,7 @@ protected:
   QuicStatNames quic_stat_names_{store_.symbolTable()};
   quic::DeterministicConnectionIdGenerator connection_id_generator_{
       quic::kQuicDefaultConnectionIdLength};
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 TEST_P(QuicNetworkConnectionTest, BufferLimits) {

--- a/test/common/quic/quic_transport_socket_factory_test.cc
+++ b/test/common/quic/quic_transport_socket_factory_test.cc
@@ -19,6 +19,7 @@ public:
   QuicServerTransportSocketFactoryConfigTest()
       : server_api_(Api::createApiForTest(server_stats_store_, simTime())) {
     ON_CALL(context_.server_context_, api()).WillByDefault(ReturnRef(*server_api_));
+    ON_CALL(context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
   }
 
   void verifyQuicServerTransportSocketFactory(std::string yaml, bool expect_early_data) {
@@ -35,6 +36,7 @@ public:
   Stats::TestUtil::TestStore server_stats_store_;
   Api::ApiPtr server_api_;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 TEST_F(QuicServerTransportSocketFactoryConfigTest, EarlyDataEnabledByDefault) {
@@ -113,6 +115,7 @@ downstream_tls_context:
 class QuicClientTransportSocketFactoryTest : public testing::Test {
 public:
   QuicClientTransportSocketFactoryTest() {
+    ON_CALL(context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
     EXPECT_CALL(context_.context_manager_, createSslClientContext(_, _)).WillOnce(Return(nullptr));
     EXPECT_CALL(*context_config_, setSecretUpdateCallback(_))
         .WillOnce(testing::SaveArg<0>(&update_callback_));
@@ -125,6 +128,7 @@ public:
   NiceMock<Ssl::MockClientContextConfig>* context_config_{
       new NiceMock<Ssl::MockClientContextConfig>};
   std::function<void()> update_callback_;
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
 };
 
 TEST_F(QuicClientTransportSocketFactoryTest, SupportedAlpns) {

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -74,6 +74,7 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
       }));
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope()).WillByDefault(ReturnRef(*stats_store_.rootScope()));
+  ON_CALL(factory_context_.server_context_, threadLocal()).WillByDefault(ReturnRef(thread_local_));
 
 #ifndef ENVOY_ADMIN_FUNCTIONALITY
   config_helper_.addConfigModifier(

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -523,6 +523,7 @@ protected:
 
   Network::DownstreamTransportSocketFactoryPtr
   createUpstreamTlsContext(const FakeUpstreamConfig& upstream_config);
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
   Extensions::TransportSockets::Tls::ContextManagerImpl context_manager_{timeSystem()};
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -368,7 +368,7 @@ void HttpIntegrationTest::initialize() {
   // Needs to be instantiated before base class calls initialize() which starts a QUIC listener
   // according to the config.
   quic_transport_socket_factory_ = IntegrationUtil::createQuicUpstreamTransportSocketFactory(
-      *api_, stats_store_, context_manager_, san_to_match_);
+      *api_, stats_store_, context_manager_, thread_local_, san_to_match_);
 
   // Needed to config QUIC transport socket factory, and needs to be added before base class calls
   // initialize().

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -300,7 +300,8 @@ public:
     ON_CALL(context.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
     ON_CALL(context, statsScope()).WillByDefault(testing::ReturnRef(stats_scope_));
     ON_CALL(context, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager_));
-    ON_CALL(context.server_context_, threadLocal()).WillByDefault(testing::ReturnRef(thread_local_));
+    ON_CALL(context.server_context_, threadLocal())
+        .WillByDefault(testing::ReturnRef(thread_local_));
     envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport
         quic_transport_socket_config;
     auto* tls_context = quic_transport_socket_config.mutable_upstream_tls_context();
@@ -328,6 +329,60 @@ public:
                 ->mutable_enable_reuse_port()
                 ->set_value(true);
           });
+    }
+  }
+
+  void testMultipleUpstreamQuicConnections() {
+    // As with testMultipleQuicConnections this function may be flaky when run with
+    // --runs_per_test=N where N > 1 but without --jobs=1.
+    setConcurrency(8);
+
+    // Avoid having to figure out which requests land on which connections by
+    // having one request per upstream connection.
+    setUpstreamProtocol(Http::CodecType::HTTP3);
+    envoy::config::listener::v3::QuicProtocolOptions options;
+    options.mutable_quic_protocol_options()->mutable_max_concurrent_streams()->set_value(1);
+    mergeOptions(options);
+
+    initialize();
+    std::vector<IntegrationCodecClientPtr> codec_clients;
+    std::vector<IntegrationStreamDecoderPtr> responses;
+    std::vector<FakeStreamPtr> upstream_requests;
+    std::vector<FakeHttpConnectionPtr> upstream_connections;
+
+    // Create |concurrency| clients
+    size_t num_requests = concurrency_ * 2;
+    for (size_t i = 1; i <= concurrency_; ++i) {
+      // See testMultipleQuicConnections for why this should result in connection spread.
+      designated_connection_ids_.push_back(quic::test::TestConnectionId(i << 32));
+      codec_clients.push_back(makeHttpConnection(lookupPort("http")));
+    }
+
+    // Create |num_requests| requests and wait for them to be received upstream
+    for (size_t i = 0; i < num_requests; ++i) {
+      responses.push_back(
+          codec_clients[i % concurrency_]->makeHeaderOnlyRequest(default_request_headers_));
+      waitForNextUpstreamRequest();
+      ASSERT(upstream_request_ != nullptr);
+      upstream_connections.push_back(std::move(fake_upstream_connection_));
+      upstream_requests.push_back(std::move(upstream_request_));
+    }
+
+    // Send |num_requests| responses as fast as possible to regression test
+    // against a prior credentials insert race.
+    for (size_t i = 0; i < num_requests; ++i) {
+      upstream_requests[i]->encodeHeaders(default_response_headers_, true);
+    }
+
+    // Wait for |num_requests| responses to complete.
+    for (size_t i = 0; i < num_requests; ++i) {
+      ASSERT_TRUE(responses[i]->waitForEndStream());
+      EXPECT_TRUE(responses[i]->complete());
+    }
+
+    // Close |concurrency| clients
+    for (size_t i = 0; i < concurrency_; ++i) {
+      codec_clients[i]->close();
     }
   }
 
@@ -374,11 +429,8 @@ public:
     for (size_t i = 0; i < concurrency_; ++i) {
       fake_upstream_connection_ = nullptr;
       upstream_request_ = nullptr;
-      auto encoder_decoder =
-          codec_clients[i]->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                                                        {":path", "/test/long/url"},
-                                                                        {":scheme", "http"},
-                                                                        {":authority", "host"}});
+      auto encoder_decoder = codec_clients[i]->startRequest(default_request_headers_);
+
       auto& request_encoder = encoder_decoder.first;
       auto response = std::move(encoder_decoder.second);
       codec_clients[i]->sendData(request_encoder, 1000, true);
@@ -694,7 +746,13 @@ TEST_P(QuicHttpIntegrationTest, EarlyDataDisabled) {
   codec_client_->close();
 }
 
-// Ensure multiple quic connections work, regardless of platform BPF support
+// Not only test multiple quic connections, but disconnect and reconnect to
+// trigger resumption.
+TEST_P(QuicHttpIntegrationTest, MultipleUpstreamQuicConnections) {
+  setUpstreamProtocol(Http::CodecType::HTTP3);
+  testMultipleUpstreamQuicConnections();
+}
+
 TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsDefaultMode) {
   testMultipleQuicConnections();
 }

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -300,6 +300,7 @@ public:
     ON_CALL(context.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
     ON_CALL(context, statsScope()).WillByDefault(testing::ReturnRef(stats_scope_));
     ON_CALL(context, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager_));
+    ON_CALL(context.server_context_, threadLocal()).WillByDefault(testing::ReturnRef(thread_local_));
     envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport
         quic_transport_socket_config;
     auto* tls_context = quic_transport_socket_config.mutable_upstream_tls_context();

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -11,6 +11,7 @@
 #include "envoy/http/header_map.h"
 #include "envoy/network/filter.h"
 #include "envoy/server/factory_context.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "source/common/common/assert.h"
 #include "source/common/common/dump_state_utils.h"
@@ -208,6 +209,7 @@ public:
   static Network::UpstreamTransportSocketFactoryPtr
   createQuicUpstreamTransportSocketFactory(Api::Api& api, Stats::Store& store,
                                            Ssl::ContextManager& context_manager,
+                                           ThreadLocal::Instance& threadlocal,
                                            const std::string& san_to_match);
 
   static Http::HeaderValidatorFactoryPtr makeHeaderValidationFactory(

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -206,11 +206,9 @@ public:
    * Create transport socket factory for Quic upstream transport socket.
    * @return TransportSocketFactoryPtr the client transport socket factory.
    */
-  static Network::UpstreamTransportSocketFactoryPtr
-  createQuicUpstreamTransportSocketFactory(Api::Api& api, Stats::Store& store,
-                                           Ssl::ContextManager& context_manager,
-                                           ThreadLocal::Instance& threadlocal,
-                                           const std::string& san_to_match);
+  static Network::UpstreamTransportSocketFactoryPtr createQuicUpstreamTransportSocketFactory(
+      Api::Api& api, Stats::Store& store, Ssl::ContextManager& context_manager,
+      ThreadLocal::Instance& threadlocal, const std::string& san_to_match);
 
   static Http::HeaderValidatorFactoryPtr makeHeaderValidationFactory(
       const ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderValidatorConfig&


### PR DESCRIPTION
Envoy as a community is not in the habit of moving "GA" code to alpha. It was believed at the time that HTTP/3 upstream code had been deployed successfully in production but based on the severity of the bug fixed here it appears that was not the case.  Changing security status to reflect the current perceived code stability.

Risk Level: low
Testing: e2e test
Docs Changes: inline
Release Notes: inline