### PR TITLE
mobile: Implement setLogger in the C++ API

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -149,6 +149,11 @@ EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
   return *this;
 }
 
+EngineBuilder& EngineBuilder::setLogger(envoy_logger envoy_logger) {
+  envoy_logger_.emplace(envoy_logger);
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::setOnEngineRunning(std::function<void()> closure) {
   callbacks_->on_engine_running = std::move(closure);
   return *this;
@@ -894,8 +899,9 @@ EngineSharedPtr EngineBuilder::build() {
 
   envoy_event_tracker null_tracker{};
 
-  Envoy::InternalEngine* envoy_engine =
-      new Envoy::InternalEngine(callbacks_->asEnvoyEngineCallbacks(), null_logger, null_tracker);
+  Envoy::InternalEngine* envoy_engine = new Envoy::InternalEngine(
+      callbacks_->asEnvoyEngineCallbacks(),
+      (envoy_logger_.has_value()) ? *envoy_logger_ : null_logger, null_tracker);
 
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -126,6 +126,7 @@ public:
   virtual ~EngineBuilder() {}
 
   EngineBuilder& addLogLevel(LogLevel log_level);
+  EngineBuilder& setLogger(envoy_logger envoy_logger);
   EngineBuilder& setOnEngineRunning(std::function<void()> closure);
   EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
   EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
@@ -213,6 +214,7 @@ private:
   };
 
   LogLevel log_level_ = LogLevel::info;
+  absl::optional<envoy_logger> envoy_logger_;
   EngineCallbacksSharedPtr callbacks_;
 
   int connect_timeout_seconds_ = 30;

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -601,17 +601,14 @@ TEST_F(InternalEngineTest, ResetConnectivityState) {
 }
 
 TEST_F(InternalEngineTest, SetLogger) {
-  bool has_logging_data = false;
+  bool logging_was_called = false;
   envoy_logger logger;
-  logger.log = [](envoy_log_level, envoy_data data, const void* context) {
-    bool* has_logging_data = const_cast<bool*>(static_cast<const bool*>(context));
-    if (!Data::Utility::copyToString(data).empty()) {
-      *has_logging_data = true;
-    }
-    release_envoy_data(data);
+  logger.log = [](envoy_log_level, envoy_data, const void* context) {
+    bool* logging_was_called = const_cast<bool*>(static_cast<const bool*>(context));
+    *logging_was_called = true;
   };
   logger.release = envoy_noop_const_release;
-  logger.context = &has_logging_data;
+  logger.context = &logging_was_called;
 
   absl::Notification engine_running;
   Platform::EngineBuilder engine_builder;
@@ -656,7 +653,7 @@ TEST_F(InternalEngineTest, SetLogger) {
 
   EXPECT_EQ(actual_status_code, 200);
   EXPECT_EQ(actual_end_stream, true);
-  EXPECT_TRUE(has_logging_data);
+  EXPECT_TRUE(logging_was_called);
   EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
 }
 

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -603,9 +603,10 @@ TEST_F(InternalEngineTest, ResetConnectivityState) {
 TEST_F(InternalEngineTest, SetLogger) {
   bool logging_was_called = false;
   envoy_logger logger;
-  logger.log = [](envoy_log_level, envoy_data, const void* context) {
+  logger.log = [](envoy_log_level, envoy_data data, const void* context) {
     bool* logging_was_called = const_cast<bool*>(static_cast<const bool*>(context));
     *logging_was_called = true;
+    release_envoy_data(data);
   };
   logger.release = envoy_noop_const_release;
   logger.context = &logging_was_called;

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -608,6 +608,7 @@ TEST_F(InternalEngineTest, SetLogger) {
     if (!Data::Utility::copyToString(data).empty()) {
       *has_logging_data = true;
     }
+    release_envoy_data(data);
   };
   logger.release = envoy_noop_const_release;
   logger.context = &has_logging_data;

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -638,7 +638,10 @@ TEST_F(InternalEngineTest, SetLogger) {
                       actual_status_code = headers->httpStatus();
                       actual_end_stream = end_stream;
                     })
-                    .setOnData([&](envoy_data, bool end_stream) { actual_end_stream = end_stream; })
+                    .setOnData([&](envoy_data data, bool end_stream) {
+                      actual_end_stream = end_stream;
+                      release_envoy_data(data);
+                    })
                     .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
                       stream_complete.Notify();
                     })

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -600,4 +600,63 @@ TEST_F(InternalEngineTest, ResetConnectivityState) {
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
+TEST_F(InternalEngineTest, SetLogger) {
+  bool has_logging_data = false;
+  envoy_logger logger;
+  logger.log = [](envoy_log_level, envoy_data data, const void* context) {
+    bool* has_logging_data = const_cast<bool*>(static_cast<const bool*>(context));
+    if (!Data::Utility::copyToString(data).empty()) {
+      *has_logging_data = true;
+    }
+  };
+  logger.release = envoy_noop_const_release;
+  logger.context = &has_logging_data;
+
+  absl::Notification engine_running;
+  Platform::EngineBuilder engine_builder;
+  Platform::EngineSharedPtr engine =
+      engine_builder.addLogLevel(Platform::LogLevel::debug)
+          .setLogger(logger)
+          .setOnEngineRunning([&] { engine_running.Notify(); })
+          .addNativeFilter(
+              "test_remote_response",
+              "{'@type': "
+              "type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+          .build();
+  engine_running.WaitForNotification();
+
+  int actual_status_code = 0;
+  bool actual_end_stream = false;
+  absl::Notification stream_complete;
+  auto stream_prototype = engine->streamClient()->newStreamPrototype();
+  auto stream = (*stream_prototype)
+                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
+                                      envoy_stream_intel) {
+                      actual_status_code = headers->httpStatus();
+                      actual_end_stream = end_stream;
+                    })
+                    .setOnData([&](envoy_data, bool end_stream) { actual_end_stream = end_stream; })
+                    .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
+                      stream_complete.Notify();
+                    })
+                    .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                                    envoy_final_stream_intel) { stream_complete.Notify(); })
+                    .setOnCancel([&](envoy_stream_intel, envoy_final_stream_intel) {
+                      stream_complete.Notify();
+                    })
+                    .start();
+
+  auto request_headers =
+      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https", "example.com", "/")
+          .build();
+  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_EQ(actual_end_stream, true);
+  EXPECT_TRUE(has_logging_data);
+  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
+}
+
 } // namespace Envoy


### PR DESCRIPTION
Implement a `setLogger` in the C++ `EngineBuilder` API. This is to allow delegating the Envoy logger into a different logging implementation depending on the platform. This change also aims to make the C++ API more consistent with other language APIs.

Risk Level: low (new function)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile