### PR TITLE
network ext_authz filter: support include_tls_session option from http variant

### DIFF
--- a/api/envoy/extensions/filters/network/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/network/ext_authz/v3/ext_authz.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // gRPC Authorization API defined by
 // :ref:`CheckRequest <envoy_v3_api_msg_service.auth.v3.CheckRequest>`.
 // A failed check will cause this filter to close the TCP connection.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.ext_authz.v2.ExtAuthz";
@@ -62,4 +62,10 @@ message ExtAuthz {
   // :ref:`destination<envoy_v3_api_field_service.auth.v3.AttributeContext.destination>`.
   // The labels will be read from :ref:`metadata<envoy_v3_api_msg_config.core.v3.Node>` with the specified key.
   string bootstrap_metadata_labels_key = 7;
+
+  // Specifies if the TLS session level details like SNI are sent to the external service.
+  //
+  // When this field is true, Envoy will include the SNI name used for TLSClientHello, if available, in the
+  // :ref:`tls_session<envoy_v3_api_field_service.auth.v3.AttributeContext.tls_session>`.
+  bool include_tls_session = 8;
 }

--- a/api/envoy/service/auth/v3/attribute_context.proto
+++ b/api/envoy/service/auth/v3/attribute_context.proto
@@ -187,7 +187,11 @@ message AttributeContext {
   config.core.v3.Metadata route_metadata_context = 13;
 
   // TLS session details of the underlying connection.
-  // This is not populated by default and will be populated if ext_authz filter's
-  // :ref:`include_tls_session <config_http_filters_ext_authz>` is set to true.
+  // This is not populated by default and will be populated only if the ext_authz filter has
+  // been specifically configured to include this information.
+  // For HTTP ext_authz, that requires :ref:`include_tls_session <config_http_filters_ext_authz>`
+  // to be set to true.
+  // For network ext_authz, that requires :ref:`include_tls_session <config_network_filters_ext_authz>`
+  // to be set to true.
   TLSSession tls_session = 12;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -384,6 +384,10 @@ new_features:
   change: |
     Added :ref:`configuration option <envoy_v3_api_field_extensions.filters.http.cors.v3.CorsPolicy.forward_not_matching_preflights>`
     to return local response when CORS preflight's origin does not match allowed origin.
+- area: ext_authz
+  change: |
+    Added support for populating the :ref:`tls_session<envoy_v3_api_field_service.auth.v3.AttributeContext.tls_session>`
+    check request attribute for network ext_authz by setting :ref:`include_tls_session <config_network_filters_ext_authz>` to true.
 
 deprecated:
 - area: listener

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -187,6 +187,15 @@ void CheckRequestUtils::setAttrContextRequest(
                  max_request_bytes, pack_as_bytes, request_header_matchers);
 }
 
