### PR TITLE
qatzstd: remove useless build parameters

### DIFF
--- a/contrib/qat/BUILD
+++ b/contrib/qat/BUILD
@@ -21,15 +21,11 @@ configure_make(
         "--disable-fast-crc-in-assembler",
         "--disable-systemd",
         "--with-pic",
-        "--enable-shared",
+        "--disable-shared",
         "--enable-static",
         "--enable-samples=no",
     ],
     lib_source = "@com_github_intel_qatlib//:all",
-    out_shared_libs = [
-        "libqat.so",
-        "libusdm.so",
-    ],
     out_static_libs = [
         "libqat.a",
         "libusdm.a",


### PR DESCRIPTION
Commit Message: qatzstd: remove useless build parameters
Additional Description:
Those useless building parameters break the CI of istio proxy https://github.com/istio/proxy/pull/5411#issuecomment-2007333439

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
