### PR TITLE
mobile: Add Envoy::Platform::Engine tests

### DIFF
--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -1,0 +1,19 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
+load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_package()
+
+envoy_cc_test(
+    name = "engine_test",
+    srcs = envoy_select_enable_yaml(
+        ["engine_test.cc"],
+        "@envoy",
+    ),
+    repository = "@envoy",
+    deps = [
+        "//library/cc:engine_builder_lib",
+        "@envoy_build_config//:test_extensions",
+    ],
+)

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -1,0 +1,115 @@
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/engine_builder.h"
+
+namespace Envoy {
+
+TEST(EngineTest, SetLogger) {
+  std::atomic logging_was_called{false};
+  auto logger = std::make_unique<EnvoyLogger>();
+  logger->on_log = [&](Logger::Logger::Levels, const std::string&) { logging_was_called = true; };
+
+  absl::Notification engine_running;
+  auto engine_callbacks = std::make_unique<EngineCallbacks>();
+  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
+  Platform::EngineBuilder engine_builder;
+  Platform::EngineSharedPtr engine =
+      engine_builder.setLogLevel(Logger::Logger::debug)
+          .setLogger(std::move(logger))
+          .setEngineCallbacks(std::move(engine_callbacks))
+          .addNativeFilter(
+              "test_remote_response",
+              "{'@type': "
+              "type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+          .build();
+  engine_running.WaitForNotification();
+
+  int actual_status_code = 0;
+  bool actual_end_stream = false;
+  absl::Notification stream_complete;
+  auto stream_prototype = engine->streamClient()->newStreamPrototype();
+  auto stream = (*stream_prototype)
+                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
+                                      envoy_stream_intel) {
+                      actual_status_code = headers->httpStatus();
+                      actual_end_stream = end_stream;
+                    })
+                    .setOnData([&](envoy_data data, bool end_stream) {
+                      actual_end_stream = end_stream;
+                      release_envoy_data(data);
+                    })
+                    .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
+                      stream_complete.Notify();
+                    })
+                    .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                                    envoy_final_stream_intel) { stream_complete.Notify(); })
+                    .setOnCancel([&](envoy_stream_intel, envoy_final_stream_intel) {
+                      stream_complete.Notify();
+                    })
+                    .start();
+
+  auto request_headers =
+      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https", "example.com", "/")
+          .build();
+  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_EQ(actual_end_stream, true);
+  EXPECT_TRUE(logging_was_called.load());
+  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
+}
+
+TEST(EngineTest, SetEngineCallbacks) {
+  absl::Notification engine_running;
+  auto engine_callbacks = std::make_unique<EngineCallbacks>();
+  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
+  Platform::EngineBuilder engine_builder;
+  Platform::EngineSharedPtr engine =
+      engine_builder.setLogLevel(Logger::Logger::debug)
+          .setEngineCallbacks(std::move(engine_callbacks))
+          .addNativeFilter(
+              "test_remote_response",
+              "{'@type': "
+              "type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+          .build();
+  engine_running.WaitForNotification();
+
+  int actual_status_code = 0;
+  bool actual_end_stream = false;
+  absl::Notification stream_complete;
+  auto stream_prototype = engine->streamClient()->newStreamPrototype();
+  auto stream = (*stream_prototype)
+                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
+                                      envoy_stream_intel) {
+                      actual_status_code = headers->httpStatus();
+                      actual_end_stream = end_stream;
+                    })
+                    .setOnData([&](envoy_data data, bool end_stream) {
+                      actual_end_stream = end_stream;
+                      release_envoy_data(data);
+                    })
+                    .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
+                      stream_complete.Notify();
+                    })
+                    .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                                    envoy_final_stream_intel) { stream_complete.Notify(); })
+                    .setOnCancel([&](envoy_stream_intel, envoy_final_stream_intel) {
+                      stream_complete.Notify();
+                    })
+                    .start();
+
+  auto request_headers =
+      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https", "example.com", "/")
+          .build();
+  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_EQ(actual_end_stream, true);
+  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
+}
+
+} // namespace Envoy

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -19,9 +19,7 @@ namespace Envoy {
 
 using testing::_;
 using testing::ByMove;
-using testing::HasSubstr;
 using testing::Return;
-using testing::ReturnRef;
 
 // This config is the minimal envoy mobile config that allows for running the engine.
 const std::string MINIMAL_TEST_CONFIG = R"(
@@ -485,61 +483,6 @@ TEST_F(InternalEngineTest, ResetConnectivityState) {
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
-TEST_F(InternalEngineTest, SetLogger) {
-  std::atomic<bool> logging_was_called{false};
-  auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log = [&](Logger::Logger::Levels, const std::string&) { logging_was_called = true; };
-
-  absl::Notification engine_running;
-  Platform::EngineBuilder engine_builder;
-  Platform::EngineSharedPtr engine =
-      engine_builder.setLogLevel(Logger::Logger::debug)
-          .setLogger(std::move(logger))
-          .setOnEngineRunning([&] { engine_running.Notify(); })
-          .addNativeFilter(
-              "test_remote_response",
-              "{'@type': "
-              "type.googleapis.com/"
-              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
-          .build();
-  engine_running.WaitForNotification();
-
-  int actual_status_code = 0;
-  bool actual_end_stream = false;
-  absl::Notification stream_complete;
-  auto stream_prototype = engine->streamClient()->newStreamPrototype();
-  auto stream = (*stream_prototype)
-                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
-                                      envoy_stream_intel) {
-                      actual_status_code = headers->httpStatus();
-                      actual_end_stream = end_stream;
-                    })
-                    .setOnData([&](envoy_data data, bool end_stream) {
-                      actual_end_stream = end_stream;
-                      release_envoy_data(data);
-                    })
-                    .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
-                      stream_complete.Notify();
-                    })
-                    .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
-                                    envoy_final_stream_intel) { stream_complete.Notify(); })
-                    .setOnCancel([&](envoy_stream_intel, envoy_final_stream_intel) {
-                      stream_complete.Notify();
-                    })
-                    .start();
-
-  auto request_headers =
-      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https", "example.com", "/")
-          .build();
-  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
-  stream_complete.WaitForNotification();
-
-  EXPECT_EQ(actual_status_code, 200);
-  EXPECT_EQ(actual_end_stream, true);
-  EXPECT_TRUE(logging_was_called.load());
-  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
-}
-
 TEST_F(InternalEngineTest, ThreadCreationFailed) {
   EngineTestContext test_context{};
   auto thread_factory = std::make_unique<Thread::MockPosixThreadFactory>();
@@ -550,57 +493,6 @@ TEST_F(InternalEngineTest, ThreadCreationFailed) {
   EXPECT_EQ(status, ENVOY_FAILURE);
   // Calling `terminate()` should not crash.
   EXPECT_EQ(engine->terminate(), ENVOY_FAILURE);
-}
-
-TEST_F(InternalEngineTest, SetEngineCallbacks) {
-  absl::Notification engine_running;
-  auto engine_callbacks = std::make_unique<EngineCallbacks>();
-  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
-  Platform::EngineBuilder engine_builder;
-  Platform::EngineSharedPtr engine =
-      engine_builder.addLogLevel(Platform::LogLevel::debug)
-          .setEngineCallbacks(std::move(engine_callbacks))
-          .addNativeFilter(
-              "test_remote_response",
-              "{'@type': "
-              "type.googleapis.com/"
-              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
-          .build();
-  engine_running.WaitForNotification();
-
-  int actual_status_code = 0;
-  bool actual_end_stream = false;
-  absl::Notification stream_complete;
-  auto stream_prototype = engine->streamClient()->newStreamPrototype();
-  auto stream = (*stream_prototype)
-                    .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
-                                      envoy_stream_intel) {
-                      actual_status_code = headers->httpStatus();
-                      actual_end_stream = end_stream;
-                    })
-                    .setOnData([&](envoy_data data, bool end_stream) {
-                      actual_end_stream = end_stream;
-                      release_envoy_data(data);
-                    })
-                    .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
-                      stream_complete.Notify();
-                    })
-                    .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
-                                    envoy_final_stream_intel) { stream_complete.Notify(); })
-                    .setOnCancel([&](envoy_stream_intel, envoy_final_stream_intel) {
-                      stream_complete.Notify();
-                    })
-                    .start();
-
-  auto request_headers =
-      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https", "example.com", "/")
-          .build();
-  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
-  stream_complete.WaitForNotification();
-
-  EXPECT_EQ(actual_status_code, 200);
-  EXPECT_EQ(actual_end_stream, true);
-  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
 }
 
 } // namespace Envoy


### PR DESCRIPTION
This PR moves the tests that use `Envoy::Platform::EngineBuilder` to `engine_test.cc`. This change will also allow us to add more tests using the high-level `Envoy::Platform::Engine` C++ API.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features:  n/a