### PR TITLE
add TRACE_ID and SPAN_ID to accesslog formatter

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -329,6 +329,9 @@ new_features:
   change: |
     Added :ref:`Fluentd access logger <envoy_v3_api_msg_extensions.access_loggers.fluentd.v3.FluentdAccessLogConfig>`
     to support flushing access logs in `Fluentd format <https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1>`_.
+- area: access_loggers
+  change: |
+    Added ``TRACE_ID`` and ``SPAN_ID`` :ref:`access log formatter <config_access_log_format>`.
 - area: redis
   change: |
     Added support for the ``ECHO`` command.

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -1177,3 +1177,15 @@ UDP
 %ENVIRONMENT(X):Z%
   Environment value of environment variable X. If no valid environment variable X, '-' symbol will be used.
   Z is an optional parameter denoting string truncation up to Z characters long.
+
+%TRACE_ID%
+  HTTP
+    The trace ID of the request. If the request does not have a trace ID, this will be an empty string.
+  TCP/UDP
+    Not implemented ("-").
+
+%SPAN_ID%
+  HTTP
+    The span ID of the request. If the request does not have a span ID, this will be an empty string.
+  TCP/UDP
+    Not implemented ("-").

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -904,7 +904,7 @@ public:
    * Set the span id for the stream.
    */
   virtual void setSpanId(std::string span_id) PURE;
-  
+
   /**
    * @return the span id for the stream.
    */

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -891,6 +891,26 @@ public:
   virtual Tracing::Reason traceReason() const PURE;
 
   /**
+   * Set the trace id for the stream.
+   */
+  virtual void setTraceId(std::string trace_id) PURE;
+
+  /**
+   * @return the trace id for the stream.
+   */
+  virtual std::string traceId() const PURE;
+
+  /**
+   * Set the span id for the stream.
+   */
+  virtual void setSpanId(std::string span_id) PURE;
+  
+  /**
+   * @return the span id for the stream.
+   */
+  virtual std::string spanId() const PURE;
+
+  /**
    * @param attempt_count, the number of times the request was attempted upstream.
    */
   virtual void setAttemptCount(uint32_t attempt_count) PURE;

--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -96,6 +96,14 @@ public:
    * @return trace ID as a hex string
    */
   virtual std::string getTraceIdAsHex() const PURE;
