### PR TITLE
mobile: Fix the flaky SendDataTest Kotlin test

### DIFF
--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -14,6 +14,7 @@ cc_library(
         "//library/jni:envoy_jni_lib",
         "@envoy_build_config//:test_extensions",
     ],
+    alwayslink = True,
 )
 
 # Library which contains all the JNI related targets.

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -238,7 +238,7 @@ envoy_mobile_jni_kt_test(
     ],
 )
 
-envoy_mobile_android_test(
+envoy_mobile_jni_kt_test(
     name = "send_data_test",
     srcs = [
         "SendDataTest.kt",
@@ -254,8 +254,6 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -10,9 +10,7 @@ import io.envoyproxy.envoymobile.engine.JniLibrary
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.junit.After
 import org.junit.Assert.fail
-import org.junit.Before
 import org.junit.Test
 
 private const val ASSERTION_FILTER_TYPE =

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -5,11 +5,8 @@ import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.Standard
-import io.envoyproxy.envoymobile.engine.AndroidJniLibrary
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
-import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory.HttpTestServer
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -20,24 +17,14 @@ import org.junit.Test
 
 private const val ASSERTION_FILTER_TYPE =
   "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+private const val TEST_RESPONSE_FILTER_TYPE =
+  "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 private const val REQUEST_STRING_MATCH = "match_me"
 
+// TODO(fredyw): Figure out why HttpTestServer prevents EngineBuilder from using native filters.
 class SendDataTest {
   init {
-    AndroidJniLibrary.loadTestLibrary()
-    JniLibrary.load()
-  }
-
-  private lateinit var httpTestServer: HttpTestServer
-
-  @Before
-  fun setUp() {
-    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
-  }
-
-  @After
-  fun tearDown() {
-    httpTestServer.shutdown()
+    JniLibrary.loadTestLibrary()
   }
 
   @Test
@@ -49,6 +36,7 @@ class SendDataTest {
           "envoy.filters.http.assertion",
           "{'@type': $ASSERTION_FILTER_TYPE, match_config: {http_request_generic_body_match: {patterns: [{string_match: $REQUEST_STRING_MATCH}]}}}"
         )
+        .addNativeFilter("test_remote_response", "{'@type': $TEST_RESPONSE_FILTER_TYPE}")
         .setTrustChainVerification(TrustChainVerification.ACCEPT_UNTRUSTED)
         .build()
 
@@ -58,8 +46,8 @@ class SendDataTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "localhost:${httpTestServer.port}",
-          path = "/simple.txt"
+          authority = "example.com",
+          path = "/test"
         )
         .build()
 


### PR DESCRIPTION
The test failed when adding the native Assertion filter, with an error from loadFromYaml:
```
INVALID_ARGUMENT: could not find @type 'type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion
```

The failure was reproduced locally with:
```
./bazelw test --cache_test_results=no --test_output=streamed --config=mobile-test-android //test/kotlin/integration:send_data_test 
```

After running git bisect, it turns out the bad commit came from https://github.com/envoyproxy/envoy/pull/33169. That PR introduces HttpTestServer to the SendDataTest.kt, which causes the required proto types to not get loaded.

In this commit, the test is fixed by using a TestRemoteResponse filter, similar to the other Kotlin tests (e.g. SendTrailersTest). However, we need to figure out why the config filter protos aren't loading when creating the HttpTestServer.