### PR TITLE
quic: remove unnecessary type cast in integration test

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -245,15 +245,13 @@ Network::ClientConnectionPtr HttpIntegrationTest::makeClientConnectionWithOption
       fmt::format("udp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
   Network::Address::InstanceConstSharedPtr local_addr =
       Network::Test::getCanonicalLoopbackAddress(version_);
-  auto& quic_transport_socket_factory_ref =
-      dynamic_cast<Quic::QuicClientTransportSocketFactory&>(*quic_transport_socket_factory_);
   return Quic::createQuicNetworkConnection(
-      *quic_connection_persistent_info_, quic_transport_socket_factory_ref.getCryptoConfig(),
+      *quic_connection_persistent_info_, quic_transport_socket_factory_->getCryptoConfig(),
       quic::QuicServerId(
-          quic_transport_socket_factory_ref.clientContextConfig()->serverNameIndication(),
+          quic_transport_socket_factory_->clientContextConfig()->serverNameIndication(),
           static_cast<uint16_t>(port)),
       *dispatcher_, server_addr, local_addr, quic_stat_names_, {}, *stats_store_.rootScope(),
-      options, nullptr, connection_id_generator_, quic_transport_socket_factory_ref);
+      options, nullptr, connection_id_generator_, *quic_transport_socket_factory_);
 #else
   ASSERT(false, "running a QUIC integration test without compiling QUIC");
   return nullptr;


### PR DESCRIPTION
Commit Message: Down casting upstream transport socket factory to `QuicClientTransportSocketFactory` type is too strong, making the test function unusable for a different quic upstream transport socket factory extension.

Risk Level: N/A, test only
Testing: existing test pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
