### PR TITLE
cryptomb: reduce memory copy in ECDSA

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
+++ b/contrib/cryptomb/private_key_providers/source/cryptomb_private_key_provider.h
@@ -40,10 +40,6 @@ public:
   enum RequestStatus getStatus() { return status_; }
   void scheduleCallback(enum RequestStatus status);
 
-  // Buffer length is the same as the max signature length (4096 bits = 512 bytes)
-  unsigned char out_buf_[MAX_SIGNATURE_SIZE];
-  // The real length of the signature.
-  size_t out_len_{};
   // Incoming data buffer.
   std::unique_ptr<uint8_t[]> in_buf_;
 
@@ -75,6 +71,10 @@ public:
   // BoringSSL ECDSA key structure, so not wrapped in smart pointers.
   const BIGNUM* priv_key_{};
   size_t sig_len_{};
+
+  // ECDSA signature.
+  uint8_t sig_r_[32]{};
+  uint8_t sig_s_[32]{};
 };
 
 // CryptoMbRsaContext is a CryptoMbContext which holds the extra RSA parameters and has
@@ -103,6 +103,11 @@ public:
 
   // Buffer for `Lenstra` check.
   unsigned char lenstra_to_[MAX_SIGNATURE_SIZE];
+
+  // Buffer length is the same as the max signature length (4096 bits = 512 bytes)
+  unsigned char out_buf_[MAX_SIGNATURE_SIZE];
+  // The real length of the signature.
+  size_t out_len_{};
 };
 
 using CryptoMbContextSharedPtr = std::shared_ptr<CryptoMbContext>;
@@ -123,8 +128,6 @@ private:
   void processRequests();
   void processRsaRequests();
   void processEcdsaRequests();
-  bool postprocessEcdsaRequest(CryptoMbEcdsaContextSharedPtr mb_ctx, const uint8_t* sign_r,
-                               const uint8_t* sign_s);
   void startTimer();
   void stopTimer();
 

