### PR TITLE
Migrate from github.com/golang/protobuf to google.golang.org/protobuf

### DIFF
--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -1,8 +1,8 @@
 load("@com_envoyproxy_protoc_gen_validate//bazel:pgv_proto_library.bzl", "pgv_cc_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("@com_github_grpc_grpc//bazel:python_rules.bzl", _py_proto_library = "py_proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//bazel:external_proto_deps.bzl",
@@ -154,14 +154,13 @@ def api_proto_package(
         [_go_proto_mapping(dep) for dep in deps] +
         [
             "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
-            "@com_github_golang_protobuf//ptypes:go_default_library_gen",
             "@go_googleapis//google/api:annotations_go_proto",
             "@go_googleapis//google/rpc:status_go_proto",
-            "@io_bazel_rules_go//proto/wkt:any_go_proto",
-            "@io_bazel_rules_go//proto/wkt:duration_go_proto",
-            "@io_bazel_rules_go//proto/wkt:struct_go_proto",
-            "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
-            "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+            "@org_golang_google_protobuf//types/known/anypb:go_default_library",
+            "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
+            "@org_golang_google_protobuf//types/known/structpb:go_default_library",
+            "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
+            "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
             "@com_github_planetscale_vtprotobuf//types/known/anypb",
             "@com_github_planetscale_vtprotobuf//types/known/durationpb",
             "@com_github_planetscale_vtprotobuf//types/known/emptypb",

--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -39,9 +39,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "xDS API Working Group (xDS-WG)",
         project_url = "https://github.com/cncf/xds",
         # During the UDPA -> xDS migration, we aren't working with releases.
-        version = "ee0267137e252710af66562e0d54bcf8669b74b1",
-        sha256 = "0adcd7a74d5158f710612f38e5b9ec8bd4aabd2f53ff7905e0c198028ca68dfc",
-        release_date = "2024-03-12",
+        version = "6b7cb9e61ad79c99765a1dea2bede517d1b7db3e",
+        sha256 = "8671884372d3af43478d6de3e05a653fffdbbe1acc6e827680e2125a0120ccd2",
+        release_date = "2024-03-22",
         strip_prefix = "xds-{version}",
         urls = ["https://github.com/cncf/xds/archive/{version}.tar.gz"],
         use_category = ["api"],


### PR DESCRIPTION
Commit Message: Migrate from github.com/golang/protobuf to google.golang.org/protobuf
Additional Description: `github.com/golang/protobuf` has been superseded by `google.golang.org/protobuf`
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
