### PR TITLE
mismatch content type should set on_error metadata in json_to_metadata filter

### DIFF
--- a/api/envoy/extensions/filters/http/json_to_metadata/v3/json_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/json_to_metadata/v3/json_to_metadata.proto
@@ -89,7 +89,7 @@ message JsonToMetadata {
     // The value in the KeyValuePair must be set.
     KeyValuePair on_missing = 3;
 
-    // If the body is too large or fail to parse, apply this metadata KeyValuePair.
+    // If the body is too large or fail to parse or content-type is mismatched, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set.
     KeyValuePair on_error = 4;

--- a/source/extensions/filters/http/json_to_metadata/filter.cc
+++ b/source/extensions/filters/http/json_to_metadata/filter.cc
@@ -405,7 +405,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     return Http::FilterHeadersStatus::Continue;
   }
   if (!config_->requestContentTypeAllowed(headers.getContentTypeValue())) {
-    request_processing_finished_ = true;
+    handleAllOnError(config_->requestRules(), true, *decoder_callbacks_,
+                     request_processing_finished_);
     config_->rqstats().mismatched_content_type_.inc();
     return Http::FilterHeadersStatus::Continue;
   }
@@ -424,7 +425,8 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
     return Http::FilterHeadersStatus::Continue;
   }
   if (!config_->responseContentTypeAllowed(headers.getContentTypeValue())) {
-    response_processing_finished_ = true;
+    handleAllOnError(config_->responseRules(), false, *encoder_callbacks_,
+                     response_processing_finished_);
     config_->respstats().mismatched_content_type_.inc();
     return Http::FilterHeadersStatus::Continue;
   }


### PR DESCRIPTION
Commit Message:
Currently filters after json_to_metadata couldn't get hints from metadata if we have a mismatched content type.
Therefore, we set `on_error` which matches semantic meaning the best.

Risk Level: low
Testing: unit test
