### PR TITLE
Stringmatcher: factory context for http cache filter

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -42,10 +42,11 @@ struct CacheResponseCodeDetailValues {
 using CacheResponseCodeDetails = ConstSingleton<CacheResponseCodeDetailValues>;
 
 CacheFilter::CacheFilter(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-                         const std::string&, Stats::Scope&, TimeSource& time_source,
+                         const std::string&, Stats::Scope&,
+                         Server::Configuration::CommonFactoryContext& context,
                          std::shared_ptr<HttpCache> http_cache)
-    : time_source_(time_source), cache_(http_cache),
-      vary_allow_list_(config.allowed_vary_headers()) {}
+    : time_source_(context.timeSource()), cache_(http_cache),
+      vary_allow_list_(config.allowed_vary_headers(), context) {}
 
 void CacheFilter::onDestroy() {
   filter_state_ = FilterState::Destroyed;

--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -54,7 +54,8 @@ class CacheFilter : public Http::PassThroughFilter,
                     public std::enable_shared_from_this<CacheFilter> {
 public:
   CacheFilter(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-              const std::string& stats_prefix, Stats::Scope& scope, TimeSource& time_source,
+              const std::string& stats_prefix, Stats::Scope& scope,
+              Server::Configuration::CommonFactoryContext& context,
               std::shared_ptr<HttpCache> http_cache);
   // Http::StreamFilterBase
   void onDestroy() override;

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -284,12 +284,14 @@ CacheHeadersUtils::parseCommaDelimitedHeader(const Http::HeaderMap::GetResult& e
 }
 
 VaryAllowList::VaryAllowList(
-    const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list) {
+    const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list,
+    Server::Configuration::CommonFactoryContext& context) {
 
   for (const auto& rule : allow_list) {
     allow_list_.emplace_back(
-        std::make_unique<Matchers::StringMatcherImpl<envoy::type::matcher::v3::StringMatcher>>(
-            rule));
+        std::make_unique<
+            Matchers::StringMatcherImplWithContext<envoy::type::matcher::v3::StringMatcher>>(
+            rule, context));
   }
 }
 

--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -128,7 +128,8 @@ class VaryAllowList {
 public:
   // Parses the allow list from the Cache Config into the object's private allow_list_.
   VaryAllowList(
-      const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list);
+      const Protobuf::RepeatedPtrField<envoy::type::matcher::v3::StringMatcher>& allow_list,
+      Server::Configuration::CommonFactoryContext& context);
 
   // Checks if the headers contain an allowed value in the Vary header.
   bool allowsHeaders(const Http::ResponseHeaderMap& headers) const;

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -28,8 +28,8 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
 
   return [config, stats_prefix, &context,
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<CacheFilter>(
-        config, stats_prefix, context.scope(), context.serverFactoryContext().timeSource(), cache));
+    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
+                                                            context.serverFactoryContext(), cache));
   };
 }
 

--- a/test/extensions/filters/http/cache/BUILD
+++ b/test/extensions/filters/http/cache/BUILD
@@ -25,6 +25,7 @@ envoy_extension_cc_test(
         "//envoy/http:header_map_interface",
         "//source/common/http:header_map_lib",
         "//source/extensions/filters/http/cache:cache_headers_utils_lib",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
     ],
@@ -56,6 +57,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/cache:http_cache_lib",
         "//source/extensions/http/cache/simple_http_cache:config",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
