### PR TITLE
mobile: Remove HTTP server code from TestJni

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -261,8 +261,8 @@ build:mobile-remote-ci --config=remote-ci
 
 build:mobile-remote-ci-android --config=mobile-remote-ci
 test:mobile-remote-ci-android --build_tests_only
-test:mobile-remote-ci-android --config=mobile-test-android
 test:mobile-remote-ci-android --config=mobile-remote-ci
+test:mobile-remote-ci-android --config=mobile-test-android
 
 build:mobile-remote-ci-cc --config=mobile-remote-ci
 # Temporary revert to C++17 for mobile NDK builds.

--- a/mobile/bazel/android_configure.bzl
+++ b/mobile/bazel/android_configure.bzl
@@ -10,8 +10,8 @@ _ANDROID_NDK_HOME = "ANDROID_NDK_HOME"
 _ANDROID_SDK_HOME = "ANDROID_HOME"
 
 def _android_autoconf_impl(repository_ctx):
-    sdk_home = repository_ctx.os.environ.get(_ANDROID_SDK_HOME)
-    ndk_home = repository_ctx.os.environ.get(_ANDROID_NDK_HOME)
+    sdk_home = "/usr/local/google/home/fredyw/Android/Sdk"
+    ndk_home = "/usr/local/google/home/fredyw/Android/Sdk/ndk/21.3.6528147"
 
     sdk_api_level = repository_ctx.attr.sdk_api_level
     ndk_api_level = repository_ctx.attr.ndk_api_level

--- a/mobile/bazel/android_configure.bzl
+++ b/mobile/bazel/android_configure.bzl
@@ -10,8 +10,8 @@ _ANDROID_NDK_HOME = "ANDROID_NDK_HOME"
 _ANDROID_SDK_HOME = "ANDROID_HOME"
 
 def _android_autoconf_impl(repository_ctx):
