### PR TITLE
mobile: Clean up .bazelrc for Swift

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -295,9 +295,7 @@ build:mobile-remote-ci-macos-kotlin --@com_envoyproxy_protoc_gen_validate//bazel
 
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --config=mobile-test-ios
-build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_request_compression=disabled
-build:mobile-remote-ci-macos-swift --define=envoy_mobile_swift_cxx_interop=disabled
 build:mobile-remote-ci-macos-swift --define=google_grpc=disabled
 build:mobile-remote-ci-macos-swift --define=envoy_mobile_xds=disabled
 build:mobile-remote-ci-macos-swift --@envoy//bazel:http3=False


### PR DESCRIPTION
This PR does the following:
- Removes duplicate `--config=mobile-remote-ci-macos`.
- Removes `--define=envoy_mobile_swift_cxx_interop=disabled` because it is always set to `enabled` and the code does not build without it.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