@@ -96,6 +98,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.filters.http.cache"],
     deps = [
         "//source/extensions/filters/http/cache:cacheability_utils_lib",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -30,15 +30,15 @@ protected:
   // The filter has to be created as a shared_ptr to enable shared_from_this() which is used in the
   // cache callbacks.
   CacheFilterSharedPtr makeFilter(std::shared_ptr<HttpCache> cache, bool auto_destroy = true) {
-    std::shared_ptr<CacheFilter> filter(
-        new CacheFilter(config_, /*stats_prefix=*/"", context_.scope(),
-                        context_.server_factory_context_.timeSource(), cache),
-        [auto_destroy](CacheFilter* f) {
-          if (auto_destroy) {
-            f->onDestroy();
-          }
-          delete f;
-        });
+    std::shared_ptr<CacheFilter> filter(new CacheFilter(config_, /*stats_prefix=*/"",
+                                                        context_.scope(),
+                                                        context_.server_factory_context_, cache),
+                                        [auto_destroy](CacheFilter* f) {
+                                          if (auto_destroy) {
+                                            f->onDestroy();
+                                          }
+                                          delete f;
+                                        });
     filter_state_ = std::make_shared<StreamInfo::FilterStateImpl>(
         StreamInfo::FilterState::LifeSpan::FilterChain);
     filter->setDecoderFilterCallbacks(decoder_callbacks_);

--- a/test/extensions/filters/http/cache/cacheability_utils_test.cc
+++ b/test/extensions/filters/http/cache/cacheability_utils_test.cc
@@ -2,6 +2,7 @@
 
 #include "source/extensions/filters/http/cache/cacheability_utils.h"
 
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -35,13 +36,16 @@ envoy::extensions::filters::http::cache::v3::CacheConfig getConfig() {
 
 class IsCacheableResponseTest : public testing::Test {
 public:
-  IsCacheableResponseTest() : vary_allow_list_(getConfig().allowed_vary_headers()) {}
+  IsCacheableResponseTest()
+      : vary_allow_list_(getConfig().allowed_vary_headers(), factory_context_) {}
 
 protected:
   std::string cache_control_ = "max-age=3600";
   Http::TestResponseHeaderMapImpl response_headers_ = {{":status", "200"},
                                                        {"date", "Sun, 06 Nov 1994 08:49:37 GMT"},
                                                        {"cache-control", cache_control_}};
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   VaryAllowList vary_allow_list_;
 };
 

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.cc
@@ -41,7 +41,8 @@ MATCHER(IsOk, "") { return arg.ok(); }
 } // namespace
 
 HttpCacheImplementationTest::HttpCacheImplementationTest()
-    : delegate_(GetParam()()), vary_allow_list_(getConfig().allowed_vary_headers()) {
+    : delegate_(GetParam()()),
+      vary_allow_list_(getConfig().allowed_vary_headers(), factory_context_) {
   request_headers_.setMethod("GET");
   request_headers_.setHost("example.com");
   request_headers_.setScheme("https");
@@ -490,7 +491,8 @@ TEST_P(HttpCacheImplementationTest, VaryResponses) {
   Protobuf::RepeatedPtrField<::envoy::type::matcher::v3::StringMatcher> proto_allow_list;
   ::envoy::type::matcher::v3::StringMatcher* matcher = proto_allow_list.Add();
   matcher->set_exact("width");
-  vary_allow_list_ = VaryAllowList(proto_allow_list);
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+  vary_allow_list_ = VaryAllowList(proto_allow_list, factory_context);
   lookup(request_path);
   EXPECT_EQ(lookup_result_.cache_entry_status_, CacheEntryStatus::Unusable);
 }

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.h
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.h
@@ -9,6 +9,7 @@
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
@@ -89,6 +90,7 @@ protected:
   expectLookupSuccessWithBodyAndTrailers(LookupContext* lookup, absl::string_view body,
                                          Http::TestResponseTrailerMapImpl trailers = {});
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   std::unique_ptr<HttpCacheTestDelegate> delegate_;
   VaryAllowList vary_allow_list_;
   LookupResult lookup_result_;

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -5,6 +5,7 @@
 #include "source/extensions/filters/http/cache/http_cache.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
@@ -39,12 +40,13 @@ envoy::extensions::filters::http::cache::v3::CacheConfig getConfig() {
 
 class LookupRequestTest : public testing::TestWithParam<LookupRequestTestCase> {
 public:
-  LookupRequestTest() : vary_allow_list_(getConfig().allowed_vary_headers()) {}
+  LookupRequestTest() : vary_allow_list_(getConfig().allowed_vary_headers(), factory_context_) {}
 
   DateFormatter formatter_{"%a, %d %b %Y %H:%M:%S GMT"};
   Http::TestRequestHeaderMapImpl request_headers_{
       {":path", "/"}, {":method", "GET"}, {":scheme", "https"}, {":authority", "example.com"}};
 
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   VaryAllowList vary_allow_list_;
 
   static const SystemTime& currentTime() {

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -370,7 +370,8 @@ protected:
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   Event::SimulatedTimeSystem time_system_;
   Http::TestRequestHeaderMapImpl request_headers_;
-  VaryAllowList vary_allow_list_{varyAllowListConfig().allowed_vary_headers()};
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
+  VaryAllowList vary_allow_list_{varyAllowListConfig().allowed_vary_headers(), factory_context_};
   DateFormatter formatter_{"%a, %d %b %Y %H:%M:%S GMT"};
   Http::TestResponseHeaderMapImpl response_headers_{
       {":status", "200"},


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Part of https://github.com/envoyproxy/envoy/issues/32792
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
