### PR TITLE
mobile: Fix incorrect JNI signature for setLogLevel

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -256,9 +256,10 @@ public class JniLibrary {
   /**
    * Update the log level for all active logs
    *
-   * @param log_level The Log level to change to. Must be an integer 0-6.
+   * @param logLevel The Log level to change to. Must be an integer 0-6.
+   *                 See source/common/common/base_logger.h
    */
-  protected static native void setLogLevel(int log_level);
+  protected static native void setLogLevel(int logLevel);
 
   /**
    * Mimic a call to AndroidNetworkLibrary#verifyServerCertificates from native code.

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -52,10 +52,9 @@ static void jvm_on_track(envoy_map events, const void* context) {
   release_envoy_map(events);
 }
 
-extern "C" JNIEXPORT jint JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_setLogLevel(JNIEnv* /*env*/, jclass, jint level) {
   Envoy::Logger::Context::changeAllLogLevels(static_cast<spdlog::level::level_enum>(level));
-  return 0;
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(


### PR DESCRIPTION
The return type is `void`, so the JNI type should also be `void` instead of `jint`.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a