### PR TITLE
quic: handle incoming packets with unknown destination address

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -583,16 +583,17 @@ void passPayloadToProcessor(uint64_t bytes_read, Buffer::InstancePtr buffer,
                             Address::InstanceConstSharedPtr peer_addess,
                             Address::InstanceConstSharedPtr local_address,
                             UdpPacketProcessor& udp_packet_processor, MonotonicTime receive_time) {
-  RELEASE_ASSERT(
-      peer_addess != nullptr,
-      fmt::format("Unable to get remote address on the socket bount to local address: {} ",
-                  local_address->asString()));
+  ENVOY_BUG(peer_addess != nullptr,
+            fmt::format("Unable to get remote address on the socket bound to local address: {}.",
+                        (local_address == nullptr ? "unknown" : local_address->asString())));
 
   // Unix domain sockets are not supported
-  RELEASE_ASSERT(peer_addess->type() == Address::Type::Ip,
-                 fmt::format("Unsupported remote address: {} local address: {}, receive size: "
-                             "{}",
-                             peer_addess->asString(), local_address->asString(), bytes_read));
+  ENVOY_BUG(peer_addess != nullptr && peer_addess->type() == Address::Type::Ip,
+            fmt::format("Unsupported remote address: {} local address: {}, receive size: "
+                        "{}",
+                        peer_addess->asString(),
+                        (local_address == nullptr ? "unknown" : local_address->asString()),
+                        bytes_read));
   udp_packet_processor.processPacket(std::move(local_address), std::move(peer_addess),
                                      std::move(buffer), receive_time);
 }

--- a/source/common/quic/envoy_quic_client_connection.h
+++ b/source/common/quic/envoy_quic_client_connection.h
@@ -147,6 +147,7 @@ private:
   Event::Dispatcher& dispatcher_;
   bool migrate_port_on_path_degrading_{false};
   uint8_t num_socket_switches_{0};
+  size_t num_packets_with_unknown_dst_address_{0};
 };
 
 } // namespace Quic

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -428,6 +428,26 @@ TEST_P(EnvoyQuicClientSessionTest, VerifyContextAbortOnFlushWriteBuffer) {
                "unexpectedly reached");
 }
 
+TEST_P(EnvoyQuicClientSessionTest, HandlePacketsWithoutDestinationAddress) {
+  // Send a STATELESS_RESET packet.
+  std::unique_ptr<quic::QuicEncryptedPacket> stateless_reset_packet =
+      quic::QuicFramer::BuildIetfStatelessResetPacket(
+          quic::test::TestConnectionId(), /*received_packet_length*/ 1200,
+          quic::QuicUtils::GenerateStatelessResetToken(quic::test::TestConnectionId()));
+  EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose))
+      .Times(0);
+  for (size_t i = 0; i < 9; ++i) {
+    auto buffer = std::make_unique<Buffer::OwnedImpl>(stateless_reset_packet->data());
+    quic_connection_->processPacket(nullptr, peer_addr_, std::move(buffer),
+                                    time_system_.monotonicTime());
+  }
+  EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose))
+      .Times(0);
+  auto buffer = std::make_unique<Buffer::OwnedImpl>(stateless_reset_packet->data());
+  quic_connection_->processPacket(nullptr, peer_addr_, std::move(buffer),
+                                  time_system_.monotonicTime());
+}
+
 // Tests that receiving a STATELESS_RESET packet on the probing socket doesn't cause crash.
 TEST_P(EnvoyQuicClientSessionTest, StatelessResetOnProbingSocket) {
   quic::QuicNewConnectionIdFrame frame;


### PR DESCRIPTION
Commit Message: QUIC client sockets always enable socket options to read destination address of the incoming UDP packets. But in some cases, the address is not returned via the system call, recvmsg or recvmmsg. In such case, Quic connection should drop the packets. And if there are a lot of such packets, the connection should be closed with detailed error sent to the server.

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
