### PR TITLE
proxy_protocol: Support optional base64 encoding of passthrough TLVs 

### DIFF
--- a/api/envoy/config/core/v3/proxy_protocol.proto
+++ b/api/envoy/config/core/v3/proxy_protocol.proto
@@ -30,6 +30,10 @@ message ProxyProtocolPassThroughTLVs {
   // TLV type is defined as uint8_t in proxy protocol. See `the spec
   // <https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt>`_ for details.
   repeated uint32 tlv_type = 2 [(validate.rules).repeated = {items {uint32 {lt: 256}}}];
+
+  // This config controls whether TLVs should be base64-encoded before being passed to filter state.
+  // This is useful in cases where the TLVs aren't UTF-8 encoded but need to be passed through.
+  bool encode_tlvs = 3;
 }
 
 message ProxyProtocolConfig {

--- a/api/envoy/config/core/v3/proxy_protocol.proto
+++ b/api/envoy/config/core/v3/proxy_protocol.proto
@@ -31,8 +31,9 @@ message ProxyProtocolPassThroughTLVs {
   // <https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt>`_ for details.
   repeated uint32 tlv_type = 2 [(validate.rules).repeated = {items {uint32 {lt: 256}}}];
 
-  // This config controls whether TLVs should be base64-encoded before being passed to filter state.
-  // This is useful in cases where the TLVs aren't UTF-8 encoded but need to be passed through.
+  // Whether TLVs should be base64-encoded before being passed to filter state.
+  // This is useful in cases where the TLVs aren't UTF-8 encoded but need to be passed through without lossy sanitisation.
+  // Defaults to false.
   bool encode_tlvs = 3;
 }
 

--- a/api/envoy/config/core/v3/proxy_protocol.proto
+++ b/api/envoy/config/core/v3/proxy_protocol.proto
@@ -32,7 +32,7 @@ message ProxyProtocolPassThroughTLVs {
   repeated uint32 tlv_type = 2 [(validate.rules).repeated = {items {uint32 {lt: 256}}}];
 
   // Whether TLVs should be base64-encoded before being passed to filter state.
-  // This is useful in cases where the TLVs aren't UTF-8 encoded but need to be passed through without lossy sanitisation.
+  // This is useful in cases where the TLVs aren't UTF-8 encoded but need to be passed through without lossy sanitization.
   // Defaults to false.
   bool encode_tlvs = 3;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -434,7 +434,7 @@ new_features:
     ``histogram_buckets`` query parameter to ``summary``.
 - area: proxy_protocol
   change: |
-    Added :ref:`encode_tlvs<envoy_v3_api_field_config.core.v3.ProxyProtocolConfig.pass_through_tlvs.encode_tlvs>` to proxy protocol filter
+    Added :ref:`encode_tlvs<envoy_v3_api_field_config.core.v3.ProxyProtocolPassThroughTLVs.encode_tlvs>` to proxy protocol filter
     configuration which turns on the safe writing of base64-encoded proxy protocol TLVs (both utf-8 and non utf-8) to filter state metadata.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -432,6 +432,10 @@ new_features:
   change: |
     The ``/stats/prometheus`` endpoint can now emit prometheus ``summary`` metric types by explicitly setting the
     ``histogram_buckets`` query parameter to ``summary``.
+- area: proxy_protocol
+  change: |
+    Added :ref:`encode_tlvs<envoy_v3_api_field_config.core.v3.ProxyProtocolConfig.pass_through_tlvs.encode_tlvs>` to proxy protocol filter
+    configuration which turns on the safe writing of base64-encoded proxy protocol TLVs (both utf-8 and non utf-8) to filter state metadata.
 
 deprecated:
 - area: listener

--- a/source/extensions/filters/listener/proxy_protocol/BUILD
+++ b/source/extensions/filters/listener/proxy_protocol/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
         "//source/common/api:os_sys_calls_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:base64_lib",
         "//source/common/common:empty_string",
         "//source/common/common:hex_lib",
         "//source/common/common:minimal_logger_lib",

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -111,8 +111,8 @@ Config::Config(
                                ProxyProtocolPassThroughTLVs::INCLUDE_ALL
                          : false),
       encode_tlvs_(proto_config.has_pass_through_tlvs()
-                         ? proto_config.pass_through_tlvs().encode_tlvs()
-                         : false) {
+                       ? proto_config.pass_through_tlvs().encode_tlvs()
+                       : false) {
   for (const auto& rule : proto_config.rules()) {
     tlv_types_[0xFF & rule.tlv_type()] = rule.on_tlv_present();
   }
@@ -165,9 +165,7 @@ bool Config::allowRequestsWithoutProxyProtocol() const {
   return allow_requests_without_proxy_protocol_;
 }
 
-bool Config::encodeTlvs() const {
-  return encode_tlvs_;
-}
+bool Config::encodeTlvs() const { return encode_tlvs_; }
 
 bool Config::isVersionV1Allowed() const { return allow_v1_; }
 
@@ -545,8 +543,8 @@ bool Filter::parseTlvs(const uint8_t* buf, size_t len) {
 
       // Base64-encode or sanitize any non utf8 characters.
       auto sanitised_tlv_value = config_->encodeTlvs()
-        ? Envoy::Base64::encode(tlv_value.data(), tlv_value.size())
-        : MessageUtil::sanitizeUtf8String(tlv_value);
+                                     ? Envoy::Base64::encode(tlv_value.data(), tlv_value.size())
+                                     : MessageUtil::sanitizeUtf8String(tlv_value);
       metadata_value.set_string_value(sanitised_tlv_value.data(), sanitised_tlv_value.size());
 
       std::string metadata_key = key_value_pair->metadata_namespace().empty()

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -542,10 +542,10 @@ bool Filter::parseTlvs(const uint8_t* buf, size_t len) {
       ProtobufWkt::Value metadata_value;
 
       // Base64-encode or sanitize any non utf8 characters.
-      auto sanitised_tlv_value = config_->encodeTlvs()
-                                     ? Envoy::Base64::encode(tlv_value.data(), tlv_value.size())
-                                     : MessageUtil::sanitizeUtf8String(tlv_value);
-      metadata_value.set_string_value(sanitised_tlv_value.data(), sanitised_tlv_value.size());
+      auto tlv_value_string = config_->encodeTlvs()
+                                  ? Envoy::Base64::encode(tlv_value.data(), tlv_value.size())
+                                  : MessageUtil::sanitizeUtf8String(tlv_value);
+      metadata_value.set_string_value(tlv_value_string.data(), tlv_value_string.size());
 
       std::string metadata_key = key_value_pair->metadata_namespace().empty()
                                      ? "envoy.filters.listener.proxy_protocol"

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -543,13 +543,10 @@ bool Filter::parseTlvs(const uint8_t* buf, size_t len) {
     if (nullptr != key_value_pair) {
       ProtobufWkt::Value metadata_value;
 
-      if (config_->encodeTlvs()) {
-        std::string encoded_tlv_value = Base64::encode(tlv_value.data(), tlv_value.size());
-        tlv_value = absl::string_view(encoded_tlv_value.data(), encoded_tlv_value.size());
-      }
-
-      // Sanitize any non utf8 characters.
-      auto sanitised_tlv_value = MessageUtil::sanitizeUtf8String(tlv_value);
+      // Base64-encode or sanitize any non utf8 characters.
+      auto sanitised_tlv_value = config_->encodeTlvs()
+        ? Envoy::Base64::encode(tlv_value.data(), tlv_value.size())
+        : MessageUtil::sanitizeUtf8String(tlv_value);
       metadata_value.set_string_value(sanitised_tlv_value.data(), sanitised_tlv_value.size());
 
       std::string metadata_key = key_value_pair->metadata_namespace().empty()

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
@@ -133,6 +133,12 @@ public:
   bool allowRequestsWithoutProxyProtocol() const;
 
   /**
+   * Filter configuration that determines if the filter should base64-encode TLVs before
+   * writing them to metadata.
+   */
+  bool encodeTlvs() const;
+
+  /**
    * Filter configuration that determines if a version is disallowed.
    */
   bool isVersionV1Allowed() const;
@@ -142,6 +148,7 @@ private:
   absl::flat_hash_map<uint8_t, KeyValuePair> tlv_types_;
   const bool allow_requests_without_proxy_protocol_;
   const bool pass_all_tlvs_;
+  const bool encode_tlvs_;
   absl::flat_hash_set<uint8_t> pass_through_tlvs_{};
   bool allow_v1_{true};
   bool allow_v2_{true};

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1782,12 +1782,11 @@ TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterestAndBase64Encode) {
   EXPECT_EQ(1, fields.count("PP2 type authority"));
   EXPECT_EQ(1, fields.count("PP2 vpc id"));
 
+  // Base64-encoded values of passed-through TLVs
   auto value_type_authority = fields.at("PP2 type authority").string_value();
-  // Base64 encoded value of the value section of tlv_type_authority.
   ASSERT_EQ(value_type_authority, "Zv5vLmNvwQ==");
 
   auto value_vpc_id = fields.at("PP2 vpc id").string_value();
-  // Base64 encoded value of the value section of tlv_vpc_id.
   ASSERT_EQ(value_vpc_id, "AXZwYy0wwDV0ZXN0MmZhNmM2M2j5Nw==");
 
   disconnect();

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1783,12 +1783,12 @@ TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterestAndBase64Encode) {
   EXPECT_EQ(1, fields.count("PP2 vpc id"));
 
   auto value_type_authority = fields.at("PP2 type authority").string_value();
-  // Base64 encoded value of tlv_type_authority.
-  ASSERT_EQ(value_type_authority, "Zv5vLm9vwQ==");
+  // Base64 encoded value of the value section of tlv_type_authority.
+  ASSERT_EQ(value_type_authority, "Zv5vLmNvwQ==");
 
   auto value_vpc_id = fields.at("PP2 vpc id").string_value();
-  // Base64 encoded value of tlv_vpc_id.
-  ASSERT_EQ(value_vpc_id, "AXZwYy0wwzV0ZXN0MmZhNjM2M2j5Nw==");
+  // Base64 encoded value of the value section of tlv_vpc_id.
+  ASSERT_EQ(value_vpc_id, "AXZwYy0wwDV0ZXN0MmZhNmM2M2j5Nw==");
 
   disconnect();
   EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v2.found").value(), 1);

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1728,6 +1728,72 @@ TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterestAndSanitiseNonUtf8) {
   EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v2.found").value(), 1);
 }
 
+TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterestAndBase64Encode) {
+  // A well-formed ipv4/tcp with a pair of TLV extensions is accepted.
+  constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
+                                0x54, 0x0a, 0x21, 0x11, 0x00, 0x39, 0x01, 0x02, 0x03, 0x04,
+                                0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x00, 0x02};
+  // A TLV of type 0x00 with size of 4 (1 byte is value).
+  constexpr uint8_t tlv1[] = {0x00, 0x00, 0x01, 0xff};
+  // A TLV of type 0x02 with size of 10 bytes (7 bytes are value). Second and last bytes in the
+  // value are non utf8 characters.
+  constexpr uint8_t tlv_type_authority[] = {0x02, 0x00, 0x07, 0x66, 0xfe,
+                                            0x6f, 0x2e, 0x63, 0x6f, 0xc1};
+  // A TLV of type 0x0f with size of 6 bytes (3 bytes are value).
+  constexpr uint8_t tlv3[] = {0x0f, 0x00, 0x03, 0xf0, 0x00, 0x0f};
+  // A TLV of type 0xea with size of 25 bytes (22 bytes are value). 7th and 21st bytes are non utf8
+  // characters.
+  constexpr uint8_t tlv_vpc_id[] = {0xea, 0x00, 0x16, 0x01, 0x76, 0x70, 0x63, 0x2d, 0x30,
+                                    0xc0, 0x35, 0x74, 0x65, 0x73, 0x74, 0x32, 0x66, 0x61,
+                                    0x36, 0x63, 0x36, 0x33, 0x68, 0xf9, 0x37};
+  constexpr uint8_t data[] = {'D', 'A', 'T', 'A'};
+
+  envoy::extensions::filters::listener::proxy_protocol::v3::ProxyProtocol proto_config;
+  auto rule_type_authority = proto_config.add_rules();
+  rule_type_authority->set_tlv_type(0x02);
+  rule_type_authority->mutable_on_tlv_present()->set_key("PP2 type authority");
+
+  auto rule_vpc_id = proto_config.add_rules();
+  rule_vpc_id->set_tlv_type(0xea);
+  rule_vpc_id->mutable_on_tlv_present()->set_key("PP2 vpc id");
+
+  auto pass_through_tlvs = proto_config.mutable_pass_through_tlvs();
+  pass_through_tlvs->set_encode_tlvs(true);
+
+  connect(true, &proto_config);
+  write(buffer, sizeof(buffer));
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+
+  write(tlv1, sizeof(tlv1));
+  write(tlv_type_authority, sizeof(tlv_type_authority));
+  write(tlv3, sizeof(tlv3));
+  write(tlv_vpc_id, sizeof(tlv_vpc_id));
+  write(data, sizeof(data));
+  expectData("DATA");
+
+  EXPECT_EQ(1, server_connection_->streamInfo().dynamicMetadata().filter_metadata_size());
+
+  auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
+  EXPECT_EQ(1, metadata.size());
+  EXPECT_EQ(1, metadata.count(ProxyProtocol));
+
+  auto fields = metadata.at(ProxyProtocol).fields();
+  EXPECT_EQ(2, fields.size());
+  EXPECT_EQ(1, fields.count("PP2 type authority"));
+  EXPECT_EQ(1, fields.count("PP2 vpc id"));
+
+  auto value_type_authority = fields.at("PP2 type authority").string_value();
+  // Base64 encoded value of tlv_type_authority.
+  ASSERT_EQ(value_type_authority, "Zv5vLm9vwQ==");
+
+  auto value_vpc_id = fields.at("PP2 vpc id").string_value();
+  // Base64 encoded value of tlv_vpc_id.
+  ASSERT_EQ(value_vpc_id, "AXZwYy0wwzV0ZXN0MmZhNjM2M2j5Nw==");
+
+  disconnect();
+  EXPECT_EQ(stats_store_.counter("proxy_proto.versions.v2.found").value(), 1);
+}
+
 TEST_P(ProxyProtocolTest, V2WillNotOverwriteTLV) {
   // A well-formed ipv4/tcp with a pair of TLV extensions is accepted
   constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: proxy_protocol filter: support base64-encoding TLV values when TLV passthrough is configured
Additional Description: As detailed in #32430 the lossy sanitization of TLV values precludes some legitimate use cases of well-formed proxy protocol headers. This PR adds configuration to optionally base64 encode TLV values added to metadata.
Risk Level: low
Testing: unit tests included
Docs Changes: included in protobuf comments
Release Notes: included as a new feature
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
