### PR TITLE
Add credentials profile in aws_lambda config

### DIFF
--- a/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
+++ b/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
@@ -57,8 +57,9 @@ message Config {
   // if an HTTP filter after AWS lambda re-evaluates the route (clears route cache).
   string host_rewrite = 4;
 
-  // Specifies the credential profile in used by the policy instance from the AWS credentials file.
-  // This parameter is optional. If set, the provider chain is limited to the AWS credentials file Provider.
+  // Specifies the credentials profile to be used from the AWS credentials file.
+  // This parameter is optional. If set, it will override value set in AWS_PROFILE env variable and
+  // the provider chain is limited to the AWS credentials file Provider.
   // Other providers are ignored
   string credentials_profile = 5;
 }

--- a/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
+++ b/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
@@ -17,6 +17,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.aws_lambda]
 
 // AWS Lambda filter config
+// [#next-free-field: 6]
 message Config {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.aws_lambda.v2alpha.Config";
@@ -55,6 +56,11 @@ message Config {
   // Changing the value of the host header can result in a different route to be selected
   // if an HTTP filter after AWS lambda re-evaluates the route (clears route cache).
   string host_rewrite = 4;
+
+  // Specifies the credential profile in used by the policy instance from the AWS credentials file.
+  // This parameter is optional. If set, the provider chain is limited to the AWS credentials file Provider.
+  // Other providers are ignored
+  string credentials_profile = 5;
 }
 
 // Per-route configuration for AWS Lambda. This can be useful when invoking a different Lambda function or a different

--- a/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
+++ b/api/envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.proto
@@ -58,7 +58,7 @@ message Config {
   string host_rewrite = 4;
 
   // Specifies the credentials profile to be used from the AWS credentials file.
-  // This parameter is optional. If set, it will override value set in AWS_PROFILE env variable and
+  // This parameter is optional. If set, it will override the value set in the AWS_PROFILE env variable and
   // the provider chain is limited to the AWS credentials file Provider.
   // Other providers are ignored
   string credentials_profile = 5;

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -276,6 +276,11 @@ new_features:
   change: |
     Update ``aws_lambda`` filter to support use as an upstream HTTP filter. This allows successful calculation of
     signatures after the forwarding stage has completed, particularly if the path element is modified.
+- area: aws_lambda
+  change: |
+    The ``aws_lambda`` filter now supports the
+    :ref:`credentials_profile <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.credentials_profile>` parameter.
+    This enables you to choose different credential profiles for each filter instance.
 - area: grpc reverse bridge
   change: |
     Change HTTP status to 200 to respect the gRPC protocol. This may cause problems for incorrect gRPC clients expecting the filter

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -280,7 +280,7 @@ new_features:
   change: |
     The ``aws_lambda`` filter now supports the
     :ref:`credentials_profile <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.credentials_profile>` parameter.
-    This enables you to choose different credential profiles for each filter instance.
+    This enables choosing different credential profiles for each filter instance.
 - area: grpc reverse bridge
   change: |
     Change HTTP status to 200 to respect the gRPC protocol. This may cause problems for incorrect gRPC clients expecting the filter

--- a/source/extensions/common/aws/credentials_provider_impl.cc
+++ b/source/extensions/common/aws/credentials_provider_impl.cc
@@ -186,7 +186,7 @@ void CredentialsFileCredentialsProvider::refresh() {
   ENVOY_LOG(debug, "Getting AWS credentials from the credentials file");
 
   auto credentials_file = Utility::getCredentialFilePath();
-  auto profile = Utility::getCredentialProfileName();
+  auto profile = profile_.empty() ? Utility::getCredentialProfileName() : profile_;
 
   ENVOY_LOG(debug, "Credentials file path = {}, profile name = {}", credentials_file, profile);
 

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -72,10 +72,14 @@ protected:
  */
 class CredentialsFileCredentialsProvider : public CachedCredentialsProviderBase {
 public:
-  CredentialsFileCredentialsProvider(Api::Api& api) : api_(api) {}
+  CredentialsFileCredentialsProvider(Api::Api& api) : CredentialsFileCredentialsProvider(api, "") {}
+
+  CredentialsFileCredentialsProvider(Api::Api& api, const std::string& profile)
+      : api_(api), profile_(profile) {}
 
 private:
   Api::Api& api_;
+  const std::string profile_;
 
   bool needsRefresh() override;
   void refresh() override;

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -35,8 +35,8 @@ getInvocationMode(const envoy::extensions::filters::http::aws_lambda::v3::Config
 } // namespace
 
 // In case credentials_profile is set in the config, instead of using the default
-// providers chain, it will be used the credentials file provider with the
-// config defined profile. all others providers will be ignored
+// providers chain, it will be use the credentials file provider with the
+// config defined profile. All others providers will be ignored
 Extensions::Common::Aws::CredentialsProviderSharedPtr
 AwsLambdaFilterFactory::getCredentialsProvider(
     const std::string& profile, Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -42,7 +42,10 @@ AwsLambdaFilterFactory::getCredentialsProvider(
     const std::string& profile, Server::Configuration::ServerFactoryContext& server_context,
     const std::string& region) const {
   if (!profile.empty()) {
-    ENVOY_LOG(debug, "config profile {} is set, defaults providers will be ignored", profile);
+    ENVOY_LOG(debug,
+              "credentials profile is set to \"{}\" in config, default credentials providers chain "
+              "will be ignored and only credentials file provider will be used",
+              profile);
     return std::make_shared<Extensions::Common::Aws::CredentialsFileCredentialsProvider>(
         server_context.api(), profile);
   }

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -34,9 +34,9 @@ getInvocationMode(const envoy::extensions::filters::http::aws_lambda::v3::Config
 
 } // namespace
 
-// In case credentials_profile is set in the config, instead of using the default
-// providers chain, it will use the credentials file provider with the
-// configured profile. All others providers will be ignored
+// In case credentials_profile is set in the configuration, instead of using the
+// default providers chain, it will use the credentials file provider with
+// the configured profile. All other providers will be ignored.
 Extensions::Common::Aws::CredentialsProviderSharedPtr
 AwsLambdaFilterFactory::getCredentialsProvider(
     const std::string& profile, Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -35,8 +35,8 @@ getInvocationMode(const envoy::extensions::filters::http::aws_lambda::v3::Config
 } // namespace
 
 // In case credentials_profile is set in the config, instead of using the default
-// providers chain, it will be use the credentials file provider with the
-// config defined profile. All others providers will be ignored
+// providers chain, it will use the credentials file provider with the
+// configured profile. All others providers will be ignored
 Extensions::Common::Aws::CredentialsProviderSharedPtr
 AwsLambdaFilterFactory::getCredentialsProvider(
     const std::string& profile, Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -3,6 +3,7 @@
 #include "envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.pb.h"
 #include "envoy/extensions/filters/http/aws_lambda/v3/aws_lambda.pb.validate.h"
 
+#include "source/extensions/common/aws/credentials_provider_impl.h"
 #include "source/extensions/filters/http/common/factory_base.h"
 
 namespace Envoy {
@@ -13,11 +14,17 @@ namespace AwsLambdaFilter {
 class AwsLambdaFilterFactory
     : public Common::DualFactoryBase<
           envoy::extensions::filters::http::aws_lambda::v3::Config,
-          envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig> {
+          envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig>,
+      Logger::Loggable<Logger::Id::filter> {
 public:
   AwsLambdaFilterFactory() : DualFactoryBase("envoy.filters.http.aws_lambda") {}
 
 private:
+  Extensions::Common::Aws::CredentialsProviderSharedPtr
+  getCredentialsProvider(const std::string& profile,
+                         Server::Configuration::ServerFactoryContext& server_context,
+                         const std::string& region) const;
+
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
       const std::string& stats_prefix, DualInfo dual_info,

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -159,6 +159,30 @@ public:
   CredentialsFileCredentialsProvider provider_;
 };
 
+TEST_F(CredentialsFileCredentialsProviderTest, CustomProfileFromConfigShouldBeHonored) {
+  auto file_path =
+      TestEnvironment::writeStringToFileForTest(CREDENTIALS_FILE, CREDENTIALS_FILE_CONTENTS);
+  TestEnvironment::setEnvVar("AWS_SHARED_CREDENTIALS_FILE", file_path, 1);
+
+  auto provider = CredentialsFileCredentialsProvider(*api_, "profile4");
+  const auto credentials = provider.getCredentials();
+  EXPECT_EQ("profile4_access_key", credentials.accessKeyId().value());
+  EXPECT_EQ("profile4_secret", credentials.secretAccessKey().value());
+  EXPECT_EQ("profile4_token", credentials.sessionToken().value());
+}
+
+TEST_F(CredentialsFileCredentialsProviderTest, UnexistingCustomProfileFomConfig) {
+  auto file_path =
+      TestEnvironment::writeStringToFileForTest(CREDENTIALS_FILE, CREDENTIALS_FILE_CONTENTS);
+  TestEnvironment::setEnvVar("AWS_SHARED_CREDENTIALS_FILE", file_path, 1);
+
+  auto provider = CredentialsFileCredentialsProvider(*api_, "unexistening_profile");
+  const auto credentials = provider.getCredentials();
+  EXPECT_FALSE(credentials.accessKeyId().has_value());
+  EXPECT_FALSE(credentials.secretAccessKey().has_value());
+  EXPECT_FALSE(credentials.sessionToken().has_value());
+}
+
 TEST_F(CredentialsFileCredentialsProviderTest, FileDoesNotExist) {
   TestEnvironment::setEnvVar("AWS_SHARED_CREDENTIALS_FILE", "/file/does/not/exist", 1);
   const auto credentials = provider_.getCredentials();


### PR DESCRIPTION
Commit Message: aws_lambda: add credential profile config to be used with AWS credentials file.

Additional Description: Adds a new config to allow a filter instance use an specific profile from the AWS Credential File.
Due to this new config only has meaning for AWS Credentials File provider, in case it is set, only that provider will be taken in consideration to avoid getting wrong credentials. If a user set this config is because it xpect to get the credentials from the file and should failed if the file is not present or the env var does is missed or incorrectly set

Related: https://github.com/envoyproxy/envoy/issues/31403

Risk Level: Low
Testing: yes
Docs Changes: yes
Release Notes: yes
Platform Specific Features: n/a