### PR TITLE
Make backtrace addresses useable with post-hoc stack_decode

### DIFF
--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -13,7 +13,7 @@
 namespace Envoy {
 
 std::terminate_handler TerminateHandler::logOnTerminate() const {
-  // Prepopulate the address mapping so it doesn't require signal-unsafe file
+  // Pre-populate the address mapping so it doesn't require signal-unsafe file
   // actions during stack trace.
   BackwardsTrace::addrMapping(/*setup=*/true);
   return std::set_terminate([]() {

--- a/source/exe/terminate_handler.cc
+++ b/source/exe/terminate_handler.cc
@@ -13,6 +13,9 @@
 namespace Envoy {
 
 std::terminate_handler TerminateHandler::logOnTerminate() const {
+  // Prepopulate the address mapping so it doesn't require signal-unsafe file
+  // actions during stack trace.
+  BackwardsTrace::addrMapping(/*setup=*/true);
   return std::set_terminate([]() {
     logException(std::current_exception());
     BACKTRACE_LOG();

--- a/source/server/backtrace.cc
+++ b/source/server/backtrace.cc
@@ -8,8 +8,11 @@ namespace Envoy {
 
 bool BackwardsTrace::log_to_stderr_ = false;
 
-const std::string& BackwardsTrace::addrMapping() {
-  CONSTRUCT_ON_FIRST_USE(std::string, []() -> std::string {
+const std::string& BackwardsTrace::addrMapping(bool setup) {
+  CONSTRUCT_ON_FIRST_USE(std::string, [setup]() -> std::string {
+    if (!setup) {
+      return "";
+    }
 #ifndef WIN32
     std::ifstream maps("/proc/self/maps");
     if (maps.fail()) {

--- a/source/server/backtrace.cc
+++ b/source/server/backtrace.cc
@@ -2,9 +2,31 @@
 
 #include <iostream>
 
+#include "absl/strings/str_split.h"
+
 namespace Envoy {
 
 bool BackwardsTrace::log_to_stderr_ = false;
+
+const std::string& BackwardsTrace::addrMapping() {
+  CONSTRUCT_ON_FIRST_USE(std::string, []() -> std::string {
+#ifndef WIN32
+    std::ifstream maps("/proc/self/maps");
+    if (maps.fail()) {
+      return "";
+    }
+    std::string line;
+    // Search for the first executable memory mapped block.
+    while (std::getline(maps, line)) {
+      std::vector<absl::string_view> parts = absl::StrSplit(line, ' ');
+      if (parts[1] == "r-xp") {
+        return absl::StrCat(parts[0], " ", parts.back());
+      }
+    }
+#endif
+    return "";
+  }());
+}
 
 void BackwardsTrace::setLogToStderr(bool log_to_stderr) { log_to_stderr_ = log_to_stderr; }
 

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -48,13 +48,13 @@ public:
    * during startup, to avoid performing the lookup during the
    * crash process.
    *
-   * @return a string representing the memory offset from ASLR of the
+   * @return a string representing the memory offset from `ASLR` of the
    * current process, or an empty string if the information is not
    * available.
    * The format of this line is
-   *   [startaddr]-[endaddr] [path_to_binary]
+   *   `[start_addr]-[end_addr] [path_to_binary]`
    * e.g.
-   *   7d34ce028000-7d34ce1bd000 /build/foo/bar/source/exe/envoy-static
+   *   `7d34ce028000-7d34ce1bd000 /build/foo/bar/source/exe/envoy-static`
    */
   static const std::string& addrMapping();
 

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -54,7 +54,7 @@ public:
    * The format of this line is
    *   `[start_addr]-[end_addr] [path_to_binary]`
    * e.g.
-   *   `7d34ce028000-7d34ce1bd000 /build/foo/bar/source/exe/envoy-static`
+   *   `7d34c0e28000-7d34c1e0d000 /build/foo/bar/source/exe/envoy-static`
    */
   static const std::string& addrMapping();
 

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -56,7 +56,7 @@ public:
    * e.g.
    *   `7d34c0e28000-7d34c1e0d000 /build/foo/bar/source/exe/envoy-static`
    */
-  static const std::string& addrMapping();
+  static const std::string& addrMapping(bool setup = false);
 
   /**
    * Directs the output of logTrace() to directly stderr rather than the

--- a/source/server/backtrace.h
+++ b/source/server/backtrace.h
@@ -11,7 +11,7 @@
 namespace Envoy {
 #define BACKTRACE_LOG()                                                                            \
   do {                                                                                             \
-    BackwardsTrace t;                                                                              \
+    ::Envoy::BackwardsTrace t;                                                                     \
     t.capture();                                                                                   \
     t.logTrace();                                                                                  \
   } while (0)
@@ -37,6 +37,26 @@ namespace Envoy {
 class BackwardsTrace : Logger::Loggable<Logger::Id::backtrace> {
 public:
   BackwardsTrace() = default;
+
+  /**
+   * Attempts to get the memory offsets of the current process, so the
+   * stack trace addresses can be mapped to line numbers even after the
+   * process is not running.
+   *
+   * This acts as a global singleton since it will be the same values for
+   * the duration of an execution - as such, it should be called once
+   * during startup, to avoid performing the lookup during the
+   * crash process.
+   *
+   * @return a string representing the memory offset from ASLR of the
+   * current process, or an empty string if the information is not
+   * available.
+   * The format of this line is
+   *   [startaddr]-[endaddr] [path_to_binary]
+   * e.g.
+   *   7d34ce028000-7d34ce1bd000 /build/foo/bar/source/exe/envoy-static
+   */
+  static const std::string& addrMapping();
 
   /**
    * Directs the output of logTrace() to directly stderr rather than the
@@ -90,6 +110,9 @@ public:
 
     ENVOY_LOG(critical, "Backtrace (use tools/stack_decode.py to get line numbers):");
     ENVOY_LOG(critical, "Envoy version: {}", VersionInfo::version());
+    if (!addrMapping().empty()) {
+      ENVOY_LOG(critical, "Address mapping: {}", addrMapping());
+    }
 
     visitTrace([](int index, const char* symbol, void* address) {
       if (symbol != nullptr) {

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -10,6 +10,9 @@
 #
 # In each case this script will add file and line information to any backtrace log
 # lines found and echo back all non-Backtrace lines untouched.
+#
+# This has been found to work best if envoy was built with gcc, and with
+# bazel option -c dbg
 
 import re
 import subprocess
@@ -25,6 +28,9 @@ def decode_stacktrace_log(object_file, input_source, address_offset=0):
     #     [backtrace] [bazel-out/local-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:84]
     backtrace_marker = "\[backtrace\] [^\s]+"
     # Match something like:
+    #     ${backtrace_marker} Address mapping: 010c0000-02a77000
+    offset_re = re.compile("%s Address mapping: ([0-9A-Fa-f]+)-([0-9A-Fa-f]+)" % backtrace_marker)
+    # Match something like:
     #     ${backtrace_marker} #10: SYMBOL [0xADDR]
     # or:
     #     ${backtrace_marker} #10: [0xADDR]
@@ -38,6 +44,11 @@ def decode_stacktrace_log(object_file, input_source, address_offset=0):
             line = input_source.readline()
             if line == "":
                 return  # EOF
+            offset_match = offset_re.search(line)
+            if offset_match:
+                address_offset = int(offset_match.groups()[0], 16)
+                sys.stdout.write("%s (used as address offset)\n" % line.strip())
+                continue
             stackaddr_match = stackaddr_re.search(line)
             if not stackaddr_match:
                 stackaddr_match = asan_re.search(line)

--- a/tools/stack_decode.py
+++ b/tools/stack_decode.py
@@ -11,8 +11,10 @@
 # In each case this script will add file and line information to any backtrace log
 # lines found and echo back all non-Backtrace lines untouched.
 #
-# This has been found to work best if envoy was built with gcc, and with
+# This has been found to work best if the envoy binary was built with gcc, and with
 # bazel option -c dbg
+# This can be used to decode a stack trace produced by a non-debug gcc build, if
+# the debug build passed to stack_decode.py is otherwise identical.
 
 import re
 import subprocess


### PR DESCRIPTION
Commit Message: Make backtrace addresses useable with post-hoc stack_decode
Additional Description: When we get a backtrace, typically the addresses are offset because of ASLR. That offset is not logged anywhere, and after the process has crashed the information is no longer available. `stack_decode.py` therefore only actually works if it's running as a wrapper around envoy; the "run afterwards" version with `-s` is unusable unless ASLR was disabled.
This change makes envoy also retrieve and log the address offset if possible (using the same mechanism `stack_decode.py` uses), and has `stack_decode.py` consume and use that logged address offset.
If `/proc/self/maps` is not present or not readable or doesn't match the expected format, the log output is unchanged.
Risk Level: Low, crashlog-output-only.
Testing: Verified that the post-hoc parsing of logs from a gcc-built with `-c dbg` instance of envoy is capable of providing correct filenames and line numbers from `stack_decode.py`.
Verified that the post-hoc parsing of logs from a gcc-built *without* `-c dbg` instance of envoy, is capable of providing correct filenames and line numbers from `stack_decode.py` if a version built *with* `-c dbg` is passed to `stack_decode.py`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Doesn't even try on Windows.
