### PR TITLE
fuzz: fix least request LB maximal active_request_bias value

### DIFF
--- a/test/common/upstream/least_request_load_balancer_corpus/large_active_request_bias
+++ b/test/common/upstream/least_request_load_balancer_corpus/large_active_request_bias
@@ -1,0 +1,19 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 59
+      random_bytestring: 9
+    }
+    seed_for_prng: 4
+  }
+  random_bytestring_for_weights: "!A"
+}
+least_request_lb_config {
+  active_request_bias {
+    default_value: 34816
+    runtime_key: "*"
+  }
+}
+random_bytestring_for_requests: "+"

--- a/test/common/upstream/least_request_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/least_request_load_balancer_fuzz_test.cc
@@ -67,7 +67,7 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::LeastRequestLoadBalancerTestCa
         least_request_lb_config.active_request_bias().default_value() > 25) {
       ENVOY_LOG_MISC(debug,
                      "active_request_bias default_value in the least-request config is too high "
-                     "({} > 25), skipping test as the config is invliad",
+                     "({} > 25), skipping test as the config is invalid",
                      least_request_lb_config.active_request_bias().default_value());
       return;
     }

--- a/test/common/upstream/least_request_load_balancer_fuzz_test.cc
+++ b/test/common/upstream/least_request_load_balancer_fuzz_test.cc
@@ -53,11 +53,22 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::LeastRequestLoadBalancerTestCa
                    MaxChoiceCountForTest);
     return;
   }
-  // Validate the correctness of the Slow-Start config values.
-  if (input.has_least_request_lb_config() &&
-      input.least_request_lb_config().has_slow_start_config()) {
-    if (!ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
-            input.least_request_lb_config().slow_start_config())) {
+  if (input.has_least_request_lb_config()) {
+    const auto& least_request_lb_config = input.least_request_lb_config();
+    // Validate the correctness of the Slow-Start config values.
+    if (least_request_lb_config.has_slow_start_config() &&
+        !ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
+            least_request_lb_config.slow_start_config())) {
+      return;
+    }
+    // Validate that the active_request_bias is not too large (or else it will
+    // effectively zero all the weights).
+    if (least_request_lb_config.has_active_request_bias() &&
+        least_request_lb_config.active_request_bias().default_value() > 25) {
+      ENVOY_LOG_MISC(debug,
+                     "active_request_bias default_value in the least-request config is too high "
+                     "({} > 25), skipping test as the config is invliad",
+                     least_request_lb_config.active_request_bias().default_value());
       return;
     }
   }


### PR DESCRIPTION
Commit Message: fuzz: fix least request LB maximal active_request_bias value
Additional Description:
The default_value of the [active_request_bias](https://github.com/envoyproxy/envoy/blob/014a68f303074fb743b780548ac58d2e1340ec53/api/envoy/extensions/load_balancing_policies/least_request/v3/least_request.proto#L79) config field can be high, which will end up setting the weight value in [this line](https://github.com/envoyproxy/envoy/blob/014a68f303074fb743b780548ac58d2e1340ec53/source/common/upstream/load_balancer_impl.cc#L1303) (`1.0 / 2^active_request_bias`) to essentially make all weights 0.
This PR adds a check to avoid setting this value to more than 25 in the fuzz tests.

Risk Level: low - tests only
Testing: Added fuzz corpus
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
