### PR TITLE
Enable static format validation where possible

### DIFF
--- a/contrib/language/filters/http/test/language_integration_test.cc
+++ b/contrib/language/filters/http/test/language_integration_test.cc
@@ -14,15 +14,14 @@ public:
   }
 
   void initializeConfig(std::string default_language, std::string supported_languages) {
-    const std::string yaml = R"EOF(
+    constexpr absl::string_view yaml = R"EOF(
 name: envoy.filters.http.language
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.language.v3alpha.Language
   default_language: {}
   supported_languages: {}
 )EOF";
-    config_helper_.prependFilter(
-        fmt::format(fmt::runtime(yaml), default_language, supported_languages));
+    config_helper_.prependFilter(fmt::format(yaml, default_language, supported_languages));
   }
 };
 

--- a/mobile/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/mobile/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -62,14 +62,14 @@ public:
     std::stringstream ss;
     filter_->dumpState(ss, 0);
 
-    std::string expected_state_template =
+    constexpr absl::string_view expected_state_template =
         R"EOF(PlatformBridgeFilter, filter_name_: {}, error_response_: {}
   Request Filter, state_.iteration_state_: {}, state_.on_headers_called_: {}, state_.headers_forwarded_: {}, state_.on_data_called_: {}, state_.data_forwarded_: {}, state_.on_trailers_called_: {}, state_.trailers_forwarded_: {}, state_.on_resume_called_: {}, pending_headers_: {}, buffer: {}, pending_trailers_: {}, state_.stream_complete_: {}
   Response Filter, state_.iteration_state_: {}, state_.on_headers_called_: {}, state_.headers_forwarded_: {}, state_.on_data_called_: {}, state_.data_forwarded_: {}, state_.on_trailers_called_: {}, state_.trailers_forwarded_: {}, state_.on_resume_called_: {}, pending_headers_: {}, buffer: {}, pending_trailers_: {}, state_.stream_complete_: {}
 )EOF";
 
     std::string expected_state = fmt::format(
-        fmt::runtime(expected_state_template), name, error_response, request.iteration_state,
+        expected_state_template, name, error_response, request.iteration_state,
         request.on_headers_called, request.headers_forwarded, request.on_data_called,
         request.data_forwarded, request.on_trailers_called, request.trailers_forwarded,
         request.on_resume_called, request.pending_headers, request.buffer, request.pending_trailers,

--- a/source/extensions/common/aws/signer_base_impl.cc
+++ b/source/extensions/common/aws/signer_base_impl.cc
@@ -161,7 +161,7 @@ std::string SignerBaseImpl::createContentHash(Http::RequestMessage& message, boo
 std::string
 SignerBaseImpl::createAuthorizationCredential(absl::string_view access_key_id,
                                               absl::string_view credential_scope) const {
-  return fmt::format(fmt::runtime(SignatureConstants::AuthorizationCredentialFormat), access_key_id,
+  return fmt::format(SignatureConstants::AuthorizationCredentialFormat, access_key_id,
                      credential_scope);
 }
 

--- a/source/extensions/common/aws/sigv4_signer_impl.cc
+++ b/source/extensions/common/aws/sigv4_signer_impl.cc
@@ -22,7 +22,7 @@ namespace Aws {
 
 std::string SigV4SignerImpl::createCredentialScope(absl::string_view short_date,
                                                    absl::string_view override_region) const {
-  return fmt::format(fmt::runtime(SigV4SignatureConstants::SigV4CredentialScopeFormat), short_date,
+  return fmt::format(SigV4SignatureConstants::SigV4CredentialScopeFormat, short_date,
                      override_region.empty() ? region_ : override_region, service_name_);
 }
 
@@ -31,8 +31,8 @@ std::string SigV4SignerImpl::createStringToSign(absl::string_view canonical_requ
                                                 absl::string_view credential_scope) const {
   auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
   return fmt::format(
-      fmt::runtime(SigV4SignatureConstants::SigV4StringToSignFormat),
-      SigV4SignatureConstants::SigV4Algorithm, long_date, credential_scope,
+      SigV4SignatureConstants::SigV4StringToSignFormat, SigV4SignatureConstants::SigV4Algorithm,
+      long_date, credential_scope,
       Hex::encode(crypto_util.getSha256Digest(Buffer::OwnedImpl(canonical_request))));
 }
 
@@ -59,7 +59,7 @@ std::string SigV4SignerImpl::createAuthorizationHeader(
     const std::map<std::string, std::string>& canonical_headers,
     absl::string_view signature) const {
   const auto signed_headers = Utility::joinCanonicalHeaderNames(canonical_headers);
-  return fmt::format(fmt::runtime(SigV4SignatureConstants::SigV4AuthorizationHeaderFormat),
+  return fmt::format(SigV4SignatureConstants::SigV4AuthorizationHeaderFormat,
                      SigV4SignatureConstants::SigV4Algorithm,
                      createAuthorizationCredential(access_key_id, credential_scope), signed_headers,
                      signature);

--- a/source/extensions/common/aws/sigv4a_signer_impl.cc
+++ b/source/extensions/common/aws/sigv4a_signer_impl.cc
@@ -27,7 +27,7 @@ std::string SigV4ASignerImpl::createAuthorizationHeader(
     const std::map<std::string, std::string>& canonical_headers,
     absl::string_view signature) const {
   const auto signed_headers = Utility::joinCanonicalHeaderNames(canonical_headers);
-  return fmt::format(fmt::runtime(SigV4ASignatureConstants::SigV4AAuthorizationHeaderFormat),
+  return fmt::format(SigV4ASignatureConstants::SigV4AAuthorizationHeaderFormat,
                      createAuthorizationCredential(access_key_id, credential_scope), signed_headers,
                      signature);
 }
@@ -35,8 +35,8 @@ std::string SigV4ASignerImpl::createAuthorizationHeader(
 std::string SigV4ASignerImpl::createCredentialScope(
     const absl::string_view short_date,
     ABSL_ATTRIBUTE_UNUSED const absl::string_view override_region) const {
-  return fmt::format(fmt::runtime(SigV4ASignatureConstants::SigV4ACredentialScopeFormat),
-                     short_date, service_name_);
+  return fmt::format(SigV4ASignatureConstants::SigV4ACredentialScopeFormat, short_date,
+                     service_name_);
 }
 
 std::string SigV4ASignerImpl::createStringToSign(const absl::string_view canonical_request,
@@ -44,8 +44,8 @@ std::string SigV4ASignerImpl::createStringToSign(const absl::string_view canonic
                                                  const absl::string_view credential_scope) const {
   auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
   return fmt::format(
-      fmt::runtime(SigV4ASignatureConstants::SigV4AStringToSignFormat), getAlgorithmString(),
-      long_date, credential_scope,
+      SigV4ASignatureConstants::SigV4AStringToSignFormat, getAlgorithmString(), long_date,
+      credential_scope,
       Hex::encode(crypto_util.getSha256Digest(Buffer::OwnedImpl(canonical_request))));
 }
 

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -68,9 +68,13 @@ absl::optional<std::string> DnsResolverImpl::maybeBuildResolversCsv(
     // resolver->asString() is avoided as that format may be modified by custom
     // Address::Instance implementations in ways that make the <port> not a simple
     // integer. See https://github.com/envoyproxy/envoy/pull/3366.
-    resolver_addrs.push_back(fmt::format(fmt::runtime(resolver->ip()->ipv6() ? "[{}]:{}" : "{}:{}"),
-                                         resolver->ip()->addressAsString(),
-                                         resolver->ip()->port()));
+    if (resolver->ip()->ipv6()) {
+      resolver_addrs.push_back(
+          fmt::format("[{}]:{}", resolver->ip()->addressAsString(), resolver->ip()->port()));
+    } else {
+      resolver_addrs.push_back(
+          fmt::format("{}:{}", resolver->ip()->addressAsString(), resolver->ip()->port()));
+    }
   }
   return {absl::StrJoin(resolver_addrs, ",")};
 }

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -38,8 +38,8 @@ sockaddr_un RpcStream::createDomainSocketAddress(uint64_t id, const std::string&
   id = id % MaxConcurrentProcesses;
   sockaddr_un address;
   initDomainSocketAddress(&address);
-  Network::Address::PipeInstance addr(
-      fmt::format(fmt::runtime(socket_path + "_{}_{}"), role, base_id_ + id), socket_mode, nullptr);
+  Network::Address::PipeInstance addr(fmt::format("{}_{}_{}", socket_path, role, base_id_ + id),
+                                      socket_mode, nullptr);
   safeMemcpy(&address, &(addr.getSockAddr()));
   fchmod(domain_socket_, socket_mode);
 

--- a/test/extensions/common/aws/sigv4a_signer_impl_test.cc
+++ b/test/extensions/common/aws/sigv4a_signer_impl_test.cc
@@ -92,10 +92,10 @@ public:
     }
 
     std::string short_date = "20180102";
-    std::string credential_scope = fmt::format(fmt::runtime("{}/service/aws4_request"), short_date);
+    std::string credential_scope = fmt::format("{}/service/aws4_request", short_date);
     std::string long_date = "20180102T030400Z";
     std::string string_to_sign =
-        fmt::format(fmt::runtime(SigV4ASignatureConstants::SigV4AStringToSignFormat),
+        fmt::format(SigV4ASignatureConstants::SigV4AStringToSignFormat,
                     SigV4ASignatureConstants::SigV4AAlgorithm, long_date, credential_scope,
                     Hex::encode(crypto_util.getSha256Digest(Buffer::OwnedImpl(canonical_request))));
     auto hash = crypto_util.getSha256Digest(Buffer::OwnedImpl(string_to_sign));

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -130,7 +130,7 @@ public:
   void triggerTimeout() { attachedRequestBuffered()->onTimeout(attachedRequest()); }
 
   std::string makeBufferedAdminYaml(uint64_t max_traces, std::string timeout_s = "0s") {
-    const std::string buffered_admin_request_yaml_ =
+    constexpr absl::string_view buffered_admin_request_yaml_ =
         R"EOF(
 config_id: test_config_id
 tap_config:
@@ -142,7 +142,7 @@ tap_config:
           max_traces: {}
           timeout: {}
 )EOF";
-    return fmt::format(fmt::runtime(buffered_admin_request_yaml_), max_traces, timeout_s);
+    return fmt::format(buffered_admin_request_yaml_, max_traces, timeout_s);
   }
 
   // Cannot be moved into individual test cases as expected calls are validated on object

--- a/test/extensions/filters/common/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/common/local_ratelimit/local_ratelimit_test.cc
@@ -218,7 +218,7 @@ public:
     rate_limiter_ = std::make_shared<LocalRateLimiterImpl>(
         fill_interval, max_tokens, tokens_per_fill, dispatcher_, descriptors_);
   }
-  const std::string single_descriptor_config_yaml = R"(
+  static constexpr absl::string_view single_descriptor_config_yaml = R"(
   entries:
   - key: foo2
     value: bar2
@@ -247,7 +247,7 @@ public:
 
 // Verify descriptor rate limit time interval is multiple of token bucket fill interval.
 TEST_F(LocalRateLimiterDescriptorImplTest, DescriptorRateLimitDivisibleByTokenFillInterval) {
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 10, 10, "60s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 10, 10, "60s"),
                             *descriptors_.Add());
 
   EXPECT_THROW_WITH_MESSAGE(
@@ -256,9 +256,9 @@ TEST_F(LocalRateLimiterDescriptorImplTest, DescriptorRateLimitDivisibleByTokenFi
 }
 
 TEST_F(LocalRateLimiterDescriptorImplTest, DuplicateDescriptor) {
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 1, 1, "0.1s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "0.1s"),
                             *descriptors_.Add());
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 1, 1, "0.1s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "0.1s"),
                             *descriptors_.Add());
 
   EXPECT_THROW_WITH_MESSAGE(
@@ -276,9 +276,8 @@ TEST_F(LocalRateLimiterDescriptorImplTest, DescriptorRateLimitNoExceptionWithout
 TEST_F(LocalRateLimiterDescriptorImplTest, CasEdgeCasesDescriptor) {
   // This tests the case in which an allowed check races with the fill timer.
   {
-    TestUtility::loadFromYaml(
-        fmt::format(fmt::runtime(single_descriptor_config_yaml), 1, 1, "0.1s"),
-        *descriptors_.Add());
+    TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "0.1s"),
+                              *descriptors_.Add());
     initializeWithDescriptor(std::chrono::milliseconds(50), 1, 1);
 
     dispatcher_.globalTimeSystem().advanceTimeAndRun(std::chrono::milliseconds(50), dispatcher_,
@@ -331,7 +330,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest, CasEdgeCasesDescriptor) {
 }
 
 TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDescriptor2) {
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 1, 1, "0.1s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "0.1s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(50), 1, 1);
 
@@ -344,7 +343,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDescriptor2) {
 
 // Verify token bucket functionality with a single token.
 TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDescriptor) {
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 1, 1, "0.1s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "0.1s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(50), 1, 1);
 
@@ -387,7 +386,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDescriptor) {
 
 // Verify token bucket functionality with request per unit > 1.
 TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketMultipleTokensPerFillDescriptor) {
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 2, 2, "0.1s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 2, 2, "0.1s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(50), 2, 2);
 
@@ -424,7 +423,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketMultipleTokensPerFillDescr
 // Verify token bucket functionality with multiple descriptors.
 TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDifferentDescriptorDifferentRateLimits) {
   TestUtility::loadFromYaml(multiple_descriptor_config_yaml, *descriptors_.Add());
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 1, 1, "1000s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 1, 1, "1000s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(50), 3, 1);
 
@@ -450,7 +449,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDifferentDescriptorDiffere
 TEST_F(LocalRateLimiterDescriptorImplTest,
        TokenBucketDifferentDescriptorDifferentRateLimitsSorted) {
   TestUtility::loadFromYaml(multiple_descriptor_config_yaml, *descriptors_.Add());
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 2, 2, "1s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 2, 2, "1s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(50), 3, 3);
   std::vector<RateLimit::LocalDescriptor> descriptors{{{{"hello", "world"}, {"foo", "bar"}}},
@@ -465,7 +464,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest,
 
 // Verify token bucket status of max tokens, remaining tokens and remaining fill interval.
 TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDescriptorStatus) {
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 2, 2, "3s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 2, 2, "3s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(1000), 2, 2);
 
@@ -512,7 +511,7 @@ TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDescriptorStatus) {
 // multiple descriptors.
 TEST_F(LocalRateLimiterDescriptorImplTest, TokenBucketDifferentDescriptorStatus) {
   TestUtility::loadFromYaml(multiple_descriptor_config_yaml, *descriptors_.Add());
-  TestUtility::loadFromYaml(fmt::format(fmt::runtime(single_descriptor_config_yaml), 2, 2, "3s"),
+  TestUtility::loadFromYaml(fmt::format(single_descriptor_config_yaml, 2, 2, "3s"),
                             *descriptors_.Add());
   initializeWithDescriptor(std::chrono::milliseconds(50), 2, 1);
 

--- a/test/extensions/filters/http/local_ratelimit/filter_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/filter_test.cc
@@ -15,7 +15,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace LocalRateLimitFilter {
 
-static const std::string config_yaml = R"(
+static constexpr absl::string_view config_yaml = R"(
 stat_prefix: test
 rate_limited_as_resource_exhausted: {}
 token_bucket:
@@ -106,17 +106,17 @@ public:
 };
 
 TEST_F(FilterTest, Runtime) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "false", "\"OFF\""), false, false);
+  setup(fmt::format(config_yaml, "false", "1", "false", "\"OFF\""), false, false);
   EXPECT_EQ(&runtime_, &(config_->runtime()));
 }
 
 TEST_F(FilterTest, ToErrorCode) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "false", "\"OFF\""), false, false);
+  setup(fmt::format(config_yaml, "false", "1", "false", "\"OFF\""), false, false);
   EXPECT_EQ(Http::Code::BadRequest, toErrorCode(400));
 }
 
 TEST_F(FilterTest, Disabled) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "false", "\"OFF\""), false, false);
