### PR TITLE
pgv_plugin_go : Use protoc_gen_validate instead of envoy_api

### DIFF
--- a/api/bazel/BUILD
+++ b/api/bazel/BUILD
@@ -18,15 +18,6 @@ exports_files([
 ])
 
 go_proto_compiler(
-    name = "pgv_plugin_go",
-    options = ["lang=go"],
-    plugin = "@com_envoyproxy_protoc_gen_validate//:protoc-gen-validate",
-    suffix = ".pb.validate.go",
-    valid_archive = False,
-    visibility = ["//visibility:public"],
-)
-
-go_proto_compiler(
     name = "vtprotobuf_plugin_go",
     options = ["features=marshal_strict+size"],
     plugin = "@com_github_planetscale_vtprotobuf//cmd/protoc-gen-go-vtproto",

--- a/api/bazel/api_build_system.bzl
+++ b/api/bazel/api_build_system.bzl
@@ -146,9 +146,9 @@ def api_proto_package(
         has_services = has_services,
     )
 
-    compilers = ["@io_bazel_rules_go//proto:go_proto", "@envoy_api//bazel:pgv_plugin_go", "@envoy_api//bazel:vtprotobuf_plugin_go"]
+    compilers = ["@io_bazel_rules_go//proto:go_proto", "@com_envoyproxy_protoc_gen_validate//bazel/go:pgv_plugin_go", "@envoy_api//bazel:vtprotobuf_plugin_go"]
     if has_services:
-        compilers = ["@io_bazel_rules_go//proto:go_grpc", "@envoy_api//bazel:pgv_plugin_go", "@envoy_api//bazel:vtprotobuf_plugin_go"]
+        compilers = ["@io_bazel_rules_go//proto:go_grpc", "@com_envoyproxy_protoc_gen_validate//bazel/go:pgv_plugin_go", "@envoy_api//bazel:vtprotobuf_plugin_go"]
 
     deps = (
         [_go_proto_mapping(dep) for dep in deps] +


### PR DESCRIPTION
Commit Message: pgv_plugin_go : Use protoc_gen_validate instead of envoy_api
Additional Description: protoc_gen_validate  has an official declaration of the pgv_plugin_go
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
