### PR TITLE
zipkin: deprecate split_spans_for_request by the unified spawn_upstream_span

### DIFF
--- a/api/envoy/config/trace/v3/zipkin.proto
+++ b/api/envoy/config/trace/v3/zipkin.proto
@@ -82,5 +82,10 @@ message ZipkinConfig {
   //   If this is set to true, then the
   //   :ref:`start_child_span of router <envoy_v3_api_field_extensions.filters.http.router.v3.Router.start_child_span>`
   //   SHOULD be set to true also to ensure the correctness of trace chain.
-  bool split_spans_for_request = 7;
+  //
+  //   Both this field and ``start_child_span`` are deprecated by the
+  //   :ref:`spawn_upstream_span <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.
+  //   Please use that ``spawn_upstream_span`` field to control the span creation.
+  bool split_spans_for_request = 7
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -242,3 +242,8 @@ deprecated:
   change: |
     deprecated runtime key ``overload.global_downstream_max_connections`` in favor of :ref:`downstream connections monitor
     <envoy_v3_api_msg_extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig>`.
+- area: tracing
+  change: |
+    deprecated :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>`
+    in favor of
+    :ref:`spawn_upstream_span <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -245,5 +245,5 @@ deprecated:
 - area: tracing
   change: |
     deprecated :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>`
-    in favor of
-    :ref:`spawn_upstream_span <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.
+    in favor of :ref:`spawn_upstream_span
+    <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.

--- a/source/extensions/tracers/zipkin/span_context.h
+++ b/source/extensions/tracers/zipkin/span_context.h
@@ -77,7 +77,7 @@ public:
   bool sampled() const { return sampled_; }
 
   /**
-   * @return the inner context flag.
+   * @return the inner context flag. True if this context is created base on the inner span.
    */
   bool innerContext() const { return inner_context_; }
 

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -12,22 +12,46 @@ namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
+/**
+ * @param spawn_child_span whether the Envoy will spawn a child span for the request. This
+ * means that the Envoy will be treated as an independent hop in the trace chain.
+ * See
+ * https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/tracing#different-modes-of-envoy
+ * for more details.
+ * @param upstream whether the span is span for an upstream request.
+ * @param direction the direction of the traffic that the span is for. Egress means
+ * the span is for an outgoing request, and Ingress means the span is for an incoming request.
+ */
+Annotation getAnnotation(bool spawn_child_span, bool upstream, Tracing::OperationName direction) {
+  Annotation annotation;
+  if (spawn_child_span) {
+    // Spawn child span is set to true and Envoy should be treated as an independent hop in the
+    // trace chain. Determine the span type based on the request type.
+
+    // Create server span for downstream request and client span for upstream request.
+    annotation.setValue(upstream ? CLIENT_SEND : SERVER_RECV);
+  } else {
+    // Spawn child span is set to false and Envoy should not be treated as an independent hop in the
+    // trace chain. Determine the span type based on the traffic direction.
+
+    // Create server span for inbound sidecar and client span for outbound sidecar.
+    annotation.setValue(direction == Tracing::OperationName::Egress ? CLIENT_SEND : SERVER_RECV);
+  }
+
+  return annotation;
+}
+
 SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span_name,
                           SystemTime timestamp) {
   // Build the endpoint
   Endpoint ep(service_name_, address_);
 
-  // Build the CS annotation
-  Annotation cs;
+  // Build the CS annotation.
+  // No previous context then this must be span created for downstream request for now.
+  Annotation cs = getAnnotation(split_spans_for_request_ || config.spawnUpstreamSpan(), false,
+                                config.operationName());
   cs.setEndpoint(std::move(ep));
-  if (split_spans_for_request_) {
-    // No previous context then this must be span created for downstream request. Server span will
-    // be created for downstream request when split_spans_for_request is set to true
-    cs.setValue(SERVER_RECV);
-  } else {
-    cs.setValue(config.operationName() == Tracing::OperationName::Egress ? CLIENT_SEND
-                                                                         : SERVER_RECV);
-  }
+
   // Create an all-new span, with no parent id
   SpanPtr span_ptr = std::make_unique<Span>(time_source_);
   span_ptr->setName(span_name);
@@ -59,30 +83,15 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span_name,
                           SystemTime timestamp, const SpanContext& previous_context) {
   SpanPtr span_ptr = std::make_unique<Span>(time_source_);
-  Annotation annotation;
+  // If the previous context is inner context then this span is span for upstream request.
+  Annotation annotation = getAnnotation(split_spans_for_request_ || config.spawnUpstreamSpan(),
+                                        previous_context.innerContext(), config.operationName());
   uint64_t timestamp_micro;
 
   timestamp_micro =
       std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count();
 
   span_ptr->setName(span_name);
-
-  // Set the span's kind (client or server)
-  if (split_spans_for_request_) {
-    // If the previous context is an inner context then this span must be a span created for an
-    // upstream request. A client span will be created for an upstream request.
-    if (previous_context.innerContext()) {
-      annotation.setValue(CLIENT_SEND);
-    } else {
-      annotation.setValue(SERVER_RECV);
-    }
-  } else {
-    if (config.operationName() == Tracing::OperationName::Egress) {
-      annotation.setValue(CLIENT_SEND);
-    } else {
-      annotation.setValue(SERVER_RECV);
-    }
-  }
 
   // Set the span's id and parent id
   if (annotation.value() == CLIENT_SEND || !shared_span_context_) {

--- a/source/extensions/tracers/zipkin/tracer.h
+++ b/source/extensions/tracers/zipkin/tracer.h
@@ -61,7 +61,8 @@ public:
    */
   Tracer(const std::string& service_name, Network::Address::InstanceConstSharedPtr address,
          Random::RandomGenerator& random_generator, const bool trace_id_128bit,
-         const bool shared_span_context, TimeSource& time_source, bool split_spans_for_request)
+         const bool shared_span_context, TimeSource& time_source,
+         bool split_spans_for_request = false)
       : service_name_(service_name), address_(address), reporter_(nullptr),
         random_generator_(random_generator), trace_id_128bit_(trace_id_128bit),
         shared_span_context_(shared_span_context), time_source_(time_source),

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -45,7 +45,7 @@ TEST_F(ZipkinTracerTest, SpanCreation) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Random::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_, false);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_);
   SystemTime timestamp = time_system_.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
@@ -229,6 +229,7 @@ TEST_F(ZipkinTracerTest, SpanCreationWithIndependentProxy) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Random::MockRandomGenerator> random_generator;
+  // Set 'split_spans_for_request' to true.
   Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_, true);
   SystemTime timestamp = time_system_.systemTime();
 
@@ -360,11 +361,147 @@ TEST_F(ZipkinTracerTest, SpanCreationWithIndependentProxy) {
   EXPECT_FALSE(server_side_shared_context_span->isSetDuration());
 }
 
+TEST_F(ZipkinTracerTest, SpanCreationWithIndependentProxyByTracingConfig) {
+  Network::Address::InstanceConstSharedPtr addr =
+      Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
+  NiceMock<Random::MockRandomGenerator> random_generator;
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_);
+  SystemTime timestamp = time_system_.systemTime();
+
+  NiceMock<Tracing::MockConfig> config;
+  ON_CALL(config, spawnUpstreamSpan()).WillByDefault(Return(true));
+
+  // ==============
+  // Test the creation of a root span. If the independent proxy is set to true, the
+  // downstream span will be server span.
+  // ==============
+  ON_CALL(random_generator, random()).WillByDefault(Return(1000));
+  time_system_.advanceTimeWait(std::chrono::milliseconds(1));
+  SpanPtr root_span = tracer.startSpan(config, "my_span", timestamp);
+
+  EXPECT_EQ("my_span", root_span->name());
+  EXPECT_NE(0LL, root_span->startTime());
+  EXPECT_NE(0ULL, root_span->traceId());            // trace id must be set
+  EXPECT_FALSE(root_span->isSetTraceIdHigh());      // by default, should be using 64 bit trace id
+  EXPECT_EQ(root_span->traceId(), root_span->id()); // span id and trace id must be the same
+  EXPECT_FALSE(root_span->isSetParentId());         // no parent set
+  // span's timestamp must be set
+  EXPECT_EQ(
+      std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count(),
+      root_span->timestamp());
+
+  // A SR annotation must have been added
+  EXPECT_EQ(1ULL, root_span->annotations().size());
+  Annotation ann = root_span->annotations()[0];
+  EXPECT_EQ(SERVER_RECV, ann.value());
+  // annotation's timestamp must be set
+  EXPECT_EQ(
+      std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count(),
+      ann.timestamp());
+  EXPECT_TRUE(ann.isSetEndpoint());
+  Endpoint endpoint = ann.endpoint();
+  EXPECT_EQ("my_service_name", endpoint.serviceName());
+
+  // The tracer must have been properly set
+  EXPECT_EQ(dynamic_cast<TracerInterface*>(&tracer), root_span->tracer());
+
+  // Duration is not set at span-creation time
+  EXPECT_FALSE(root_span->isSetDuration());
+
+  // ==============
+  // Test the creation of a upstream span. If the independent proxy is set to true,
+  // the upstream span will be client span.
+  // ==============
+
+  ON_CALL(random_generator, random()).WillByDefault(Return(2000));
+  SpanContext root_span_context(*root_span);
+  SpanPtr child_span = tracer.startSpan(config, "my_child_span", timestamp, root_span_context);
+
+  EXPECT_EQ("my_child_span", child_span->name());
+  EXPECT_NE(0LL, child_span->startTime());
+
+  // trace id must be retained
+  EXPECT_NE(0ULL, child_span->traceId());
+  EXPECT_EQ(root_span_context.traceId(), child_span->traceId());
+
+  // span id and trace id must NOT be the same
+  EXPECT_NE(child_span->traceId(), child_span->id());
+
+  // parent should be the previous span
+  EXPECT_TRUE(child_span->isSetParentId());
+  EXPECT_EQ(root_span_context.id(), child_span->parentId());
+
+  // span's timestamp must be set
+  EXPECT_EQ(
+      std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count(),
+      child_span->timestamp());
+
+  // A CS annotation must have been added
+  EXPECT_EQ(1ULL, child_span->annotations().size());
+  ann = child_span->annotations()[0];
+  EXPECT_EQ(CLIENT_SEND, ann.value());
+  // Annotation's timestamp must be set
+  EXPECT_EQ(
+      std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count(),
+      ann.timestamp());
+  EXPECT_TRUE(ann.isSetEndpoint());
+  endpoint = ann.endpoint();
+  EXPECT_EQ("my_service_name", endpoint.serviceName());
+
+  // The tracer must have been properly set
+  EXPECT_EQ(dynamic_cast<TracerInterface*>(&tracer), child_span->tracer());
+
+  // Duration is not set at span-creation time
+  EXPECT_FALSE(child_span->isSetDuration());
+
+  // ==============
+  // Test the downstream span with parent context and the shared context is enabled. If the
+  // independent proxy is set to true, the downstream span will be server span.
+  // ==============
+  SpanContext child_span_context(*child_span, false);
+  SpanPtr server_side_shared_context_span =
+      tracer.startSpan(config, "my_span", timestamp, child_span_context);
+
+  EXPECT_NE(0LL, server_side_shared_context_span->startTime());
+
+  EXPECT_EQ("my_span", server_side_shared_context_span->name());
+
+  // trace id must be the same in the CS and SR sides
+  EXPECT_EQ(child_span_context.traceId(), server_side_shared_context_span->traceId());
+
+  // span id must be the same in the CS and SR sides
+  EXPECT_EQ(child_span_context.id(), server_side_shared_context_span->id());
+
+  // The parent should be the same as in the CS side.
+  EXPECT_TRUE(server_side_shared_context_span->isSetParentId());
+
+  // span timestamp should not be set (it was set in the CS side)
+  EXPECT_FALSE(server_side_shared_context_span->isSetTimestamp());
+
+  // An SR annotation must have been added
+  EXPECT_EQ(1ULL, server_side_shared_context_span->annotations().size());
+  ann = server_side_shared_context_span->annotations()[0];
+  EXPECT_EQ(SERVER_RECV, ann.value());
+  // annotation's timestamp must be set
+  EXPECT_EQ(
+      std::chrono::duration_cast<std::chrono::microseconds>(timestamp.time_since_epoch()).count(),
+      ann.timestamp());
+  EXPECT_TRUE(ann.isSetEndpoint());
+  endpoint = ann.endpoint();
+  EXPECT_EQ("my_service_name", endpoint.serviceName());
+
+  // The tracer must have been properly set
+  EXPECT_EQ(dynamic_cast<TracerInterface*>(&tracer), server_side_shared_context_span->tracer());
+
+  // Duration is not set at span-creation time
+  EXPECT_FALSE(server_side_shared_context_span->isSetDuration());
+}
+
 TEST_F(ZipkinTracerTest, FinishSpan) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Random::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_, false);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_);
   SystemTime timestamp = time_system_.systemTime();
 
   // ==============
@@ -447,7 +584,7 @@ TEST_F(ZipkinTracerTest, FinishNotSampledSpan) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Random::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_, false);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_);
   SystemTime timestamp = time_system_.systemTime();
 
   // ==============
@@ -475,7 +612,7 @@ TEST_F(ZipkinTracerTest, SpanSampledPropagatedToChild) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Random::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_, false);
+  Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_);
   SystemTime timestamp = time_system_.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
@@ -503,7 +640,7 @@ TEST_F(ZipkinTracerTest, RootSpan128bitTraceId) {
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddressAndPort("127.0.0.1:9000");
   NiceMock<Random::MockRandomGenerator> random_generator;
-  Tracer tracer("my_service_name", addr, random_generator, true, true, time_system_, false);
+  Tracer tracer("my_service_name", addr, random_generator, true, true, time_system_);
   SystemTime timestamp = time_system_.systemTime();
 
   NiceMock<Tracing::MockConfig> config;
@@ -560,8 +697,8 @@ TEST_F(ZipkinTracerTest, NotSharedSpanContext) {
   NiceMock<Random::MockRandomGenerator> random_generator;
 
   const bool shared_span_context = false;
-  Tracer tracer("my_service_name", addr, random_generator, false, shared_span_context, time_system_,
-                false);
+  Tracer tracer("my_service_name", addr, random_generator, false, shared_span_context,
+                time_system_);
   const SystemTime timestamp = time_system_.systemTime();
 
   NiceMock<Tracing::MockConfig> config;


### PR DESCRIPTION
Commit Message: zipkin: deprecate split_spans_for_request by the unified spawn_upstream_span
Additional Description:

Enable the `spawn_upstream_span` support for the zipkin tracer and deprecated the legacy `split_spans_for_request`.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