+
+  /**
+   * Retrieve the span ID associated with this span.
+   * The span id may be generated for this span, propagated by parent spans, or
+   * not created yet.
+   * @return span ID as a hex string
+   */
+  virtual std::string getSpanIdAsHex() const PURE;
 };
 
 /**

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -636,858 +636,967 @@ private:
 };
 
 const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProviders() {
-  CONSTRUCT_ON_FIRST_USE(
-      StreamInfoFormatterProviderLookupTable,
-      {
-          {"REQUEST_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    StreamInfo::TimingUtility timing(stream_info);
-                    return timing.lastDownstreamRxByteReceived();
-                  });
-            }}},
-          {"REQUEST_TX_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    StreamInfo::TimingUtility timing(stream_info);
-                    return timing.lastUpstreamTxByteSent();
-                  });
-            }}},
-          {"RESPONSE_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    StreamInfo::TimingUtility timing(stream_info);
-                    return timing.firstUpstreamRxByteReceived();
-                  });
-            }}},
-          {"RESPONSE_TX_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    StreamInfo::TimingUtility timing(stream_info);
-                    auto downstream = timing.lastDownstreamTxByteSent();
-                    auto upstream = timing.firstUpstreamRxByteReceived();
+  CONSTRUCT_ON_FIRST_USE(StreamInfoFormatterProviderLookupTable,
+                         {
+                             {"REQUEST_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       StreamInfo::TimingUtility timing(stream_info);
+                                       return timing.lastDownstreamRxByteReceived();
+                                     });
+                               }}},
+                             {"REQUEST_TX_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       StreamInfo::TimingUtility timing(stream_info);
+                                       return timing.lastUpstreamTxByteSent();
+                                     });
+                               }}},
+                             {"RESPONSE_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       StreamInfo::TimingUtility timing(stream_info);
+                                       return timing.firstUpstreamRxByteReceived();
+                                     });
+                               }}},
+                             {"RESPONSE_TX_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       StreamInfo::TimingUtility timing(stream_info);
+                                       auto downstream = timing.lastDownstreamTxByteSent();
+                                       auto upstream = timing.firstUpstreamRxByteReceived();
 
-                    absl::optional<std::chrono::nanoseconds> result;
-                    if (downstream && upstream) {
-                      result = downstream.value() - upstream.value();
-                    }
+                                       absl::optional<std::chrono::nanoseconds> result;
+                                       if (downstream && upstream) {
+                                         result = downstream.value() - upstream.value();
+                                       }
 
-                    return result;
-                  });
-            }}},
-          {"DOWNSTREAM_HANDSHAKE_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    StreamInfo::TimingUtility timing(stream_info);
-                    return timing.downstreamHandshakeComplete();
-                  });
-            }}},
-          {"ROUNDTRIP_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    StreamInfo::TimingUtility timing(stream_info);
-                    return timing.lastDownstreamAckReceived();
-                  });
-            }}},
-          {"BYTES_RECEIVED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.bytesReceived();
-                  });
-            }}},
-          {"BYTES_RETRANSMITTED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.bytesRetransmitted();
-                  });
-            }}},
-          {"PACKETS_RETRANSMITTED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.packetsRetransmitted();
-                  });
-            }}},
-          {"UPSTREAM_WIRE_BYTES_RECEIVED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getUpstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->wireBytesReceived() : 0;
-                  });
-            }}},
-          {"UPSTREAM_HEADER_BYTES_RECEIVED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getUpstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->headerBytesReceived() : 0;
-                  });
-            }}},
-          {"DOWNSTREAM_WIRE_BYTES_RECEIVED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getDownstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->wireBytesReceived() : 0;
-                  });
-            }}},
-          {"DOWNSTREAM_HEADER_BYTES_RECEIVED",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getDownstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->headerBytesReceived() : 0;
-                  });
-            }}},
-          {"PROTOCOL",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return SubstitutionFormatUtils::protocolToString(stream_info.protocol());
-                  });
-            }}},
-          {"UPSTREAM_PROTOCOL",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.upstreamInfo()
-                               ? SubstitutionFormatUtils::protocolToString(
-                                     stream_info.upstreamInfo()->upstreamProtocol())
-                               : absl::nullopt;
-                  });
-            }}},
-          {"RESPONSE_CODE",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.responseCode().value_or(0);
-                  });
-            }}},
-          {"RESPONSE_CODE_DETAILS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.responseCodeDetails();
-                  });
-            }}},
-          {"CONNECTION_TERMINATION_DETAILS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.connectionTerminationDetails();
-                  });
-            }}},
-          {"BYTES_SENT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.bytesSent();
-                  });
-            }}},
-          {"UPSTREAM_WIRE_BYTES_SENT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getUpstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->wireBytesSent() : 0;
-                  });
-            }}},
-          {"UPSTREAM_HEADER_BYTES_SENT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getUpstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->headerBytesSent() : 0;
-                  });
-            }}},
-          {"DOWNSTREAM_WIRE_BYTES_SENT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getDownstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->wireBytesSent() : 0;
-                  });
-            }}},
-          {"DOWNSTREAM_HEADER_BYTES_SENT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    const auto& bytes_meter = stream_info.getDownstreamBytesMeter();
-                    return bytes_meter ? bytes_meter->headerBytesSent() : 0;
-                  });
-            }}},
-          {"DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.currentDuration();
-                  });
-            }}},
-          {"RESPONSE_FLAGS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return StreamInfo::ResponseFlagUtils::toShortString(stream_info);
-                  });
-            }}},
-          {"RESPONSE_FLAGS_LONG",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return StreamInfo::ResponseFlagUtils::toString(stream_info);
-                  });
-            }}},
-          {"UPSTREAM_HOST",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-                      return stream_info.upstreamInfo()->upstreamHost()->address();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_CONNECTION_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    uint64_t upstream_connection_id = 0;
-                    if (stream_info.upstreamInfo().has_value()) {
-                      upstream_connection_id =
-                          stream_info.upstreamInfo()->upstreamConnectionId().value_or(0);
-                    }
-                    return upstream_connection_id;
-                  });
-            }}},
-          {"UPSTREAM_CLUSTER",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    std::string upstream_cluster_name;
-                    if (stream_info.upstreamClusterInfo().has_value() &&
-                        stream_info.upstreamClusterInfo().value() != nullptr) {
-                      upstream_cluster_name =
-                          stream_info.upstreamClusterInfo().value()->observabilityName();
-                    }
+                                       return result;
+                                     });
+                               }}},
+                             {"DOWNSTREAM_HANDSHAKE_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       StreamInfo::TimingUtility timing(stream_info);
+                                       return timing.downstreamHandshakeComplete();
+                                     });
+                               }}},
+                             {"ROUNDTRIP_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       StreamInfo::TimingUtility timing(stream_info);
+                                       return timing.lastDownstreamAckReceived();
+                                     });
+                               }}},
+                             {"BYTES_RECEIVED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.bytesReceived();
+                                     });
+                               }}},
+                             {"BYTES_RETRANSMITTED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.bytesRetransmitted();
+                                     });
+                               }}},
+                             {"PACKETS_RETRANSMITTED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.packetsRetransmitted();
+                                     });
+                               }}},
+                             {"UPSTREAM_WIRE_BYTES_RECEIVED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getUpstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->wireBytesReceived() : 0;
+                                     });
+                               }}},
+                             {"UPSTREAM_HEADER_BYTES_RECEIVED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getUpstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->headerBytesReceived() : 0;
+                                     });
+                               }}},
+                             {"DOWNSTREAM_WIRE_BYTES_RECEIVED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getDownstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->wireBytesReceived() : 0;
+                                     });
+                               }}},
+                             {"DOWNSTREAM_HEADER_BYTES_RECEIVED",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getDownstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->headerBytesReceived() : 0;
+                                     });
+                               }}},
+                             {"PROTOCOL",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return SubstitutionFormatUtils::protocolToString(
+                                           stream_info.protocol());
+                                     });
+                               }}},
+                             {"UPSTREAM_PROTOCOL",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.upstreamInfo()
+                                                  ? SubstitutionFormatUtils::protocolToString(
+                                                        stream_info.upstreamInfo()
+                                                            ->upstreamProtocol())
+                                                  : absl::nullopt;
+                                     });
+                               }}},
+                             {"RESPONSE_CODE",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.responseCode().value_or(0);
+                                     });
+                               }}},
+                             {"RESPONSE_CODE_DETAILS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.responseCodeDetails();
+                                     });
+                               }}},
+                             {"CONNECTION_TERMINATION_DETAILS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.connectionTerminationDetails();
+                                     });
+                               }}},
+                             {"BYTES_SENT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.bytesSent();
+                                     });
+                               }}},
+                             {"UPSTREAM_WIRE_BYTES_SENT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getUpstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->wireBytesSent() : 0;
+                                     });
+                               }}},
+                             {"UPSTREAM_HEADER_BYTES_SENT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getUpstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->headerBytesSent() : 0;
+                                     });
+                               }}},
+                             {"DOWNSTREAM_WIRE_BYTES_SENT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getDownstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->wireBytesSent() : 0;
+                                     });
+                               }}},
+                             {"DOWNSTREAM_HEADER_BYTES_SENT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       const auto& bytes_meter =
+                                           stream_info.getDownstreamBytesMeter();
+                                       return bytes_meter ? bytes_meter->headerBytesSent() : 0;
+                                     });
+                               }}},
+                             {"DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.currentDuration();
+                                     });
+                               }}},
+                             {"RESPONSE_FLAGS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return StreamInfo::ResponseFlagUtils::toShortString(
+                                           stream_info);
+                                     });
+                               }}},
+                             {"RESPONSE_FLAGS_LONG",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return StreamInfo::ResponseFlagUtils::toString(stream_info);
+                                     });
+                               }}},
+                             {"UPSTREAM_HOST",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo() &&
+                                           stream_info.upstreamInfo()->upstreamHost()) {
+                                         return stream_info.upstreamInfo()
+                                             ->upstreamHost()
+                                             ->address();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_CONNECTION_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       uint64_t upstream_connection_id = 0;
+                                       if (stream_info.upstreamInfo().has_value()) {
+                                         upstream_connection_id = stream_info.upstreamInfo()
+                                                                      ->upstreamConnectionId()
+                                                                      .value_or(0);
+                                       }
+                                       return upstream_connection_id;
+                                     });
+                               }}},
+                             {"UPSTREAM_CLUSTER",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       std::string upstream_cluster_name;
+                                       if (stream_info.upstreamClusterInfo().has_value() &&
+                                           stream_info.upstreamClusterInfo().value() != nullptr) {
+                                         upstream_cluster_name = stream_info.upstreamClusterInfo()
+                                                                     .value()
+                                                                     ->observabilityName();
+                                       }
 
-                    return upstream_cluster_name.empty()
-                               ? absl::nullopt
-                               : absl::make_optional<std::string>(upstream_cluster_name);
-                  });
-            }}},
-          {"UPSTREAM_LOCAL_ADDRESS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo().has_value()) {
-                      return stream_info.upstreamInfo().value().get().upstreamLocalAddress();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withoutPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo().has_value()) {
-                      return stream_info.upstreamInfo().value().get().upstreamLocalAddress();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_LOCAL_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::justPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo().has_value()) {
-                      return stream_info.upstreamInfo().value().get().upstreamLocalAddress();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_REMOTE_ADDRESS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-                      return stream_info.upstreamInfo()->upstreamHost()->address();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withoutPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-                      return stream_info.upstreamInfo()->upstreamHost()->address();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_REMOTE_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::justPort(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> std::shared_ptr<const Envoy::Network::Address::Instance> {
-                    if (stream_info.upstreamInfo() && stream_info.upstreamInfo()->upstreamHost()) {
-                      return stream_info.upstreamInfo()->upstreamHost()->address();
-                    }
-                    return nullptr;
-                  });
-            }}},
-          {"UPSTREAM_REQUEST_ATTEMPT_COUNT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.attemptCount().value_or(0);
-                  });
-            }}},
-          {"UPSTREAM_TLS_CIPHER",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.ciphersuiteString();
-                  });
-            }}},
-          {"UPSTREAM_TLS_VERSION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.tlsVersion();
-                  });
-            }}},
-          {"UPSTREAM_TLS_SESSION_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.sessionId();
-                  });
-            }}},
-          {"UPSTREAM_PEER_ISSUER",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.issuerPeerCertificate();
-                  });
-            }}},
-          {"UPSTREAM_PEER_CERT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.urlEncodedPemEncodedPeerCertificate();
-                  });
-            }}},
-          {"UPSTREAM_PEER_SUBJECT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.subjectPeerCertificate();
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_ADDRESS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withPort(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().localAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withoutPort(
-                  [](const Envoy::StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().localAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::justPort(
-                  [](const Envoy::StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().localAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_REMOTE_ADDRESS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withPort(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().remoteAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withoutPort(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().remoteAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_REMOTE_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::justPort(
-                  [](const Envoy::StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().remoteAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_DIRECT_REMOTE_ADDRESS",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withPort(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().directRemoteAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::withoutPort(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().directRemoteAddress();
-                  });
-            }}},
-          {"DOWNSTREAM_DIRECT_REMOTE_PORT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return StreamInfoAddressFormatterProvider::justPort(
-                  [](const Envoy::StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().directRemoteAddress();
-                  });
-            }}},
-          {"CONNECTION_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoUInt64FormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    return stream_info.downstreamAddressProvider().connectionID().value_or(0);
-                  });
-            }}},
-          {"REQUESTED_SERVER_NAME",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    absl::optional<std::string> result;
-                    if (!stream_info.downstreamAddressProvider().requestedServerName().empty()) {
-                      result = std::string(
-                          stream_info.downstreamAddressProvider().requestedServerName());
-                    }
-                    return result;
-                  });
-            }}},
-          {"ROUTE_NAME",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    absl::optional<std::string> result;
-                    std::string route_name = stream_info.getRouteName();
-                    if (!route_name.empty()) {
-                      result = route_name;
-                    }
-                    return result;
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_URI_SAN",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return absl::StrJoin(connection_info.uriSanPeerCertificate(), ",");
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_DNS_SAN",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return absl::StrJoin(connection_info.dnsSansPeerCertificate(), ",");
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_IP_SAN",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return absl::StrJoin(connection_info.ipSansPeerCertificate(), ",");
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_URI_SAN",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return absl::StrJoin(connection_info.uriSanLocalCertificate(), ",");
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_DNS_SAN",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return absl::StrJoin(connection_info.dnsSansLocalCertificate(), ",");
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_IP_SAN",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return absl::StrJoin(connection_info.ipSansLocalCertificate(), ",");
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_SUBJECT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.subjectPeerCertificate();
-                  });
-            }}},
-          {"DOWNSTREAM_LOCAL_SUBJECT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.subjectLocalCertificate();
-                  });
-            }}},
-          {"DOWNSTREAM_TLS_SESSION_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.sessionId();
-                  });
-            }}},
-          {"DOWNSTREAM_TLS_CIPHER",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.ciphersuiteString();
-                  });
-            }}},
-          {"DOWNSTREAM_TLS_VERSION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.tlsVersion();
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_FINGERPRINT_256",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.sha256PeerCertificateDigest();
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_FINGERPRINT_1",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.sha1PeerCertificateDigest();
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_SERIAL",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.serialNumberPeerCertificate();
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_ISSUER",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.issuerPeerCertificate();
-                  });
-            }}},
-          {"DOWNSTREAM_PEER_CERT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoSslConnectionInfoFormatterProvider>(
-                  [](const Ssl::ConnectionInfo& connection_info) {
-                    return connection_info.urlEncodedPemEncodedPeerCertificate();
-                  });
-            }}},
-          {"DOWNSTREAM_TRANSPORT_FAILURE_REASON",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    absl::optional<std::string> result;
-                    if (!stream_info.downstreamTransportFailureReason().empty()) {
-                      result = absl::StrReplaceAll(stream_info.downstreamTransportFailureReason(),
-                                                   {{" ", "_"}});
-                    }
-                    return result;
-                  });
-            }}},
-          {"UPSTREAM_TRANSPORT_FAILURE_REASON",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    absl::optional<std::string> result;
-                    if (stream_info.upstreamInfo().has_value() &&
-                        !stream_info.upstreamInfo()
-                             .value()
-                             .get()
-                             .upstreamTransportFailureReason()
-                             .empty()) {
-                      result =
-                          stream_info.upstreamInfo().value().get().upstreamTransportFailureReason();
-                    }
-                    if (result) {
-                      std::replace(result->begin(), result->end(), ' ', '_');
-                    }
-                    return result;
-                  });
-            }}},
-          {"HOSTNAME",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              absl::optional<std::string> hostname = SubstitutionFormatUtils::getHostname();
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [hostname](const StreamInfo::StreamInfo&) { return hostname; });
-            }}},
-          {"FILTER_CHAIN_NAME",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
-                    if (const auto info = stream_info.downstreamAddressProvider().filterChainInfo();
-                        info.has_value()) {
-                      if (!info->name().empty()) {
-                        return std::string(info->name());
-                      }
-                    }
-                    return absl::nullopt;
-                  });
-            }}},
-          {"VIRTUAL_CLUSTER_NAME",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
-                    return stream_info.virtualClusterName();
-                  });
-            }}},
-          {"TLS_JA3_FINGERPRINT",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) {
-                    absl::optional<std::string> result;
-                    if (!stream_info.downstreamAddressProvider().ja3Hash().empty()) {
-                      result = std::string(stream_info.downstreamAddressProvider().ja3Hash());
-                    }
-                    return result;
-                  });
-            }}},
-          {"STREAM_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
-                    auto provider = stream_info.getStreamIdProvider();
-                    if (!provider.has_value()) {
-                      return {};
-                    }
-                    auto id = provider->toStringView();
-                    if (!id.has_value()) {
-                      return {};
-                    }
-                    return absl::make_optional<std::string>(id.value());
-                  });
-            }}},
-          {"START_TIME",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL,
-            [](const std::string& format, absl::optional<size_t>) {
-              return std::make_unique<SystemTimeFormatter>(
-                  format,
-                  std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
-                      [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
-                        return stream_info.startTime();
-                      }));
-            }}},
-          {"EMIT_TIME",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL,
-            [](const std::string& format, absl::optional<size_t>) {
-              return std::make_unique<SystemTimeFormatter>(
-                  format,
-                  std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
-                      [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
-                        return stream_info.timeSource().systemTime();
-                      }));
-            }}},
-          {"DYNAMIC_METADATA",
-           {CommandSyntaxChecker::PARAMS_REQUIRED,
-            [](const std::string& format, absl::optional<size_t> max_length) {
-              std::string filter_namespace;
-              std::vector<std::string> path;
+                                       return upstream_cluster_name.empty()
+                                                  ? absl::nullopt
+                                                  : absl::make_optional<std::string>(
+                                                        upstream_cluster_name);
+                                     });
+                               }}},
+                             {"UPSTREAM_LOCAL_ADDRESS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo().has_value()) {
+                                         return stream_info.upstreamInfo()
+                                             .value()
+                                             .get()
+                                             .upstreamLocalAddress();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_LOCAL_ADDRESS_WITHOUT_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withoutPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo().has_value()) {
+                                         return stream_info.upstreamInfo()
+                                             .value()
+                                             .get()
+                                             .upstreamLocalAddress();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_LOCAL_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::justPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo().has_value()) {
+                                         return stream_info.upstreamInfo()
+                                             .value()
+                                             .get()
+                                             .upstreamLocalAddress();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_REMOTE_ADDRESS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo() &&
+                                           stream_info.upstreamInfo()->upstreamHost()) {
+                                         return stream_info.upstreamInfo()
+                                             ->upstreamHost()
+                                             ->address();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_REMOTE_ADDRESS_WITHOUT_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withoutPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo() &&
+                                           stream_info.upstreamInfo()->upstreamHost()) {
+                                         return stream_info.upstreamInfo()
+                                             ->upstreamHost()
+                                             ->address();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_REMOTE_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::justPort(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::shared_ptr<
+                                             const Envoy::Network::Address::Instance> {
+                                       if (stream_info.upstreamInfo() &&
+                                           stream_info.upstreamInfo()->upstreamHost()) {
+                                         return stream_info.upstreamInfo()
+                                             ->upstreamHost()
+                                             ->address();
+                                       }
+                                       return nullptr;
+                                     });
+                               }}},
+                             {"UPSTREAM_REQUEST_ATTEMPT_COUNT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.attemptCount().value_or(0);
+                                     });
+                               }}},
+                             {"UPSTREAM_TLS_CIPHER",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.ciphersuiteString();
+                                     });
+                               }}},
+                             {"UPSTREAM_TLS_VERSION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.tlsVersion();
+                                     });
+                               }}},
+                             {"UPSTREAM_TLS_SESSION_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.sessionId();
+                                     });
+                               }}},
+                             {"UPSTREAM_PEER_ISSUER",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.issuerPeerCertificate();
+                                     });
+                               }}},
+                             {"UPSTREAM_PEER_CERT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.urlEncodedPemEncodedPeerCertificate();
+                                     });
+                               }}},
+                             {"UPSTREAM_PEER_SUBJECT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.subjectPeerCertificate();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_ADDRESS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withPort(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .localAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withoutPort(
+                                     [](const Envoy::StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .localAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::justPort(
+                                     [](const Envoy::StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .localAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_REMOTE_ADDRESS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withPort(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .remoteAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withoutPort(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .remoteAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_REMOTE_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::justPort(
+                                     [](const Envoy::StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .remoteAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_DIRECT_REMOTE_ADDRESS",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withPort(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .directRemoteAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::withoutPort(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .directRemoteAddress();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_DIRECT_REMOTE_PORT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return StreamInfoAddressFormatterProvider::justPort(
+                                     [](const Envoy::StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .directRemoteAddress();
+                                     });
+                               }}},
+                             {"CONNECTION_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoUInt64FormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       return stream_info.downstreamAddressProvider()
+                                           .connectionID()
+                                           .value_or(0);
+                                     });
+                               }}},
+                             {"REQUESTED_SERVER_NAME",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       absl::optional<std::string> result;
+                                       if (!stream_info.downstreamAddressProvider()
+                                                .requestedServerName()
+                                                .empty()) {
+                                         result =
+                                             std::string(stream_info.downstreamAddressProvider()
+                                                             .requestedServerName());
+                                       }
+                                       return result;
+                                     });
+                               }}},
+                             {"ROUTE_NAME",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       absl::optional<std::string> result;
+                                       std::string route_name = stream_info.getRouteName();
+                                       if (!route_name.empty()) {
+                                         result = route_name;
+                                       }
+                                       return result;
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_URI_SAN",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return absl::StrJoin(connection_info.uriSanPeerCertificate(),
+                                                            ",");
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_DNS_SAN",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return absl::StrJoin(
+                                           connection_info.dnsSansPeerCertificate(), ",");
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_IP_SAN",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return absl::StrJoin(connection_info.ipSansPeerCertificate(),
+                                                            ",");
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_URI_SAN",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return absl::StrJoin(
+                                           connection_info.uriSanLocalCertificate(), ",");
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_DNS_SAN",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return absl::StrJoin(
+                                           connection_info.dnsSansLocalCertificate(), ",");
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_IP_SAN",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return absl::StrJoin(
+                                           connection_info.ipSansLocalCertificate(), ",");
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_SUBJECT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.subjectPeerCertificate();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_LOCAL_SUBJECT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.subjectLocalCertificate();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_TLS_SESSION_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.sessionId();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_TLS_CIPHER",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.ciphersuiteString();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_TLS_VERSION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.tlsVersion();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_FINGERPRINT_256",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.sha256PeerCertificateDigest();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_FINGERPRINT_1",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.sha1PeerCertificateDigest();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_SERIAL",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.serialNumberPeerCertificate();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_ISSUER",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.issuerPeerCertificate();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_PEER_CERT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<
+                                     StreamInfoSslConnectionInfoFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& connection_info) {
+                                       return connection_info.urlEncodedPemEncodedPeerCertificate();
+                                     });
+                               }}},
+                             {"DOWNSTREAM_TRANSPORT_FAILURE_REASON",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       absl::optional<std::string> result;
+                                       if (!stream_info.downstreamTransportFailureReason()
+                                                .empty()) {
+                                         result = absl::StrReplaceAll(
+                                             stream_info.downstreamTransportFailureReason(),
+                                             {{" ", "_"}});
+                                       }
+                                       return result;
+                                     });
+                               }}},
+                             {"UPSTREAM_TRANSPORT_FAILURE_REASON",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       absl::optional<std::string> result;
+                                       if (stream_info.upstreamInfo().has_value() &&
+                                           !stream_info.upstreamInfo()
+                                                .value()
+                                                .get()
+                                                .upstreamTransportFailureReason()
+                                                .empty()) {
+                                         result = stream_info.upstreamInfo()
+                                                      .value()
+                                                      .get()
+                                                      .upstreamTransportFailureReason();
+                                       }
+                                       if (result) {
+                                         std::replace(result->begin(), result->end(), ' ', '_');
+                                       }
+                                       return result;
+                                     });
+                               }}},
+                             {"HOSTNAME",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 absl::optional<std::string> hostname =
+                                     SubstitutionFormatUtils::getHostname();
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [hostname](const StreamInfo::StreamInfo&) {
+                                       return hostname;
+                                     });
+                               }}},
+                             {"FILTER_CHAIN_NAME",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> absl::optional<std::string> {
+                                       if (const auto info = stream_info.downstreamAddressProvider()
+                                                                 .filterChainInfo();
+                                           info.has_value()) {
+                                         if (!info->name().empty()) {
+                                           return std::string(info->name());
+                                         }
+                                       }
+                                       return absl::nullopt;
+                                     });
+                               }}},
+                             {"VIRTUAL_CLUSTER_NAME",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> absl::optional<std::string> {
+                                       return stream_info.virtualClusterName();
+                                     });
+                               }}},
+                             {"TLS_JA3_FINGERPRINT",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info) {
+                                       absl::optional<std::string> result;
+                                       if (!stream_info.downstreamAddressProvider()
+                                                .ja3Hash()
+                                                .empty()) {
+                                         result = std::string(
+                                             stream_info.downstreamAddressProvider().ja3Hash());
+                                       }
+                                       return result;
+                                     });
+                               }}},
+                             {"STREAM_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> absl::optional<std::string> {
+                                       auto provider = stream_info.getStreamIdProvider();
+                                       if (!provider.has_value()) {
+                                         return {};
+                                       }
+                                       auto id = provider->toStringView();
+                                       if (!id.has_value()) {
+                                         return {};
+                                       }
+                                       return absl::make_optional<std::string>(id.value());
+                                     });
+                               }}},
+                             {"START_TIME",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL,
+                               [](const std::string& format, absl::optional<size_t>) {
+                                 return std::make_unique<SystemTimeFormatter>(
+                                     format,
+                                     std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
+                                         [](const StreamInfo::StreamInfo& stream_info)
+                                             -> absl::optional<SystemTime> {
+                                           return stream_info.startTime();
+                                         }));
+                               }}},
+                             {"EMIT_TIME",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL,
+                               [](const std::string& format, absl::optional<size_t>) {
+                                 return std::make_unique<SystemTimeFormatter>(
+                                     format,
+                                     std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
+                                         [](const StreamInfo::StreamInfo& stream_info)
+                                             -> absl::optional<SystemTime> {
+                                           return stream_info.timeSource().systemTime();
+                                         }));
+                               }}},
+                             {"DYNAMIC_METADATA",
+                              {CommandSyntaxChecker::PARAMS_REQUIRED,
+                               [](const std::string& format, absl::optional<size_t> max_length) {
+                                 std::string filter_namespace;
+                                 std::vector<std::string> path;
 
-              SubstitutionFormatUtils::parseSubcommand(format, ':', filter_namespace, path);
-              return std::make_unique<DynamicMetadataFormatter>(filter_namespace, path, max_length);
-            }}},
+                                 SubstitutionFormatUtils::parseSubcommand(format, ':',
+                                                                          filter_namespace, path);
+                                 return std::make_unique<DynamicMetadataFormatter>(
+                                     filter_namespace, path, max_length);
+                               }}},
 
-          {"CLUSTER_METADATA",
-           {CommandSyntaxChecker::PARAMS_REQUIRED,
-            [](const std::string& format, absl::optional<size_t> max_length) {
-              std::string filter_namespace;
-              std::vector<std::string> path;
+                             {"CLUSTER_METADATA",
+                              {CommandSyntaxChecker::PARAMS_REQUIRED,
+                               [](const std::string& format, absl::optional<size_t> max_length) {
+                                 std::string filter_namespace;
+                                 std::vector<std::string> path;
 
-              SubstitutionFormatUtils::parseSubcommand(format, ':', filter_namespace, path);
-              return std::make_unique<ClusterMetadataFormatter>(filter_namespace, path, max_length);
-            }}},
-          {"UPSTREAM_METADATA",
-           {CommandSyntaxChecker::PARAMS_REQUIRED,
-            [](const std::string& format, absl::optional<size_t> max_length) {
-              std::string filter_namespace;
-              std::vector<std::string> path;
+                                 SubstitutionFormatUtils::parseSubcommand(format, ':',
+                                                                          filter_namespace, path);
+                                 return std::make_unique<ClusterMetadataFormatter>(
+                                     filter_namespace, path, max_length);
+                               }}},
+                             {"UPSTREAM_METADATA",
+                              {CommandSyntaxChecker::PARAMS_REQUIRED,
+                               [](const std::string& format, absl::optional<size_t> max_length) {
+                                 std::string filter_namespace;
+                                 std::vector<std::string> path;
 
-              SubstitutionFormatUtils::parseSubcommand(format, ':', filter_namespace, path);
-              return std::make_unique<UpstreamHostMetadataFormatter>(filter_namespace, path,
-                                                                     max_length);
-            }}},
-          {"FILTER_STATE",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL | CommandSyntaxChecker::LENGTH_ALLOWED,
-            [](const std::string& format, absl::optional<size_t> max_length) {
-              return FilterStateFormatter::create(format, max_length, false);
-            }}},
-          {"UPSTREAM_FILTER_STATE",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL | CommandSyntaxChecker::LENGTH_ALLOWED,
-            [](const std::string& format, absl::optional<size_t> max_length) {
-              return FilterStateFormatter::create(format, max_length, true);
-            }}},
-          {"DOWNSTREAM_PEER_CERT_V_START",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL,
-            [](const std::string& format, absl::optional<size_t>) {
-              return std::make_unique<DownstreamPeerCertVStartFormatter>(format);
-            }}},
-          {"DOWNSTREAM_PEER_CERT_V_END",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL,
-            [](const std::string& format, absl::optional<size_t>) {
-              return std::make_unique<DownstreamPeerCertVEndFormatter>(format);
-            }}},
-          {"UPSTREAM_PEER_CERT_V_START",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL,
-            [](const std::string& format, absl::optional<size_t>) {
-              return std::make_unique<UpstreamPeerCertVStartFormatter>(format);
-            }}},
-          {"UPSTREAM_PEER_CERT_V_END",
-           {CommandSyntaxChecker::PARAMS_OPTIONAL,
-            [](const std::string& format, absl::optional<size_t>) {
-              return std::make_unique<UpstreamPeerCertVEndFormatter>(format);
-            }}},
-          {"ENVIRONMENT",
-           {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
-            [](const std::string& key, absl::optional<size_t> max_length) {
-              return std::make_unique<EnvironmentFormatter>(key, max_length);
-            }}},
-          {"UPSTREAM_CONNECTION_POOL_READY_DURATION",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, const absl::optional<size_t>&) {
-              return std::make_unique<StreamInfoDurationFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info)
-                      -> absl::optional<std::chrono::nanoseconds> {
-                    if (auto upstream_info = stream_info.upstreamInfo();
-                        upstream_info.has_value()) {
-                      if (auto connection_pool_callback_latency =
-                              upstream_info.value()
-                                  .get()
-                                  .upstreamTiming()
-                                  .connectionPoolCallbackLatency();
-                          connection_pool_callback_latency.has_value()) {
-                        return connection_pool_callback_latency;
-                      }
-                    }
-                    return absl::nullopt;
-                  });
-            }}},
-            {"TRACE_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
-                    return stream_info.traceId();
-                  });
-            }}},
-            {"SPAN_ID",
-           {CommandSyntaxChecker::COMMAND_ONLY,
-            [](const std::string&, absl::optional<size_t>) {
-              return std::make_unique<StreamInfoStringFormatterProvider>(
-                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
-                    return stream_info.spanId();
-                  });
-            }}},
-      });
+                                 SubstitutionFormatUtils::parseSubcommand(format, ':',
+                                                                          filter_namespace, path);
+                                 return std::make_unique<UpstreamHostMetadataFormatter>(
+                                     filter_namespace, path, max_length);
+                               }}},
+                             {"FILTER_STATE",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL |
+                                   CommandSyntaxChecker::LENGTH_ALLOWED,
+                               [](const std::string& format, absl::optional<size_t> max_length) {
+                                 return FilterStateFormatter::create(format, max_length, false);
+                               }}},
+                             {"UPSTREAM_FILTER_STATE",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL |
+                                   CommandSyntaxChecker::LENGTH_ALLOWED,
+                               [](const std::string& format, absl::optional<size_t> max_length) {
+                                 return FilterStateFormatter::create(format, max_length, true);
+                               }}},
+                             {"DOWNSTREAM_PEER_CERT_V_START",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL,
+                               [](const std::string& format, absl::optional<size_t>) {
+                                 return std::make_unique<DownstreamPeerCertVStartFormatter>(format);
+                               }}},
+                             {"DOWNSTREAM_PEER_CERT_V_END",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL,
+                               [](const std::string& format, absl::optional<size_t>) {
+                                 return std::make_unique<DownstreamPeerCertVEndFormatter>(format);
+                               }}},
+                             {"UPSTREAM_PEER_CERT_V_START",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL,
+                               [](const std::string& format, absl::optional<size_t>) {
+                                 return std::make_unique<UpstreamPeerCertVStartFormatter>(format);
+                               }}},
+                             {"UPSTREAM_PEER_CERT_V_END",
+                              {CommandSyntaxChecker::PARAMS_OPTIONAL,
+                               [](const std::string& format, absl::optional<size_t>) {
+                                 return std::make_unique<UpstreamPeerCertVEndFormatter>(format);
+                               }}},
+                             {"ENVIRONMENT",
+                              {CommandSyntaxChecker::PARAMS_REQUIRED |
+                                   CommandSyntaxChecker::LENGTH_ALLOWED,
+                               [](const std::string& key, absl::optional<size_t> max_length) {
+                                 return std::make_unique<EnvironmentFormatter>(key, max_length);
+                               }}},
+                             {"UPSTREAM_CONNECTION_POOL_READY_DURATION",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, const absl::optional<size_t>&) {
+                                 return std::make_unique<StreamInfoDurationFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> absl::optional<std::chrono::nanoseconds> {
+                                       if (auto upstream_info = stream_info.upstreamInfo();
+                                           upstream_info.has_value()) {
+                                         if (auto connection_pool_callback_latency =
+                                                 upstream_info.value()
+                                                     .get()
+                                                     .upstreamTiming()
+                                                     .connectionPoolCallbackLatency();
+                                             connection_pool_callback_latency.has_value()) {
+                                           return connection_pool_callback_latency;
+                                         }
+                                       }
+                                       return absl::nullopt;
+                                     });
+                               }}},
+                             {"TRACE_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> absl::optional<std::string> {
+                                       return stream_info.traceId();
+                                     });
+                               }}},
+                             {"SPAN_ID",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](const std::string&, absl::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> absl::optional<std::string> {
+                                       return stream_info.spanId();
+                                     });
+                               }}},
+                         });
 }
 
 } // namespace Formatter

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1471,6 +1471,22 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                     return absl::nullopt;
                   });
             }}},
+            {"TRACE_ID",
+           {CommandSyntaxChecker::COMMAND_ONLY,
+            [](const std::string&, absl::optional<size_t>) {
+              return std::make_unique<StreamInfoStringFormatterProvider>(
+                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
+                    return stream_info.traceId();
+                  });
+            }}},
+            {"SPAN_ID",
+           {CommandSyntaxChecker::COMMAND_ONLY,
+            [](const std::string&, absl::optional<size_t>) {
+              return std::make_unique<StreamInfoStringFormatterProvider>(
+                  [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<std::string> {
+                    return stream_info.spanId();
+                  });
+            }}},
       });
 }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1385,7 +1385,6 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
   // Check if tracing is enabled.
   if (connection_manager_tracing_config_.has_value()) {
     traceRequest();
-    // TODO: propagate the trace context to the stream info.
   }
 
   if (!connection_manager_.shouldDeferRequestProxyingToNextIoCycle()) {
@@ -1413,7 +1412,8 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
     return;
   }
 
-  // filter_manager_.streamInfo().setTraceReason(Tracing::Reason reason)
+  filter_manager_.streamInfo().setTraceId(active_span_->getTraceIdAsHex());
+  filter_manager_.streamInfo().setSpanId(active_span_->getSpanIdAsHex());
 
   // TODO: Need to investigate the following code based on the cached route, as may
   // be broken in the case a filter changes the route.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1385,6 +1385,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapSharedPt
   // Check if tracing is enabled.
   if (connection_manager_tracing_config_.has_value()) {
     traceRequest();
+    // TODO: propagate the trace context to the stream info.
   }
 
   if (!connection_manager_.shouldDeferRequestProxyingToNextIoCycle()) {
@@ -1411,6 +1412,8 @@ void ConnectionManagerImpl::ActiveStream::traceRequest() {
   if (!active_span_) {
     return;
   }
+
+  // filter_manager_.streamInfo().setTraceReason(Tracing::Reason reason)
 
   // TODO: Need to investigate the following code based on the cached route, as may
   // be broken in the case a filter changes the route.

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <string>
 
 #include "envoy/common/time.h"
 #include "envoy/config/core/v3/base.pb.h"
@@ -309,6 +310,12 @@ struct StreamInfoImpl : public StreamInfo {
   void setTraceReason(Tracing::Reason reason) override { trace_reason_ = reason; }
   Tracing::Reason traceReason() const override { return trace_reason_; }
 
+  void setTraceId(const std::string trace_id) override { trace_id_ = trace_id; }
+  std::string traceId() const override { return trace_id_; }
+
+  void setSpanId(const std::string span_id) override { span_id_ = span_id; }
+  std::string spanId() const override { return span_id_; }
+
   void dumpState(std::ostream& os, int indent_level = 0) const override {
     const char* spaces = spacesForLevel(indent_level);
     os << spaces << "StreamInfoImpl " << this << DUMP_OPTIONAL_MEMBER(protocol_)
@@ -487,6 +494,8 @@ private:
   bool is_shadow_{false};
   std::string downstream_transport_failure_reason_;
   bool should_drain_connection_{false};
+  std::string trace_id_;
+  std::string span_id_;
 };
 
 } // namespace StreamInfo

--- a/source/common/tracing/null_span_impl.h
+++ b/source/common/tracing/null_span_impl.h
@@ -27,6 +27,7 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  std::string getSpanIdAsHex() const override { return EMPTY_STRING; }
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -47,6 +47,7 @@ public:
 
   // TODO: This method is unimplemented for OpenTracing.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  std::string getSpanIdAsHex() const override { return EMPTY_STRING; };
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/datadog/span.cc
+++ b/source/extensions/tracers/datadog/span.cc
@@ -12,6 +12,7 @@
 #include "datadog/sampling_priority.h"
 #include "datadog/span_config.h"
 #include "datadog/trace_segment.h"
+#include "span.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -137,6 +138,13 @@ void Span::setBaggage(absl::string_view, absl::string_view) {
 }
 
 std::string Span::getTraceIdAsHex() const {
+  if (!span_) {
+    return std::string{};
+  }
+  return absl::StrCat(absl::Hex(span_->id()));
+}
+
+std::string Span::getSpanIdAsHex() const {
   if (!span_) {
     return std::string{};
   }

--- a/source/extensions/tracers/datadog/span.h
+++ b/source/extensions/tracers/datadog/span.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <string>
 
 #include "envoy/common/time.h"
 #include "envoy/tracing/trace_driver.h"
@@ -48,6 +49,7 @@ public:
   std::string getBaggage(absl::string_view key) override;
   void setBaggage(absl::string_view key, absl::string_view value) override;
   std::string getTraceIdAsHex() const override;
+  std::string getSpanIdAsHex() const override;
 
 private:
   datadog::tracing::Optional<datadog::tracing::Span> span_;

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -81,6 +81,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; };
 
   std::string getTraceIdAsHex() const override;
+  std::string getSpanIdAsHex() const override;
 
 private:
   ::opencensus::trace::Span span_;
@@ -240,6 +241,11 @@ void Span::injectContext(Tracing::TraceContext& trace_context,
 std::string Span::getTraceIdAsHex() const {
   const auto& ctx = span_.context();
   return ctx.trace_id().ToHex();
+}
+
+std::string Span::getSpanIdAsHex() const {
+  const auto& ctx = span_.context();
+  return ctx.span_id().ToHex();
 }
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config& /*config*/, const std::string& name,

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -118,6 +118,7 @@ public:
   }
 
   std::string getTraceIdAsHex() const override { return absl::BytesToHexString(span_.trace_id()); };
