### PR TITLE
Stringmatcher: cleanup temporary code

### DIFF
--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -220,9 +220,11 @@ bool PathMatcher::match(const absl::string_view path) const {
 }
 
 StringMatcherPtr getExtensionStringMatcher(const ::xds::core::v3::TypedExtensionConfig& config,
-                                           ThreadLocal::SlotAllocator& tls, Api::Api& api) {
+                                           Server::Configuration::CommonFactoryContext& context) {
   auto factory = Config::Utility::getAndCheckFactory<StringMatcherExtensionFactory>(config, false);
-  return factory->createStringMatcher(config.typed_config(), tls, api);
+  ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
+      config, context.messageValidationContext().staticValidationVisitor(), *factory);
+  return factory->createStringMatcher(*message, context);
 }
 
 } // namespace Matchers

--- a/source/common/common/matchers.cc
+++ b/source/common/common/matchers.cc
@@ -223,7 +223,7 @@ StringMatcherPtr getExtensionStringMatcher(const ::xds::core::v3::TypedExtension
                                            Server::Configuration::CommonFactoryContext& context) {
   auto factory = Config::Utility::getAndCheckFactory<StringMatcherExtensionFactory>(config, false);
   ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
-      config, context.messageValidationContext().staticValidationVisitor(), *factory);
+      config, context.messageValidationVisitor(), *factory);
   return factory->createStringMatcher(*message, context);
 }
 

--- a/source/extensions/string_matcher/lua/match.h
+++ b/source/extensions/string_matcher/lua/match.h
@@ -29,9 +29,9 @@ private:
 
 class LuaStringMatcherFactory : public Matchers::StringMatcherExtensionFactory {
 public:
-  Matchers::StringMatcherPtr createStringMatcher(const ProtobufWkt::Any& message,
-                                                 ThreadLocal::SlotAllocator& tls,
-                                                 Api::Api& api) override;
+  Matchers::StringMatcherPtr
+  createStringMatcher(const Protobuf::Message& config,
+                      Server::Configuration::CommonFactoryContext& context) override;
   std::string name() const override { return "envoy.string_matcher.lua"; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 };

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -106,20 +106,7 @@ InstanceBase::InstanceBase(Init::Manager& init_manager, const Options& options,
       grpc_context_(store.symbolTable()), http_context_(store.symbolTable()),
       router_context_(store.symbolTable()), process_context_(std::move(process_context)),
       hooks_(hooks), quic_stat_names_(store.symbolTable()), server_contexts_(*this),
-      enable_reuse_port_default_(true), stats_flush_in_progress_(false) {
-
-  // These are needed for string matcher extensions. It is too painful to pass these objects through
-  // all call chains that construct a `StringMatcherImpl`, so these are singletons.
-  //
-  // They must be cleared before being set to make the multi-envoy integration test pass. Note that
-  // this means that extensions relying on these singletons probably will not function correctly in
-  // some Envoy mobile setups where multiple Envoy engines are used in the same process. The same
-  // caveat also applies to a few other singletons, such as the global regex engine.
-  InjectableSingleton<ThreadLocal::SlotAllocator>::clear();
-  InjectableSingleton<ThreadLocal::SlotAllocator>::initialize(&thread_local_);
-  InjectableSingleton<Api::Api>::clear();
-  InjectableSingleton<Api::Api>::initialize(api_.get());
-}
+      enable_reuse_port_default_(true), stats_flush_in_progress_(false) {}
 
 InstanceBase::~InstanceBase() {
   terminate();
@@ -151,9 +138,6 @@ InstanceBase::~InstanceBase() {
     close(tracing_fd_);
   }
 #endif
-
-  InjectableSingleton<ThreadLocal::SlotAllocator>::clear();
-  InjectableSingleton<Api::Api>::clear();
 }
 
 Upstream::ClusterManager& InstanceBase::clusterManager() {

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -140,9 +140,6 @@ DEFINE_PROTO_FUZZER(const test::common::router::RouteTestCase& input) {
   static NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   static NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
   static ScopedInjectableLoader<Regex::Engine> engine(std::make_unique<Regex::GoogleReEngine>());
-  static ScopedInjectableLoader<ThreadLocal::SlotAllocator> tls_inject(
-      std::make_unique<ThreadLocal::MockInstance>());
-  static ScopedInjectableLoader<Api::Api> api_inject(std::make_unique<Api::MockApi>());
 
   try {
     if (!validateConfig(input)) {

--- a/test/extensions/string_matcher/lua/BUILD
+++ b/test/extensions/string_matcher/lua/BUILD
@@ -17,8 +17,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.string_matcher.lua"],
     deps = [
         "//source/extensions/string_matcher/lua:config",
-        "//test/mocks/api:api_mocks",
-        "//test/mocks/thread_local:thread_local_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/string_matcher/lua/v3:pkg_cc_proto",

--- a/test/extensions/string_matcher/lua/lua_test.cc
+++ b/test/extensions/string_matcher/lua/lua_test.cc
@@ -2,8 +2,7 @@
 
 #include "source/extensions/string_matcher/lua/match.h"
 
-#include "test/mocks/api/mocks.h"
-#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/utility.h"
 
@@ -88,20 +87,16 @@ TEST(LuaStringMatcher, LuaStdLib) {
 }
 
 TEST(LuaStringMatcher, NoCode) {
-  Api::MockApi api;
-  ThreadLocal::MockInstance tls;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   LuaStringMatcherFactory factory;
   ::envoy::extensions::string_matcher::lua::v3::Lua empty_config;
-  ProtobufWkt::Any any;
-  any.PackFrom(empty_config);
-  EXPECT_THROW_WITH_MESSAGE(factory.createStringMatcher(any, tls, api), EnvoyException,
-                            "Failed to get lua string matcher code from source: INVALID_ARGUMENT: "
-                            "Unexpected DataSource::specifier_case(): 0");
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createStringMatcher(empty_config, context), EnvoyException,
+      "Proto constraint validation failed (LuaValidationError.SourceCode: value is required): ");
 
   empty_config.mutable_source_code()->set_inline_string("");
-  any.PackFrom(empty_config);
-  EXPECT_THROW_WITH_MESSAGE(factory.createStringMatcher(any, tls, api), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(factory.createStringMatcher(empty_config, context), EnvoyException,
                             "Failed to get lua string matcher code from source: INVALID_ARGUMENT: "
                             "DataSource cannot be empty");
 }

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -7,7 +7,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/api:84.5" # flaky due to posix: be careful adjusting
 "source/common/api/posix:83.8" # flaky (accept failover non-deterministic): be careful adjusting
 "source/common/common/posix:88.8" # No easy way to test pthread_create failure.
-"source/common/config:95.8"
+"source/common/config:95.6"
 "source/common/crypto:95.5"
 "source/common/event:95.1" # Emulated edge events guards don't report LCOV
 "source/common/filesystem/posix:96.2" # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Removes temporary extra classes, and moves to a better way to handle string matcher extension factories
Additional Description:
Risk Level: Low
Fixes #32792
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
