### PR TITLE
oauth2: remove version attribute from Set-Cookie

### DIFF
--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -37,8 +37,7 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Request
 constexpr const char* CookieDeleteFormatString =
     "{}=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 constexpr const char* CookieTailFormatString = ";path=/;Max-Age={};secure";
-constexpr const char* CookieTailHttpOnlyFormatString =
-    ";path=/;Max-Age={};secure;HttpOnly";
+constexpr const char* CookieTailHttpOnlyFormatString = ";path=/;Max-Age={};secure;HttpOnly";
 
 constexpr absl::string_view UnauthorizedBodyMessage = "OAuth flow failed.";
 

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -36,9 +36,9 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Request
 
 constexpr const char* CookieDeleteFormatString =
     "{}=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
-constexpr const char* CookieTailFormatString = ";version=1;path=/;Max-Age={};secure";
+constexpr const char* CookieTailFormatString = ";path=/;Max-Age={};secure";
 constexpr const char* CookieTailHttpOnlyFormatString =
-    ";version=1;path=/;Max-Age={};secure;HttpOnly";
+    ";path=/;Max-Age={};secure;HttpOnly";
 
 constexpr absl::string_view UnauthorizedBodyMessage = "OAuth flow failed.";
 

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -177,8 +177,7 @@ public:
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
          fmt::format("{}={}", cookie_names.oauth_expires_, expires_at_s)},
-        {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
+        {Http::Headers::get().Cookie.get(), absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
          absl::StrCat(cookie_names.oauth_hmac_, "=dCu0otMcLoaGF73jrT+R8rGA0pnWyMgNf4+GivGrHEI=")},
     };
@@ -809,8 +808,7 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
          fmt::format("{}={}", cookie_names.oauth_expires_, expires_at_s)},
-        {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
+        {Http::Headers::get().Cookie.get(), absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
          absl::StrCat(cookie_names.oauth_hmac_, "=MSq8mkNQGdXx2LKGlLHMwSIj8rLZRnrHE6EWvvTUFx0=")},
     };
@@ -840,8 +838,7 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
          fmt::format("{}={}", cookie_names.oauth_expires_, new_expires_at_s)},
-        {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
+        {Http::Headers::get().Cookie.get(), absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
          absl::StrCat(cookie_names.oauth_hmac_, "=dbl04CSr6eWF52wdNDCRt/Uw6A4y41wbpmtUWRyD2Fo=")},
     };
@@ -875,8 +872,7 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
          fmt::format("{}={}", cookie_names.oauth_expires_, expires_at_s)},
