### PR TITLE
mobile: fix quic_test_server_test

### DIFF
--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -78,7 +78,8 @@ TestServer::TestServer()
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope())
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
-  ON_CALL(factory_context_, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager_));
+  ON_CALL(factory_context_, sslContextManager())
+      .WillByDefault(testing::ReturnRef(context_manager_));
 }
 
 void TestServer::startTestServer(TestServerType test_server_type) {

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -78,6 +78,7 @@ TestServer::TestServer()
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope())
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
+  ON_CALL(factory_context_, sslContextManager()).WillByDefault(testing::ReturnRef(context_manager_));
 }
 
 void TestServer::startTestServer(TestServerType test_server_type) {


### PR DESCRIPTION
Commit Message: the test failed after https://github.com/envoyproxy/envoy/pull/32260 because the test server uses a mocked MockTransportSocketFactoryContext which doesn't return a real  ContextManager object in sslContextManager(). The mocked object returns nullptr in createSslServerContext(), thus fail to initialize the new member ssl_ctx_ in QuicServerTransportSocketFactory.

Additional Description: bazel test //test/java/io/envoyproxy/envoymobile/engine/testing:quic_test_server_test passes in this PR
Risk Level: low, test only
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A