### PR TITLE
make the error message better when there's a duplicate filter chain matcher.

### DIFF
--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -146,12 +146,18 @@ void FilterChainManagerImpl::addFilterChains(
     if (!filter_chain_matcher) {
       const auto& matching_iter = filter_chains.find(filter_chain_match);
       if (matching_iter != filter_chains.end()) {
-        throw EnvoyException(
+        std::string error_msg =
             fmt::format("error adding listener '{}': filter chain '{}' has "
-                        "the same matching rules defined as '{}'. duplicate matcher is: {}",
+                        "the same matching rules defined as '{}'",
                         absl::StrJoin(addresses_, ",", Network::AddressStrFormatter()),
-                        filter_chain->name(), matching_iter->second,
-                        MessageUtil::getJsonStringFromMessageOrError(filter_chain_match, false)));
+                        filter_chain->name(), matching_iter->second);
+#ifdef ENVOY_ENABLE_YAML
+        error_msg =
+            absl::StrCat(error_msg, ". duplicate matcher is: ",
+                         MessageUtil::getJsonStringFromMessageOrError(filter_chain_match, false));
+#endif
+
+        throw EnvoyException(error_msg);
       }
       filter_chains.insert({filter_chain_match, filter_chain->name()});
     }

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -148,9 +148,10 @@ void FilterChainManagerImpl::addFilterChains(
       if (matching_iter != filter_chains.end()) {
         throw EnvoyException(
             fmt::format("error adding listener '{}': filter chain '{}' has "
-                        "the same matching rules defined as '{}'",
+                        "the same matching rules defined as '{}'. duplicate matcher is: {}",
                         absl::StrJoin(addresses_, ",", Network::AddressStrFormatter()),
-                        filter_chain->name(), matching_iter->second));
+                        filter_chain->name(), matching_iter->second,
+                        MessageUtil::getJsonStringFromMessageOrError(filter_chain_match, false)));
       }
       filter_chains.insert({filter_chain_match, filter_chain->name()});
     }

--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -298,8 +298,12 @@ TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {
                                 nullptr, filter_chain_factory_builder_, *filter_chain_manager_),
                             EnvoyException,
                             "error adding listener '127.0.0.1:1234': filter chain 'foo' has the "
-                            "same matching rules defined as 'foo'. duplicate matcher is: "
-                            "{\"destination_port\":10000,\"server_names\":[\"example.com\"]}");
+                            "same matching rules defined as 'foo'"
+#ifdef ENVOY_ENABLE_YAML
+                            ". duplicate matcher is: "
+                            "{\"destination_port\":10000,\"server_names\":[\"example.com\"]}"
+#endif
+  );
 }
 
 INSTANTIATE_TEST_SUITE_P(Matcher, FilterChainManagerImplTest, ::testing::Values(true, false));

--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -286,6 +286,22 @@ TEST_P(FilterChainManagerImplTest, CreatedFilterChainFactoryContextHasIndependen
   EXPECT_FALSE(context1->drainDecision().drainClose());
 }
 
+TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {
+  envoy::config::listener::v3::FilterChain new_filter_chain1 = filter_chain_template_;
+  new_filter_chain1.mutable_filter_chain_match()->add_server_names("example.com");
+  envoy::config::listener::v3::FilterChain new_filter_chain2 = new_filter_chain1;
+
+  EXPECT_THROW_WITH_MESSAGE(filter_chain_manager_->addFilterChains(
+                                nullptr,
+                                std::vector<const envoy::config::listener::v3::FilterChain*>{
+                                    &new_filter_chain1, &new_filter_chain2},
+                                nullptr, filter_chain_factory_builder_, *filter_chain_manager_),
+                            EnvoyException,
+                            "error adding listener '127.0.0.1:1234': filter chain 'foo' has the "
+                            "same matching rules defined as 'foo'. duplicate matcher is: "
+                            "{\"destination_port\":10000,\"server_names\":[\"example.com\"]}");
+}
+
 INSTANTIATE_TEST_SUITE_P(Matcher, FilterChainManagerImplTest, ::testing::Values(true, false));
 
 } // namespace Server

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -5318,7 +5318,11 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithSameMatch
   }
   EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(parseListenerFromV3Yaml(yaml)), EnvoyException,
                             "error adding listener '127.0.0.1:1234': filter chain 'bar' has "
-                            "the same matching rules defined as 'foo'");
+                            "the same matching rules defined as 'foo'"
+#ifdef ENVOY_ENABLE_YAML
+                            ". duplicate matcher is: {\"transport_protocol\":\"tls\"}"
+#endif
+  );
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest,


### PR DESCRIPTION
Commit Message:

when duplicate filter chain match error happens, it is hard to find the offending matcher, especially when there are many of them. This commit adds the matcher to the error message, so it is easier to understand the cause.


Additional Description:
This is  especially a problem with large multi tenant setups, making it hard to find the tenant that added the duplicate matcher.

Risk Level:
Low - just a message change
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
