### PR TITLE
Admin tap: supports multiple attached requests

### DIFF
--- a/api/envoy/extensions/common/tap/v3/common.proto
+++ b/api/envoy/extensions/common/tap/v3/common.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.common.tap.v3;
 
 import "envoy/config/tap/v3/common.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -42,5 +43,8 @@ message AdminConfig {
   // Opaque configuration ID. When requests are made to the admin handler, the passed opaque ID is
   // matched to the configured filter opaque ID to determine which filter to configure.
   string config_id = 1 [(validate.rules).string = {min_len: 1}];
-  uint64 max_concurrent_streams = 2 [(validate.rules).uint64 = {gt: 0}];
+
+  // Threshold of maximum atached request supported. Additional request's will be attached until re
+  // aching the maximum concurrency. The default value is 1. The maximum value is 512*1024.
+  google.protobuf.UInt32Value max_concurrent_streams = 2 [(validate.rules).uint32 = {lte: 524288 gte: 1}];
 }

--- a/api/envoy/extensions/common/tap/v3/common.proto
+++ b/api/envoy/extensions/common/tap/v3/common.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.common.tap.v3;
 
 import "envoy/config/tap/v3/common.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
@@ -46,5 +47,6 @@ message AdminConfig {
 
   // Threshold of maximum attached request supported. Additional request's will be attached until re
   // aching the maximum concurrency. The default value is 1. The maximum value is 512*1024.
-  google.protobuf.UInt32Value max_concurrent_streams = 2 [(validate.rules).uint32 = {lte: 524288 gte: 1}];
+  google.protobuf.UInt32Value max_concurrent_streams = 2
+      [(validate.rules).uint32 = {lte: 524288 gte: 1}];
 }

--- a/api/envoy/extensions/common/tap/v3/common.proto
+++ b/api/envoy/extensions/common/tap/v3/common.proto
@@ -42,4 +42,5 @@ message AdminConfig {
   // Opaque configuration ID. When requests are made to the admin handler, the passed opaque ID is
   // matched to the configured filter opaque ID to determine which filter to configure.
   string config_id = 1 [(validate.rules).string = {min_len: 1}];
+  uint64 max_concurrent_streams = 2 [(validate.rules).uint64 = {gt: 0}];
 }

--- a/api/envoy/extensions/common/tap/v3/common.proto
+++ b/api/envoy/extensions/common/tap/v3/common.proto
@@ -44,7 +44,7 @@ message AdminConfig {
   // matched to the configured filter opaque ID to determine which filter to configure.
   string config_id = 1 [(validate.rules).string = {min_len: 1}];
 
-  // Threshold of maximum atached request supported. Additional request's will be attached until re
+  // Threshold of maximum attached request supported. Additional request's will be attached until re
   // aching the maximum concurrency. The default value is 1. The maximum value is 512*1024.
   google.protobuf.UInt32Value max_concurrent_streams = 2 [(validate.rules).uint32 = {lte: 524288 gte: 1}];
 }

--- a/docs/root/configuration/http/http_filters/tap_filter.rst
+++ b/docs/root/configuration/http/http_filters/tap_filter.rst
@@ -36,6 +36,7 @@ Example filter configuration:
     common_config:
       admin_config:
         config_id: test_config_id
+        max_concurrent_streams: 1
 
 The previous snippet configures the filter for control via the :http:post:`/tap` admin handler.
 See the following section for more details.
@@ -71,6 +72,7 @@ An example POST body:
 .. code-block:: yaml
 
   config_id: test_config_id
+  max_concurrent_streams: 1
   tap_config:
     match_config:
       and_match:
@@ -98,6 +100,7 @@ Another example POST body:
 .. code-block:: yaml
 
   config_id: test_config_id
+  max_concurrent_streams: 1
   tap_config:
     match_config:
       or_match:
@@ -125,6 +128,7 @@ Another example POST body:
 .. code-block:: yaml
 
   config_id: test_config_id
+  max_concurrent_streams: 1
   tap_config:
     match_config:
       any_match: true
@@ -140,6 +144,7 @@ Another example POST body:
 .. code-block:: yaml
 
   config_id: test_config_id
+  max_concurrent_streams: 1
   tap_config:
     match_config:
       and_match:
@@ -191,6 +196,7 @@ An example of a streaming admin tap configuration that uses the :ref:`JSON_BODY_
 .. code-block:: yaml
 
   config_id: test_config_id
+  max_concurrent_streams: 1
   tap_config:
     match_config:
       any_match: true
@@ -226,6 +232,7 @@ An example of a buffered admin tap configuration:
 .. code-block:: yaml
 
   config_id: test_config_id
+  max_concurrent_streams: 1
   tap_config:
     match_config:
       any_match: true

--- a/source/extensions/common/tap/admin.cc
+++ b/source/extensions/common/tap/admin.cc
@@ -17,10 +17,10 @@ namespace Tap {
 // Singleton registration via macro defined in envoy/singleton/manager.h
 SINGLETON_MANAGER_REGISTRATION(tap_admin_handler);
 
-AdminHandlerSharedPtr
-AdminHandler::getSingleton(OptRef<Server::Admin> admin, Singleton::Manager& singleton_manager,
-                           Event::Dispatcher& main_thread_dispatcher,
-                           const uint64_t& max_concurrent_streams) {
+AdminHandlerSharedPtr AdminHandler::getSingleton(OptRef<Server::Admin> admin,
+                                                 Singleton::Manager& singleton_manager,
+                                                 Event::Dispatcher& main_thread_dispatcher,
+                                                 const uint64_t& max_concurrent_streams) {
   return singleton_manager.getTyped<AdminHandler>(
       SINGLETON_MANAGER_REGISTERED_NAME(tap_admin_handler),
       [&admin, &main_thread_dispatcher, &max_concurrent_streams] {
@@ -241,8 +241,8 @@ AdminHandler::AttachedRequest::AttachedRequest(AdminHandler* admin_handler,
                                                const envoy::admin::v3::TapRequest& tap_request,
                                                Server::AdminStream* admin_stream)
     : config_id_(tap_request.config_id()), config_(tap_request.tap_config()),
-      main_thread_dispatcher_(admin_handler->main_thread_dispatcher_),
-      admin_stream_set_{admin_stream} {}
+      main_thread_dispatcher_(admin_handler->main_thread_dispatcher_), admin_stream_set_{
+                                                                           admin_stream} {}
 
 AdminHandler::AttachedRequestBuffered::AttachedRequestBuffered(
     AdminHandler* admin_handler, const envoy::admin::v3::TapRequest& tap_request,

--- a/source/extensions/common/tap/admin.cc
+++ b/source/extensions/common/tap/admin.cc
@@ -17,10 +17,10 @@ namespace Tap {
 // Singleton registration via macro defined in envoy/singleton/manager.h
 SINGLETON_MANAGER_REGISTRATION(tap_admin_handler);
 
-AdminHandlerSharedPtr AdminHandler::getSingleton(OptRef<Server::Admin> admin,
-                                                 Singleton::Manager& singleton_manager,
-                                                 Event::Dispatcher& main_thread_dispatcher,
-                                                 const uint64_t& max_concurrent_streams) {
+AdminHandlerSharedPtr
+AdminHandler::getSingleton(OptRef<Server::Admin> admin, Singleton::Manager& singleton_manager,
+                           Event::Dispatcher& main_thread_dispatcher,
+                           const uint64_t& max_concurrent_streams) {
   return singleton_manager.getTyped<AdminHandler>(
       SINGLETON_MANAGER_REGISTERED_NAME(tap_admin_handler),
       [&admin, &main_thread_dispatcher, &max_concurrent_streams] {
@@ -67,9 +67,9 @@ Http::Code AdminHandler::handler(Http::HeaderMap&, Buffer::Instance& response,
           response, fmt::format("Unknown config id '{}'. No extension has registered with this id.",
                                 tap_request.config_id()));
     }
-    if (attached_request_->streams().size() >= max_concurrent()) {
-      return badRequest(
-          response, fmt::format("Maximum concurrent attached request reach. Detach it."));
+    if (static_cast<uint32_t>(attached_request_->streams().size()) >= max_concurrent()) {
+      return badRequest(response,
+                        fmt::format("Maximum concurrent attached request reach. Detach it."));
     } else {
       ENVOY_LOG(debug, "New request stream has appended to attached request for tapping.");
       attached_request_->streams().insert(&admin_stream);

--- a/source/extensions/common/tap/admin.h
+++ b/source/extensions/common/tap/admin.h
@@ -208,13 +208,13 @@ private:
   Http::Code handler(Http::HeaderMap& response_headers, Buffer::Instance& response,
                      Server::AdminStream& admin_stream);
   Http::Code badRequest(Buffer::Instance& response, absl::string_view error);
-  const uint64_t& max_concurrent() const { return max_concurrent_streams_; }
+  const uint32_t& max_concurrent() const { return max_concurrent_streams_; }
 
   Server::Admin& admin_;
   Event::Dispatcher& main_thread_dispatcher_;
   absl::node_hash_map<std::string, absl::node_hash_set<ExtensionConfig*>> config_id_map_;
   std::shared_ptr<AttachedRequest> attached_request_;
-  const uint64_t max_concurrent_streams_;
+  const uint32_t max_concurrent_streams_;
   friend class BaseAdminHandlerTest;     // For testing purposes
   friend class BufferedAdminHandlerTest; // For testing Purposes
 };

--- a/source/extensions/common/tap/admin.h
+++ b/source/extensions/common/tap/admin.h
@@ -36,7 +36,8 @@ class AdminHandler : public Singleton::Instance,
                      public Extensions::Common::Tap::Sink,
                      Logger::Loggable<Logger::Id::tap> {
 public:
-  AdminHandler(OptRef<Server::Admin> admin, Event::Dispatcher& main_thread_dispatcher, const uint64_t& max_concurrent_streams);
+  AdminHandler(OptRef<Server::Admin> admin, Event::Dispatcher& main_thread_dispatcher,
+               const uint64_t& max_concurrent_streams);
   ~AdminHandler() override;
 
   /**
@@ -148,7 +149,7 @@ private:
     envoy::config::tap::v3::OutputSink::Format format() const {
       return config_.output_config().sinks()[0].format();
     }
-    std::set<Server::AdminStream*>& streams()  { return admin_stream_set_; }
+    std::set<Server::AdminStream*>& streams() { return admin_stream_set_; }
 
   protected:
     Event::Dispatcher& dispatcher() { return main_thread_dispatcher_; }

--- a/source/extensions/common/tap/extension_config_base.cc
+++ b/source/extensions/common/tap/extension_config_base.cc
@@ -18,7 +18,7 @@ ExtensionConfigBase::ExtensionConfigBase(
 
   switch (proto_config_.config_type_case()) {
   case envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::kAdminConfig: {
-    admin_handler_ = AdminHandler::getSingleton(admin, singleton_manager, main_thread_dispatcher, proto_config_.admin_config().max_concurrent_streams()) ;
+    admin_handler_ = AdminHandler::getSingleton(admin, singleton_manager, main_thread_dispatcher, proto_config_.admin_config().max_concurrent_streams().value()) ;
     admin_handler_->registerConfig(*this, proto_config_.admin_config().config_id());
     ENVOY_LOG(debug, "initializing tap extension with admin endpoint (config_id={})",
               proto_config_.admin_config().config_id());

--- a/source/extensions/common/tap/extension_config_base.cc
+++ b/source/extensions/common/tap/extension_config_base.cc
@@ -18,7 +18,7 @@ ExtensionConfigBase::ExtensionConfigBase(
 
   switch (proto_config_.config_type_case()) {
   case envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::kAdminConfig: {
-    admin_handler_ = AdminHandler::getSingleton(admin, singleton_manager, main_thread_dispatcher);
+    admin_handler_ = AdminHandler::getSingleton(admin, singleton_manager, main_thread_dispatcher, proto_config_.admin_config().max_concurrent_streams()) ;
     admin_handler_->registerConfig(*this, proto_config_.admin_config().config_id());
     ENVOY_LOG(debug, "initializing tap extension with admin endpoint (config_id={})",
               proto_config_.admin_config().config_id());

--- a/source/extensions/common/tap/extension_config_base.cc
+++ b/source/extensions/common/tap/extension_config_base.cc
@@ -18,7 +18,9 @@ ExtensionConfigBase::ExtensionConfigBase(
 
   switch (proto_config_.config_type_case()) {
   case envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::kAdminConfig: {
-    admin_handler_ = AdminHandler::getSingleton(admin, singleton_manager, main_thread_dispatcher, proto_config_.admin_config().max_concurrent_streams().value()) ;
+    admin_handler_ =
+        AdminHandler::getSingleton(admin, singleton_manager, main_thread_dispatcher,
+                                   proto_config_.admin_config().max_concurrent_streams().value());
     admin_handler_->registerConfig(*this, proto_config_.admin_config().config_id());
     ENVOY_LOG(debug, "initializing tap extension with admin endpoint (config_id={})",
               proto_config_.admin_config().config_id());

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -72,12 +72,14 @@ private:
 
 class BaseAdminHandlerTest : public testing::Test {
 public:
-  void setup(Network::Address::Type socket_type = Network::Address::Type::Ip, uint32_t max_concurrent_streams = 1) {
+  void setup(Network::Address::Type socket_type = Network::Address::Type::Ip,
+             uint32_t max_concurrent_streams = 1) {
     ON_CALL(admin_.socket_, addressType()).WillByDefault(Return(socket_type));
     EXPECT_CALL(admin_, addHandler("/tap", "tap filter control", _, true, true, _))
         .WillOnce(DoAll(SaveArg<2>(&cb_), Return(true)));
     EXPECT_CALL(admin_, socket());
-    handler_ = std::make_unique<AdminHandler>(admin_, main_thread_dispatcher_, max_concurrent_streams);
+    handler_ =
+        std::make_unique<AdminHandler>(admin_, main_thread_dispatcher_, max_concurrent_streams);
   }
 
   void TearDown() override { main_thread_dispatcher_.drain(); }
@@ -330,7 +332,7 @@ TEST_F(AdminHandlerTest, UnknownConfigId) {
 
 // Request while exceeding the max concurrency number (1 in this situation).
 TEST_F(AdminHandlerTest, RequestTapExceedMaxConcurrency) {
-  setup(Network::Address::Type::Pipe,1);
+  setup(Network::Address::Type::Pipe, 1);
   MockExtensionConfig extension_config;
   handler_->registerConfig(extension_config, "test_config_id");
 
@@ -345,9 +347,9 @@ TEST_F(AdminHandlerTest, RequestTapExceedMaxConcurrency) {
   EXPECT_EQ("Maximum concurrent attached request reach. Detach it.", response_.toString());
 }
 
-// Requests whlie max_concurrent_streams = 2 is set to allow 2 admin request attaching.
+// Requests while max_concurrent_streams = 2 is set to allow 2 admin request attaching.
 TEST_F(AdminHandlerTest, MultipleRequestTapAttached) {
-  setup(Network::Address::Type::Pipe,2);
+  setup(Network::Address::Type::Pipe, 2);
   MockExtensionConfig extension_config;
   handler_->registerConfig(extension_config, "test_config_id");
 

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -72,7 +72,7 @@ private:
 
 class BaseAdminHandlerTest : public testing::Test {
 public:
-  void setup(Network::Address::Type socket_type = Network::Address::Type::Ip, uint64_t max_concurrent_streams = 1) {
+  void setup(Network::Address::Type socket_type = Network::Address::Type::Ip, uint32_t max_concurrent_streams = 1) {
     ON_CALL(admin_.socket_, addressType()).WillByDefault(Return(socket_type));
     EXPECT_CALL(admin_, addHandler("/tap", "tap filter control", _, true, true, _))
         .WillOnce(DoAll(SaveArg<2>(&cb_), Return(true)));

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -203,6 +203,7 @@ typed_config:
   common_config:
     admin_config:
       config_id: test_config_id
+      max_concurrent_streams: 2
 )EOF";
 
   IntegrationCodecClientPtr admin_client_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: 
Additional Description: Currently, admin tap support only single attached request to capture traffic for observation, this feature allow user to attach more request to admin tap until reach the num in `max_concurrent_streams`  added in AdminConfig API. 
Risk Level: Low
Testing: Added unit tests for multiple attached request.
Docs Changes:  tap filter doc example add `max_concurrent_streams` filed
Release Notes: N/A