--- a/contrib/cryptomb/private_key_providers/test/BUILD
+++ b/contrib/cryptomb/private_key_providers/test/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_contrib_package",
@@ -80,5 +81,19 @@ envoy_cc_test(
         "//test/test_common:environment_lib",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_benchmark_binary(
+    name = "speed_test",
+    srcs = ["speed_test.cc"],
+    external_deps = [
+        "benchmark",
+        "ssl",
+    ],
+    deps = [
+        "//contrib/cryptomb/private_key_providers/source:ipp_crypto_wrapper_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
     ],
 )

--- a/contrib/cryptomb/private_key_providers/test/ops_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/ops_test.cc
@@ -22,8 +22,12 @@ namespace PrivateKeyMethodProvider {
 namespace CryptoMb {
 
 // Testing interface
-ssl_private_key_result_t privateKeyCompleteForTest(CryptoMbPrivateKeyConnection* ops, uint8_t* out,
-                                                   size_t* out_len, size_t max_out);
+ssl_private_key_result_t ecdsaPrivateKeyCompleteForTest(CryptoMbPrivateKeyConnection* ops,
+                                                        uint8_t* out, size_t* out_len,
+                                                        size_t max_out);
+ssl_private_key_result_t rsaPrivateKeyCompleteForTest(CryptoMbPrivateKeyConnection* ops,
+                                                      uint8_t* out, size_t* out_len,
+                                                      size_t max_out);
 ssl_private_key_result_t ecdsaPrivateKeySignForTest(CryptoMbPrivateKeyConnection* ops, uint8_t* out,
                                                     size_t* out_len, size_t max_out,
                                                     uint16_t signature_algorithm, const uint8_t* in,
@@ -148,14 +152,14 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaSigning) {
     // No processing done after first requests.
     // After the last request, the status is set only from the event loop which is not run. This
     // should still be "retry", the cryptographic result is present anyway.
-    res_ = privateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
+    res_ = ecdsaPrivateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
     EXPECT_EQ(res_, ssl_private_key_retry);
   }
 
   // Timeout does not have to be triggered when queue is at maximum size.
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  res_ = ecdsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 }
@@ -179,14 +183,14 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaPkcs1Signing) {
     // No processing done after first requests.
     // After the last request, the status is set only from the event loop which is not run. This
     // should still be "retry", the cryptographic result is present anyway.
-    res_ = privateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
+    res_ = rsaPrivateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
     EXPECT_EQ(res_, ssl_private_key_retry);
   }
 
   // Timeout does not have to be triggered when queue is at maximum size.
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 
@@ -217,14 +221,14 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaPssSigning) {
     // No processing done after first requests.
     // After the last request, the status is set only from the event loop which is not run. This
     // should still be "retry", the cryptographic result is present anyway.
-    res_ = privateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
+    res_ = rsaPrivateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
     EXPECT_EQ(res_, ssl_private_key_retry);
   }
 
   // Timeout does not have to be triggered when queue is at maximum size.
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 
@@ -263,14 +267,14 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaDecrypt) {
     // No processing done after first requests.
     // After the last request, the status is set only from the event loop which is not run. This
     // should still be "retry", the cryptographic result is present anyway.
-    res_ = privateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
+    res_ = rsaPrivateKeyCompleteForTest(connections[i].get(), nullptr, nullptr, max_out_len_);
     EXPECT_EQ(res_, ssl_private_key_retry);
   }
 
   // Timeout does not have to be triggered when queue is at maximum size.
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 }
@@ -333,14 +337,14 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaTimer) {
                                     SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
   EXPECT_EQ(res_, ssl_private_key_retry);
 
-  res_ = privateKeyCompleteForTest(&op0, nullptr, nullptr, max_out_len_);
+  res_ = ecdsaPrivateKeyCompleteForTest(&op0, nullptr, nullptr, max_out_len_);
   // No processing done yet after first request
   EXPECT_EQ(res_, ssl_private_key_retry);
 
   time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(&op0, out_, &out_len_, max_out_len_);
+  res_ = ecdsaPrivateKeyCompleteForTest(&op0, out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 
@@ -354,14 +358,14 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaTimer) {
                                     SSL_SIGN_ECDSA_SECP256R1_SHA256, in_, in_len_);
   EXPECT_EQ(res_, ssl_private_key_retry);
 
-  res_ = privateKeyCompleteForTest(&op1, nullptr, nullptr, max_out_len_);
+  res_ = ecdsaPrivateKeyCompleteForTest(&op1, nullptr, nullptr, max_out_len_);
   // No processing done yet after first request
   EXPECT_EQ(res_, ssl_private_key_retry);
 
   time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(&op1, out_, &out_len_, max_out_len_);
+  res_ = ecdsaPrivateKeyCompleteForTest(&op1, out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_failure);
 }
 
@@ -374,14 +378,14 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaTimer) {
                                   in_, in_len_);
   EXPECT_EQ(res_, ssl_private_key_retry);
 
