### PR TITLE
mobile: Use Builder APIs in Swift integration tests

### DIFF
--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -51,7 +51,7 @@ envoy_mobile_swift_test(
 )
 
 envoy_mobile_swift_test(
-    name = "filter_reset_idle",
+    name = "filter_reset_idle_test",
     srcs = [
         "FilterResetIdleTest.swift",
     ],
@@ -65,7 +65,7 @@ envoy_mobile_swift_test(
 )
 
 envoy_mobile_swift_test(
-    name = "grpc_receive_error",
+    name = "grpc_receive_error_test",
     srcs = [
         "GRPCReceiveErrorTest.swift",
     ],
@@ -236,6 +236,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 

--- a/mobile/test/swift/integration/CancelGRPCStreamTest.swift
+++ b/mobile/test/swift/integration/CancelGRPCStreamTest.swift
@@ -1,5 +1,6 @@
 import Envoy
 import EnvoyEngine
+import EnvoyTestServer
 import Foundation
 import TestExtensions
 import XCTest
@@ -12,57 +13,6 @@ final class CancelGRPCStreamTests: XCTestCase {
 
   func testCancelGRPCStream() {
     let filterName = "cancel_validation_filter"
-
-// swiftlint:disable line_length
-    let config =
-"""
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
-    api_listener:
-      api_listener:
-        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager
-        config:
-          stat_prefix: api_hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-            - name: api
-              domains: ["*"]
-              routes:
-              - match: { prefix: "/" }
-                route: { cluster: fake_remote }
-          http_filters:
-          - name: envoy.filters.http.local_error
-            typed_config:
-              "@type": type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError
-          - name: envoy.filters.http.platform_bridge
-            typed_config:
-              "@type": type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge
-              platform_filter_name: \(filterName)
-          - name: envoy.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-  clusters:
-  - name: fake_remote
-    connect_timeout: 0.25s
-    type: STATIC
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: fake_remote
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address: { address: 127.0.0.1, port_value: \(Int.random(in: 10001...11000)) }
-"""
-// swiftlint:enable line_length
 
     struct CancelValidationFilter: ResponseFilter {
       let expectation: XCTestExpectation
@@ -96,7 +46,9 @@ static_resources:
     let onCancelCallbackExpectation = self.expectation(description: "onCancel callback called")
     let filterExpectation = self.expectation(description: "Filter called with cancellation")
 
-    let engine = EngineBuilder(yaml: config)
+    EnvoyTestServer.startHttp1PlaintextServer()
+
+    let engine = EngineBuilder()
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
@@ -107,8 +59,9 @@ static_resources:
     let client = GRPCClient(streamClient: engine.streamClient())
 
     let requestHeaders = GRPCRequestHeadersBuilder(
-        scheme: "https",
-        authority: "example.com", path: "/test")
+        scheme: "http",
+        authority: "localhost:" + String(EnvoyTestServer.getEnvoyPort()),
+        path: "/")
       .build()
 
     client
@@ -124,5 +77,6 @@ static_resources:
     XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 10), .completed)
 
     engine.terminate()
+    EnvoyTestServer.shutdownTestServer()
   }
 }


### PR DESCRIPTION
Also, updates the BUILD target for some tests to have the _test suffix, for consistency in how test targets are named.