### PR TITLE
mobile: Make the opt AAR build use the non-debug .so file

### DIFF
--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -14,8 +14,8 @@ android_artifacts(
     archive_name = "envoy",
     manifest = "EnvoyManifest.xml",
     native_deps = select({
-        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so.debug_info"],
-        "//conditions:default": ["//library/jni:libenvoy_jni.so"],
+        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so"],
+        "//conditions:default": ["//library/jni:libenvoy_jni.so.debug_info"],
     }),
     proguard_rules = "//library:proguard_rules",
     substitutions = {

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -31,8 +31,8 @@ android_artifacts(
     archive_name = "envoy_xds",
     manifest = "EnvoyManifest.xml",
     native_deps = select({
-        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so.debug_info"],
-        "//conditions:default": ["//library/jni:libenvoy_jni.so"],
+        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so"],
+        "//conditions:default": ["//library/jni:libenvoy_jni.so.debug_info"],
     }),
     proguard_rules = "//library:proguard_rules",
     substitutions = {


### PR DESCRIPTION
The opt build should use the non-debug version of libenvoy_jni.so, not the other way around.