### PR TITLE
tests: refactor SSL TAP tests

### DIFF
--- a/test/common/tls/integration/BUILD
+++ b/test/common/tls/integration/BUILD
@@ -3,7 +3,6 @@ load(
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
-    "envoy_select_admin_functionality",
 )
 
 licenses(["notice"])  # Apache 2
@@ -12,7 +11,16 @@ envoy_package()
 
 envoy_cc_test_library(
     name = "ssl_integration_test_lib",
-    hdrs = ["ssl_integration_test.h"],
+    srcs = [
+        "ssl_integration_test_base.cc",
+    ],
+    hdrs = ["ssl_integration_test_base.h"],
+    deps = [
+        "//test/common/config:dummy_config_proto_cc_proto",
+        "//test/integration:http_integration_lib",
+        "//test/mocks/secret:secret_mocks",
+        "//test/test_common:utility_lib",
+    ],
 )
 
 envoy_cc_test(
@@ -37,7 +45,6 @@ envoy_cc_test(
         "//source/extensions/transport_sockets/tls:config",
         "//test/common/config:dummy_config_proto_cc_proto",
         "//test/common/tls/cert_validator:timed_cert_validator",
-        "//test/integration:http_integration_lib",
         "//test/integration/filters:stream_info_to_headers_filter_lib",
         "//test/mocks/secret:secret_mocks",
         "//test/test_common:test_runtime_lib",
@@ -45,14 +52,7 @@ envoy_cc_test(
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
-    ] + envoy_select_admin_functionality([
-        "//source/extensions/transport_sockets/tap:config",
-        "//test/extensions/common/tap:common",
-        "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
-        "@envoy_api//envoy/data/tap/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/tap/v3:pkg_cc_proto",
-    ]),
+    ],
 )
 
 envoy_cc_test_library(

--- a/test/common/tls/integration/ssl_integration_test.cc
+++ b/test/common/tls/integration/ssl_integration_test.cc
@@ -1,5 +1,3 @@
-#include "ssl_integration_test.h"
-
 #include <memory>
 #include <string>
 
@@ -19,6 +17,7 @@
 
 #include "test/common/config/dummy_config.pb.h"
 #include "test/common/tls/cert_validator/timed_cert_validator.h"
+#include "test/common/tls/integration/ssl_integration_test_base.h"
 #include "test/integration/autonomous_upstream.h"
 #include "test/integration/integration.h"
 #include "test/integration/ssl_utility.h"
@@ -33,14 +32,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#ifdef ENVOY_ADMIN_FUNCTIONALITY
-#include "envoy/config/tap/v3/common.pb.h"
-#include "envoy/data/tap/v3/wrapper.pb.h"
-#include "envoy/extensions/transport_sockets/tap/v3/tap.pb.h"
-#include "envoy/extensions/transport_sockets/tls/v3/cert.pb.h"
-#include "test/extensions/common/tap/common.h"
-#endif
-
 using testing::StartsWith;
 
 namespace Envoy {
@@ -49,155 +40,11 @@ using Extensions::TransportSockets::Tls::ContextImplPeer;
 
 namespace Ssl {
 
-void SslIntegrationTestBase::initialize() {
-  config_helper_.addSslConfig(ConfigHelper::ServerSslOptions()
-                                  .setRsaCert(server_rsa_cert_)
-                                  .setRsaCertOcspStaple(server_rsa_cert_ocsp_staple_)
-                                  .setEcdsaCert(server_ecdsa_cert_)
-                                  .setEcdsaCertOcspStaple(server_ecdsa_cert_ocsp_staple_)
-                                  .setOcspStapleRequired(ocsp_staple_required_)
-                                  .setTlsV13(server_tlsv1_3_)
-                                  .setCurves(server_curves_)
-                                  .setExpectClientEcdsaCert(client_ecdsa_cert_)
-                                  .setTlsKeyLogFilter(keylog_local_, keylog_remote_,
-                                                      keylog_local_negative_,
-                                                      keylog_remote_negative_, keylog_path_,
-                                                      keylog_multiple_ips_, version_));
-
-  HttpIntegrationTest::initialize();
-
-  context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
-      server_factory_context_);
-
-  registerTestServerPorts({"http"});
-}
-
-void SslIntegrationTestBase::TearDown() {
-  HttpIntegrationTest::cleanupUpstreamAndDownstream();
-  codec_client_.reset();
-  context_manager_.reset();
-}
-
-Network::ClientConnectionPtr
-SslIntegrationTestBase::makeSslClientConnection(const ClientSslTransportOptions& options) {
-  Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
-  if (debug_with_s_client_) {
-    const std::string s_client_cmd = TestEnvironment::substitute(
-        "openssl s_client -connect " + address->asString() +
-            " -showcerts -debug -msg -CAfile "
-            "{{ test_rundir }}/test/config/integration/certs/cacert.pem "
-            "-servername lyft.com -cert "
-            "{{ test_rundir }}/test/config/integration/certs/clientcert.pem "
-            "-key "
-            "{{ test_rundir }}/test/config/integration/certs/clientkey.pem ",
-        version_);
-    ENVOY_LOG_MISC(debug, "Executing {}", s_client_cmd);
-    RELEASE_ASSERT(::system(s_client_cmd.c_str()) == 0, "");
-  }
-  auto client_transport_socket_factory_ptr =
-      createClientSslTransportSocketFactory(options, *context_manager_, *api_);
-  return dispatcher_->createClientConnection(
-      address, Network::Address::InstanceConstSharedPtr(),
-      client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);
-}
-
-void SslIntegrationTestBase::checkStats() {
-  const uint32_t expected_handshakes = debug_with_s_client_ ? 2 : 1;
-  Stats::CounterSharedPtr counter = test_server_->counter(listenerStatPrefix("ssl.handshake"));
-  EXPECT_EQ(expected_handshakes, counter->value());
-  counter->reset();
-}
-
-class SslKeyLogTest : public SslIntegrationTest {
+class SslIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                           public SslIntegrationTestBase {
 public:
-  void setLogPath() {
-    keylog_path_ = TestEnvironment::temporaryPath(TestUtility::uniqueFilename());
-  }
-  void setLocalFilter() {
-    keylog_local_ = true;
-    keylog_remote_ = false;
-    keylog_local_negative_ = false;
-    keylog_remote_negative_ = false;
-  }
-  void setRemoteFilter() {
-    keylog_remote_ = true;
-    keylog_local_ = false;
-    keylog_local_negative_ = false;
-    keylog_remote_negative_ = false;
-  }
-  void setBothLocalAndRemoteFilter() {
-    keylog_local_ = true;
-    keylog_remote_ = true;
-    keylog_local_negative_ = false;
-    keylog_remote_negative_ = false;
-  }
-  void setNeitherLocalNorRemoteFilter() {
-    keylog_remote_ = false;
-    keylog_local_ = false;
-    keylog_local_negative_ = false;
-    keylog_remote_negative_ = false;
-  }
-  void setNegative() {
-    keylog_local_ = true;
-    keylog_remote_ = true;
-    keylog_local_negative_ = true;
-    keylog_remote_negative_ = true;
-  }
-  void setLocalNegative() {
-    keylog_local_ = true;
-    keylog_remote_ = true;
-    keylog_local_negative_ = false;
-    keylog_remote_negative_ = true;
-  }
-  void setRemoteNegative() {
-    keylog_local_ = true;
-    keylog_remote_ = true;
-    keylog_local_negative_ = true;
-    keylog_remote_negative_ = false;
-  }
-  void setMultipleIps() {
-    keylog_local_ = true;
-    keylog_remote_ = true;
-    keylog_local_negative_ = false;
-    keylog_remote_negative_ = false;
-    keylog_multiple_ips_ = true;
-  }
-  void logCheck() {
-    EXPECT_TRUE(api_->fileSystem().fileExists(keylog_path_));
-    std::string log = waitForAccessLog(keylog_path_);
-    if (server_tlsv1_3_) {
-      /** The key log for TLS1.3 is as follows:
-       * CLIENT_HANDSHAKE_TRAFFIC_SECRET
-         c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
-         b335f2ce9079d824a7d2f5ef9af6572d43942d6803bac1ae9de1e840c15c993ae4efdf4ac087877031d1936d5bb858e3
-         SERVER_HANDSHAKE_TRAFFIC_SECRET
-         c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
-         f498c03446c936d8a17f31669dd54cee2d9bc8d5b7e1a658f677b5cd6e0965111c2331fcc337c01895ec9a0ed12be34a
-         CLIENT_TRAFFIC_SECRET_0 c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
-         0bbbb2056f3d35a3b610c5cc8ae0b9b63a120912ff25054ee52b853fefc59e12e9fdfebc409347c737394457bfd36bde
-         SERVER_TRAFFIC_SECRET_0 c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
-         bd3e1757174d82c308515a0c02b981084edda53e546df551ddcf78043bff831c07ff93c7ab3e8ef9e2206c8319c25331
-         EXPORTER_SECRET c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
-         6bd19fbdd12e6710159bcb406fd42a580c41236e2d53072dba3064f9b3ff214662081f023e9b22325e31fee5bb11b172
-       */
-      EXPECT_THAT(log, testing::HasSubstr("CLIENT_TRAFFIC_SECRET"));
-      EXPECT_THAT(log, testing::HasSubstr("SERVER_TRAFFIC_SECRET"));
-      EXPECT_THAT(log, testing::HasSubstr("CLIENT_HANDSHAKE_TRAFFIC_SECRET"));
-      EXPECT_THAT(log, testing::HasSubstr("SERVER_HANDSHAKE_TRAFFIC_SECRET"));
-      EXPECT_THAT(log, testing::HasSubstr("EXPORTER_SECRET"));
-    } else {
-      /** The key log for TLS1.1/1.2 is as follows:
-       * CLIENT_RANDOM 5a479a50fe3e85295840b84e298aeb184cecc34ced22d963e16b01dc48c9530f
-         d6840f8100e4ceeb282946cdd72fe403b8d0724ee816ab2d0824b6d6b5033d333ec4b2e77f515226f5d829e137855ef1
-       */
-      EXPECT_THAT(log, testing::HasSubstr("CLIENT_RANDOM"));
-    }
-  }
-  void negativeCheck() {
-    EXPECT_TRUE(api_->fileSystem().fileExists(keylog_path_));
-    auto size = api_->fileSystem().fileSize(keylog_path_);
-    EXPECT_EQ(size, 0);
-  }
+  SslIntegrationTest() : SslIntegrationTestBase(GetParam()) {}
+  void TearDown() override { SslIntegrationTestBase::TearDown(); };
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, SslIntegrationTest,
@@ -1096,319 +943,97 @@ TEST_P(SslCertficateIntegrationTest, BothEcdsaAndRsaWithOcspResponseStaplingRequ
   checkStats();
 }
 
-#ifdef ENVOY_ADMIN_FUNCTIONALITY
-// TODO(zuercher): write an additional OCSP integration test that validates behavior with an
-// expired OCSP response. (Requires OCSP client-side support in upstream TLS.)
-
-// TODO(mattklein123): Move this into a dedicated integration test for the tap transport socket as
-// well as add more tests.
-class SslTapIntegrationTest : public SslIntegrationTest {
+class SslKeyLogTest : public SslIntegrationTest {
 public:
-  void initialize() override {
-    // TODO(mattklein123): Merge/use the code in ConfigHelper::setTapTransportSocket().
-    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // The test supports tapping either the downstream or upstream connection, but not both.
-      if (upstream_tap_) {
-        setupUpstreamTap(bootstrap);
-      } else {
-        setupDownstreamTap(bootstrap);
-      }
-    });
-    SslIntegrationTest::initialize();
-    // This confuses our socket counting.
-    debug_with_s_client_ = false;
+  void setLogPath() {
+    keylog_path_ = TestEnvironment::temporaryPath(TestUtility::uniqueFilename());
   }
-
-  void setupUpstreamTap(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-    auto* transport_socket =
-        bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
-    transport_socket->set_name("envoy.transport_sockets.tap");
-    envoy::config::core::v3::TransportSocket raw_transport_socket;
-    raw_transport_socket.set_name("envoy.transport_sockets.raw_buffer");
-    envoy::extensions::transport_sockets::tap::v3::Tap tap_config =
-        createTapConfig(raw_transport_socket);
-    tap_config.mutable_transport_socket()->MergeFrom(raw_transport_socket);
-    transport_socket->mutable_typed_config()->PackFrom(tap_config);
+  void setLocalFilter() {
+    keylog_local_ = true;
+    keylog_remote_ = false;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = false;
   }
-
-  void setupDownstreamTap(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-    auto* filter_chain =
-        bootstrap.mutable_static_resources()->mutable_listeners(0)->mutable_filter_chains(0);
-    // Configure inner SSL transport socket based on existing config.
-    envoy::config::core::v3::TransportSocket ssl_transport_socket;
-    auto* transport_socket = filter_chain->mutable_transport_socket();
-    ssl_transport_socket.Swap(transport_socket);
-    // Configure outer tap transport socket.
-    transport_socket->set_name("envoy.transport_sockets.tap");
-    envoy::extensions::transport_sockets::tap::v3::Tap tap_config =
-        createTapConfig(ssl_transport_socket);
-    tap_config.mutable_transport_socket()->MergeFrom(ssl_transport_socket);
-    transport_socket->mutable_typed_config()->PackFrom(tap_config);
+  void setRemoteFilter() {
+    keylog_remote_ = true;
+    keylog_local_ = false;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = false;
   }
-
-  envoy::extensions::transport_sockets::tap::v3::Tap
-  createTapConfig(const envoy::config::core::v3::TransportSocket& inner_transport) {
-    envoy::extensions::transport_sockets::tap::v3::Tap tap_config;
-    tap_config.mutable_common_config()->mutable_static_config()->mutable_match()->set_any_match(
-        true);
-    auto* output_config =
-        tap_config.mutable_common_config()->mutable_static_config()->mutable_output_config();
-    if (max_rx_bytes_.has_value()) {
-      output_config->mutable_max_buffered_rx_bytes()->set_value(max_rx_bytes_.value());
+  void setBothLocalAndRemoteFilter() {
+    keylog_local_ = true;
+    keylog_remote_ = true;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = false;
+  }
+  void setNeitherLocalNorRemoteFilter() {
+    keylog_remote_ = false;
+    keylog_local_ = false;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = false;
+  }
+  void setNegative() {
+    keylog_local_ = true;
+    keylog_remote_ = true;
+    keylog_local_negative_ = true;
+    keylog_remote_negative_ = true;
+  }
+  void setLocalNegative() {
+    keylog_local_ = true;
+    keylog_remote_ = true;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = true;
+  }
+  void setRemoteNegative() {
+    keylog_local_ = true;
+    keylog_remote_ = true;
+    keylog_local_negative_ = true;
+    keylog_remote_negative_ = false;
+  }
+  void setMultipleIps() {
+    keylog_local_ = true;
+    keylog_remote_ = true;
+    keylog_local_negative_ = false;
+    keylog_remote_negative_ = false;
+    keylog_multiple_ips_ = true;
+  }
+  void logCheck() {
+    EXPECT_TRUE(api_->fileSystem().fileExists(keylog_path_));
+    std::string log = waitForAccessLog(keylog_path_);
+    if (server_tlsv1_3_) {
+      /** The key log for TLS1.3 is as follows:
+       * CLIENT_HANDSHAKE_TRAFFIC_SECRET
+         c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
+         b335f2ce9079d824a7d2f5ef9af6572d43942d6803bac1ae9de1e840c15c993ae4efdf4ac087877031d1936d5bb858e3
+         SERVER_HANDSHAKE_TRAFFIC_SECRET
+         c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
+         f498c03446c936d8a17f31669dd54cee2d9bc8d5b7e1a658f677b5cd6e0965111c2331fcc337c01895ec9a0ed12be34a
+         CLIENT_TRAFFIC_SECRET_0 c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
+         0bbbb2056f3d35a3b610c5cc8ae0b9b63a120912ff25054ee52b853fefc59e12e9fdfebc409347c737394457bfd36bde
+         SERVER_TRAFFIC_SECRET_0 c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
+         bd3e1757174d82c308515a0c02b981084edda53e546df551ddcf78043bff831c07ff93c7ab3e8ef9e2206c8319c25331
+         EXPORTER_SECRET c62fe86cb3a714451abc7496062251e16862ca3dfc1487c97ab4b291b83a1787
+         6bd19fbdd12e6710159bcb406fd42a580c41236e2d53072dba3064f9b3ff214662081f023e9b22325e31fee5bb11b172
+       */
+      EXPECT_THAT(log, testing::HasSubstr("CLIENT_TRAFFIC_SECRET"));
+      EXPECT_THAT(log, testing::HasSubstr("SERVER_TRAFFIC_SECRET"));
+      EXPECT_THAT(log, testing::HasSubstr("CLIENT_HANDSHAKE_TRAFFIC_SECRET"));
+      EXPECT_THAT(log, testing::HasSubstr("SERVER_HANDSHAKE_TRAFFIC_SECRET"));
+      EXPECT_THAT(log, testing::HasSubstr("EXPORTER_SECRET"));
+    } else {
+      /** The key log for TLS1.1/1.2 is as follows:
+       * CLIENT_RANDOM 5a479a50fe3e85295840b84e298aeb184cecc34ced22d963e16b01dc48c9530f
+         d6840f8100e4ceeb282946cdd72fe403b8d0724ee816ab2d0824b6d6b5033d333ec4b2e77f515226f5d829e137855ef1
+       */
+      EXPECT_THAT(log, testing::HasSubstr("CLIENT_RANDOM"));
     }
-    if (max_tx_bytes_.has_value()) {
-      output_config->mutable_max_buffered_tx_bytes()->set_value(max_tx_bytes_.value());
-    }
-    output_config->set_streaming(streaming_tap_);
-
-    auto* output_sink = output_config->mutable_sinks()->Add();
-    output_sink->set_format(format_);
-    output_sink->mutable_file_per_tap()->set_path_prefix(path_prefix_);
-    tap_config.mutable_transport_socket()->MergeFrom(inner_transport);
-    return tap_config;
   }
-
-  std::string path_prefix_ = TestEnvironment::temporaryPath("ssl_trace");
-  envoy::config::tap::v3::OutputSink::Format format_{
-      envoy::config::tap::v3::OutputSink::PROTO_BINARY};
-  absl::optional<uint64_t> max_rx_bytes_;
-  absl::optional<uint64_t> max_tx_bytes_;
-  bool upstream_tap_{};
-  bool streaming_tap_{};
+  void negativeCheck() {
+    EXPECT_TRUE(api_->fileSystem().fileExists(keylog_path_));
+    auto size = api_->fileSystem().fileSize(keylog_path_);
+    EXPECT_EQ(size, 0);
+  }
 };
-
-INSTANTIATE_TEST_SUITE_P(IpVersions, SslTapIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
-
-// Validate two back-to-back requests with binary proto output.
-TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
-  initialize();
-  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
-    return makeSslClientConnection({});
-  };
-
-  // First request (ID will be +1 since the client will also bump).
-  const uint64_t first_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
-  codec_client_ = makeHttpConnection(creator());
-  Http::TestRequestHeaderMapImpl post_request_headers{
-      {":method", "POST"},       {":path", "/test/long/url"},
-      {":scheme", "http"},       {":authority", "sni.lyft.com"},
-      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
-  auto response =
-      sendRequestAndWaitForResponse(post_request_headers, 128, default_response_headers_, 256);
-  EXPECT_TRUE(upstream_request_->complete());
-  EXPECT_EQ(128, upstream_request_->bodyLength());
-  ASSERT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_EQ(256, response->body().size());
-  checkStats();
-  envoy::config::core::v3::Address expected_local_address;
-  Network::Utility::addressToProtobufAddress(
-      *codec_client_->connection()->connectionInfoProvider().remoteAddress(),
-      expected_local_address);
-  envoy::config::core::v3::Address expected_remote_address;
-  Network::Utility::addressToProtobufAddress(
-      *codec_client_->connection()->connectionInfoProvider().localAddress(),
-      expected_remote_address);
-  codec_client_->close();
-  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-  envoy::data::tap::v3::TraceWrapper trace;
-  TestUtility::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, first_id), trace, *api_);
-  // Validate general expected properties in the trace.
-  EXPECT_EQ(first_id, trace.socket_buffered_trace().trace_id());
-  EXPECT_THAT(expected_local_address,
-              ProtoEq(trace.socket_buffered_trace().connection().local_address()));
-  EXPECT_THAT(expected_remote_address,
-              ProtoEq(trace.socket_buffered_trace().connection().remote_address()));
-  ASSERT_GE(trace.socket_buffered_trace().events().size(), 2);
-  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
-                               "POST /test/long/url HTTP/1.1"));
-  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
-                               "HTTP/1.1 200 OK"));
-  EXPECT_FALSE(trace.socket_buffered_trace().read_truncated());
-  EXPECT_FALSE(trace.socket_buffered_trace().write_truncated());
-
-  // Verify a second request hits a different file.
-  const uint64_t second_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
-  codec_client_ = makeHttpConnection(creator());
-  Http::TestRequestHeaderMapImpl get_request_headers{
-      {":method", "GET"},        {":path", "/test/long/url"},
-      {":scheme", "http"},       {":authority", "sni.lyft.com"},
-      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
-  response =
-      sendRequestAndWaitForResponse(get_request_headers, 128, default_response_headers_, 256);
-  EXPECT_TRUE(upstream_request_->complete());
-  EXPECT_EQ(128, upstream_request_->bodyLength());
-  ASSERT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_EQ(256, response->body().size());
-  checkStats();
-  codec_client_->close();
-  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 2);
-  TestUtility::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, second_id), trace, *api_);
-  // Validate second connection ID.
-  EXPECT_EQ(second_id, trace.socket_buffered_trace().trace_id());
-  ASSERT_GE(trace.socket_buffered_trace().events().size(), 2);
-  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
-                               "GET /test/long/url HTTP/1.1"));
-  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
-                               "HTTP/1.1 200 OK"));
-  EXPECT_FALSE(trace.socket_buffered_trace().read_truncated());
-  EXPECT_FALSE(trace.socket_buffered_trace().write_truncated());
-}
-
-// Verify that truncation works correctly across multiple transport socket frames.
-TEST_P(SslTapIntegrationTest, TruncationWithMultipleDataFrames) {
-  max_rx_bytes_ = 4;
-  max_tx_bytes_ = 5;
-
-  initialize();
-  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
-    return makeSslClientConnection({});
-  };
-
-  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
-  codec_client_ = makeHttpConnection(creator());
-  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
-                                                       {":path", "/test/long/url"},
-                                                       {":scheme", "http"},
-                                                       {":authority", "sni.lyft.com"}};
-  auto result = codec_client_->startRequest(request_headers);
-  auto response = std::move(result.second);
-  Buffer::OwnedImpl data1("one");
-  result.first.encodeData(data1, false);
-  Buffer::OwnedImpl data2("two");
-  result.first.encodeData(data2, true);
-  waitForNextUpstreamRequest();
-  const Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
-  upstream_request_->encodeHeaders(response_headers, false);
-  Buffer::OwnedImpl data3("three");
-  upstream_request_->encodeData(data3, false);
-  response->waitForBodyData(5);
-  Buffer::OwnedImpl data4("four");
-  upstream_request_->encodeData(data4, true);
-  ASSERT_TRUE(response->waitForEndStream());
-
-  checkStats();
-  codec_client_->close();
-  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-
-  envoy::data::tap::v3::TraceWrapper trace;
-  TestUtility::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, id), trace, *api_);
-
-  ASSERT_EQ(trace.socket_buffered_trace().events().size(), 2);
-  EXPECT_TRUE(trace.socket_buffered_trace().events(0).read().data().truncated());
-  EXPECT_TRUE(trace.socket_buffered_trace().events(1).write().data().truncated());
-  EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
-  EXPECT_TRUE(trace.socket_buffered_trace().write_truncated());
-}
-
-// Validate a single request with text proto output.
-TEST_P(SslTapIntegrationTest, RequestWithTextProto) {
-  format_ = envoy::config::tap::v3::OutputSink::PROTO_TEXT;
-  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
-    return makeSslClientConnection({});
-  };
-
-  // Disable for this test because it uses connection IDs, which disrupts the accounting below
-  // leading to the wrong path for the `pb_text` being used.
-  skip_tag_extraction_rule_check_ = true;
-
-  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
-  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
-  checkStats();
-  codec_client_->close();
-  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-  envoy::data::tap::v3::TraceWrapper trace;
-  TestUtility::loadFromFile(fmt::format("{}_{}.pb_text", path_prefix_, id), trace, *api_);
-  // Test some obvious properties.
-  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
-                               "GET /test/long/url HTTP/1.1"));
-  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
-                               "HTTP/1.1 200 OK"));
-  EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
-  EXPECT_FALSE(trace.socket_buffered_trace().write_truncated());
-}
-
-// Validate a single request with JSON (body as string) output. This test uses an upstream tap.
-TEST_P(SslTapIntegrationTest, RequestWithJsonBodyAsStringUpstreamTap) {
-  upstream_tap_ = true;
-  max_rx_bytes_ = 5;
-  max_tx_bytes_ = 4;
-
-  format_ = envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING;
-  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
-    return makeSslClientConnection({});
-  };
-
-  // Disable for this test because it uses connection IDs, which disrupts the accounting below
-  // leading to the wrong path for the `pb_text` being used.
-  skip_tag_extraction_rule_check_ = true;
-
-  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
-  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
-  checkStats();
-  codec_client_->close();
-  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-  test_server_.reset();
-
-  // This must be done after server shutdown so that connection pool connections are closed and
-  // the tap written.
-  envoy::data::tap::v3::TraceWrapper trace;
-  TestUtility::loadFromFile(fmt::format("{}_{}.json", path_prefix_, id), trace, *api_);
-
-  // Test some obvious properties.
-  EXPECT_EQ(trace.socket_buffered_trace().events(0).write().data().as_string(), "GET ");
-  EXPECT_EQ(trace.socket_buffered_trace().events(1).read().data().as_string(), "HTTP/");
-  EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
-  EXPECT_TRUE(trace.socket_buffered_trace().write_truncated());
-}
-
-// Validate a single request with length delimited binary proto output. This test uses an upstream
-// tap.
-TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTap) {
-  upstream_tap_ = true;
-  streaming_tap_ = true;
-  max_rx_bytes_ = 5;
-  max_tx_bytes_ = 4;
-
-  format_ = envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED;
-  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
-    return makeSslClientConnection({});
-  };
-
-  // Disable for this test because it uses connection IDs, which disrupts the accounting below
-  // leading to the wrong path for the `pb_text` being used.
-  skip_tag_extraction_rule_check_ = true;
-
-  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
-  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
-  checkStats();
-  codec_client_->close();
-  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
-  test_server_.reset();
-
-  // This must be done after server shutdown so that connection pool connections are closed and
-  // the tap written.
-  std::vector<envoy::data::tap::v3::TraceWrapper> traces =
-      Extensions::Common::Tap::readTracesFromFile(
-          fmt::format("{}_{}.pb_length_delimited", path_prefix_, id));
-  ASSERT_GE(traces.size(), 4);
-
-  // The initial connection message has no local address, but has a remote address (not connected
-  // yet).
-  EXPECT_TRUE(traces[0].socket_streamed_trace_segment().has_connection());
-  EXPECT_FALSE(traces[0].socket_streamed_trace_segment().connection().has_local_address());
-  EXPECT_TRUE(traces[0].socket_streamed_trace_segment().connection().has_remote_address());
-
-  // Verify truncated request/response data.
-  EXPECT_EQ(traces[1].socket_streamed_trace_segment().event().write().data().as_bytes(), "GET ");
-  EXPECT_TRUE(traces[1].socket_streamed_trace_segment().event().write().data().truncated());
-  EXPECT_EQ(traces[2].socket_streamed_trace_segment().event().read().data().as_bytes(), "HTTP/");
-  EXPECT_TRUE(traces[2].socket_streamed_trace_segment().event().read().data().truncated());
-}
-#endif
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, SslKeyLogTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),