-        {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
+        {Http::Headers::get().Cookie.get(), absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
 
          absl::StrCat(cookie_names.oauth_hmac_, "="
@@ -909,8 +905,7 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
          fmt::format("{}={}", cookie_names.oauth_expires_, new_expires_at_s)},
-        {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
+        {Http::Headers::get().Cookie.get(), absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
          absl::StrCat(cookie_names.oauth_hmac_, "="
                                                 "NzViOTc0ZTAyNGFiZTllNTg1ZTc2YzFkMzQzMDkxYjdmNTMwZT"
@@ -968,9 +963,9 @@ TEST_F(OAuth2Test, CookieValidatorInvalidExpiresAt) {
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber"},
         {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken"},
-        {Http::Headers::get().Cookie.get(),
-         "OauthHMAC="
-         "NzNlZDZhY2YyYWNjOWFhMWJjZjhlZTFkOWZiNmY2ZjBlYmNkMzQzNTljNmY0ZTMyMjVmMzViNjQyMTM1Y2Q4MQ=="},
+        {Http::Headers::get().Cookie.get(), "OauthHMAC="
+                                            "NzNlZDZhY2YyYWNjOWFhMWJjZjhlZTFkOWZiNmY2ZjBlYmNkMzQzNT"
+                                            "ljNmY0ZTMyMjVmMzViNjQyMTM1Y2Q4MQ=="},
     };
 
     auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
@@ -991,8 +986,7 @@ TEST_F(OAuth2Test, CookieValidatorCanUpdateToken) {
       {Http::Headers::get().Path.get(), "/anypath"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber"},
-      {Http::Headers::get().Cookie.get(),
-       "BearerToken=xyztoken;RefreshToken=dsdtoken;"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken;RefreshToken=dsdtoken;"},
   };
 
   auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
@@ -1291,10 +1285,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParametersLegacyEncoding) {
         {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                                "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
                                                "path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test?name=admin&level=trace"},
     };
@@ -1382,10 +1374,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParametersLegacyEncoding) {
          "OauthHMAC="
          "N2Q1ZWI2M2EwMmUyYTQyODUzNDEwMGI3NTA1ODAzYTdlOTc5YjAyODkyNmY3Y2VkZWU3MGE4MjYyNTYyYmQ2Yw==;"
          "path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test?name=admin&level=trace"},
     };
@@ -1470,12 +1460,10 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParametersFillRefreshAndIdToken) {
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "OYnODPsSGabEpZ2LAiPxyjAFgN/7/5Xg24G7jUoUbyI=;"
                                              "path=/;Max-Age=10;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=10;path=/;Max-Age=10;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "OauthExpires=10;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "BearerToken=accessToken;path=/;Max-Age=10;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "IdToken=idToken;path=/;Max-Age=10;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "IdToken=idToken;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "RefreshToken=refreshToken;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
@@ -1571,10 +1559,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
         {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                                "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
                                                "path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test/utf8%C3%83?name=admin&level=trace"},
     };
@@ -1665,10 +1651,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
          "OauthHMAC="
          "N2Q1ZWI2M2EwMmUyYTQyODUzNDEwMGI3NTA1ODAzYTdlOTc5YjAyODkyNmY3Y2VkZWU3MGE4MjYyNTYyYmQ2Yw==;"
          "path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-        {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+        {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test/utf8%C3%83?name=admin&level=trace"},
     };
@@ -1772,8 +1756,7 @@ TEST_P(OAuth2Test, OAuthAccessTokenSucessWithTokens_oauth_use_standard_max_age_v
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
        "OauthHMAC=" + oauthHMAC + "path=/;Max-Age=600;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=600;path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "OauthExpires=600;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "BearerToken=access_code;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
@@ -1825,10 +1808,8 @@ TEST_P(OAuth2Test, OAuthAccessTokenSucessWithTokens_oauth_make_token_cookie_http
        "OauthHMAC=" + oauthHMAC + "path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
        "OauthExpires=1600;path=/;Max-Age=600;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "BearerToken=access_code;path=/;Max-Age=600;secure"},
-      {Http::Headers::get().SetCookie.get(),
-       "IdToken=some-id-token;path=/;Max-Age=600;secure"},
+      {Http::Headers::get().SetCookie.get(), "BearerToken=access_code;path=/;Max-Age=600;secure"},
+      {Http::Headers::get().SetCookie.get(), "IdToken=some-id-token;path=/;Max-Age=600;secure"},
       {Http::Headers::get().SetCookie.get(),
        "RefreshToken=some-refresh-token;path=/;Max-Age=600;secure"},
       {Http::Headers::get().Location.get(), ""},
@@ -2003,10 +1984,8 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
                                              "path=/;Max-Age=;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://traffic.example.com/test?name=admin&level=trace"},
   };
@@ -2193,10 +2172,8 @@ TEST_F(OAuth2Test, OAuthTestSetCookiesAfterRefreshAccessToken) {
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
                                              "path=/;Max-Age=;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
   };
 
   EXPECT_THAT(response_headers, HeaderMapEqualRef(&expected_response_headers));
@@ -2242,10 +2219,8 @@ TEST_F(OAuth2Test, OAuthTestSetCookiesAfterRefreshAccessTokenWithBasicAuth) {
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
                                              "path=/;Max-Age=;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
-      {Http::Headers::get().SetCookie.get(),
-       "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(), "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
   };
 
   EXPECT_THAT(response_headers, HeaderMapEqualRef(&expected_response_headers));

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -176,13 +176,11 @@ public:
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
-         fmt::format("{}={};version=test", cookie_names.oauth_expires_, expires_at_s)},
+         fmt::format("{}={}", cookie_names.oauth_expires_, expires_at_s)},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken;version=test")},
+         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.oauth_hmac_, "="
-                                                "dCu0otMcLoaGF73jrT+R8rGA0pnWyMgNf4+GivGrHEI="
-                                                ";version=test")},
+         absl::StrCat(cookie_names.oauth_hmac_, "=dCu0otMcLoaGF73jrT+R8rGA0pnWyMgNf4+GivGrHEI=")},
     };
 
     auto cookie_validator = std::make_shared<OAuth2CookieValidator>(test_time_, cookie_names);
