### PR TITLE
Remove spdy_testonly and http2_testonly flags.

### DIFF
--- a/source/common/quic/platform/quiche_flags_impl.cc
+++ b/source/common/quic/platform/quiche_flags_impl.cc
@@ -105,14 +105,6 @@ absl::flat_hash_map<absl::string_view, ReloadableFlag*> makeReloadableFlagMap() 
   ASSERT(absl::GetFlag(FLAGS_envoy_quic_restart_flag_quic_testonly_default_true) == true);
 #define QUIC_FLAG(flag, ...) flags.emplace("FLAGS_envoy_" #flag, &FLAGS_envoy_##flag);
 #include "quiche/quic/core/quic_flags_list.h"
-  QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_false, false)
-  QUIC_FLAG(quic_reloadable_flag_spdy_testonly_default_true, true)
-  QUIC_FLAG(quic_restart_flag_spdy_testonly_default_false, false)
-  QUIC_FLAG(quic_restart_flag_spdy_testonly_default_true, true)
-  QUIC_FLAG(quic_reloadable_flag_http2_testonly_default_false, false)
-  QUIC_FLAG(quic_reloadable_flag_http2_testonly_default_true, true)
-  QUIC_FLAG(quic_restart_flag_http2_testonly_default_false, false)
-  QUIC_FLAG(quic_restart_flag_http2_testonly_default_true, true)
 #undef QUIC_FLAG
   return flags;
 }

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -553,14 +553,18 @@ TEST_F(StaticLoaderImplTest, QuicheReloadableFlags) {
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
 
   // Test that Quiche flags can be overwritten via Envoy runtime config.
-  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>("envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: true");
+  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(
+      "envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: "
+      "true");
   setup();
 
   EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
 
   // Test that Quiche flags can be overwritten again.
-  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>("envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: false");
+  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(
+      "envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: "
+      "false");
   setup();
 
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -544,27 +544,27 @@ TEST_F(StaticLoaderImplTest, All) {
 
 #ifdef ENVOY_ENABLE_QUIC
 TEST_F(StaticLoaderImplTest, QuicheReloadableFlags) {
-  // Test that Quiche flags can be overwritten via Envoy runtime config.
-  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
-    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_false: true
-    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: false
-    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_spdy_testonly_default_false: false
-  )EOF");
-  SetQuicheReloadableFlag(spdy, spdy_testonly_default_false, true);
-  EXPECT_TRUE(GetQuicheReloadableFlag(spdy, spdy_testonly_default_false));
-  setup();
-  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+
+  SetQuicheReloadableFlag(spdy, quic_testonly_default_true, false);
+
   EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
-  EXPECT_FALSE(GetQuicheReloadableFlag(spdy, spdy_testonly_default_false));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
+
+  // Test that Quiche flags can be overwritten via Envoy runtime config.
+  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>("envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: true");
+  setup();
+
+  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
 
   // Test that Quiche flags can be overwritten again.
-  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>(R"EOF(
-    envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: true
-  )EOF");
+  base_ = TestUtility::parseYaml<ProtobufWkt::Struct>("envoy.reloadable_features.FLAGS_envoy_quic_reloadable_flag_quic_testonly_default_true: false");
   setup();
-  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_false));
-  EXPECT_TRUE(GetQuicReloadableFlag(quic_testonly_default_true));
-  EXPECT_FALSE(GetQuicheReloadableFlag(spdy, spdy_testonly_default_false));
+
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_true));
+  EXPECT_FALSE(GetQuicReloadableFlag(quic_testonly_default_false));
 }
 #endif
 


### PR DESCRIPTION
These flags are leftover artifacts from the time when there were three different kind of flags in QUICHE. This PR is part of the effort to clean up QUICHE flag framework. See also
https://quiche.googlesource.com/quiche/+/b36587781c9532e3b0715ea522cca57dec561854

Commit Message: Remove spdy_testonly and http2_testonly flags.
Additional Description: These flags are leftover artifacts from the time when there were three different kind of flags in QUICHE. This PR is part of the effort to clean up QUICHE flag framework. See also https://quiche.googlesource.com/quiche/+/b36587781c9532e3b0715ea522cca57dec561854
Risk Level: low
Testing: test/common/runtime:runtime_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a