--- a/test/common/tls/integration/ssl_integration_test_base.cc
+++ b/test/common/tls/integration/ssl_integration_test_base.cc
@@ -1,0 +1,66 @@
+#include "ssl_integration_test_base.h"
+
+namespace Envoy {
+namespace Ssl {
+
+void SslIntegrationTestBase::initialize() {
+  config_helper_.addSslConfig(ConfigHelper::ServerSslOptions()
+                                  .setRsaCert(server_rsa_cert_)
+                                  .setRsaCertOcspStaple(server_rsa_cert_ocsp_staple_)
+                                  .setEcdsaCert(server_ecdsa_cert_)
+                                  .setEcdsaCertOcspStaple(server_ecdsa_cert_ocsp_staple_)
+                                  .setOcspStapleRequired(ocsp_staple_required_)
+                                  .setTlsV13(server_tlsv1_3_)
+                                  .setCurves(server_curves_)
+                                  .setExpectClientEcdsaCert(client_ecdsa_cert_)
+                                  .setTlsKeyLogFilter(keylog_local_, keylog_remote_,
+                                                      keylog_local_negative_,
+                                                      keylog_remote_negative_, keylog_path_,
+                                                      keylog_multiple_ips_, version_));
+
+  HttpIntegrationTest::initialize();
+
+  context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
+      server_factory_context_);
+
+  registerTestServerPorts({"http"});
+}
+
+void SslIntegrationTestBase::TearDown() {
+  HttpIntegrationTest::cleanupUpstreamAndDownstream();
+  codec_client_.reset();
+  context_manager_.reset();
+}
+
+Network::ClientConnectionPtr
+SslIntegrationTestBase::makeSslClientConnection(const ClientSslTransportOptions& options) {
+  Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
+  if (debug_with_s_client_) {
+    const std::string s_client_cmd = TestEnvironment::substitute(
+        "openssl s_client -connect " + address->asString() +
+            " -showcerts -debug -msg -CAfile "
+            "{{ test_rundir }}/test/config/integration/certs/cacert.pem "
+            "-servername lyft.com -cert "
+            "{{ test_rundir }}/test/config/integration/certs/clientcert.pem "
+            "-key "
+            "{{ test_rundir }}/test/config/integration/certs/clientkey.pem ",
+        version_);
+    ENVOY_LOG_MISC(debug, "Executing {}", s_client_cmd);
+    RELEASE_ASSERT(::system(s_client_cmd.c_str()) == 0, "");
+  }
+  auto client_transport_socket_factory_ptr =
+      createClientSslTransportSocketFactory(options, *context_manager_, *api_);
+  return dispatcher_->createClientConnection(
+      address, Network::Address::InstanceConstSharedPtr(),
+      client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);
+}
+
+void SslIntegrationTestBase::checkStats() {
+  const uint32_t expected_handshakes = debug_with_s_client_ ? 2 : 1;
+  Stats::CounterSharedPtr counter = test_server_->counter(listenerStatPrefix("ssl.handshake"));
+  EXPECT_EQ(expected_handshakes, counter->value());
+  counter->reset();
+}
+
+} // namespace Ssl
+} // namespace Envoy

