### PR TITLE
Make hot restart tolerate premature death of the parent instance

### DIFF
--- a/api/envoy/admin/v3/server_info.proto
+++ b/api/envoy/admin/v3/server_info.proto
@@ -59,7 +59,7 @@ message ServerInfo {
   config.core.v3.Node node = 7;
 }
 
-// [#next-free-field: 39]
+// [#next-free-field: 40]
 message CommandLineOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.admin.v2alpha.CommandLineOptions";
@@ -97,6 +97,9 @@ message CommandLineOptions {
 
   // See :option:`--use-dynamic-base-id` for details.
   bool use_dynamic_base_id = 31;
+
+  // See :option:`--skip-hot-restart-on-no-parent` for details.
+  bool skip_hot_restart_on_no_parent = 39;
 
   // See :option:`--base-id-path` for details.
   string base_id_path = 32;

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -249,6 +249,9 @@ new_features:
     and
     :ref:`ExtProcOverrides.grpc_service <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExtProcOverrides.grpc_service>`
     with the new or updated values.
+- area: hot_restart
+  change: |
+    Added new command-line flag :option:`--skip-hot-restart-on-no-parent`.
 - area: aws_request_signing
   change: |
     Update ``aws_request_signing`` filter to support use as an upstream HTTP filter. This allows successful calculation of

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -67,6 +67,12 @@ following are the command line options that Envoy supports.
   :option:`--restart-epoch` is non-zero. Instead, for subsequent hot restarts, set
   :option:`--base-id` option with the selected base ID. See :option:`--base-id-path`.
 
+.. option:: --skip-hot-restart-on-no-parent
+
+  *(optional)* In conjunction with :option:`--restart-epoch`, this flag allows for a failing hot
+  restart to fall back to normal startup behavior. When this flag is false, if the parent instance
+  was terminated, the child instance will also terminate during startup.
+
 .. option:: --base-id-path <path_string>
 
   *(optional)* Writes the base ID to the given path. While this option is compatible with

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -73,6 +73,10 @@ following are the command line options that Envoy supports.
   restart to fall back to normal startup behavior. When this flag is false, if the parent instance
   was terminated, the child instance will also terminate during startup.
 
+  This only impacts if the parent instance was terminated before the new instance is initialized -
+  an unexpected parent termination after interprocess communication is established will still cause
+  the child instance to terminate due to failing communication.
+
 .. option:: --base-id-path <path_string>
 
   *(optional)* Writes the base ID to the given path. While this option is compatible with

--- a/envoy/server/options.h
+++ b/envoy/server/options.h
@@ -85,6 +85,12 @@ public:
   virtual bool useDynamicBaseId() const PURE;
 
   /**
+   * @return bool don't get hot restart information from the parent if the communication channel
+   *         to the parent instance fails to connect.
+   */
+  virtual bool skipHotRestartOnNoParent() const PURE;
+
+  /**
    * @return const std::string& the dynamic base id output file.
    */
   virtual const std::string& baseIdPath() const PURE;

--- a/source/exe/stripped_main_base.cc
+++ b/source/exe/stripped_main_base.cc
@@ -126,7 +126,8 @@ void StrippedMainBase::configureHotRestarter(Random::RandomGenerator& random_gen
 
         TRY_ASSERT_MAIN_THREAD {
           restarter = std::make_unique<Server::HotRestartImpl>(base_id, 0, options_.socketPath(),
-                                                               options_.socketMode());
+                                                               options_.socketMode(),
+                                                               options_.skipHotRestartOnNoParent());
         }
         END_TRY
         CATCH(Server::HotRestartDomainSocketInUseException & ex, {
@@ -142,7 +143,8 @@ void StrippedMainBase::configureHotRestarter(Random::RandomGenerator& random_gen
       restarter_.swap(restarter);
     } else {
       restarter_ = std::make_unique<Server::HotRestartImpl>(
-          base_id, options_.restartEpoch(), options_.socketPath(), options_.socketMode());
+          base_id, options_.restartEpoch(), options_.socketPath(), options_.socketMode(),
+          options_.skipHotRestartOnNoParent());
     }
 
     // Write the base-id to the requested path whether we selected it

--- a/source/server/hot_restart.proto
+++ b/source/server/hot_restart.proto
@@ -26,6 +26,8 @@ message HotRestartMessage {
       bytes payload = 4;
       uint32 worker_index = 5;
     }
+    message TestConnection {
+    }
     oneof request {
       PassListenSocket pass_listen_socket = 1;
       ShutdownAdmin shutdown_admin = 2;
@@ -33,6 +35,7 @@ message HotRestartMessage {
       DrainListeners drain_listeners = 4;
       Terminate terminate = 5;
       ForwardedUdpPacket forwarded_udp_packet = 6;
+      TestConnection test_connection = 7;
     }
   }
 

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -96,9 +96,11 @@ void initializeMutex(pthread_mutex_t& mutex) {
 // TODO(zuercher): ideally, the base_id would be separated from the restart_epoch in
 // the socket names to entirely prevent collisions between consecutive base ids.
 HotRestartImpl::HotRestartImpl(uint32_t base_id, uint32_t restart_epoch,
-                               const std::string& socket_path, mode_t socket_mode)
+                               const std::string& socket_path, mode_t socket_mode,
+                               bool skip_hot_restart_on_no_parent)
     : base_id_(base_id), scaled_base_id_(base_id * 10),
-      as_child_(HotRestartingChild(scaled_base_id_, restart_epoch, socket_path, socket_mode)),
+      as_child_(HotRestartingChild(scaled_base_id_, restart_epoch, socket_path, socket_mode,
+                                   skip_hot_restart_on_no_parent)),
       as_parent_(HotRestartingParent(scaled_base_id_, restart_epoch, socket_path, socket_mode)),
       shmem_(attachSharedMemory(scaled_base_id_, restart_epoch)), log_lock_(shmem_->log_lock_),
       access_log_lock_(shmem_->access_log_lock_) {

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -98,7 +98,7 @@ private:
 class HotRestartImpl : public HotRestart {
 public:
   HotRestartImpl(uint32_t base_id, uint32_t restart_epoch, const std::string& socket_path,
-                 mode_t socket_mode);
+                 mode_t socket_mode, bool skip_hot_restart_on_no_parent);
 
   // Server::HotRestart
   void drainParentListeners() override;

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -67,7 +67,8 @@ void RpcStream::bindDomainSocket(uint64_t id, const std::string& role,
   }
 }
 
-void RpcStream::sendHotRestartMessage(sockaddr_un& address, const HotRestartMessage& proto) {
+bool RpcStream::sendHotRestartMessage(sockaddr_un& address, const HotRestartMessage& proto,
+                                      bool allow_failure) {
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   const uint64_t serialized_size = proto.ByteSizeLong();
   const uint64_t total_size = sizeof(uint64_t) + serialized_size;
@@ -127,6 +128,9 @@ void RpcStream::sendHotRestartMessage(sockaddr_un& address, const HotRestartMess
       }
 
       if (saved_errno == ECONNREFUSED) {
+        if (allow_failure) {
+          return false;
+        }
         ENVOY_LOG(error, "hot restart sendmsg() connection refused, retrying");
         absl::SleepFor(CONNECTION_REFUSED_RETRY_DELAY);
         continue;
@@ -144,6 +148,7 @@ void RpcStream::sendHotRestartMessage(sockaddr_un& address, const HotRestartMess
 
   RELEASE_ASSERT(fcntl(domain_socket_, F_SETFL, O_NONBLOCK) != -1,
                  fmt::format("Set domain socket nonblocking failed, errno = {}", errno));
+  return true;
 }
 
 bool RpcStream::replyIsExpectedType(const HotRestartMessage* proto,

--- a/source/server/hot_restarting_base.h
+++ b/source/server/hot_restarting_base.h
@@ -46,7 +46,8 @@ public:
   //
   // There is no mechanism to explicitly pair responses to requests. However, the child initiates
   // all exchanges, and blocks until a reply is received, so there is implicit pairing.
-  void sendHotRestartMessage(sockaddr_un& address, const envoy::HotRestartMessage& proto);
+  bool sendHotRestartMessage(sockaddr_un& address, const envoy::HotRestartMessage& proto,
+                             bool allow_failure = false);
 
   // Receive data, possibly enough to build one of our protocol messages.
   // If block is true, blocks until a full protocol message is available.

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -49,9 +49,11 @@ HotRestartingChild::UdpForwardingContext::getListenerForDestination(
 // If restart_epoch is 0 there is no parent, so it's effectively already
 // drained and terminated.
 HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
-                                       const std::string& socket_path, mode_t socket_mode)
+                                       const std::string& socket_path, mode_t socket_mode,
+                                       bool skip_hot_restart_on_no_parent)
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch),
-      parent_terminated_(restart_epoch == 0), parent_drained_(restart_epoch == 0) {
+      parent_terminated_(restart_epoch == 0), parent_drained_(restart_epoch == 0),
+      skip_hot_restart_on_no_parent_(skip_hot_restart_on_no_parent) {
   main_rpc_stream_.initDomainSocketAddress(&parent_address_);
   std::string socket_path_udp = socket_path + "_udp";
   udp_forwarding_rpc_stream_.initDomainSocketAddress(&parent_address_udp_forwarding_);
@@ -66,7 +68,25 @@ HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
                                               socket_mode);
 }
 
+bool HotRestartingChild::abortDueToFailedParentConnection() {
+  if (!skip_hot_restart_on_no_parent_) {
+    return false;
+  }
+  HotRestartMessage wrapped_request;
+  wrapped_request.mutable_request()->mutable_test_connection();
+  if (!main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request, true)) {
+    return true;
+  }
+  return false;
+}
+
 void HotRestartingChild::initialize(Event::Dispatcher& dispatcher) {
+  if (abortDueToFailedParentConnection()) {
+    ENVOY_LOG(warn, "hot restart sendmsg() connection refused, falling back to regular restart");
+    absl::MutexLock lock(&registry_mu_);
+    parent_terminated_ = parent_drained_ = true;
+    return;
+  }
   socket_event_udp_forwarding_ = dispatcher.createFileEvent(
       udp_forwarding_rpc_stream_.domain_socket_,
       [this](uint32_t events) -> void {

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -43,7 +43,7 @@ public:
   };
 
   HotRestartingChild(int base_id, int restart_epoch, const std::string& socket_path,
-                     mode_t socket_mode);
+                     mode_t socket_mode, bool skip_hot_restart_on_no_parent);
   ~HotRestartingChild() override = default;
 
   void initialize(Event::Dispatcher& dispatcher);
@@ -69,11 +69,13 @@ protected:
   void allDrainsImplicitlyComplete();
 
 private:
+  bool abortDueToFailedParentConnection();
   friend class HotRestartUdpForwardingTestHelper;
   absl::Mutex registry_mu_;
   const int restart_epoch_;
   bool parent_terminated_;
   bool parent_drained_ ABSL_GUARDED_BY(registry_mu_);
+  const bool skip_hot_restart_on_no_parent_;
   sockaddr_un parent_address_;
   sockaddr_un parent_address_udp_forwarding_;
   std::unique_ptr<Stats::StatMerger> stat_merger_{};

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -100,6 +100,10 @@ void HotRestartingParent::onSocketEvent() {
       break;
     }
 
+    case HotRestartMessage::Request::kTestConnection: {
+      break;
+    }
+
     default: {
       ENVOY_LOG(error, "child sent us an unfamiliar type of HotRestartMessage; ignoring.");
       HotRestartMessage wrapped_reply;

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -65,6 +65,12 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       "The server chooses a base ID dynamically. Supersedes a static base ID. May not be used "
       "when the restart epoch is non-zero.",
       cmd, false);
+  TCLAP::SwitchArg skip_hot_restart_on_no_parent(
+      "", "skip-hot-restart-on-no-parent",
+      "When hot restarting with epoch>0, the default behavior is for the child to crash if the"
+      " connection to the parent cannot be established. Set this to true to instead continue with"
+      " a regular startup, while retaining the new epoch value.",
+      cmd, false);
   TCLAP::ValueArg<std::string> base_id_path(
       "", "base-id-path", "Path to which the base ID is written", false, "", "string", cmd);
   TCLAP::ValueArg<uint32_t> concurrency("", "concurrency", "# of worker threads to run", false,
@@ -228,6 +234,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   }
   base_id_ = base_id.getValue();
   use_dynamic_base_id_ = use_dynamic_base_id.getValue();
+  skip_hot_restart_on_no_parent_ = skip_hot_restart_on_no_parent.getValue();
   base_id_path_ = base_id_path.getValue();
   restart_epoch_ = restart_epoch.getValue();
 
@@ -372,6 +379,7 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
       std::make_unique<envoy::admin::v3::CommandLineOptions>();
   command_line_options->set_base_id(baseId());
   command_line_options->set_use_dynamic_base_id(useDynamicBaseId());
+  command_line_options->set_skip_hot_restart_on_no_parent(skipHotRestartOnNoParent());
   command_line_options->set_base_id_path(baseIdPath());
   command_line_options->set_concurrency(concurrency());
   command_line_options->set_config_path(configPath());

--- a/source/server/options_impl_base.h
+++ b/source/server/options_impl_base.h
@@ -32,6 +32,7 @@ public:
   // Setters for option fields. These are not part of the Options interface.
   void setBaseId(uint64_t base_id) { base_id_ = base_id; };
   void setUseDynamicBaseId(bool use_dynamic_base_id) { use_dynamic_base_id_ = use_dynamic_base_id; }
+  void setSkipHotRestartOnNoParent(bool skip) { skip_hot_restart_on_no_parent_ = skip; }
   void setBaseIdPath(const std::string& base_id_path) { base_id_path_ = base_id_path; }
   void setConcurrency(uint32_t concurrency) { concurrency_ = concurrency; }
   void setConfigPath(const std::string& config_path) { config_path_ = config_path; }
@@ -96,6 +97,7 @@ public:
   // Server::Options
   uint64_t baseId() const override { return base_id_; }
   bool useDynamicBaseId() const override { return use_dynamic_base_id_; }
+  bool skipHotRestartOnNoParent() const override { return skip_hot_restart_on_no_parent_; }
   const std::string& baseIdPath() const override { return base_id_path_; }
   uint32_t concurrency() const override { return concurrency_; }
   const std::string& configPath() const override { return config_path_; }
@@ -167,6 +169,7 @@ private:
 
   uint64_t base_id_{0};
   bool use_dynamic_base_id_{false};
+  bool skip_hot_restart_on_no_parent_{false};
   std::string base_id_path_;
   uint32_t concurrency_{1};
   std::string config_path_;

--- a/test/integration/python/hotrestart_handoff_test.py
+++ b/test/integration/python/hotrestart_handoff_test.py
@@ -341,6 +341,51 @@ class IntegrationTest(unittest.IsolatedAsyncioTestCase):
         await self.fast_upstream.stop()
         return await super().asyncTearDown()
 
+    async def test_dead_parent_startup(self) -> None:
+        log.info("starting envoy")
+        envoy_process_1 = await asyncio.create_subprocess_exec(
+            *self.base_envoy_args,
+            "--restart-epoch",
+            "0",
+            "--use-dynamic-base-id",
+            "--base-id-path",
+            self.base_id_path,
+            "-c",
+            self.slow_config_path,
+        )
+        log.info(f"cert path = {IntegrationTest.server_cert}")
+        log.info("waiting for envoy ready")
+        await _wait_for_envoy_epoch(0)
+        base_id = int(self.base_id_path.read_text())
+        log.info("terminating first envoy process")
+        envoy_process_1.terminate()
+        await envoy_process_1.wait()
+
+        log.info("starting envoy with hot restart config but parent is dead")
+        envoy_process_2 = await asyncio.create_subprocess_exec(
+            *self.base_envoy_args,
+            "--restart-epoch",
+            "1",
+            "--base-id",
+            str(base_id),
+            "--skip-hot-restart-on-no-parent",
+            "-c",
+            self.fast_config_path,
+        )
+        log.info("waiting for envoy ready")
+        await _wait_for_envoy_epoch(1)
+        log.info("sending request to fast upstream")
+        request_url = f"http://{ENVOY_HOST}:{ENVOY_PORT}/"
+        response = _full_http_request(request_url)
+        self.assertEqual(
+            await response,
+            "fast instance",
+            "envoy server should be running despite failed hot restart",
+        )
+        log.info("shutting instance down")
+        envoy_process_2.terminate()
+        await envoy_process_2.wait()
+
     async def test_connection_handoffs(self) -> None:
         log.info("starting envoy")
         envoy_process_1 = await asyncio.create_subprocess_exec(

--- a/test/mocks/server/options.h
+++ b/test/mocks/server/options.h
@@ -17,6 +17,7 @@ public:
 
   MOCK_METHOD(uint64_t, baseId, (), (const));
   MOCK_METHOD(bool, useDynamicBaseId, (), (const));
+  MOCK_METHOD(bool, skipHotRestartOnNoParent, (), (const));
   MOCK_METHOD(const std::string&, baseIdPath, (), (const));
   MOCK_METHOD(uint32_t, concurrency, (), (const));
   MOCK_METHOD(const std::string&, configPath, (), (const));

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -67,7 +67,7 @@ public:
     EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(4);
 
     // Test we match the correct stat with empty-slots before, after, or both.
-    hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0);
+    hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false);
     hot_restart_->drainParentListeners();
 
     // We close both sockets, both ends, totaling 4.
@@ -133,7 +133,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketAlreadyInUse) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0),
+  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false),
                Server::HotRestartDomainSocketInUseException);
 }
 
