### PR TITLE
oauth2: on refresh, replace instead of append cookies

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -146,8 +146,8 @@ bug_fixes:
     Dynatrace resource detector: Only log warning message when no enrichment attributes are found.
 - area: oauth
   change: |
-    When performing a token refresh and forwarding tokens upstream, replace existing token cookies rather than appending as 
-    another Cookie header
+    When performing a token refresh and forwarding tokens upstream, replace existing token cookies rather than appending as
+    another Cookie header.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -144,6 +144,10 @@ bug_fixes:
 - area: tracing
   change: |
     Dynatrace resource detector: Only log warning message when no enrichment attributes are found.
+- area: oauth
+  change: |
+    When performing a token refresh and forwarding tokens upstream, replace existing token cookies rather than appending as 
+    another Cookie header
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -608,7 +608,7 @@ void OAuth2Filter::finishRefreshAccessTokenFlow() {
   }
 
   std::string new_cookies(absl::StrJoin(cookies, "; ", absl::PairFormatter("=")));
-  request_headers_->addReferenceKey(Http::Headers::get().Cookie, new_cookies);
+  request_headers_->setReferenceKey(Http::Headers::get().Cookie, new_cookies);
   if (config_->forwardBearerToken() && !access_token_.empty()) {
     setBearerToken(*request_headers_, access_token_);
   }


### PR DESCRIPTION
Commit Message: oauth2: on refresh, replace instead of append cookies
Additional Description:
The [issue](https://github.com/envoyproxy/envoy/issues/32771) has most of the context, but in short when we refresh the access token we aren't removing the existing access token cookie and instead are appending the new cookie, which is not valid.
Risk Level: low
Testing: unit testing. wrote the failing test first
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
fixes https://github.com/envoyproxy/envoy/issues/32771
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
