### PR TITLE
Make the instance_interface dependency explicit

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -397,6 +397,7 @@ envoy_cc_library(
     hdrs = ["listener_manager_factory.h"],
     deps = [
         "//envoy/server:factory_context_interface",
+        "//envoy/server:instance_interface",
         "//envoy/server:listener_manager_interface",
         "//envoy/server:worker_interface",
         "//source/common/quic:quic_stat_names_lib",


### PR DESCRIPTION
Additional Description:
Caused by newer interval version.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
