### PR TITLE
mobile: Remove envoy_cert_verify_status_t C type

### DIFF
--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -427,27 +427,3 @@ typedef struct {
   // Context passed through to callbacks to provide dispatch and execution state.
   void* context;
 } envoy_http_callbacks;
-
-/**
- * The list of certificate verification results returned from Java side to the
- * C++ side.
- * A Java counterpart lives in org.chromium.net.CertVerifyStatusAndroid.java
- */
-typedef enum {
-  // Certificate is trusted.
-  CERT_VERIFY_STATUS_OK = 0,
-  // Certificate verification could not be conducted.
-  CERT_VERIFY_STATUS_FAILED = -1,
-  // Certificate is not trusted due to non-trusted root of the certificate
-  // chain.
-  CERT_VERIFY_STATUS_NO_TRUSTED_ROOT = -2,
-  // Certificate is not trusted because it has expired.
-  CERT_VERIFY_STATUS_EXPIRED = -3,
-  // Certificate is not trusted because it is not valid yet.
-  CERT_VERIFY_STATUS_NOT_YET_VALID = -4,
-  // Certificate is not trusted because it could not be parsed.
-  CERT_VERIFY_STATUS_UNABLE_TO_PARSE = -5,
-  // Certificate is not trusted because it has an extendedKeyUsage field, but
-  // its value is not correct for a web server.
-  CERT_VERIFY_STATUS_INCORRECT_KEY_USAGE = -6,
-} envoy_cert_verify_status_t;

--- a/mobile/library/jni/BUILD
+++ b/mobile/library/jni/BUILD
@@ -101,7 +101,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":jni_utility_lib",
-        "//library/common/api:c_types",
         "//library/common/data:utility_lib",
         "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
         "//library/common/types:c_types_lib",

--- a/mobile/library/jni/android_network_utility.h
+++ b/mobile/library/jni/android_network_utility.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "absl/strings/string_view.h"
-#include "library/common/api/c_types.h"
 #include "library/common/extensions/cert_validator/platform_bridge/c_types.h"
 #include "library/jni/import/jni_import.h"
 #include "library/jni/jni_helper.h"


### PR DESCRIPTION
This PR removes `envoy_cert_verify_status_t` C `enum` type from `c_types.h` and replaces it with `CertVerifyStatus` C++ `enum class`. This PR also moves the enum into `android_network_utility.cc` since it's internal to the implementation.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

