### PR TITLE
DFP: move CM callbacks to thread local objects

### DIFF
--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -64,17 +64,8 @@ ProxyFilterConfig::ProxyFilterConfig(
       cluster_init_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(proto_config.sub_cluster_config(),
                                                        cluster_init_timeout, 5000)),
       save_upstream_address_(proto_config.save_upstream_address()) {
-  //tls_slot_.set(
-  //    [&](Event::Dispatcher&) { return std::make_shared<ThreadLocalClusterInfo>(*this); });
-
-  std::weak_ptr<ProxyFilterConfig> this_weak_ptr = this->shared_from_this();
-  tls_slot_.set([this_weak_ptr](
-                Event::Dispatcher&) -> std::shared_ptr<ThreadLocalClusterInfo> {
-    if (auto this_shared_ptr = this_weak_ptr.lock()) {
-      return std::make_shared<ThreadLocalClusterInfo>(this_weak_ptr);
-    }
-    return nullptr;
-  });
+  tls_slot_.set(
+      [&](Event::Dispatcher&) { return std::make_shared<ThreadLocalClusterInfo>(*this); });
 }
 
 LoadClusterEntryHandlePtr ProxyFilterConfig::addDynamicCluster(
@@ -109,11 +100,6 @@ LoadClusterEntryHandlePtr ProxyFilterConfig::addDynamicCluster(
                                                       cluster_name, callbacks);
 }
 
-Upstream::ClusterUpdateCallbacksHandlePtr
-ProxyFilterConfig::addThreadLocalClusterUpdateCallbacks() {
-  return cluster_manager_.addThreadLocalClusterUpdateCallbacks(*this);
-}
-
 ProxyFilterConfig::ThreadLocalClusterInfo::~ThreadLocalClusterInfo() {
   for (const auto& it : pending_clusters_) {
     for (auto cluster : it.second) {
@@ -121,31 +107,23 @@ ProxyFilterConfig::ThreadLocalClusterInfo::~ThreadLocalClusterInfo() {
     }
   }
 }
-
-void ProxyFilterConfig::onClusterAddOrUpdate(absl::string_view cluster_name,
-                                             Upstream::ThreadLocalClusterCommand&) {
-  // Ensure the filter is not deleted in the main thread during this method.
-  auto shared_parent = parent_.lock();
-  if (!shared_parent) {
-    return;
-  }
-
+void ProxyFilterConfig::ThreadLocalClusterInfo::onClusterAddOrUpdate(
+    absl::string_view cluster_name, Upstream::ThreadLocalClusterCommand&) {
   ENVOY_LOG(debug, "thread local cluster {} added or updated", cluster_name);
-  ThreadLocalClusterInfo& tls_cluster_info = *tls_slot_;
-  auto it = tls_cluster_info.pending_clusters_.find(cluster_name);
-  if (it != tls_cluster_info.pending_clusters_.end()) {
+  auto it = pending_clusters_.find(cluster_name);
+  if (it != pending_clusters_.end()) {
     for (auto* cluster : it->second) {
       auto& callbacks = cluster->callbacks_;
       cluster->cancel();
       callbacks.onLoadClusterComplete();
     }
-    tls_cluster_info.pending_clusters_.erase(it);
+    pending_clusters_.erase(it);
   } else {
     ENVOY_LOG(debug, "but not pending request waiting on {}", cluster_name);
   }
 }
 
-void ProxyFilterConfig::onClusterRemoval(const std::string&) {
+void ProxyFilterConfig::ThreadLocalClusterInfo::onClusterRemoval(const std::string&) {
   // do nothing, should have no pending clusters.
 }
 

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
@@ -69,7 +69,15 @@ private:
     LoadClusterEntryCallbacks& callbacks_;
   };
 
-  // Per-thread cluster info including pending callbacks.
+  // Per-thread cluster info including pending clusters.
+  // The lifetime of ThreadLocalClusterInfo, which is allocated on each working thread
+  // may exceed lifetime of the parent object (ProxyFilterConfig), which is allocated
+  // and deleted on the main thread.
+  // Currently ThreadLocalClusterInfo does not hold any references to the parent object
+  // and therefore does not need to check if the parent object is still valid.
+  // IMPORTANT: If a reference to the parent object is added here, the validity of
+  // that object must be checked before using it. It is best achieved via
+  // combination of shared and weak pointers.
   struct ThreadLocalClusterInfo : public ThreadLocal::ThreadLocalObject,
                                   public Envoy::Upstream::ClusterUpdateCallbacks,
                                   Logger::Loggable<Logger::Id::forward_proxy> {

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
@@ -35,6 +35,7 @@ public:
 };
 
 class ProxyFilterConfig : public Upstream::ClusterUpdateCallbacks,
+                          public std::enable_shared_from_this<ProxyFilterConfig>,
                           Logger::Loggable<Logger::Id::forward_proxy> {
 public:
   ProxyFilterConfig(
@@ -79,12 +80,13 @@ private:
 
   // Per-thread cluster info including pending callbacks.
   struct ThreadLocalClusterInfo : public ThreadLocal::ThreadLocalObject {
-    ThreadLocalClusterInfo(ProxyFilterConfig& parent) : parent_{parent} {
-      handle_ = parent.addThreadLocalClusterUpdateCallbacks();
+    ThreadLocalClusterInfo(std::shared_ptr<ProxyFilterConfig> parent) : parent_{parent} {
+      handle_ = parent->addThreadLocalClusterUpdateCallbacks();
     }
     ~ThreadLocalClusterInfo() override;
     absl::flat_hash_map<std::string, std::list<LoadClusterEntryHandleImpl*>> pending_clusters_;
-    ProxyFilterConfig& parent_;
+    std::weak_ptr<ProxyFilterConfig> parent_;
+    //ProxyFilterConfig& parent_;
     Upstream::ClusterUpdateCallbacksHandlePtr handle_;
   };
 


### PR DESCRIPTION
Commit Message:
DFP: move CM callbacks to thread local objects
Additional Description:
This is third attempt to fix #32427. (The previous are #32692 and #32798). 
The solution simply moves callbacks out of main object to thread local objects. Thread local objects do not hold any references to the main object, so both object types are independent and may have different lifespans.

This fixes the reported crash, but is not a generic solution.
I also played with combination of shared/weak pointers and modified signature of the function registering callbacks in CM. That also fixed the problem, but affected other modules (CM itself, aggregate cluster, redis proxy and udp proxy).
At this moment I believe that it is possible to build a generic mechanism which will take care of difference in lifespans of parent object and callbacks, but it will take me few weeks to build and test one and adjust other modules. I will open another PR when such framework is ready for review.

Risk Level: Low
Testing: Manual. Code which used to crash within 15 minutes runs without a crash.
Docs Changes: No
Release Notes: No
Platform Specific Features: No
Fixes #32427
