### PR TITLE
cors: do not modify response headers for requests not matching origin

### DIFF
--- a/docs/root/configuration/http/http_filters/cors_filter.rst
+++ b/docs/root/configuration/http/http_filters/cors_filter.rst
@@ -15,8 +15,8 @@ For the meaning of the headers please refer to the pages below.
 .. note::
   This filter will be used to respond to preflight ``OPTIONS`` requests. Any legal ``OPTIONS`` requests will be
   responded directly by the filter and will not be passed to the next filter in the filter chain. Other requests
-  will not be responded directly but if they are accepted cors requests, the filter will add the related headers
-  to the response.
+  will not be responded directly but if they are accepted cors requests, matching configured allowed origins,
+  the filter will add the related headers to the response.
 
   In addition, this filter will be bypassed if a direct response or route redirect is configured for the route.
 

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -184,10 +184,13 @@ Http::FilterHeadersStatus CorsFilter::encodeHeaders(Http::ResponseHeaderMap& hea
   if (!is_cors_request_) {
     return Http::FilterHeadersStatus::Continue;
   }
-
-  if (!latched_origin_.empty()) {
-    headers.setInline(access_control_allow_origin_handle.handle(), latched_origin_);
+  // Origin did not match. Do not modify the response headers.
+  if (latched_origin_.empty()) {
+    return Http::FilterHeadersStatus::Continue;
   }
+
+  headers.setInline(access_control_allow_origin_handle.handle(), latched_origin_);
+
   if (allowCredentials()) {
     headers.setReferenceInline(access_control_allow_credentials_handle.handle(),
                                Http::CustomHeaders::get().CORSValues.True);


### PR DESCRIPTION
Commit Message:
cors: Do not modify response headers for requests not matching origin
Additional Description:
Regular cors requests (not preflights), which did not match configured allowed origins are forwarded upstream to the server. It seems that treatment of responses to such requests was undefined. There was no documentation, no unit nor integration tests which enforced whether extra headers should be added to responses to such request. Before #33051, the headers were not added and after the #33051 headers were added. This PR brings the behaviour to original and headers are not added. Docs have been updated and unit test was added to enforce this behaviour. 
Risk Level: Low
Testing: Added unit test.
Docs Changes: Updated.
Release Notes: No
Platform Specific Features: No
Fixes #33086
