### PR TITLE
[http-cache] Don't bypass the cache for if-unmodified-since or if-match

### DIFF
--- a/source/extensions/filters/http/cache/cacheability_utils.cc
+++ b/source/extensions/filters/http/cache/cacheability_utils.cc
@@ -25,10 +25,9 @@ const absl::flat_hash_set<absl::string_view>& cacheableStatusCodes() {
 
 const std::vector<const Http::LowerCaseString*>& conditionalHeaders() {
   // As defined by: https://httpwg.org/specs/rfc7232.html#preconditions.
-  CONSTRUCT_ON_FIRST_USE(
-      std::vector<const Http::LowerCaseString*>, &Http::CustomHeaders::get().IfMatch,
-      &Http::CustomHeaders::get().IfNoneMatch, &Http::CustomHeaders::get().IfModifiedSince,
-      &Http::CustomHeaders::get().IfUnmodifiedSince, &Http::CustomHeaders::get().IfRange);
+  CONSTRUCT_ON_FIRST_USE(std::vector<const Http::LowerCaseString*>,
+                         &Http::CustomHeaders::get().IfNoneMatch,
+                         &Http::CustomHeaders::get().IfModifiedSince);
 }
 } // namespace
 
@@ -36,11 +35,14 @@ bool CacheabilityUtils::canServeRequestFromCache(const Http::RequestHeaderMap& h
   const absl::string_view method = headers.getMethodValue();
   const Http::HeaderValues& header_values = Http::Headers::get();
 
-  // Check if the request contains any conditional headers.
+  // Check if the request contains any conditional headers other than if-unmodified-since
+  // or if-match.
   // For now, requests with conditional headers bypass the CacheFilter.
   // This behavior does not cause any incorrect results, but may reduce the cache effectiveness.
   // If needed to be handled properly refer to:
   // https://httpwg.org/specs/rfc7234.html#validation.received
+  // if-unmodified-since and if-match are ignored, as the spec explicitly says these
+  // header fields can be ignored by caches and intermediaries.
   for (auto conditional_header : conditionalHeaders()) {
     if (!headers.get(*conditional_header).empty()) {
       return false;

--- a/source/extensions/filters/http/cache/cacheability_utils.cc
+++ b/source/extensions/filters/http/cache/cacheability_utils.cc
@@ -25,9 +25,9 @@ const absl::flat_hash_set<absl::string_view>& cacheableStatusCodes() {
 
 const std::vector<const Http::LowerCaseString*>& conditionalHeaders() {
   // As defined by: https://httpwg.org/specs/rfc7232.html#preconditions.
-  CONSTRUCT_ON_FIRST_USE(std::vector<const Http::LowerCaseString*>,
-                         &Http::CustomHeaders::get().IfNoneMatch,
-                         &Http::CustomHeaders::get().IfModifiedSince);
+  CONSTRUCT_ON_FIRST_USE(
+      std::vector<const Http::LowerCaseString*>, &Http::CustomHeaders::get().IfNoneMatch,
+      &Http::CustomHeaders::get().IfModifiedSince, &Http::CustomHeaders::get().IfRange);
 }
 } // namespace
 

--- a/test/extensions/filters/http/cache/cacheability_utils_test.cc
+++ b/test/extensions/filters/http/cache/cacheability_utils_test.cc
@@ -94,8 +94,7 @@ TEST_F(CanServeRequestFromCacheTest, AuthorizationHeader) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ConditionalHeaders, RequestConditionalHeadersTest,
-                         testing::Values("if-match", "if-none-match", "if-modified-since",
-                                         "if-unmodified-since", "if-range"),
+                         testing::Values("if-none-match", "if-modified-since", "if-range"),
                          [](const auto& info) {
                            std::string test_name = info.param;
                            absl::c_replace_if(


### PR DESCRIPTION
Commit Message: [http-cache] Don't bypass the cache for if-unmodified-since or if-match
Additional Description: There's a whole section of the cache filter to do with conditional headers that's unimplemented ("if needed, implement it to this spec!"). Turns out we only need the very easy to implement subset, where the cache is supposed to ignore one of the conditional headers. I threw in the other one that's supposed to be ignored as well.
Risk Level: Very low, it's a WIP filter and an edge case use of it where before the change it does the wrong thing.
Testing: Doesn't even make sense to have a special test for this - there are an infinite number of headers the cache should ignore.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
