### PR TITLE
mobile: Remove jni_log

### DIFF
--- a/mobile/library/jni/android_network_utility.cc
+++ b/mobile/library/jni/android_network_utility.cc
@@ -88,7 +88,6 @@ LocalRefUniquePtr<jobject> callJvmVerifyX509CertChain(Envoy::JNI::JniHelper& jni
                                                       const std::vector<std::string>& cert_chain,
                                                       std::string auth_type,
                                                       absl::string_view hostname) {
-  jni_log("[Envoy]", "jvmVerifyX509CertChain");
   LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
       findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
   jmethodID jmid_verifyServerCertificates = jni_helper.getStaticMethodId(
@@ -107,8 +106,6 @@ LocalRefUniquePtr<jobject> callJvmVerifyX509CertChain(Envoy::JNI::JniHelper& jni
 
 envoy_cert_validation_result verifyX509CertChain(const std::vector<std::string>& certs,
                                                  absl::string_view hostname) {
-  jni_log("[Envoy]", "verifyX509CertChain");
-
   envoy_cert_verify_status_t result;
   bool is_issued_by_known_root;
   std::vector<std::string> verified_chain;

--- a/mobile/library/jni/java_jni_support.cc
+++ b/mobile/library/jni/java_jni_support.cc
@@ -2,10 +2,6 @@
 
 // NOLINT(namespace-envoy)
 
-int jni_log_fmt(const char* /*tag*/, const char* /*fmt*/, void* /*value*/) { return 0; }
-
-int jni_log(const char* /*tag*/, const char* /*str*/) { return 0; }
-
 jint attach_jvm(JavaVM* vm, JNIEnv** p_env, void* thr_args) {
   return vm->AttachCurrentThread(reinterpret_cast<void**>(p_env), thr_args);
 }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -38,7 +38,6 @@ static void jvm_on_engine_running(void* context) {
     return;
   }
 
-  jni_log("[Envoy]", "jvm_on_engine_running");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmonEngineRunningContext =
@@ -72,7 +71,6 @@ static void jvm_on_log(envoy_log_level log_level, envoy_data data, const void* c
 }
 
 static void jvm_on_exit(void*) {
-  jni_log("[Envoy]", "library is exiting");
   // Note that this is not dispatched because the thread that
   // needs to be detached is the engine thread.
   // This function is called from the context of the engine's
@@ -81,7 +79,6 @@ static void jvm_on_exit(void*) {
 }
 
 static void jvm_on_track(envoy_map events, const void* context) {
-  jni_log("[Envoy]", "jvm_on_track");
   if (context == nullptr) {
     return;
   }
@@ -125,7 +122,6 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     // TODO(goaway): The retained_context leaks, but it's tied to the life of the engine.
     // This will need to be updated for https://github.com/envoyproxy/envoy-mobile/issues/332.
     jobject retained_context = env->NewGlobalRef(j_event_tracker);
-    jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
     event_tracker.track = jvm_on_track;
     event_tracker.context = retained_context;
   }
@@ -180,7 +176,6 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_dumpStats(JNIEnv* env,
                                                            jclass, // class
                                                            jlong engine_handle) {
-  jni_log("[Envoy]", "dumpStats");
   auto engine = reinterpret_cast<Envoy::InternalEngine*>(engine_handle);
   std::string stats = engine->dumpStats();
   Envoy::JNI::JniHelper jni_helper(env);
@@ -228,7 +223,6 @@ static void passHeaders(const char* method, const Envoy::Types::ManagedEnvoyHead
 static Envoy::JNI::LocalRefUniquePtr<jobjectArray>
 jvm_on_headers(const char* method, const Envoy::Types::ManagedEnvoyHeaders& headers,
                bool end_stream, envoy_stream_intel stream_intel, void* context) {
-  jni_log("[Envoy]", "jvm_on_headers");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
   passHeaders("passHeader", headers, j_context);
@@ -337,7 +331,6 @@ static Envoy::JNI::LocalRefUniquePtr<jobjectArray> jvm_on_data(const char* metho
                                                                bool end_stream,
                                                                envoy_stream_intel stream_intel,
                                                                void* context) {
-  jni_log("[Envoy]", "jvm_on_data");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
@@ -432,18 +425,13 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
                                     /*pending_headers*/ pending_headers};
 }
 
-static void jvm_on_metadata(envoy_headers metadata, envoy_stream_intel /*stream_intel*/,
-                            void* /*context*/) {
-  jni_log("[Envoy]", "jvm_on_metadata");
-  jni_log("[Envoy]", std::to_string(metadata.length).c_str());
-}
+static void jvm_on_metadata(envoy_headers /* metadata */, envoy_stream_intel /*stream_intel*/,
+                            void* /*context*/) {}
 
 static Envoy::JNI::LocalRefUniquePtr<jobjectArray> jvm_on_trailers(const char* method,
                                                                    envoy_headers trailers,
                                                                    envoy_stream_intel stream_intel,
                                                                    void* context) {
-  jni_log("[Envoy]", "jvm_on_trailers");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
   passHeaders("passHeader", trailers, j_context);
@@ -555,8 +543,6 @@ jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel 
 static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks,
                                                   const void* context) {
 
-  jni_log("[Envoy]", "jvm_http_filter_set_request_callbacks");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmCallbackContext =
@@ -574,8 +560,6 @@ static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks ca
 
 static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks callbacks,
                                                    const void* context) {
-
-  jni_log("[Envoy]", "jvm_http_filter_set_response_callbacks");
 
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -596,8 +580,6 @@ static envoy_filter_resume_status
 jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data* data,
                           envoy_headers* trailers, bool end_stream, envoy_stream_intel stream_intel,
                           const void* context) {
-  jni_log("[Envoy]", "jvm_on_resume");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   jlong headers_length = -1;
@@ -666,8 +648,6 @@ jvm_http_filter_on_resume_response(envoy_headers* headers, envoy_data* data,
 
 static void call_jvm_on_complete(envoy_stream_intel stream_intel,
                                  envoy_final_stream_intel final_stream_intel, void* context) {
-  jni_log("[Envoy]", "jvm_on_complete");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
@@ -686,7 +666,6 @@ static void call_jvm_on_complete(envoy_stream_intel stream_intel,
 
 static void call_jvm_on_error(envoy_error error, envoy_stream_intel stream_intel,
                               envoy_final_stream_intel final_stream_intel, void* context) {
-  jni_log("[Envoy]", "jvm_on_error");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
@@ -717,8 +696,6 @@ static void jvm_on_error(envoy_error error, envoy_stream_intel stream_intel,
 
 static void call_jvm_on_cancel(envoy_stream_intel stream_intel,
                                envoy_final_stream_intel final_stream_intel, void* context) {
-  jni_log("[Envoy]", "jvm_on_cancel");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
@@ -761,8 +738,6 @@ static void jvm_http_filter_on_cancel(envoy_stream_intel stream_intel,
 }
 
 static void jvm_on_send_window_available(envoy_stream_intel stream_intel, void* context) {
-  jni_log("[Envoy]", "jvm_on_send_window_available");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   jobject j_context = static_cast<jobject>(context);
 
@@ -780,7 +755,6 @@ static void jvm_on_send_window_available(envoy_stream_intel stream_intel, void* 
 
 // JvmKeyValueStoreContext
 static envoy_data jvm_kv_store_read(envoy_data key, const void* context) {
-  jni_log("[Envoy]", "jvm_kv_store_read");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -799,7 +773,6 @@ static envoy_data jvm_kv_store_read(envoy_data key, const void* context) {
 }
 
 static void jvm_kv_store_remove(envoy_data key, const void* context) {
-  jni_log("[Envoy]", "jvm_kv_store_remove");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -814,7 +787,6 @@ static void jvm_kv_store_remove(envoy_data key, const void* context) {
 }
 
 static void jvm_kv_store_save(envoy_data key, envoy_data value, const void* context) {
-  jni_log("[Envoy]", "jvm_kv_store_save");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -833,14 +805,10 @@ static void jvm_kv_store_save(envoy_data key, envoy_data value, const void* cont
 // JvmFilterFactoryContext
 
 static const void* jvm_http_filter_init(const void* context) {
-  jni_log("[Envoy]", "jvm_filter_init");
-
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
 
   envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
   jobject j_context = static_cast<jobject>(const_cast<void*>(c_filter->static_context));
-
-  jni_log_fmt("[Envoy]", "j_context: %p", j_context);
 
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmFilterFactoryContext =
       jni_helper.getObjectClass(j_context);
@@ -850,7 +818,6 @@ static const void* jvm_http_filter_init(const void* context) {
 
   Envoy::JNI::LocalRefUniquePtr<jobject> j_filter =
       jni_helper.callObjectMethod(j_context, jmid_create);
-  jni_log_fmt("[Envoy]", "j_filter: %p", j_filter.get());
   Envoy::JNI::GlobalRefUniquePtr<jobject> retained_filter = jni_helper.newGlobalRef(j_filter.get());
 
   return retained_filter.release();
@@ -913,10 +880,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerKeyValueStore(JNIEnv* e
 
   // TODO(goaway): The java context here leaks, but it's tied to the life of the engine.
   // This will need to be updated for https://github.com/envoyproxy/envoy-mobile/issues/332
-  jni_log("[Envoy]", "registerKeyValueStore");
-  jni_log_fmt("[Envoy]", "j_context: %p", j_context);
   jobject retained_context = env->NewGlobalRef(j_context);
-  jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
   envoy_kv_store* api = static_cast<envoy_kv_store*>(safe_malloc(sizeof(envoy_kv_store)));
   api->save = jvm_kv_store_save;
   api->read = jvm_kv_store_read;
@@ -938,10 +902,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
 
   // TODO(goaway): Everything here leaks, but it's all be tied to the life of the engine.
   // This will need to be updated for https://github.com/envoyproxy/envoy-mobile/issues/332
-  jni_log("[Envoy]", "registerFilterFactory");
-  jni_log_fmt("[Envoy]", "j_context: %p", j_context);
   jobject retained_context = env->NewGlobalRef(j_context);
-  jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
   envoy_http_filter* api = static_cast<envoy_http_filter*>(safe_malloc(sizeof(envoy_http_filter)));
   api->init_filter = jvm_http_filter_init;
   api->on_request_headers = jvm_http_filter_on_request_headers;
@@ -970,7 +931,6 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResumeIteration(
     JNIEnv* env, jclass, jlong callback_handle, jobject j_context) {
-  jni_log("[Envoy]", "callResumeIteration");
   // Context is only passed here to ensure it's not inadvertently gc'd during execution of this
   // function. To be extra safe, do an explicit retain with a GlobalRef.
   jobject retained_context = env->NewGlobalRef(j_context);
@@ -983,7 +943,6 @@ Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResumeIte
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResetIdleTimer(
     JNIEnv* env, jclass, jlong callback_handle, jobject j_context) {
-  jni_log("[Envoy]", "callResetIdleTimer");
   // Context is only passed here to ensure it's not inadvertently gc'd during execution of this
   // function. To be extra safe, do an explicit retain with a GlobalRef.
   jobject retained_context = env->NewGlobalRef(j_context);
@@ -996,7 +955,6 @@ Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResetIdle
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callReleaseCallbacks(
     JNIEnv* /*env*/, jclass, jlong callback_handle) {
-  jni_log("[Envoy]", "callReleaseCallbacks");
   envoy_http_filter_callbacks* callbacks =
       reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
   callbacks->release_callbacks(callbacks->callback_context);
@@ -1017,9 +975,6 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
     JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobject data, jint length,
     jboolean end_stream) {
   Envoy::JNI::JniHelper jni_helper(env);
-  if (end_stream) {
-    jni_log("[Envoy]", "jvm_send_data_end_stream");
-  }
   return reinterpret_cast<Envoy::InternalEngine*>(engine_handle)
       ->sendData(static_cast<envoy_stream_t>(stream_handle),
                  Envoy::JNI::javaByteBufferToEnvoyData(jni_helper, data, length), end_stream);
@@ -1036,9 +991,6 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendDataByteArray(JNIEnv* env, 
                                                                    jbyteArray data, jint length,
                                                                    jboolean end_stream) {
   Envoy::JNI::JniHelper jni_helper(env);
-  if (end_stream) {
-    jni_log("[Envoy]", "jvm_send_data_end_stream");
-  }
   return reinterpret_cast<Envoy::InternalEngine*>(engine_handle)
       ->sendData(static_cast<envoy_stream_t>(stream_handle),
                  Envoy::JNI::javaByteArrayToEnvoyData(jni_helper, data, length), end_stream);
@@ -1057,7 +1009,6 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
     JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobjectArray trailers) {
   Envoy::JNI::JniHelper jni_helper(env);
-  jni_log("[Envoy]", "jvm_send_trailers");
   return reinterpret_cast<Envoy::InternalEngine*>(engine_handle)
       ->sendTrailers(static_cast<envoy_stream_t>(stream_handle),
                      Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, trailers));
@@ -1341,7 +1292,6 @@ extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetConnectivityState(JNIEnv* /*env*/,
                                                                         jclass, // class
                                                                         jlong engine) {
-  jni_log("[Envoy]", "resetConnectivityState");
   return reinterpret_cast<Envoy::InternalEngine*>(engine)->resetConnectivityState();
 }
 
@@ -1349,7 +1299,6 @@ extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_setPreferredNetwork(JNIEnv* /*env*/,
                                                                      jclass, // class
                                                                      jlong engine, jint network) {
-  jni_log("[Envoy]", "setting preferred network");
   return reinterpret_cast<Envoy::InternalEngine*>(engine)->setPreferredNetwork(
       static_cast<envoy_network_t>(network));
 }
@@ -1358,8 +1307,6 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring host, jint port) {
-  jni_log("[Envoy]", "setProxySettings");
-
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::JNI::StringUtfUniquePtr java_host = jni_helper.getStringUtfChars(host, nullptr);
   const uint16_t native_port = static_cast<uint16_t>(port);
@@ -1371,7 +1318,6 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 }
 
 static void jvm_add_test_root_certificate(const uint8_t* cert, size_t len) {
-  jni_log("[Envoy]", "jvm_add_test_root_certificate");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
       Envoy::JNI::findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
@@ -1385,7 +1331,6 @@ static void jvm_add_test_root_certificate(const uint8_t* cert, size_t len) {
 }
 
 static void jvm_clear_test_root_certificate() {
-  jni_log("[Envoy]", "jvm_clear_test_root_certificate");
   Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
   Envoy::JNI::LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
       Envoy::JNI::findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");

--- a/mobile/library/jni/jni_support.h
+++ b/mobile/library/jni/jni_support.h
@@ -4,8 +4,4 @@
 
 // NOLINT(namespace-envoy)
 
-extern "C" int jni_log_fmt(const char* tag, const char* fmt, void* value);
-
-extern "C" int jni_log(const char* tag, const char* str);
-
 extern "C" jint attach_jvm(JavaVM* vm, JNIEnv** p_env, void* thr_args);

--- a/mobile/library/jni/ndk_jni_support.cc
+++ b/mobile/library/jni/ndk_jni_support.cc
@@ -1,5 +1,3 @@
-#include <android/log.h>
-
 #include "library/jni/jni_support.h"
 
 // NOLINT(namespace-envoy)

--- a/mobile/library/jni/ndk_jni_support.cc
+++ b/mobile/library/jni/ndk_jni_support.cc
@@ -4,16 +4,6 @@
 
 // NOLINT(namespace-envoy)
 
-int jni_log_fmt(const char* /*tag*/, const char* /*fmt*/, void* /*value*/) {
-  // For debug logging, use __android_log_print(ANDROID_LOG_VERBOSE, tag, fmt, value);
-  return 0;
-}
-
-int jni_log(const char* /*tag*/, const char* /*str*/) {
-  // For debug logging, use __android_log_write(ANDROID_LOG_VERBOSE, tag, str);
-  return 0;
-}
-
 jint attach_jvm(JavaVM* vm, JNIEnv** p_env, void* thr_args) {
   return vm->AttachCurrentThread(p_env, thr_args);
 }

--- a/mobile/test/jni/test_jni_impl.cc
+++ b/mobile/test/jni/test_jni_impl.cc
@@ -13,70 +13,60 @@
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttpProxyTestServer(JNIEnv* env,
                                                                                      jclass clazz) {
-  jni_log("[QTS]", "starting server");
   start_server(Envoy::TestServerType::HTTP_PROXY);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttpsProxyTestServer(
     JNIEnv* env, jclass clazz) {
-  jni_log("[QTS]", "starting server");
   start_server(Envoy::TestServerType::HTTPS_PROXY);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttp3TestServer(JNIEnv* env,
                                                                                  jclass clazz) {
-  jni_log("[QTS]", "starting server");
   start_server(Envoy::TestServerType::HTTP3);
 }
 
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetServerPort(JNIEnv* env,
                                                                           jclass clazz) {
-  jni_log("[QTS]", "getting server port");
   return get_server_port();
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttp2TestServer(JNIEnv* env,
                                                                                  jclass clazz) {
-  jni_log("[QTS]", "starting server");
   start_server(Envoy::TestServerType::HTTP2_WITH_TLS);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeShutdownTestServer(JNIEnv* env,
                                                                                jclass clazz) {
-  jni_log("[QTS]", "shutting down server");
   shutdown_server();
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeInitXdsTestServer(JNIEnv* env,
                                                                               jclass clazz) {
-  jni_log("[XTS]", "initializing xDS server");
   initXdsServer();
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartXdsTestServer(JNIEnv* env,
                                                                                jclass clazz) {
-  jni_log("[XTS]", "starting xDS server");
   startXdsServer();
 }
 
 extern "C" JNIEXPORT jstring JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetXdsTestServerHost(JNIEnv* env,
                                                                                  jclass clazz) {
-  jni_log("[XTS]", "getting xDS server host");
   return env->NewStringUTF(getXdsServerHost());
 }
 
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetXdsTestServerPort(JNIEnv* env,
                                                                                  jclass clazz) {
-  jni_log("[XTS]", "getting xDS server port");
   return getXdsServerPort();
 }
 
@@ -85,7 +75,6 @@ extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeSendDiscoveryResponse(JNIEnv* env,
                                                                                   jclass clazz,
                                                                                   jstring yaml) {
-  jni_log("[XTS]", "sending DiscoveryResponse from the xDS server");
   const char* yaml_chars = env->GetStringUTFChars(yaml, /* isCopy= */ nullptr);
   // The yaml utilities have non-relevant thread asserts.
   Envoy::Thread::SkipAsserts skip;
@@ -99,7 +88,6 @@ Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeSendDiscoveryRespons
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeShutdownXdsTestServer(JNIEnv* env,
                                                                                   jclass clazz) {
-  jni_log("[XTS]", "shutting down xDS server");
   shutdownXdsServer();
 }
 


### PR DESCRIPTION
The `jni_log_fmt` and `jni_log` functions have empty implementations and their uses are not very useful other than cluttering the code.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
