### PR TITLE
mobile: Remove envoy_event_tracker C wrapper type

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -186,6 +186,11 @@ EngineBuilder& EngineBuilder::setOnEngineRunning(std::function<void()> closure) 
   return *this;
 }
 
+EngineBuilder& EngineBuilder::setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker) {
+  event_tracker_ = std::move(event_tracker);
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::addConnectTimeoutSeconds(int connect_timeout_seconds) {
   connect_timeout_seconds_ = connect_timeout_seconds;
   return *this;
@@ -916,10 +921,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 }
 
 EngineSharedPtr EngineBuilder::build() {
-  envoy_event_tracker null_tracker{};
-
   InternalEngine* envoy_engine =
-      new InternalEngine(std::move(callbacks_), std::move(logger_), null_tracker);
+      new InternalEngine(std::move(callbacks_), std::move(logger_), std::move(event_tracker_));
 
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -131,6 +131,7 @@ public:
   EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
   [[deprecated("Use EngineBuilder::setEngineCallbacks instead")]] EngineBuilder&
   setOnEngineRunning(std::function<void()> closure);
+  EngineBuilder& setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker);
   EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
   EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
   EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
@@ -219,6 +220,7 @@ private:
   Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
   std::unique_ptr<EnvoyLogger> logger_{nullptr};
   std::unique_ptr<EngineCallbacks> callbacks_;
+  std::unique_ptr<EnvoyEventTracker> event_tracker_{nullptr};
 
   int connect_timeout_seconds_ = 30;
   int dns_refresh_seconds_ = 60;

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -82,6 +82,8 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
         "@envoy//source/common/common:base_logger_lib",
     ],
 )

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -15,6 +15,9 @@
 
 #include "source/common/common/base_logger.h"
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 
 /** The callbacks for the Envoy Engine. */
