### PR TITLE
Shard file_system_buffer_integration_test to avoid bazel timeouts

### DIFF
--- a/test/extensions/filters/http/file_system_buffer/BUILD
+++ b/test/extensions/filters/http/file_system_buffer/BUILD
@@ -47,6 +47,7 @@ envoy_extension_cc_test(
         "filter_integration_test.cc",
     ],
     extension_names = ["envoy.filters.http.file_system_buffer"],
+    shard_count = 4,
     tags = [
         "cpu:3",
         "skip_on_windows",


### PR DESCRIPTION
Additional Description:
Attempt to deflake this test timeouts in compile time options build.

Risk Level: Low
Testing: Unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
