### PR TITLE
doc: add missing `connect_timeout` field in demo config file in quick start guide

### DIFF
--- a/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
@@ -48,6 +48,7 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
+    connect_timeout: 5s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
@@ -43,6 +43,7 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
+    connect_timeout: 5s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-validation.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-validation.yaml
@@ -30,6 +30,7 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
+    connect_timeout: 5s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
@@ -40,6 +40,7 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
+    connect_timeout: 5s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo.yaml
@@ -34,6 +34,7 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
+    connect_timeout: 5s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
add `connect_timeout` in demo config file
Additional Description:
failed to run envoy by following the quick start guide, add missing field in demo config file
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Fixes #33147