### PR TITLE
Enable static validation of the EVENT log macros

### DIFF
--- a/mobile/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/mobile/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -101,8 +101,7 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
     callback_time_ms->complete();
     auto elapsed = callback_time_ms->elapsed();
     if (elapsed > SlowCallbackWarningThreshold) {
-      ENVOY_LOG_EVENT(warn, "slow_init_cb",
-                      filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+      ENVOY_LOG_EVENT(warn, "slow_init_cb", "{}|{}ms", filter_name_, elapsed.count());
     }
 
     ASSERT(platform_filter_.instance_context,
@@ -180,8 +179,7 @@ void PlatformBridgeFilter::onDestroy() {
     callback_time_ms->complete();
     auto elapsed = callback_time_ms->elapsed();
     if (elapsed > SlowCallbackWarningThreshold) {
-      ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb",
-                      filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+      ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb", "{}|{}ms", filter_name_, elapsed.count());
     }
   }
 
@@ -285,8 +283,8 @@ Http::FilterHeadersStatus PlatformBridgeFilter::FilterBase::onHeaders(Http::Head
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_headers_cb",
-                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_headers_cb", "{}|{}ms", parent_.filter_name_,
+                    elapsed.count());
   }
 
   state_.on_headers_called_ = true;
@@ -346,8 +344,8 @@ Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_data_cb",
-                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_data_cb", "{}|{}ms", parent_.filter_name_,
+                    elapsed.count());
   }
 
   state_.on_data_called_ = true;
@@ -441,8 +439,8 @@ Http::FilterTrailersStatus PlatformBridgeFilter::FilterBase::onTrailers(Http::He
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_trailers_cb",
-                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_trailers_cb", "{}|{}ms", parent_.filter_name_,
+                    elapsed.count());
   }
 
   state_.on_trailers_called_ = true;
@@ -680,8 +678,8 @@ void PlatformBridgeFilter::FilterBase::onResume() {
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_resume_cb",
-                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_resume_cb", "{}|{}ms", parent_.filter_name_,
+                    elapsed.count());
   }
 
   state_.on_resume_called_ = true;

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -87,7 +87,7 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_headers_cb", std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_headers_cb", "{}ms", elapsed.count());
   }
 
   response_headers_forwarded_ = true;
@@ -173,7 +173,7 @@ void Client::DirectStreamCallbacks::sendDataToBridge(Buffer::Instance& data, boo
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_data_cb", std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_data_cb", "{}ms", elapsed.count());
   }
 
   if (send_end_stream) {
@@ -214,7 +214,7 @@ void Client::DirectStreamCallbacks::sendTrailersToBridge(const ResponseTrailerMa
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_trailers_cb", std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_trailers_cb", "{}ms", elapsed.count());
   }
 
   onComplete();
@@ -288,7 +288,7 @@ void Client::DirectStreamCallbacks::onComplete() {
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_complete_cb", std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_complete_cb", "{}ms", elapsed.count());
   }
 }
 
@@ -345,7 +345,7 @@ void Client::DirectStreamCallbacks::sendErrorToBridge() {
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_error_cb", std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_error_cb", "{}ms", elapsed.count());
   }
 }
 
@@ -372,7 +372,7 @@ void Client::DirectStreamCallbacks::onCancel() {
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb", std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb", "{}ms", elapsed.count());
   }
 }
 

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -307,17 +307,20 @@ Stats::Store& InternalEngine::getStatsStore() {
 
 void InternalEngine::logInterfaces(absl::string_view event,
                                    std::vector<Network::InterfacePair>& interfaces) {
-  std::vector<std::string> names;
-  names.resize(interfaces.size());
-  std::transform(interfaces.begin(), interfaces.end(), names.begin(),
-                 [](Network::InterfacePair& pair) { return std::get<0>(pair); });
+  auto all_names_printer = [](std::vector<Network::InterfacePair>& interfaces) -> std::string {
+    std::vector<std::string> names;
+    names.resize(interfaces.size());
+    std::transform(interfaces.begin(), interfaces.end(), names.begin(),
+                   [](Network::InterfacePair& pair) { return std::get<0>(pair); });
 
-  auto unique_end = std::unique(names.begin(), names.end());
-  std::string all_names = std::accumulate(names.begin(), unique_end, std::string{},
-                                          [](std::string acc, std::string next) {
-                                            return acc.empty() ? next : std::move(acc) + "," + next;
-                                          });
-  ENVOY_LOG_EVENT(debug, event, all_names);
+    auto unique_end = std::unique(names.begin(), names.end());
+    std::string all_names = std::accumulate(
+        names.begin(), unique_end, std::string{}, [](std::string acc, std::string next) {
+          return acc.empty() ? next : std::move(acc) + "," + next;
+        });
+    return all_names;
+  };
+  ENVOY_LOG_EVENT(debug, event, "{}", all_names_printer(interfaces));
 }
 
 } // namespace Envoy