+void CheckRequestUtils::setTLSSession(
+    envoy::service::auth::v3::AttributeContext::TLSSession& session,
+    const Ssl::ConnectionInfoConstSharedPtr ssl_info) {
+  if (!ssl_info->sni().empty()) {
+    const std::string server_name(ssl_info->sni());
+    session.set_sni(server_name);
+  }
+}
+
 void CheckRequestUtils::createHttpCheck(
     const Envoy::Http::StreamDecoderFilterCallbacks* callbacks,
     const Envoy::Http::RequestHeaderMap& headers,
@@ -212,14 +221,8 @@ void CheckRequestUtils::createHttpCheck(
                         cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes,
                         request_header_matchers);
 
-  if (include_tls_session) {
-    if (cb->connection()->ssl() != nullptr) {
-      attrs->mutable_tls_session();
-      if (!cb->connection()->ssl()->sni().empty()) {
-        const std::string server_name(cb->connection()->ssl()->sni());
-        attrs->mutable_tls_session()->set_sni(server_name);
-      }
-    }
+  if (include_tls_session && cb->connection()->ssl() != nullptr) {
+    setTLSSession(*attrs->mutable_tls_session(), cb->connection()->ssl());
   }
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
   // Fill in the context extensions and metadata context.
@@ -242,14 +245,8 @@ void CheckRequestUtils::createTcpCheck(
                      include_peer_certificate);
   setAttrContextPeer(*attrs->mutable_destination(), cb->connection(), server_name, true,
                      include_peer_certificate);
-  if (include_tls_session) {
-    if (cb->connection().ssl() != nullptr) {
-      attrs->mutable_tls_session();
-      if (!cb->connection().ssl()->sni().empty()) {
-        const std::string server_name(cb->connection().ssl()->sni());
-        attrs->mutable_tls_session()->set_sni(server_name);
-      }
-    }
+  if (include_tls_session && cb->connection().ssl() != nullptr) {
+    setTLSSession(*attrs->mutable_tls_session(), cb->connection().ssl());
   }
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
 }

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -230,7 +230,7 @@ void CheckRequestUtils::createHttpCheck(
 
 void CheckRequestUtils::createTcpCheck(
     const Network::ReadFilterCallbacks* callbacks, envoy::service::auth::v3::CheckRequest& request,
-    bool include_peer_certificate,
+    bool include_peer_certificate, bool include_tls_session,
     const Protobuf::Map<std::string, std::string>& destination_labels) {
 
   auto attrs = request.mutable_attributes();
@@ -242,6 +242,15 @@ void CheckRequestUtils::createTcpCheck(
                      include_peer_certificate);
   setAttrContextPeer(*attrs->mutable_destination(), cb->connection(), server_name, true,
                      include_peer_certificate);
+  if (include_tls_session) {
+    if (cb->connection().ssl() != nullptr) {
+      attrs->mutable_tls_session();
+      if (!cb->connection().ssl()->sni().empty()) {
+        const std::string server_name(cb->connection().ssl()->sni());
+        attrs->mutable_tls_session()->set_sni(server_name);
+      }
+    }
+  }
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
 }
 

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -109,7 +109,7 @@ public:
    */
   static void createTcpCheck(const Network::ReadFilterCallbacks* callbacks,
                              envoy::service::auth::v3::CheckRequest& request,
-                             bool include_peer_certificate,
+                             bool include_peer_certificate, bool include_tls_session,
                              const Protobuf::Map<std::string, std::string>& destination_labels);
 
   static MatcherSharedPtr toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -138,6 +138,8 @@ private:
                                     const Envoy::Http::RequestHeaderMap& headers,
                                     uint64_t max_request_bytes, bool pack_as_bytes,
                                     const MatcherSharedPtr& request_header_matchers);
+  static void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
+                            const Ssl::ConnectionInfoConstSharedPtr ssl_info);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);
 };

