### PR TITLE
mobile: Add EngineBuilder::setLogLevel

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -145,6 +145,13 @@ EngineBuilder::EngineBuilder() : callbacks_(std::make_unique<EngineCallbacks>())
 }
 
 EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
+  // Envoy::Platform::LogLevel is essentially the same as Logger::Logger::Levels, so we can
+  // safely cast it.
+  log_level_ = static_cast<Logger::Logger::Levels>(log_level);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setLogLevel(Logger::Logger::Levels log_level) {
   log_level_ = log_level;
   return *this;
 }
@@ -933,7 +940,10 @@ EngineSharedPtr EngineBuilder::build() {
   if (bootstrap) {
     options->setConfigProto(std::move(bootstrap));
   }
-  ENVOY_BUG(options->setLogLevel(logLevelToString(log_level_)).ok(), "invalid log level");
+  ENVOY_BUG(
+      options->setLogLevel(logLevelToString(static_cast<Envoy::Platform::LogLevel>(log_level_)))
+          .ok(),
+      "invalid log level");
   options->setConcurrency(1);
   envoy_engine->run(options);
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -124,7 +124,9 @@ public:
   EngineBuilder(EngineBuilder&&) = default;
   virtual ~EngineBuilder() = default;
 
-  EngineBuilder& addLogLevel(LogLevel log_level);
+  [[deprecated("Use EngineBuilder::setLogLevel instead")]] EngineBuilder&
+  addLogLevel(LogLevel log_level);
+  EngineBuilder& setLogLevel(Logger::Logger::Levels log_level);
   EngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
   EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
   [[deprecated("Use EngineBuilder::setEngineCallbacks instead")]] EngineBuilder&
@@ -214,7 +216,7 @@ private:
     std::string typed_config_;
   };
 
-  LogLevel log_level_ = LogLevel::info;
+  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
   std::unique_ptr<EnvoyLogger> logger_{nullptr};
   std::unique_ptr<EngineCallbacks> callbacks_;
 

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -493,7 +493,7 @@ TEST_F(InternalEngineTest, SetLogger) {
   absl::Notification engine_running;
   Platform::EngineBuilder engine_builder;
   Platform::EngineSharedPtr engine =
-      engine_builder.addLogLevel(Platform::LogLevel::debug)
+      engine_builder.setLogLevel(Logger::Logger::debug)
           .setLogger(std::move(logger))
           .setOnEngineRunning([&] { engine_running.Notify(); })
           .addNativeFilter(


### PR DESCRIPTION
This PR adds `EngineBuilder::setLogLevel` and deprecates `EngineBuilder::addLogLevel`. The `EngineBuilder::setLogLevel` takes `Envoy::Logger::Logger::Levels` directly instead of `Envoy::Platform::LogLevel`, which is a wrapper around `Envoy::Logger::Logger::Levels`. Eventually, we will remove the `Envoy::Platform::LogLevel`.

Risk Level: low (a new function)
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
