### PR TITLE
Expand worker id tag matcher to include thread_local_cluster_manager

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -59,7 +59,7 @@ minor_behavior_changes:
   change: |
     ``thread_local_cluster_manager.worker_0.*`` metrics are now parsed to use the
     ``worker_id`` tag like other metrics with ``worker_id`` do, when
-    :ref:`use_all_default_tags <envoy_v3_api_msg_config.metrics.v3.StatsConfig.use_all_default_tags>` is true.
+    :ref:`use_all_default_tags <envoy_v3_api_field_config.metrics.v3.StatsConfig.use_all_default_tags>` is true.
 - area: aws
   change: |
     AWS region string is now retrieved from environment and profile consistently within aws_request_signer and

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -55,6 +55,11 @@ minor_behavior_changes:
   change: |
     Make each upstream connection to read as many as 32 packets in each event loop. This feature can be disabled by setting
     ``envoy.reloadable_features.quic_upstream_reads_fixed_number_packets`` to false.
+- area: stats
+  change: |
+    ``thread_local_cluster_manager.worker_0.*`` metrics are now parsed to use the
+    ``worker_id`` tag like other metrics with ``worker_id`` do, when
+    :ref:`use_all_default_tags <envoy_v3_api_msg_config.metrics.v3.StatsConfig.use_all_default_tags>` is true.
 - area: aws
   change: |
     AWS region string is now retrieved from environment and profile consistently within aws_request_signer and

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -162,9 +162,10 @@ TagNameValues::TagNameValues() {
   // listener.<address|stat_prefix>.(worker_<id>.)*
   // listener_manager.(worker_<id>.)*
   // server.(worker_<id>.)*
+  // thread_local_cluster_manager.(worker_<id>.)*
   addRe2(
       WORKER_ID,
-      R"(^(?:listener\.(?:<ADDRESS>|<TAG_VALUE>)\.|server\.|listener_manager\.)worker_((\d+)\.))",
+      R"(^(?:listener\.(?:<ADDRESS>|<TAG_VALUE>)|server|listener_manager|thread_local_cluster_manager)\.worker_((\d+)\.))",
       "");
 
   // listener.(<address|stat_prefix>.)*, but specifically excluding "admin"


### PR DESCRIPTION
Commit Message: Expand worker_id tag matcher to include thread_local_cluster_manager
Additional Description: It was noticed in our local configuration (where we had a historical worker_id tag matcher) that our tag matcher conflicts with the default one and causes worker_id metrics not to be registered. However, there was one metric with a worker_id tag still being registered. My assumption is this was an oversight envoy-side, and that this one should be also picked up, which would make removing our custom tag matcher leave all the stats working correctly, rather than switching from `thread_local_cluster_manager` being the only one working, to `thread_local_cluster_manager` being the missing one.
Risk Level: Small, change is only to sunk metrics.
Testing: Same as it is for the rest of the metrics in this regex.
Docs Changes: n/a
Release Notes: Described the change.
Platform Specific Features: n/a
