### PR TITLE
Revert "deps: Bump `rules_fuzzing` -> 0.5.1 (#33188)"

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -84,11 +84,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
         # Patch contains workaround for https://github.com/bazelbuild/rules_python/issues/1221
-        version = "0.5.1",
-        sha256 = "7528a59df503e18797ca601095e69ffe880de42610429f9168e75a96b7d9a25a",
+        version = "0.4.1",
+        sha256 = "f6f3f42c48576acd5653bf07637deee2ae4ebb77ccdb0dacc67c184508bedc8c",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v{version}.tar.gz"],
-        release_date = "2024-03-27",
+        release_date = "2023-10-19",
         use_category = ["test_only"],
         implied_untracked_deps = [
             # This is a repository rule generated to define an OSS-Fuzz fuzzing

--- a/bazel/rules_fuzzing.patch
+++ b/bazel/rules_fuzzing.patch
@@ -1,8 +1,8 @@
 diff --git a/fuzzing/private/oss_fuzz/package.bzl b/fuzzing/private/oss_fuzz/package.bzl
-index 4f4e636..a1add46 100644
+index e5e9dc4..a3bb1b8 100644
 --- a/fuzzing/private/oss_fuzz/package.bzl
 +++ b/fuzzing/private/oss_fuzz/package.bzl
-@@ -79,7 +79,7 @@ def _oss_fuzz_package_impl(ctx):
+@@ -71,7 +71,7 @@ def _oss_fuzz_package_impl(ctx):
              if [[ -n "{options_path}" ]]; then
                  ln -s "$(pwd)/{options_path}" "$STAGING_DIR/{base_name}.options"
              fi
@@ -12,17 +12,18 @@ index 4f4e636..a1add46 100644
              base_name = ctx.attr.base_name,
              binary_path = binary_info.binary_file.path,
 diff --git a/fuzzing/tools/validate_dict.py b/fuzzing/tools/validate_dict.py
-index 52cbcb8..dac313a 100644
+index d561e68..24e3adc 100644
 --- a/fuzzing/tools/validate_dict.py
 +++ b/fuzzing/tools/validate_dict.py
-@@ -22,6 +22,10 @@ from absl import flags
- from fuzzing.tools.dict_validation import validate_line
- from sys import stderr
+@@ -19,6 +19,11 @@ Validates and merges a set of fuzzing dictionary files into a single output.
  
+ from absl import app
+ from absl import flags
++
 +import os
 +import sys
 +sys.path += [os.path.dirname(__file__)]
 +
- FLAGS = flags.FLAGS
+ from dict_validation import validate_line
+ from sys import stderr
  
- flags.DEFINE_list("dict_list", [],


### PR DESCRIPTION
This reverts commit d47731444bcd5a11671f5ffda203b5cb093bb883.

The new rules_fuzzing requires Bazel v7.0.0+ whereas we currently use v6.5.0 (see more details [here](https://github.com/envoyproxy/envoy/pull/33188#issuecomment-2029769819)).

Reverting the upgrade for now.
