### PR TITLE
mobile: Use suffix _ for struct member variables

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -172,7 +172,7 @@ EngineBuilder& EngineBuilder::setEngineCallbacks(std::unique_ptr<EngineCallbacks
 }
 
 EngineBuilder& EngineBuilder::setOnEngineRunning(std::function<void()> closure) {
-  callbacks_->on_engine_running = std::move(closure);
+  callbacks_->on_engine_running_ = std::move(closure);
   return *this;
 }
 

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -22,24 +22,24 @@ namespace Envoy {
 
 /** The callbacks for the Envoy Engine. */
 struct EngineCallbacks {
-  std::function<void()> on_engine_running = [] {};
-  std::function<void()> on_exit = [] {};
+  std::function<void()> on_engine_running_ = [] {};
+  std::function<void()> on_exit_ = [] {};
 };
 
 /** The callbacks for Envoy Logger. */
 struct EnvoyLogger {
-  std::function<void(Logger::Logger::Levels, const std::string&)> on_log =
+  std::function<void(Logger::Logger::Levels, const std::string&)> on_log_ =
       [](Logger::Logger::Levels, const std::string&) {};
-  std::function<void()> on_exit = [] {};
+  std::function<void()> on_exit_ = [] {};
 };
 
 inline constexpr absl::string_view ENVOY_EVENT_TRACKER_API_NAME = "event_tracker_api";
 
 /** The callbacks for Envoy Event Tracker. */
 struct EnvoyEventTracker {
-  std::function<void(const absl::flat_hash_map<std::string, std::string>&)> on_track =
+  std::function<void(const absl::flat_hash_map<std::string, std::string>&)> on_track_ =
       [](const absl::flat_hash_map<std::string, std::string>&) {};
-  std::function<void()> on_exit = [] {};
+  std::function<void()> on_exit_ = [] {};
 };
 
 } // namespace Envoy

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -119,13 +119,13 @@ envoy_status_t InternalEngine::main(std::shared_ptr<Envoy::OptionsImplBase> opti
             Assert::addDebugAssertionFailureRecordAction([this](const char* location) {
               absl::flat_hash_map<std::string, std::string> event{
                   {{"name", "assertion"}, {"location", std::string(location)}}};
-              event_tracker_->on_track(event);
+              event_tracker_->on_track_(event);
             });
         bug_handler_registration_ =
             Assert::addEnvoyBugFailureRecordAction([this](const char* location) {
               absl::flat_hash_map<std::string, std::string> event{
                   {{"name", "bug"}, {"location", std::string(location)}}};
-              event_tracker_->on_track(event);
+              event_tracker_->on_track_(event);
             });
       }
 
@@ -178,7 +178,7 @@ envoy_status_t InternalEngine::main(std::shared_ptr<Envoy::OptionsImplBase> opti
                                                         server_->serverFactoryContext().scope(),
                                                         server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
-          callbacks_->on_engine_running();
+          callbacks_->on_engine_running_();
         });
   } // mutex_
 
@@ -196,9 +196,9 @@ envoy_status_t InternalEngine::main(std::shared_ptr<Envoy::OptionsImplBase> opti
   assert_handler_registration_.reset(nullptr);
 
   if (event_tracker_ != nullptr) {
-    event_tracker_->on_exit();
+    event_tracker_->on_exit_();
   }
-  callbacks_->on_exit();
+  callbacks_->on_exit_();
 
   return run_success ? ENVOY_SUCCESS : ENVOY_FAILURE;
 }

--- a/mobile/library/common/logger/logger_delegate.cc
+++ b/mobile/library/common/logger/logger_delegate.cc
@@ -14,9 +14,9 @@ void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, abs
   }
 
   (*event_tracker_)
