### PR TITLE
mobile: Delete outdated mobile CODEOWNERS

### DIFF
--- a/mobile/.github/CODEOWNERS
+++ b/mobile/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @lyft/envoy-mobile-admin


### PR DESCRIPTION
Envoy Mobile uses [envoy/CODEOWNERS](https://github.com/envoyproxy/envoy/blob/8714c2e537746862e459c154f7db586135c26e04/CODEOWNERS#L367-L368).

Commit Message:
Additional Description:
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
