### PR TITLE
mobile: Disable the Swift and Kotlin proxying tests

### DIFF
--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -16,6 +16,7 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -39,6 +40,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
     JniLibrary.load()
   }
 
+  @Ignore("https://github.com/envoyproxy/envoy/issues/33014")
   @Test
   fun `performs an HTTPs request through a proxy using async DNS resolution`() {
     TestJni.startHttpsProxyTestServer()

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -16,6 +16,7 @@ import io.envoyproxy.envoymobile.engine.testing.TestJni
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -39,6 +39,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
     JniLibrary.load()
   }
 
+  @Ignore("https://github.com/envoyproxy/envoy/issues/33014")
   @Test
   fun `performs an HTTPs request through a proxy`() {
     TestJni.startHttpsProxyTestServer()

--- a/mobile/test/swift/integration/proxying/HTTPRequestUsingProxyTest.swift
+++ b/mobile/test/swift/integration/proxying/HTTPRequestUsingProxyTest.swift
@@ -12,7 +12,8 @@ final class HTTPRequestUsingProxyTest: XCTestCase {
     register_test_extensions()
   }
 
-  func testHTTPRequestUsingProxy() throws {
+  // https://github.com/envoyproxy/envoy/issues/33014
+  func skipped_testHTTPRequestUsingProxy() throws {
     EnvoyTestServer.startHttpProxyServer()
     let port = EnvoyTestServer.getEnvoyPort()
 
@@ -65,7 +66,8 @@ final class HTTPRequestUsingProxyTest: XCTestCase {
     EnvoyTestServer.shutdownTestServer()
   }
 
-  func testHTTPSRequestUsingProxy() throws {
+  // https://github.com/envoyproxy/envoy/issues/33014
+  func skipped_testHTTPSRequestUsingProxy() throws {
     EnvoyTestServer.startHttpsProxyServer()
     let port = EnvoyTestServer.getEnvoyPort()
 
@@ -120,7 +122,8 @@ final class HTTPRequestUsingProxyTest: XCTestCase {
     EnvoyTestServer.shutdownTestServer()
   }
 
-  func testHTTPSRequestUsingPacFileUrlResolver() throws {
+  // https://github.com/envoyproxy/envoy/issues/33014
+  func skipped_testHTTPSRequestUsingPacFileUrlResolver() throws {
     EnvoyTestServer.startHttpsProxyServer()
     let port = EnvoyTestServer.getEnvoyPort()
 
@@ -175,7 +178,8 @@ final class HTTPRequestUsingProxyTest: XCTestCase {
     EnvoyTestServer.shutdownTestServer()
   }
 
-  func testHTTPRequestUsingProxyCancelStream() throws {
+  // https://github.com/envoyproxy/envoy/issues/33014
+  func skipped_testHTTPRequestUsingProxyCancelStream() throws {
     EnvoyTestServer.startHttpProxyServer()
     let port = EnvoyTestServer.getEnvoyPort()
 


### PR DESCRIPTION
They are causing issues on CI.

See https://github.com/envoyproxy/envoy/issues/33014.