### PR TITLE
Remove uses of `android_cfg.android_cpu` in Starlark.

### DIFF
--- a/mobile/bazel/android_debug_info.bzl
+++ b/mobile/bazel/android_debug_info.bzl
@@ -19,18 +19,17 @@ def _impl(ctx):
 
         cc_toolchain = ctx.split_attr._cc_toolchain[platform][cc_common.CcToolchainInfo]
         lib = dep.files.to_list()[0]
-        platform_name = platform or ctx.fragments.android.android_cpu
-        objdump_output = ctx.actions.declare_file(platform_name + "/" + platform_name + ".objdump.gz")
+        objdump_output = ctx.actions.declare_file(platform + "/" + platform + ".objdump.gz")
 
         ctx.actions.run_shell(
             inputs = [lib],
             outputs = [objdump_output],
             command = cc_toolchain.objdump_executable + " --syms " + lib.path + "| gzip -c >" + objdump_output.path,
             tools = [cc_toolchain.all_files],
-            progress_message = "Generating symbol map " + platform_name,
+            progress_message = "Generating symbol map " + platform,
         )
 
-        strip_output = ctx.actions.declare_file(platform_name + "/" + lib.basename)
+        strip_output = ctx.actions.declare_file(platform + "/" + lib.basename)
         ctx.actions.run_shell(
             inputs = [lib],
             outputs = [strip_output],


### PR DESCRIPTION
Part of removing `--android_cpu` entirely.

Note that this is safe: the `platform` value is the key of the `android_common.multi_cpu_configuration` split transition, which will always have a value.

Internal issue b/328058376.

Commit Message: Remove uses of `android_cfg.android_cpu` in Starlark
Additional Description:Part of removing `--android_cpu` entirely