@@ -27,6 +30,15 @@ struct EngineCallbacks {
 struct EnvoyLogger {
   std::function<void(Logger::Logger::Levels, const std::string&)> on_log =
       [](Logger::Logger::Levels, const std::string&) {};
+  std::function<void()> on_exit = [] {};
+};
+
+inline constexpr absl::string_view ENVOY_EVENT_TRACKER_API_NAME = "event_tracker_api";
+
+/** The callbacks for Envoy Event Tracker. */
+struct EnvoyEventTracker {
+  std::function<void(const absl::flat_hash_map<std::string, std::string>&)> on_track =
+      [](const absl::flat_hash_map<std::string, std::string>&) {};
   std::function<void()> on_exit = [] {};
 };
 

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -26,7 +26,7 @@ public:
    * @param event_tracker, the event tracker to use for the emission of events.
    */
   InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
-                 envoy_event_tracker event_tracker);
+                 std::unique_ptr<EnvoyEventTracker> event_tracker);
 
   /**
    * InternalEngine destructor.
@@ -123,7 +123,8 @@ private:
   GTEST_FRIEND_CLASS(InternalEngineTest, ThreadCreationFailed);
 
   InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
-                 envoy_event_tracker event_tracker, Thread::PosixThreadFactoryPtr thread_factory);
+                 std::unique_ptr<EnvoyEventTracker> event_tracker,
+                 Thread::PosixThreadFactoryPtr thread_factory);
 
   envoy_status_t main(std::shared_ptr<Envoy::OptionsImplBase> options);
   static void logInterfaces(absl::string_view event,
@@ -135,7 +136,7 @@ private:
   Stats::StatNameSetPtr stat_name_set_;
   std::unique_ptr<EngineCallbacks> callbacks_;
   std::unique_ptr<EnvoyLogger> logger_;
-  envoy_event_tracker event_tracker_;
+  std::unique_ptr<EnvoyEventTracker> event_tracker_;
   Assert::ActionRegistrationPtr assert_handler_registration_;
   Assert::ActionRegistrationPtr bug_handler_registration_;
   Thread::MutexBasicLockable mutex_;

--- a/mobile/library/common/logger/logger_delegate.cc
+++ b/mobile/library/common/logger/logger_delegate.cc
@@ -9,14 +9,14 @@ namespace Logger {
 
 void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, absl::string_view,
                                               absl::string_view, absl::string_view msg) {
-  if (event_tracker_.track == nullptr) {
+  if (event_tracker_ == nullptr || (*event_tracker_) == nullptr) {
     return;
   }
 
-  event_tracker_.track(Bridge::Utility::makeEnvoyMap({{"name", "event_log"},
-                                                      {"log_name", std::string(stable_name)},
-                                                      {"message", std::string(msg)}}),
-                       event_tracker_.context);
+  (*event_tracker_)
+      ->on_track({{"name", "event_log"},
+                  {"log_name", std::string(stable_name)},
+                  {"message", std::string(msg)}});
 }
 
 LambdaDelegate::LambdaDelegate(std::unique_ptr<EnvoyLogger> logger,

--- a/mobile/library/common/logger/logger_delegate.h
+++ b/mobile/library/common/logger/logger_delegate.h
@@ -15,14 +15,14 @@ namespace Logger {
 class EventTrackingDelegate : public SinkDelegate {
 public:
   explicit EventTrackingDelegate(DelegatingLogSinkSharedPtr log_sink)
-      : SinkDelegate(log_sink), event_tracker_(*static_cast<envoy_event_tracker*>(
-                                    Api::External::retrieveApi(envoy_event_tracker_api_name))) {}
+      : SinkDelegate(log_sink), event_tracker_(static_cast<std::unique_ptr<EnvoyEventTracker>*>(
+                                    Api::External::retrieveApi(ENVOY_EVENT_TRACKER_API_NAME))) {}
 
   void logWithStableName(absl::string_view stable_name, absl::string_view level,
                          absl::string_view component, absl::string_view msg) override;
 
 private:
-  envoy_event_tracker& event_tracker_;
+  std::unique_ptr<EnvoyEventTracker>* event_tracker_;
 };
 
 using EventTrackingDelegatePtr = std::unique_ptr<EventTrackingDelegate>;

--- a/mobile/library/common/types/c_types.cc
+++ b/mobile/library/common/types/c_types.cc
@@ -72,5 +72,3 @@ const envoy_data envoy_nodata = {0, NULL, envoy_noop_release, NULL};
 const envoy_headers envoy_noheaders = {0, NULL};
 
 const envoy_stats_tags envoy_stats_notags = {0, NULL};
-
-const char* envoy_event_tracker_api_name = "event_tracker_api";

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -73,9 +73,6 @@ typedef enum {
   ENVOY_NET_WWAN = 2,
 } envoy_network_t;
 
-// The name used to registered event tracker api.
-extern const char* envoy_event_tracker_api_name;
-
 #ifdef __cplusplus
 extern "C" { // release function
 #endif
@@ -411,15 +408,6 @@ typedef void (*envoy_on_cancel_f)(envoy_stream_intel stream_intel,
  */
 typedef void (*envoy_on_send_window_available_f)(envoy_stream_intel stream_intel, void* context);
 
-/**
- * Called when envoy's event tracker tracks an event.
- *
- * @param event, the dictionary with attributes that describe the event.
- * @param context, contains the necessary state to carry out platform-specific dispatch and
- * execution.
- */
-typedef void (*envoy_event_tracker_track_f)(envoy_map event, const void* context);
-
 #ifdef __cplusplus
 } // function pointers
 #endif
@@ -439,15 +427,6 @@ typedef struct {
   // Context passed through to callbacks to provide dispatch and execution state.
   void* context;
 } envoy_http_callbacks;
