### PR TITLE
[bp/1.29] contrib: Fix build for fips arm (#32382)

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -481,6 +481,14 @@ config_setting(
     values = {"define": "boringssl=disabled"},
 )
 
+selects.config_setting_group(
+    name = "boringssl_fips_x86",
+    match_all = [
+        ":boringssl_fips",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 config_setting(
     name = "zlib_ng",
     constraint_values = [

--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -28,5 +28,9 @@ PPC_SKIP_CONTRIB_TARGETS = [
     "envoy.compression.qatzip.compressor",
 ]
 
+FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS = [
+    "envoy.compression.qatzip.compressor",
+]
+
 def envoy_all_contrib_extensions(denylist = []):
     return [v + "_envoy_extension" for k, v in CONTRIB_EXTENSIONS.items() if not k in denylist]

--- a/contrib/exe/BUILD
+++ b/contrib/exe/BUILD
@@ -7,6 +7,7 @@ load(
 load(
     "//contrib:all_contrib_extensions.bzl",
     "ARM64_SKIP_CONTRIB_TARGETS",
+    "FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS",
     "PPC_SKIP_CONTRIB_TARGETS",
     "envoy_all_contrib_extensions",
 )
@@ -19,6 +20,13 @@ alias(
     name = "envoy",
     actual = ":envoy-static",
 )
+
+SELECTED_CONTRIB_EXTENSIONS = select({
+    "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
+    "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
+    "//bazel:boringssl_fips_x86": envoy_all_contrib_extensions(FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS),
+    "//conditions:default": envoy_all_contrib_extensions(),
+})
 
 envoy_cc_binary(
     name = "envoy-static",
@@ -41,9 +49,5 @@ envoy_cc_test(
     },
     deps = [
         "//test/config_test:example_configs_test_lib",
-    ] + select({
-        "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
-        "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
-        "//conditions:default": envoy_all_contrib_extensions(),
-    }),
+    ] + SELECTED_CONTRIB_EXTENSIONS,
 )


### PR DESCRIPTION
Previously, the ARM build with FIPS enabled was failing when building on v1.29.0

```
ERROR: /go/src/github.com/DataDog/envoy/contrib/exe/BUILD:31:16: Illegal ambiguous match on configurable attribute "deps" in //contrib/exe:envoy-static:
//bazel:linux_aarch64
//bazel:boringssl_fips
```

This adds `config_setting_group` to make the match explicit - that is, we will skip the `FIPS_LINUX_X86_SKIP_CONTRIB_TARGETS` targets if the target arch is linux x86 and boringssl fips is enabled.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
