### PR TITLE
mobile: Add EngineBuilder::setEngineCallbacks

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -41,7 +41,7 @@ envoy_cc_library(
         "@envoy_api//envoy/extensions/transport_sockets/http_11_proxy/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/raw_buffer/v3:pkg_cc_proto",
-        "@envoy_mobile//library/common:internal_engine_types_lib",
+        "@envoy_mobile//library/common:engine_types_lib",
         "@envoy_mobile//library/common/config:certificates_lib",
         "@envoy_mobile//library/common/extensions/cert_validator/platform_bridge:platform_bridge_cc_proto",
         "@envoy_mobile//library/common/extensions/filters/http/local_error:filter_cc_proto",

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -138,7 +138,7 @@ void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const
 }
 #endif
 
-EngineBuilder::EngineBuilder() : callbacks_(std::make_unique<InternalEngineCallbacks>()) {
+EngineBuilder::EngineBuilder() : callbacks_(std::make_unique<EngineCallbacks>()) {
 #ifndef ENVOY_ENABLE_QUIC
   enable_http3_ = false;
 #endif
@@ -151,6 +151,11 @@ EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
 
 EngineBuilder& EngineBuilder::setLogger(envoy_logger envoy_logger) {
   envoy_logger_.emplace(envoy_logger);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks) {
+  callbacks_ = std::move(callbacks);
   return *this;
 }
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -12,13 +12,11 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
-#include "direct_response_testing.h"
 #include "library/cc/engine.h"
 #include "library/cc/key_value_store.h"
 #include "library/cc/log_level.h"
 #include "library/cc/string_accessor.h"
-#include "library/common/internal_engine_types.h"
-#include "library/common/types/matcher_data.h"
+#include "library/common/engine_types.h"
 
 namespace Envoy {
 namespace Platform {
@@ -128,7 +126,9 @@ public:
 
   EngineBuilder& addLogLevel(LogLevel log_level);
   EngineBuilder& setLogger(envoy_logger envoy_logger);
-  EngineBuilder& setOnEngineRunning(std::function<void()> closure);
+  EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
+  [[deprecated("Use EngineBuilder::setEngineCallbacks instead")]] EngineBuilder&
+  setOnEngineRunning(std::function<void()> closure);
   EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
   EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
   EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
@@ -216,7 +216,7 @@ private:
 
   LogLevel log_level_ = LogLevel::info;
   absl::optional<envoy_logger> envoy_logger_;
-  std::unique_ptr<InternalEngineCallbacks> callbacks_;
+  std::unique_ptr<EngineCallbacks> callbacks_;
 
   int connect_timeout_seconds_ = 30;
   int dns_refresh_seconds_ = 60;

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -24,7 +24,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":engine_common_lib",
-        ":internal_engine_types_lib",
+        ":engine_types_lib",
         "//library/common/bridge:utility_lib",
         "//library/common/data:utility_lib",
         "//library/common/event:provisional_dispatcher_lib",
@@ -76,9 +76,9 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "internal_engine_types_lib",
+    name = "engine_types_lib",
     hdrs = [
-        "internal_engine_types.h",
+        "engine_types.h",
     ],
     repository = "@envoy",
 )

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -14,8 +14,8 @@
 
 namespace Envoy {
 
-/** The callbacks for the `InternalEngine`. */
-struct InternalEngineCallbacks {
+/** The callbacks for the Envoy Engine. */
+struct EngineCallbacks {
   std::function<void()> on_engine_running = [] {};
   std::function<void()> on_exit = [] {};
 };

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -15,8 +15,8 @@ static std::atomic<envoy_stream_t> current_stream_handle_{0};
 
 envoy_stream_t InternalEngine::initStream() { return current_stream_handle_++; }
 
-InternalEngine::InternalEngine(std::unique_ptr<InternalEngineCallbacks> callbacks,
-                               envoy_logger logger, envoy_event_tracker event_tracker,
+InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
+                               envoy_event_tracker event_tracker,
                                Thread::PosixThreadFactoryPtr thread_factory)
     : thread_factory_(std::move(thread_factory)), callbacks_(std::move(callbacks)), logger_(logger),
       event_tracker_(event_tracker), dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
@@ -33,8 +33,8 @@ InternalEngine::InternalEngine(std::unique_ptr<InternalEngineCallbacks> callback
   Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.dfp_mixed_scheme", true);
 }
 
-InternalEngine::InternalEngine(std::unique_ptr<InternalEngineCallbacks> callbacks,
-                               envoy_logger logger, envoy_event_tracker event_tracker)
+InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
+                               envoy_event_tracker event_tracker)
     : InternalEngine(std::move(callbacks), logger, event_tracker,
                      Thread::PosixThreadFactory::create()) {}
 

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -9,8 +9,8 @@
 
 #include "extension_registry.h"
 #include "library/common/engine_common.h"
+#include "library/common/engine_types.h"
 #include "library/common/http/client.h"
-#include "library/common/internal_engine_types.h"
 #include "library/common/logger/logger_delegate.h"
 #include "library/common/network/connectivity_manager.h"
 #include "library/common/types/c_types.h"
@@ -25,7 +25,7 @@ public:
    * @param logger, the callbacks to use for engine logging.
    * @param event_tracker, the event tracker to use for the emission of events.
    */
-  InternalEngine(std::unique_ptr<InternalEngineCallbacks> callbacks, envoy_logger logger,
+  InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
                  envoy_event_tracker event_tracker);
 
   /**
@@ -122,7 +122,7 @@ public:
 private:
   GTEST_FRIEND_CLASS(InternalEngineTest, ThreadCreationFailed);
 
-  InternalEngine(std::unique_ptr<InternalEngineCallbacks> callbacks, envoy_logger logger,
+  InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
                  envoy_event_tracker event_tracker, Thread::PosixThreadFactoryPtr thread_factory);
 
   envoy_status_t main(std::shared_ptr<Envoy::OptionsImplBase> options);
@@ -133,7 +133,7 @@ private:
   Event::Dispatcher* event_dispatcher_{};
   Stats::ScopeSharedPtr client_scope_;
   Stats::StatNameSetPtr stat_name_set_;
-  std::unique_ptr<InternalEngineCallbacks> callbacks_;
+  std::unique_ptr<EngineCallbacks> callbacks_;
   envoy_logger logger_;
   envoy_event_tracker event_tracker_;
   Assert::ActionRegistrationPtr assert_handler_registration_;

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -79,8 +79,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_setLogLevel(JNIEnv* /*env*/, jc
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
     JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context,
     jobject j_event_tracker) {
-  std::unique_ptr<Envoy::InternalEngineCallbacks> callbacks =
-      std::make_unique<Envoy::InternalEngineCallbacks>();
+  std::unique_ptr<Envoy::EngineCallbacks> callbacks = std::make_unique<Envoy::EngineCallbacks>();
 
   jobject retained_on_start_context =
       env->NewGlobalRef(on_start_context); // Required to keep context in memory

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -1,6 +1,7 @@
 #import "library/objective-c/EnvoyEngine.h"
 
 #import "library/cc/engine_builder.h"
+#import "library/cc/direct_response_testing.h"
 #include "source/common/protobuf/utility.h"
 
 @implementation NSString (CXX)

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -395,8 +395,8 @@ static void ios_track_event(envoy_map map, const void *context) {
   }
 
   self.onEngineRunning = onEngineRunning;
-  std::unique_ptr<Envoy::InternalEngineCallbacks> native_callbacks =
-      std::make_unique<Envoy::InternalEngineCallbacks>();
+  std::unique_ptr<Envoy::EngineCallbacks> native_callbacks =
+      std::make_unique<Envoy::EngineCallbacks>();
   native_callbacks->on_engine_running = [self] {
     // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
     // block is necessary to act as a breaker for any Objective-C allocation that happens.


### PR DESCRIPTION
This PR adds a new API `EngineBuilder::setEngineCallbacks` to allow setting the `Engine` callbacks. It also deprecates `EngineBuilder::setOnEngineRunning` since the same thing can be achieved by using `EngineBuilder::setEngineCallbacks`.

By introducing `EngineBuilder::setEngineCallbacks`, the C++ API now has support for `on_exit` callback similar to the other languages. The goal is to make the C++ API a first-class citizen instead of a low-level implementation for the other languages.

Risk Level: low (not used)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
