### PR TITLE
fluentd_access_logger: add option for extended formatters

### DIFF
--- a/api/envoy/extensions/access_loggers/fluentd/v3/fluentd.proto
+++ b/api/envoy/extensions/access_loggers/fluentd/v3/fluentd.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.access_loggers.fluentd.v3;
 
 import "envoy/config/core/v3/backoff.proto";
+import "envoy/config/core/v3/extension.proto";
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -24,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // the Fluentd Forward Protocol as described in: `Fluentd Forward Protocol Specification
 // <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1>`_.
 // [#extension: envoy.access_loggers.fluentd]
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message FluentdAccessLogConfig {
   message RetryOptions {
     // The number of times the logger will attempt to connect to the upstream during reconnects.
@@ -85,4 +86,9 @@ message FluentdAccessLogConfig {
   // as specified in the :ref:`RetryOptions <envoy_v3_api_msg_extensions.access_loggers.fluentd.v3.FluentdAccessLogConfig.RetryOptions>`
   // configuration.
   RetryOptions retry_options = 7;
+
+  // Specifies a collection of Formatter plugins that can be called from the access log configuration.
+  // See the formatters extensions documentation for details.
+  // [#extension-category: envoy.formatter]
+  repeated config.core.v3.TypedExtensionConfig formatters = 8;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -344,6 +344,10 @@ new_features:
     Update ``aws_request_signing`` filter to support optionally sending the aws signature in query parameters rather than headers,
     by specifying the :ref:`query_string <envoy_v3_api_field_extensions.filters.http.aws_request_signing.v3.AwsRequestSigning.query_string>`
     configuration section.
+- area: formatters
+  change: |
+    Added :ref:`formatters <envoy_v3_api_field_extensions.access_loggers.fluentd.v3.FluentdAccessLogConfig.formatters>`
+    to Fluentd access logger to allow adding extension commands when formatter access logs.
 - area: rbac
   change: |
     Added :ref:`rules_stat_prefix <envoy_v3_api_field_extensions.filters.http.rbac.v3.RBAC.rules_stat_prefix>`

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -60,9 +60,11 @@ FluentdAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config
   // payload.
   // TODO(ohadvano): Improve the formatting operation by creating a dedicated formatter that
   //                 will directly serialize the record to msgpack payload.
+  auto commands = Formatter::SubstitutionFormatStringUtils::parseFormatters(
+      proto_config.formatters(), context);
   Formatter::FormatterPtr json_formatter =
       Formatter::SubstitutionFormatStringUtils::createJsonFormatter(proto_config.record(), true,
-                                                                    false, false);
+                                                                    false, false, commands);
   FluentdFormatterPtr fluentd_formatter =
       std::make_unique<FluentdFormatterImpl>(std::move(json_formatter));
 

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -60,8 +60,8 @@ FluentdAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config
   // payload.
   // TODO(ohadvano): Improve the formatting operation by creating a dedicated formatter that
   //                 will directly serialize the record to msgpack payload.
-  auto commands = Formatter::SubstitutionFormatStringUtils::parseFormatters(
-      proto_config.formatters(), context);
+  auto commands =
+      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context);
   Formatter::FormatterPtr json_formatter =
       Formatter::SubstitutionFormatStringUtils::createJsonFormatter(proto_config.record(), true,
                                                                     false, false, commands);

--- a/test/extensions/access_loggers/fluentd/BUILD
+++ b/test/extensions/access_loggers/fluentd/BUILD
@@ -46,6 +46,7 @@ envoy_extension_cc_test(
     srcs = ["fluentd_access_log_integration_test.cc"],
     extension_names = ["envoy.access_loggers.fluentd"],
     deps = [
+        "//source/extensions/formatter/cel:config",
         "//source/extensions/access_loggers/fluentd:config",
         "//source/extensions/filters/network/tcp_proxy:config",
         "//test/integration:integration_lib",

--- a/test/extensions/access_loggers/fluentd/BUILD
+++ b/test/extensions/access_loggers/fluentd/BUILD
@@ -46,9 +46,9 @@ envoy_extension_cc_test(
     srcs = ["fluentd_access_log_integration_test.cc"],
     extension_names = ["envoy.access_loggers.fluentd"],
     deps = [
-        "//source/extensions/formatter/cel:config",
         "//source/extensions/access_loggers/fluentd:config",
         "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/formatter/cel:config",
         "//test/integration:integration_lib",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/access_loggers/fluentd/fluentd_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/fluentd/fluentd_access_log_integration_test.cc
@@ -99,7 +99,8 @@ public:
                 name: envoy.formatter.metadata
                 typed_config:
                   "@type": type.googleapis.com/{}
-            )EOF", formatter_type.value());
+            )EOF",
+                                                 formatter_type.value());
 
             auto* formatter = access_log_config.add_formatters();
             envoy::config::core::v3::TypedExtensionConfig proto;
@@ -182,10 +183,10 @@ TEST_F(FluentdAccessLogIntegrationTest, InvalidBackoffConfig) {
 }
 
 TEST_F(FluentdAccessLogIntegrationTest, InvalidUnknownFormatter) {
-  EXPECT_THROW_WITH_REGEX(init(default_cluster_name, false, 1, 1, 20, 30,
-                                 "envoy.extensions.formatter.Unknown"),
-                            EnvoyException,
-    ".*could not find @type 'type.googleapis.com/envoy.extensions.formatter.Unknown'.*");
+  EXPECT_THROW_WITH_REGEX(
+      init(default_cluster_name, false, 1, 1, 20, 30, "envoy.extensions.formatter.Unknown"),
+      EnvoyException,
+      ".*could not find @type 'type.googleapis.com/envoy.extensions.formatter.Unknown'.*");
 }
 
 TEST_F(FluentdAccessLogIntegrationTest, LogLostOnBufferFull) {
@@ -215,8 +216,7 @@ TEST_F(FluentdAccessLogIntegrationTest, SingleEntrySingleRecord) {
 }
 
 TEST_F(FluentdAccessLogIntegrationTest, SingleEntrySingleRecordWithFormatter) {
-  init(default_cluster_name, false, 1, 1, 20, 30,
-       "envoy.extensions.formatter.cel.v3.Cel");
+  init(default_cluster_name, false, 1, 1, 20, 30, "envoy.extensions.formatter.cel.v3.Cel");
   sendBidirectionalData();
 
   test_server_->waitForCounterEq("access_logs.fluentd.fluentd_1.entries_buffered", 1);

--- a/test/extensions/access_loggers/fluentd/fluentd_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/fluentd/fluentd_access_log_integration_test.cc
@@ -35,7 +35,8 @@ public:
             absl::optional<uint32_t> buffer_size_bytes = absl::nullopt,
             absl::optional<uint32_t> max_connect_attempts = 1,
             absl::optional<uint64_t> base_backoff_interval = absl::nullopt,
-            absl::optional<uint64_t> max_backoff_interval = absl::nullopt) {
+            absl::optional<uint64_t> max_backoff_interval = absl::nullopt,
+            absl::optional<std::string> formatter_type = absl::nullopt) {
     setUpstreamCount(2);
     config_helper_.renameListener("tcp_proxy");
     config_helper_.addConfigModifier(
@@ -89,6 +90,22 @@ public:
           auto* record = access_log_config.mutable_record();
           (*record->mutable_fields())["Message"].set_string_value("SomeValue");
           (*record->mutable_fields())["LogType"].set_string_value("%ACCESS_LOG_TYPE%");
+
+          if (formatter_type.has_value()) {
+            std::string cel_key = "%CEL(connection.mtls)%";
+            (*record->mutable_fields())["FromFormatterIsDownstreamMtls"].set_string_value(cel_key);
+
+            const std::string yaml = fmt::format(R"EOF(
+                name: envoy.formatter.metadata
+                typed_config:
+                  "@type": type.googleapis.com/{}
+            )EOF", formatter_type.value());
+
+            auto* formatter = access_log_config.add_formatters();
+            envoy::config::core::v3::TypedExtensionConfig proto;
+            TestUtility::loadFromYaml(yaml, proto);
+            *formatter = proto;
+          }
 
           access_log->mutable_typed_config()->PackFrom(access_log_config);
           config_blob->PackFrom(tcp_proxy_config);
@@ -164,6 +181,13 @@ TEST_F(FluentdAccessLogIntegrationTest, InvalidBackoffConfig) {
   EXPECT_DEATH(init(default_cluster_name, false, 1, 1, 30, 20), "");
 }
 
+TEST_F(FluentdAccessLogIntegrationTest, InvalidUnknownFormatter) {
+  EXPECT_THROW_WITH_REGEX(init(default_cluster_name, false, 1, 1, 20, 30,
+                                 "envoy.extensions.formatter.Unknown"),
+                            EnvoyException,
+    ".*could not find @type 'type.googleapis.com/envoy.extensions.formatter.Unknown'.*");
+}
+
 TEST_F(FluentdAccessLogIntegrationTest, LogLostOnBufferFull) {
   init(default_cluster_name, false, /* max_buffer_size = */ 0);
   sendBidirectionalData();
@@ -186,6 +210,28 @@ TEST_F(FluentdAccessLogIntegrationTest, SingleEntrySingleRecord) {
     bool validated = false;
     validateFluentdPayload(tcp_data, &validated,
                            {{"{\"Message\":\"SomeValue\",\"LogType\":\"TcpConnectionEnd\"}"}});
+    return validated;
+  }));
+}
+
+TEST_F(FluentdAccessLogIntegrationTest, SingleEntrySingleRecordWithFormatter) {
+  init(default_cluster_name, false, 1, 1, 20, 30,
+       "envoy.extensions.formatter.cel.v3.Cel");
+  sendBidirectionalData();
+
+  test_server_->waitForCounterEq("access_logs.fluentd.fluentd_1.entries_buffered", 1);
+  test_server_->waitForCounterEq("access_logs.fluentd.fluentd_1.events_sent", 1);
+
+  ASSERT_TRUE(fake_upstreams_[1]->waitForRawConnection(fake_access_log_connection_));
+  test_server_->waitForCounterEq("cluster.fluentd_cluster.upstream_cx_total", 1);
+  test_server_->waitForGaugeEq("cluster.fluentd_cluster.upstream_cx_active", 1);
+
+  // Using CEL for formatter validation with sample use case.
+  EXPECT_TRUE(fake_access_log_connection_->waitForData([&](const std::string& tcp_data) -> bool {
+    bool validated = false;
+    validateFluentdPayload(tcp_data, &validated,
+                           {{"{\"FromFormatterIsDownstreamMtls\":\"false\","
+                             "\"Message\":\"SomeValue\",\"LogType\":\"TcpConnectionEnd\"}"}});
     return validated;
   }));
 }


### PR DESCRIPTION
Additional Description: Adding option to provide formatters by extension to Fluentd access logger
Risk Level: low
Testing: unit tests, integration tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None