--- a/test/common/tls/integration/ssl_integration_test_base.h
+++ b/test/common/tls/integration/ssl_integration_test_base.h
@@ -49,12 +49,5 @@ protected:
   std::unique_ptr<ContextManager> context_manager_;
 };
 
-class SslIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
-                           public SslIntegrationTestBase {
-public:
-  SslIntegrationTest() : SslIntegrationTestBase(GetParam()) {}
-  void TearDown() override { SslIntegrationTestBase::TearDown(); };
-};
-
 } // namespace Ssl
 } // namespace Envoy

--- a/test/extensions/transport_sockets/tap/BUILD
+++ b/test/extensions/transport_sockets/tap/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_package",
+    "envoy_select_admin_functionality",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -25,7 +26,7 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "ssl_tap_integration_test",
-    srcs = ["ssl_tap_integration_test.cc"],
+    srcs = envoy_select_admin_functionality(["ssl_tap_integration_test.cc"]),
     data = [
         "//test/config/integration/certs",
     ],

--- a/test/extensions/transport_sockets/tap/BUILD
+++ b/test/extensions/transport_sockets/tap/BUILD
@@ -22,3 +22,23 @@ envoy_extension_cc_test(
         "//test/test_common:simulated_time_system_lib",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "ssl_tap_integration_test",
+    srcs = ["ssl_tap_integration_test.cc"],
+    data = [
+        "//test/config/integration/certs",
+    ],
+    extension_names = ["envoy.transport_sockets.tap"],
+    deps = [
+        "//source/common/network:connection_lib",
+        "//source/extensions/transport_sockets/tap:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//test/common/tls/integration:ssl_integration_test_lib",
+        "//test/extensions/common/tap:common",
+        "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/data/tap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
+++ b/test/extensions/transport_sockets/tap/ssl_tap_integration_test.cc
@@ -1,0 +1,329 @@
+#include "envoy/config/tap/v3/common.pb.h"
+#include "envoy/data/tap/v3/wrapper.pb.h"
+#include "envoy/extensions/transport_sockets/tap/v3/tap.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/cert.pb.h"
+
+#include "source/common/network/connection_impl.h"
+
+#include "test/common/tls/integration/ssl_integration_test_base.h"
+#include "test/extensions/common/tap/common.h"
+
+namespace Envoy {
+namespace Ssl {
+
+// TODO(zuercher): write an additional OCSP integration test that validates behavior with an
+// expired OCSP response. (Requires OCSP client-side support in upstream TLS.)
+class SslTapIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                              public SslIntegrationTestBase {
+public:
+  SslTapIntegrationTest() : SslIntegrationTestBase(GetParam()) {}
+
+  void TearDown() override { SslIntegrationTestBase::TearDown(); };
+
+  void initialize() override {
+    // TODO(mattklein123): Merge/use the code in ConfigHelper::setTapTransportSocket().
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // The test supports tapping either the downstream or upstream connection, but not both.
+      if (upstream_tap_) {
+        setupUpstreamTap(bootstrap);
+      } else {
+        setupDownstreamTap(bootstrap);
+      }
+    });
+    SslIntegrationTestBase::initialize();
+    // This confuses our socket counting.
+    debug_with_s_client_ = false;
+  }
+
+  void setupUpstreamTap(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* transport_socket =
+        bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+    transport_socket->set_name("envoy.transport_sockets.tap");
+    envoy::config::core::v3::TransportSocket raw_transport_socket;
+    raw_transport_socket.set_name("envoy.transport_sockets.raw_buffer");
+    envoy::extensions::transport_sockets::tap::v3::Tap tap_config =
+        createTapConfig(raw_transport_socket);
+    tap_config.mutable_transport_socket()->MergeFrom(raw_transport_socket);
+    transport_socket->mutable_typed_config()->PackFrom(tap_config);
+  }
+
+  void setupDownstreamTap(envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* filter_chain =
+        bootstrap.mutable_static_resources()->mutable_listeners(0)->mutable_filter_chains(0);
+    // Configure inner SSL transport socket based on existing config.
+    envoy::config::core::v3::TransportSocket ssl_transport_socket;
+    auto* transport_socket = filter_chain->mutable_transport_socket();
+    ssl_transport_socket.Swap(transport_socket);
+    // Configure outer tap transport socket.
+    transport_socket->set_name("envoy.transport_sockets.tap");
+    envoy::extensions::transport_sockets::tap::v3::Tap tap_config =
+        createTapConfig(ssl_transport_socket);
+    tap_config.mutable_transport_socket()->MergeFrom(ssl_transport_socket);
+    transport_socket->mutable_typed_config()->PackFrom(tap_config);
+  }
+
+  envoy::extensions::transport_sockets::tap::v3::Tap
+  createTapConfig(const envoy::config::core::v3::TransportSocket& inner_transport) {
+    envoy::extensions::transport_sockets::tap::v3::Tap tap_config;
+    tap_config.mutable_common_config()->mutable_static_config()->mutable_match()->set_any_match(
+        true);
+    auto* output_config =
+        tap_config.mutable_common_config()->mutable_static_config()->mutable_output_config();
+    if (max_rx_bytes_.has_value()) {
+      output_config->mutable_max_buffered_rx_bytes()->set_value(max_rx_bytes_.value());
+    }
+    if (max_tx_bytes_.has_value()) {
+      output_config->mutable_max_buffered_tx_bytes()->set_value(max_tx_bytes_.value());
+    }
+    output_config->set_streaming(streaming_tap_);
+
+    auto* output_sink = output_config->mutable_sinks()->Add();
+    output_sink->set_format(format_);
+    output_sink->mutable_file_per_tap()->set_path_prefix(path_prefix_);
+    tap_config.mutable_transport_socket()->MergeFrom(inner_transport);
+    return tap_config;
+  }
+
+  std::string path_prefix_ = TestEnvironment::temporaryPath("ssl_trace");
+  envoy::config::tap::v3::OutputSink::Format format_{
+      envoy::config::tap::v3::OutputSink::PROTO_BINARY};
+  absl::optional<uint64_t> max_rx_bytes_;
+  absl::optional<uint64_t> max_tx_bytes_;
+  bool upstream_tap_{};
+  bool streaming_tap_{};
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, SslTapIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+// Validate two back-to-back requests with binary proto output.
+TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
+  initialize();
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  // First request (ID will be +1 since the client will also bump).
+  const uint64_t first_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
+  codec_client_ = makeHttpConnection(creator());
+  Http::TestRequestHeaderMapImpl post_request_headers{
+      {":method", "POST"},       {":path", "/test/long/url"},
+      {":scheme", "http"},       {":authority", "sni.lyft.com"},
+      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
+  auto response =
+      sendRequestAndWaitForResponse(post_request_headers, 128, default_response_headers_, 256);
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(128, upstream_request_->bodyLength());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ(256, response->body().size());
+  checkStats();
+  envoy::config::core::v3::Address expected_local_address;
+  Network::Utility::addressToProtobufAddress(
+      *codec_client_->connection()->connectionInfoProvider().remoteAddress(),
+      expected_local_address);
+  envoy::config::core::v3::Address expected_remote_address;
+  Network::Utility::addressToProtobufAddress(
+      *codec_client_->connection()->connectionInfoProvider().localAddress(),
+      expected_remote_address);
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  envoy::data::tap::v3::TraceWrapper trace;
+  TestUtility::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, first_id), trace, *api_);
+  // Validate general expected properties in the trace.
+  EXPECT_EQ(first_id, trace.socket_buffered_trace().trace_id());
+  EXPECT_THAT(expected_local_address,
+              ProtoEq(trace.socket_buffered_trace().connection().local_address()));
+  EXPECT_THAT(expected_remote_address,
+              ProtoEq(trace.socket_buffered_trace().connection().remote_address()));
+  ASSERT_GE(trace.socket_buffered_trace().events().size(), 2);
+  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
+                               "POST /test/long/url HTTP/1.1"));
+  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
+                               "HTTP/1.1 200 OK"));
+  EXPECT_FALSE(trace.socket_buffered_trace().read_truncated());
+  EXPECT_FALSE(trace.socket_buffered_trace().write_truncated());
+
+  // Verify a second request hits a different file.
+  const uint64_t second_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
+  codec_client_ = makeHttpConnection(creator());
+  Http::TestRequestHeaderMapImpl get_request_headers{
+      {":method", "GET"},        {":path", "/test/long/url"},
+      {":scheme", "http"},       {":authority", "sni.lyft.com"},
+      {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
+  response =
+      sendRequestAndWaitForResponse(get_request_headers, 128, default_response_headers_, 256);
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ(128, upstream_request_->bodyLength());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ(256, response->body().size());
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 2);
+  TestUtility::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, second_id), trace, *api_);
+  // Validate second connection ID.
+  EXPECT_EQ(second_id, trace.socket_buffered_trace().trace_id());
+  ASSERT_GE(trace.socket_buffered_trace().events().size(), 2);
+  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
+                               "GET /test/long/url HTTP/1.1"));
+  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
+                               "HTTP/1.1 200 OK"));
+  EXPECT_FALSE(trace.socket_buffered_trace().read_truncated());
+  EXPECT_FALSE(trace.socket_buffered_trace().write_truncated());
+}
+
+// Verify that truncation works correctly across multiple transport socket frames.
+TEST_P(SslTapIntegrationTest, TruncationWithMultipleDataFrames) {
+  max_rx_bytes_ = 4;
+  max_tx_bytes_ = 5;
+
+  initialize();
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
+  codec_client_ = makeHttpConnection(creator());
+  const Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                       {":path", "/test/long/url"},
+                                                       {":scheme", "http"},
+                                                       {":authority", "sni.lyft.com"}};
+  auto result = codec_client_->startRequest(request_headers);
+  auto response = std::move(result.second);
+  Buffer::OwnedImpl data1("one");
+  result.first.encodeData(data1, false);
+  Buffer::OwnedImpl data2("two");
+  result.first.encodeData(data2, true);
+  waitForNextUpstreamRequest();
+  const Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  upstream_request_->encodeHeaders(response_headers, false);
+  Buffer::OwnedImpl data3("three");
+  upstream_request_->encodeData(data3, false);
+  response->waitForBodyData(5);
+  Buffer::OwnedImpl data4("four");
+  upstream_request_->encodeData(data4, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+
+  envoy::data::tap::v3::TraceWrapper trace;
+  TestUtility::loadFromFile(fmt::format("{}_{}.pb", path_prefix_, id), trace, *api_);
+
+  ASSERT_EQ(trace.socket_buffered_trace().events().size(), 2);
+  EXPECT_TRUE(trace.socket_buffered_trace().events(0).read().data().truncated());
+  EXPECT_TRUE(trace.socket_buffered_trace().events(1).write().data().truncated());
+  EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
+  EXPECT_TRUE(trace.socket_buffered_trace().write_truncated());
+}
+
+// Validate a single request with text proto output.
+TEST_P(SslTapIntegrationTest, RequestWithTextProto) {
+  format_ = envoy::config::tap::v3::OutputSink::PROTO_TEXT;
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  // Disable for this test because it uses connection IDs, which disrupts the accounting below
+  // leading to the wrong path for the `pb_text` being used.
+  skip_tag_extraction_rule_check_ = true;
+
+  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  envoy::data::tap::v3::TraceWrapper trace;
+  TestUtility::loadFromFile(fmt::format("{}_{}.pb_text", path_prefix_, id), trace, *api_);
+  // Test some obvious properties.
+  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(0).read().data().as_bytes(),
+                               "GET /test/long/url HTTP/1.1"));
+  EXPECT_TRUE(absl::StartsWith(trace.socket_buffered_trace().events(1).write().data().as_bytes(),
+                               "HTTP/1.1 200 OK"));
+  EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
+  EXPECT_FALSE(trace.socket_buffered_trace().write_truncated());
+}
+
+// Validate a single request with JSON (body as string) output. This test uses an upstream tap.
+TEST_P(SslTapIntegrationTest, RequestWithJsonBodyAsStringUpstreamTap) {
+  upstream_tap_ = true;
+  max_rx_bytes_ = 5;
+  max_tx_bytes_ = 4;
+
+  format_ = envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING;
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  // Disable for this test because it uses connection IDs, which disrupts the accounting below
+  // leading to the wrong path for the `pb_text` being used.
+  skip_tag_extraction_rule_check_ = true;
+
+  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
+  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  test_server_.reset();
+
+  // This must be done after server shutdown so that connection pool connections are closed and
+  // the tap written.
+  envoy::data::tap::v3::TraceWrapper trace;
+  TestUtility::loadFromFile(fmt::format("{}_{}.json", path_prefix_, id), trace, *api_);
+
+  // Test some obvious properties.
+  EXPECT_EQ(trace.socket_buffered_trace().events(0).write().data().as_string(), "GET ");
+  EXPECT_EQ(trace.socket_buffered_trace().events(1).read().data().as_string(), "HTTP/");
+  EXPECT_TRUE(trace.socket_buffered_trace().read_truncated());
+  EXPECT_TRUE(trace.socket_buffered_trace().write_truncated());
+}
+
+// Validate a single request with length delimited binary proto output. This test uses an upstream
+// tap.
+TEST_P(SslTapIntegrationTest, RequestWithStreamingUpstreamTap) {
+  upstream_tap_ = true;
+  streaming_tap_ = true;
+  max_rx_bytes_ = 5;
+  max_tx_bytes_ = 4;
+
+  format_ = envoy::config::tap::v3::OutputSink::PROTO_BINARY_LENGTH_DELIMITED;
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection({});
+  };
+
+  // Disable for this test because it uses connection IDs, which disrupts the accounting below
+  // leading to the wrong path for the `pb_text` being used.
+  skip_tag_extraction_rule_check_ = true;
+
+  const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
+  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
+  checkStats();
+  codec_client_->close();
+  test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
+  test_server_.reset();
+
+  // This must be done after server shutdown so that connection pool connections are closed and
+  // the tap written.
+  std::vector<envoy::data::tap::v3::TraceWrapper> traces =
+      Extensions::Common::Tap::readTracesFromFile(
+          fmt::format("{}_{}.pb_length_delimited", path_prefix_, id));
+  ASSERT_GE(traces.size(), 4);
+
+  // The initial connection message has no local address, but has a remote address (not connected
+  // yet).
+  EXPECT_TRUE(traces[0].socket_streamed_trace_segment().has_connection());
+  EXPECT_FALSE(traces[0].socket_streamed_trace_segment().connection().has_local_address());
+  EXPECT_TRUE(traces[0].socket_streamed_trace_segment().connection().has_remote_address());
+
+  // Verify truncated request/response data.
+  EXPECT_EQ(traces[1].socket_streamed_trace_segment().event().write().data().as_bytes(), "GET ");
+  EXPECT_TRUE(traces[1].socket_streamed_trace_segment().event().write().data().truncated());
+  EXPECT_EQ(traces[2].socket_streamed_trace_segment().event().read().data().as_bytes(), "HTTP/");
+  EXPECT_TRUE(traces[2].socket_streamed_trace_segment().event().read().data().truncated());
+}
+
+} // namespace Ssl
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: tests: refactor SSL TAP tests
Additional Description:
Moved SSL TAP based tests to be under the transport_socket/tap extension directory (old TODO).

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
