### PR TITLE
quic: lowering quic brokenness  timer

### DIFF
--- a/source/common/http/http3_status_tracker_impl.cc
+++ b/source/common/http/http3_status_tracker_impl.cc
@@ -8,7 +8,7 @@ namespace {
 // Initially, HTTP/3 is marked broken for 1 second.
 const std::chrono::seconds DefaultExpirationTime{1};
 // Cap the broken period around a day and a half.
-const int MaxConsecutiveBrokenCount = 18;
+const int MaxConsecutiveBrokenCount = 17;
 } // namespace
 
 Http3StatusTrackerImpl::Http3StatusTrackerImpl(Event::Dispatcher& dispatcher)

--- a/source/common/http/http3_status_tracker_impl.cc
+++ b/source/common/http/http3_status_tracker_impl.cc
@@ -5,10 +5,10 @@ namespace Http {
 
 namespace {
 
-// Initially, HTTP/3 is be marked broken for 5 minutes.
-const std::chrono::minutes DefaultExpirationTime{5};
-// Cap the broken period at just under 1 day.
-const int MaxConsecutiveBrokenCount = 8;
+// Initially, HTTP/3 is marked broken for 1 second.
+const std::chrono::seconds DefaultExpirationTime{1};
+// Cap the broken period around a day and a half.
+const int MaxConsecutiveBrokenCount = 18;
 } // namespace
 
 Http3StatusTrackerImpl::Http3StatusTrackerImpl(Event::Dispatcher& dispatcher)
@@ -25,10 +25,10 @@ bool Http3StatusTrackerImpl::hasHttp3FailedRecently() const {
 void Http3StatusTrackerImpl::markHttp3Broken() {
   state_ = State::Broken;
   if (!expiration_timer_->enabled()) {
-    std::chrono::minutes expiration_in_min =
+    std::chrono::seconds expiration_in_sec =
         DefaultExpirationTime * (1 << consecutive_broken_count_);
     expiration_timer_->enableTimer(
-        std::chrono::duration_cast<std::chrono::milliseconds>(expiration_in_min));
+        std::chrono::duration_cast<std::chrono::milliseconds>(expiration_in_sec));
     if (consecutive_broken_count_ < MaxConsecutiveBrokenCount) {
       ++consecutive_broken_count_;
     }

--- a/test/common/http/http3_status_tracker_impl_test.cc
+++ b/test/common/http/http3_status_tracker_impl_test.cc
@@ -33,7 +33,7 @@ TEST_F(Http3StatusTrackerImplTest, Initialized) {
 
 TEST_F(Http3StatusTrackerImplTest, MarkBroken) {
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
   EXPECT_TRUE(tracker_.isHttp3Broken());
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
@@ -42,7 +42,7 @@ TEST_F(Http3StatusTrackerImplTest, MarkBroken) {
 
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenRepeatedly) {
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
   EXPECT_TRUE(tracker_.isHttp3Broken());
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
@@ -55,7 +55,7 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenRepeatedly) {
 
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenExpires) {
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
 
   timer_->invokeCallback();
@@ -67,19 +67,19 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenExpires) {
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenWithBackoff) {
   EXPECT_CALL(*timer_, enabled()).WillRepeatedly(Return(false));
 
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
 
   timer_->invokeCallback();
 
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(10 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(2 * 1000), nullptr));
   tracker_.markHttp3Broken();
 
   timer_->invokeCallback();
   EXPECT_FALSE(tracker_.isHttp3Broken());
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
 
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(20 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(4 * 1000), nullptr));
   tracker_.markHttp3Broken();
   EXPECT_TRUE(tracker_.isHttp3Broken());
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
@@ -88,7 +88,7 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenWithBackoff) {
   EXPECT_FALSE(tracker_.isHttp3Broken());
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
 
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(8 * 1000), nullptr));
   tracker_.markHttp3Broken();
   EXPECT_TRUE(tracker_.isHttp3Broken());
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
@@ -101,51 +101,25 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenWithBackoff) {
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenWithBackoffMax) {
   EXPECT_CALL(*timer_, enabled()).WillRepeatedly(Return(false));
 
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  for (int i = 0; i < 17; ++i) {
+    EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, i)) * 1000), nullptr));
+    tracker_.markHttp3Broken();
+    timer_->invokeCallback();
+  }
+
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, 17)) * 1000), nullptr));
   tracker_.markHttp3Broken();
   timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(10 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(20 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(80 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(160 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(320 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(640 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1280 * 60 * 1000), nullptr));
-  tracker_.markHttp3Broken();
-  timer_->invokeCallback();
-
+/*
   // Broken period no longer increases.
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1280 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, 17)) * 1000), nullptr));
   tracker_.markHttp3Broken();
-  timer_->invokeCallback();
+  timer_->invokeCallback();*/
 }
 
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenExpiresThenConfirmedThenBroken) {
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
   timer_->invokeCallback();
 
@@ -157,7 +131,7 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenExpiresThenConfirmedThenBroken)
 
   // markConfirmed will have reset the timeout back to the initial value.
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
 
   EXPECT_TRUE(tracker_.isHttp3Broken());
@@ -167,7 +141,7 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenExpiresThenConfirmedThenBroken)
 
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenConfirmed) {
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
   timer_->invokeCallback();
 
@@ -185,7 +159,7 @@ TEST_F(Http3StatusTrackerImplTest, MarkFailedRecentlyAndThenBroken) {
   EXPECT_FALSE(tracker_.isHttp3Confirmed());
 
   EXPECT_CALL(*timer_, enabled()).WillOnce(Return(false));
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(5 * 60 * 1000), nullptr));
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * 1000), nullptr));
   tracker_.markHttp3Broken();
 
   EXPECT_TRUE(tracker_.isHttp3Broken());

--- a/test/common/http/http3_status_tracker_impl_test.cc
+++ b/test/common/http/http3_status_tracker_impl_test.cc
@@ -102,19 +102,25 @@ TEST_F(Http3StatusTrackerImplTest, MarkBrokenWithBackoffMax) {
   EXPECT_CALL(*timer_, enabled()).WillRepeatedly(Return(false));
 
   for (int i = 0; i < 17; ++i) {
-    EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, i)) * 1000), nullptr));
+    EXPECT_CALL(
+        *timer_,
+        enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, i)) * 1000), nullptr));
     tracker_.markHttp3Broken();
     timer_->invokeCallback();
   }
 
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, 17)) * 1000), nullptr));
+  EXPECT_CALL(
+      *timer_,
+      enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, 17)) * 1000), nullptr));
   tracker_.markHttp3Broken();
   timer_->invokeCallback();
-/*
+
   // Broken period no longer increases.
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, 17)) * 1000), nullptr));
+  EXPECT_CALL(
+      *timer_,
+      enableTimer(std::chrono::milliseconds(1 * static_cast<int>(pow(2, 17)) * 1000), nullptr));
   tracker_.markHttp3Broken();
-  timer_->invokeCallback();*/
+  timer_->invokeCallback();
 }
 
 TEST_F(Http3StatusTrackerImplTest, MarkBrokenThenExpiresThenConfirmedThenBroken) {


### PR DESCRIPTION
turns out we always ran with roughly this override in production

Testing: updated tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a