### PR TITLE
Change udpa renaming workaround to not compile the same archive twice

### DIFF
--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -29,13 +29,6 @@ def api_dependencies():
         name = "com_github_cncf_xds",
     )
 
-    # Needed until @com_github_grpc_grpc renames @com_github_cncf_udpa
-    # to @com_github_cncf_xds as well.
-    external_http_archive(
-        name = "com_github_cncf_udpa",
-        location_name = "com_github_cncf_xds",
-    )
-
     external_http_archive(
         name = "prometheus_metrics_model",
         build_file_content = PROMETHEUSMETRICS_BUILD_CONTENT,

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1173,7 +1173,7 @@ def _com_github_grpc_grpc():
         name = "com_github_grpc_grpc",
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:grpc.patch"],
-        # Needed until grpc updates its naming.
+        # Needed until grpc updates its naming (v1.62.0)
         repo_mapping = {"@com_github_cncf_udpa": "@com_github_cncf_xds"},
     )
     external_http_archive("build_bazel_rules_apple")

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1173,6 +1173,8 @@ def _com_github_grpc_grpc():
         name = "com_github_grpc_grpc",
         patch_args = ["-p1"],
         patches = ["@envoy//bazel:grpc.patch"],
+        # Needed until grpc updates its naming.
+        repo_mapping = {"@com_github_cncf_udpa": "@com_github_cncf_xds"},
     )
     external_http_archive("build_bazel_rules_apple")
 


### PR DESCRIPTION
Commit Message: Change udpa renaming workaround to not compile the same archive twice
Additional Description: I copied the prior workaround into a different build environment and it caused linker errors in one subset of the space, which made it clear that the repo was downloaded and compiled twice in the bazel cache under different paths. This change fixes that.
Risk Level: None - if it builds it's better.
Testing: If it builds it ships.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
