### PR TITLE
bazel: remove `output_to_genfiles = True`

### DIFF
--- a/api/bazel/cc_proto_descriptor_library/builddefs.bzl
+++ b/api/bazel/cc_proto_descriptor_library/builddefs.bzl
@@ -335,7 +335,6 @@ cc_proto_descriptor_library_aspect = aspect(
 )
 
 cc_proto_descriptor_library = rule(
-    output_to_genfiles = True,
     implementation = _cc_proto_descriptor_rule_impl,
     attrs = {
         "deps": attr.label_list(


### PR DESCRIPTION
This is a no-op, as Bazel already enables `--incompatible_merge_genfiles_directory` by default, which makes the distinction between `genfiles` and `bin` moot.