-  res_ = privateKeyCompleteForTest(&op0, nullptr, nullptr, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(&op0, nullptr, nullptr, max_out_len_);
   // No processing done yet after first request
   EXPECT_EQ(res_, ssl_private_key_retry);
 
   time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(&op0, out_, &out_len_, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(&op0, out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 
@@ -395,14 +399,14 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaTimer) {
                                   in_, in_len_);
   EXPECT_EQ(res_, ssl_private_key_retry);
 
-  res_ = privateKeyCompleteForTest(&op1, nullptr, nullptr, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(&op1, nullptr, nullptr, max_out_len_);
   // No processing done yet after first request
   EXPECT_EQ(res_, ssl_private_key_retry);
 
   time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
                                  Event::Dispatcher::RunType::NonBlock);
 
-  res_ = privateKeyCompleteForTest(&op1, out_, &out_len_, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(&op1, out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_failure);
 }
 
@@ -428,7 +432,7 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaQueueSizeStatistics) {
                                    Event::Dispatcher::RunType::NonBlock);
 
     out_len_ = 0;
-    res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+    res_ = ecdsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
     EXPECT_EQ(res_, ssl_private_key_success);
     EXPECT_NE(out_len_, 0);
 
@@ -451,7 +455,7 @@ TEST_F(CryptoMbProviderEcdsaTest, TestEcdsaQueueSizeStatistics) {
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   out_len_ = 0;
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  res_ = ecdsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 
@@ -483,7 +487,7 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaQueueSizeStatistics) {
                                    Event::Dispatcher::RunType::NonBlock);
 
     out_len_ = 0;
-    res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+    res_ = rsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
     EXPECT_EQ(res_, ssl_private_key_success);
     EXPECT_NE(out_len_, 0);
 
@@ -506,7 +510,7 @@ TEST_F(CryptoMbProviderRsaTest, TestRsaQueueSizeStatistics) {
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   out_len_ = 0;
-  res_ = privateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
+  res_ = rsaPrivateKeyCompleteForTest(connections[0].get(), out_, &out_len_, max_out_len_);
   EXPECT_EQ(res_, ssl_private_key_success);
   EXPECT_NE(out_len_, 0);
 

--- a/contrib/cryptomb/private_key_providers/test/speed_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/speed_test.cc
@@ -1,15 +1,18 @@
 #include "source/common/common/assert.h"
 
 #include "benchmark/benchmark.h"
-#include "crypto_mb/ec_nistp256.h"
-#include "crypto_mb/rsa.h"
-#include "crypto_mb/x25519.h"
 #include "gtest/gtest.h"
 #include "openssl/curve25519.h"
 #include "openssl/evp.h"
 #include "openssl/pem.h"
 #include "openssl/rand.h"
 #include "openssl/ssl.h"
+
+#ifndef IPP_CRYPTO_DISABLED
+#include "crypto_mb/ec_nistp256.h"
+#include "crypto_mb/rsa.h"
+#include "crypto_mb/x25519.h"
+#endif
 
 namespace Envoy {
 
@@ -124,6 +127,7 @@ static void BM_ECDSA_Signing(benchmark::State& state) {
 }
 BENCHMARK(BM_ECDSA_Signing);
 
+#ifndef IPP_CRYPTO_DISABLED
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_ECDSA_Signing_CryptoMB(benchmark::State& state) {
   bssl::UniquePtr<EVP_PKEY> pkey = makeEcdsaKey();
@@ -200,6 +204,7 @@ static void BM_ECDSA_Signing_CryptoMB(benchmark::State& state) {
       benchmark::Counter(state.iterations() * 8, benchmark::Counter::kIsRate);
 }
 BENCHMARK(BM_ECDSA_Signing_CryptoMB);
+#endif
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_RSA_Signing(benchmark::State& state) {
@@ -224,6 +229,7 @@ static void BM_RSA_Signing(benchmark::State& state) {
 }
 BENCHMARK(BM_RSA_Signing);
 
+#ifndef IPP_CRYPTO_DISABLED
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_RSA_Signing_CryptoMB(benchmark::State& state) {
   bssl::UniquePtr<EVP_PKEY> pkey = makeRsaKey();
@@ -282,6 +288,7 @@ static void BM_RSA_Signing_CryptoMB(benchmark::State& state) {
       benchmark::Counter(state.iterations() * 8, benchmark::Counter::kIsRate);
 }
 BENCHMARK(BM_RSA_Signing_CryptoMB);
+#endif
 
 const std::vector<uint8_t>& x25519Key() {
   CONSTRUCT_ON_FIRST_USE(std::vector<uint8_t>,
@@ -357,6 +364,7 @@ static void BM_X25519_Computing(benchmark::State& state) {
 }
 BENCHMARK(BM_X25519_Computing);
 
+#ifndef IPP_CRYPTO_DISABLED
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_X25519_Computing_CryptoMB(benchmark::State& state) {
   uint8_t ciphertext[8][32];
@@ -403,6 +411,7 @@ static void BM_X25519_Computing_CryptoMB(benchmark::State& state) {
       benchmark::Counter(state.iterations() * 8, benchmark::Counter::kIsRate);
 }
 BENCHMARK(BM_X25519_Computing_CryptoMB);
+#endif
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_P256_Computing(benchmark::State& state) {
@@ -434,6 +443,7 @@ static void BM_P256_Computing(benchmark::State& state) {
 }
 BENCHMARK(BM_P256_Computing);
 
+#ifndef IPP_CRYPTO_DISABLED
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_P256_Computing_CryptoMB(benchmark::State& state) {
   const EC_GROUP* group = EC_group_p256();
@@ -508,5 +518,6 @@ static void BM_P256_Computing_CryptoMB(benchmark::State& state) {
       benchmark::Counter(state.iterations() * 8, benchmark::Counter::kIsRate);
 }
 BENCHMARK(BM_P256_Computing_CryptoMB);
+#endif
 
 } // namespace Envoy

--- a/contrib/cryptomb/private_key_providers/test/speed_test.cc
+++ b/contrib/cryptomb/private_key_providers/test/speed_test.cc
@@ -1,0 +1,283 @@
+#include "source/common/common/assert.h"
+
+#include "benchmark/benchmark.h"
+#include "crypto_mb/ec_nistp256.h"
+#include "crypto_mb/rsa.h"
+#include "gtest/gtest.h"
+#include "openssl/evp.h"
+#include "openssl/pem.h"
+#include "openssl/ssl.h"
+
+namespace Envoy {
+
+const std::string RsaKey = R"EOF(
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAtBPRFC+8WpCauAyIr1uCTSK6qtAeevEW1vRkn/KkFQX27UWS
+NgU/IukTbA091BDae7HEiWSp7IA1IDbu2q4IwY9UksjF8yFVNZYifr/IzS6lbHOI
+ZRxuBzQOWgn0+7WNqzylXQ4y88yVVqSsdfiB8kJHi9o5r+M/3TBOrWCu75iYJeBV
+w0nhMYIYOxB0RkPqB1+5z4cgLjyZYuC6iZe+9m718J4LRHTd60lg9wtg4H7RUE3u
+VgjLSNpNyvVpOW2qHq+o21gdS7xBQ3pbD619vBWeNDkvCaBp6YZw4ENhUxeg4xaZ
+nOrNEKZw4HQnzklDJe1a69InQI6F2b/26VEGgQIDAQABAoIBABKTzMkBV7QcIOoF
+2QAGN74PbCR9Dffu8UVBtzPNC2Jj2CKIP9o01luaofdOsmczSebi4vytlt4gJ9rn
+7+I9fAfD6pyt+8XmVW0OzQY4cNXCDyzOCm8r7Knvk990EYL6KuBUhFbCRT1jiLCE
+koolFfrRHaJu4+6iSg9ekW9PfxyWfAxtEp4XrrqgN4jN3Lrx1rYCZnuYp3Lb+7WI
+fJC/rK6MTphUMLbPMvmUwHjFzoe7g9MZxRRY3kY3h1n3Ju1ZbaCbP0Vi/+tdgKAl
+290J2MStWWJfOoTNnnOSYhWIPQUiFtuUiab7tJ90GGb1DyLbOrr6wG2awJoqF9ZM
+Qwvkf/UCgYEA5dsHhxuX+cTHF6m+aGuyB0pF/cnFccTtwWz2WwiH6tldnOAIPfSi
+WJU33C988KwJFmAurcW43VVVs7fxYbC6ptQluEI+/L/3Mj/3WgwZaqX00cEPkzKA
+M1XbvanQAU0nGfq+ja7sZVpdbBoBUb6Bh7HFyLM3LgliT0kMQeolKXMCgYEAyI9W
+tEHnkHoPjAVSSobBOqCVpTp1WGb7XoxhahjjZcTOgxucna26mUyJeHQrOPp88PJo
+xxdDJU410p/tZARtFBoAa++IK9qC6QLjN23CuwhD7y6RNZsRZg0kOCg9SLj+zVj5
+mrvZFf6663EpL82UZ2zUGl4L1sMhYkia0TMjYzsCgYAFHuAIDoFQOyYETO/E+8E3
+kFwGz1vqsOxrBrZmSMZeYQFI4WTNnImRV6Gq8hPieLKrIPFpRaJcq+4A1vQ1rO47
+kTZV6IPmtZAYOnyUMPjP+2p80cQ7D0Dz49HFY+cSYFmipodgOKljiKPUKLAm1guk
+rj0tv3BXQjZCdeoj/cdeKQKBgF8u3+hWqs5/j2dVkzN5drUbR0oOT2iwHzZFC2pt
++2XuHFBOx2px6/AbSdbX0zeMccVsVlu+Z4iJ8LNQYTqpexciK/cNzCN75csuKqXA
+ur1G8+7Mu++j84LqU7kvJ76exZaxVmygICv3I8DfiLt+JqNbG+KTpay8GNjrOkZ0
+raPHAoGAQ1p/Qvp7DHP2qOnUB/rItEVgWECD3uPx4NOCq7Zcx7mb9p7CI6nePT5y
+heHpaJIqVyaS5/LHJDwvdB1nvtlgc9xKa5d1fWhLL3dwFCa98x5PDlN/JztH8DIt
+tTlD+8NECIvI+ytbzLS0PZWBYctAR2rP2qlMCGdYerdjwl8S98E=
+-----END RSA PRIVATE KEY-----
+)EOF";
+
+const std::string EcdsaKey = R"EOF(
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMpJw5U66K+DcA963b+/jZYrMrZDjaB0khHSwZte3vYCoAoGCCqGSM49
+AwEHoUQDQgAELp3XvBfkVWQBOKo3ttAaJ6SUaUb8uKqCS504WXHWMO4h89F+nYtC
+Ecgl8EiLXXyc86tawKjGdizcCjrKMiFo3A==
+-----END EC PRIVATE KEY-----
+)EOF";
+
+bssl::UniquePtr<EVP_PKEY> makeEcdsaKey() {
+  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(EcdsaKey.data(), EcdsaKey.size()));
+  bssl::UniquePtr<EVP_PKEY> key(EVP_PKEY_new());
+  EC_KEY* ec = PEM_read_bio_ECPrivateKey(bio.get(), nullptr, nullptr, nullptr);
+  RELEASE_ASSERT(ec != nullptr, "PEM_read_bio_ECPrivateKey failed.");
+  RELEASE_ASSERT(1 == EVP_PKEY_assign_EC_KEY(key.get(), ec), "EVP_PKEY_assign_EC_KEY failed.");
+  return key;
+}
+bssl::UniquePtr<EVP_PKEY> makeRsaKey() {
+  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(RsaKey.data(), RsaKey.size()));
+  bssl::UniquePtr<EVP_PKEY> key(EVP_PKEY_new());
+  RSA* rsa = PEM_read_bio_RSAPrivateKey(bio.get(), nullptr, nullptr, nullptr);
+  RELEASE_ASSERT(rsa != nullptr, "PEM_read_bio_RSAPrivateKey failed.");
+  RELEASE_ASSERT(1 == EVP_PKEY_assign_RSA(key.get(), rsa), "EVP_PKEY_assign_RSA failed.");
+  return key;
+}
+
+static constexpr size_t in_len_ = 32;
+static constexpr uint8_t in_[in_len_] = {0x7f};
+static constexpr size_t max_out_len_ = 256;
+
+int calculateDigest(const EVP_MD* md, const uint8_t* in, size_t in_len, unsigned char* hash,
+                    unsigned int* hash_len) {
+  bssl::ScopedEVP_MD_CTX ctx;
+
+  // Calculate the message digest for signing.
+  if (!EVP_DigestInit_ex(ctx.get(), md, nullptr) || !EVP_DigestUpdate(ctx.get(), in, in_len) ||
+      !EVP_DigestFinal_ex(ctx.get(), hash, hash_len)) {
+    return 0;
+  }
+  return 1;
+}
+
+void verifyEcdsa(EC_KEY* ec_key, uint8_t* out, uint32_t out_len) {
+  const EVP_MD* md = SSL_get_signature_algorithm_digest(SSL_SIGN_ECDSA_SECP256R1_SHA256);
+  uint8_t hash[EVP_MAX_MD_SIZE];
+  uint32_t hash_len;
+  calculateDigest(md, in_, in_len_, hash, &hash_len);
+
+  EXPECT_EQ(ECDSA_verify(0, hash, hash_len, out, out_len, ec_key), 1);
+}
+void verifyRsa(RSA* rsa, uint8_t* out, uint32_t out_len) {
+  const EVP_MD* md = SSL_get_signature_algorithm_digest(SSL_SIGN_RSA_PSS_SHA256);
+  uint8_t buf[max_out_len_];
+  uint32_t buf_len;
+  calculateDigest(md, in_, in_len_, buf, &buf_len);
+
+  EXPECT_EQ(RSA_verify_pss_mgf1(rsa, buf, buf_len, md, nullptr, -1, out, out_len), 1);
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_ECDSA_Signing(benchmark::State& state) {
+  bssl::UniquePtr<EVP_PKEY> pkey = makeEcdsaKey();
+  uint8_t out[512];
+  uint32_t out_len;
+  for (auto _ : state) { // NOLINT
+    EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
+    const EVP_MD* md = SSL_get_signature_algorithm_digest(SSL_SIGN_ECDSA_SECP256R1_SHA256);
+
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned int hash_len;
+    calculateDigest(md, in_, in_len_, hash, &hash_len);
+
+    ECDSA_sign(0, hash, hash_len, out, &out_len, ec_key);
+  }
+
+  EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
+  verifyEcdsa(ec_key, out, out_len);
+
+  state.counters["Requests"] = benchmark::Counter(state.iterations(), benchmark::Counter::kIsRate);
+}
+BENCHMARK(BM_ECDSA_Signing);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_ECDSA_Signing_CryptoMB(benchmark::State& state) {
+  bssl::UniquePtr<EVP_PKEY> pkey = makeEcdsaKey();
+  uint8_t out[8][512];
+  size_t out_len[8];
+  for (auto _ : state) { // NOLINT
+    std::unique_ptr<uint8_t[]> in_buf[8];
+    size_t sig_len[8];
+    const BIGNUM* priv_key[8];
+    bssl::UniquePtr<BN_CTX> ctx[8];
+    BIGNUM* k[8];
+    for (int i = 0; i < 8; i++) {
+      EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
+      const EVP_MD* md = SSL_get_signature_algorithm_digest(SSL_SIGN_ECDSA_SECP256R1_SHA256);
+
+      unsigned char hash[EVP_MAX_MD_SIZE];
+      unsigned int hash_len;
+      calculateDigest(md, in_, in_len_, hash, &hash_len);
+
+      priv_key[i] = EC_KEY_get0_private_key(ec_key);
+      const EC_GROUP* group = EC_KEY_get0_group(ec_key);
+      const BIGNUM* order = EC_GROUP_get0_order(group);
+      ctx[i] = bssl::UniquePtr<BN_CTX>(BN_CTX_new());
+      BN_CTX_start(ctx[i].get());
+      k[i] = BN_CTX_get(ctx[i].get());
+      while (BN_is_zero(k[i])) {
+        BN_rand_range(k[i], order);
+      }
+
+      int len = BN_num_bits(order);
+      size_t buf_len = (len + 7) / 8;
+      if (8 * hash_len < static_cast<unsigned long>(len)) {
+        in_buf[i] = std::make_unique<uint8_t[]>(buf_len);
+        memcpy(in_buf[i].get() + buf_len - hash_len, hash, hash_len);
+      } else {
+        in_buf[i] = std::make_unique<uint8_t[]>(hash_len);
+        memcpy(in_buf[i].get(), hash, hash_len);
+      }
+      sig_len[i] = ECDSA_size(ec_key);
+    }
+
+    uint8_t sig_r[8][32];
+    uint8_t sig_s[8][32];
+    uint8_t* pa_sig_r[8];
+    uint8_t* pa_sig_s[8];
+    const uint8_t* digest[8];
+    for (int i = 0; i < 8; i++) {
+      pa_sig_r[i] = sig_r[i];
+      pa_sig_s[i] = sig_s[i];
+      digest[i] = in_buf[i].get();
+    }
+    mbx_nistp256_ecdsa_sign_ssl_mb8(pa_sig_r, pa_sig_s, digest, k, priv_key, nullptr);
+
+    for (int i = 0; i < 8; i++) {
+      ECDSA_SIG* sig = ECDSA_SIG_new();
+      BIGNUM* cur_sig_r = BN_bin2bn(sig_r[i], 32, nullptr);
+      BIGNUM* cur_sig_s = BN_bin2bn(sig_s[i], 32, nullptr);
+      ECDSA_SIG_set0(sig, cur_sig_r, cur_sig_s);
+
+      CBB cbb;
+      CBB_init_fixed(&cbb, out[i], sig_len[i]);
+      ECDSA_SIG_marshal(&cbb, sig);
+      CBB_finish(&cbb, nullptr, &out_len[i]);
+      ECDSA_SIG_free(sig);
+    }
+  }
+
+  EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
+  for (int i = 0; i < 8; i++) {
+    verifyEcdsa(ec_key, out[i], out_len[i]);
+  }
+
+  state.counters["Requests"] =
+      benchmark::Counter(state.iterations() * 8, benchmark::Counter::kIsRate);
+}
+BENCHMARK(BM_ECDSA_Signing_CryptoMB);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_RSA_Signing(benchmark::State& state) {
+  bssl::UniquePtr<EVP_PKEY> pkey = makeRsaKey();
+  uint8_t out[512];
+  size_t out_len;
+  for (auto _ : state) { // NOLINT
+    RSA* rsa = EVP_PKEY_get0_RSA(pkey.get());
+    const EVP_MD* md = SSL_get_signature_algorithm_digest(SSL_SIGN_RSA_PSS_SHA256);
+
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned int hash_len;
+    calculateDigest(md, in_, in_len_, hash, &hash_len);
+
+    RSA_sign_pss_mgf1(rsa, &out_len, out, max_out_len_, hash, hash_len, md, nullptr, -1);
+  }
+
+  RSA* rsa = EVP_PKEY_get0_RSA(pkey.get());
+  verifyRsa(rsa, out, out_len);
+
+  state.counters["Requests"] = benchmark::Counter(state.iterations(), benchmark::Counter::kIsRate);
+}
+BENCHMARK(BM_RSA_Signing);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_RSA_Signing_CryptoMB(benchmark::State& state) {
+  bssl::UniquePtr<EVP_PKEY> pkey = makeRsaKey();
+  uint8_t out[8][512];
+  uint32_t out_len[8];
+  for (auto _ : state) { // NOLINT
+    std::unique_ptr<uint8_t[]> in_buf[8];
+    uint8_t out_buf[8][512];
+    uint32_t out_buf_len[8];
+    const BIGNUM* p[8];
+    const BIGNUM* q[8];
+    const BIGNUM* dmp1[8];
+    const BIGNUM* dmq1[8];
+    const BIGNUM* iqmp[8];
+    for (int i = 0; i < 8; i++) {
+      RSA* rsa = EVP_PKEY_get0_RSA(pkey.get());
+      const EVP_MD* md = SSL_get_signature_algorithm_digest(SSL_SIGN_RSA_PSS_SHA256);
+
+      unsigned char hash[EVP_MAX_MD_SIZE];
+      unsigned int hash_len;
+      calculateDigest(md, in_, in_len_, hash, &hash_len);
+
+      size_t msg_len = RSA_size(rsa);
+      uint8_t* msg = static_cast<uint8_t*>(OPENSSL_malloc(msg_len));
+      RSA_padding_add_PKCS1_PSS_mgf1(rsa, msg, hash, md, nullptr, -1);
+
+      RSA_get0_factors(rsa, &p[i], &q[i]);
+      RSA_get0_crt_params(rsa, &dmp1[i], &dmq1[i], &iqmp[i]);
+
+      out_buf_len[i] = msg_len;
+      in_buf[i] = std::make_unique<uint8_t[]>(msg_len);
+      memcpy(in_buf[i].get(), msg, msg_len);
+      OPENSSL_free(msg);
+    }
+
+    const uint8_t* from[8];
+    uint8_t* to[8];
+    for (int i = 0; i < 8; i++) {
+      from[i] = in_buf[i].get();
+      to[i] = out_buf[i];
+    }
+    mbx_rsa_private_crt_ssl_mb8(from, to, p, q, dmp1, dmq1, iqmp, out_buf_len[0] * 8);
+
+    for (int i = 0; i < 8; i++) {
+      out_len[i] = out_buf_len[i];
+      memcpy(out[i], out_buf[i], out_buf_len[i]);
+    }
+  }
+
+  RSA* rsa = EVP_PKEY_get0_RSA(pkey.get());
+  for (int i = 0; i < 8; i++) {
+    verifyRsa(rsa, out[i], out_len[i]);
+  }
+
+  state.counters["Requests"] =
+      benchmark::Counter(state.iterations() * 8, benchmark::Counter::kIsRate);
+}
+BENCHMARK(BM_RSA_Signing_CryptoMB);
+
+} // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Xie Zhihao <zhihao.xie@intel.com>

Commit Message: cryptomb: reduce memory copy in ECDSA
Additional Description:

The original implementation serializes signatures into a temporary output buffer during processing phase and then copy to the BoringSSL buffer in the completion phase. This patch change the way and directly serializes signatures to the BoringSSL buffer.

In addition, the patch adds a speed test to track the performance change by mathematical implementation of private key provider.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: Requires AVX512 or equivalent CPU instruction set