--- a/mobile/library/common/network/connectivity_manager.cc
+++ b/mobile/library/common/network/connectivity_manager.cc
@@ -92,7 +92,7 @@ envoy_netconf_t ConnectivityManagerImpl::setPreferredNetwork(envoy_network_t net
   //  return network_state_.configuration_key_ - 1;
   //}
 
-  ENVOY_LOG_EVENT(debug, "netconf_network_change", std::to_string(network));
+  ENVOY_LOG_EVENT(debug, "netconf_network_change", "{}", std::to_string(network));
 
   network_state_.configuration_key_++;
   network_state_.network_ = network;
@@ -104,14 +104,14 @@ envoy_netconf_t ConnectivityManagerImpl::setPreferredNetwork(envoy_network_t net
 
 void ConnectivityManagerImpl::setProxySettings(ProxySettingsConstSharedPtr new_proxy_settings) {
   if (proxy_settings_ == nullptr && new_proxy_settings != nullptr) {
-    ENVOY_LOG_EVENT(info, "netconf_proxy_change", new_proxy_settings->asString());
+    ENVOY_LOG_EVENT(info, "netconf_proxy_change", "{}", new_proxy_settings->asString());
     proxy_settings_ = new_proxy_settings;
   } else if (proxy_settings_ != nullptr && new_proxy_settings == nullptr) {
     ENVOY_LOG_EVENT(info, "netconf_proxy_change", "no_proxy_configured");
     proxy_settings_ = new_proxy_settings;
   } else if (proxy_settings_ != nullptr && new_proxy_settings != nullptr &&
              *proxy_settings_ != *new_proxy_settings) {
-    ENVOY_LOG_EVENT(info, "netconf_proxy_change", new_proxy_settings->asString());
+    ENVOY_LOG_EVENT(info, "netconf_proxy_change", "{}", new_proxy_settings->asString());
     proxy_settings_ = new_proxy_settings;
   }
 
@@ -215,7 +215,7 @@ void ConnectivityManagerImpl::onDnsResolutionComplete(
     // drain connections. It may be possible to refine this logic in the future.
     // TODO(goaway): check the set of cached hosts from the last triggered DNS refresh for this
     // host, and if present, remove it and trigger connection drain for this host specifically.
-    ENVOY_LOG_EVENT(debug, "netconf_post_dns_drain_cx", resolved_host);
+    ENVOY_LOG_EVENT(debug, "netconf_post_dns_drain_cx", "{}", resolved_host);
 
     // Pass predicate to only drain connections to the resolved host (for any cluster).
     cluster_manager_.drainConnections(
@@ -252,13 +252,13 @@ void ConnectivityManagerImpl::refreshDns(envoy_netconf_t configuration_key,
     // Note this does NOT completely prevent parallel refreshes from being triggered in multiple
     // flip-flop scenarios.
     if (configuration_key != network_state_.configuration_key_) {
-      ENVOY_LOG_EVENT(debug, "netconf_dns_flipflop", std::to_string(configuration_key));
+      ENVOY_LOG_EVENT(debug, "netconf_dns_flipflop", "{}", std::to_string(configuration_key));
       return;
     }
   }
 
   if (auto dns_cache = dnsCache()) {
-    ENVOY_LOG_EVENT(debug, "netconf_refresh_dns", std::to_string(configuration_key));
+    ENVOY_LOG_EVENT(debug, "netconf_refresh_dns", "{}", std::to_string(configuration_key));
 
     if (drain_connections && enable_drain_post_dns_refresh_) {
       dns_cache->iterateHostMap(
@@ -275,7 +275,7 @@ void ConnectivityManagerImpl::refreshDns(envoy_netconf_t configuration_key,
 Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr ConnectivityManagerImpl::dnsCache() {
   auto cache = dns_cache_manager_->lookUpCacheByName(BaseDnsCache);
   if (!cache) {
-    ENVOY_LOG_EVENT(warn, "netconf_dns_cache_missing", std::string(BaseDnsCache));
+    ENVOY_LOG_EVENT(warn, "netconf_dns_cache_missing", "{}", std::string(BaseDnsCache));
   }
   return cache;
 }

--- a/mobile/library/jni/types/exception.cc
+++ b/mobile/library/jni/types/exception.cc
@@ -16,7 +16,7 @@ bool Exception::checkAndClear(const std::string& details) {
     env->ExceptionClear();
 
     const auto exception = Exception(env, throwable);
-    ENVOY_LOG_EVENT_TO_LOGGER(GET_MISC_LOGGER(), info, "jni_cleared_pending_exception",
+    ENVOY_LOG_EVENT_TO_LOGGER(GET_MISC_LOGGER(), info, "jni_cleared_pending_exception", "{}",
                               exception.description(details));
     return true;
   } else {

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -158,6 +158,17 @@ void DelegatingLogSink::setTlsDelegate(SinkDelegate* sink) { *tlsSink() = sink; 
 
 SinkDelegate* DelegatingLogSink::tlsDelegate() { return *tlsSink(); }
 
+void DelegatingLogSink::logWithStableName(absl::string_view stable_name, absl::string_view level,
+                                          absl::string_view component, absl::string_view message) {
+  auto tls_sink = tlsDelegate();
+  if (tls_sink != nullptr) {
+    tls_sink->logWithStableName(stable_name, level, component, message);
+    return;
+  }
+  absl::ReaderMutexLock sink_lock(&sink_mutex_);
+  sink_->logWithStableName(stable_name, level, component, message);
+}
+
 static std::atomic<Context*> current_context = nullptr;
 static_assert(std::atomic<Context*>::is_always_lock_free);
 


### PR DESCRIPTION
Commit Message:
The fmt::runtime method prevents static validation of format strings. This change eliminates the need for fmt::runtime by formatting the message before calling the logWithStableName method.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A