### PR TITLE
test: bump shard count for idle_timeout_integration_test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -985,7 +985,7 @@ envoy_cc_test(
     srcs = ["idle_timeout_integration_test.cc"],
     # As this test has many pauses for idle timeouts, it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
-    shard_count = 4,
+    shard_count = 8,
     tags = [
         "cpu:3",
     ],


### PR DESCRIPTION
Attempt to reduce number of timeout flakes we're witnessing.

Signed-off-by: Harvey Tuch <htuch@google.com>