### PR TITLE
clang tidy: use default member initializers

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -354,43 +354,38 @@ private:
 
     // All state for the stream. Put here for readability.
     struct State {
-      State()
-          : codec_saw_local_complete_(false), codec_encode_complete_(false),
-            on_reset_stream_called_(false), is_zombie_stream_(false), successful_upgrade_(false),
-            is_internally_destroyed_(false), is_internally_created_(false), is_tunneling_(false),
-            decorated_propagate_(true), deferred_to_next_io_iteration_(false) {}
-
       // It's possibly for the codec to see the completed response but not fully
       // encode it.
-      bool codec_saw_local_complete_ : 1; // This indicates that local is complete as the completed
-                                          // response has made its way to the codec.
-      bool codec_encode_complete_ : 1;    // This indicates that the codec has
-                                          // completed encoding the response.
-      bool on_reset_stream_called_ : 1;   // Whether the stream has been reset.
-      bool is_zombie_stream_ : 1;         // Whether stream is waiting for signal
-                                          // the underlying codec to be destroyed.
-      bool successful_upgrade_ : 1;
+      bool codec_saw_local_complete_ : 1 {
+          false}; // This indicates that local is complete as the completed
+                  // response has made its way to the codec.
+      bool codec_encode_complete_ : 1 {false};  // This indicates that the codec has
+                                                // completed encoding the response.
+      bool on_reset_stream_called_ : 1 {false}; // Whether the stream has been reset.
+      bool is_zombie_stream_ : 1 {false};       // Whether stream is waiting for signal
+                                                // the underlying codec to be destroyed.
+      bool successful_upgrade_ : 1 {false};
 
       // True if this stream was the original externally created stream, but was
       // destroyed as part of internal redirect.
-      bool is_internally_destroyed_ : 1;
+      bool is_internally_destroyed_ : 1 {false};
       // True if this stream is internally created. Currently only used for
       // internal redirects or other streams created via recreateStream().
-      bool is_internally_created_ : 1;
+      bool is_internally_created_ : 1 {false};
 
       // True if the response headers indicate a successful upgrade or connect
       // response.
-      bool is_tunneling_ : 1;
+      bool is_tunneling_ : 1 {false};
 
-      bool decorated_propagate_ : 1;
+      bool decorated_propagate_ : 1 {true};
 
       // Indicates that sending headers to the filter manager is deferred to the
       // next I/O cycle. If data or trailers are received when this flag is set
       // they are deferred too.
       // TODO(yanavlasov): encapsulate the entire state of deferred streams into a separate
       // structure, so it can be atomically created and cleared.
-      bool deferred_to_next_io_iteration_ : 1;
-      bool deferred_end_stream_ : 1;
+      bool deferred_to_next_io_iteration_ : 1 {false};
+      bool deferred_end_stream_ : 1 {false};
     };
 
     bool canDestroyStream() const {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -185,14 +185,14 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   // hasn't parsed data and trailers. As a result, the filter iteration should start with the
   // current filter instead of the next one. If true, filter iteration starts with the current
   // filter. Otherwise, starts with the next filter in the chain.
-  bool iterate_from_current_filter_ : 1;
-  bool headers_continued_ : 1;
-  bool continued_1xx_headers_ : 1;
+  bool iterate_from_current_filter_ : 1 {false};
+  bool headers_continued_ : 1 {false};
+  bool continued_1xx_headers_ : 1 {false};
   // If true, end_stream is called for this filter.
-  bool end_stream_ : 1;
-  const bool is_encoder_decoder_filter_ : 1;
+  bool end_stream_ : 1 {false};
+  const bool is_encoder_decoder_filter_ : 1 {false};
   // If true, the filter has processed headers.
-  bool processed_headers_ : 1;
+  bool processed_headers_ : 1 {false};
 };
 
 /**
@@ -863,27 +863,27 @@ protected:
           encoder_filter_chain_aborted_(false), saw_downstream_reset_(false) {}
     uint32_t filter_call_state_{0};
 
-    bool remote_decode_complete_ : 1;
-    bool remote_encode_complete_ : 1;
-    bool local_complete_ : 1; // This indicates that local is complete prior to filter processing.
-                              // A filter can still stop the stream from being complete as seen
-                              // by the codec.
+    bool remote_decode_complete_ : 1 {false};
+    bool remote_encode_complete_ : 1 {false};
+    bool local_complete_ : 1 {false}; // This indicates that local is complete prior to filter
+                                      // processing. A filter can still stop the stream from being
+                                      // complete as seen by the codec.
     // By default, we will assume there are no 1xx. If encode1xxHeaders
     // is ever called, this is set to true so commonContinue resumes processing the 1xx.
-    bool has_1xx_headers_ : 1;
-    bool created_filter_chain_ : 1;
+    bool has_1xx_headers_ : 1 {false};
+    bool created_filter_chain_ : 1 {false};
     // These two are latched on initial header read, to determine if the original headers
     // constituted a HEAD or gRPC request, respectively.
-    bool is_head_request_ : 1;
-    bool is_grpc_request_ : 1;
+    bool is_head_request_ : 1 {false};
+    bool is_grpc_request_ : 1 {false};
     // Tracks if headers other than 100-Continue have been encoded to the codec.
-    bool non_100_response_headers_encoded_ : 1;
+    bool non_100_response_headers_encoded_ : 1 {false};
     // True under the stack of onLocalReply, false otherwise.
-    bool under_on_local_reply_ : 1;
+    bool under_on_local_reply_ : 1 {false};
     // True when the filter chain iteration was aborted with local reply.
-    bool decoder_filter_chain_aborted_ : 1;
-    bool encoder_filter_chain_aborted_ : 1;
-    bool saw_downstream_reset_ : 1;
+    bool decoder_filter_chain_aborted_ : 1 {false};
+    bool encoder_filter_chain_aborted_ : 1 {false};
+    bool saw_downstream_reset_ : 1 {false};
 
     // The following 3 members are booleans rather than part of the space-saving bitfield as they
     // are passed as arguments to functions expecting bools. Extend State using the bitfield

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -855,12 +855,6 @@ public:
 
 protected:
   struct State {
-    State()
-        : remote_decode_complete_(false), remote_encode_complete_(false), local_complete_(false),
-          has_1xx_headers_(false), created_filter_chain_(false), is_head_request_(false),
-          is_grpc_request_(false), non_100_response_headers_encoded_(false),
-          under_on_local_reply_(false), decoder_filter_chain_aborted_(false),
-          encoder_filter_chain_aborted_(false), saw_downstream_reset_(false) {}
     uint32_t filter_call_state_{0};
 
     bool remote_decode_complete_ : 1 {false};


### PR DESCRIPTION
Commit Message: use default initializers. This helps when a new constructor is introduced that does not initialize a field.
Risk Level: low
Testing: unit