### PR TITLE
Add per_route stat_prefix

### DIFF
--- a/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
+++ b/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
@@ -64,4 +64,7 @@ message PerRouteConfig {
       "envoy.config.filter.http.aws_lambda.v2alpha.PerRouteConfig";
 
   Config invoke_config = 1;
+
+  // The human readable prefix to use when emitting stats.
+  string stat_prefix = 2;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -237,6 +237,10 @@ new_features:
   change: |
     Update ``aws_lambda`` filter to support use as an upstream HTTP filter. This allows successful calculation of
     signatures after the forwarding stage has completed, particularly if the path element is modified.
+- area: aws_lambda
+  change: |
+    Add ``stat_prefix`` to per route configuration to be consistent with aws_request_signing.
+    :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.PerRouteConfig.stat_prefix>` parameter.
 - area: grpc reverse bridge
   change: |
     Change HTTP status to 200 to respect the gRPC protocol. This may cause problems for incorrect gRPC clients expecting the filter

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -116,32 +116,16 @@ bool isContentTypeTextual(const Http::RequestOrResponseHeaderMap& headers) {
 } // namespace
 
 // TODO(nbaws) Implement Sigv4a support
-Filter::Filter(const FilterSettings& settings, const FilterStats& stats,
-               const std::shared_ptr<Extensions::Common::Aws::Signer>& sigv4_signer,
-               bool is_upstream)
-    : settings_(settings), stats_(stats), sigv4_signer_(sigv4_signer), is_upstream_(is_upstream) {}
+Filter::Filter(const FilterSettingsSharedPtr& settings, bool is_upstream)
+    : settings_(settings), is_upstream_(is_upstream) {}
 
-absl::optional<FilterSettings> Filter::getRouteSpecificSettings() const {
-  const auto* settings =
-      Http::Utility::resolveMostSpecificPerFilterConfig<FilterSettings>(decoder_callbacks_);
-  if (!settings) {
-    return absl::nullopt;
+FilterSettings& Filter::getSettings() {
+  auto* settings = const_cast<FilterSettings*>(
+      Http::Utility::resolveMostSpecificPerFilterConfig<FilterSettings>(decoder_callbacks_));
+  if (settings) {
+    return *settings;
   }
-
-  return *settings;
-}
-
-void Filter::resolveSettings() {
-  if (auto route_settings = getRouteSpecificSettings()) {
-    payload_passthrough_ = route_settings->payloadPassthrough();
-    invocation_mode_ = route_settings->invocationMode();
-    arn_ = route_settings->arn();
-    host_rewrite_ = route_settings->hostRewrite();
-  } else {
-    payload_passthrough_ = settings_.payloadPassthrough();
-    invocation_mode_ = settings_.invocationMode();
-    host_rewrite_ = settings_.hostRewrite();
-  }
+  return *settings_;
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
@@ -154,20 +138,16 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     }
   }
 
-  resolveSettings();
-
-  if (!arn_) {
-    arn_ = settings_.arn();
-  }
+  auto& settings = getSettings();
 
   if (!end_stream) {
     request_headers_ = &headers;
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  if (payload_passthrough_) {
-    setLambdaHeaders(headers, arn_, invocation_mode_, host_rewrite_);
-    sigv4_signer_->signEmptyPayload(headers, arn_->region());
+  if (settings.payloadPassthrough()) {
+    setLambdaHeaders(headers, settings.arn(), settings.invocationMode(), settings.hostRewrite());
+    settings.signer().signEmptyPayload(headers, settings.arn().region());
     return Http::FilterHeadersStatus::Continue;
   }
 
@@ -175,12 +155,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   jsonizeRequest(headers, nullptr, json_buf);
   // We must call setLambdaHeaders *after* the JSON transformation of the request. That way we
   // reflect the actual incoming request headers instead of the overwritten ones.
-  setLambdaHeaders(headers, arn_, invocation_mode_, host_rewrite_);
+  setLambdaHeaders(headers, settings.arn(), settings.invocationMode(), settings.hostRewrite());
   headers.setContentLength(json_buf.length());
   headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   auto& hashing_util = Envoy::Common::Crypto::UtilitySingleton::get();
   const auto hash = Hex::encode(hashing_util.getSha256Digest(json_buf));
-  sigv4_signer_->sign(headers, hash, arn_->region());
+  settings.signer().sign(headers, hash, settings.arn().region());
   decoder_callbacks_->addDecodedData(json_buf, false);
   return Http::FilterHeadersStatus::Continue;
 }
@@ -223,7 +203,9 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
 
   const Buffer::Instance& decoding_buffer = *decoder_callbacks_->decodingBuffer();
 
-  if (!payload_passthrough_) {
+  auto& settings = getSettings();
+
+  if (!settings.payloadPassthrough()) {
     decoder_callbacks_->modifyDecodingBuffer([this](Buffer::Instance& dec_buf) {
       Buffer::OwnedImpl json_buf;
       jsonizeRequest(*request_headers_, &dec_buf, json_buf);
@@ -235,15 +217,18 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
     request_headers_->setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   }
 
-  setLambdaHeaders(*request_headers_, arn_, invocation_mode_, host_rewrite_);
+  setLambdaHeaders(*request_headers_, settings.arn(), settings.invocationMode(),
+                   settings.hostRewrite());
   const auto hash = Hex::encode(hashing_util.getSha256Digest(decoding_buffer));
-  sigv4_signer_->sign(*request_headers_, hash, arn_->region());
-  stats().upstream_rq_payload_size_.recordValue(decoding_buffer.length());
+  settings.signer().sign(*request_headers_, hash, settings.arn().region());
+  settings.stats().upstream_rq_payload_size_.recordValue(decoding_buffer.length());
   return Http::FilterDataStatus::Continue;
 }
 
 Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_stream) {
-  if (skip_ || payload_passthrough_ || invocation_mode_ == InvocationMode::Asynchronous) {
+  auto& settings = getSettings();
+  if (skip_ || settings.payloadPassthrough() ||
+      settings.invocationMode() == InvocationMode::Asynchronous) {
     return Http::FilterDataStatus::Continue;
   }
 
@@ -254,9 +239,11 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_strea
   ENVOY_LOG(trace, "Tranforming JSON payload to HTTP response.");
   encoder_callbacks_->addEncodedData(data, false);
   const Buffer::Instance& encoding_buffer = *encoder_callbacks_->encodingBuffer();
-  encoder_callbacks_->modifyEncodingBuffer([this](Buffer::Instance& enc_buf) {
+  encoder_callbacks_->modifyEncodingBuffer([this, &settings](Buffer::Instance& enc_buf) {
     Buffer::OwnedImpl body;
-    dejsonizeResponse(*response_headers_, enc_buf, body);
+    if (!dejsonizeResponse(*response_headers_, enc_buf, body)) {
+      settings.stats().server_error_.inc();
+    }
     enc_buf.drain(enc_buf.length());
     enc_buf.move(body);
   });
@@ -318,7 +305,7 @@ void Filter::jsonizeRequest(Http::RequestHeaderMap const& headers, const Buffer:
   out.add(json_data);
 }
 
-void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::Instance& json_buf,
+bool Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::Instance& json_buf,
                                Buffer::Instance& body) {
   using source::extensions::filters::http::aws_lambda::Response;
   Response json_resp;
@@ -333,8 +320,7 @@ void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::I
     // 3- There was no x-amz-function-error header
     // 4- The body contains invalid JSON
     headers.setStatus(static_cast<int>(Http::Code::InternalServerError));
-    stats().server_error_.inc();
-    return;
+    return false;
   }
 
   // Use JSON as the default content-type. If the response headers have a different content-type
@@ -363,6 +349,7 @@ void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::I
       body.add(json_resp.body());
     }
   }
+  return true;
 }
 
 absl::optional<Arn> parseArn(absl::string_view arn) {

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -80,28 +80,46 @@ enum class InvocationMode { Synchronous, Asynchronous };
 
 class FilterSettings : public Router::RouteSpecificFilterConfig {
 public:
-  FilterSettings(const Arn& arn, InvocationMode mode, bool payload_passthrough,
-                 const std::string& host_rewrite)
-      : arn_(arn), invocation_mode_(mode), payload_passthrough_(payload_passthrough),
-        host_rewrite_(host_rewrite) {}
+  ~FilterSettings() override = default;
 
-  const Arn& arn() const& { return arn_; }
-  bool payloadPassthrough() const { return payload_passthrough_; }
-  InvocationMode invocationMode() const { return invocation_mode_; }
-  const std::string& hostRewrite() const { return host_rewrite_; }
+  virtual const Arn& arn() const PURE;
+  virtual bool payloadPassthrough() const PURE;
+  virtual InvocationMode invocationMode() const PURE;
+  virtual const std::string& hostRewrite() const PURE;
+  virtual Extensions::Common::Aws::Signer& signer() PURE;
+  virtual FilterStats& stats() PURE;
+};
+
+class FilterSettingsImpl : public FilterSettings {
+public:
+  FilterSettingsImpl(const Arn& arn, InvocationMode mode, bool payload_passthrough,
+                     const std::string& host_rewrite, const FilterStats& stats,
+                     Extensions::Common::Aws::SignerPtr&& signer)
+      : arn_(arn), invocation_mode_(mode), payload_passthrough_(payload_passthrough),
+        host_rewrite_(host_rewrite), stats_(stats), signer_(std::move(signer)) {}
+
+  const Arn& arn() const override { return arn_; }
+  bool payloadPassthrough() const override { return payload_passthrough_; }
+  InvocationMode invocationMode() const override { return invocation_mode_; }
+  const std::string& hostRewrite() const override { return host_rewrite_; }
+  Extensions::Common::Aws::Signer& signer() override { return *signer_; }
+  FilterStats& stats() override { return stats_; }
 
 private:
   Arn arn_;
   InvocationMode invocation_mode_;
   bool payload_passthrough_;
   const std::string host_rewrite_;
+  FilterStats stats_;
+  Extensions::Common::Aws::SignerPtr signer_;
 };
+
+using FilterSettingsSharedPtr = std::shared_ptr<FilterSettings>;
 
 class Filter : public Http::PassThroughFilter, Logger::Loggable<Logger::Id::filter> {
 
 public:
-  Filter(const FilterSettings& config, const FilterStats& stats,
-         const std::shared_ptr<Extensions::Common::Aws::Signer>& sigv4_signer, bool is_upstream);
+  Filter(const FilterSettingsSharedPtr& settings, bool is_upstream);
 
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
@@ -110,37 +128,28 @@ public:
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
 
   /**
-   * Calculates the function ARN, value of pass-through, etc. by checking per-filter configurations
-   * and general filter configuration. Ultimately, the most specific configuration wins.
-   * @return error message if settings are invalid. Otherwise, empty string.
-   */
-  void resolveSettings();
-  FilterStats& stats() { return stats_; }
-
-  /**
    * Used for unit testing only
    */
-  const FilterSettings& settingsForTest() const { return settings_; }
+  const FilterSettings& settingsForTest() const { return *settings_; }
 
 private:
-  absl::optional<FilterSettings> getRouteSpecificSettings() const;
+  /**
+   * Calculates the function ARN, value of pass-through, etc. by checking per-filter configurations
+   * and general filter configuration. Ultimately, the most specific configuration is returned.
+   */
+  FilterSettings& getSettings();
   // Convert the HTTP request to JSON request.
   void jsonizeRequest(const Http::RequestHeaderMap& headers, const Buffer::Instance* body,
                       Buffer::Instance& out) const;
   // Convert the JSON response to a standard HTTP response.
-  void dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::Instance& body,
+  bool dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::Instance& body,
                          Buffer::Instance& out);
-  const FilterSettings settings_;
-  FilterStats stats_;
+
+  FilterSettingsSharedPtr settings_;
   Http::RequestHeaderMap* request_headers_ = nullptr;
   Http::ResponseHeaderMap* response_headers_ = nullptr;
-  std::shared_ptr<Extensions::Common::Aws::Signer> sigv4_signer_;
-  absl::optional<Arn> arn_;
-  InvocationMode invocation_mode_ = InvocationMode::Synchronous;
-  bool payload_passthrough_ = false;
   bool skip_ = false;
   bool is_upstream_ = false;
-  std::string host_rewrite_;
 };
 
 } // namespace AwsLambdaFilter

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -50,36 +50,54 @@ absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createFilterFactor
           server_context.api(), makeOptRef(server_context), region,
           Extensions::Common::Aws::Utility::fetchMetadata);
 
-  auto signer = std::make_shared<Extensions::Common::Aws::SigV4SignerImpl>(
+  auto signer = std::make_unique<Extensions::Common::Aws::SigV4SignerImpl>(
       service_name, region, std::move(credentials_provider), server_context,
       // TODO: extend API to allow specifying header exclusion. ref:
       // https://github.com/envoyproxy/envoy/pull/18998
       Extensions::Common::Aws::AwsSigningHeaderExclusionVector{});
 
-  FilterSettings filter_settings{*arn, getInvocationMode(proto_config),
-                                 proto_config.payload_passthrough(), proto_config.host_rewrite()};
-
   FilterStats stats = generateStats(stats_prefix, dual_info.scope);
-  return [stats, signer, filter_settings, dual_info](Http::FilterChainFactoryCallbacks& cb) {
-    auto filter = std::make_shared<Filter>(filter_settings, stats, signer, dual_info.is_upstream);
+  auto filter_settings = std::make_shared<FilterSettingsImpl>(
+      *arn, getInvocationMode(proto_config), proto_config.payload_passthrough(),
+      proto_config.host_rewrite(), stats, std::move(signer));
+
+  return [filter_settings, dual_info](Http::FilterChainFactoryCallbacks& cb) -> void {
+    auto filter = std::make_shared<Filter>(filter_settings, dual_info.is_upstream);
     cb.addStreamFilter(filter);
   };
 }
 
 Router::RouteSpecificFilterConfigConstSharedPtr
 AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig& proto_config,
-    Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {
+    const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig& per_route_config,
+    Server::Configuration::ServerFactoryContext& server_context,
+    ProtobufMessage::ValidationVisitor&) {
 
-  const auto arn = parseArn(proto_config.invoke_config().arn());
+  const auto arn = parseArn(per_route_config.invoke_config().arn());
   if (!arn) {
     throw EnvoyException(
-        fmt::format("aws_lambda_filter: Invalid ARN: {}", proto_config.invoke_config().arn()));
+        fmt::format("aws_lambda_filter: Invalid ARN: {}", per_route_config.invoke_config().arn()));
   }
-  return std::make_shared<const FilterSettings>(
-      FilterSettings{*arn, getInvocationMode(proto_config.invoke_config()),
-                     proto_config.invoke_config().payload_passthrough(),
-                     proto_config.invoke_config().host_rewrite()});
+  const std::string region = arn->region();
+
+  auto credentials_provider =
+      std::make_shared<Extensions::Common::Aws::DefaultCredentialsProviderChain>(
+          server_context.api(), makeOptRef(server_context), region,
+          Extensions::Common::Aws::Utility::fetchMetadata);
+
+  auto signer = std::make_unique<Extensions::Common::Aws::SigV4SignerImpl>(
+      service_name, region, std::move(credentials_provider), server_context,
+      // TODO: extend API to allow specifying header exclusion. ref:
+      // https://github.com/envoyproxy/envoy/pull/18998
+      Extensions::Common::Aws::AwsSigningHeaderExclusionVector{});
+
+  FilterStats stats = generateStats(per_route_config.stat_prefix(), server_context.scope());
+  auto filter_settings = std::make_shared<FilterSettingsImpl>(
+      *arn, getInvocationMode(per_route_config.invoke_config()),
+      per_route_config.invoke_config().payload_passthrough(),
+      per_route_config.invoke_config().host_rewrite(), stats, std::move(signer));
+
+  return filter_settings;
 }
 
 /*

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -29,16 +29,48 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::UnorderedElementsAre;
 
+class FilterSettingsMock : public FilterSettings {
+public:
+  FilterSettingsMock(InvocationMode mode, bool payload_passthrough, const std::string& host_rewrite)
+      : invocation_mode_(mode), payload_passthrough_(payload_passthrough),
+        host_rewrite_(host_rewrite), stats_(generateStats("test", *stats_store_.rootScope())) {}
+  FilterSettingsMock(InvocationMode mode, bool payload_passthrough, const std::string& host_rewrite,
+                     FilterStats stat)
+      : invocation_mode_(mode), payload_passthrough_(payload_passthrough),
+        host_rewrite_(host_rewrite), stats_(stat) {}
+
+  const Arn& arn() const override { return arn_; }
+  bool payloadPassthrough() const override { return payload_passthrough_; }
+  InvocationMode invocationMode() const override { return invocation_mode_; }
+  const std::string& hostRewrite() const override { return host_rewrite_; }
+  Extensions::Common::Aws::Signer& signer() override { return *signer_; }
+  FilterStats& stats() override { return stats_; }
+
+  Arn arn_{parseArn("arn:aws:lambda:us-west-2:1337:function:fun").value()};
+  InvocationMode invocation_mode_;
+  bool payload_passthrough_;
+  const std::string host_rewrite_;
+  Stats::IsolatedStoreImpl stats_store_;
+  FilterStats stats_;
+  std::shared_ptr<NiceMock<MockSigner>> signer_{std::make_shared<NiceMock<MockSigner>>()};
+};
+
 class AwsLambdaFilterTest : public ::testing::Test {
 public:
-  AwsLambdaFilterTest() : arn_(parseArn("arn:aws:lambda:us-west-2:1337:function:fun").value()) {}
+  AwsLambdaFilterTest() {}
 
-  void setupFilter(const FilterSettings& settings) {
-    signer_ = std::make_shared<NiceMock<MockSigner>>();
-    filter_ = std::make_unique<Filter>(settings, stats_, signer_, false);
+  void setupFilter(const FilterSettingsSharedPtr& settings, bool upstream) {
+    filter_ = std::make_unique<Filter>(settings, upstream);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+  }
+
+  std::shared_ptr<FilterSettingsMock> setupDownstreamFilter(InvocationMode mode, bool passthrough,
+                                                            const std::string& host_rewrite) {
+    auto filter_settings = std::make_shared<FilterSettingsMock>(mode, passthrough, host_rewrite);
+    setupFilter(filter_settings, false);
     setupClusterMetadata();
+    return filter_settings;
   }
 
   void setupClusterMetadata() {
@@ -49,13 +81,9 @@ public:
   }
 
   std::unique_ptr<Filter> filter_;
-  std::shared_ptr<NiceMock<MockSigner>> signer_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   envoy::config::core::v3::Metadata metadata_;
-  Arn arn_;
-  Stats::IsolatedStoreImpl stats_store_;
-  FilterStats stats_ = generateStats("test", *stats_store_.rootScope());
   const std::string metadata_yaml_ = "egress_gateway: true";
 };
 
@@ -63,7 +91,7 @@ public:
  * Requests that are _not_ header only, should result in StopIteration.
  */
 TEST_F(AwsLambdaFilterTest, DecodingHeaderStopIteration) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
   Http::TestRequestHeaderMapImpl headers;
   const auto result = filter_->decodeHeaders(headers, false /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, result);
@@ -73,8 +101,9 @@ TEST_F(AwsLambdaFilterTest, DecodingHeaderStopIteration) {
  * Header only pass-through requests should be signed and Continue iteration.
  */
 TEST_F(AwsLambdaFilterTest, HeaderOnlyShouldContinue) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
-  EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
+  auto filter_settings = setupDownstreamFilter(InvocationMode::Synchronous, true, "");
+  EXPECT_CALL(*filter_settings->signer_,
+              signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
   Http::TestRequestHeaderMapImpl input_headers;
   const auto result = filter_->decodeHeaders(input_headers, true /*end_stream*/);
   EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
@@ -90,13 +119,12 @@ TEST_F(AwsLambdaFilterTest, HeaderOnlyShouldContinue) {
  * Cluster Metadata is not needed if the filter is loaded as upstream filter
  */
 TEST_F(AwsLambdaFilterTest, ClusterMetadataIsNotNeededInUpstreamMode) {
-  signer_ = std::make_shared<NiceMock<MockSigner>>();
-  auto settings = FilterSettings{arn_, InvocationMode::Synchronous, true, ""};
-  filter_ = std::make_unique<Filter>(settings, stats_, signer_, true);
-  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
-  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
-  // setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/});
-  EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
+  auto filter_settings =
+      std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, true, "");
+  setupFilter(filter_settings, true);
+
+  EXPECT_CALL(*filter_settings->signer_,
+              signEmptyPayload(An<Http::RequestHeaderMap&>(), An<absl::string_view>()));
   Http::TestRequestHeaderMapImpl input_headers;
   const auto result = filter_->decodeHeaders(input_headers, true /*end_stream*/);
   EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
@@ -117,15 +145,16 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
   egress_gateway: true
   )EOF";
 
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
+
   ProtobufWkt::Struct cluster_metadata;
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(metadata_yaml, cluster_metadata);
   metadata.mutable_filter_metadata()->insert({"WrongMetadataKey", cluster_metadata});
 
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
-  FilterSettings route_settings{arn_, InvocationMode::Synchronous, true /*passthrough*/, ""};
+  auto route_settings = std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, true, "");
   ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
-      .WillByDefault(Return(&route_settings));
+      .WillByDefault(Return(&*route_settings));
 
   ON_CALL(*decoder_callbacks_.cluster_info_, metadata()).WillByDefault(ReturnRef(metadata));
   Http::TestRequestHeaderMapImpl headers;
@@ -144,10 +173,11 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigWrongClusterMetadata) {
  * process the request (i.e. StopIteration if end_stream is false)
  */
 TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectClusterMetadata) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
-  FilterSettings route_settings{arn_, InvocationMode::Synchronous, true /*passthrough*/, ""};
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
+
+  auto route_settings = std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, true, "");
   ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
-      .WillByDefault(Return(&route_settings));
+      .WillByDefault(Return(&*route_settings));
 
   Http::TestRequestHeaderMapImpl headers;
   const auto result = filter_->decodeHeaders(headers, false /*end_stream*/);
@@ -159,16 +189,16 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectClusterMetadata) {
  * then the SigV4 signer will sign with the region where the lambda function is present.
  */
 TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectRegionForSigning) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   const absl::string_view override_region = "us-west-1";
-  const auto per_route_arn =
+  auto route_settings = std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, true, "");
+  route_settings->arn_ =
       parseArn(fmt::format("arn:aws:lambda:{}:1337:function:fun", override_region)).value();
-  FilterSettings route_settings{per_route_arn, InvocationMode::Synchronous, true /*passthrough*/,
-                                ""};
   ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
-      .WillByDefault(Return(&route_settings));
+      .WillByDefault(Return(&*route_settings));
 
-  EXPECT_CALL(*signer_, signEmptyPayload(An<Http::RequestHeaderMap&>(), override_region));
+  EXPECT_CALL(*route_settings->signer_,
+              signEmptyPayload(An<Http::RequestHeaderMap&>(), override_region));
   Http::TestRequestHeaderMapImpl headers;
   const auto result = filter_->decodeHeaders(headers, true /*end_stream*/);
   EXPECT_EQ(fmt::format("/2015-03-31/functions/arn:aws:lambda:{}:1337:function:fun/invocations",
@@ -178,16 +208,16 @@ TEST_F(AwsLambdaFilterTest, PerRouteConfigCorrectRegionForSigning) {
 }
 
 TEST_F(AwsLambdaFilterTest, DecodeDataRecordsPayloadSize) {
-  FilterSettings settings{arn_, InvocationMode::Synchronous, true /*passthrough*/, ""};
   NiceMock<Stats::MockStore> store;
   NiceMock<Stats::MockHistogram> histogram;
   EXPECT_CALL(store, histogram(_, _)).WillOnce(ReturnRef(histogram));
 
   setupClusterMetadata();
 
-  FilterStats stats(generateStats("test", *store.rootScope()));
-  signer_ = std::make_shared<NiceMock<MockSigner>>();
-  filter_ = std::make_unique<Filter>(settings, stats, signer_, false);
+  auto filter_settings =
+      std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, true, "",
+                                           FilterStats(generateStats("test", *store.rootScope())));
+  filter_ = std::make_unique<Filter>(filter_settings, false);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
   // Payload
@@ -205,7 +235,8 @@ TEST_F(AwsLambdaFilterTest, DecodeDataRecordsPayloadSize) {
 }
 
 TEST_F(AwsLambdaFilterTest, DecodeDataShouldBuffer) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
+  setupClusterMetadata();
   Http::TestRequestHeaderMapImpl headers;
   const auto header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, header_result);
@@ -215,7 +246,7 @@ TEST_F(AwsLambdaFilterTest, DecodeDataShouldBuffer) {
 }
 
 TEST_F(AwsLambdaFilterTest, DecodeDataShouldSign) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
+  auto filter_settings = setupDownstreamFilter(InvocationMode::Synchronous, true, "");
   Http::TestRequestHeaderMapImpl headers;
   const auto header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, header_result);
@@ -224,8 +255,8 @@ TEST_F(AwsLambdaFilterTest, DecodeDataShouldSign) {
   InSequence seq;
   EXPECT_CALL(decoder_callbacks_, addDecodedData(_, false));
   EXPECT_CALL(decoder_callbacks_, decodingBuffer).WillOnce(Return(&buffer));
-  EXPECT_CALL(*signer_, sign(An<Http::RequestHeaderMap&>(), An<const std::string&>(),
-                             An<absl::string_view>()));
+  EXPECT_CALL(*filter_settings->signer_, sign(An<Http::RequestHeaderMap&>(),
+                                              An<const std::string&>(), An<absl::string_view>()));
 
   const auto data_result = filter_->decodeData(buffer, true /*end_stream*/);
   EXPECT_EQ("/2015-03-31/functions/arn:aws:lambda:us-west-2:1337:function:fun/invocations",
@@ -234,15 +265,14 @@ TEST_F(AwsLambdaFilterTest, DecodeDataShouldSign) {
 }
 
 TEST_F(AwsLambdaFilterTest, DecodeDataSigningWithPerRouteConfig) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
 
   const absl::string_view override_region = "us-west-1";
-  const auto per_route_arn =
+  auto route_settings = std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, true, "");
+  route_settings->arn_ =
       parseArn(fmt::format("arn:aws:lambda:{}:1337:function:fun", override_region)).value();
-  FilterSettings route_settings{per_route_arn, InvocationMode::Synchronous, true /*passthrough*/,
-                                ""};
   ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
-      .WillByDefault(Return(&route_settings));
+      .WillByDefault(Return(route_settings.get()));
 
   Http::TestRequestHeaderMapImpl headers;
   const auto header_result = filter_->decodeHeaders(headers, false /*end_stream*/);
@@ -252,7 +282,7 @@ TEST_F(AwsLambdaFilterTest, DecodeDataSigningWithPerRouteConfig) {
   InSequence seq;
   EXPECT_CALL(decoder_callbacks_, addDecodedData(_, false));
   EXPECT_CALL(decoder_callbacks_, decodingBuffer).WillOnce(Return(&buffer));
-  EXPECT_CALL(*signer_,
+  EXPECT_CALL(*route_settings->signer_,
               sign(An<Http::RequestHeaderMap&>(), An<const std::string&>(), override_region));
 
   const auto data_result = filter_->decodeData(buffer, true /*end_stream*/);
@@ -263,7 +293,9 @@ TEST_F(AwsLambdaFilterTest, DecodeDataSigningWithPerRouteConfig) {
 }
 
 TEST_F(AwsLambdaFilterTest, DecodeHeadersInvocationModeSetsHeader) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
+  setupClusterMetadata();
+
   Http::TestRequestHeaderMapImpl headers;
   const auto header_result = filter_->decodeHeaders(headers, true /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, header_result);
@@ -289,7 +321,8 @@ TEST_F(AwsLambdaFilterTest, DecodeHeadersInvocationModeSetsHeader) {
  */
 TEST_F(AwsLambdaFilterTest, DecodeHeadersOnlyRequestWithJsonOn) {
   using source::extensions::filters::http::aws_lambda::Request;
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
+
   Buffer::OwnedImpl json_buf;
   auto on_add_decoded_data = [&json_buf](Buffer::Instance& buf, bool) { json_buf.move(buf); };
   ON_CALL(decoder_callbacks_, addDecodedData(_, _)).WillByDefault(Invoke(on_add_decoded_data));
@@ -337,7 +370,7 @@ TEST_F(AwsLambdaFilterTest, DecodeHeadersOnlyRequestWithJsonOn) {
  */
 TEST_F(AwsLambdaFilterTest, DecodeDataWithTextualBodyWithJsonOn) {
   using source::extensions::filters::http::aws_lambda::Request;
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
 
   Buffer::OwnedImpl decoded_buf;
   constexpr absl::string_view expected_plain_text = "Foo bar bazz";
@@ -406,7 +439,7 @@ TEST_F(AwsLambdaFilterTest, DecodeDataWithTextualBodyWithJsonOn) {
  */
 TEST_F(AwsLambdaFilterTest, DecodeDataWithBinaryBodyWithJsonOn) {
   using source::extensions::filters::http::aws_lambda::Request;
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
 
   Buffer::OwnedImpl decoded_buf;
   const absl::string_view fake_binary_data = "this should get base64 encoded";
@@ -449,12 +482,14 @@ TEST_F(AwsLambdaFilterTest, DecodeDataWithBinaryBodyWithJsonOn) {
 }
 
 TEST_F(AwsLambdaFilterTest, EncodeHeadersEndStreamShouldSkip) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
+
   Http::TestResponseHeaderMapImpl headers;
   auto result = filter_->encodeHeaders(headers, true /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
 
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
+
   result = filter_->encodeHeaders(headers, true /*end_stream*/);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
 }
@@ -464,7 +499,9 @@ TEST_F(AwsLambdaFilterTest, EncodeHeadersEndStreamShouldSkip) {
  * encoding headers and skip the filter.
  */
 TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambdaErrorShouldSkipAndContinue) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
+  setupClusterMetadata();
+
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   headers.addCopy(Http::LowerCaseString("x-Amz-Function-Error"), "unhandled");
@@ -476,7 +513,7 @@ TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambdaErrorShouldSkipAndContinue) {
  * If Lambda returns a 5xx error then we should skip encoding headers and skip the filter.
  */
 TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambda5xxShouldSkipAndContinue) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(500);
   auto result = filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -487,7 +524,7 @@ TEST_F(AwsLambdaFilterTest, EncodeHeadersWithLambda5xxShouldSkipAndContinue) {
  * encodeHeaders() in a happy path should stop iteration.
  */
 TEST_F(AwsLambdaFilterTest, EncodeHeadersStopsIteration) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   auto result = filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -499,17 +536,15 @@ TEST_F(AwsLambdaFilterTest, EncodeHeadersStopsIteration) {
  * This is true whether end_stream is true or false.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataInPassThroughMode) {
-  setupFilter({arn_, InvocationMode::Synchronous, true /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
   Buffer::OwnedImpl buf;
-  filter_->resolveSettings();
   auto result = filter_->encodeData(buf, false /*end_stream*/);
   EXPECT_EQ(Http::FilterDataStatus::Continue, result);
 
   result = filter_->encodeData(buf, true /*end_stream*/);
   EXPECT_EQ(Http::FilterDataStatus::Continue, result);
 
-  setupFilter({arn_, InvocationMode::Asynchronous, true /*passthrough*/, ""});
-  filter_->resolveSettings();
+  setupDownstreamFilter(InvocationMode::Synchronous, true, "");
   result = filter_->encodeData(buf, false /*end_stream*/);
   EXPECT_EQ(Http::FilterDataStatus::Continue, result);
 
@@ -522,9 +557,8 @@ TEST_F(AwsLambdaFilterTest, EncodeDataInPassThroughMode) {
  * This is true whether end_stream is true or false.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataInAsynchrnous) {
-  setupFilter({arn_, InvocationMode::Asynchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Asynchronous, false, "");
   Buffer::OwnedImpl buf;
-  filter_->resolveSettings();
   auto result = filter_->encodeData(buf, false /*end_stream*/);
   EXPECT_EQ(Http::FilterDataStatus::Continue, result);
 
@@ -536,16 +570,14 @@ TEST_F(AwsLambdaFilterTest, EncodeDataInAsynchrnous) {
  * encodeData() data in JSON mode should stop iteration if end_stream is false.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeStopIterationAndBuffer) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Buffer::OwnedImpl buf;
-  filter_->resolveSettings();
   auto result = filter_->encodeData(buf, false /*end_stream*/);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, result);
 }
 
 TEST_F(AwsLambdaFilterTest, EncodeDataAddsLastChunk) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
-  filter_->resolveSettings();
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -561,8 +593,7 @@ TEST_F(AwsLambdaFilterTest, EncodeDataAddsLastChunk) {
  * headers while ignoring any HTTP/2 pseudo-headers.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
-  filter_->resolveSettings();
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -612,8 +643,7 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
  * encodeData() data in JSON mode should respect content-type header.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeContentTypeHeader) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
-  filter_->resolveSettings();
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -647,8 +677,7 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeContentTypeHeader) {
  * base64-encoded.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeBase64EncodedBody) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
-  filter_->resolveSettings();
+  auto filter_settings = setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -689,15 +718,14 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeBase64EncodedBody) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, result);
   EXPECT_STREQ("Beans", encoded_buf.toString().c_str());
 
-  EXPECT_EQ(0ul, filter_->stats().server_error_.value());
+  EXPECT_EQ(0ul, filter_settings->stats_.server_error_.value());
 }
 
 /**
  * Encode data in JSON mode _returning_ invalid JSON payload should result in a 500 error.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeInvalidJson) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, ""});
-  filter_->resolveSettings();
+  auto filter_settings = setupDownstreamFilter(InvocationMode::Synchronous, false, "");
   Http::TestResponseHeaderMapImpl headers;
   headers.setStatus(200);
   filter_->encodeHeaders(headers, false /*end_stream*/);
@@ -724,13 +752,11 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeInvalidJson) {
   ASSERT_NE(nullptr, headers.Status());
   EXPECT_EQ("500", headers.getStatusValue());
 
-  EXPECT_EQ(1ul, filter_->stats().server_error_.value());
+  EXPECT_EQ(1ul, filter_settings->stats_.server_error_.value());
 }
 
 TEST_F(AwsLambdaFilterTest, SignWithHostRewrite) {
-  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/, "new_host"});
-  filter_->resolveSettings();
-
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "new_host");
   Http::TestRequestHeaderMapImpl headers;
   headers.setHost("any_host");
   headers.setPath("/");
@@ -739,6 +765,26 @@ TEST_F(AwsLambdaFilterTest, SignWithHostRewrite) {
 
   EXPECT_EQ("new_host", headers.get_(":authority"));
   EXPECT_EQ("new_host", headers.Host()->value().getStringView());
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
+}
+
+TEST_F(AwsLambdaFilterTest, SignWithHostRewritePerRoute) {
+  setupDownstreamFilter(InvocationMode::Synchronous, false, "new_host");
+
+  auto route_settings = std::make_shared<FilterSettingsMock>(InvocationMode::Synchronous, false,
+                                                             "new_host_per_route");
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig(_))
+      .WillByDefault(Return(route_settings.get()));
+
+  Http::TestRequestHeaderMapImpl headers;
+  headers.setHost("any_host");
+  headers.setPath("/");
+  headers.setMethod("POST");
+  const auto result = filter_->decodeHeaders(headers, true);
+
+  EXPECT_EQ("new_host_per_route", headers.get_(":authority"));
+  EXPECT_EQ("new_host_per_route", headers.Host()->value().getStringView());
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, result);
 }


### PR DESCRIPTION
Commit Message: aws_lambda: add stat_prefix config

Additional Description: It was decided to follow aws_request_signature approach. doing this will make easier in the future to adopt SigV4a.

Risk Level: Low
Testing: yes
Docs Changes: yes
Release Notes: yes
Platform Specific Features: n/a