+  setup(fmt::format(config_yaml, "false", "1", "false", "\"OFF\""), false, false);
   auto headers = Http::TestRequestHeaderMapImpl();
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
   EXPECT_EQ(0U, findCounter("test.http_local_rate_limit.enabled"));
@@ -124,7 +124,7 @@ TEST_F(FilterTest, Disabled) {
 }
 
 TEST_F(FilterTest, RequestOk) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "false", "\"OFF\""));
+  setup(fmt::format(config_yaml, "false", "1", "false", "\"OFF\""));
   auto headers = Http::TestRequestHeaderMapImpl();
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_2_->decodeHeaders(headers, false));
@@ -135,7 +135,7 @@ TEST_F(FilterTest, RequestOk) {
 }
 
 TEST_F(FilterTest, RequestOkPerConnection) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "true", "\"OFF\""));
+  setup(fmt::format(config_yaml, "false", "1", "true", "\"OFF\""));
   auto headers = Http::TestRequestHeaderMapImpl();
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_2_->decodeHeaders(headers, false));
@@ -146,7 +146,7 @@ TEST_F(FilterTest, RequestOkPerConnection) {
 }
 
 TEST_F(FilterTest, RequestRateLimited) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "false", "\"OFF\""));
+  setup(fmt::format(config_yaml, "false", "1", "false", "\"OFF\""));
 
   EXPECT_CALL(decoder_callbacks_2_, sendLocalReply(Http::Code::TooManyRequests, _, _, _, _))
       .WillOnce(Invoke([](Http::Code code, absl::string_view body,
@@ -187,7 +187,7 @@ TEST_F(FilterTest, RequestRateLimited) {
 }
 
 TEST_F(FilterTest, RequestRateLimitedResourceExhausted) {
-  setup(fmt::format(fmt::runtime(config_yaml), "true", "1", "false", "\"OFF\""));
+  setup(fmt::format(config_yaml, "true", "1", "false", "\"OFF\""));
 
   EXPECT_CALL(decoder_callbacks_2_, sendLocalReply(Http::Code::TooManyRequests, _, _, _, _))
       .WillOnce(Invoke([](Http::Code code, absl::string_view body,
@@ -235,7 +235,7 @@ connection rate limiting and even though 'max_token' is set to 1, it allows 2 re
 allowed (across the process) for the same configuration.
 */
 TEST_F(FilterTest, RequestRateLimitedPerConnection) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "true", "\"OFF\""));
+  setup(fmt::format(config_yaml, "false", "1", "true", "\"OFF\""));
 
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::TooManyRequests, _, _, _, _))
       .WillOnce(Invoke([](Http::Code code, absl::string_view body,
@@ -272,7 +272,7 @@ TEST_F(FilterTest, RequestRateLimitedPerConnection) {
 }
 
 TEST_F(FilterTest, RequestRateLimitedButNotEnforced) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "0", "false", "\"OFF\""), true, false);
+  setup(fmt::format(config_yaml, "false", "0", "false", "\"OFF\""), true, false);
 
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::TooManyRequests, _, _, _, _)).Times(0);
 
@@ -288,7 +288,7 @@ TEST_F(FilterTest, RequestRateLimitedButNotEnforced) {
 }
 
 TEST_F(FilterTest, RequestRateLimitedXRateLimitHeaders) {
-  setup(fmt::format(fmt::runtime(config_yaml), "false", "1", "false", "DRAFT_VERSION_03"));
+  setup(fmt::format(config_yaml, "false", "1", "false", "DRAFT_VERSION_03"));
 
   auto request_headers = Http::TestRequestHeaderMapImpl();
   auto response_headers = Http::TestResponseHeaderMapImpl();
@@ -310,7 +310,7 @@ TEST_F(FilterTest, RequestRateLimitedXRateLimitHeaders) {
   EXPECT_EQ(1U, findCounter("test.http_local_rate_limit.rate_limited"));
 }
 
-static const std::string descriptor_config_yaml = R"(
+static constexpr absl::string_view descriptor_config_yaml = R"(
 stat_prefix: test
 token_bucket:
   max_tokens: {}
@@ -353,7 +353,7 @@ descriptors:
 stage: {}
   )";
 
-static const std::string consume_default_token_config_yaml = R"(
+static constexpr absl::string_view consume_default_token_config_yaml = R"(
 stat_prefix: test
 token_bucket:
   max_tokens: {}
@@ -396,7 +396,7 @@ descriptors:
 stage: {}
   )";
 
-static const std::string descriptor_vh_config_yaml = R"(
+static constexpr absl::string_view descriptor_vh_config_yaml = R"(
 stat_prefix: test
 token_bucket:
   max_tokens: {}
@@ -469,8 +469,7 @@ public:
 };
 
 TEST_F(DescriptorFilterTest, NoRouteEntry) {
-  setupPerRoute(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "0"), true,
-                true, true);
+  setupPerRoute(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "0"), true, true, true);
 
   auto headers = Http::TestRequestHeaderMapImpl();
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
@@ -480,7 +479,7 @@ TEST_F(DescriptorFilterTest, NoRouteEntry) {
 }
 
 TEST_F(DescriptorFilterTest, NoCluster) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_, clusterInfo()).WillRepeatedly(testing::Return(nullptr));
 
