### PR TITLE
formatter: truncate with a string view

### DIFF
--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -91,9 +91,9 @@ absl::optional<std::string> HeaderFormatter::format(const Http::HeaderMap& heade
     return absl::nullopt;
   }
 
-  std::string val = std::string(header->value().getStringView());
-  SubstitutionFormatUtils::truncate(val, max_length_);
-  return val;
+  absl::string_view val = header->value().getStringView();
+  val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
+  return std::string(val);
 }
 
 ProtobufWkt::Value HeaderFormatter::formatValue(const Http::HeaderMap& headers) const {
@@ -102,9 +102,9 @@ ProtobufWkt::Value HeaderFormatter::formatValue(const Http::HeaderMap& headers) 
     return SubstitutionFormatUtils::unspecifiedValue();
   }
 
-  std::string val = std::string(header->value().getStringView());
-  SubstitutionFormatUtils::truncate(val, max_length_);
-  return ValueUtil::stringValue(val);
+  absl::string_view val = header->value().getStringView();
+  val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
+  return ValueUtil::stringValue(std::string(val));
 }
 
 ResponseHeaderFormatter::ResponseHeaderFormatter(const std::string& main_header,

--- a/source/common/formatter/substitution_format_utility.cc
+++ b/source/common/formatter/substitution_format_utility.cc
@@ -85,6 +85,15 @@ void SubstitutionFormatUtils::truncate(std::string& str, absl::optional<size_t> 
   }
 }
 
+absl::string_view SubstitutionFormatUtils::truncateStringView(absl::string_view str,
+                                                              absl::optional<size_t> max_length) {
+  if (!max_length) {
+    return str;
+  }
+
+  return str.substr(0, max_length.value());
+}
+
 void SubstitutionFormatUtils::parseSubcommandHeaders(const std::string& subcommand,
                                                      std::string& main_header,
                                                      std::string& alternative_header) {

--- a/source/common/formatter/substitution_format_utility.h
+++ b/source/common/formatter/substitution_format_utility.h
@@ -54,6 +54,14 @@ public:
   static void truncate(std::string& str, absl::optional<size_t> max_length);
 
   /**
+   * Truncate an input string view to a maximum length, and return the resulting string view. Do not
+   * truncate if max_length is not set or max_length is greater than the length of the input string
+   * view.
+   */
+  static absl::string_view truncateStringView(absl::string_view str,
+                                              absl::optional<size_t> max_length);
+
+  /**
    * Parse a header subcommand of the form: X?Y .
    * Will populate a main_header and an optional alternative header if specified.
    * See doc:

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -209,6 +209,35 @@ TEST(SubstitutionFormatUtilsTest, protocolToStringOrDefault) {
   EXPECT_EQ("-", SubstitutionFormatUtils::protocolToStringOrDefault({}));
 }
 
+TEST(SubstitutionFormatUtilsTest, truncate) {
+  std::string str;
+
+  str = "abcd";
+  SubstitutionFormatUtils::truncate(str, {});
+  EXPECT_EQ("abcd", str);
+
+  str = "abcd";
+  SubstitutionFormatUtils::truncate(str, 0);
+  EXPECT_EQ("", str);
+
+  str = "abcd";
+  SubstitutionFormatUtils::truncate(str, 2);
+  EXPECT_EQ("ab", str);
+
+  str = "abcd";
+  SubstitutionFormatUtils::truncate(str, 100);
+  EXPECT_EQ("abcd", str);
+}
+
+TEST(SubstitutionFormatUtilsTest, truncateStringView) {
+  std::string str = "abcd";
+
+  EXPECT_EQ("abcd", SubstitutionFormatUtils::truncateStringView(str, {}));
+  EXPECT_EQ("", SubstitutionFormatUtils::truncateStringView(str, 0));
+  EXPECT_EQ("ab", SubstitutionFormatUtils::truncateStringView(str, 2));
+  EXPECT_EQ("abcd", SubstitutionFormatUtils::truncateStringView(str, 100));
+}
+
 TEST(SubstitutionFormatterTest, plainStringFormatter) {
   PlainStringFormatter formatter("plain");
   StreamInfo::MockStreamInfo stream_info;


### PR DESCRIPTION
Commit Message:
Additional Description: Memory optimization. New function SubstitutionFormatUtils::truncateStringView()
Risk Level: Low
Testing: Unit test
Docs Changes:
Release Notes:
Platform Specific Features: