### PR TITLE
opentelemetrytracer: Add User-Agent header to OTLP trace exporters

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -255,6 +255,9 @@ new_features:
 - area: tracing
   change: |
     Added support to configure a Dynatrace sampler for the OpenTelemetry tracer.
+- area: tracing
+  change: |
+    Added User-Agent header to OTLP trace exporters according to the OpenTelemetry specification.
 
 deprecated:
 - area: listener

--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -77,6 +77,7 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/protobuf",
         "//source/common/tracing:trace_context_lib",
+        "//source/common/version:version_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@opentelemetry_proto//:trace_cc_proto",
     ],

--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -26,11 +26,13 @@ envoy_cc_library(
     name = "opentelemetry_tracer_lib",
     srcs = [
         "opentelemetry_tracer_impl.cc",
+        "otlp_utils.cc",
         "span_context_extractor.cc",
         "tracer.cc",
     ],
     hdrs = [
         "opentelemetry_tracer_impl.h",
+        "otlp_utils.h",
         "span_context.h",
         "span_context_extractor.h",
         "tracer.h",
@@ -59,10 +61,12 @@ envoy_cc_library(
     srcs = [
         "grpc_trace_exporter.cc",
         "http_trace_exporter.cc",
+        "otlp_utils.cc",
     ],
     hdrs = [
         "grpc_trace_exporter.h",
         "http_trace_exporter.h",
+        "otlp_utils.h",
         "trace_exporter.h",
     ],
     deps = [

--- a/source/extensions/tracers/opentelemetry/BUILD
+++ b/source/extensions/tracers/opentelemetry/BUILD
@@ -26,13 +26,11 @@ envoy_cc_library(
     name = "opentelemetry_tracer_lib",
     srcs = [
         "opentelemetry_tracer_impl.cc",
-        "otlp_utils.cc",
         "span_context_extractor.cc",
         "tracer.cc",
     ],
     hdrs = [
         "opentelemetry_tracer_impl.h",
-        "otlp_utils.h",
         "span_context.h",
         "span_context_extractor.h",
         "tracer.h",

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
@@ -30,7 +30,9 @@ public:
     LocalStream(OpenTelemetryGrpcTraceExporterClient& parent) : parent_(parent) {}
 
     // Grpc::AsyncStreamCallbacks
-    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
+    void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override {
+      metadata.setReferenceUserAgent("OTel-OTLP-Exporter-Envoy");
+    }
     void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
     void onReceiveMessage(
         std::unique_ptr<opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse>&&)

--- a/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
+++ b/source/extensions/tracers/opentelemetry/grpc_trace_exporter.h
@@ -4,6 +4,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/grpc/typed_async_client.h"
+#include "source/extensions/tracers/opentelemetry/otlp_utils.h"
 #include "source/extensions/tracers/opentelemetry/trace_exporter.h"
 
 #include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
@@ -31,7 +32,7 @@ public:
 
     // Grpc::AsyncStreamCallbacks
     void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override {
-      metadata.setReferenceUserAgent("OTel-OTLP-Exporter-Envoy");
+      metadata.setReferenceUserAgent(OtlpUtils::getOtlpUserAgentHeader());
     }
     void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
     void onReceiveMessage(

--- a/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
@@ -50,6 +50,10 @@ bool OpenTelemetryHttpTraceExporter::log(const ExportTraceServiceRequest& reques
   message->headers().setReferenceMethod(Http::Headers::get().MethodValues.Post);
   message->headers().setReferenceContentType(Http::Headers::get().ContentTypeValues.Protobuf);
 
+  // User-Agent header follows the OTLP specification:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.30.0/specification/protocol/exporter.md#user-agent
+  message->headers().setReferenceUserAgent("OTel-OTLP-Exporter-Envoy");
+
   // Add all custom headers to the request.
   for (const auto& header_pair : parsed_headers_to_add_) {
     message->headers().setReference(header_pair.first, header_pair.second);

--- a/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
@@ -8,6 +8,7 @@
 #include "source/common/common/enum_to_int.h"
 #include "source/common/common/logger.h"
 #include "source/common/protobuf/protobuf.h"
+#include "source/extensions/tracers/opentelemetry/otlp_utils.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -52,7 +53,7 @@ bool OpenTelemetryHttpTraceExporter::log(const ExportTraceServiceRequest& reques
 
   // User-Agent header follows the OTLP specification:
   // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.30.0/specification/protocol/exporter.md#user-agent
-  message->headers().setReferenceUserAgent("OTel-OTLP-Exporter-Envoy");
+  message->headers().setReferenceUserAgent(OtlpUtils::getOtlpUserAgentHeader());
 
   // Add all custom headers to the request.
   for (const auto& header_pair : parsed_headers_to_add_) {

--- a/source/extensions/tracers/opentelemetry/otlp_utils.cc
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.cc
@@ -1,0 +1,21 @@
+#include "source/extensions/tracers/opentelemetry/otlp_utils.h"
+
+#include <string>
+
+#include "source/common/common/fmt.h"
+#include "source/common/common/macros.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+const std::string& OtlpUtils::getOtlpUserAgentHeader() {
+  CONSTRUCT_ON_FIRST_USE(std::string,
+                         fmt::format("OTel-OTLP-Exporter-Envoy/{}", VersionInfo::version()));
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/otlp_utils.cc
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.cc
@@ -13,7 +13,7 @@ namespace OpenTelemetry {
 
 const std::string& OtlpUtils::getOtlpUserAgentHeader() {
   CONSTRUCT_ON_FIRST_USE(std::string,
-                         fmt::format("OTel-OTLP-Exporter-Envoy/{}", VersionInfo::version()));
+                         fmt::format("OTel-OTLP-Exporter-Envoy/{}", Envoy::VersionInfo::version()));
 }
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/otlp_utils.cc
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.cc
@@ -4,6 +4,7 @@
 
 #include "source/common/common/fmt.h"
 #include "source/common/common/macros.h"
+#include "source/common/version/version.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+#include "source/common/version/version.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+/**
+ * Contains utility functions  for Otel
+ */
+class OtlpUtils {
+
+public:
+  /**
+   * @brief Get the User-Agent header value to be used on the OTLP exporter request.
+   *
+   * The header value is compliant with the OpenTelemetry specification. See:
+   * https://github.com/open-telemetry/opentelemetry-specification/blob/v1.30.0/specification/protocol/exporter.md#user-agent
+   * @return std::string The User-Agent for the OTLP exporters in Envoy.
+   */
+  static const std::string& getOtlpUserAgentHeader();
+};
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -2,8 +2,6 @@
 
 #include <string>
 
-#include "source/common/version/version.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 
 #include "source/common/buffer/zero_copy_input_stream_impl.h"
+#include "source/common/version/version.h"
 #include "source/extensions/tracers/opentelemetry/grpc_trace_exporter.h"
 
 #include "test/mocks/common.h"
@@ -15,7 +16,6 @@ namespace Tracers {
 namespace OpenTelemetry {
 
 using testing::_;
-using testing::HasSubstr;
 using testing::Invoke;
 using testing::Return;
 
@@ -74,7 +74,8 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, CreateExporterAndExportSpan) {
 
   Http::TestRequestHeaderMapImpl metadata;
   callbacks_->onCreateInitialMetadata(metadata);
-  EXPECT_THAT(metadata.getUserAgentValue(), HasSubstr("OTel-OTLP-Exporter-Envoy/"));
+  EXPECT_EQ(metadata.getUserAgentValue(),
+            "OTel-OTLP-Exporter-Envoy/" + Envoy::VersionInfo::version());
 }
 
 TEST_F(OpenTelemetryGrpcTraceExporterTest, NoExportWithHighWatermark) {

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
@@ -15,6 +15,7 @@ namespace Tracers {
 namespace OpenTelemetry {
 
 using testing::_;
+using testing::HasSubstr;
 using testing::Invoke;
 using testing::Return;
 
@@ -73,7 +74,7 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, CreateExporterAndExportSpan) {
 
   Http::TestRequestHeaderMapImpl metadata;
   callbacks_->onCreateInitialMetadata(metadata);
-  EXPECT_EQ("OTel-OTLP-Exporter-Envoy", metadata.getUserAgentValue());
+  EXPECT_THAT(metadata.getUserAgentValue(), HasSubstr("OTel-OTLP-Exporter-Envoy/"));
 }
 
 TEST_F(OpenTelemetryGrpcTraceExporterTest, NoExportWithHighWatermark) {

--- a/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/grpc_trace_exporter_test.cc
@@ -70,6 +70,10 @@ TEST_F(OpenTelemetryGrpcTraceExporterTest, CreateExporterAndExportSpan) {
   span.set_name("test");
   *request.add_resource_spans()->add_scope_spans()->add_spans() = span;
   EXPECT_TRUE(exporter.log(request));
+
+  Http::TestRequestHeaderMapImpl metadata;
+  callbacks_->onCreateInitialMetadata(metadata);
+  EXPECT_EQ("OTel-OTLP-Exporter-Envoy", metadata.getUserAgentValue());
 }
 
 TEST_F(OpenTelemetryGrpcTraceExporterTest, NoExportWithHighWatermark) {

--- a/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
@@ -1,6 +1,7 @@
 #include <sys/types.h>
 
 #include "source/common/buffer/zero_copy_input_stream_impl.h"
+#include "source/common/version/version.h"
 #include "source/extensions/tracers/opentelemetry/http_trace_exporter.h"
 
 #include "test/mocks/common.h"
@@ -19,7 +20,6 @@ namespace Tracers {
 namespace OpenTelemetry {
 
 using testing::_;
-using testing::HasSubstr;
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnRef;
@@ -79,8 +79,8 @@ TEST_F(OpenTelemetryHttpTraceExporterTest, CreateExporterAndExportSpan) {
             callback = &callbacks;
 
             EXPECT_EQ(Http::Headers::get().MethodValues.Post, message->headers().getMethodValue());
-            EXPECT_THAT(message->headers().getUserAgentValue(),
-                        HasSubstr("OTel-OTLP-Exporter-Envoy/"));
+            EXPECT_EQ(message->headers().getUserAgentValue(),
+                      "OTel-OTLP-Exporter-Envoy/" + Envoy::VersionInfo::version());
             EXPECT_EQ(Http::Headers::get().ContentTypeValues.Protobuf,
                       message->headers().getContentTypeValue());
 

--- a/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
@@ -78,6 +78,7 @@ TEST_F(OpenTelemetryHttpTraceExporterTest, CreateExporterAndExportSpan) {
             callback = &callbacks;
 
             EXPECT_EQ(Http::Headers::get().MethodValues.Post, message->headers().getMethodValue());
+            EXPECT_EQ("OTel-OTLP-Exporter-Envoy", message->headers().getUserAgentValue());
             EXPECT_EQ(Http::Headers::get().ContentTypeValues.Protobuf,
                       message->headers().getContentTypeValue());
 

--- a/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
@@ -19,6 +19,7 @@ namespace Tracers {
 namespace OpenTelemetry {
 
 using testing::_;
+using testing::HasSubstr;
 using testing::Invoke;
 using testing::Return;
 using testing::ReturnRef;
@@ -78,7 +79,8 @@ TEST_F(OpenTelemetryHttpTraceExporterTest, CreateExporterAndExportSpan) {
             callback = &callbacks;
 
             EXPECT_EQ(Http::Headers::get().MethodValues.Post, message->headers().getMethodValue());
-            EXPECT_EQ("OTel-OTLP-Exporter-Envoy", message->headers().getUserAgentValue());
+            EXPECT_THAT(message->headers().getUserAgentValue(),
+                        HasSubstr("OTel-OTLP-Exporter-Envoy/"));
             EXPECT_EQ(Http::Headers::get().ContentTypeValues.Protobuf,
                       message->headers().getContentTypeValue());
 


### PR DESCRIPTION
Commit Message: opentelemetrytracer: Add User-Agent header to OTLP trace exporters

Additional Description: The [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.30.0/specification/protocol/exporter.md#user-agent) defines that OTLP exporters should emit the User-Agent header to help identify the the source/exporter. This PR adds such header to both the OTLP gRPC and HTTP exporters.

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] 
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
