### PR TITLE
Adding an integration test to reproduce a race issue with logical host.

### DIFF
--- a/test/extensions/clusters/common/BUILD
+++ b/test/extensions/clusters/common/BUILD
@@ -16,3 +16,17 @@ envoy_cc_test(
         "//test/mocks/upstream:host_mocks",
     ],
 )
+
+envoy_cc_test(
+    name = "logical_host_integration_test",
+    srcs = ["logical_host_integration_test.cc"],
+    deps = [
+        "//source/common/config:utility_lib",
+        "//source/extensions/clusters/common:logical_host_lib",
+        "//source/extensions/clusters/logical_dns:logical_dns_cluster_lib",
+        "//test/integration:http_integration_lib",
+        "//test/mocks/network:network_mocks",
+        "//test/test_common:registry_lib",
+        "//test/test_common:threadsafe_singleton_injector_lib",
+    ],
+)

--- a/test/extensions/clusters/common/logical_host_integration_test.cc
+++ b/test/extensions/clusters/common/logical_host_integration_test.cc
@@ -51,7 +51,7 @@ TEST_P(LogicalHostIntegrationTest, DISABLED_LogicalDNSRaceCrashTest) {
             // Keep changing the returned addresses to force address update.
             dns_callback(Network::DnsResolver::ResolutionStatus::Success,
                          TestUtility::makeDnsResponse({
-                             // The only signficant address is the first one; the other ones are
+                             // The only significant address is the first one; the other ones are
                              // just used to populate a list
                              // whose maintenance is race-prone.
                              first_address_string_,

--- a/test/extensions/clusters/common/logical_host_integration_test.cc
+++ b/test/extensions/clusters/common/logical_host_integration_test.cc
@@ -32,7 +32,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, LogicalHostIntegrationTest,
 // Reproduces a race from https://github.com/envoyproxy/envoy/issues/32850.
 // The test is by mocking the DNS resolver to return multiple different
 // addresses, also config dns_refresh_rate to be extremely fast.
-TEST_P(LogicalHostIntegrationTest, LogicalDNSRaceCrashTest) {
+TEST_P(LogicalHostIntegrationTest, DISABLED_LogicalDNSRaceCrashTest) {
   // first_address_string_ is used to make connections. It needs
   // to match with the IpVersion of the test.
   if (version_ == Network::Address::IpVersion::v4) {

--- a/test/extensions/clusters/common/logical_host_integration_test.cc
+++ b/test/extensions/clusters/common/logical_host_integration_test.cc
@@ -1,0 +1,128 @@
+#include "source/common/config/utility.h"
+#include "test/integration/http_integration.h"
+#include "test/test_common/registry.h"
+#include "test/mocks/network/mocks.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Clusters {
+
+// Logical Host integration test.
+class LogicalHostIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                   public HttpIntegrationTest {
+ public:
+  LogicalHostIntegrationTest() :
+    HttpIntegrationTest(Http::CodecType::HTTP1,
+                       GetParam()), registered_dns_factory_(dns_resolver_factory_) {}
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+  }
+
+  NiceMock<Network::MockDnsResolverFactory> dns_resolver_factory_;
+  Registry::InjectFactory<Network::DnsResolverFactory> registered_dns_factory_;
+  uint32_t address_ = 0;
+  std::string address_string = "::1";
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, LogicalHostIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+// Reproduces a race from https://github.com/envoyproxy/envoy/issues/32850.
+// The test is by mocking the DNS resolver to return multiple different
+// addresses, also config dns_refresh_rate to be extremely fast.
+TEST_P(LogicalHostIntegrationTest, FastChangingDnsResult) {
+  // Only needs to test the race with one stack.
+  if (version_ == Network::Address::IpVersion::v4) {
+    return;
+  }
+
+  auto dns_resolver = std::make_shared<Network::MockDnsResolver>();
+  EXPECT_CALL(dns_resolver_factory_, createDnsResolver(_, _, _)).WillRepeatedly(testing::Return(dns_resolver));
+  EXPECT_CALL(*dns_resolver, resolve(_, _, _))
+      .WillRepeatedly(
+          Invoke([&](const std::string&, Network::DnsLookupFamily,
+                     Network::DnsResolver::ResolveCb dns_callback) -> Network::ActiveDnsQuery* {
+            // Return multiple mixed v4/v6 addresses to increase the race window.
+            dns_callback(Network::DnsResolver::ResolutionStatus::Success,
+                         TestUtility::makeDnsResponse({"::1", absl::StrCat("127.0.0.", address_),
+                                                       absl::StrCat("127.0.0.", address_ + 1),
+                                                       absl::StrCat("127.0.0.", address_ + 2),
+                                                       absl::StrCat("127.0.0.", address_ + 3),
+                                                       absl::StrCat("127.0.0.", address_ + 4),
+                                                       absl::StrCat("127.0.0.", address_ + 5),
+                                                       absl::StrCat("127.0.0.", address_ + 6),
+                                                       absl::StrCat("127.0.0.", address_ + 7),
+                                                       absl::StrCat("127.0.0.", address_ + 8),
+                                                       absl::StrCat("127.0.0.", address_ + 9),
+                                                       absl::StrCat("127.0.0.", address_ + 10),
+                                                       absl::StrCat("127.0.0.", address_ + 11),
+                                                       absl::StrCat("127.0.0.", address_ + 12),
+                                                       absl::StrCat("127.0.0.", address_ + 13),
+                                                       absl::StrCat("127.0.0.", address_ + 14),
+                                                       absl::StrCat("127.0.0.", address_ + 15),
+                                                       absl::StrCat("127.0.0.", address_ + 16),
+                                                       "::2",
+                                                       "::3",
+                                                       "::4",
+                                                       "::5",
+                                                       "::6",
+                                                       "::7",
+                                                       "::8",
+                                                       "::9",
+                                                       absl::StrCat("127.0.0.", address_ + 17),
+                                                       absl::StrCat("127.0.0.", address_ + 18),
+                                                       absl::StrCat("127.0.0.", address_ + 19),
+                                                       absl::StrCat("127.0.0.", address_ + 20),
+                                                       absl::StrCat("127.0.0.", address_ + 21),
+                                                       absl::StrCat("127.0.0.", address_ + 22),
+                                                       absl::StrCat("127.0.0.", address_ + 23),
+                                                       absl::StrCat("127.0.0.", address_ + 24),
+                                                       "::10",
+                                                       "::11",
+                                                       "::12",
+                                                       "::13",
+                                                       "::14",
+                                                       "::15",
+                                                       "::16",
+                                                       "::17",
+                                                       absl::StrCat("127.0.0.", address_ + 25),
+                                                       absl::StrCat("127.0.0.", address_ + 26),
+                                                       absl::StrCat("127.0.0.", address_ + 27),
+                                                       absl::StrCat("127.0.0.", address_ + 28),
+                                                       absl::StrCat("127.0.0.", address_ + 29),
+                                                       absl::StrCat("127.0.0.", address_ + 30),
+                                                       absl::StrCat("127.0.0.", address_ + 31),
+                                                       absl::StrCat("127.0.0.", address_ + 32)
+                           }));
+            address_ = (address_ + 1) % 128;
+            return nullptr;
+          }));
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
+    auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster.set_type(envoy::config::cluster::v3::Cluster::LOGICAL_DNS);
+    cluster.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
+    // Make the refresh rate fast to hit the R/W race.
+    cluster.mutable_dns_refresh_rate()->set_nanos(1000001);
+  });
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
+        route->mutable_route()->mutable_auto_host_rewrite()->set_value(true);
+      });
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+} // namespace Clusters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/clusters/common/logical_host_integration_test.cc
+++ b/test/extensions/clusters/common/logical_host_integration_test.cc
@@ -48,10 +48,12 @@ TEST_P(LogicalHostIntegrationTest, DISABLED_LogicalDNSRaceCrashTest) {
       .WillRepeatedly(
           Invoke([&](const std::string&, Network::DnsLookupFamily,
                      Network::DnsResolver::ResolveCb dns_callback) -> Network::ActiveDnsQuery* {
-            // Return multiple mixed v4/v6 addresses to increase the race window.
             // Keep changing the returned addresses to force address update.
             dns_callback(Network::DnsResolver::ResolutionStatus::Success,
                          TestUtility::makeDnsResponse({
+                             // The only signficant address is the first one; the other ones are
+                             // just used to populate a list
+                             // whose maintenance is race-prone.
                              first_address_string_,
                              absl::StrCat("127.0.0.", address_),
                              absl::StrCat("127.0.0.", address_ + 1),


### PR DESCRIPTION
Adding an integration test to reproduce: https://github.com/envoyproxy/envoy/issues/32850

This test is able to reproduce the race issue when run with below command:

bazel test test/extensions/clusters/common:logical_host_integration_test  --config=clang-tsan --cache_test_results=no --runs_per_test=100   --config=remote

This test is used by all the approaches mentioned under https://github.com/envoyproxy/envoy/issues/32850 to verify the fix, including: https://github.com/envoyproxy/envoy/pull/32830.

This PR is to separate the test from protocol_integration_test.cc. And just to have a simple integration test using logical DNS cluster.


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
