### PR TITLE
Revert "Enable static validation of the EVENT log macros (#33067)"

### DIFF
--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -158,17 +158,6 @@ void DelegatingLogSink::setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; 
 
 SinkDelegate* DelegatingLogSink::tlsDelegate() { return *tlsSink(); }
 
-void DelegatingLogSink::logWithStableName(absl::string_view stable_name, absl::string_view level,
-                                          absl::string_view component, absl::string_view message) {
-  auto tls_sink = tlsDelegate();
-  if (tls_sink != nullptr) {
-    tls_sink->logWithStableName(stable_name, level, component, message);
-    return;
-  }
-  absl::ReaderMutexLock sink_lock(&sink_mutex_);
-  sink_->logWithStableName(stable_name, level, component, message);
-}
-
 static std::atomic<Context*> current_context = nullptr;
 static_assert(std::atomic<Context*>::is_always_lock_free);
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -205,8 +205,19 @@ public:
   void setLock(Thread::BasicLockable& lock) { stderr_sink_->setLock(lock); }
   void clearLock() { stderr_sink_->clearLock(); }
 
+  template <class FmtStr, class... Args>
   void logWithStableName(absl::string_view stable_name, absl::string_view level,
-                         absl::string_view component, absl::string_view message);
+                         absl::string_view component, FmtStr fmt_str, Args... msg) {
+    auto tls_sink = tlsDelegate();
+    if (tls_sink != nullptr) {
+      tls_sink->logWithStableName(stable_name, level, component,
+                                  fmt::format(fmt::runtime(fmt_str), msg...));
+      return;
+    }
+    absl::ReaderMutexLock sink_lock(&sink_mutex_);
+    sink_->logWithStableName(stable_name, level, component,
+                             fmt::format(fmt::runtime(fmt_str), msg...));
+  }
   // spdlog::sinks::sink
   void log(const spdlog::details::log_msg& msg) override;
   void flush() override;
@@ -646,7 +657,7 @@ public:
     ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ##__VA_ARGS__);                                             \
     if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
       ::Envoy::Logger::Registry::getSink()->logWithStableName(EVENT_NAME, #LEVEL, (LOGGER).name(), \
-                                                              fmt::format(__VA_ARGS__));           \
+                                                              ##__VA_ARGS__);                      \
     }                                                                                              \
   } while (0)
 
@@ -658,9 +669,8 @@ public:
       ENVOY_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, "{}" FORMAT,                                      \
                           ::Envoy::Logger::Utility::serializeLogTags(log_tags), ##__VA_ARGS__);    \
       ::Envoy::Logger::Registry::getSink()->logWithStableName(                                     \
-          EVENT_NAME, #LEVEL, (ENVOY_LOGGER()).name(),                                             \
-          fmt::format("{}" FORMAT, ::Envoy::Logger::Utility::serializeLogTags(log_tags),           \
-                      ##__VA_ARGS__));                                                             \
+          EVENT_NAME, #LEVEL, (ENVOY_LOGGER()).name(), "{}" FORMAT,                                \
+          ::Envoy::Logger::Utility::serializeLogTags(log_tags), ##__VA_ARGS__);                    \
     }                                                                                              \
   } while (0)
 


### PR DESCRIPTION
This reverts commit 6d1363a40824ee31dd6643e03e17568c8fa502df.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