@@ -149,7 +149,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketError) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0), EnvoyException);
+  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false), EnvoyException);
 }
 
 class HotRestartUdpForwardingContextTest : public HotRestartImplTest {

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -299,7 +299,7 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
     Stats::Gauge& g2 = child_store.rootScope()->gaugeFromStatName(
         dynamic.add("g2"), Stats::Gauge::ImportMode::Accumulate);
 
-    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0);
+    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0, false);
     hot_restarting_child.mergeParentStats(child_store, stats_proto);
     EXPECT_EQ(1, c1.value());
     EXPECT_EQ(1, c2.value());


### PR DESCRIPTION
Commit Message: Make hot restart tolerate premature death of the parent instance
Additional Description: The current behavior of hot restart makes it difficult to manage crashes, especially when envoy instances are run in containers - if epoch 1 crashed before epoch 2 tries to start up, there's no simple mechanism to have epoch 2 detect the crash and run as epoch 0 instead. If epoch 2 tries to start up while epoch 1 is not running, epoch 2 also crashes during startup, potentially causing an endless crashloop if there isn't some sort of "break out" detection.
This change makes it so instead of crashing during startup if the parent instance is not responsive, the child instance does one check at the beginning of its initialization of whether the parent is responsive, and if it is not, the child starts up without the hot restart socket/stats handoff, as if it was epoch 0 (but keeps the epoch, so any manager doesn't need to accommodate this).
Risk Level: Very small - new behavior is command-line-flag guarded and default is to persist the old behavior.
Testing: Unit tests and also added to the hot restart end-to-end test. Also patched in and deployed in production, which resolved the fact that we couldn't get hot restart to play nicely with our production tooling any other way!
Docs Changes: Documented the new flag.
Release Notes: Linked to the new flag documentation.
Platform Specific Features: n/a