@@ -810,13 +808,11 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
-         fmt::format("{}={};version=test", cookie_names.oauth_expires_, expires_at_s)},
+         fmt::format("{}={}", cookie_names.oauth_expires_, expires_at_s)},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken;version=test")},
+         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.oauth_hmac_, "="
-                                                "MSq8mkNQGdXx2LKGlLHMwSIj8rLZRnrHE6EWvvTUFx0="
-                                                ";version=test")},
+         absl::StrCat(cookie_names.oauth_hmac_, "=MSq8mkNQGdXx2LKGlLHMwSIj8rLZRnrHE6EWvvTUFx0=")},
     };
 
     auto cookie_validator = std::make_shared<OAuth2CookieValidator>(test_time_, cookie_names);
@@ -843,13 +839,11 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
-         fmt::format("{}={};version=test", cookie_names.oauth_expires_, new_expires_at_s)},
+         fmt::format("{}={}", cookie_names.oauth_expires_, new_expires_at_s)},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken;version=test")},
+         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.oauth_hmac_, "="
-                                                "dbl04CSr6eWF52wdNDCRt/Uw6A4y41wbpmtUWRyD2Fo="
-                                                ";version=test")},
+         absl::StrCat(cookie_names.oauth_hmac_, "=dbl04CSr6eWF52wdNDCRt/Uw6A4y41wbpmtUWRyD2Fo=")},
     };
 
     cookie_validator->setParams(request_headers_second, "mock-secret");
@@ -880,15 +874,14 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
-         fmt::format("{}={};version=test", cookie_names.oauth_expires_, expires_at_s)},
+         fmt::format("{}={}", cookie_names.oauth_expires_, expires_at_s)},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken;version=test")},
+         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
 
          absl::StrCat(cookie_names.oauth_hmac_, "="
                                                 "MzEyYWJjOWE0MzUwMTlkNWYxZDhiMjg2OTRiMWNjYzEyMjIzZj"
-                                                "JiMmQ5NDY3YWM3MTNhMTE2YmVmNGQ0MTcxZA=="
-                                                ";version=test")},
+                                                "JiMmQ5NDY3YWM3MTNhMTE2YmVmNGQ0MTcxZA==")},
     };
 
     auto cookie_validator = std::make_shared<OAuth2CookieValidator>(test_time_, cookie_names);
@@ -915,14 +908,13 @@ TEST_F(OAuth2Test, CookieValidatorSame) {
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
         {Http::Headers::get().Cookie.get(),
-         fmt::format("{}={};version=test", cookie_names.oauth_expires_, new_expires_at_s)},
+         fmt::format("{}={}", cookie_names.oauth_expires_, new_expires_at_s)},
         {Http::Headers::get().Cookie.get(),
-         absl::StrCat(cookie_names.bearer_token_, "=xyztoken;version=test")},
+         absl::StrCat(cookie_names.bearer_token_, "=xyztoken")},
         {Http::Headers::get().Cookie.get(),
          absl::StrCat(cookie_names.oauth_hmac_, "="
                                                 "NzViOTc0ZTAyNGFiZTllNTg1ZTc2YzFkMzQzMDkxYjdmNTMwZT"
-                                                "gwZTMyZTM1YzFiYTY2YjU0NTkxYzgzZDg1YQ=="
-                                                ";version=test")},
+                                                "gwZTMyZTM1YzFiYTY2YjU0NTkxYzgzZDg1YQ==")},
     };
 
     cookie_validator->setParams(request_headers_second, "mock-secret");
