### PR TITLE
mobile: Remove envoy_logger C wrapper type

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -149,8 +149,8 @@ EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setLogger(envoy_logger envoy_logger) {
-  envoy_logger_.emplace(envoy_logger);
+EngineBuilder& EngineBuilder::setLogger(std::unique_ptr<EnvoyLogger> logger) {
+  logger_ = std::move(logger);
   return *this;
 }
 
@@ -897,16 +897,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 }
 
 EngineSharedPtr EngineBuilder::build() {
-  envoy_logger null_logger;
-  null_logger.log = nullptr;
-  null_logger.release = envoy_noop_const_release;
-  null_logger.context = nullptr;
-
   envoy_event_tracker null_tracker{};
 
   InternalEngine* envoy_engine =
-      new InternalEngine(std::move(callbacks_),
-                         (envoy_logger_.has_value()) ? *envoy_logger_ : null_logger, null_tracker);
+      new InternalEngine(std::move(callbacks_), std::move(logger_), null_tracker);
 
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -125,7 +125,7 @@ public:
   virtual ~EngineBuilder() = default;
 
   EngineBuilder& addLogLevel(LogLevel log_level);
-  EngineBuilder& setLogger(envoy_logger envoy_logger);
+  EngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
   EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
   [[deprecated("Use EngineBuilder::setEngineCallbacks instead")]] EngineBuilder&
   setOnEngineRunning(std::function<void()> closure);
@@ -215,7 +215,7 @@ private:
   };
 
   LogLevel log_level_ = LogLevel::info;
-  absl::optional<envoy_logger> envoy_logger_;
+  std::unique_ptr<EnvoyLogger> logger_{nullptr};
   std::unique_ptr<EngineCallbacks> callbacks_;
 
   int connect_timeout_seconds_ = 30;

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -81,4 +81,7 @@ envoy_cc_library(
         "engine_types.h",
     ],
     repository = "@envoy",
+    deps = [
+        "@envoy//source/common/common:base_logger_lib",
+    ],
 )

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -11,12 +11,22 @@
 // https://github.com/apple/swift/blob/swift-5.7.3-RELEASE/docs/CppInteroperability/CppInteroperabilityStatus.md
 
 #include <functional>
+#include <string>
+
+#include "source/common/common/base_logger.h"
 
 namespace Envoy {
 
 /** The callbacks for the Envoy Engine. */
 struct EngineCallbacks {
   std::function<void()> on_engine_running = [] {};
+  std::function<void()> on_exit = [] {};
+};
+
+/** The callbacks for Envoy Logger. */
+struct EnvoyLogger {
+  std::function<void(Logger::Logger::Levels, const std::string&)> on_log =
+      [](Logger::Logger::Levels, const std::string&) {};
   std::function<void()> on_exit = [] {};
 };
 

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -15,11 +15,13 @@ static std::atomic<envoy_stream_t> current_stream_handle_{0};
 
 envoy_stream_t InternalEngine::initStream() { return current_stream_handle_++; }
 
-InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
+InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks,
+                               std::unique_ptr<EnvoyLogger> logger,
                                envoy_event_tracker event_tracker,
                                Thread::PosixThreadFactoryPtr thread_factory)
-    : thread_factory_(std::move(thread_factory)), callbacks_(std::move(callbacks)), logger_(logger),
-      event_tracker_(event_tracker), dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
+    : thread_factory_(std::move(thread_factory)), callbacks_(std::move(callbacks)),
+      logger_(std::move(logger)), event_tracker_(event_tracker),
+      dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
   ExtensionRegistry::registerFactories();
 
   // TODO(Augustyniak): Capturing an address of event_tracker_ and registering it in the API
@@ -33,9 +35,10 @@ InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy
   Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.dfp_mixed_scheme", true);
 }
 
-InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
+InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks,
+                               std::unique_ptr<EnvoyLogger> logger,
                                envoy_event_tracker event_tracker)
