### PR TITLE
fuzz: adding constraint for slow-start aggression values

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -719,6 +719,7 @@ envoy_cc_test_library(
         ":zone_aware_load_balancer_fuzz_proto_cc_proto",
         "//test/mocks/upstream:host_set_mocks",
         "//test/mocks/upstream:priority_set_mocks",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/upstream/least_request_load_balancer_corpus/small_agression
+++ b/test/common/upstream/least_request_load_balancer_corpus/small_agression
@@ -1,0 +1,85 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 28
+        zum_degraded_hosts: 1811939328
+        random_bytestring: 1870266368
+        random_bytestring: 8
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 33
+        random_bytestring: 4
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      preconnect {
+      }
+    }
+    actions {
+      choose_host {
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 1195853345
+        num_degraded_hosts: 95
+        num_excluded_hosts: 9
+        random_bytestring: 4
+      }
+    }
+    actions {
+      update_health_flags {
+        num_healthy_hosts: 1195853345
+        num_degraded_hosts: 95
+        num_excluded_hosts: 9
+        random_bytestring: 4
+      }
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 8
+      num_hosts_locality_a: 4
+      random_bytestring: 2
+    }
+    seed_for_prng: 5
+  }
+  random_bytestring_for_weights: "$/"
+}
+least_request_lb_config {
+  active_requTrueest_bias {
+    runtime_key: "envoy_"
+  }
+  slow_start_config {
+    slow_start_window {
+      seconds: 2
+    }
+    aggression {
+      default_value: 5.05429155695595e-321
+      runtime_key: "envoy_"
+    }
+    min_weight_percent {
+      value: 5.05429155695595e-321
+    }
+  }
+}
+random_bytestring_for_requests: "@\275"

--- a/test/common/upstream/least_request_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/least_request_load_balancer_fuzz_test.cc
@@ -53,6 +53,15 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::LeastRequestLoadBalancerTestCa
                    MaxChoiceCountForTest);
     return;
   }
+  // Validate the correctness of the Slow-Start config values.
+  if (input.has_least_request_lb_config() &&
+      input.least_request_lb_config().has_slow_start_config()) {
+    if (!ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
+            input.least_request_lb_config().slow_start_config())) {
+      return;
+    }
+  }
+
   const test::common::upstream::ZoneAwareLoadBalancerTestCase& zone_aware_load_balancer_test_case =
       input.zone_aware_load_balancer_test_case();
 

--- a/test/common/upstream/round_robin_load_balancer_corpus/small_aggression
+++ b/test/common/upstream/round_robin_load_balancer_corpus/small_aggression
@@ -1,0 +1,26 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 99
+      random_bytestring: 2
+    }
+    seed_for_prng: 8
+  }
+  need_local_priority_set: true
+  random_bytestring_for_weights: " "
+}
+round_robin_lb_config {
+  slow_start_config {
+    slow_start_window {
+      seconds: 2304
+    }
+    aggression {
+      default_value: 6.42285339593621e-322
+      runtime_key: "RRRRRRRRRRRRRRRRRRRRRRR"
+    }
+    min_weight_percent {
+    }
+  }
+}

--- a/test/common/upstream/round_robin_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/round_robin_load_balancer_fuzz_test.cc
@@ -21,6 +21,14 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::RoundRobinLoadBalancerTestCase
   const test::common::upstream::ZoneAwareLoadBalancerTestCase& zone_aware_load_balancer_test_case =
       input.zone_aware_load_balancer_test_case();
 
+  // Validate the correctness of the Slow-Start config values.
+  if (input.has_round_robin_lb_config() && input.round_robin_lb_config().has_slow_start_config()) {
+    if (!ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
+            input.round_robin_lb_config().slow_start_config())) {
+      return;
+    }
+  }
+
   ZoneAwareLoadBalancerFuzzBase zone_aware_load_balancer_fuzz = ZoneAwareLoadBalancerFuzzBase(
       zone_aware_load_balancer_test_case.need_local_priority_set(),
       zone_aware_load_balancer_test_case.random_bytestring_for_weights());

--- a/test/common/upstream/zone_aware_load_balancer_fuzz_base.cc
+++ b/test/common/upstream/zone_aware_load_balancer_fuzz_base.cc
@@ -67,5 +67,20 @@ void ZoneAwareLoadBalancerFuzzBase::addWeightsToHosts() {
   }
 }
 
+bool ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
+    const envoy::config::cluster::v3::Cluster_SlowStartConfig& slow_start_config) {
+  if (slow_start_config.has_aggression()) {
+    const auto& aggression = slow_start_config.aggression();
+    if (aggression.default_value() < 1e-30) {
+      ENVOY_LOG_MISC(
+          warn,
+          "Aggression value ({}) cannot be smaller than 1e-30, error in slow-start validation",
+          aggression.default_value());
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/zone_aware_load_balancer_fuzz_base.h
+++ b/test/common/upstream/zone_aware_load_balancer_fuzz_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/config/cluster/v3/cluster.pb.h"
+
 #include "test/mocks/upstream/priority_set.h"
 #include "test/test_common/simulated_time_system.h"
 
@@ -49,6 +51,13 @@ public:
   void setupZoneAwareLoadBalancingSpecificLogic();
 
   void addWeightsToHosts();
+
+  // A helper function to validate the SlowStart config values.
+  // TODO(adisuissa): This should probably be reflected in the real LB config
+  // constraints (see https://github.com/envoyproxy/envoy/pull/32506#issuecomment-1970047351).
+  // For now, it is sufficient to validate these constraints only in the fuzzer.
+  static bool
+  validateSlowStart(const envoy::config::cluster::v3::Cluster_SlowStartConfig& slow_start_config);
 
   // If fuzzing Zone Aware Load Balancers, local priority set will get constructed sometimes. If not
   // constructed, a local_priority_set_.get() call will return a nullptr.


### PR DESCRIPTION
Commit Message: fuzz: adding constraint for slow-start aggression values
Additional Description:
Alternative solution to #32506.
The SlowStartConfig has an aggression field, that if set to too small may cause the weights to be very small.
In this PR we limit the aggression value *of fuzz tests*  to be GTE than 1e-30, which I think should be small enough for a reasonable value.
Following [this comment](https://github.com/envoyproxy/envoy/pull/32506#issuecomment-1970047351), more work needs to be done to estimate the correct boundaries of configs.

Risk Level: low - fuzz tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A