-    sdk_home = "/usr/local/google/home/fredyw/Android/Sdk"
-    ndk_home = "/usr/local/google/home/fredyw/Android/Sdk/ndk/21.3.6528147"
+    sdk_home = repository_ctx.os.environ.get(_ANDROID_SDK_HOME)
+    ndk_home = repository_ctx.os.environ.get(_ANDROID_NDK_HOME)
 
     sdk_api_level = repository_ctx.attr.sdk_api_level
     ndk_api_level = repository_ctx.attr.ndk_api_level

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -167,14 +167,12 @@ envoy_cc_test_library(
 
 # interface libs for test servers` jni implementations
 envoy_cc_test_library(
-    name = "test_server_interface_lib",
+    name = "test_server_lib",
     srcs = [
         "test_server.cc",
-        "test_server_interface.cc",
     ],
     hdrs = [
         "test_server.h",
-        "test_server_interface.h",
     ],
     data = [
         "@envoy//test/config/integration/certs",
@@ -193,6 +191,20 @@ envoy_cc_test_library(
         ["@envoy//source/common/signal:sigaction_lib"],
         "@envoy",
     ),
+)
+
+envoy_cc_test_library(
+    name = "test_server_interface_lib",
+    srcs = [
+        "test_server_interface.cc",
+    ],
+    hdrs = [
+        "test_server_interface.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":test_server_lib",
+    ],
 )
 
 envoy_cc_test_library(

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/BUILD
@@ -37,6 +37,22 @@ android_library(
     ],
 )
 
+android_library(
+    name = "http_proxy_test_server_factory_lib",
+    testonly = True,
+    srcs = [
+        "HttpProxyTestServerFactory.java",
+    ],
+    data = [
+        "//test/jni:libenvoy_jni_http_proxy_test_server_factory.so",
+    ],
+    visibility = ["//test:__subpackages__"],
+    deps = [
+        "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+    ],
+)
+
 envoy_mobile_android_test(
     name = "quic_test_server_test",
     srcs = [

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory.java
@@ -1,0 +1,38 @@
+package io.envoyproxy.envoymobile.engine.testing;
+
+/** An HTTP proxy test server factory. */
+public final class HttpProxyTestServerFactory {
+  /** The supported {@link HttpProxyTestServer} types. */
+  public static class Type {
+    public static final int HTTP_PROXY = 3;
+    public static final int HTTPS_PROXY = 4;
+
+    private Type() {}
+  }
+
+  /** The instance of {@link HttpProxyTestServer}. */
+  public static class HttpProxyTestServer {
+    private final long handle; // Used by the native code.
+    private final int port;
+
+    private HttpProxyTestServer(long handle, int port) {
+      this.handle = handle;
+      this.port = port;
+    }
+
+    /** Returns the server port. */
+    public int getPort() { return port; }
+
+    /** Shuts down the server. */
+    public native void shutdown();
+  }
+
+  static { System.loadLibrary("envoy_jni_http_proxy_test_server_factory"); }
+
+  /**
+   * Starts the HTTP proxy server.
+   *
+   * @param type the value in {@link HttpProxyTestServerFactory.Type}
+   */
+  public static native HttpProxyTestServer start(int type);
+}

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory.java
@@ -10,8 +10,6 @@ public final class HttpTestServerFactory {
     public static final int HTTP1_WITHOUT_TLS = 0;
     public static final int HTTP2_WITH_TLS = 1;
     public static final int HTTP3 = 2;
-    public static final int HTTP_PROXY = 3;
-    public static final int HTTPS_PROXY = 4;
 
     private Type() {}
   }

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/TestJni.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/TestJni.java
@@ -7,33 +7,7 @@ import io.envoyproxy.envoymobile.engine.EnvoyConfiguration;
  * Wrapper class for test JNI functions
  */
 public final class TestJni {
-
-  private static final AtomicBoolean sServerRunning = new AtomicBoolean();
   private static final AtomicBoolean xdsServerRunning = new AtomicBoolean();
-
-  /**
-   * Initializes an envoy server which will terminate cleartext CONNECT requests.
-   *
-   * @throws IllegalStateException if it's already started.
-   */
-  public static void startHttpProxyTestServer() {
-    if (!sServerRunning.compareAndSet(false, true)) {
-      throw new IllegalStateException("Server is already running");
-    }
-    nativeStartHttpProxyTestServer();
-  }
-
-  /**
-   * Initializes an envoy server which will terminate encrypted CONNECT requests.
-   *
-   * @throws IllegalStateException if it's already started.
-   */
-  public static void startHttpsProxyTestServer() {
-    if (!sServerRunning.compareAndSet(false, true)) {
-      throw new IllegalStateException("Server is already running");
-    }
-    nativeStartHttpsProxyTestServer();
-  }
 
   /**
    * Initializes the xDS test server.
@@ -45,26 +19,6 @@ public final class TestJni {
       throw new IllegalStateException("xDS server is already running");
     }
     nativeInitXdsTestServer();
-  }
-
-  /*
-   * Starts the server. Throws an {@link IllegalStateException} if already started.
-   */
-  public static void startHttp3TestServer() {
-    if (!sServerRunning.compareAndSet(false, true)) {
-      throw new IllegalStateException("Server is already running");
-    }
-    nativeStartHttp3TestServer();
-  }
-
-  /*
-   * Starts the server. Throws an {@link IllegalStateException} if already started.
-   */
-  public static void startHttp2TestServer() {
-    if (!sServerRunning.compareAndSet(false, true)) {
-      throw new IllegalStateException("Server is already running");
-    }
-    nativeStartHttp2TestServer();
   }
 
   /**
@@ -90,16 +44,6 @@ public final class TestJni {
   }
 
   /**
-   * Shutdowns the server. No-op if the server is already shutdown.
-   */
-  public static void shutdownTestServer() {
-    if (!sServerRunning.compareAndSet(true, false)) {
-      return;
-    }
-    nativeShutdownTestServer();
-  }
-
-  /**
    * Shutdowns the xDS test server. No-op if the server is already shutdown.
    */
   public static void shutdownXdsTestServer() {
@@ -108,12 +52,6 @@ public final class TestJni {
     }
     nativeShutdownXdsTestServer();
   }
-
-  public static String getServerURL() {
-    return "https://" + getServerHost() + ":" + getServerPort();
-  }
-
-  public static String getServerHost() { return "test.example.com"; }
 
   /**
    * Gets the xDS test server host.
@@ -125,31 +63,9 @@ public final class TestJni {
    */
   public static int getXdsTestServerPort() { return nativeGetXdsTestServerPort(); }
 
-  /**
-   * Returns the server attributed port. Throws an {@link IllegalStateException} if not started.
-   */
-  public static int getServerPort() {
-    if (!sServerRunning.get()) {
-      throw new IllegalStateException("Server not started.");
-    }
-    return nativeGetServerPort();
-  }
-
   public static String createYaml(EnvoyConfiguration envoyConfiguration) {
     return nativeCreateYaml(envoyConfiguration.createBootstrap());
   }
-
-  private static native void nativeStartHttp3TestServer();
-
-  private static native void nativeStartHttp2TestServer();
-
-  private static native void nativeShutdownTestServer();
-
-  private static native int nativeGetServerPort();
-
-  private static native void nativeStartHttpProxyTestServer();
-
-  private static native void nativeStartHttpsProxyTestServer();
 
   private static native void nativeInitXdsTestServer();
 

--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -29,7 +29,7 @@ cc_library(
     }),
     deps = [
         "//library/jni:envoy_jni_lib",
-        "//test/common/integration:test_server_interface_lib",
+        "//test/common/integration:test_server_lib",
         "//test/common/integration:xds_test_server_interface_lib",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
@@ -51,7 +51,7 @@ cc_library(
         "//library/jni:envoy_jni_lib",
         "//library/jni:jni_helper_lib",
         "//library/jni:jni_utility_lib",
-        "//test/common/integration:test_server_interface_lib",
+        "//test/common/integration:test_server_lib",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,
@@ -63,6 +63,37 @@ cc_binary(
     linkshared = True,
     deps = [
         ":jni_http_test_server_factory_lib",
+        "@envoy_mobile_extra_jni_deps//:extra_jni_dep",
+    ],
+)
+
+# Library which contains JNI functions for the HttpProxyTestServer.
+cc_library(
+    name = "jni_http_proxy_test_server_factory_lib",
+    testonly = True,
+    srcs = [
+        "jni_http_proxy_test_server_factory.cc",
+    ],
+    linkopts = select({
+        "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//library/jni:envoy_jni_lib",
+        "//library/jni:jni_helper_lib",
+        "//library/jni:jni_utility_lib",
+        "//test/common/integration:test_server_lib",
+    ],
+    # We need this to ensure that we link this into the .so even though there are no code references.
+    alwayslink = True,
+)
+
+cc_binary(
+    name = "libenvoy_jni_http_proxy_test_server_factory.so",
+    testonly = True,
+    linkshared = True,
+    deps = [
+        ":jni_http_proxy_test_server_factory_lib",
         "@envoy_mobile_extra_jni_deps//:extra_jni_dep",
     ],
 )

--- a/mobile/test/jni/jni_http_proxy_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_proxy_test_server_factory.cc
@@ -1,0 +1,41 @@
+#include <jni.h>
+
+#include "test/common/integration/test_server.h"
+
+#include "extension_registry.h"
+#include "library/jni/jni_helper.h"
+#include "library/jni/jni_utility.h"
+
+// NOLINT(namespace-envoy)
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_start(JNIEnv* env, jclass,
+                                                                               jint type) {
+  Envoy::JNI::JniHelper jni_helper(env);
+
+  Envoy::ExtensionRegistry::registerFactories();
+  Envoy::TestServer* test_server = new Envoy::TestServer();
+  test_server->startTestServer(static_cast<Envoy::TestServerType>(type));
+
+  auto java_http_proxy_server_factory_class = jni_helper.findClass(
+      "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
+  auto java_init_method_id =
+      jni_helper.getMethodId(java_http_proxy_server_factory_class.get(), "<init>", "(JI)V");
+  int port = test_server->getServerPort();
+  return jni_helper
+      .newObject(java_http_proxy_server_factory_class.get(), java_init_method_id,
+                 reinterpret_cast<jlong>(test_server), static_cast<jint>(port))
+      .release();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_00024HttpProxyTestServer_shutdown(
+    JNIEnv* env, jobject instance) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  auto java_class = jni_helper.getObjectClass(instance);
+  auto java_handle_field_id = jni_helper.getFieldId(java_class.get(), "handle", "J");
+  jlong java_handle = jni_helper.getLongField(instance, java_handle_field_id);
+  Envoy::TestServer* test_server = reinterpret_cast<Envoy::TestServer*>(java_handle);
+  test_server->shutdownTestServer();
+  delete test_server;
+}

--- a/mobile/test/jni/test_jni_impl.cc
+++ b/mobile/test/jni/test_jni_impl.cc
@@ -1,50 +1,11 @@
 #include <jni.h>
 
-#include "test/common/integration/test_server_interface.h"
 #include "test/common/integration/xds_test_server_interface.h"
 #include "test/test_common/utility.h"
 
 #include "library/jni/jni_support.h"
 
 // NOLINT(namespace-envoy)
-
-// Quic Test ServerJniLibrary
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttpProxyTestServer(JNIEnv* env,
-                                                                                     jclass clazz) {
-  start_server(Envoy::TestServerType::HTTP_PROXY);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttpsProxyTestServer(
-    JNIEnv* env, jclass clazz) {
-  start_server(Envoy::TestServerType::HTTPS_PROXY);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttp3TestServer(JNIEnv* env,
-                                                                                 jclass clazz) {
-  start_server(Envoy::TestServerType::HTTP3);
-}
-
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeGetServerPort(JNIEnv* env,
-                                                                          jclass clazz) {
-  return get_server_port();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeStartHttp2TestServer(JNIEnv* env,
-                                                                                 jclass clazz) {
-  start_server(Envoy::TestServerType::HTTP2_WITH_TLS);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeShutdownTestServer(JNIEnv* env,
-                                                                               jclass clazz) {
-  shutdown_server();
-}
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_TestJni_nativeInitXdsTestServer(JNIEnv* env,

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -255,6 +255,7 @@ envoy_mobile_android_test(
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 

--- a/mobile/test/kotlin/integration/proxying/BUILD
+++ b/mobile/test/kotlin/integration/proxying/BUILD
@@ -28,6 +28,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
     ],
 )
 
@@ -54,6 +55,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
     ],
 )
 
@@ -80,6 +82,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
     ],
 )
 
@@ -106,6 +109,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
     ],
 )
 
@@ -132,6 +136,7 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
     ],
 )
 
@@ -158,5 +163,6 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_proxy_test_server_factory_lib",
     ],
 )

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
@@ -12,10 +12,12 @@ import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import io.envoyproxy.envoymobile.engine.testing.TestJni
+import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -39,18 +41,28 @@ class ProxyInfoIntentPerformHTTPRequestUsingProxyTest {
     JniLibrary.load()
   }
 
+  private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+
+  @Before
+  fun setUp() {
+    httpProxyTestServer =
+      HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTP_PROXY)
+  }
+
+  @After
+  fun tearDown() {
+    httpProxyTestServer.shutdown()
+  }
+
   @Test
   fun `performs an HTTP request through a proxy`() {
-    TestJni.startHttpProxyTestServer()
-    val port = TestJni.getServerPort()
-
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager)
       .`when`(context)
       .getSystemService(Context.CONNECTIVITY_SERVICE)
     Mockito.`when`(connectivityManager.defaultProxy)
-      .thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
+      .thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onRespondeHeadersLatch = CountDownLatch(1)
@@ -93,6 +105,5 @@ class ProxyInfoIntentPerformHTTPRequestUsingProxyTest {
     assertThat(onRespondeHeadersLatch.count).isEqualTo(0)
 
     engine.terminate()
-    TestJni.shutdownTestServer()
   }
 }

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
@@ -12,10 +12,12 @@ import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import io.envoyproxy.envoymobile.engine.testing.TestJni
+import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -39,18 +41,28 @@ class ProxyInfoIntentPerformHTTPSRequestBadHostnameTest {
     JniLibrary.load()
   }
 
+  private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+
+  @Before
+  fun setUp() {
+    httpProxyTestServer =
+      HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTPS_PROXY)
+  }
+
+  @After
+  fun tearDown() {
+    httpProxyTestServer.shutdown()
+  }
+
   @Test
   fun `attempts an HTTPs request through a proxy using an async DNS resolution that fails`() {
-    TestJni.startHttpsProxyTestServer()
-    val port = TestJni.getServerPort()
-
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager)
       .`when`(context)
       .getSystemService(Context.CONNECTIVITY_SERVICE)
     Mockito.`when`(connectivityManager.defaultProxy)