-    : InternalEngine(std::move(callbacks), logger, event_tracker,
+    : InternalEngine(std::move(callbacks), std::move(logger), event_tracker,
                      Thread::PosixThreadFactory::create()) {}
 
 envoy_status_t InternalEngine::run(const std::string& config, const std::string& log_level) {
@@ -81,9 +84,9 @@ envoy_status_t InternalEngine::main(std::shared_ptr<Envoy::OptionsImplBase> opti
       }
 
       // We let the thread clean up this log delegate pointer
-      if (logger_.log) {
-        log_delegate_ptr_ =
-            std::make_unique<Logger::LambdaDelegate>(logger_, Logger::Registry::getSink());
+      if (logger_ != nullptr) {
+        log_delegate_ptr_ = std::make_unique<Logger::LambdaDelegate>(std::move(logger_),
+                                                                     Logger::Registry::getSink());
       } else {
         log_delegate_ptr_ =
             std::make_unique<Logger::DefaultDelegate>(log_mutex_, Logger::Registry::getSink());

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -25,7 +25,7 @@ public:
    * @param logger, the callbacks to use for engine logging.
    * @param event_tracker, the event tracker to use for the emission of events.
    */
-  InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
+  InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
                  envoy_event_tracker event_tracker);
 
   /**
@@ -122,7 +122,7 @@ public:
 private:
   GTEST_FRIEND_CLASS(InternalEngineTest, ThreadCreationFailed);
 
-  InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, envoy_logger logger,
+  InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
                  envoy_event_tracker event_tracker, Thread::PosixThreadFactoryPtr thread_factory);
 
   envoy_status_t main(std::shared_ptr<Envoy::OptionsImplBase> options);
@@ -134,7 +134,7 @@ private:
   Stats::ScopeSharedPtr client_scope_;
   Stats::StatNameSetPtr stat_name_set_;
   std::unique_ptr<EngineCallbacks> callbacks_;
-  envoy_logger logger_;
+  std::unique_ptr<EnvoyLogger> logger_;
   envoy_event_tracker event_tracker_;
   Assert::ActionRegistrationPtr assert_handler_registration_;
   Assert::ActionRegistrationPtr bug_handler_registration_;

--- a/mobile/library/common/logger/BUILD
+++ b/mobile/library/common/logger/BUILD
@@ -10,6 +10,7 @@ envoy_cc_library(
     hdrs = ["logger_delegate.h"],
     repository = "@envoy",
     deps = [
+        "//library/common:engine_types_lib",
         "//library/common/api:external_api_lib",
         "//library/common/bridge:utility_lib",
         "//library/common/data:utility_lib",

--- a/mobile/library/common/logger/logger_delegate.cc
+++ b/mobile/library/common/logger/logger_delegate.cc
@@ -3,35 +3,9 @@
 #include <iostream>
 
 #include "library/common/bridge/utility.h"
-#include "library/common/data/utility.h"
 
 namespace Envoy {
 namespace Logger {
-
-namespace {
-
-envoy_log_level toEnvoyLogLevel(spdlog::level::level_enum spd_log_level) {
-  switch (spd_log_level) {
-  case spdlog::level::trace:
-    return envoy_log_level::ENVOY_LOG_LEVEL_TRACE;
-  case spdlog::level::debug:
-    return envoy_log_level::ENVOY_LOG_LEVEL_DEBUG;
-  case spdlog::level::info:
-    return envoy_log_level::ENVOY_LOG_LEVEL_INFO;
-  case spdlog::level::warn:
-    return envoy_log_level::ENVOY_LOG_LEVEL_WARN;
-  case spdlog::level::err:
-    return envoy_log_level::ENVOY_LOG_LEVEL_ERROR;
-  case spdlog::level::critical:
-    return envoy_log_level::ENVOY_LOG_LEVEL_CRITICAL;
-  case spdlog::level::off:
-    return envoy_log_level::ENVOY_LOG_LEVEL_OFF;
-  default:
-    PANIC("not implemented");
-  }
-}
-
-} //  namespace
 
 void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, absl::string_view,
                                               absl::string_view, absl::string_view msg) {
@@ -45,19 +19,20 @@ void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, abs
                        event_tracker_.context);
 }
 
-LambdaDelegate::LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink)
-    : EventTrackingDelegate(log_sink), logger_(logger) {
+LambdaDelegate::LambdaDelegate(std::unique_ptr<EnvoyLogger> logger,
+                               DelegatingLogSinkSharedPtr log_sink)
+    : EventTrackingDelegate(log_sink), logger_(std::move(logger)) {
   setDelegate();
 }
 
 LambdaDelegate::~LambdaDelegate() {
   restoreDelegate();
-  logger_.release(logger_.context);
+  logger_->on_exit();
 }
 
 void LambdaDelegate::log(absl::string_view msg, const spdlog::details::log_msg& log_msg) {
-  logger_.log(toEnvoyLogLevel(log_msg.level), Data::Utility::copyToBridgeData(msg),
-              logger_.context);
+  // Logger::Levels is simply an alias to spdlog::level::level_enum, so we can safely cast it.
+  logger_->on_log(static_cast<Logger::Levels>(log_msg.level), std::string(msg));
 }
 
 DefaultDelegate::DefaultDelegate(absl::Mutex& mutex, DelegatingLogSinkSharedPtr log_sink)

--- a/mobile/library/common/logger/logger_delegate.h
+++ b/mobile/library/common/logger/logger_delegate.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <iostream>
-#include <string>
 
 #include "source/common/common/logger.h"
 
 #include "absl/strings/string_view.h"
 #include "library/common/api/external.h"
+#include "library/common/engine_types.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -28,7 +28,7 @@ private:
 using EventTrackingDelegatePtr = std::unique_ptr<EventTrackingDelegate>;
 class LambdaDelegate : public EventTrackingDelegate {
 public:
-  LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink);
+  LambdaDelegate(std::unique_ptr<EnvoyLogger> logger, DelegatingLogSinkSharedPtr log_sink);
   ~LambdaDelegate() override;
 
   // SinkDelegate
@@ -37,7 +37,7 @@ public:
   void flush() override{};
 
 private:
-  envoy_logger logger_;
+  std::unique_ptr<EnvoyLogger> logger_{nullptr};
 };
 
 // A default log delegate that logs to stderr, mimicking the default used by Envoy

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -222,17 +222,6 @@ typedef struct {
   int64_t upstream_protocol;
 } envoy_final_stream_intel;
 
-/** The log level for the Envoy logger. The values should match with `Logger::Levels`. */
-typedef enum {
-  ENVOY_LOG_LEVEL_TRACE = 0,
-  ENVOY_LOG_LEVEL_DEBUG = 1,
-  ENVOY_LOG_LEVEL_INFO = 2,
-  ENVOY_LOG_LEVEL_WARN = 3,
-  ENVOY_LOG_LEVEL_ERROR = 4,
-  ENVOY_LOG_LEVEL_CRITICAL = 5,
-  ENVOY_LOG_LEVEL_OFF = 6,
-} envoy_log_level;
-
 #ifdef __cplusplus
 extern "C" { // utility functions
 #endif
@@ -408,24 +397,6 @@ typedef void (*envoy_on_cancel_f)(envoy_stream_intel stream_intel,
                                   envoy_final_stream_intel final_stream_intel, void* context);
 
 /**
- * Called when envoy's logger logs data.
- *
- * @param level the log level
- * @param data, the logged data.
- * @param context, contains the necessary state to carry out platform-specific dispatch and
- * execution.
- */
-typedef void (*envoy_logger_log_f)(envoy_log_level level, envoy_data data, const void* context);
-
-/**
- * Called when Envoy is done with the logger.
- *
- * @param context, contains the necessary state to carry out platform-specific dispatch and
- * execution.
- */
-typedef void (*envoy_logger_release_f)(const void* context);
-
-/**
  * Callback signature which notify when there is buffer available for request
  * body upload.
  *
@@ -468,16 +439,6 @@ typedef struct {
   // Context passed through to callbacks to provide dispatch and execution state.
   void* context;
 } envoy_http_callbacks;
-
-/**
- * Interface for logging.
- */
-typedef struct {
-  envoy_logger_log_f log;
-  envoy_logger_release_f release;
-  // Context passed through to callbacks to provide dispatch and execution state.
-  const void* context;
-} envoy_logger;
 
 /**
  * Interface for event tracking.

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -33,24 +33,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
 
 // JniLibrary
 
-static void jvm_on_log(envoy_log_level log_level, envoy_data data, const void* context) {
-  if (context == nullptr) {
-    return;
-  }
-
-  Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
-  Envoy::JNI::LocalRefUniquePtr<jstring> str = Envoy::JNI::envoyDataToJavaString(jni_helper, data);
-
-  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
-  Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmLoggerContext =
-      jni_helper.getObjectClass(j_context);
-  jmethodID jmid_onLog =
-      jni_helper.getMethodId(jcls_JvmLoggerContext.get(), "log", "(ILjava/lang/String;)V");
-  jni_helper.callVoidMethod(j_context, jmid_onLog, log_level, str.get());
-
-  release_envoy_data(data);
-}
-
 static void jvm_on_track(envoy_map events, const void* context) {
   if (context == nullptr) {
     return;
@@ -79,10 +61,10 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_setLogLevel(JNIEnv* /*env*/, jc
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
     JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context,
     jobject j_event_tracker) {
-  std::unique_ptr<Envoy::EngineCallbacks> callbacks = std::make_unique<Envoy::EngineCallbacks>();
 
   jobject retained_on_start_context =
       env->NewGlobalRef(on_start_context); // Required to keep context in memory
+  std::unique_ptr<Envoy::EngineCallbacks> callbacks = std::make_unique<Envoy::EngineCallbacks>();
   callbacks->on_engine_running = [retained_on_start_context] {
     Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
     Envoy::JNI::LocalRefUniquePtr<jclass> jcls_JvmonEngineRunningContext =
@@ -96,7 +78,6 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     // This will need to be updated for https://github.com/envoyproxy/envoy-mobile/issues/332
     jni_helper.getEnv()->DeleteGlobalRef(retained_on_start_context);
   };
-
   callbacks->on_exit = [] {
     // Note that this is not dispatched because the thread that
     // needs to be detached is the engine thread.
@@ -106,10 +87,22 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   };
 
   const jobject retained_logger_context = env->NewGlobalRef(envoy_logger_context);
-  envoy_logger logger = {nullptr, nullptr, nullptr};
-  if (envoy_logger_context != nullptr) {
-    logger = envoy_logger{jvm_on_log, Envoy::JNI::jniDeleteConstGlobalRef, retained_logger_context};
-  }
+  std::unique_ptr<Envoy::EnvoyLogger> logger = std::make_unique<Envoy::EnvoyLogger>();
+  logger->on_log = [retained_logger_context](Envoy::Logger::Logger::Levels level,
+                                             const std::string& message) {
+    Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
+    Envoy::JNI::LocalRefUniquePtr<jstring> java_message = jni_helper.newStringUtf(message.c_str());
+    jint java_level = static_cast<jint>(level);
+    Envoy::JNI::LocalRefUniquePtr<jclass> java_envoy_logger_class =
+        jni_helper.getObjectClass(retained_logger_context);
+    jmethodID java_log_method_id =
+        jni_helper.getMethodId(java_envoy_logger_class.get(), "log", "(ILjava/lang/String;)V");
+    jni_helper.callVoidMethod(retained_logger_context, java_log_method_id, java_level,
+                              java_message.get());
+  };
+  logger->on_exit = [retained_logger_context] {
+    Envoy::JNI::getEnv()->DeleteGlobalRef(retained_logger_context);
+  };
 
   envoy_event_tracker event_tracker = {nullptr, nullptr};
   if (j_event_tracker != nullptr) {
@@ -121,7 +114,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   }
 
   return reinterpret_cast<intptr_t>(
-      new Envoy::InternalEngine(std::move(callbacks), logger, event_tracker));
+      new Envoy::InternalEngine(std::move(callbacks), std::move(logger), event_tracker));
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(

--- a/mobile/library/objective-c/EnvoyEngine.h
+++ b/mobile/library/objective-c/EnvoyEngine.h
@@ -94,8 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
 // Concrete implementation of the `EnvoyEngine` interface.
 @interface EnvoyEngineImpl : NSObject <EnvoyEngine>
 
-@property (nonatomic, copy, nullable) void (^onEngineRunning)();
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -20,17 +20,6 @@
 - (std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap>)generateBootstrap;
 @end
 
-static void ios_on_log(envoy_log_level log_level, envoy_data data, const void *context) {
-  // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
-  // is necessary to act as a breaker for any Objective-C allocation that happens.
-  @autoreleasepool {
-    EnvoyLogger *logger = (__bridge EnvoyLogger *)context;
-    logger.log(log_level, to_ios_string(data));
-  }
-}
-
-static void ios_on_logger_release(const void *context) { CFRelease(context); }
-
 static const void *ios_http_filter_init(const void *context) {
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
   // is necessary to act as a breaker for any Objective-C allocation that happens.
@@ -394,15 +383,14 @@ static void ios_track_event(envoy_map map, const void *context) {
     return nil;
   }
 
-  self.onEngineRunning = onEngineRunning;
   std::unique_ptr<Envoy::EngineCallbacks> native_callbacks =
       std::make_unique<Envoy::EngineCallbacks>();
-  native_callbacks->on_engine_running = [self] {
+  native_callbacks->on_engine_running = [onEngineRunning = std::move(onEngineRunning)] {
     // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
     // block is necessary to act as a breaker for any Objective-C allocation that happens.
     @autoreleasepool {
-      if (self.onEngineRunning) {
-        self.onEngineRunning();
+      if (onEngineRunning) {
+        onEngineRunning();
       }
     }
   };
@@ -414,12 +402,16 @@ static void ios_track_event(envoy_map map, const void *context) {
     }
   };
 
-  envoy_logger native_logger = {NULL, NULL, NULL};
+  std::unique_ptr<Envoy::EnvoyLogger> native_logger = std::make_unique<Envoy::EnvoyLogger>();
   if (logger) {
-    EnvoyLogger *objcLogger = [[EnvoyLogger alloc] initWithLogClosure:logger];
-    native_logger.log = ios_on_log;
-    native_logger.release = ios_on_logger_release;
-    native_logger.context = CFBridgingRetain(objcLogger);
+    native_logger->on_log = [logger = std::move(logger)](Envoy::Logger::Logger::Levels level,
+                                                         const std::string &message) {
+      // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
+      // block is necessary to act as a breaker for any Objective-C allocation that happens.
+      @autoreleasepool {
+        logger(level, @(message.c_str()));
+      }
+    };
   }
 
   // TODO(Augustyniak): Everything here leaks, but it's all tied to the life of the engine.
@@ -432,8 +424,8 @@ static void ios_track_event(envoy_map map, const void *context) {
     native_event_tracker.context = CFBridgingRetain(objcEventTracker);
   }
 
-  _engine =
-      new Envoy::InternalEngine(std::move(native_callbacks), native_logger, native_event_tracker);
+  _engine = new Envoy::InternalEngine(std::move(native_callbacks), std::move(native_logger),
+                                      native_event_tracker);
   _engineHandle = reinterpret_cast<envoy_engine_t>(_engine);
 
   if (networkMonitoringMode == 1) {


### PR DESCRIPTION
This PR removes the `envoy_logger` C wrapper type and replaces it with the standard C++ code.

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
