### PR TITLE
Enable static validation of the EVENT log macros

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -158,6 +158,17 @@ void DelegatingLogSink::setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; 
 
 SinkDelegate* DelegatingLogSink::tlsDelegate() { return *tlsSink(); }
 
+void DelegatingLogSink::logWithStableName(absl::string_view stable_name, absl::string_view level,
+                                          absl::string_view component, absl::string_view message) {
+  auto tls_sink = tlsDelegate();
+  if (tls_sink != nullptr) {
+    tls_sink->logWithStableName(stable_name, level, component, message);
+    return;
+  }
+  absl::ReaderMutexLock sink_lock(&sink_mutex_);
+  sink_->logWithStableName(stable_name, level, component, message);
+}
+
 static std::atomic<Context*> current_context = nullptr;
 static_assert(std::atomic<Context*>::is_always_lock_free);
 


### PR DESCRIPTION
Commit Message:
The fmt::runtime method prevents static validation of format strings. This change eliminates the need for fmt::runtime by formatting the message before calling the `logWithStableName` method.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
