### PR TITLE
tcp_proxy: Fix SIGSEGV on ASSERT

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -372,7 +372,8 @@ void Filter::UpstreamCallbacks::onEvent(Network::ConnectionEvent event) {
 
 void Filter::UpstreamCallbacks::onAboveWriteBufferHighWatermark() {
   // TCP Tunneling may call on high/low watermark multiple times.
-  ASSERT(parent_->config_->tunnelingConfigHelper() || !on_high_watermark_called_);
+  ASSERT(parent_ != nullptr && parent_->config_->tunnelingConfigHelper() ||
+         !on_high_watermark_called_);
   on_high_watermark_called_ = true;
 
   if (parent_ != nullptr) {
@@ -383,7 +384,8 @@ void Filter::UpstreamCallbacks::onAboveWriteBufferHighWatermark() {
 
 void Filter::UpstreamCallbacks::onBelowWriteBufferLowWatermark() {
   // TCP Tunneling may call on high/low watermark multiple times.
-  ASSERT(parent_->config_->tunnelingConfigHelper() || on_high_watermark_called_);
+  ASSERT(parent_ != nullptr && parent_->config_->tunnelingConfigHelper() ||
+         on_high_watermark_called_);
   on_high_watermark_called_ = false;
 
   if (parent_ != nullptr) {


### PR DESCRIPTION
Commit Message: Parent pointer can be null, so test for that before dereferencing in ASSERT.

Fixes: #28014