@@ -492,7 +491,7 @@ TEST_F(DescriptorFilterTest, NoCluster) {
 }
 
 TEST_F(DescriptorFilterTest, DisabledInRoute) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -507,7 +506,7 @@ TEST_F(DescriptorFilterTest, DisabledInRoute) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorRequestOk) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -523,7 +522,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorRequestOk) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorRequestRatelimited) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "0", "\"OFF\"", "0", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "0", "\"OFF\"", "0", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -539,7 +538,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorRequestRatelimited) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorNotFound) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -555,7 +554,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorNotFound) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorNotFoundWithConsumeDefaultTokenTrue) {
-  setUpTest(fmt::format(fmt::runtime(consume_default_token_config_yaml), "0", "true", "1", "0"));
+  setUpTest(fmt::format(consume_default_token_config_yaml, "0", "true", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -571,7 +570,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorNotFoundWithConsumeDefaultTokenTrue)
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorWithConsumeDefaultTokenTrue) {
-  setUpTest(fmt::format(fmt::runtime(consume_default_token_config_yaml), "0", "true", "1", "0"));
+  setUpTest(fmt::format(consume_default_token_config_yaml, "0", "true", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -587,7 +586,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorWithConsumeDefaultTokenTrue) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorWithConsumeDefaultTokenFalse) {
-  setUpTest(fmt::format(fmt::runtime(consume_default_token_config_yaml), "0", "false", "1", "0"));
+  setUpTest(fmt::format(consume_default_token_config_yaml, "0", "false", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -603,7 +602,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorWithConsumeDefaultTokenFalse) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorNotFoundWithConsumeDefaultTokenFalse) {
-  setUpTest(fmt::format(fmt::runtime(consume_default_token_config_yaml), "0", "false", "1", "0"));
+  setUpTest(fmt::format(consume_default_token_config_yaml, "0", "false", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -620,7 +619,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorNotFoundWithConsumeDefaultTokenFalse
 
 TEST_F(DescriptorFilterTest, RouteDescriptorBothMatch) {
   // Request should also be rate limited as it should match both descriptors and global token.
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "0", "\"OFF\"", "0", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "0", "\"OFF\"", "0", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -636,7 +635,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorBothMatch) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorWithStageConfig) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "1"));
+  setUpTest(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "1"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(1));
@@ -652,7 +651,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorWithStageConfig) {
 }
 
 TEST_F(DescriptorFilterTest, RouteDescriptorRequestRatelimitedXRateLimitHeaders) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "0", "DRAFT_VERSION_03", "0", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "0", "DRAFT_VERSION_03", "0", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -675,7 +674,7 @@ TEST_F(DescriptorFilterTest, RouteDescriptorRequestRatelimitedXRateLimitHeaders)
 }
 
 TEST_F(DescriptorFilterTest, NoVHRateLimitOption) {
-  setUpTest(fmt::format(fmt::runtime(descriptor_config_yaml), "1", "\"OFF\"", "1", "0"));
+  setUpTest(fmt::format(descriptor_config_yaml, "1", "\"OFF\"", "1", "0"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -698,8 +697,7 @@ TEST_F(DescriptorFilterTest, NoVHRateLimitOption) {
 // Tests that the route rate limit is used when VhRateLimitsOptions::OVERRIDE and route rate limit
 // is set
 TEST_F(DescriptorFilterTest, OverrideVHRateLimitOptionWithRouteRateLimitSet) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "OVERRIDE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "OVERRIDE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -722,8 +720,7 @@ TEST_F(DescriptorFilterTest, OverrideVHRateLimitOptionWithRouteRateLimitSet) {
 // Tests that the virtual host rate limit is used when VhRateLimitsOptions::OVERRIDE is set and
 // route rate limit is empty
 TEST_F(DescriptorFilterTest, OverrideVHRateLimitOptionWithoutRouteRateLimit) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "OVERRIDE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "OVERRIDE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -746,8 +743,7 @@ TEST_F(DescriptorFilterTest, OverrideVHRateLimitOptionWithoutRouteRateLimit) {
 // Tests that the virtual host rate limit is used when VhRateLimitsOptions::INCLUDE is set and route
 // rate limit is empty
 TEST_F(DescriptorFilterTest, IncludeVHRateLimitOptionWithOnlyVHRateLimitSet) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "INCLUDE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "INCLUDE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -767,8 +763,7 @@ TEST_F(DescriptorFilterTest, IncludeVHRateLimitOptionWithOnlyVHRateLimitSet) {
 // Tests that the virtual host rate limit is used when VhRateLimitsOptions::INCLUDE and route rate
 // limit is set
 TEST_F(DescriptorFilterTest, IncludeVHRateLimitOptionWithRouteAndVHRateLimitSet) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "INCLUDE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "INCLUDE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -791,8 +786,7 @@ TEST_F(DescriptorFilterTest, IncludeVHRateLimitOptionWithRouteAndVHRateLimitSet)
 // Tests that the route rate limit is used when VhRateLimitsOptions::IGNORE and route rate limit is
 // set
 TEST_F(DescriptorFilterTest, IgnoreVHRateLimitOptionWithRouteRateLimitSet) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "IGNORE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "IGNORE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -814,8 +808,7 @@ TEST_F(DescriptorFilterTest, IgnoreVHRateLimitOptionWithRouteRateLimitSet) {
 // Tests that no rate limit is used when VhRateLimitsOptions::IGNORE is set and route rate limit
 // empty
 TEST_F(DescriptorFilterTest, IgnoreVHRateLimitOptionWithOutRouteRateLimit) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "IGNORE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "IGNORE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));
@@ -833,8 +826,7 @@ TEST_F(DescriptorFilterTest, IgnoreVHRateLimitOptionWithOutRouteRateLimit) {
 
 // Tests that the virtual host rate limit is used when includeVirtualHostRateLimits is used
 TEST_F(DescriptorFilterTest, IncludeVirtualHostRateLimitsSetTrue) {
-  setUpTest(
-      fmt::format(fmt::runtime(descriptor_vh_config_yaml), "1", "\"OFF\"", "1", "0", "IGNORE"));
+  setUpTest(fmt::format(descriptor_vh_config_yaml, "1", "\"OFF\"", "1", "0", "IGNORE"));
 
   EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
               getApplicableRateLimit(0));

--- a/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/local_ratelimit_integration_test.cc
@@ -79,7 +79,7 @@ protected:
     }
   }
 
-  const std::string filter_config_ =
+  static constexpr absl::string_view filter_config_ =
       R"EOF(
 name: envoy.filters.http.local_ratelimit
 typed_config:
@@ -186,7 +186,7 @@ INSTANTIATE_TEST_SUITE_P(
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(LocalRateLimitFilterIntegrationTest, DenyRequestPerProcess) {
-  initializeFilter(fmt::format(fmt::runtime(filter_config_), "false"));
+  initializeFilter(fmt::format(filter_config_, "false"));
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 0);
@@ -213,7 +213,7 @@ TEST_P(LocalRateLimitFilterIntegrationTest, DenyRequestPerProcess) {
 }
 
 TEST_P(LocalRateLimitFilterIntegrationTest, DenyRequestWithinSameConnection) {
-  initializeFilter(fmt::format(fmt::runtime(filter_config_), "true"));
+  initializeFilter(fmt::format(filter_config_, "true"));
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 0);
@@ -238,7 +238,7 @@ TEST_P(LocalRateLimitFilterIntegrationTest, DenyRequestWithinSameConnection) {
 }
 
 TEST_P(LocalRateLimitFilterIntegrationTest, PermitRequestAcrossDifferentConnections) {
-  initializeFilter(fmt::format(fmt::runtime(filter_config_), "true"));
+  initializeFilter(fmt::format(filter_config_, "true"));
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 0);
@@ -272,8 +272,7 @@ TEST_P(LocalRateLimitFilterIntegrationTest, PermitRequestAcrossDifferentConnecti
 }
 
 TEST_P(LocalRateLimitFilterIntegrationTest, BasicTestPerRouteAndRds) {
-  initializeFilterWithRds(fmt::format(fmt::runtime(filter_config_), true), "basic_routes",
-                          initial_route_config_);
+  initializeFilterWithRds(fmt::format(filter_config_, true), "basic_routes", initial_route_config_);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -134,8 +134,7 @@ public:
   }
 
   void verifyStaticFilePerTap(const std::string& filter_config) {
-    const std::string path_prefix = getTempPathPrefix();
-    initializeFilter(fmt::format(fmt::runtime(filter_config), path_prefix));
+    initializeFilter(filter_config);
 
     // Initial request/response with tap.
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
@@ -144,7 +143,7 @@ public:
     test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
 
     // Find the written .pb file and verify it.
-    auto files = TestUtility::listFiles(path_prefix, false);
+    auto files = TestUtility::listFiles(getTempPathPrefix(), false);
     auto pb_file = std::find_if(files.begin(), files.end(),
                                 [](const std::string& s) { return absl::EndsWith(s, ".pb"); });
     ASSERT_NE(pb_file, files.end());
@@ -215,7 +214,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, TapIntegrationTest,
 
 // Verify a static configuration with an any matcher, writing to a file per tap sink.
 TEST_P(TapIntegrationTest, StaticFilePerTap) {
-  const std::string filter_config =
+  constexpr absl::string_view filter_config =
       R"EOF(
 name: tap
 typed_config:
@@ -231,12 +230,12 @@ typed_config:
               path_prefix: {}
 )EOF";
 
-  verifyStaticFilePerTap(filter_config);
+  verifyStaticFilePerTap(fmt::format(filter_config, getTempPathPrefix()));
 }
 
 // Verify the match field takes precedence over the deprecated match_config field.
 TEST_P(TapIntegrationTest, DEPRECATED_FEATURE_TEST(StaticFilePerTapWithMatchConfigAndMatch)) {
-  const std::string filter_config =
+  constexpr absl::string_view filter_config =
       R"EOF(
 name: tap
 typed_config:
@@ -256,12 +255,12 @@ typed_config:
               path_prefix: {}
 )EOF";
 
-  verifyStaticFilePerTap(filter_config);
+  verifyStaticFilePerTap(fmt::format(filter_config, getTempPathPrefix()));
 }
 
 // Verify the deprecated match_config field.
 TEST_P(TapIntegrationTest, DEPRECATED_FEATURE_TEST(StaticFilePerTapWithMatchConfig)) {
-  const std::string filter_config =
+  constexpr absl::string_view filter_config =
       R"EOF(
 name: tap
 typed_config:
@@ -277,7 +276,7 @@ typed_config:
               path_prefix: {}
 )EOF";
 
-  verifyStaticFilePerTap(filter_config);
+  verifyStaticFilePerTap(fmt::format(filter_config, getTempPathPrefix()));
 }
 
 // Verify a basic tap flow using the admin handler.

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -25,8 +25,8 @@ const std::string header = R"EOF(
 { "header": {"name": "key", "exact_match": "value"} }
 )EOF";
 
-const absl::string_view header_key = "key";
-const absl::string_view header_value = "value";
+constexpr absl::string_view header_key = "key";
+constexpr absl::string_view header_value = "value";
 
 } // namespace
 
@@ -36,9 +36,7 @@ public:
     checkRule(fmt::sprintf(policy_json, header));
   }
 
-  void validateMatcher(const std::string& matcher_yaml) {
-    checkMatcher(fmt::format(fmt::runtime(matcher_yaml), header_key, header_value));
-  }
+  void validateMatcher(const std::string& matcher_yaml) { checkMatcher(matcher_yaml); }
 
 private:
   void checkRule(const std::string& policy_json) {
@@ -188,7 +186,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, InvalidPrincipal) {
 }
 
 TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, InvalidMatcher) {
-  validateMatcher(R"EOF(
+  validateMatcher(fmt::format(R"EOF(
 matcher_tree:
   input:
     name: source-ip
@@ -203,9 +201,10 @@ matcher_tree:
           typed_config:
             '@type': type.googleapis.com/envoy.config.rbac.v3.Action
             name: deny
-)EOF");
+)EOF",
+                              header_key, header_value));
 
-  validateMatcher(R"EOF(
+  validateMatcher(fmt::format(R"EOF(
 matcher_tree:
   input:
     name: source-ip
@@ -220,7 +219,8 @@ matcher_tree:
           typed_config:
             '@type': type.googleapis.com/envoy.config.rbac.v3.Action
             name: deny
-)EOF");
+)EOF",
+                              header_key, header_value));
 }
 
 } // namespace RBACFilter

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -79,7 +79,7 @@ const std::string CONFIG_WITH_REDIRECTION = CONFIG + R"EOF(
 )EOF";
 
 // This is a configuration with moved/ask redirection support and DNS lookups enabled.
-const std::string CONFIG_WITH_REDIRECTION_DNS = CONFIG_WITH_REDIRECTION + R"EOF(
+constexpr absl::string_view CONFIG_WITH_REDIRECTION_DNS = R"EOF({}
             dns_cache_config:
               name: foo
               dns_lookup_family: {}
@@ -470,7 +470,7 @@ class RedisProxyWithRedirectionAndDNSIntegrationTest
 public:
   RedisProxyWithRedirectionAndDNSIntegrationTest()
       : RedisProxyWithRedirectionIntegrationTest(
-            fmt::format(fmt::runtime(CONFIG_WITH_REDIRECTION_DNS),
+            fmt::format(CONFIG_WITH_REDIRECTION_DNS, CONFIG_WITH_REDIRECTION,
                         Network::Test::ipVersionToDnsFamily(GetParam())),
             2) {}
 };


### PR DESCRIPTION
Commit Message:
Use static format validation where format string is already constexpr.

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
