### PR TITLE
mobile: Java code cleanup

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -52,7 +52,7 @@ class JvmFilterContext {
    */
   public Object onRequestHeaders(long headerCount, boolean endStream, long[] streamIntel) {
     assert headerUtility.validateCount(headerCount);
-    final Map headers = headerUtility.retrieveHeaders();
+    final Map<String, List<String>> headers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(
         filter.onRequestHeaders(headers, endStream, new EnvoyStreamIntelImpl(streamIntel)));
   }
@@ -82,7 +82,7 @@ class JvmFilterContext {
    */
   public Object onRequestTrailers(long trailerCount, long[] streamIntel) {
     assert headerUtility.validateCount(trailerCount);
-    final Map trailers = headerUtility.retrieveHeaders();
+    final Map<String, List<String>> trailers = headerUtility.retrieveHeaders();
     return toJniFilterTrailersStatus(
         filter.onRequestTrailers(trailers, new EnvoyStreamIntelImpl(streamIntel)));
   }
@@ -97,7 +97,7 @@ class JvmFilterContext {
    */
   public Object onResponseHeaders(long headerCount, boolean endStream, long[] streamIntel) {
     assert headerUtility.validateCount(headerCount);
-    final Map headers = headerUtility.retrieveHeaders();
+    final Map<String, List<String>> headers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(
         filter.onResponseHeaders(headers, endStream, new EnvoyStreamIntelImpl(streamIntel)));
   }
@@ -127,7 +127,7 @@ class JvmFilterContext {
    */
   public Object onResponseTrailers(long trailerCount, long[] streamIntel) {
     assert headerUtility.validateCount(trailerCount);
-    final Map trailers = headerUtility.retrieveHeaders();
+    final Map<String, List<String>> trailers = headerUtility.retrieveHeaders();
     return toJniFilterTrailersStatus(
         filter.onResponseTrailers(trailers, new EnvoyStreamIntelImpl(streamIntel)));
   }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
@@ -122,7 +122,7 @@ public interface EnvoyHTTPFilter {
    * @param finalStreamIntel, contains final internal HTTP stream metrics, context, and other
    *     details.
    */
-  void onCancel(EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalSteamIntel);
+  void onCancel(EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
   /**
    * Called when the async HTTP stream is complete.
@@ -131,5 +131,5 @@ public interface EnvoyHTTPFilter {
    * @param finalStreamIntel, contains final internal HTTP stream metrics, context, and other
    *     details.
    */
-  void onComplete(EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalSteamIntel);
+  void onComplete(EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 }


### PR DESCRIPTION
This PR does the following cleanup:
- Fixed typos.
- Used generic types instead of raw types.
- Used lambda expression instead of anonymous class.
- Removed unused imports.

Risk Level: low (cosmetic changes only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
