### PR TITLE
mobile: Use test server instead of TestRemoteResponse filter for the Kotlin tests

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -176,6 +176,7 @@ build:mobile-remote-ci-common --config=rbe-engflow
 build:mobile-remote-ci-common --jobs=40
 build:mobile-remote-ci-common --verbose_failures
 build:mobile-remote-ci-common --spawn_strategy=remote,sandboxed,local
+build:mobile-remote-ci-common --experimental_ui_max_stdouterr_bytes=10485760
 
 #############################################################################
 # mobile-remote-ci-linux: These options are linux-only using GCC by default
@@ -306,7 +307,6 @@ build:mobile-remote-ci-macos-ios-admin --define=admin_functionality=enabled
 
 
 build:mobile-remote-ci-macos-ios-swift --config=mobile-remote-ci-macos-ios
-test:mobile-remote-ci-macos-ios-swift --experimental_ui_max_stdouterr_bytes=10485760
 test:mobile-remote-ci-macos-ios-swift --build_tests_only
 
 build:mobile-remote-ci-macos-ios-obj-c --config=mobile-remote-ci-macos-ios

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -60,7 +60,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -119,7 +118,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -140,7 +138,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -180,7 +177,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -220,7 +216,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -241,7 +236,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -262,7 +256,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -283,7 +276,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -304,7 +296,6 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -371,7 +362,6 @@ envoy_mobile_android_test(
     deps = [
         ":test_utilities",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//test/java/io/envoyproxy/envoymobile/engine/testing",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:xds_test_server_factory_lib",
     ],
 )

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -60,6 +60,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -117,6 +119,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -136,6 +140,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -174,6 +180,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -201,10 +209,6 @@ envoy_mobile_jni_kt_test(
     srcs = [
         "ReceiveDataTest.kt",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -216,6 +220,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -235,6 +241,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -254,6 +262,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -273,6 +283,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 
@@ -292,6 +304,8 @@ envoy_mobile_jni_kt_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing",
+        "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
 

--- a/mobile/test/kotlin/integration/CancelStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelStreamTest.kt
@@ -7,6 +7,7 @@ import io.envoyproxy.envoymobile.FilterDataStatus
 import io.envoyproxy.envoymobile.FilterHeadersStatus
 import io.envoyproxy.envoymobile.FilterTrailersStatus
 import io.envoyproxy.envoymobile.FinalStreamIntel
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.ResponseFilter
@@ -14,20 +15,32 @@ import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
 import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.StreamIntel
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_CONFIG =
-  "[type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}"
-
 class CancelStreamTest {
-
   init {
     JniLibrary.loadTestLibrary()
+  }
+
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
   }
 
   private val filterExpectation = CountDownLatch(1)
@@ -70,11 +83,13 @@ class CancelStreamTest {
   fun `cancel stream calls onCancel callback`() {
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .addPlatformFilter(
           name = "cancel_validation_filter",
           factory = { CancelValidationFilter(filterExpectation) }
         )
-        .addNativeFilter("test_remote_response", "$TEST_RESPONSE_FILTER_CONFIG")
         .build()
 
     val client = engine.streamClient()
@@ -83,8 +98,8 @@ class CancelStreamTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/KeyValueStoreTest.kt
+++ b/mobile/test/kotlin/integration/KeyValueStoreTest.kt
@@ -3,29 +3,42 @@ package test.kotlin.integration
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.KeyValueStore
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_CONFIG =
-  "[type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}"
 private const val TEST_KEY = "foo"
 private const val TEST_VALUE = "bar"
 
 class KeyValueStoreTest {
-
   init {
     JniLibrary.loadTestLibrary()
   }
 
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
+  }
+
   @Test
   fun `a registered KeyValueStore implementation handles calls from a TestKeyValueStore filter`() {
-
     val readExpectation = CountDownLatch(3)
     val saveExpectation = CountDownLatch(1)
     val testKeyValueStore =
@@ -44,12 +57,14 @@ class KeyValueStoreTest {
 
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .addKeyValueStore("envoy.key_value.platform_test", testKeyValueStore)
         .addNativeFilter(
           "envoy.filters.http.test_kv_store",
           "[type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore] { kv_store_name: 'envoy.key_value.platform_test', test_key: '$TEST_KEY', test_value: '$TEST_VALUE'}"
         )
-        .addNativeFilter("test_remote_response", "$TEST_RESPONSE_FILTER_CONFIG")
         .build()
     val client = engine.streamClient()
 
@@ -57,8 +72,8 @@ class KeyValueStoreTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/ReceiveDataTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveDataTest.kt
@@ -2,31 +2,46 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_CONFIG =
-  "[type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}"
-
 class ReceiveDataTest {
-
   init {
     JniLibrary.loadTestLibrary()
   }
 
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer =
+      HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS, mapOf(), "data")
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
+  }
+
   @Test
   fun `response headers and response data call onResponseHeaders and onResponseData`() {
-
     val engine =
       EngineBuilder(Standard())
-        .addNativeFilter("test_remote_response", "$TEST_RESPONSE_FILTER_CONFIG")
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .build()
     val client = engine.streamClient()
 
@@ -34,8 +49,8 @@ class ReceiveDataTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 
@@ -43,7 +58,7 @@ class ReceiveDataTest {
     val dataExpectation = CountDownLatch(1)
 
     var status: Int? = null
-    var body: ByteBuffer? = null
+    val body: ByteBuffer = ByteBuffer.allocate(4) // 4 bytes for "data"
     client
       .newStreamPrototype()
       .setOnResponseHeaders { responseHeaders, _, _ ->
@@ -51,7 +66,7 @@ class ReceiveDataTest {
         headersExpectation.countDown()
       }
       .setOnResponseData { data, _, _ ->
-        body = data
+        body.put(data)
         dataExpectation.countDown()
       }
       .setOnError { _, _ -> fail("Unexpected error") }
@@ -66,6 +81,6 @@ class ReceiveDataTest {
     assertThat(dataExpectation.count).isEqualTo(0)
 
     assertThat(status).isEqualTo(200)
-    assertThat(body!!.array().toString(Charsets.UTF_8)).isEqualTo("data")
+    assertThat(body.array().toString(Charsets.UTF_8)).isEqualTo("data")
   }
 }

--- a/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
+++ b/mobile/test/kotlin/integration/ResetConnectivityStateTest.kt
@@ -2,24 +2,36 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_CONFIG =
-  "[type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}"
-
-// This test doesn't do what it advertises (https://github.com/envoyproxy/envoy/issues/25180)
 class ResetConnectivityStateTest {
-
   init {
     JniLibrary.loadTestLibrary()
+  }
+
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
   }
 
   @Test
@@ -28,7 +40,9 @@ class ResetConnectivityStateTest {
 
     val engine =
       EngineBuilder(Standard())
-        .addNativeFilter("test_remote_response", "$TEST_RESPONSE_FILTER_CONFIG")
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .build()
     val client = engine.streamClient()
 
@@ -36,8 +50,8 @@ class ResetConnectivityStateTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -30,7 +30,8 @@ class SendDataTest {
 
   @Before
   fun setUp() {
-    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+    httpTestServer =
+      HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS, mapOf(), "data")
   }
 
   @After

--- a/mobile/test/kotlin/integration/SendHeadersTest.kt
+++ b/mobile/test/kotlin/integration/SendHeadersTest.kt
@@ -2,23 +2,36 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_CONFIG =
-  "[type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse] {}"
-
 class SendHeadersTest {
-
   init {
     JniLibrary.loadTestLibrary()
+  }
+
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
   }
 
   @Test
@@ -27,7 +40,9 @@ class SendHeadersTest {
 
     val engine =
       EngineBuilder(Standard())
-        .addNativeFilter("test_remote_response", "$TEST_RESPONSE_FILTER_CONFIG")
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .build()
     val client = engine.streamClient()
 
@@ -35,8 +50,8 @@ class SendHeadersTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/SendTrailersTest.kt
+++ b/mobile/test/kotlin/integration/SendTrailersTest.kt
@@ -2,36 +2,52 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.RequestTrailersBuilder
 import io.envoyproxy.envoymobile.Standard
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_TYPE =
-  "type.googleapis.com/envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
 private const val ASSERTION_FILTER_TYPE =
   "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
 private const val MATCHER_TRAILER_NAME = "test-trailer"
 private const val MATCHER_TRAILER_VALUE = "test.code"
 
 class SendTrailersTest {
-
   init {
     JniLibrary.loadTestLibrary()
   }
 
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
+  }
+
   @Test
   fun `successful sending of trailers`() {
-
     val expectation = CountDownLatch(1)
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .addNativeFilter(
           "envoy.filters.http.assertion",
           "[$ASSERTION_FILTER_TYPE] {match_config: {http_request_trailers_match: {headers: [{name: 'test-trailer', exact_match: 'test.code'}]}}}"
@@ -40,7 +56,6 @@ class SendTrailersTest {
           "envoy.filters.http.buffer",
           "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes: { value: 65000 } }"
         )
-        .addNativeFilter("test_remote_response", "[$TEST_RESPONSE_FILTER_TYPE]{}")
         .build()
 
     val client = engine.streamClient()
@@ -49,8 +64,8 @@ class SendTrailersTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 

--- a/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
+++ b/mobile/test/kotlin/integration/StreamIdleTimeoutTest.kt
@@ -7,6 +7,7 @@ import io.envoyproxy.envoymobile.FilterDataStatus
 import io.envoyproxy.envoymobile.FilterHeadersStatus
 import io.envoyproxy.envoymobile.FilterTrailersStatus
 import io.envoyproxy.envoymobile.FinalStreamIntel
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.ResponseFilter
@@ -14,22 +15,33 @@ import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
 import io.envoyproxy.envoymobile.Standard
 import io.envoyproxy.envoymobile.StreamIntel
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import io.envoyproxy.envoymobile.engine.testing.HttpTestServerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.junit.After
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 
-private const val TEST_RESPONSE_FILTER_TYPE =
-  "type.googleapis.com/" +
-    "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse"
-
 class StreamIdleTimeoutTest {
-
   init {
     JniLibrary.loadTestLibrary()
+  }
+
+  private lateinit var httpTestServer: HttpTestServerFactory.HttpTestServer
+
+  @Before
+  fun setUp() {
+    httpTestServer = HttpTestServerFactory.start(HttpTestServerFactory.Type.HTTP2_WITH_TLS)
+  }
+
+  @After
+  fun tearDown() {
+    httpTestServer.shutdown()
   }
 
   private val filterExpectation = CountDownLatch(1)
@@ -75,11 +87,13 @@ class StreamIdleTimeoutTest {
   fun `stream idle timeout triggers onError callbacks`() {
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .addPlatformFilter(
           name = "idle_timeout_validation_filter",
           factory = { IdleTimeoutValidationFilter(filterExpectation) }
         )
-        .addNativeFilter("test_remote_response", "[$TEST_RESPONSE_FILTER_TYPE] {}")
         .addStreamIdleTimeoutSeconds(1)
         .build()
 
@@ -89,8 +103,8 @@ class StreamIdleTimeoutTest {
       RequestHeadersBuilder(
           method = RequestMethod.GET,
           scheme = "https",
-          authority = "example.com",
-          path = "/test"
+          authority = "localhost:${httpTestServer.port}",
+          path = "/simple.txt"
         )
         .build()
 


### PR DESCRIPTION
This PR updates the Kotlin tests to use `HttpTestServer` instead of using a native `TestRemoteResponse` to make the tests more realistic. This PR also updates the tests to set the logger because debugging the test failure without any debugging info can be very difficult.

This PR also fixes https://github.com/envoyproxy/envoy/issues/25180 because the `ResetConnectivityStateTest` now makes a real connection.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
