### PR TITLE
tests: text and path glob path matching

### DIFF
--- a/test/extensions/path/uri_template_lib/uri_template_test.cc
+++ b/test/extensions/path/uri_template_lib/uri_template_test.cc
@@ -184,7 +184,6 @@ TEST_P(PathPatternMatchAndRewrite, IsValidTextGlobMatchPattern) {
   EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=**}").ok());
   EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=**}/doo").ok());
   EXPECT_TRUE(isValidMatchPattern("/{foo=*}/bar/{goo=**}").ok());
-  EXPECT_TRUE(isValidMatchPattern("/{*}/bar/{**}").ok());
   EXPECT_TRUE(isValidMatchPattern("/*/bar/**").ok());
 
   EXPECT_FALSE(isValidMatchPattern("/{foo=**}/bar/{goo=*}").ok());
@@ -196,9 +195,9 @@ TEST_P(PathPatternMatchAndRewrite, IsValidRewritePattern) {
   EXPECT_TRUE(isValidRewritePattern("/foo/bar/{goo}/{doo}").ok());
   EXPECT_TRUE(isValidRewritePattern("/{hoo}/bar/{goo}").ok());
 
-  EXPECT_FALSE(isValidMatchPattern("/foo//bar/{goo}").ok());
-  EXPECT_FALSE(isValidMatchPattern("/foo//bar/{goo}").ok());
-  EXPECT_FALSE(isValidMatchPattern("/foo/bar/{goo}}").ok());
+  EXPECT_FALSE(isValidRewritePattern("/foo//bar/{goo}").ok());
+  EXPECT_FALSE(isValidRewritePattern("//bar/{goo}").ok());
+  EXPECT_FALSE(isValidRewritePattern("/foo/bar/{goo}}").ok());
 }
 
 TEST_P(PathPatternMatchAndRewrite, IsValidSharedVariableSet) {

--- a/test/extensions/path/uri_template_lib/uri_template_test.cc
+++ b/test/extensions/path/uri_template_lib/uri_template_test.cc
@@ -170,6 +170,26 @@ TEST_P(PathPatternMatchAndRewrite, IsValidMatchPattern) {
   EXPECT_FALSE(isValidMatchPattern("/foo/bar/{goo}}").ok());
 }
 
+TEST_P(PathPatternMatchAndRewrite, IsValidPathGlobMatchPattern) {
+  EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=*}").ok());
+  EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=*}/{doo=*}").ok());
+  EXPECT_TRUE(isValidMatchPattern("/{hoo=*}/bar/{goo=*}").ok());
+
+  EXPECT_FALSE(isValidMatchPattern("/foo//bar/{goo=*}").ok());
+  EXPECT_FALSE(isValidMatchPattern("//bar/{goo=*}").ok());
+  EXPECT_FALSE(isValidMatchPattern("/foo/bar/{goo=*}}").ok());
+}
+
+TEST_P(PathPatternMatchAndRewrite, IsValidTextGlobMatchPattern) {
+  EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=**}").ok());
+  EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=**}/doo").ok());
+  EXPECT_TRUE(isValidMatchPattern("/{hoo=*}/bar/{goo=**}").ok());
+  EXPECT_TRUE(isValidMatchPattern("/*/bar/**").ok());
+
+  EXPECT_FALSE(isValidMatchPattern("/{hoo=**}/bar/{goo=*}").ok());
+  EXPECT_FALSE(isValidMatchPattern("/**/bar/*").ok());
+}
+
 TEST_P(PathPatternMatchAndRewrite, IsValidRewritePattern) {
   EXPECT_TRUE(isValidRewritePattern("/foo/bar/{goo}").ok());
   EXPECT_TRUE(isValidRewritePattern("/foo/bar/{goo}/{doo}").ok());

--- a/test/extensions/path/uri_template_lib/uri_template_test.cc
+++ b/test/extensions/path/uri_template_lib/uri_template_test.cc
@@ -183,10 +183,11 @@ TEST_P(PathPatternMatchAndRewrite, IsValidPathGlobMatchPattern) {
 TEST_P(PathPatternMatchAndRewrite, IsValidTextGlobMatchPattern) {
   EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=**}").ok());
   EXPECT_TRUE(isValidMatchPattern("/foo/bar/{goo=**}/doo").ok());
-  EXPECT_TRUE(isValidMatchPattern("/{hoo=*}/bar/{goo=**}").ok());
+  EXPECT_TRUE(isValidMatchPattern("/{foo=*}/bar/{goo=**}").ok());
+  EXPECT_TRUE(isValidMatchPattern("/{*}/bar/{**}").ok());
   EXPECT_TRUE(isValidMatchPattern("/*/bar/**").ok());
 
-  EXPECT_FALSE(isValidMatchPattern("/{hoo=**}/bar/{goo=*}").ok());
+  EXPECT_FALSE(isValidMatchPattern("/{foo=**}/bar/{goo=*}").ok());
   EXPECT_FALSE(isValidMatchPattern("/**/bar/*").ok());
 }
 

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -177,6 +177,7 @@ FIRSTHDR
 FQDN
 FREEBIND
 curr
+doo
 eslint
 freeifaddrs
 FUZZER
@@ -259,6 +260,7 @@ LEV
 LF
 LHS
 hls
+hoo
 iframe
 ilp
 ingressed


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Adds additional test cases for path and text glob path pattern matching.
Additional Description: Specifically verifies that `=**` or `**` must be the last operator in the path pattern match.
Risk Level: Low
Testing: Ran new tests locally.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
