### PR TITLE
mobile: Remove Executor from EnvoyHTTPCallbacks API

### DIFF
--- a/mobile/docs/root/api/grpc.rst
+++ b/mobile/docs/root/api/grpc.rst
@@ -42,7 +42,7 @@ Start and interact with a gRPC stream in **Kotlin**::
       }
       .setOnError { ... }
       .setOnCancel { ... }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(headers, false)
       .sendMessage(...)
       ...
@@ -180,7 +180,7 @@ stream.
     .newGRPCStreamPrototype()
     ...
   val stream = prototype
-    .start(Executors.newSingleThreadExecutor())
+    .start()
     .sendHeaders(...)
     .sendMessage(...)
 

--- a/mobile/docs/root/api/http.rst
+++ b/mobile/docs/root/api/http.rst
@@ -33,7 +33,7 @@ Start and interact with an HTTP stream in **Kotlin**::
     }
     .setOnError { ... }
     .setOnCancel { ... }
-    .start(Executors.newSingleThreadExecutor())
+    .start()
     .sendHeaders(...)
     .sendData(...)
 
@@ -166,7 +166,7 @@ Doing so returns a ``Stream`` which allows the sender to interact with the strea
     .newStreamPrototype()
     ...
   val stream = prototype
-    .start(Executors.newSingleThreadExecutor())
+    .start()
     .sendHeaders(...)
     .sendData(...)
 
@@ -215,7 +215,7 @@ For example:
     .build()
   val stream = streamClient
     .newStreamPrototype()
-    .start(Executors.newSingleThreadExecutor())
+    .start()
 
   // Headers-only
   stream.sendHeaders(requestHeaders, true)

--- a/mobile/examples/java/hello_world/MainActivity.java
+++ b/mobile/examples/java/hello_world/MainActivity.java
@@ -22,7 +22,6 @@ import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter;
 import io.envoyproxy.envoymobile.shared.Success;
 import kotlin.Unit;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -131,7 +130,7 @@ public class MainActivity extends Activity {
           recyclerView.post(() -> viewAdapter.add(new Failure(message)));
           return Unit.INSTANCE;
         })
-        .start(Executors.newSingleThreadExecutor())
+        .start()
         .sendHeaders(requestHeaders, true);
 
     clear_text = !clear_text;

