### PR TITLE
mobile: Reenable the FilterIntegrationTest.AltSvcCachedH2Slow test

### DIFF
--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -262,7 +262,7 @@ TEST_P(FilterIntegrationTest, AltSvcCachedH3Slow) {
 }
 
 // TODO(32151): Figure out why it's flaky and re-enable.
-TEST_P(FilterIntegrationTest, DISABLED_AltSvcCachedH2Slow) {
+TEST_P(FilterIntegrationTest, AltSvcCachedH2Slow) {
 #ifdef WIN32
   // TODO: sort out what race only happens on windows and GCC.
   GTEST_SKIP() << "Skipping on Windows";

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_integration_test.cc
@@ -261,7 +261,6 @@ TEST_P(FilterIntegrationTest, AltSvcCachedH3Slow) {
                                100);
 }
 
-// TODO(32151): Figure out why it's flaky and re-enable.
 TEST_P(FilterIntegrationTest, AltSvcCachedH2Slow) {
 #ifdef WIN32
   // TODO: sort out what race only happens on windows and GCC.


### PR DESCRIPTION
After some upstream changes, the test no longer seems to flake.

Tested with:
```
bazelisk test --runs_per_test=500 --test_output=streamed
 --cache_test_results=no
 --test_arg="--gtest_filter=*FilterIntegrationTest*AltSvcCachedH2Slow*"
 test/extensions/filters/http/alternate_protocols_cache:filter_integration_test
```

Fixes #32151 