@@ -950,11 +942,10 @@ TEST_F(OAuth2Test, CookieValidatorInvalidExpiresAt) {
         {Http::Headers::get().Host.get(), "traffic.example.com"},
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-        {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber;version=test"},
-        {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken;version=test"},
+        {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber"},
+        {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken"},
         {Http::Headers::get().Cookie.get(), "OauthHMAC="
-                                            "c+1qzyrMmqG8+O4dn7b28OvNNDWcb04yJfNbZCE1zYE="
-                                            ";version=test"},
+                                            "c+1qzyrMmqG8+O4dn7b28OvNNDWcb04yJfNbZCE1zYE="},
     };
 
     auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
@@ -975,12 +966,11 @@ TEST_F(OAuth2Test, CookieValidatorInvalidExpiresAt) {
         {Http::Headers::get().Host.get(), "traffic.example.com"},
         {Http::Headers::get().Path.get(), "/anypath"},
         {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-        {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber;version=test"},
-        {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken;version=test"},
+        {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber"},
+        {Http::Headers::get().Cookie.get(), "BearerToken=xyztoken"},
         {Http::Headers::get().Cookie.get(),
          "OauthHMAC="
-         "NzNlZDZhY2YyYWNjOWFhMWJjZjhlZTFkOWZiNmY2ZjBlYmNkMzQzNTljNmY0ZTMyMjVmMzViNjQyMTM1Y2Q4MQ=="
-         ";version=test"},
+         "NzNlZDZhY2YyYWNjOWFhMWJjZjhlZTFkOWZiNmY2ZjBlYmNkMzQzNTljNmY0ZTMyMjVmMzViNjQyMTM1Y2Q4MQ=="},
     };
 
     auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
@@ -1000,9 +990,9 @@ TEST_F(OAuth2Test, CookieValidatorCanUpdateToken) {
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Path.get(), "/anypath"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=notanumber"},
       {Http::Headers::get().Cookie.get(),
-       "BearerToken=xyztoken;version=test;RefreshToken=dsdtoken;"},
+       "BearerToken=xyztoken;RefreshToken=dsdtoken;"},
   };
 
   auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
@@ -1020,12 +1010,12 @@ TEST_F(OAuth2Test, OAuthTestInvalidUrlInStateQueryParam) {
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
       {Http::Headers::get().Path.get(),
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES + "&state=blah"},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
   };
 
   Http::TestRequestHeaderMapImpl expected_headers{
@@ -1056,12 +1046,12 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES +
            "&state=https%3A%2F%2Ftraffic.example.com%2F_oauth"},
 
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
   };
 
   Http::TestRequestHeaderMapImpl expected_response_headers{
@@ -1088,12 +1078,12 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES +
            "&state=https%3A%2F%2Ftraffic.example.com%2F_oauth"},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
       {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_token"},
   };
 
@@ -1119,12 +1109,12 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccessLegacyEncoding) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES +
            "&state=https%3A%2F%2Ftraffic.example.com%2Foriginal_path"},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
   };
 
   Http::TestRequestHeaderMapImpl expected_response_headers{
@@ -1150,12 +1140,12 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccessLegacyEncoding) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES +
            "&state=https%3A%2F%2Ftraffic.example.com%2Foriginal_path"},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
       {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_token"},
   };
 
@@ -1174,12 +1164,12 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES +
            "&state=https://traffic.example.com/original_path?var1=1%26var2=2"},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
   };
 
   Http::TestRequestHeaderMapImpl expected_response_headers{
@@ -1206,12 +1196,12 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
       {Http::Headers::get().Path.get(),
        "/_oauth?code=abcdefxyz123&scope=" + TEST_ENCODED_AUTH_SCOPES +
            "&state=https://traffic.example.com/original_path?var1=1%26var2=2"},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
        "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
-       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ===="},
       {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_token"},
   };
 
@@ -1300,11 +1290,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParametersLegacyEncoding) {
         {Http::Headers::get().Status.get(), "302"},
         {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                                "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
-                                               "version=1;path=/;Max-Age=;secure;HttpOnly"},
+                                               "path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test?name=admin&level=trace"},
     };
@@ -1391,11 +1381,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParametersLegacyEncoding) {
         {Http::Headers::get().SetCookie.get(),
          "OauthHMAC="
          "N2Q1ZWI2M2EwMmUyYTQyODUzNDEwMGI3NTA1ODAzYTdlOTc5YjAyODkyNmY3Y2VkZWU3MGE4MjYyNTYyYmQ2Yw==;"
-         "version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test?name=admin&level=trace"},
     };