+  std::string getSpanIdAsHex() const override { return absl::BytesToHexString(span_.span_id()); };
 
   OTelSpanKind spankind() const { return span_.kind(); }
 

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -89,6 +89,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  std::string getSpanIdAsHex() const override { return EMPTY_STRING; }
 
   const TracingContextPtr tracingContext() { return tracing_context_; }
   const TracingSpanPtr spanEntity() { return span_entity_; }

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -232,6 +232,7 @@ public:
 
   // TODO: This method is unimplemented for X-Ray.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  std::string getSpanIdAsHex() const override { return EMPTY_STRING; };
 
   /**
    * Creates a child span.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -85,6 +85,7 @@ public:
 
   // TODO: This method is unimplemented for Zipkin.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  std::string getSpanIdAsHex() const override { return EMPTY_STRING; };
 
   /**
    * @return a reference to the Zipkin::Span object.

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -892,6 +892,24 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
         upstream_connection_pool_callback_duration_format.formatValueWithContext({}, stream_info),
         ProtoEq(ValueUtil::numberValue(15.0)));
   }
+
+  {
+    StreamInfoFormatter trace_format("TRACE_ID");
+    EXPECT_CALL(stream_info, traceId()).WillRepeatedly(Return("ae0046f9075194306d7de2931bd38ce3"));
+
+    EXPECT_EQ("ae0046f9075194306d7de2931bd38ce3", trace_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(trace_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("ae0046f9075194306d7de2931bd38ce3")));
+  }
+
+  {
+    StreamInfoFormatter trace_format("SPAN_ID");
+    EXPECT_CALL(stream_info, spanId()).WillRepeatedly(Return("ceb177d18b22ee6c"));
+
+    EXPECT_EQ("ceb177d18b22ee6c", trace_format.formatWithContext({}, stream_info));
+    EXPECT_THAT(trace_format.formatValueWithContext({}, stream_info),
+                ProtoEq(ValueUtil::stringValue("ceb177d18b22ee6c")));
+  }
 }
 
 TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -155,6 +155,10 @@ public:
   MOCK_METHOD(void, setStreamIdProvider, (StreamIdProviderSharedPtr provider));
   MOCK_METHOD(void, setTraceReason, (Tracing::Reason reason));
   MOCK_METHOD(Tracing::Reason, traceReason, (), (const));
+  MOCK_METHOD(void, setTraceId, (std::string trace_id));
+  MOCK_METHOD(std::string, traceId, (), (const));
+  MOCK_METHOD(void, setSpanId, (std::string span_id));
+  MOCK_METHOD(std::string, spanId, (), (const));
   MOCK_METHOD(absl::optional<uint64_t>, connectionID, (), (const));
   MOCK_METHOD(void, setConnectionID, (uint64_t));
   MOCK_METHOD(void, setAttemptCount, (uint32_t), ());

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -45,6 +45,7 @@ public:
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
   MOCK_METHOD(std::string, getTraceIdAsHex, (), (const));
+  MOCK_METHOD(std::string, getSpanIdAsHex, (), (const));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: add common command to format TRACE_ID and SPAN_ID
Additional Description: trace provider (zipkin) may not implement `getTraceIdAsHex` and `getSpanIdAsHex` properly.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