-      ->on_track({{"name", "event_log"},
-                  {"log_name", std::string(stable_name)},
-                  {"message", std::string(msg)}});
+      ->on_track_({{"name", "event_log"},
+                   {"log_name", std::string(stable_name)},
+                   {"message", std::string(msg)}});
 }
 
 LambdaDelegate::LambdaDelegate(std::unique_ptr<EnvoyLogger> logger,
@@ -27,12 +27,12 @@ LambdaDelegate::LambdaDelegate(std::unique_ptr<EnvoyLogger> logger,
 
 LambdaDelegate::~LambdaDelegate() {
   restoreDelegate();
-  logger_->on_exit();
+  logger_->on_exit_();
 }
 
 void LambdaDelegate::log(absl::string_view msg, const spdlog::details::log_msg& log_msg) {
   // Logger::Levels is simply an alias to spdlog::level::level_enum, so we can safely cast it.
-  logger_->on_log(static_cast<Logger::Levels>(log_msg.level), std::string(msg));
+  logger_->on_log_(static_cast<Logger::Levels>(log_msg.level), std::string(msg));
 }
 
 DefaultDelegate::DefaultDelegate(absl::Mutex& mutex, DelegatingLogSinkSharedPtr log_sink)

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -45,7 +45,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   if (on_start_context != nullptr) {
     jobject retained_on_start_context =
         env->NewGlobalRef(on_start_context); // Required to keep context in memory
-    callbacks->on_engine_running = [retained_on_start_context] {
+    callbacks->on_engine_running_ = [retained_on_start_context] {
       Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
       Envoy::JNI::LocalRefUniquePtr<jclass> java_on_engine_running_class =
           jni_helper.getObjectClass(retained_on_start_context);
@@ -58,7 +58,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       // This will need to be updated for https://github.com/envoyproxy/envoy-mobile/issues/332
       jni_helper.getEnv()->DeleteGlobalRef(retained_on_start_context);
     };
-    callbacks->on_exit = [] {
+    callbacks->on_exit_ = [] {
       // Note that this is not dispatched because the thread that
       // needs to be detached is the engine thread.
       // This function is called from the context of the engine's
@@ -72,8 +72,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   std::unique_ptr<Envoy::EnvoyLogger> logger = std::make_unique<Envoy::EnvoyLogger>();
   if (envoy_logger_context != nullptr) {
     const jobject retained_logger_context = env->NewGlobalRef(envoy_logger_context);
-    logger->on_log = [retained_logger_context](Envoy::Logger::Logger::Levels level,
-                                               const std::string& message) {
+    logger->on_log_ = [retained_logger_context](Envoy::Logger::Logger::Levels level,
+                                                const std::string& message) {
       Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
       Envoy::JNI::LocalRefUniquePtr<jstring> java_message =
           jni_helper.newStringUtf(message.c_str());
@@ -85,7 +85,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       jni_helper.callVoidMethod(retained_logger_context, java_log_method_id, java_level,
                                 java_message.get());
     };
-    logger->on_exit = [retained_logger_context] {
+    logger->on_exit_ = [retained_logger_context] {
       Envoy::JNI::getEnv()->DeleteGlobalRef(retained_logger_context);
     };
   }
@@ -96,8 +96,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       std::make_unique<Envoy::EnvoyEventTracker>();
   if (event_tracker_context != nullptr) {
     const jobject retained_event_tracker_context = env->NewGlobalRef(event_tracker_context);
-    event_tracker->on_track = [retained_event_tracker_context](
-                                  const absl::flat_hash_map<std::string, std::string>& events) {
+    event_tracker->on_track_ = [retained_event_tracker_context](
+                                   const absl::flat_hash_map<std::string, std::string>& events) {
       Envoy::JNI::JniHelper jni_helper(Envoy::JNI::getEnv());
       Envoy::JNI::LocalRefUniquePtr<jobject> java_events =
           Envoy::JNI::cppMapToJavaMap(jni_helper, events);
@@ -108,7 +108,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       jni_helper.callVoidMethod(retained_event_tracker_context, java_track_method_id,
                                 java_events.get());
     };
-    event_tracker->on_exit = [retained_event_tracker_context] {
+    event_tracker->on_exit_ = [retained_event_tracker_context] {
       Envoy::JNI::getEnv()->DeleteGlobalRef(retained_event_tracker_context);
     };
   }

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -376,7 +376,7 @@ static envoy_data ios_get_string(const void *context) {
 
   std::unique_ptr<Envoy::EngineCallbacks> native_callbacks =
       std::make_unique<Envoy::EngineCallbacks>();
-  native_callbacks->on_engine_running = [onEngineRunning = std::move(onEngineRunning)] {
+  native_callbacks->on_engine_running_ = [onEngineRunning = std::move(onEngineRunning)] {
     // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
     // block is necessary to act as a breaker for any Objective-C allocation that happens.
     @autoreleasepool {
@@ -385,7 +385,7 @@ static envoy_data ios_get_string(const void *context) {
       }
     }
   };
-  native_callbacks->on_exit = [] {
+  native_callbacks->on_exit_ = [] {
     // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
     // block is necessary to act as a breaker for any Objective-C allocation that happens.
     @autoreleasepool {
@@ -395,8 +395,8 @@ static envoy_data ios_get_string(const void *context) {
 
   std::unique_ptr<Envoy::EnvoyLogger> native_logger = std::make_unique<Envoy::EnvoyLogger>();
   if (logger) {
-    native_logger->on_log = [logger = std::move(logger)](Envoy::Logger::Logger::Levels level,
-                                                         const std::string &message) {
+    native_logger->on_log_ = [logger = std::move(logger)](Envoy::Logger::Logger::Levels level,
+                                                          const std::string &message) {
       // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
       // block is necessary to act as a breaker for any Objective-C allocation that happens.
       @autoreleasepool {
@@ -408,7 +408,7 @@ static envoy_data ios_get_string(const void *context) {
   std::unique_ptr<Envoy::EnvoyEventTracker> native_event_tracker =
       std::make_unique<Envoy::EnvoyEventTracker>();
   if (eventTracker) {
-    native_event_tracker->on_track =
+    native_event_tracker->on_track_ =
         [eventTracker =
              std::move(eventTracker)](const absl::flat_hash_map<std::string, std::string> &events) {
           NSMutableDictionary *newMap = [NSMutableDictionary new];

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -9,11 +9,11 @@ namespace Envoy {
 TEST(EngineTest, SetLogger) {
   std::atomic logging_was_called{false};
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log = [&](Logger::Logger::Levels, const std::string&) { logging_was_called = true; };
+  logger->on_log_ = [&](Logger::Logger::Levels, const std::string&) { logging_was_called = true; };
 
   absl::Notification engine_running;
   auto engine_callbacks = std::make_unique<EngineCallbacks>();
-  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
+  engine_callbacks->on_engine_running_ = [&] { engine_running.Notify(); };
   Platform::EngineBuilder engine_builder;
   Platform::EngineSharedPtr engine =
       engine_builder.setLogLevel(Logger::Logger::debug)
@@ -66,7 +66,7 @@ TEST(EngineTest, SetLogger) {
 TEST(EngineTest, SetEngineCallbacks) {
   absl::Notification engine_running;
   auto engine_callbacks = std::make_unique<EngineCallbacks>();
-  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
+  engine_callbacks->on_engine_running_ = [&] { engine_running.Notify(); };
   Platform::EngineBuilder engine_builder;
   Platform::EngineSharedPtr engine =
       engine_builder.setLogLevel(Logger::Logger::debug)
@@ -117,18 +117,18 @@ TEST(EngineTest, SetEngineCallbacks) {
 TEST(EngineTest, SetEventTracker) {
   absl::Notification engine_running;
   auto engine_callbacks = std::make_unique<EngineCallbacks>();
-  engine_callbacks->on_engine_running = [&] { engine_running.Notify(); };
+  engine_callbacks->on_engine_running_ = [&] { engine_running.Notify(); };
 
   absl::Notification on_track;
   auto event_tracker = std::make_unique<EnvoyEventTracker>();
-  event_tracker->on_track = [&](const absl::flat_hash_map<std::string, std::string>& events) {
+  event_tracker->on_track_ = [&](const absl::flat_hash_map<std::string, std::string>& events) {
     if (events.count("name") && events.at("name") == "assertion") {
       EXPECT_EQ(events.at("location"), "foo_location");
       on_track.Notify();
     }
   };
   absl::Notification on_track_exit;
-  event_tracker->on_exit = [&] { on_track_exit.Notify(); };
+  event_tracker->on_exit_ = [&] { on_track_exit.Notify(); };
 
   Platform::EngineBuilder engine_builder;
   Platform::EngineSharedPtr engine =

--- a/mobile/test/common/http/filters/test_event_tracker/filter.h
+++ b/mobile/test/common/http/filters/test_event_tracker/filter.h
@@ -23,7 +23,7 @@ public:
   absl::flat_hash_map<std::string, std::string> attributes() { return attributes_; };
   void track(const absl::flat_hash_map<std::string, std::string>& events) {
     if (event_tracker_ != nullptr) {
-      (*event_tracker_)->on_track(events);
+      (*event_tracker_)->on_track_(events);
     }
   }
 

--- a/mobile/test/common/logger/logger_delegate_test.cc
+++ b/mobile/test/common/logger/logger_delegate_test.cc
@@ -28,7 +28,7 @@ TEST_F(LambdaDelegateTest, LogCb) {
   std::string actual_msg;
 
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log = [&](Logger::Levels, const std::string& message) { actual_msg = message; };
+  logger->on_log_ = [&](Logger::Levels, const std::string& message) { actual_msg = message; };
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
   ENVOY_LOG_MISC(error, expected_msg);
@@ -41,7 +41,7 @@ TEST_F(LambdaDelegateTest, LogCbWithLevels) {
   std::string actual_msg;
 
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log = [&](Logger::Levels, const std::string& message) { actual_msg = message; };
+  logger->on_log_ = [&](Logger::Levels, const std::string& message) { actual_msg = message; };
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
   // Set the log to critical. The message should not be logged.
@@ -65,7 +65,7 @@ TEST_F(LambdaDelegateTest, ReleaseCb) {
 
   {
     auto logger = std::make_unique<EnvoyLogger>();
-    logger->on_exit = [&] { released = true; };
+    logger->on_exit_ = [&] { released = true; };
     LambdaDelegate(std::move(logger), Registry::getSink());
   }
 
@@ -89,7 +89,7 @@ TEST_P(LambdaDelegateWithLevelTest, Log) {
   Logger::Levels actual_level;
   std::string actual_msg;
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log = [&](Logger::Levels level, const std::string& message) {
+  logger->on_log_ = [&](Logger::Levels level, const std::string& message) {
     actual_level = level;
     actual_msg = message;
   };


### PR DESCRIPTION
This PR updates the code to use suffix `_` for `struct` member variables as per [Envoy Code Style](https://github.com/envoyproxy/envoy/blob/main/STYLE.md?plain=1#L30).

Risk Level: low (rename only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
