### PR TITLE
Revert "xDS: enable envoy.restart_features.use_eds_cache_for_ads by default (#32604)"

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -16,15 +16,6 @@ behavior_changes:
     Changes the default value of ``envoy.reloadable_features.http2_use_oghttp2`` to ``false``. This changes the codec used for HTTP/2
     requests and responses. A number of users have reported issues with oghttp2 including issue 32611 and issue 32401 This behavior
     can be reverted by setting the feature to ``true``.
-- area: eds
-  change: |
-    Enabling caching caching of EDS assignments when used with ADS by default (introduced in Envoy v1.28).
-    Prior to this change, Envoy required that EDS assignments were sent after an EDS cluster was updated.
-    If no EDS assignment was received for the cluster, it ended up with an empty assignment.
-    Following this change, after a cluster update, Envoy waits for an EDS assignment until
-    :ref:`initial_fetch_timeout <envoy_v3_api_field_config.core.v3.ConfigSource.initial_fetch_timeout>` times out, and will then apply
-    the cached assignment and finish updating the warmed cluster. This change temporarily disabled by setting
-    the runtime flag ``envoy.restart_features.use_eds_cache_for_ads`` to ``false``.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -104,7 +104,6 @@ RUNTIME_GUARD(envoy_restart_features_allow_client_socket_creation_failure);
 RUNTIME_GUARD(envoy_restart_features_quic_handle_certs_with_shared_tls_code);
 RUNTIME_GUARD(envoy_restart_features_send_goaway_for_premature_rst_streams);
 RUNTIME_GUARD(envoy_restart_features_udp_read_normalize_addresses);
-RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
 
@@ -135,6 +134,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 // remove the feature flag and remove code path that relies on old technique to fetch credentials
 // via libcurl and remove the bazel steps to pull and test the curl dependency.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_http_client_to_fetch_aws_credentials);
+// TODO(adisuissa): enable by default once this is tested in prod.
+FALSE_RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 // TODO(#10646) change to true when UHV is sufficiently tested
 // For more information about Universal Header Validation, please see
 // https://github.com/envoyproxy/envoy/issues/10646


### PR DESCRIPTION
Commit Message: This reverts commit 136f7fd53f0546d8abf6f42a8293ff91fd573eef.
Additional Description:
We are investigating a race between cluster destruction and EDS caching removal.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