--- a/source/extensions/filters/network/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/network/ext_authz/ext_authz.cc
@@ -22,9 +22,9 @@ InstanceStats Config::generateStats(const std::string& name, Stats::Scope& scope
 }
 
 void Filter::callCheck() {
-  Filters::Common::ExtAuthz::CheckRequestUtils::createTcpCheck(filter_callbacks_, check_request_,
-                                                               config_->includePeerCertificate(),
-                                                               config_->destinationLabels());
+  Filters::Common::ExtAuthz::CheckRequestUtils::createTcpCheck(
+      filter_callbacks_, check_request_, config_->includePeerCertificate(),
+      config_->includeTLSSession(), config_->destinationLabels());
   // Store start time of ext_authz filter call
   start_time_ = filter_callbacks_->connection().dispatcher().timeSource().monotonicTime();
   status_ = Status::Calling;

--- a/source/extensions/filters/network/ext_authz/ext_authz.h
+++ b/source/extensions/filters/network/ext_authz/ext_authz.h
@@ -55,6 +55,7 @@ public:
       : stats_(generateStats(config.stat_prefix(), scope)),
         failure_mode_allow_(config.failure_mode_allow()),
         include_peer_certificate_(config.include_peer_certificate()),
+        include_tls_session_(config.include_tls_session()),
         filter_enabled_metadata_(
             config.has_filter_enabled_metadata()
                 ? absl::optional<Matchers::MetadataMatcher>(
@@ -73,6 +74,7 @@ public:
   bool failureModeAllow() const { return failure_mode_allow_; }
   void setFailModeAllow(bool value) { failure_mode_allow_ = value; }
   bool includePeerCertificate() const { return include_peer_certificate_; }
+  bool includeTLSSession() const { return include_tls_session_; }
   const LabelsMap& destinationLabels() const { return destination_labels_; }
   bool filterEnabledMetadata(const envoy::config::core::v3::Metadata& metadata) const {
     return filter_enabled_metadata_.has_value() ? filter_enabled_metadata_->match(metadata) : true;
@@ -84,6 +86,7 @@ private:
   bool failure_mode_allow_;
   LabelsMap destination_labels_;
   const bool include_peer_certificate_;
+  const bool include_tls_session_;
   const absl::optional<Matchers::MetadataMatcher> filter_enabled_metadata_;
 };
 

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -149,7 +149,7 @@ TEST_F(CheckRequestUtilsTest, BasicTcp) {
   Protobuf::Map<std::string, std::string> labels;
   labels["label_1"] = "value_1";
   labels["label_2"] = "value_2";
-  CheckRequestUtils::createTcpCheck(&net_callbacks_, request, false, labels);
+  CheckRequestUtils::createTcpCheck(&net_callbacks_, request, false, false, labels);
 
   EXPECT_EQ(request.attributes().source().certificate().size(), 0);
   EXPECT_EQ("value_1", request.attributes().destination().labels().at("label_1"));
@@ -170,10 +170,30 @@ TEST_F(CheckRequestUtilsTest, TcpPeerCertificate) {
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   EXPECT_CALL(*ssl_, urlEncodedPemEncodedPeerCertificate()).WillOnce(ReturnRef(cert_data_));
 
-  CheckRequestUtils::createTcpCheck(&net_callbacks_, request, true,
+  CheckRequestUtils::createTcpCheck(&net_callbacks_, request, true, false,
                                     Protobuf::Map<std::string, std::string>());
 
   EXPECT_EQ(cert_data_, request.attributes().source().certificate());
+}
+
+// Verify that createTcpCheck populates the tls session details correctly.
+TEST_F(CheckRequestUtilsTest, TcpTlsSession) {
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(net_callbacks_, connection()).Times(6).WillRepeatedly(ReturnRef(connection_));
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
+  EXPECT_CALL(Const(connection_), ssl()).Times(5).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
+  EXPECT_CALL(*ssl_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"destination"}));
+  envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
+  want_tls_session.set_sni(sni_);
+  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
+
+  CheckRequestUtils::createTcpCheck(&net_callbacks_, request, false, true,
+                                    Protobuf::Map<std::string, std::string>());
+  EXPECT_TRUE(request.attributes().has_tls_session());
+  EXPECT_EQ(want_tls_session.sni(), request.attributes().tls_session().sni());
 }
 
 // Verify that createHttpCheck's dependencies are invoked when it's called.

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -179,10 +179,10 @@ TEST_F(CheckRequestUtilsTest, TcpPeerCertificate) {
 // Verify that createTcpCheck populates the tls session details correctly.
 TEST_F(CheckRequestUtilsTest, TcpTlsSession) {
   envoy::service::auth::v3::CheckRequest request;
-  EXPECT_CALL(net_callbacks_, connection()).Times(6).WillRepeatedly(ReturnRef(connection_));
+  EXPECT_CALL(net_callbacks_, connection()).Times(5).WillRepeatedly(ReturnRef(connection_));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(Const(connection_), ssl()).Times(5).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
@@ -453,11 +453,11 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerCertificate) {
 // Verify that the SNI is populated correctly.
 TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
   EXPECT_CALL(callbacks_, connection())
-      .Times(5)
+      .Times(4)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(Const(connection_), ssl()).Times(5).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
   EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
   EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));


### PR DESCRIPTION
Commit Message: network ext_authz filter: support include_tls_session option from http variant
Additional Description: the http ext_authz filter supports [including tls session details](https://github.com/envoyproxy/envoy/blob/bd81cea070e5dbf45a60f56fa599822f8cef8ae1/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto#L209-L213) in the check request. This PR ports that functionality over to the network ext_authz filter using the exact same mechanisms and the same field in the check request.
Risk Level: low
Testing: unit tests included
Docs Changes: docs are included in the protodoc for api changes. Slightly altered the protodoc for the check request attribute to link to both filters' config.
Release Notes: included as a new feature
Platform Specific Features: n/a
