### PR TITLE
tools: Fix generate_debug_config.py

### DIFF
--- a/tools/vscode/generate_debug_config.py
+++ b/tools/vscode/generate_debug_config.py
@@ -38,9 +38,8 @@ def binary_path(bazel_bin, target):
 
 
 def build_binary_with_debug_info(target):
-    targets = [target, target + ".dwp"]
-    subprocess.check_call(["bazel", *BAZEL_STARTUP_OPTIONS, "build", "-c", "dbg"] + BAZEL_OPTIONS
-                          + targets)
+    subprocess.check_call(["bazel", *BAZEL_STARTUP_OPTIONS, "build", "-c", "dbg", target]
+                          + BAZEL_OPTIONS)
 
     bazel_bin = bazel_info("bazel-bin", ["-c", "dbg"])
     return binary_path(bazel_bin, target)


### PR DESCRIPTION
This PR updates `tools/vscode/generate_debug_config.py` to not run with `bazel build <target>.dwp` since it generates corrupted / truncated data. See also https://github.com/envoyproxy/envoy/issues/13578.

This fixes https://github.com/envoyproxy/envoy/issues/32700.

Risk Level: low (development tool only)
Testing: tested inside devcontainer and ran `tools/vscode/generate_debug_config.py //source/exe:envoy-static --args "-c configs/demo-envoy.yaml" --debugger lldb`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