--- a/mobile/examples/kotlin/hello_world/MainActivity.kt
+++ b/mobile/examples/kotlin/hello_world/MainActivity.kt
@@ -18,7 +18,6 @@ import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
 import io.envoyproxy.envoymobile.shared.Success
 import java.io.IOException
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val REQUEST_HANDLER_THREAD_NAME = "hello_envoy_kt"
@@ -141,7 +140,7 @@ class MainActivity : Activity() {
         Log.d("MainActivity", message)
         recyclerView.post { viewAdapter.add(Failure(message)) }
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
   }
 

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -37,10 +37,7 @@ class JvmCallbackContext {
   public Object onResponseHeaders(long headerCount, boolean endStream, long[] streamIntel) {
     assert bridgeUtility.validateCount(headerCount);
     final Map<String, List<String>> headers = bridgeUtility.retrieveHeaders();
-
-    callbacks.getExecutor().execute(
-        () -> callbacks.onHeaders(headers, endStream, new EnvoyStreamIntelImpl(streamIntel)));
-
+    callbacks.onHeaders(headers, endStream, new EnvoyStreamIntelImpl(streamIntel));
     return null;
   }
 
@@ -54,10 +51,7 @@ class JvmCallbackContext {
   public Object onResponseTrailers(long trailerCount, long[] streamIntel) {
     assert bridgeUtility.validateCount(trailerCount);
     final Map<String, List<String>> trailers = bridgeUtility.retrieveHeaders();
-
-    callbacks.getExecutor().execute(
-        () -> callbacks.onTrailers(trailers, new EnvoyStreamIntelImpl(streamIntel)));
-
+    callbacks.onTrailers(trailers, new EnvoyStreamIntelImpl(streamIntel));
     return null;
   }
 
@@ -70,11 +64,7 @@ class JvmCallbackContext {
    * @return Object,     not used for response callbacks.
    */
   public Object onResponseData(ByteBuffer data, boolean endStream, long[] streamIntel) {
-    // Create a copy of the `data` because the `data` uses direct `ByteBuffer` and the `data` will
-    // be destroyed after calling this callback.
-    ByteBuffer copiedData = ByteBuffers.copy(data);
-    callbacks.getExecutor().execute(
-        () -> callbacks.onData(copiedData, endStream, new EnvoyStreamIntelImpl(streamIntel)));
+    callbacks.onData(data, endStream, new EnvoyStreamIntelImpl(streamIntel));
     return null;
   }
 
@@ -91,13 +81,9 @@ class JvmCallbackContext {
    */
   public Object onError(int errorCode, byte[] message, int attemptCount, long[] streamIntel,
                         long[] finalStreamIntel) {
-    callbacks.getExecutor().execute(() -> {
-      String errorMessage = new String(message);
-      callbacks.onError(errorCode, errorMessage, attemptCount,
-                        new EnvoyStreamIntelImpl(streamIntel),
-                        new EnvoyFinalStreamIntelImpl(finalStreamIntel));
-    });
-
+    String errorMessage = new String(message);
+    callbacks.onError(errorCode, errorMessage, attemptCount, new EnvoyStreamIntelImpl(streamIntel),
+                      new EnvoyFinalStreamIntelImpl(finalStreamIntel));
     return null;
   }
 
@@ -109,12 +95,9 @@ class JvmCallbackContext {
    * @return Object, not used for response callbacks.
    */
   public Object onCancel(long[] streamIntel, long[] finalStreamIntel) {
-    callbacks.getExecutor().execute(() -> {
-      // This call is atomically gated at the call-site and will only happen once.
-      callbacks.onCancel(new EnvoyStreamIntelImpl(streamIntel),
-                         new EnvoyFinalStreamIntelImpl(finalStreamIntel));
-    });
-
+    // This call is atomically gated at the call-site and will only happen once.
+    callbacks.onCancel(new EnvoyStreamIntelImpl(streamIntel),
+                       new EnvoyFinalStreamIntelImpl(finalStreamIntel));
     return null;
   }
 
@@ -125,11 +108,8 @@ class JvmCallbackContext {
    * @return Object, not used for response callbacks.
    */
   public Object onSendWindowAvailable(long[] streamIntel) {
-    callbacks.getExecutor().execute(() -> {
-      // This call is atomically gated at the call-site and will only happen once.
-      callbacks.onSendWindowAvailable(new EnvoyStreamIntelImpl(streamIntel));
-    });
-
+    // This call is atomically gated at the call-site and will only happen once.
+    callbacks.onSendWindowAvailable(new EnvoyStreamIntelImpl(streamIntel));
     return null;
   }
   /**
@@ -140,12 +120,9 @@ class JvmCallbackContext {
    * @return Object, not used for response callbacks.
    */
   public Object onComplete(long[] streamIntel, long[] finalStreamIntel) {
-    callbacks.getExecutor().execute(() -> {
-      // This call is atomically gated at the call-site and will only happen once.
-      callbacks.onComplete(new EnvoyStreamIntelImpl(streamIntel),
-                           new EnvoyFinalStreamIntelImpl(finalStreamIntel));
-    });
-
+    // This call is atomically gated at the call-site and will only happen once.
+    callbacks.onComplete(new EnvoyStreamIntelImpl(streamIntel),
+                         new EnvoyFinalStreamIntelImpl(finalStreamIntel));
     return null;
   }
 }

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -66,11 +66,8 @@ class JvmFilterContext {
    * @return Object[],   pair of HTTP filter status and optional modified data.
    */
   public Object onRequestData(ByteBuffer data, boolean endStream, long[] streamIntel) {
-    // Create a copy of the `data` because the `data` uses direct `ByteBuffer` and the `data` will
-    // be destroyed after calling this callback.
-    ByteBuffer copiedData = ByteBuffers.copy(data);
     return toJniFilterDataStatus(
-        filter.onRequestData(copiedData, endStream, new EnvoyStreamIntelImpl(streamIntel)));
+        filter.onRequestData(data, endStream, new EnvoyStreamIntelImpl(streamIntel)));
   }
 
   /**
@@ -111,11 +108,8 @@ class JvmFilterContext {
    * @return Object[],   pair of HTTP filter status and optional modified data.
    */
   public Object onResponseData(ByteBuffer data, boolean endStream, long[] streamIntel) {
-    // Create a copy of the `data` because the `data` uses direct `ByteBuffer` and the `data` will
-    // be destroyed after calling this callback.
-    ByteBuffer copiedData = ByteBuffers.copy(data);
     return toJniFilterDataStatus(
-        filter.onResponseData(copiedData, endStream, new EnvoyStreamIntelImpl(streamIntel)));
+        filter.onResponseData(data, endStream, new EnvoyStreamIntelImpl(streamIntel)));
   }
 
   /**
@@ -144,9 +138,6 @@ class JvmFilterContext {
    */
   public Object onResumeRequest(long headerCount, ByteBuffer data, long trailerCount,
                                 boolean endStream, long[] streamIntel) {
-    // Create a copy of the `data` because the `data` uses direct `ByteBuffer` and the `data` will
-    // be destroyed after calling this callback.
-    ByteBuffer copiedData = ByteBuffers.copy(data);
     // Headers are optional in this call, and a negative length indicates omission.
     Map<String, List<String>> headers = null;
     if (headerCount >= 0) {
@@ -159,7 +150,7 @@ class JvmFilterContext {
       assert trailerUtility.validateCount(trailerCount);
       trailers = trailerUtility.retrieveHeaders();
     }
-    return toJniFilterResumeStatus(filter.onResumeRequest(headers, copiedData, trailers, endStream,
+    return toJniFilterResumeStatus(filter.onResumeRequest(headers, data, trailers, endStream,
                                                           new EnvoyStreamIntelImpl(streamIntel)));
   }
 
@@ -175,9 +166,6 @@ class JvmFilterContext {
    */
   public Object onResumeResponse(long headerCount, ByteBuffer data, long trailerCount,
                                  boolean endStream, long[] streamIntel) {
-    // Create a copy of the `data` because the `data` uses direct `ByteBuffer` and the `data` will
-    // be destroyed after calling this callback.
-    ByteBuffer copiedData = ByteBuffers.copy(data);
     // Headers are optional in this call, and a negative length indicates omission.
     Map<String, List<String>> headers = null;
     if (headerCount >= 0) {
@@ -190,7 +178,7 @@ class JvmFilterContext {
       assert trailerUtility.validateCount(trailerCount);
       trailers = trailerUtility.retrieveHeaders();
     }
-    return toJniFilterResumeStatus(filter.onResumeResponse(headers, copiedData, trailers, endStream,
+    return toJniFilterResumeStatus(filter.onResumeResponse(headers, data, trailers, endStream,
                                                            new EnvoyStreamIntelImpl(streamIntel)));
   }
 

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JvmFilterFactoryContext.java
@@ -1,6 +1,5 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.JvmFilterContext;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
 
 /**

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -24,6 +24,8 @@ public interface EnvoyHTTPCallbacks {
    * callback can be invoked multiple times if the data gets streamed.
    *
    * @param data,        the buffer of the data received.
+   *                     The `data` will be destroyed upon completing this callback. Create a copy
+   *                     of the `data` if the `data` is going to outlive this callback lifetime.
    * @param endStream,   whether the data is the last data frame.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -6,9 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 public interface EnvoyHTTPCallbacks {
-
-  Executor getExecutor();
-
   /**
    * Called when all headers get received on the async HTTP stream.
    *
@@ -25,7 +22,7 @@ public interface EnvoyHTTPCallbacks {
    *
    * @param data,        the buffer of the data received.
    *                     The `data` will be destroyed upon completing this callback. Create a copy
-   *                     of the `data` if the `data` is going to outlive this callback lifetime.
+   *                     of the `data` if the `data` is going to outlive this callback.
    * @param endStream,   whether the data is the last data frame.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
@@ -21,7 +21,7 @@ public interface EnvoyHTTPFilter {
    *
    * @param data,        the buffer of the data received.
    *                     The `data` will be destroyed upon completing this callback. Create a copy
-   *                     of the `data` if the `data` is going to outlive this callback lifetime.
+   *                     of the `data` if the `data` is going to outlive this callback.
    * @param endStream,   whether the data is the last data frame.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
@@ -20,6 +20,8 @@ public interface EnvoyHTTPFilter {
    * callback can be invoked multiple times.
    *
    * @param data,        the buffer of the data received.
+   *                     The `data` will be destroyed upon completing this callback. Create a copy
+   *                     of the `data` if the `data` is going to outlive this callback lifetime.
    * @param endStream,   whether the data is the last data frame.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
@@ -47,7 +49,9 @@ public interface EnvoyHTTPFilter {
    * Called when a data frame is received on the HTTP stream. This
    * callback can be invoked multiple times.
    *
-   * @param data,        the buffer of the data received.
+   * @param data,        the buffer of the data received. The `data` will be destroyed upon
+   *                     completing this callback. Create a copy of the `data` if the `data` is
+   *                     going to outlive this callback.
    * @param endStream,   whether the data is the last data frame.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
@@ -69,10 +73,12 @@ public interface EnvoyHTTPFilter {
   void setRequestFilterCallbacks(EnvoyHTTPFilterCallbacks callbacks);
 
   /**
-   * Called when request filter iteration has been asynchronsouly resumed via callback.
+   * Called when request filter iteration has been asynchronously resumed via callback.
    *
    * @param headers,     pending headers that have not yet been forwarded along the filter chain.
    * @param data,        pending data that has not yet been forwarded along the filter chain.
+   *                     The `data` will be destroyed upon completing this callback. Create a copy
+   *                     of the `data` if the `data` is going to outlive this callback.
    * @param trailers,    pending trailers that have not yet been forwarded along the filter chain.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
@@ -88,10 +94,12 @@ public interface EnvoyHTTPFilter {
   void setResponseFilterCallbacks(EnvoyHTTPFilterCallbacks callbacks);
 
   /**
-   * Called when response filter iteration has been asynchronsouly resumed via callback.
+   * Called when response filter iteration has been asynchronously resumed via callback.
    *
    * @param headers,     pending headers that have not yet been forwarded along the filter chain.
    * @param data,        pending data that has not yet been forwarded along the filter chain.
+   *                     The `data` will be destroyed upon completing this callback. Create a copy
+   *                     of the `data` if the `data` is going to outlive this callback.
    * @param trailers,    pending trailers that have not yet been forwarded along the filter chain.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */

--- a/mobile/library/java/org/chromium/net/impl/CronvoyBidirectionalStream.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyBidirectionalStream.java
@@ -118,7 +118,6 @@ public final class CronvoyBidirectionalStream
   private static final String X_ENVOY = "x-envoy";
   private static final String X_ENVOY_SELECTED_TRANSPORT = "x-envoy-upstream-alpn";
   private static final String USER_AGENT = "User-Agent";
-  private static final Executor DIRECT_EXECUTOR = new DirectExecutor();
 
   private final CronvoyUrlRequestContext mRequestContext;
   private final Executor mExecutor;
@@ -933,11 +932,6 @@ public final class CronvoyBidirectionalStream
   }
 
   @Override
-  public Executor getExecutor() {
-    return DIRECT_EXECUTOR;
-  }
-
-  @Override
   public void onSendWindowAvailable(EnvoyStreamIntel streamIntel) {
     switch (mState.nextAction(Event.ON_SEND_WINDOW_AVAILABLE)) {
     case NextAction.CHAIN_NEXT_WRITE:
@@ -1106,13 +1100,6 @@ public final class CronvoyBidirectionalStream
       this.mByteBuffer = mByteBuffer;
       this.mInitialPosition = mByteBuffer.position();
       this.mInitialLimit = mByteBuffer.limit();
-    }
-  }
-
-  private static class DirectExecutor implements Executor {
-    @Override
-    public void execute(Runnable runnable) {
-      runnable.run();
     }
   }
 }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
@@ -870,6 +870,8 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
       ByteBuffer userBuffer = mUserCurrentReadBuffer;
       mUserCurrentReadBuffer = null; // Avoid the reference to a potentially large buffer.
       int dataRead = data.remaining();
+      // Copy the `data` outside the thread before passing into the thread because the `data`
+      // will be destroyed upon completing this callback.
       userBuffer.put(data); // NPE ==> BUG, BufferOverflowException ==> User not behaving.
       Runnable task = () -> {
         checkCallingThread();

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
@@ -4,7 +4,6 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyFinalStreamIntel
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks
 import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel
 import java.nio.ByteBuffer
-import java.util.concurrent.Executor
 
 /**
  * A collection of platform-level callbacks that are specified by consumers who wish to interact
@@ -28,14 +27,8 @@ internal class StreamCallbacks {
  * Class responsible for bridging between the platform-level `StreamCallbacks` and the engine's
  * `EnvoyHTTPCallbacks`.
  */
-internal class EnvoyHTTPCallbacksAdapter(
-  private val executor: Executor,
-  private val callbacks: StreamCallbacks
-) : EnvoyHTTPCallbacks {
-  override fun getExecutor(): Executor {
-    return executor
-  }
-
+internal class EnvoyHTTPCallbacksAdapter(private val callbacks: StreamCallbacks) :
+  EnvoyHTTPCallbacks {
   override fun onHeaders(
     headers: Map<String, List<String>>,
     endStream: Boolean,

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
@@ -2,8 +2,6 @@ package io.envoyproxy.envoymobile
 
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import java.nio.ByteBuffer
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 /**
  * A type representing a stream that has not yet been started.
@@ -21,11 +19,10 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
   /**
    * Start a new stream.
    *
-   * @param executor Executor on which to receive callback events.
    * @return The new stream.
    */
-  open fun start(executor: Executor = Executors.newSingleThreadExecutor()): Stream {
-    val engineStream = engine.startStream(createCallbacks(executor), explicitFlowControl)
+  open fun start(): Stream {
+    val engineStream = engine.startStream(createCallbacks(), explicitFlowControl)
     return Stream(engineStream, useByteBufferPosition)
   }
 
@@ -154,10 +151,9 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
   /**
    * Create engine callbacks using the provided queue.
    *
-   * @param executor Executor on which to receive callback events.
    * @return A new set of engine callbacks.
    */
-  internal fun createCallbacks(executor: Executor): EnvoyHTTPCallbacksAdapter {
-    return EnvoyHTTPCallbacksAdapter(executor, callbacks)
+  internal fun createCallbacks(): EnvoyHTTPCallbacksAdapter {
+    return EnvoyHTTPCallbacksAdapter(callbacks)
   }
 }

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStreamPrototype.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStreamPrototype.kt
@@ -3,8 +3,6 @@ package io.envoyproxy.envoymobile
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 /**
  * A type representing a gRPC stream that has not yet been started.
@@ -16,11 +14,10 @@ class GRPCStreamPrototype(private val underlyingStream: StreamPrototype) {
   /**
    * Start a new gRPC stream.
    *
-   * @param executor Executor on which to receive callback events.
    * @return The new gRPC stream.
    */
-  fun start(executor: Executor = Executors.newSingleThreadExecutor()): GRPCStream {
-    val stream = underlyingStream.start(executor)
+  fun start(): GRPCStream {
+    val stream = underlyingStream.start()
     return GRPCStream(stream)
   }
 

--- a/mobile/test/java/integration/AndroidEngineSocketTagTest.java
+++ b/mobile/test/java/integration/AndroidEngineSocketTagTest.java
@@ -17,6 +17,7 @@ import io.envoyproxy.envoymobile.ResponseTrailers;
 import io.envoyproxy.envoymobile.Stream;
 import io.envoyproxy.envoymobile.StreamIntel;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import io.envoyproxy.envoymobile.engine.ByteBuffers;
 import io.envoyproxy.envoymobile.engine.testing.RequestScenario;
 import io.envoyproxy.envoymobile.engine.testing.Response;
 import java.net.MalformedURLException;
@@ -125,7 +126,7 @@ public class AndroidEngineSocketTagTest {
                           return null;
                         })
                         .setOnResponseData((data, endStream, streamIntel) -> {
-                          response.get().addBody(data);
+                          response.get().addBody(ByteBuffers.copy(data));
                           if (!endStream) {
                             if (requestScenario.waitOnReadData) {
                               try {

--- a/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
@@ -17,6 +17,7 @@ import io.envoyproxy.envoymobile.ResponseTrailers;
 import io.envoyproxy.envoymobile.Stream;
 import io.envoyproxy.envoymobile.StreamIntel;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import io.envoyproxy.envoymobile.engine.ByteBuffers;
 import io.envoyproxy.envoymobile.engine.testing.RequestScenario;
 import io.envoyproxy.envoymobile.engine.testing.Response;
 import java.net.MalformedURLException;
@@ -486,7 +487,7 @@ public class AndroidEnvoyExplicitFlowTest {
                           return null;
                         })
                         .setOnResponseData((data, endStream, streamIntel) -> {
-                          response.get().addBody(data);
+                          response.get().addBody(ByteBuffers.copy(data));
                           response.get().addStreamIntel(streamIntel);
                           if (!endStream) {
                             if (requestScenario.waitOnReadData) {

--- a/mobile/test/java/integration/AndroidEnvoyFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyFlowTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.netty.buffer.ByteBuf;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;

--- a/mobile/test/java/integration/AndroidEnvoyFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyFlowTest.java
@@ -14,6 +14,7 @@ import io.envoyproxy.envoymobile.ResponseHeaders;
 import io.envoyproxy.envoymobile.ResponseTrailers;
 import io.envoyproxy.envoymobile.Stream;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import io.envoyproxy.envoymobile.engine.ByteBuffers;
 import io.envoyproxy.envoymobile.engine.testing.RequestScenario;
 import io.envoyproxy.envoymobile.engine.testing.Response;
 import java.io.IOException;
@@ -31,6 +32,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.netty.buffer.ByteBuf;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -292,7 +295,7 @@ public class AndroidEnvoyFlowTest {
                           return null;
                         })
                         .setOnResponseData((data, endStream, ignored) -> {
-                          response.get().addBody(data);
+                          response.get().addBody(ByteBuffers.copy(data));
                           if (endStream) {
                             latch.countDown();
                           }

--- a/mobile/test/java/integration/AndroidEnvoyFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyFlowTest.java
@@ -313,7 +313,7 @@ public class AndroidEnvoyFlowTest {
                           latch.countDown();
                           return null;
                         })
-                        .start(Executors.newSingleThreadExecutor())
+                        .start()
                         .sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
     if (requestScenario.cancelBeforeSendingRequestBody) {
       stream.cancel();

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -16,6 +16,7 @@ import io.envoyproxy.envoymobile.ResponseHeaders;
 import io.envoyproxy.envoymobile.ResponseTrailers;
 import io.envoyproxy.envoymobile.Stream;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import io.envoyproxy.envoymobile.engine.ByteBuffers;
 import io.envoyproxy.envoymobile.engine.JniLibrary;
 import io.envoyproxy.envoymobile.engine.testing.RequestScenario;
 import io.envoyproxy.envoymobile.engine.testing.Response;
@@ -156,7 +157,7 @@ public class QuicTestServerTest {
                           return null;
                         })
                         .setOnResponseData((data, endStream, ignored) -> {
-                          response.get().addBody(data);
+                          response.get().addBody(ByteBuffers.copy(data));
                           return null;
                         })
                         .setOnResponseTrailers((trailers, ignored) -> {
@@ -177,7 +178,7 @@ public class QuicTestServerTest {
                           latch.countDown();
                           return null;
                         })
-                        .start(Executors.newSingleThreadExecutor())
+                        .start()
                         .sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
     requestScenario.getBodyChunks().forEach(stream::sendData);
     requestScenario.getClosingBodyChunk().ifPresent(stream::close);

--- a/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -8,6 +8,8 @@ import static org.chromium.net.testing.CronetTestRule.SERVER_KEY_PKCS8_PEM;
 import static org.junit.Assert.assertNotNull;
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
+
+import io.envoyproxy.envoymobile.engine.ByteBuffers;
 import io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary;
 import io.envoyproxy.envoymobile.AndroidEngineBuilder;
 import io.envoyproxy.envoymobile.Engine;
@@ -192,7 +194,7 @@ public class Http2TestServerTest {
           return null;
         })
         .setOnResponseData((data, endStream, ignored) -> {
-          response.get().addBody(data);
+          response.get().addBody(ByteBuffers.copy(data));
           return null;
         })
         .setOnResponseTrailers((trailers, ignored) -> {

--- a/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
@@ -126,7 +125,7 @@ public class Http2TestServerTest {
           return null;
         })
         .setOnCancel((ignored) -> { throw new AssertionError("Unexpected OnCancel called."); })
-        .start(Executors.newSingleThreadExecutor())
+        .start()
         .sendHeaders(requestScenario.getHeaders(), false);
 
     latch.await();
@@ -163,7 +162,7 @@ public class Http2TestServerTest {
           return null;
         })
         .setOnCancel((ignored) -> { throw new AssertionError("Unexpected OnCancel called."); })
-        .start(Executors.newSingleThreadExecutor())
+        .start()
         .sendHeaders(requestScenario.getHeaders(), false);
 
     latch.await();
@@ -214,7 +213,7 @@ public class Http2TestServerTest {
           latch.countDown();
           return null;
         })
-        .start(Executors.newSingleThreadExecutor())
+        .start()
         .sendHeaders(requestScenario.getHeaders(), /* hasRequestBody= */ false);
 
     latch.await();

--- a/mobile/test/kotlin/apps/baseline/MainActivity.kt
+++ b/mobile/test/kotlin/apps/baseline/MainActivity.kt
@@ -18,7 +18,6 @@ import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
 import io.envoyproxy.envoymobile.shared.Success
 import java.io.IOException
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val REQUEST_HANDLER_THREAD_NAME = "hello_envoy_kt"
@@ -140,7 +139,7 @@ class MainActivity : Activity() {
         Log.d("MainActivity", message)
         recyclerView.post { viewAdapter.add(Failure(message)) }
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
   }
 

--- a/mobile/test/kotlin/apps/experimental/MainActivity.kt
+++ b/mobile/test/kotlin/apps/experimental/MainActivity.kt
@@ -20,7 +20,6 @@ import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
 import io.envoyproxy.envoymobile.shared.Success
 import java.io.IOException
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val REQUEST_HANDLER_THREAD_NAME = "hello_envoy_kt"
@@ -153,7 +152,7 @@ class MainActivity : Activity() {
         Log.d("MainActivity", message)
         recyclerView.post { viewAdapter.add(Failure(message)) }
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
   }
 

--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -17,7 +17,6 @@ import io.envoyproxy.envoymobile.StreamIntel
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 
@@ -92,7 +91,7 @@ class CancelGRPCStreamTest {
     client
       .newGRPCStreamPrototype()
       .setOnCancel { _ -> onCancelCallbackExpectation.countDown() }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, false)
       .cancel()
 

--- a/mobile/test/kotlin/integration/CancelStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelStreamTest.kt
@@ -17,7 +17,6 @@ import io.envoyproxy.envoymobile.StreamIntel
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 
@@ -91,7 +90,7 @@ class CancelStreamTest {
     client
       .newStreamPrototype()
       .setOnCancel { _ -> runExpectation.countDown() }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, false)
       .cancel()
 

--- a/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
+++ b/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
@@ -22,7 +22,6 @@ import io.envoyproxy.envoymobile.StreamIntel
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -134,7 +133,7 @@ class FilterThrowingExceptionTest {
         assertThat(status).isEqualTo(200)
         onRespondeHeadersLatch.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/ReceiveDataTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveDataTest.kt
@@ -5,6 +5,7 @@ import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.engine.ByteBuffers
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
@@ -51,7 +52,7 @@ class ReceiveDataTest {
         headersExpectation.countDown()
       }
       .setOnResponseData { data, _, _ ->
-        body = data
+        body = ByteBuffers.copy(data)
         dataExpectation.countDown()
       }
       .setOnError { _, _ -> fail("Unexpected error") }

--- a/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
+++ b/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
@@ -17,7 +17,6 @@ import io.envoyproxy.envoymobile.StreamIntel
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.fail
 import org.junit.Test
@@ -100,7 +99,7 @@ class StreamIdleTimeoutTest {
         assertThat(error.errorCode).isEqualTo(4)
         callbackExpectation.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, false)
 
     filterExpectation.await(10, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
@@ -14,7 +14,6 @@ import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,7 +85,7 @@ class PerformHTTPRequestUsingProxy {
         assertThat(responseHeaders.value("x-proxy-response")).isEqualTo(listOf("true"))
         onRespondeHeadersLatch.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
@@ -14,7 +14,6 @@ import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -81,7 +80,7 @@ class PerformHTTPSRequestBadHostname {
       .streamClient()
       .newStreamPrototype()
       .setOnError { _, _ -> onErrorLatch.countDown() }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onErrorLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -14,7 +14,6 @@ import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,7 +85,7 @@ class PerformHTTPSRequestUsingAsyncProxyTest {
         assertThat(responseHeaders.value("x-response-header-that-should-be-stripped")).isNull()
         onRespondeHeadersLatch.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -14,7 +14,6 @@ import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,7 +85,7 @@ class PerformHTTPSRequestUsingProxy {
         assertThat(responseHeaders.value("x-response-header-that-should-be-stripped")).isNull()
         onRespondeHeadersLatch.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
@@ -13,7 +13,6 @@ import io.envoyproxy.envoymobile.engine.AndroidJniLibrary
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -84,7 +83,7 @@ class PerformHTTPRequestUsingProxy {
         assertThat(responseHeaders.value("x-proxy-response")).isEqualTo(listOf("true"))
         onRespondeHeadersLatch.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
@@ -13,7 +13,6 @@ import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -84,7 +83,7 @@ class PerformHTTPRequestUsingProxy {
         assertThat(responseHeaders.value("x-proxy-response")).isNull()
         onRespondeHeadersLatch.countDown()
       }
-      .start(Executors.newSingleThreadExecutor())
+      .start()
       .sendHeaders(requestHeaders, true)
 
     onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
@@ -7,7 +7,6 @@ import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import org.junit.Test
 
@@ -23,7 +22,7 @@ class GRPCStreamTest {
       stream.onRequestData = { data, _ -> sentData.write(data.array()) }
     }
 
-    GRPCClient(streamClient).newGRPCStreamPrototype().start(Executor {}).sendMessage(message1)
+    GRPCClient(streamClient).newGRPCStreamPrototype().start().sendMessage(message1)
 
     assertThat(sentData.size()).isEqualTo(5 + message1.array().count())
   }
@@ -35,7 +34,7 @@ class GRPCStreamTest {
       stream.onRequestData = { data, _ -> sentData.write(data.array()) }
     }
 
-    GRPCClient(streamClient).newGRPCStreamPrototype().start(Executor {}).sendMessage(message1)
+    GRPCClient(streamClient).newGRPCStreamPrototype().start().sendMessage(message1)
 
     assertThat(sentData.toByteArray()[0]).isEqualTo(0)
   }
@@ -47,7 +46,7 @@ class GRPCStreamTest {
       stream.onRequestData = { data, _ -> sentData.write(data.array()) }
     }
 
-    GRPCClient(streamClient).newGRPCStreamPrototype().start(Executor {}).sendMessage(message1)
+    GRPCClient(streamClient).newGRPCStreamPrototype().start().sendMessage(message1)
 
     val size =
       ByteBuffer.wrap(sentData.toByteArray().sliceArray(1 until 5)).order(ByteOrder.BIG_ENDIAN).int
@@ -61,7 +60,7 @@ class GRPCStreamTest {
       stream.onRequestData = { data, _ -> sentData.write(data.array()) }
     }
 
-    GRPCClient(streamClient).newGRPCStreamPrototype().start(Executor {}).sendMessage(message1)
+    GRPCClient(streamClient).newGRPCStreamPrototype().start().sendMessage(message1)
 
     assertThat(sentData.toByteArray().sliceArray(5 until sentData.size()))
       .isEqualTo(message1.array())
@@ -74,7 +73,7 @@ class GRPCStreamTest {
       stream.onCancel = { countDownLatch.countDown() }
     }
 
-    GRPCClient(streamClient).newGRPCStreamPrototype().start(Executor {}).cancel()
+    GRPCClient(streamClient).newGRPCStreamPrototype().start().cancel()
 
     assertThat(countDownLatch.await(2000, TimeUnit.MILLISECONDS)).isTrue()
   }
@@ -96,7 +95,7 @@ class GRPCStreamTest {
         assertThat(endStream).isTrue()
         countDownLatch.countDown()
       }
-      .start(Executor {})
+      .start()
 
     stream?.receiveHeaders(expectedHeaders, true)
     countDownLatch.await()
@@ -117,7 +116,7 @@ class GRPCStreamTest {
           .isEqualTo(expectedTrailers.caseSensitiveHeaders())
         countDownLatch.countDown()
       }
-      .start(Executor {})
+      .start()
 
     stream?.receiveTrailers(expectedTrailers)
     countDownLatch.await()
@@ -135,7 +134,7 @@ class GRPCStreamTest {
         assertThat(message.array()).isEqualTo(message1.array())
         countDownLatch.countDown()
       }
-      .start(Executor {})
+      .start()
 
     val messageLength = message1.array().count()
     val data = ByteBuffer.allocate(5 + messageLength)
@@ -189,7 +188,7 @@ class GRPCStreamTest {
         }
         countDownLatch.countDown()
       }
-      .start(Executor {})
+      .start()
 
     stream?.receiveData(firstMessageBuffer, false)
     stream?.receiveData(secondMessageBufferPart1, false)
@@ -209,7 +208,7 @@ class GRPCStreamTest {
         assertThat(message.array()).hasLength(0)
         countDownLatch.countDown()
       }
-      .start(Executor {})
+      .start()
 
     val emptyMessage =
       ByteBuffer.wrap(
@@ -265,7 +264,7 @@ class GRPCStreamTest {
         }
         countDownLatch.countDown()
       }
-      .start(Executor {})
+      .start()
 
     stream?.receiveData(emptyMessageBuffer, false)
     stream?.receiveData(secondMessageBuffer, false)

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamPrototype.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStreamPrototype.kt
@@ -2,7 +2,6 @@ package io.envoyproxy.envoymobile.mocks
 
 import io.envoyproxy.envoymobile.Stream
 import io.envoyproxy.envoymobile.StreamPrototype
-import java.util.concurrent.Executor
 
 /**
  * Mock implementation of `StreamPrototype` which is used to produce `MockStream` instances.
@@ -11,8 +10,8 @@ import java.util.concurrent.Executor
  */
 class MockStreamPrototype(private val onStart: ((stream: MockStream) -> Unit)?) :
   StreamPrototype(MockEnvoyEngine()) {
-  override fun start(executor: Executor): Stream {
-    val callbacks = createCallbacks(executor)
+  override fun start(): Stream {
+    val callbacks = createCallbacks()
     val stream = MockStream(MockEnvoyHTTPStream(callbacks, false))
     onStart?.invoke(stream)
     return stream


### PR DESCRIPTION
This PR removes running the callbacks with the `Executor` in the API. Although, it makes sense to run the certain callbacks with the `Executor`, especially for blocking I/O so that we don't block the Envoy thread, having the API that forces the use of `Executor` is not always a good idea because we will always need to copy the `ByteBuffer` before executing the callback with the `Executor` or else we may run into accessing a `free`-ed `ByteBuffer`. This change is essentially making the use of the `Executor` for the callbacks a user choice. Both the `EnvoyHTTPCallbacks` and `EnvoyHTTPFilter` interfaces have been updated with the comments related to using `ByteBuffer data`. The change also makes the Java/Kotlin API consistent with the other language APIs.

The PR is also a follow-up of https://github.com/envoyproxy/envoy/pull/32715 to reduce the number of copies, especially for item 5 in the after section. With this change, there is only one copy from `Envoy::Buffer::Instance` to `envoy_data`. The `ByteBuffer` passed into the callbacks will be backed by `envoy_data` (outside the JVM memory management). The users are still free to copy the `ByteBuffer` as needed, but Envoy Mobile will no longer impose this.

For Cronvoy, there is no substantial change because Cronvoy does not use the `Executor` defined in the `EnvoyHTTPCallbacks` and `CronvoyUrlRequest#onData` already makes a copy of the `ByteBuffer` passed from the callback before passing it into a separate thread. The only change is to make a copy earlier prior to spawning a thread.

Risk Level: high
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
