### PR TITLE
POC wasm as upstream filter

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -807,7 +807,7 @@ WasmResult Context::setHeaderMapPairs(WasmHeaderMapType type, const Pairs& pairs
     const Http::LowerCaseString lower_key{std::string(p.first)};
     map->addCopy(lower_key, std::string(p.second));
   }
-  if (type == WasmHeaderMapType::RequestHeaders && decoder_callbacks_) {
+  if (type == WasmHeaderMapType::RequestHeaders && decoder_callbacks_ && decoder_callbacks_->downstreamCallbacks()) {
     decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
   }
   return WasmResult::Ok;

--- a/source/extensions/filters/http/wasm/config.cc
+++ b/source/extensions/filters/http/wasm/config.cc
@@ -13,10 +13,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Wasm {
 
-Http::FilterFactoryCb WasmFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::wasm::v3::Wasm& proto_config, const std::string&,
-    Server::Configuration::FactoryContext& context) {
-  context.serverFactoryContext().api().customStatNamespaces().registerStatNamespace(
+absl::StatusOr<Http::FilterFactoryCb> WasmFilterConfig::createFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::wasm::v3::Wasm& proto_config,
+      const std::string&, DualInfo,
+      Server::Configuration::ServerFactoryContext& context) {
+
+  context.api().customStatNamespaces().registerStatNamespace(
       Extensions::Common::Wasm::CustomStatNamespace);
   auto filter_config = std::make_shared<FilterConfig>(proto_config, context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
@@ -33,6 +35,8 @@ Http::FilterFactoryCb WasmFilterConfig::createFilterFactoryFromProtoTyped(
  * Static registration for the Wasm filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(WasmFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory);
+REGISTER_FACTORY(UpstreamWasmFilterConfig,
+                 Server::Configuration::UpstreamHttpFilterConfigFactory);
 
 } // namespace Wasm
 } // namespace HttpFilters

--- a/source/extensions/filters/http/wasm/config.h
+++ b/source/extensions/filters/http/wasm/config.h
@@ -14,15 +14,18 @@ namespace Wasm {
  * Config registration for the Wasm filter. @see NamedHttpFilterConfigFactory.
  */
 class WasmFilterConfig
-    : public Common::FactoryBase<envoy::extensions::filters::http::wasm::v3::Wasm> {
+    : public Common::DualFactoryBase<envoy::extensions::filters::http::wasm::v3::Wasm> {
 public:
-  WasmFilterConfig() : FactoryBase("envoy.filters.http.wasm") {}
+  WasmFilterConfig() : DualFactoryBase("envoy.filters.http.wasm") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::wasm::v3::Wasm& proto_config, const std::string&,
-      Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::wasm::v3::Wasm& proto_config,
+      const std::string& stats_prefix, DualInfo dual_info,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
+
+using UpstreamWasmFilterConfig = WasmFilterConfig;
 
 } // namespace Wasm
 } // namespace HttpFilters

--- a/source/extensions/filters/http/wasm/wasm_filter.cc
+++ b/source/extensions/filters/http/wasm/wasm_filter.cc
@@ -5,15 +5,141 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Wasm {
 
+struct MyAsyncClientManager: public Grpc::AsyncClientManager{
+   absl::StatusOr<Grpc::RawAsyncClientSharedPtr>
+  getOrCreateRawAsyncClient(const envoy::config::core::v3::GrpcService& ,
+                            Stats::Scope& , bool ) override {return absl::StatusOr<Grpc::RawAsyncClientSharedPtr>();};
+
+   absl::StatusOr<Grpc::RawAsyncClientSharedPtr>
+  getOrCreateRawAsyncClientWithHashKey(const Grpc::GrpcServiceConfigWithHashKey& ,
+                                       Stats::Scope& , bool ) override {return absl::StatusOr<Grpc::RawAsyncClientSharedPtr>();}
+
+   absl::StatusOr<Grpc::AsyncClientFactoryPtr>
+  factoryForGrpcService(const envoy::config::core::v3::GrpcService& ,
+                        Stats::Scope& , bool ) override {return absl::StatusOr<Grpc::AsyncClientFactoryPtr>();}
+
+};
+
+class MyClusterManagerFactory: public Upstream::ClusterManagerFactory {
+public:
+
+  Upstream::ClusterManagerPtr
+  clusterManagerFromProto(const envoy::config::bootstrap::v3::Bootstrap& ) override {return nullptr;}
+
+  virtual Http::ConnectionPool::InstancePtr
+  allocateConnPool(Event::Dispatcher& , Upstream::HostConstSharedPtr ,
+                   Upstream::ResourcePriority , std::vector<Http::Protocol>& ,
+                   const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
+                       ,
+                   const Network::ConnectionSocket::OptionsSharedPtr& ,
+                   const Network::TransportSocketOptionsConstSharedPtr& ,
+                   TimeSource& , Upstream::ClusterConnectivityState& ,
+                   Http::PersistentQuicInfoPtr& ) override {return nullptr;}
+
+  virtual Tcp::ConnectionPool::InstancePtr
+  allocateTcpConnPool(Event::Dispatcher& , Upstream::HostConstSharedPtr ,
+                      Upstream::ResourcePriority ,
+                      const Network::ConnectionSocket::OptionsSharedPtr& ,
+                      Network::TransportSocketOptionsConstSharedPtr ,
+                      Upstream::ClusterConnectivityState& ,
+                      absl::optional<std::chrono::milliseconds> ) override {return nullptr;}
+
+  virtual absl::StatusOr<std::pair<Upstream::ClusterSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>>
+  clusterFromProto(const envoy::config::cluster::v3::Cluster& , Upstream::ClusterManager& ,
+                   Upstream::Outlier::EventLoggerSharedPtr , bool ) override {return absl::StatusOr<std::pair<Upstream::ClusterSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>>();};
+
+  virtual Upstream::CdsApiPtr createCds(const envoy::config::core::v3::ConfigSource& ,
+                              const xds::core::v3::ResourceLocator* ,
+                              Upstream::ClusterManager& ) override {return nullptr;}
+
+  virtual Secret::SecretManager& secretManager() override { throw 1; }
+
+  virtual Singleton::Manager& singletonManager() override { throw 1; }
+};
+
+struct MyClusterManager : public Upstream::ClusterManager {
+  bool addOrUpdateCluster(const envoy::config::cluster::v3::Cluster& ,const std::string& ) override {return true;}
+
+
+  const Upstream::ClusterLbStatNames& clusterLbStatNames() const override { throw 1; }
+  const Upstream::ClusterEndpointStatNames& clusterEndpointStatNames() const override {
+    throw 1;
+  }
+  const Upstream::ClusterLoadReportStatNames& clusterLoadReportStatNames() const override {
+    throw 1;
+  }
+  const Upstream::ClusterCircuitBreakersStatNames& clusterCircuitBreakersStatNames() const override {
+    throw 1;
+  }
+  const Upstream::ClusterRequestResponseSizeStatNames& clusterRequestResponseSizeStatNames() const override {
+    throw 1;
+  }
+  const Upstream::ClusterTimeoutBudgetStatNames& clusterTimeoutBudgetStatNames() const override {
+    throw 1;
+  }
+  void drainConnections(const std::string& ,
+                        DrainConnectionsHostPredicate ) override{};
+  void drainConnections(DrainConnectionsHostPredicate ) override{};
+  absl::Status checkActiveStaticCluster(const std::string& ) override{ return absl::OkStatus(); };
+  //void notifyMissingCluster(absl::string_view) override{};
+
+  std::shared_ptr<const envoy::config::cluster::v3::Cluster::CommonLbConfig> getCommonLbConfigPtr(
+      const envoy::config::cluster::v3::Cluster::CommonLbConfig& ) override {
+    return nullptr;
+  }
+  Config::EdsResourcesCacheOptRef edsResourcesCache() override { return Config::EdsResourcesCacheOptRef();}
+  void setPrimaryClustersInitializedCb(PrimaryClustersReadyCallback ) override {}
+  void setInitializedCb(InitializationCompleteCallback ) override {}
+  bool removeCluster(const std::string& ) override {return true;}
+  void shutdown() override {}
+  bool isShutdown() override {return true;}
+  const absl::optional<std::string>& localClusterName() const override {return any;}
+
+  ClusterInfoMaps clusters() const override {return clusters_;}
+  const absl::optional<envoy::config::core::v3::BindConfig>& bindConfig() const override {return config_;}
+  Upstream::ThreadLocalCluster* getThreadLocalCluster(absl::string_view ) override {return nullptr;}
+  Grpc::AsyncClientManager& grpcAsyncClientManager() override {return async_manager;}
+   Config::GrpcMuxSharedPtr adsMux() override {return nullptr;}
+  Upstream::OdCdsApiHandlePtr
+  allocateOdCdsApi(const envoy::config::core::v3::ConfigSource& ,
+                   OptRef<xds::core::v3::ResourceLocator> ,
+                   ProtobufMessage::ValidationVisitor& ) override {return nullptr;}
+  absl::Status
+  initializeSecondaryClusters(const envoy::config::bootstrap::v3::Bootstrap& ) override {return absl::Status();}
+  const Upstream::ClusterConfigUpdateStatNames& clusterConfigUpdateStatNames() const override {throw 1;}
+  Upstream::ClusterUpdateCallbacksHandlePtr
+  addThreadLocalClusterUpdateCallbacks(Upstream::ClusterUpdateCallbacks& ) override {return nullptr;}
+  const Upstream::ClusterTrafficStatNames& clusterStatNames() const override {throw 1;}
+  const ClusterSet& primaryClusters() override {return clusterset_;}
+  Upstream::ClusterManagerFactory& clusterManagerFactory() override { return c_manager_; }
+  Config::SubscriptionFactory& subscriptionFactory() override { throw 1;}
+
+  //Upstream::ClusterConfigUpdateStatNames cluster_config_update_stat_names_;
+  //Upstream::ClusterLbStatNames cluster_lb_stat_names_;
+  //Upstream::ClusterEndpointStatNames cluster_endpoint_stat_names_;
+  //Upstream::ClusterLoadReportStatNames cluster_load_report_stat_names_;
+  //Upstream::ClusterCircuitBreakersStatNames cluster_circuit_breakers_stat_names_;
+  //Upstream::ClusterRequestResponseSizeStatNames cluster_request_response_size_stat_names_;
+  //Upstream::ClusterTimeoutBudgetStatNames cluster_timeout_budget_stat_names_;
+  //Upstream::ClusterTrafficStatNames cluster_traffic_stat_name_;
+  absl::optional<std::string> any{""};
+
+  ClusterInfoMaps clusters_;
+  ClusterSet clusterset_;
+  absl::optional<envoy::config::core::v3::BindConfig> config_;
+  MyAsyncClientManager async_manager;
+  MyClusterManagerFactory c_manager_;
+} mycluster;
+
 FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Wasm& config,
-                           Server::Configuration::FactoryContext& context) {
-  auto& server = context.serverFactoryContext();
+                           Server::Configuration::ServerFactoryContext& context) {
+  auto& server = context;
   tls_slot_ = ThreadLocal::TypedSlot<Common::Wasm::PluginHandleSharedPtrThreadLocal>::makeUnique(
       server.threadLocal());
 
   const auto plugin = std::make_shared<Common::Wasm::Plugin>(
-      config.config(), context.listenerInfo().direction(), server.localInfo(),
-      &context.listenerInfo().metadata());
+      config.config(), envoy::config::core::v3::TrafficDirection::INBOUND, server.localInfo(),
+      nullptr);
 
   auto callback = [plugin, this](const Common::Wasm::WasmHandleSharedPtr& base_wasm) {
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
@@ -23,7 +149,7 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
     });
   };
 
-  if (!Common::Wasm::createWasm(plugin, context.scope().createScope(""), server.clusterManager(),
+  if (!Common::Wasm::createWasm(plugin, context.scope().createScope(""), mycluster /*server.clusterManager()*/,
                                 context.initManager(), server.mainThreadDispatcher(), server.api(),
                                 server.lifecycleNotifier(), remote_data_provider_,
                                 std::move(callback))) {

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -25,7 +25,7 @@ using Envoy::Extensions::Common::Wasm::Wasm;
 class FilterConfig : Logger::Loggable<Logger::Id::wasm> {
 public:
   FilterConfig(const envoy::extensions::filters::http::wasm::v3::Wasm& config,
-               Server::Configuration::FactoryContext& context);
+               Server::Configuration::ServerFactoryContext& context);
 
   std::shared_ptr<Context> createFilter() {
     Wasm* wasm = nullptr;


### PR DESCRIPTION

When the filter is trying to be created. it try to get the clusterManager reference from ServerFactoryContext but it seems it is not available at that moment the pointer is null. not initialized at that moment.

[2024-03-26 12:35:53.520][144854083][critical][assert] [source/server/server.cc:144] assert failure: config_.clusterManager() != nullptr.
[2024-03-26 12:35:53.520][144854083][critical][backtrace] [./source/server/backtrace.h:104] Caught Abort trap: 6, suspect faulting address 0x182652a60
[2024-03-26 12:35:53.520][144854083][critical][backtrace] [./source/server/backtrace.h:91] Backtrace (use tools/stack_decode.py to get line numbers):
[2024-03-26 12:35:53.520][144854083][critical][backtrace] [./source/server/backtrace.h:92] Envoy version: 22e6a78621ca66d3109cfa2a0f075e7efb721801/1.30.0-dev/Modified/DEBUG/BoringSSL
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #0: Envoy::SignalAction::sigHandler() [0x10c6dc9b8]
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #1: _sigtramp [0x1826bb584]
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #2: pthread_kill [0x18268ac20]
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #3: abort [0x182597a20]
[2024-03-26 12:35:53.545][144854083][critical][backtrace] [./source/server/backtrace.h:96] #4: Envoy::Server::InstanceBase::clusterManager() [0x10a3f5bcc]
[2024-03-26 12:35:53.547][144854083][critical][backtrace] [./source/server/backtrace.h:96] #5: Envoy::Server::ServerFactoryContextImpl::clusterManager() [0x10a374710]
[2024-03-26 12:35:53.548][144854083][critical][backtrace] [./source/server/backtrace.h:96] #6: Envoy::Extensions::HttpFilters::Wasm::FilterConfig::FilterConfig() 

To make it work I just mock the clusterManager and could create a policy to add a header as upstream filter.
I have to add a check to not make the clearCacheRoute, I guess this has no meaning as upstream. Probably other checks are needed in the code.
Due to mock the clusterManager, I understand some functionality is not available like making calls to any server. not sure if has sens in an upstream filter.

I don't know how we could solve the clusterManager issue. 


More Context in the stack

[2024-03-26 12:35:53.509][144854083][debug][misc] [source/common/network/dns_resolver/dns_factory_util.cc:39] create Apple DNS resolver type: envoy.network.dns_resolver.apple in MacOS.
[2024-03-26 12:35:53.509][144854083][debug][misc] [source/common/network/dns_resolver/dns_factory_util.cc:75] create DNS resolver type: envoy.network.dns_resolver.apple
[2024-03-26 12:35:53.519][144854083][debug][config] [./source/common/http/filter_chain_helper.h:111]     upstream http filter #0
[2024-03-26 12:35:53.520][144854083][critical][assert] [source/server/server.cc:144] assert failure: config_.clusterManager() != nullptr.
[2024-03-26 12:35:53.520][144854083][critical][backtrace] [./source/server/backtrace.h:104] Caught Abort trap: 6, suspect faulting address 0x182652a60
[2024-03-26 12:35:53.520][144854083][critical][backtrace] [./source/server/backtrace.h:91] Backtrace (use tools/stack_decode.py to get line numbers):
[2024-03-26 12:35:53.520][144854083][critical][backtrace] [./source/server/backtrace.h:92] Envoy version: 22e6a78621ca66d3109cfa2a0f075e7efb721801/1.30.0-dev/Modified/DEBUG/BoringSSL
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #0: Envoy::SignalAction::sigHandler() [0x10c6dc9b8]
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #1: _sigtramp [0x1826bb584]
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #2: pthread_kill [0x18268ac20]
[2024-03-26 12:35:53.541][144854083][critical][backtrace] [./source/server/backtrace.h:96] #3: abort [0x182597a20]
[2024-03-26 12:35:53.545][144854083][critical][backtrace] [./source/server/backtrace.h:96] #4: Envoy::Server::InstanceBase::clusterManager() [0x10a3f5bcc]
[2024-03-26 12:35:53.547][144854083][critical][backtrace] [./source/server/backtrace.h:96] #5: Envoy::Server::ServerFactoryContextImpl::clusterManager() [0x10a374710]
[2024-03-26 12:35:53.548][144854083][critical][backtrace] [./source/server/backtrace.h:96] #6: Envoy::Extensions::HttpFilters::Wasm::FilterConfig::FilterConfig() [0x10553fe64]
[2024-03-26 12:35:53.550][144854083][critical][backtrace] [./source/server/backtrace.h:96] #7: Envoy::Extensions::HttpFilters::Wasm::FilterConfig::FilterConfig() [0x1055403d8]
[2024-03-26 12:35:53.551][144854083][critical][backtrace] [./source/server/backtrace.h:96] #8: std::__1::construct_at[abi:v160006]<>() [0x10553ac3c]
[2024-03-26 12:35:53.553][144854083][critical][backtrace] [./source/server/backtrace.h:96] #9: std::__1::allocator_traits<>::construct[abi:v160006]<>() [0x10553aa54]
[2024-03-26 12:35:53.555][144854083][critical][backtrace] [./source/server/backtrace.h:96] #10: std::__1::__shared_ptr_emplace<>::__shared_ptr_emplace[abi:v160006]<>() [0x10553a978]
[2024-03-26 12:35:53.557][144854083][critical][backtrace] [./source/server/backtrace.h:96] #11: std::__1::__shared_ptr_emplace<>::__shared_ptr_emplace[abi:v160006]<>() [0x10553a658]
[2024-03-26 12:35:53.558][144854083][critical][backtrace] [./source/server/backtrace.h:96] #12: std::__1::allocate_shared[abi:v160006]<>() [0x10553a558]
[2024-03-26 12:35:53.560][144854083][critical][backtrace] [./source/server/backtrace.h:96] #13: std::__1::make_shared[abi:v160006]<>() [0x1055397b8]
[2024-03-26 12:35:53.561][144854083][critical][backtrace] [./source/server/backtrace.h:96] #14: Envoy::Extensions::HttpFilters::Wasm::WasmFilterConfig::createFilterFactoryFromProtoTyped() [0x105539718]
[2024-03-26 12:35:53.563][144854083][critical][backtrace] [./source/server/backtrace.h:96] #15: Envoy::Extensions::HttpFilters::Common::DualFactoryBase<>::createFilterFactoryFromProto() [0x105539cdc]
[2024-03-26 12:35:53.565][144854083][critical][backtrace] [./source/server/backtrace.h:96] #16: Envoy::Http::FilterChainHelper<>::processFilter() [0x10b0bed64]
[2024-03-26 12:35:53.567][144854083][critical][backtrace] [./source/server/backtrace.h:96] #17: Envoy::Http::FilterChainHelper<>::processFilters() [0x10b054b38]
[2024-03-26 12:35:53.569][144854083][critical][backtrace] [./source/server/backtrace.h:96] #18: Envoy::Upstream::ClusterInfoImpl::ClusterInfoImpl() [0x10b0507a8]
[2024-03-26 12:35:53.571][144854083][critical][backtrace] [./source/server/backtrace.h:96] #19: Envoy::Upstream::ClusterInfoImpl::ClusterInfoImpl() [0x10b0550b8]
[2024-03-26 12:35:53.572][144854083][critical][backtrace] [./source/server/backtrace.h:96] #20: Envoy::Upstream::ClusterImplBase::ClusterImplBase() [0x10b056550]
[2024-03-26 12:35:53.574][144854083][critical][backtrace] [./source/server/backtrace.h:96] #21: Envoy::Upstream::BaseDynamicClusterImpl::?::ClusterImplBase() [0x1044ba19c]
[2024-03-26 12:35:53.576][144854083][critical][backtrace] [./source/server/backtrace.h:96] #22: Envoy::Upstream::StrictDnsClusterImpl::StrictDnsClusterImpl() [0x1045393cc]
[2024-03-26 12:35:53.577][144854083][critical][backtrace] [./source/server/backtrace.h:96] #23: Envoy::Upstream::StrictDnsClusterImpl::StrictDnsClusterImpl() [0x104539fac]
[2024-03-26 12:35:53.579][144854083][critical][backtrace] [./source/server/backtrace.h:96] #24: std::__1::construct_at[abi:v160006]<>() [0x104547a70]
[2024-03-26 12:35:53.580][144854083][critical][backtrace] [./source/server/backtrace.h:96] #25: std::__1::allocator_traits<>::construct[abi:v160006]<>() [0x10454785c]
[2024-03-26 12:35:53.582][144854083][critical][backtrace] [./source/server/backtrace.h:96] #26: std::__1::__shared_ptr_emplace<>::__shared_ptr_emplace[abi:v160006]<>() [0x104547778]
[2024-03-26 12:35:53.583][144854083][critical][backtrace] [./source/server/backtrace.h:96] #27: std::__1::__shared_ptr_emplace<>::__shared_ptr_emplace[abi:v160006]<>() [0x104547450]
[2024-03-26 12:35:53.585][144854083][critical][backtrace] [./source/server/backtrace.h:96] #28: std::__1::allocate_shared[abi:v160006]<>() [0x104547348]
[2024-03-26 12:35:53.586][144854083][critical][backtrace] [./source/server/backtrace.h:96] #29: std::__1::make_shared[abi:v160006]<>() [0x10453ace0]
[2024-03-26 12:35:53.588][144854083][critical][backtrace] [./source/server/backtrace.h:96] #30: Envoy::Upstream::StrictDnsClusterFactory::createClusterImpl() [0x10453abb4]
[2024-03-26 12:35:53.590][144854083][critical][backtrace] [./source/server/backtrace.h:96] #31: Envoy::Upstream::ClusterFactoryImplBase::create() [0x10b0f53d0]
[2024-03-26 12:35:53.591][144854083][critical][backtrace] [./source/server/backtrace.h:96] #32: Envoy::Upstream::ClusterFactoryImplBase::create() [0x10b0f4a38]
[2024-03-26 12:35:53.593][144854083][critical][backtrace] [./source/server/backtrace.h:96] #33: Envoy::Upstream::ProdClusterManagerFactory::clusterFromProto() [0x10a5a6e50]
[2024-03-26 12:35:53.595][144854083][critical][backtrace] [./source/server/backtrace.h:96] #34: Envoy::Upstream::ClusterManagerImpl::loadCluster() [0x10a58c7c0]
[2024-03-26 12:35:53.597][144854083][critical][backtrace] [./source/server/backtrace.h:96] #35: Envoy::Upstream::ClusterManagerImpl::init() [0x10a58a9ec]
[2024-03-26 12:35:53.599][144854083][critical][backtrace] [./source/server/backtrace.h:96] #36: Envoy::Upstream::ProdClusterManagerFactory::clusterManagerFromProto() [0x10a5a3a3c]
[2024-03-26 12:35:53.600][144854083][critical][backtrace] [./source/server/backtrace.h:96] #37: Envoy::Server::Configuration::MainImpl::initialize() [0x10bc37e9c]
[2024-03-26 12:35:53.602][144854083][critical][backtrace] [./source/server/backtrace.h:96] #38: Envoy::Server::InstanceBase::initializeOrThrow() [0x10a3fdae0]
[2024-03-26 12:35:53.604][144854083][critical][backtrace] [./source/server/backtrace.h:96] #39: Envoy::Server::InstanceBase::initialize() [0x10a3f886c]
[2024-03-26 12:35:53.606][144854083][critical][backtrace] [./source/server/backtrace.h:96] #40: Envoy::createFunction()::$_1::operator()() [0x10a3011a0]