### PR TITLE
test: Use Envoy::Thread::MockThreadFactory

### DIFF
--- a/contrib/golang/filters/network/test/BUILD
+++ b/contrib/golang/filters/network/test/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test(
     deps = [
         "//contrib/golang/filters/network/source:config",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/thread:thread_mocks",
         "//test/test_common:utility_lib",
     ],
 )
@@ -50,6 +51,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/ssl:ssl_mocks",
+        "//test/mocks/thread:thread_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/test_common:logging_lib",

--- a/contrib/golang/filters/network/test/config_test.cc
+++ b/contrib/golang/filters/network/test/config_test.cc
@@ -3,6 +3,7 @@
 #include "envoy/registry/registry.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/thread/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
@@ -19,12 +20,6 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Golang {
 namespace {
-
-class MockThreadFactory : public Thread::ThreadFactory {
-public:
-  MOCK_METHOD(Thread::ThreadPtr, createThread, (std::function<void()>, Thread::OptionsOptConstRef));
-  MOCK_METHOD(Thread::ThreadId, currentThreadId, ());
-};
 
 class GolangFilterConfigTestBase {
 public:
@@ -44,7 +39,7 @@ public:
   }
 
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  NiceMock<MockThreadFactory> thread_factory_;
+  NiceMock<Thread::MockThreadFactory> thread_factory_;
   ThreadLocal::MockInstance slot_allocator_;
   GolangConfigFactory factory_;
 };

--- a/contrib/golang/filters/network/test/upstream_test.cc
+++ b/contrib/golang/filters/network/test/upstream_test.cc
@@ -5,6 +5,7 @@
 #include "source/common/network/filter_state_dst_address.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/thread/mocks.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
@@ -22,12 +23,6 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Golang {
 namespace {
-
-class MockThreadFactory : public Thread::ThreadFactory {
-public:
-  MOCK_METHOD(Thread::ThreadPtr, createThread, (std::function<void()>, Thread::OptionsOptConstRef));
-  MOCK_METHOD(Thread::ThreadId, currentThreadId, ());
-};
 
 class UpstreamConnTest : public testing::Test {
 public:
@@ -47,7 +42,7 @@ public:
   }
 
   ThreadLocal::MockInstance slot_allocator_;
-  NiceMock<MockThreadFactory> thread_factory_;
+  NiceMock<Thread::MockThreadFactory> thread_factory_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   std::shared_ptr<Dso::MockNetworkFilterDsoImpl> dso_;
   NiceMock<Event::MockDispatcher> dispatcher_;

--- a/contrib/kafka/filters/network/test/mesh/BUILD
+++ b/contrib/kafka/filters/network/test/mesh/BUILD
@@ -20,6 +20,7 @@ envoy_cc_test(
     deps = [
         "//contrib/kafka/filters/network/source/mesh:config_lib",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/thread:thread_mocks",
     ],
 )
 
@@ -58,6 +59,7 @@ envoy_cc_test(
     tags = ["skip_on_windows"],
     deps = [
         "//contrib/kafka/filters/network/source/mesh:upstream_kafka_facade_lib",
+        "//test/mocks/thread:thread_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:thread_factory_for_test_lib",
     ],
@@ -81,6 +83,7 @@ envoy_cc_test(
     tags = ["skip_on_windows"],
     deps = [
         "//contrib/kafka/filters/network/source/mesh:shared_consumer_manager_impl_lib",
+        "//test/mocks/thread:thread_mocks",
     ],
 )
 

--- a/contrib/kafka/filters/network/test/mesh/config_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/config_unit_test.cc
@@ -1,4 +1,5 @@
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/thread/mocks.h"
 
 #include "contrib/kafka/filters/network/source/mesh/config.h"
 #include "gmock/gmock.h"
@@ -9,12 +10,6 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace Kafka {
 namespace Mesh {
-
-class MockThreadFactory : public Thread::ThreadFactory {
-public:
-  MOCK_METHOD(Thread::ThreadPtr, createThread, (std::function<void()>, Thread::OptionsOptConstRef));
-  MOCK_METHOD(Thread::ThreadId, currentThreadId, ());
-};
 
 TEST(KafkaMeshConfigFactoryUnitTest, shouldCreateFilter) {
   // given
@@ -47,7 +42,7 @@ forwarding_rules:
   TestUtility::loadFromYamlAndValidate(yaml, proto_config);
 
   testing::NiceMock<Server::Configuration::MockFactoryContext> context;
-  testing::NiceMock<MockThreadFactory> thread_factory;
+  testing::NiceMock<Thread::MockThreadFactory> thread_factory;
   ON_CALL(context.server_factory_context_.api_, threadFactory())
       .WillByDefault(ReturnRef(thread_factory));
   KafkaMeshConfigFactory factory;

--- a/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
@@ -3,6 +3,8 @@
 #include "envoy/common/exception.h"
 #include "envoy/thread/thread.h"
 
+#include "test/mocks/thread/mocks.h"
+
 #include "contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -17,12 +19,6 @@ namespace {
 using testing::_;
 using testing::NiceMock;
 using testing::Return;
-
-class MockThreadFactory : public Thread::ThreadFactory {
-public:
-  MOCK_METHOD(Thread::ThreadPtr, createThread, (std::function<void()>, Thread::OptionsOptConstRef));
-  MOCK_METHOD(Thread::ThreadId, currentThreadId, ());
-};
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {
 public:
@@ -41,7 +37,7 @@ public:
 
 class SharedConsumerManagerTest : public testing::Test {
 protected:
-  MockThreadFactory thread_factory_;
+  Thread::MockThreadFactory thread_factory_;
   MockUpstreamKafkaConfiguration configuration_;
   MockKafkaConsumerFactory consumer_factory_;
 

--- a/contrib/kafka/filters/network/test/mesh/upstream_kafka_facade_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/upstream_kafka_facade_unit_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/thread/thread.h"
 #include "envoy/thread_local/thread_local.h"
 
+#include "test/mocks/thread/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/thread_factory_for_test.h"
 
@@ -22,12 +23,6 @@ public:
   MOCK_METHOD(absl::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
               (const));
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
-};
-
-class MockThreadFactory : public Thread::ThreadFactory {
-public:
-  MOCK_METHOD(Thread::ThreadPtr, createThread, (std::function<void()>, Thread::OptionsOptConstRef));
-  MOCK_METHOD(Thread::ThreadId, currentThreadId, ());
 };
 
 TEST(UpstreamKafkaFacadeTest, shouldCreateProducerOnlyOnceForTheSameCluster) {

--- a/test/mocks/thread/mocks.h
+++ b/test/mocks/thread/mocks.h
@@ -2,6 +2,8 @@
 
 #include "envoy/thread/thread.h"
 
+#include "gmock/gmock.h"
+
 #if defined(__linux__) || defined(__APPLE__)
 #include "source/common/common/posix/thread_impl.h"
 #endif


### PR DESCRIPTION
This cleans up the tests to use `Envoy::Thread::MockThreadFactory` to reduce code duplication.

Risk Level: low (tests only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
