### PR TITLE
quic: Terminate streams with empty trailers

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -211,6 +211,9 @@ bug_fixes:
   change: |
     Switch to use StopAllIterationAndWatermark instead of StopIteration in geoip filter to fix an issue where large
     POST request body may get corrupted when geoip is enabled.
+- area: quic
+  change: |
+    Terminate streams with empty trailers.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/quic/envoy_quic_stream.cc
+++ b/source/common/quic/envoy_quic_stream.cc
@@ -88,11 +88,11 @@ void EnvoyQuicStream::encodeTrailersImpl(spdy::Http2HeaderBlock&& trailers) {
   local_end_stream_ = true;
 
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(&quic_stream_, this);
-  
+
   size_t bytes_sent = 0;
   if (trailers.empty()) {
     // No trailers to send. Send an empty data frame to terminate the stream.
-    auto result = quic_stream_.WriteBodySlices({}, /*end_stream=*/ true);
+    auto result = quic_stream_.WriteBodySlices({}, /*end_stream=*/true);
     ENVOY_BUG(result.fin_consumed, "Failed to encode empty trailers.");
   } else {
     IncrementalBytesSentTracker tracker(quic_stream_, *mutableBytesMeter(), true);
@@ -100,7 +100,7 @@ void EnvoyQuicStream::encodeTrailersImpl(spdy::Http2HeaderBlock&& trailers) {
     ENVOY_BUG(bytes_sent != 0, "Failed to encode trailers.");
   }
   if (stats_gatherer_ != nullptr) {
-    stats_gatherer_->addBytesSent(bytes_sent, /*end_stream=*/ true);
+    stats_gatherer_->addBytesSent(bytes_sent, /*end_stream=*/true);
   }
   if (codec_callbacks_) {
     codec_callbacks_->onCodecEncodeComplete();

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -739,7 +739,7 @@ TEST_F(EnvoyQuicClientStreamTest, EncodeTrailersWithEmptyTrailers) {
   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
       .WillRepeatedly(
           Invoke([&](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
-                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
+                     quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
             ++num_writes;
             last_write_length = write_length;
             last_state = state;

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -366,7 +366,7 @@ TEST_F(EnvoyQuicServerStreamTest, EncodeTrailersWithEmptyTrailers) {
   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
       .WillRepeatedly(
           Invoke([&](quic::QuicStreamId, size_t write_length, quic::QuicStreamOffset,
-                    quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
+                     quic::StreamSendingState state, bool, absl::optional<quic::EncryptionLevel>) {
             ++num_writes;
             last_write_length = write_length;
             last_state = state;


### PR DESCRIPTION
Commit Message: quic: Terminate streams with empty trailers
Additional Description:

QUIC streams with empty trailers are currently improperly terminated: https://github.com/envoyproxy/envoy/issues/33226

This pull request fixes the handling of empty trailers to terminate the stream instead of sending an empty HEADERS frame.

An alternative would be to skip the call to encodeTrailers when headers are empty. That would require broader changes to Envoy and may break the design of filters if we expect empty trailers processed by a first filter to be handled by a subsequent ones. This change is more narrowly scoped but it would be good for a maintainer to confirm that this is the right fix.

Risk Level: Low. Few clients should be affected by this change since empty trailers together with HTTP/3 should be rare (but needed for gRPC-Web).
Testing: Verified that gRPC Web requests are working as expected after this fix.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #33226 