-      .thenReturn(ProxyInfo.buildDirectProxy("loopback", port))
+      .thenReturn(ProxyInfo.buildDirectProxy("loopback", httpProxyTestServer.port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onErrorLatch = CountDownLatch(1)
@@ -88,6 +100,5 @@ class ProxyInfoIntentPerformHTTPSRequestBadHostnameTest {
     assertThat(onErrorLatch.count).isEqualTo(0)
 
     engine.terminate()
-    TestJni.shutdownTestServer()
   }
 }

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -12,10 +12,12 @@ import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import io.envoyproxy.envoymobile.engine.testing.TestJni
+import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,19 +42,29 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
     JniLibrary.load()
   }
 
+  private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+
+  @Before
+  fun setUp() {
+    httpProxyTestServer =
+      HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTPS_PROXY)
+  }
+
+  @After
+  fun tearDown() {
+    httpProxyTestServer.shutdown()
+  }
+
   @Ignore("https://github.com/envoyproxy/envoy/issues/33014")
   @Test
   fun `performs an HTTPs request through a proxy using async DNS resolution`() {
-    TestJni.startHttpsProxyTestServer()
-    val port = TestJni.getServerPort()
-
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager)
       .`when`(context)
       .getSystemService(Context.CONNECTIVITY_SERVICE)
     Mockito.`when`(connectivityManager.defaultProxy)
