### PR TITLE
Deflake FileDeletedWhileIterating

### DIFF
--- a/test/common/filesystem/directory_test.cc
+++ b/test/common/filesystem/directory_test.cc
@@ -273,7 +273,7 @@ TEST_F(DirectoryTest, FileDeletedWhileIterating) {
                          EntrySet{
                              {".", FileType::Directory, absl::nullopt},
                              {"..", FileType::Directory, absl::nullopt},
-                             {"file1", FileType::Regular, 0},
+                             {"file2", FileType::Regular, 0},
                          }));
 }
 #endif


### PR DESCRIPTION
Commit Message: This test is right to be concerned about arbitrary iteration order. However, it failed to list `"file2"` as a possibility.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
