### PR TITLE
mobile: Fix JNI test server BUILD files

### DIFF
--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -48,10 +48,11 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "//library/jni:envoy_jni_lib",
         "//library/jni:jni_helper_lib",
         "//library/jni:jni_utility_lib",
         "//test/common/integration:test_server_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
+        "@envoy_build_config//:extension_registry",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,
@@ -79,10 +80,10 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "//library/jni:envoy_jni_lib",
         "//library/jni:jni_helper_lib",
-        "//library/jni:jni_utility_lib",
         "//test/common/integration:test_server_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
+        "@envoy_build_config//:extension_registry",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,
@@ -110,10 +111,11 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "//library/jni:envoy_jni_lib",
         "//library/jni:jni_helper_lib",
         "//library/jni:jni_utility_lib",
         "//test/common/integration:xds_test_server_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
+        "@envoy_build_config//:extension_registry",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,

--- a/mobile/test/jni/jni_http_proxy_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_proxy_test_server_factory.cc
@@ -4,7 +4,6 @@
 
 #include "extension_registry.h"
 #include "library/jni/jni_helper.h"
-#include "library/jni/jni_utility.h"
 
 // NOLINT(namespace-envoy)
 

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -19,7 +19,6 @@ private const val TEST_RESPONSE_FILTER_TYPE =
   "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 private const val REQUEST_STRING_MATCH = "match_me"
 
-// TODO(fredyw): Figure out why HttpTestServer prevents EngineBuilder from using native filters.
 class SendDataTest {
   init {
     JniLibrary.loadTestLibrary()


### PR DESCRIPTION
This PR fixes the JNI test server BUILD files by not depending on `//library/jni:envoy_jni_lib` but making it depend on `//@envoy/test/test_common:test_version_linkstamp` that can generate the `build_scm_revision` and `build_scm_status` constants.

This PR also fixes the issue raised in https://github.com/envoyproxy/envoy/pull/33230 but the fix in https://github.com/envoyproxy/envoy/pull/33230 to use `TestRemoteResponse` is more correct and also more consistent with the other tests, so this PR simply removes the TODO instead of reverting the PR. I tested this by reverting the PR and running `./bazelw test --cache_test_results=no --test_output=streamed --config=mobile-test-android //test/kotlin/integration:send_data_test` with and without this fix. Although, I still can't fully figure out why this PR fixes the issue, I suspect it is because it no longer depends on `//library/jni:envoy_jni_lib`, which indirectly depends on `//library/cc:engine_builder_lib`.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
