### PR TITLE
mobile: Fix memory leak in the terminate JNI code

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -60,7 +60,9 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
    * when a new EnvoyEngine is created.
    */
   @VisibleForTesting
-  public static void shutdown() { instance = null; }
+  public static void shutdown() {
+    instance = null;
+  }
 
   private AndroidNetworkMonitor(Context context, EnvoyEngine envoyEngine) {
     int permission =

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -55,6 +55,12 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
     }
   }
 
+  /**
+   * Sets the {@link AndroidNetworkMonitor} singleton instance to null, so that it can be recreated
+   * when a new EnvoyEngine is created.
+   */
+  public static void shutdown() { instance = null; }
+
   private AndroidNetworkMonitor(Context context, EnvoyEngine envoyEngine) {
     int permission =
         ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_NETWORK_STATE);

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -59,6 +59,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
    * Sets the {@link AndroidNetworkMonitor} singleton instance to null, so that it can be recreated
    * when a new EnvoyEngine is created.
    */
+  @VisibleForTesting
   public static void shutdown() { instance = null; }
 
   private AndroidNetworkMonitor(Context context, EnvoyEngine envoyEngine) {

--- a/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -35,11 +35,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import io.envoyproxy.envoymobile.engine.AndroidNetworkMonitor;
 import org.chromium.net.impl.CronvoyUrlRequest;
+import org.chromium.net.impl.CronvoyUrlRequestContext;
 import org.chromium.net.impl.Errors.EnvoyMobileError;
 import org.chromium.net.impl.Errors.NetError;
 import org.chromium.net.impl.CronvoyUrlResponseInfoImpl;
 import org.chromium.net.testing.CronetTestRule;
-import org.chromium.net.testing.CronetTestRule.CronetTestFramework;
 import org.chromium.net.testing.CronetTestRule.RequiresMinApi;
 import org.chromium.net.testing.FailurePhase;
 import org.chromium.net.testing.Feature;
@@ -77,7 +77,6 @@ public class CronetUrlRequestTest {
   @Rule
   public final RuleChain chain = RuleChain.outerRule(mTestRule).around(mRuntimePermissionRule);
 
-  private CronetTestFramework mTestFramework;
   private MockUrlRequestJobFactory mMockUrlRequestJobFactory;
 
   @Before
@@ -91,6 +90,11 @@ public class CronetUrlRequestTest {
   public void tearDown() {
     mMockUrlRequestJobFactory.shutdown();
     NativeTestServer.shutdownNativeTestServer();
+    // Calling AndroidNetworkMonitor.shutdown() will set the AndroidNetworkMonitor singleton
+    // instance to null so that the next EnvoyEngine creation will have a new AndroidNetworkMonitor
+    // instance instead of holding on a dangling EnvoyEngine because AndroidNetworkMonitor.load
+    // does not update the singleton instance to a new one if there is already an existing instance.
+    AndroidNetworkMonitor.shutdown();
   }
 
   private TestUrlRequestCallback startAndWaitForComplete(CronetEngine engine, String url)


### PR DESCRIPTION
This PR fixes a memory leak by deleting the `InternalEngine *` after calling the `InternalEngine::terminate`.

This PR also fixes an issue with `CronetUrlRequestTest.testInternetDisconnectedError()` to always load a new singleton instance of `AndroidNetworkMonitor` by calling `AndroidNetworkMonitor.shutdown()`. Prior to this, `AndroidNetworkInstance` singleton instance might be holding on an `EnvoyEngine` that had been destroyed. Ideally, we should fix this by exposing the `EngineCallbacks.on_exit_` callback to automatically reset the instance of `AndroidNetworkMonitor` to `null` instead of manually calling `AndroidNetworkMonitor.shutdown()`. However, that `EngineCallbacks.on_exit_` callback has not been exposed yet into the Java API.

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
