### PR TITLE
Replace DebugString with text proto printer

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -613,6 +613,16 @@ void MessageUtil::wireCast(const Protobuf::Message& src, Protobuf::Message& dst)
   }
 }
 
+std::string MessageUtil::toTextProto(const Protobuf::Message& message) {
+  std::string text_format;
+  Protobuf::TextFormat::Printer printer;
+  printer.SetExpandAny(true);
+  printer.SetHideUnknownFields(true);
+  bool result = printer.PrintToString(message, &text_format);
+  ASSERT(result);
+  return text_format;
+}
+
 bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2) {
   ProtobufWkt::Value::KindCase kind = v1.kind_case();
   if (kind != v2.kind_case()) {

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -614,6 +614,7 @@ void MessageUtil::wireCast(const Protobuf::Message& src, Protobuf::Message& dst)
 }
 
 std::string MessageUtil::toTextProto(const Protobuf::Message& message) {
+#if defined(ENVOY_ENABLE_FULL_PROTOS)
   std::string text_format;
   Protobuf::TextFormat::Printer printer;
   printer.SetExpandAny(true);
@@ -621,6 +622,11 @@ std::string MessageUtil::toTextProto(const Protobuf::Message& message) {
   bool result = printer.PrintToString(message, &text_format);
   ASSERT(result);
   return text_format;
+#else
+  // Note that MessageLite::DebugString never had guarantees of producing
+  // serializable text proto representation.
+  return message.DebugString();
+#endif
 }
 
 bool ValueUtil::equal(const ProtobufWkt::Value& v1, const ProtobufWkt::Value& v2) {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -582,6 +582,13 @@ public:
    * the input string is valid UTF-8, it will be returned unmodified.
    */
   static std::string sanitizeUtf8String(absl::string_view str);
+
+  /**
+   * Return text proto representation of the `message`.
+   * @param message proto to print.
+   * @return text representation of the proto `message`.
+   */
+  static std::string toTextProto(const Protobuf::Message& message);
 };
 
 class ValueUtil {

--- a/source/extensions/common/tap/tap_config_base.cc
+++ b/source/extensions/common/tap/tap_config_base.cc
@@ -268,7 +268,7 @@ void FilePerTapSink::FilePerTapSinkHandle::submitTrace(
     break;
   }
   case envoy::config::tap::v3::OutputSink::PROTO_TEXT:
-    output_file_ << trace->DebugString();
+    output_file_ << MessageUtil::toTextProto(*trace);
     break;
   case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_BYTES:
   case envoy::config::tap::v3::OutputSink::JSON_BODY_AS_STRING:

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1751,8 +1751,8 @@ void CdsHelper::setCds(const std::vector<envoy::config::cluster::v3::Cluster>& c
   }
   // Past the initial write, need move semantics to trigger inotify move event that the
   // FilesystemSubscriptionImpl is subscribed to.
-  std::string path =
-      TestEnvironment::writeStringToFileForTest("cds.update.pb_text", cds_response.DebugString());
+  std::string path = TestEnvironment::writeStringToFileForTest(
+      "cds.update.pb_text", MessageUtil::toTextProto(cds_response));
   TestEnvironment::renameFile(path, cds_path_);
 }
 
@@ -1773,8 +1773,8 @@ void EdsHelper::setEds(const std::vector<envoy::config::endpoint::v3::ClusterLoa
   }
   // Past the initial write, need move semantics to trigger inotify move event that the
   // FilesystemSubscriptionImpl is subscribed to.
-  std::string path =
-      TestEnvironment::writeStringToFileForTest("eds.update.pb_text", eds_response.DebugString());
+  std::string path = TestEnvironment::writeStringToFileForTest(
+      "eds.update.pb_text", MessageUtil::toTextProto(eds_response));
   TestEnvironment::renameFile(path, eds_path_);
 }
 


### PR DESCRIPTION
Commit Message:
Add canonical formatter of the text proto representation and use in places where text proto were expected.

Future protobuf update adds PII sanitization to DebugString() and will stop producing valid text proto. Unfortunately Envoy incorrectly used DebugString to produce text proto representation when ::proto::TextFormat::Printer should have been used. This PR fixes known places where canonical text printer should have been used.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