-      .thenReturn(ProxyInfo.buildDirectProxy("localhost", port))
+      .thenReturn(ProxyInfo.buildDirectProxy("localhost", httpProxyTestServer.port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onRespondeHeadersLatch = CountDownLatch(1)
@@ -95,6 +107,5 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
     assertThat(onRespondeHeadersLatch.count).isEqualTo(0)
 
     engine.terminate()
-    TestJni.shutdownTestServer()
   }
 }

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
@@ -11,10 +11,12 @@ import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import io.envoyproxy.envoymobile.engine.testing.TestJni
+import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -39,18 +41,28 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
     JniLibrary.load()
   }
 
+  private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+
+  @Before
+  fun setUp() {
+    httpProxyTestServer =
+      HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTP_PROXY)
+  }
+
+  @After
+  fun tearDown() {
+    httpProxyTestServer.shutdown()
+  }
+
   @Test
   fun `performs an HTTP request through a proxy`() {
-    TestJni.startHttpProxyTestServer()
-    val port = TestJni.getServerPort()
-
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager)
       .`when`(context)
       .getSystemService(Context.CONNECTIVITY_SERVICE)
     Mockito.`when`(connectivityManager.defaultProxy)
-      .thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
+      .thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onRespondeHeadersLatch = CountDownLatch(1)
@@ -91,6 +103,5 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
     assertThat(onRespondeHeadersLatch.count).isEqualTo(0)
 
     engine.terminate()
