### PR TITLE
build: remove incorrect cc_library after tls code move

### DIFF
--- a/source/common/tls/BUILD
+++ b/source/common/tls/BUILD
@@ -11,21 +11,6 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
-    name = "config",
-    srcs = ["config.cc"],
-    hdrs = ["config.h"],
-    # TLS is core functionality.
-    visibility = ["//visibility:public"],
-    deps = [
-        ":ssl_socket_lib",
-        "//envoy/network:transport_socket_interface",
-        "//envoy/registry",
-        "//envoy/server:transport_socket_config_interface",
-    ],
-    alwayslink = 1,
-)
-
-envoy_cc_library(
     name = "connection_info_impl_base_lib",
     srcs = ["connection_info_impl_base.cc"],
     hdrs = ["connection_info_impl_base.h"],


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: build: remove incorrect cc_library after tls code move
Additional Description: This fixes building `//source/...` or generating a compile_commands.json

```
ERROR: /source/common/tls/BUILD:13:17: //source/common/tls:config, aspect @bazel_compdb//:aspects.bzl%compilation_database_aspect: missing input file '//source/common/tls:config.h'
ERROR: //source/common/tls:config, aspect @bazel_compdb//:aspects.bzl%compilation_database_aspect 1 input file(s) do not exist
```
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
