### PR TITLE
Fix lifecycle notifier callback loop

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1091,7 +1091,7 @@ void InstanceBase::notifyCallbacksForStage(Stage stage, std::function<void()> co
   ASSERT_IS_MAIN_OR_TEST_THREAD();
   const auto stage_it = stage_callbacks_.find(stage);
   if (stage_it != stage_callbacks_.end()) {
-    LifecycleNotifierCallbacks& callbacks = it->second;
+    LifecycleNotifierCallbacks& callbacks = stage_it->second;
     for (auto callback_it = callbacks.begin(); callback_it != callbacks.end();) {
       StageCallback callback = *callback_it;
       // Increment the iterator before invoking the callback in case the

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1089,15 +1089,15 @@ InstanceBase::registerCallback(Stage stage, StageCallbackWithCompletion callback
 
 void InstanceBase::notifyCallbacksForStage(Stage stage, std::function<void()> completion_cb) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
-  const auto it = stage_callbacks_.find(stage);
-  if (it != stage_callbacks_.end()) {
+  const auto stage_it = stage_callbacks_.find(stage);
+  if (stage_it != stage_callbacks_.end()) {
     LifecycleNotifierCallbacks& callbacks = it->second;
-    for (auto it = callbacks.begin(); it != callbacks.end();) {
-      StageCallback callback = *it;
+    for (auto callback_it = callbacks.begin(); callback_it != callbacks.end();) {
+      StageCallback callback = *callback_it;
       // Increment the iterator before invoking the callback in case the
       // callback deletes the handle which will unregister itself and
       // invalidate this iterator if we're still pointing at it.
-      ++it;
+      ++callback_it;
       callback();
     }
   }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -1091,7 +1091,13 @@ void InstanceBase::notifyCallbacksForStage(Stage stage, std::function<void()> co
   ASSERT_IS_MAIN_OR_TEST_THREAD();
   const auto it = stage_callbacks_.find(stage);
   if (it != stage_callbacks_.end()) {
-    for (const StageCallback& callback : it->second) {
+    LifecycleNotifierCallbacks& callbacks = it->second;
+    for (auto it = callbacks.begin(); it != callbacks.end();) {
+      StageCallback callback = *it;
+      // Increment the iterator before invoking the callback in case the
+      // callback deletes the handle which will unregister itself and
+      // invalidate this iterator if we're still pointing at it.
+      ++it;
       callback();
     }
   }

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -614,6 +614,7 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
     server_->run();
     handle1 = nullptr;
     handle2 = nullptr;
+    // handle3 is nulled out in the callback itself, to test that works as well
     handle4 = nullptr;
     server_ = nullptr;
     thread_local_ = nullptr;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -591,10 +591,12 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
       post_init = true;
       post_init_fired.Notify();
     });
-    auto handle3 = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit, [&] {
-      shutdown = true;
-      shutdown_begin.Notify();
-    });
+    ServerLifecycleNotifier::HandlePtr handle3 =
+        server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit, [&] {
+          shutdown = true;
+          shutdown_begin.Notify();
+          handle3 = nullptr;
+        });
     auto handle4 = server_->registerCallback(ServerLifecycleNotifier::Stage::ShutdownExit,
                                              [&](Event::PostCb completion_cb) {
                                                // Block till we're told to complete
@@ -612,7 +614,6 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
     server_->run();
     handle1 = nullptr;
     handle2 = nullptr;
-    handle3 = nullptr;
     handle4 = nullptr;
     server_ = nullptr;
     thread_local_ = nullptr;


### PR DESCRIPTION
Change the lifecycle notifier to invoke callbacks after incrementing the iterator. This will allow callbacks to delete their registration handle when they are called.


Risk Level: low
Testing: unit test