-    TestJni.shutdownTestServer()
   }
 }

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
@@ -11,10 +11,12 @@ import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import io.envoyproxy.envoymobile.engine.testing.TestJni
+import io.envoyproxy.envoymobile.engine.testing.HttpProxyTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -40,10 +42,21 @@ class ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest {
     JniLibrary.load()
   }
 
+  private lateinit var httpProxyTestServer: HttpProxyTestServerFactory.HttpProxyTestServer
+
+  @Before
+  fun setUp() {
+    httpProxyTestServer =
+      HttpProxyTestServerFactory.start(HttpProxyTestServerFactory.Type.HTTP_PROXY)
+  }
+
+  @After
+  fun tearDown() {
+    httpProxyTestServer.shutdown()
+  }
+
   @Test
   fun `performs an HTTP request through a proxy`() {
-    TestJni.startHttpProxyTestServer()
-
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager)
@@ -91,6 +104,5 @@ class ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest {
     assertThat(onRespondeHeadersLatch.count).isEqualTo(0)
 
     engine.terminate()
-    TestJni.shutdownTestServer()
   }
 }


### PR DESCRIPTION
This PR removes the HTTP server code from `TestJni`. The tests have been updated to use either `HttpTestServer` or `HttpProxyTestServer`.

This PR also moves `test_server_interface.[h|cc]` into its own build target.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