@@ -1479,15 +1469,15 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParametersFillRefreshAndIdToken) {
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "OYnODPsSGabEpZ2LAiPxyjAFgN/7/5Xg24G7jUoUbyI=;"
-                                             "version=1;path=/;Max-Age=10;secure;HttpOnly"},
+                                             "path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=10;version=1;path=/;Max-Age=10;secure;HttpOnly"},
+       "OauthExpires=10;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=accessToken;version=1;path=/;Max-Age=10;secure;HttpOnly"},
+       "BearerToken=accessToken;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "IdToken=idToken;version=1;path=/;Max-Age=10;secure;HttpOnly"},
+       "IdToken=idToken;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "RefreshToken=refreshToken;version=1;path=/;Max-Age=10;secure;HttpOnly"},
+       "RefreshToken=refreshToken;path=/;Max-Age=10;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://traffic.example.com/test?name=admin&level=trace"},
   };
@@ -1580,11 +1570,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
         {Http::Headers::get().Status.get(), "302"},
         {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                                "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
-                                               "version=1;path=/;Max-Age=;secure;HttpOnly"},
+                                               "path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test/utf8%C3%83?name=admin&level=trace"},
     };
@@ -1674,11 +1664,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
         {Http::Headers::get().SetCookie.get(),
          "OauthHMAC="
          "N2Q1ZWI2M2EwMmUyYTQyODUzNDEwMGI3NTA1ODAzYTdlOTc5YjAyODkyNmY3Y2VkZWU3MGE4MjYyNTYyYmQ2Yw==;"
-         "version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().SetCookie.get(),
-         "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+         "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
         {Http::Headers::get().Location.get(),
          "https://traffic.example.com/test/utf8%C3%83?name=admin&level=trace"},
     };
@@ -1727,15 +1717,15 @@ TEST_P(OAuth2Test, OAuthAccessTokenSucessWithTokens) {
   Http::TestRequestHeaderMapImpl expected_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthHMAC=" + oauthHMAC + "version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "OauthHMAC=" + oauthHMAC + "path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=1600;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "OauthExpires=1600;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=access_code;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "BearerToken=access_code;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "IdToken=some-id-token;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "IdToken=some-id-token;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "RefreshToken=some-refresh-token;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "RefreshToken=some-refresh-token;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(), ""},
   };
 
@@ -1781,15 +1771,15 @@ TEST_P(OAuth2Test, OAuthAccessTokenSucessWithTokens_oauth_use_standard_max_age_v
   Http::TestRequestHeaderMapImpl expected_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthHMAC=" + oauthHMAC + "version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "OauthHMAC=" + oauthHMAC + "path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=600;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "OauthExpires=600;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=access_code;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "BearerToken=access_code;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "IdToken=some-id-token;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "IdToken=some-id-token;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "RefreshToken=some-refresh-token;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "RefreshToken=some-refresh-token;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().Location.get(), ""},
   };
 
@@ -1832,15 +1822,15 @@ TEST_P(OAuth2Test, OAuthAccessTokenSucessWithTokens_oauth_make_token_cookie_http
   Http::TestRequestHeaderMapImpl expected_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthHMAC=" + oauthHMAC + "version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "OauthHMAC=" + oauthHMAC + "path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=1600;version=1;path=/;Max-Age=600;secure;HttpOnly"},
+       "OauthExpires=1600;path=/;Max-Age=600;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=access_code;version=1;path=/;Max-Age=600;secure"},
+       "BearerToken=access_code;path=/;Max-Age=600;secure"},
       {Http::Headers::get().SetCookie.get(),
-       "IdToken=some-id-token;version=1;path=/;Max-Age=600;secure"},
+       "IdToken=some-id-token;path=/;Max-Age=600;secure"},
       {Http::Headers::get().SetCookie.get(),
-       "RefreshToken=some-refresh-token;version=1;path=/;Max-Age=600;secure"},
+       "RefreshToken=some-refresh-token;path=/;Max-Age=600;secure"},
       {Http::Headers::get().Location.get(), ""},
   };
 
