### PR TITLE
Revert "Disable file system tests broken by infra change (#33117)"

### DIFF
--- a/test/extensions/common/async_files/async_file_handle_thread_pool_test.cc
+++ b/test/extensions/common/async_files/async_file_handle_thread_pool_test.cc
@@ -139,8 +139,6 @@ TEST_F(AsyncFileHandleTest, WriteReadClose) {
 }
 
 TEST_F(AsyncFileHandleTest, LinkCreatesNamedFile) {
-  // TODO(https://github.com/envoyproxy/envoy/issues/33114) Enable
-  GTEST_SKIP();
   auto handle = createAnonymousFile();
   std::promise<absl::StatusOr<size_t>> write_status_promise;
   // Write "hello" to the anonymous file.

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -1241,15 +1241,11 @@ public:
 };
 
 // For the standard cache tests from http_cache_implementation_test_common.cc
-// TODO(https://github.com/envoyproxy/envoy/issues/33114) Enable
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(HttpCacheImplementationTest);
-/*
 INSTANTIATE_TEST_SUITE_P(FileSystemHttpCacheTest, HttpCacheImplementationTest,
                          testing::Values(std::make_unique<FileSystemHttpCacheTestDelegate>),
                          [](const testing::TestParamInfo<HttpCacheImplementationTest::ParamType>&) {
                            return "FileSystemHttpCache";
                          });
-*/
 
 TEST(Registration, GetCacheFromFactory) {
   HttpCacheFactory* factory = Registry::FactoryRegistry<HttpCacheFactory>::getFactoryByType(

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -42,7 +42,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/network/sni_cluster:88.9"
 "source/extensions/filters/network/wasm:76.9"
 "source/extensions/http/cache/simple_http_cache:95.9"
-"source/extensions/http/cache/file_system_http_cache:30.0" # TODO(https://github.com/envoyproxy/envoy/issues/33114)
 "source/extensions/rate_limit_descriptors:95.0"
 "source/extensions/rate_limit_descriptors/expr:95.0"
 "source/extensions/stat_sinks/graphite_statsd:82.8" # Death tests don't report LCOV


### PR DESCRIPTION
This reverts commit 2d368c340833ce1a86db81a7eb48700c13575435.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
