### PR TITLE
opentelemetrytracer: fix missing operation name

### DIFF
--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -123,6 +123,8 @@ void Span::setAttribute(absl::string_view name, const OTelAttribute& attribute_v
 
 void Span::setTag(absl::string_view name, absl::string_view value) { setAttribute(name, value); }
 
+void Span::setOperation(absl::string_view operation) { span_.set_name(operation); }
+
 Tracer::Tracer(OpenTelemetryTraceExporterPtr exporter, Envoy::TimeSource& time_source,
                Random::RandomGenerator& random, Runtime::Loader& runtime,
                Event::Dispatcher& dispatcher, OpenTelemetryTracerStats tracing_stats,

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -85,7 +85,7 @@ public:
        Tracer& parent_tracer, OTelSpanKind span_kind);
 
   // Tracing::Span functions
-  void setOperation(absl::string_view /*operation*/) override{};
+  void setOperation(absl::string_view /*operation*/) override;
   void setTag(absl::string_view /*name*/, absl::string_view /*value*/) override;
   void log(SystemTime /*timestamp*/, const std::string& /*event*/) override{};
   void finishSpan() override;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix missing operation name in opentelemetry spans

Additional Description:
We used to use `envoy.tracers.dynamic_ot` tracing provider and recently switched to `envoy.tracers.opentelemetry`. This caused a bug: before in opentelemetry UI every span was displayed as `[service_name]: [operation_name]` where `operation_name` was taken from `decorator.operation` field in envoy config. Now it just shows `[service_name]: ingress`. This PR fixes this and makes opentelemetry tracer consider `decorator.operation` value.

Risk Level: assumedly low
Testing: this is my first contribution to a c++ project, so I'm not sure if I need to modify tests to include this case, and which tests exactly, sorry for that.
Docs Changes: assumedly not needed