@@ -1899,13 +1889,12 @@ TEST_P(OAuth2Test, CookieValidatorInTransition) {
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Path.get(), "/_signout"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=1600;version=1"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=access_code;version=1"},
-      {Http::Headers::get().Cookie.get(), "IdToken=some-id-token;version=1"},
-      {Http::Headers::get().Cookie.get(), "RefreshToken=some-refresh-token;version=1"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=1600"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=access_code"},
+      {Http::Headers::get().Cookie.get(), "IdToken=some-id-token"},
+      {Http::Headers::get().Cookie.get(), "RefreshToken=some-refresh-token"},
       {Http::Headers::get().Cookie.get(), "OauthHMAC="
-                                          "Y9gCpVnhyaY+ecSxt/ZLZc/OMb8ZNivrVH1RByJxEbs="
-                                          ";version=test"},
+                                          "Y9gCpVnhyaY+ecSxt/ZLZc/OMb8ZNivrVH1RByJxEbs="},
   };
 
   auto cookie_validator = std::make_shared<OAuth2CookieValidator>(
@@ -1920,14 +1909,13 @@ TEST_P(OAuth2Test, CookieValidatorInTransition) {
       {Http::Headers::get().Host.get(), "traffic.example.com"},
       {Http::Headers::get().Path.get(), "/_signout"},
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
-      {Http::Headers::get().Cookie.get(), "OauthExpires=1600;version=1"},
-      {Http::Headers::get().Cookie.get(), "BearerToken=access_code;version=1"},
-      {Http::Headers::get().Cookie.get(), "IdToken=some-id-token;version=1"},
-      {Http::Headers::get().Cookie.get(), "RefreshToken=some-refresh-token;version=1"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=1600"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=access_code"},
+      {Http::Headers::get().Cookie.get(), "IdToken=some-id-token"},
+      {Http::Headers::get().Cookie.get(), "RefreshToken=some-refresh-token"},
       {Http::Headers::get().Cookie.get(),
        "OauthHMAC="
-       "NjNkODAyYTU1OWUxYzlhNjNlNzljNGIxYjdmNjRiNjVjZmNlMzFiZjE5MzYyYmViNTQ3ZDUxMDcyMjcxMTFiYg=="
-       ";version=test"},
+       "NjNkODAyYTU1OWUxYzlhNjNlNzljNGIxYjdmNjRiNjVjZmNlMzFiZjE5MzYyYmViNTQ3ZDUxMDcyMjcxMTFiYg=="},
   };
   cookie_validator->setParams(request_headers_hexbase64, "mock-secret");
 
@@ -2014,11 +2002,11 @@ TEST_F(OAuth2Test, OAuthTestFullFlowWithUseRefreshToken) {
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
-                                             "version=1;path=/;Max-Age=;secure;HttpOnly"},
+                                             "path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+       "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+       "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().Location.get(),
        "https://traffic.example.com/test?name=admin&level=trace"},
   };
@@ -2204,11 +2192,11 @@ TEST_F(OAuth2Test, OAuthTestSetCookiesAfterRefreshAccessToken) {
   Http::TestResponseHeaderMapImpl expected_response_headers{
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
-                                             "version=1;path=/;Max-Age=;secure;HttpOnly"},
+                                             "path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+       "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+       "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
   };
 
   EXPECT_THAT(response_headers, HeaderMapEqualRef(&expected_response_headers));
@@ -2253,11 +2241,11 @@ TEST_F(OAuth2Test, OAuthTestSetCookiesAfterRefreshAccessTokenWithBasicAuth) {
   Http::TestResponseHeaderMapImpl expected_response_headers{
       {Http::Headers::get().SetCookie.get(), "OauthHMAC="
                                              "fV62OgLipChTQQC3UFgDp+l5sCiSb3zt7nCoJiVivWw=;"
-                                             "version=1;path=/;Max-Age=;secure;HttpOnly"},
+                                             "path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "OauthExpires=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+       "OauthExpires=;path=/;Max-Age=;secure;HttpOnly"},
       {Http::Headers::get().SetCookie.get(),
-       "BearerToken=;version=1;path=/;Max-Age=;secure;HttpOnly"},
+       "BearerToken=;path=/;Max-Age=;secure;HttpOnly"},
   };
 
   EXPECT_THAT(response_headers, HeaderMapEqualRef(&expected_response_headers));


### PR DESCRIPTION
Commit Message: Remove extraneous and deprecated version attribute on Set-Cookie
Additional Description:
The oauth2 filter sets a `version` attribute on the cookies, which is obsolete per [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265) (2011). It was specified in [RFC 2965](https://datatracker.ietf.org/doc/html/rfc2965) (2000) and [RFC 2109](https://datatracker.ietf.org/doc/html/rfc2109) (1997) but AFAICT, no browsers use this. The change should be a noop and is simply a code cleanup. Also removes the attribute in the request cookies in the tests (not sure if this even did anything, since it likely is parsed as a separate cookie entirely)
Risk Level: low
Testing: unit testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