-
-/**
- * Interface for event tracking.
- */
-typedef struct {
-  envoy_event_tracker_track_f track;
-  // Context passed through to callbacks to provide dispatch and execution state.
-  const void* context;
-} envoy_event_tracker;
 
 /**
  * The list of certificate verification results returned from Java side to the

--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "@envoy//source/common/common:assert_lib",
         "@envoy_build_config//:test_extensions",
     ],
 )

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -1,3 +1,5 @@
+#include "source/common/common/assert.h"
+
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 #include "library/cc/engine_builder.h"
@@ -56,7 +58,7 @@ TEST(EngineTest, SetLogger) {
   stream_complete.WaitForNotification();
 
   EXPECT_EQ(actual_status_code, 200);
-  EXPECT_EQ(actual_end_stream, true);
+  EXPECT_TRUE(actual_end_stream);
   EXPECT_TRUE(logging_was_called.load());
   EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
 }
@@ -108,8 +110,44 @@ TEST(EngineTest, SetEngineCallbacks) {
   stream_complete.WaitForNotification();
 
   EXPECT_EQ(actual_status_code, 200);
-  EXPECT_EQ(actual_end_stream, true);
+  EXPECT_TRUE(actual_end_stream);
   EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
+}
+
+TEST(EngineTest, SetEventTracker) {
+  absl::Notification engine_running;
+  auto engine_callbacks = std::make_unique<EngineCallbacks>();
+  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
+
+  absl::Notification on_track;
+  auto event_tracker = std::make_unique<EnvoyEventTracker>();
+  event_tracker->on_track = [&](const absl::flat_hash_map<std::string, std::string>& events) {
+    if (events.count("name") && events.at("name") == "assertion") {
+      EXPECT_EQ(events.at("location"), "foo_location");
+      on_track.Notify();
+    }
+  };
+  absl::Notification on_track_exit;
+  event_tracker->on_exit = [&] { on_track_exit.Notify(); };
+
+  Platform::EngineBuilder engine_builder;
+  Platform::EngineSharedPtr engine =
+      engine_builder.setLogLevel(Logger::Logger::debug)
+          .setEngineCallbacks(std::move(engine_callbacks))
+          .setEventTracker(std::move(event_tracker))
+          .addNativeFilter(
+              "test_remote_response",
+              "{'@type': "
+              "type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+          .build();
+  engine_running.WaitForNotification();
+
+  Assert::invokeDebugAssertionFailureRecordActionForAssertMacroUseOnly("foo_location");
+
+  EXPECT_TRUE(on_track.WaitForNotificationWithTimeout(absl::Seconds(3)));
+  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
+  EXPECT_TRUE(on_track.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
 } // namespace Envoy

--- a/mobile/test/common/http/filters/test_event_tracker/BUILD
+++ b/mobile/test/common/http/filters/test_event_tracker/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         "filter_cc_proto",
+        "//library/common:engine_types_lib",
         "//library/common/api:c_types",
         "//library/common/api:external_api_lib",
         "//library/common/bridge:utility_lib",

--- a/mobile/test/common/http/filters/test_event_tracker/filter.cc
+++ b/mobile/test/common/http/filters/test_event_tracker/filter.cc
@@ -11,17 +11,15 @@ namespace TestEventTracker {
 TestEventTrackerFilterConfig::TestEventTrackerFilterConfig(
     const envoymobile::extensions::filters::http::test_event_tracker::TestEventTracker&
         proto_config)
-    : event_tracker_(static_cast<envoy_event_tracker*>(
-          Api::External::retrieveApi(envoy_event_tracker_api_name))) {
-  auto attributes = std::vector<std::pair<std::string, std::string>>();
-  for (auto& pair : proto_config.attributes()) {
-    attributes.push_back({std::string(pair.first), std::string(pair.second)});
+    : event_tracker_(static_cast<std::unique_ptr<EnvoyEventTracker>*>(
+          Api::External::retrieveApi(ENVOY_EVENT_TRACKER_API_NAME))) {
+  for (auto& [key, value] : proto_config.attributes()) {
+    attributes_.emplace(std::string(key), std::string(value));
   }
-  attributes_ = attributes;
 }
 
 Http::FilterHeadersStatus TestEventTrackerFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
-  config_->track(Bridge::Utility::makeEnvoyMap(config_->attributes()));
+  config_->track(config_->attributes());
   return Http::FilterHeadersStatus::Continue;
 }
 

--- a/mobile/test/common/logger/logger_delegate_test.cc
+++ b/mobile/test/common/logger/logger_delegate_test.cc
@@ -13,14 +13,15 @@ namespace Logger {
 
 class LambdaDelegateTest : public testing::Test {
 public:
-  static envoy_event_tracker tracker;
+  static std::unique_ptr<EnvoyEventTracker> event_tracker;
 
   static void SetUpTestSuite() {
-    Api::External::registerApi(std::string(envoy_event_tracker_api_name), &tracker);
+    Api::External::registerApi(std::string(ENVOY_EVENT_TRACKER_API_NAME), &event_tracker);
   }
 };
 
-envoy_event_tracker LambdaDelegateTest::tracker{};
+std::unique_ptr<EnvoyEventTracker> LambdaDelegateTest::event_tracker =
+    std::make_unique<EnvoyEventTracker>();
 
 TEST_F(LambdaDelegateTest, LogCb) {
   std::string expected_msg = "Hello LambdaDelegate";

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Map;
+
 @RunWith(RobolectricTestRunner.class)
 public class JniUtilityTest {
   public JniUtilityTest() { System.loadLibrary("envoy_jni_utility_test"); }
@@ -16,6 +18,7 @@ public class JniUtilityTest {
   // Native methods for testing.
   //================================================================================
   public static native byte[] protoJavaByteArrayConversion(byte[] source);
+  public static native Map<String, String> cppMapToJavaMap();
 
   @Test
   public void testProtoJavaByteArrayConversion() throws Exception {
@@ -27,5 +30,11 @@ public class JniUtilityTest {
             .build();
     Struct dest = Struct.parseFrom(protoJavaByteArrayConversion(source.toByteArray()));
     assertThat(source).isEqualTo(dest);
+  }
+
+  @Test
+  public void testCppStringMapToJavaStringMap() {
+    Map<String, String> map = cppMapToJavaMap();
+    assertThat(map).containsExactly("key1", "value1", "key2", "value2", "key3", "value3");
   }
 }

--- a/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
+++ b/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
@@ -831,6 +831,7 @@ public class BidirectionalStreamTest {
     callback.blockForDone();
     assertEquals(200, callback.mResponseInfo.getHttpStatusCode());
     assertEquals(userAgentValue, callback.mResponseAsString);
+    engine.shutdown();
   }
 
   @Test

--- a/mobile/test/jni/jni_utility_test.cc
+++ b/mobile/test/jni/jni_utility_test.cc
@@ -1,5 +1,6 @@
 #include <jni.h>
 
+#include "absl/container/flat_hash_map.h"
 #include "library/jni/jni_utility.h"
 
 // NOLINT(namespace-envoy)
@@ -14,4 +15,15 @@ Java_io_envoyproxy_envoymobile_jni_JniUtilityTest_protoJavaByteArrayConversion(J
   Envoy::ProtobufWkt::Struct s;
   Envoy::JNI::javaByteArrayToProto(jni_helper, source, &s);
   return Envoy::JNI::protoToJavaByteArray(jni_helper, s).release();
+}
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniUtilityTest_cppMapToJavaMap(JNIEnv* env, jclass) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  absl::flat_hash_map<std::string, std::string> cpp_map{
+      {"key1", "value1"},
+      {"key2", "value2"},
+      {"key3", "value3"},
+  };
+  return Envoy::JNI::cppMapToJavaMap(jni_helper, cpp_map).release();
 }


### PR DESCRIPTION
This PR removes `envoy_event_tracker` C wrapper type and replaces it with `EnvoyEventTracker` C++ type. This PR also fixes a memory leak by introducing `EnvoyEventTracker.on_exit`, which adds a callback to allow doing any clean up prior to the engine termination.

This PR also adds `EngineBuilder:setEventTracker` in the C++ API to keep the same feature parity as the other language APIs.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile