### PR TITLE
Revert "mobile: Make the opt AAR build use the non-debug .so file"

### DIFF
--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -14,8 +14,8 @@ android_artifacts(
     archive_name = "envoy",
     manifest = "EnvoyManifest.xml",
     native_deps = select({
-        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so"],
-        "//conditions:default": ["//library/jni:libenvoy_jni.so.debug_info"],
+        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so.debug_info"],
+        "//conditions:default": ["//library/jni:libenvoy_jni.so"],
     }),
     proguard_rules = "//library:proguard_rules",
     substitutions = {
@@ -31,8 +31,8 @@ android_artifacts(
     archive_name = "envoy_xds",
     manifest = "EnvoyManifest.xml",
     native_deps = select({
-        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so"],
-        "//conditions:default": ["//library/jni:libenvoy_jni.so.debug_info"],
+        "@envoy//bazel:opt_build": ["//library/jni:libenvoy_jni.so.debug_info"],
+        "//conditions:default": ["//library/jni:libenvoy_jni.so"],
     }),
     proguard_rules = "//library:proguard_rules",
     substitutions = {


### PR DESCRIPTION
Reverts envoyproxy/envoy#33038

Unfortunately, this change had the opposite effect. The AAR size in Maven went from 28MB[1] to 123MB[2].

[1] https://repo1.maven.org/maven2/io/envoyproxy/envoymobile/envoy/0.5.0.20240318/
[2] https://repo1.maven.org/maven2/io/envoyproxy/envoymobile/envoy/0.5.0.20240325/