### PR TITLE
ci: Make the mobile-cc CI job run on all Envoy changes

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -208,14 +208,7 @@ run:
     - tools/code_format/check_format.py
   mobile-cc:
     paths:
-    - .bazelrc
-    - .bazelversion
-    - .github/config.yml
-    - bazel/external/quiche.BUILD
-    - bazel/repository_locations.bzl
-    - mobile/.bazelrc
-    - mobile/**/*
-    - tools/code_format/check_format.py
+    - "**/*"
   mobile-compile-time-cc:
     paths:
     - "**/*"

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -208,10 +208,36 @@ run:
     - tools/code_format/check_format.py
   mobile-cc:
     paths:
-    - "**/*"
+    - .bazelrc
+    - .bazelversion
+    - .github/config.yml
+    - api/**/*
+    - bazel/external/quiche.BUILD
+    - bazel/repository_locations.bzl
+    - envoy/**/*
+    - mobile/.bazelrc
+    - mobile/**/*
+    - source/**/*
+    - test/config/**/*
+    - test/integration/*
+    - test/mocks/**/*
+    - test/test_common/**/*
   mobile-compile-time-cc:
     paths:
-    - "**/*"
+    - .bazelrc
+    - .bazelversion
+    - .github/config.yml
+    - api/**/*
+    - bazel/external/quiche.BUILD
+    - bazel/repository_locations.bzl
+    - envoy/**/*
+    - mobile/.bazelrc
+    - mobile/**/*
+    - source/**/*
+    - test/config/**/*
+    - test/integration/*
+    - test/mocks/**/*
+    - test/test_common/**/*
   mobile-compile-time-options:
     paths:
     - .bazelrc
@@ -234,9 +260,20 @@ run:
     - tools/code_format/check_format.py
   mobile-core:
     paths:
-    - "**/*"
-    - "*"
+    - .bazelrc
+    - .bazelversion
+    - .github/config.yml
+    - api/**/*
+    - bazel/external/quiche.BUILD
+    - bazel/repository_locations.bzl
+    - envoy/**/*
     - mobile/.bazelrc
+    - mobile/**/*
+    - source/**/*
+    - test/config/**/*
+    - test/integration/*
+    - test/mocks/**/*
+    - test/test_common/**/*
   mobile-format:
     paths:
     - .bazelrc


### PR DESCRIPTION
It's important for us to run the mobile C++ unit and integration tests on any Envoy change. If we don't, we run the risk of breaking Envoy Mobile with seemingly benign changes.

For example, https://github.com/envoyproxy/envoy/pull/32775 caused Envoy Mobile to permafail because an Envoy Mobile unit test wasn't run (see https://github.com/envoyproxy/envoy/pull/33158 for the fix).

This change ensures that the Envoy Mobile C++ tests run on all core Envoy changes. There aren't too many of these tests, so it shouldn't add much to the runtime of CI per PR.