### PR TITLE
mobile: Call setLogger in the Java and Kotlin tests

### DIFF
--- a/mobile/test/java/integration/AndroidEngineSocketTagTest.java
+++ b/mobile/test/java/integration/AndroidEngineSocketTagTest.java
@@ -43,7 +43,11 @@ public class AndroidEngineSocketTagTest {
     CountDownLatch latch = new CountDownLatch(1);
     Context appContext = ApplicationProvider.getApplicationContext();
     engine = new AndroidEngineBuilder(appContext)
-                 .addLogLevel(LogLevel.OFF)
+                 .addLogLevel(LogLevel.DEBUG)
+                 .setLogger((level, message) -> {
+                   System.out.print(message);
+                   return null;
+                 })
                  .enableSocketTagging(true)
                  .setOnEngineRunning(() -> {
                    latch.countDown();

--- a/mobile/test/java/integration/AndroidEnvoyEngineStartUpTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyEngineStartUpTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import io.envoyproxy.envoymobile.AndroidEngineBuilder;
 import io.envoyproxy.envoymobile.Engine;
+import io.envoyproxy.envoymobile.LogLevel;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +22,13 @@ public class AndroidEnvoyEngineStartUpTest {
 
   @Test
   public void ensure_engine_starts_and_terminates() throws InterruptedException {
-    Engine engine = new AndroidEngineBuilder(appContext).build();
+    Engine engine = new AndroidEngineBuilder(appContext)
+                        .addLogLevel(LogLevel.DEBUG)
+                        .setLogger((level, message) -> {
+                          System.out.print(message);
+                          return null;
+                        })
+                        .build();
     Thread.sleep(1000);
     engine.terminate();
     assertThat(true).isTrue();

--- a/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyExplicitFlowTest.java
@@ -50,7 +50,11 @@ public class AndroidEnvoyExplicitFlowTest {
     CountDownLatch latch = new CountDownLatch(1);
     Context appContext = ApplicationProvider.getApplicationContext();
     engine = new AndroidEngineBuilder(appContext)
-                 .addLogLevel(LogLevel.OFF)
+                 .addLogLevel(LogLevel.DEBUG)
+                 .setLogger((level, message) -> {
+                   System.out.print(message);
+                   return null;
+                 })
                  .setOnEngineRunning(() -> {
                    latch.countDown();
                    return null;

--- a/mobile/test/java/integration/AndroidEnvoyFlowTest.java
+++ b/mobile/test/java/integration/AndroidEnvoyFlowTest.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import io.envoyproxy.envoymobile.AndroidEngineBuilder;
 import io.envoyproxy.envoymobile.Engine;
+import io.envoyproxy.envoymobile.LogLevel;
 import io.envoyproxy.envoymobile.RequestMethod;
 import io.envoyproxy.envoymobile.Stream;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
@@ -44,6 +45,11 @@ public class AndroidEnvoyFlowTest {
     CountDownLatch latch = new CountDownLatch(1);
     Context appContext = ApplicationProvider.getApplicationContext();
     engine = new AndroidEngineBuilder(appContext)
+                 .addLogLevel(LogLevel.DEBUG)
+                 .setLogger((level, message) -> {
+                   System.out.print(message);
+                   return null;
+                 })
                  .setOnEngineRunning(() -> {
                    latch.countDown();
                    return null;

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -57,7 +57,11 @@ public class QuicTestServerTest {
     CountDownLatch latch = new CountDownLatch(1);
     engine = new AndroidEngineBuilder(appContext,
                                       new Custom(String.format(CONFIG, httpTestServer.getPort())))
-                 .addLogLevel(LogLevel.WARN)
+                 .addLogLevel(LogLevel.DEBUG)
+                 .setLogger((level, message) -> {
+                   System.out.print(message);
+                   return null;
+                 })
                  .setOnEngineRunning(() -> {
                    latch.countDown();
                    return null;

--- a/mobile/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
+++ b/mobile/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
@@ -44,6 +44,10 @@ public class AndroidEnvoyExplicitH2FlowTest {
     engine = new AndroidEngineBuilder(appContext)
                  .setTrustChainVerification(ACCEPT_UNTRUSTED)
                  .addLogLevel(LogLevel.DEBUG)
+                 .setLogger((level, message) -> {
+                   System.out.print(message);
+                   return null;
+                 })
                  .setOnEngineRunning(() -> {
                    latch.countDown();
                    return null;

--- a/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -8,6 +8,8 @@ import static org.chromium.net.testing.CronetTestRule.SERVER_KEY_PKCS8_PEM;
 import static org.junit.Assert.assertNotNull;
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
+
+import io.envoyproxy.envoymobile.LogLevel;
 import io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary;
 import io.envoyproxy.envoymobile.AndroidEngineBuilder;
 import io.envoyproxy.envoymobile.Engine;
@@ -62,6 +64,11 @@ public class Http2TestServerTest {
     CountDownLatch latch = new CountDownLatch(1);
     Context appContext = ApplicationProvider.getApplicationContext();
     engine = new AndroidEngineBuilder(appContext)
+                 .addLogLevel(LogLevel.DEBUG)
+                 .setLogger((level, message) -> {
+                   System.out.print(message);
+                   return null;
+                 })
                  .enablePlatformCertificatesValidation(enablePlatformCertificatesValidation)
                  .setTrustChainVerification(trustChainVerification)
                  .setOnEngineRunning(() -> {

--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -9,6 +9,7 @@ import io.envoyproxy.envoymobile.FilterTrailersStatus
 import io.envoyproxy.envoymobile.FinalStreamIntel
 import io.envoyproxy.envoymobile.GRPCClient
 import io.envoyproxy.envoymobile.GRPCRequestHeadersBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
@@ -71,11 +72,13 @@ class CancelGRPCStreamTest {
   fun `cancel grpc stream calls onCancel callback`() {
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .addPlatformFilter(
           name = FILTER_NAME,
           factory = { CancelValidationFilter(filterExpectation) }
         )
-        .addNativeFilter("envoy.filters.http.local_error", "$LOCAL_ERROR_FILTER_CONFIG")
+        .addNativeFilter("envoy.filters.http.local_error", LOCAL_ERROR_FILTER_CONFIG)
         .build()
 
     val client = GRPCClient(engine.streamClient())

--- a/mobile/test/kotlin/integration/EngineApiTest.kt
+++ b/mobile/test/kotlin/integration/EngineApiTest.kt
@@ -22,7 +22,8 @@ class EngineApiTest {
     val countDownLatch = CountDownLatch(1)
     val engine =
       EngineBuilder()
-        .addLogLevel(LogLevel.INFO)
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .setNodeId("node-id")
         .setNodeLocality("region", "zone", "subzone")
         .setNodeMetadata(

--- a/mobile/test/kotlin/integration/EnvoyEngineSimpleIntegrationTest.kt
+++ b/mobile/test/kotlin/integration/EnvoyEngineSimpleIntegrationTest.kt
@@ -2,6 +2,7 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import org.junit.Test
 
@@ -12,7 +13,8 @@ class EnvoyEngineSimpleIntegrationTest {
 
   @Test
   fun `ensure engine build and termination succeeds with no errors`() {
-    val engine = EngineBuilder().build()
+    val engine =
+      EngineBuilder().addLogLevel(LogLevel.DEBUG).setLogger { _, msg -> print(msg) }.build()
     Thread.sleep(5000)
     engine.terminate()
     assertThat(true).isTrue()

--- a/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
+++ b/mobile/test/kotlin/integration/FilterThrowingExceptionTest.kt
@@ -105,6 +105,7 @@ class FilterThrowingExceptionTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .setEventTracker { event ->
           if (
             event["name"] == "event_log" && event["log_name"] == "jni_cleared_pending_exception"

--- a/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -9,6 +9,7 @@ import io.envoyproxy.envoymobile.FilterTrailersStatus
 import io.envoyproxy.envoymobile.FinalStreamIntel
 import io.envoyproxy.envoymobile.GRPCClient
 import io.envoyproxy.envoymobile.GRPCRequestHeadersBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
@@ -82,6 +83,8 @@ class GRPCReceiveErrorTest {
 
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .addPlatformFilter(
           name = FILTER_NAME,
           factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }

--- a/mobile/test/kotlin/integration/ReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveErrorTest.kt
@@ -9,6 +9,7 @@ import io.envoyproxy.envoymobile.FilterHeadersStatus
 import io.envoyproxy.envoymobile.FilterTrailersStatus
 import io.envoyproxy.envoymobile.FinalStreamIntel
 import io.envoyproxy.envoymobile.GRPCRequestHeadersBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
@@ -84,6 +85,8 @@ class ReceiveErrorTest {
 
     val engine =
       EngineBuilder(Standard())
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .addPlatformFilter(
           name = FILTER_NAME,
           factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }

--- a/mobile/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/mobile/test/kotlin/integration/SetEventTrackerTest.kt
@@ -2,6 +2,7 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.engine.JniLibrary
@@ -21,6 +22,8 @@ class SetEventTrackerTest {
     val countDownLatch = CountDownLatch(1)
     val engine =
       EngineBuilder()
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .setEventTracker { events ->
           for (entry in events) {
             assertThat(entry.key).isEqualTo("foo")

--- a/mobile/test/kotlin/integration/SetLoggerTest.kt
+++ b/mobile/test/kotlin/integration/SetLoggerTest.kt
@@ -24,6 +24,7 @@ class SetLoggerTest {
     val engine =
       EngineBuilder(Standard())
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .addNativeFilter(
           "test_logger",
           "[type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger] {}"

--- a/mobile/test/kotlin/integration/XdsTest.kt
+++ b/mobile/test/kotlin/integration/XdsTest.kt
@@ -38,6 +38,7 @@ class XdsTest {
     engine =
       AndroidEngineBuilder(appContext)
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .setOnEngineRunning { latch.countDown() }
         .setXds(
           XdsBuilder(

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
@@ -73,6 +73,7 @@ class ProxyInfoIntentPerformHTTPRequestUsingProxyTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
         .build()

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt
@@ -73,6 +73,7 @@ class ProxyInfoIntentPerformHTTPSRequestBadHostnameTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
         .build()

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -75,6 +75,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
         .build()

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -75,6 +75,7 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
         .build()

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestUsingProxyTest.kt
@@ -71,6 +71,7 @@ class ProxyPollPerformHTTPRequestUsingProxyTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
         .build()

--- a/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt
@@ -72,6 +72,7 @@ class ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest {
     val engine =
       builder
         .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
         .enableProxying(true)
         .setOnEngineRunning { onEngineRunningLatch.countDown() }
         .build()


### PR DESCRIPTION
This PR adds a call to `addLogLevel` and `setLogger` with `DEBUG` log level to make it easier to debug any test failures.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
