### PR TITLE
basic_auth: add support for per-route filter

### DIFF
--- a/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
+++ b/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
@@ -8,8 +8,6 @@ import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
-import "validate/validate.proto";
-
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.basic_auth.v3";
 option java_outer_classname = "BasicAuthProto";
 option java_multiple_files = true;

--- a/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
+++ b/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
@@ -43,15 +43,9 @@ message BasicAuth {
       [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
 }
 
+// Extra settings that may be added to per-route configuration for
+// a virtual host or a cluster.
 message BasicAuthPerRoute {
-  oneof override {
-    option (validate.required) = true;
-
-    // Disable the basic auth filter for this particular vhost or route.
-    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
-    bool disabled = 1 [(validate.rules).bool.const = true];
-
-    // Username-password pairs for this route.
-    config.core.v3.DataSource users = 2 [(validate.rules).message.required = true, (udpa.annotations.sensitive) = true];
-  }
+  // Username-password pairs for this route.
+  config.core.v3.DataSource users = 1 [(validate.rules).message.required = true, (udpa.annotations.sensitive) = true];
 }

--- a/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
+++ b/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
@@ -47,5 +47,6 @@ message BasicAuth {
 // a virtual host or a cluster.
 message BasicAuthPerRoute {
   // Username-password pairs for this route.
-  config.core.v3.DataSource users = 1 [(validate.rules).message.required = true, (udpa.annotations.sensitive) = true];
+  config.core.v3.DataSource users = 1
+      [(validate.rules).message = {required: true}, (udpa.annotations.sensitive) = true];
 }

--- a/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
+++ b/api/envoy/extensions/filters/http/basic_auth/v3/basic_auth.proto
@@ -8,6 +8,8 @@ import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
+import "validate/validate.proto";
+
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.basic_auth.v3";
 option java_outer_classname = "BasicAuthProto";
 option java_multiple_files = true;
@@ -41,4 +43,17 @@ message BasicAuth {
   // If it is not specified, the username will not be forwarded.
   string forward_username_header = 2
       [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
+}
+
+message BasicAuthPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the basic auth filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool.const = true];
+
+    // Username-password pairs for this route.
+    config.core.v3.DataSource users = 2 [(validate.rules).message.required = true, (udpa.annotations.sensitive) = true];
+  }
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -463,6 +463,9 @@ new_features:
     Added maximum gRPC message size that is allowed to be received in Envoy gRPC. If a message over this limit is received,
     the gRPC stream is terminated with the RESOURCE_EXHAUSTED error. This limit is applied to individual messages in the
     streaming response and not the total size of streaming response. Defaults to 0, which means unlimited.
+- area: filters
+  change: |
+    Added :ref:`the Basic Auth per-route filter <envoy_v3_api_msg_extensions.filters.http.basic_auth.v3.BasicAuthPerRoute>`.
 
 deprecated:
 - area: listener

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -465,7 +465,7 @@ new_features:
     streaming response and not the total size of streaming response. Defaults to 0, which means unlimited.
 - area: filters
   change: |
-    Added :ref:`the Basic Auth per-route filter <envoy_v3_api_msg_extensions.filters.http.basic_auth.v3.BasicAuthPerRoute>`.
+    Added :ref:`per-route configuration support to the Basic Auth filter <envoy_v3_api_msg_extensions.filters.http.basic_auth.v3.BasicAuthPerRoute>`.
 
 deprecated:
 - area: listener

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -465,7 +465,8 @@ new_features:
     streaming response and not the total size of streaming response. Defaults to 0, which means unlimited.
 - area: filters
   change: |
-    Added :ref:`per-route configuration support to the Basic Auth filter <envoy_v3_api_msg_extensions.filters.http.basic_auth.v3.BasicAuthPerRoute>`.
+    Added :ref:`per-route configuration support to the Basic Auth filter
+    <envoy_v3_api_msg_extensions.filters.http.basic_auth.v3.BasicAuthPerRoute>`.
 
 deprecated:
 - area: listener

--- a/docs/root/configuration/http/http_filters/basic_auth_filter.rst
+++ b/docs/root/configuration/http/http_filters/basic_auth_filter.rst
@@ -57,7 +57,7 @@ An example configuration of the route filter may look like the following:
             "@type": type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
             users:
               inline_string: |-
-                admin:{SHA}0DPiKuNIrrVmD8IUCuw1hQxNqZc=
+                admin:{SHA}hashed_admin_password
       - match: { prefix: "/static" }
         route: { cluster: some_service }
         typed_per_filter_config:

--- a/docs/root/configuration/http/http_filters/basic_auth_filter.rst
+++ b/docs/root/configuration/http/http_filters/basic_auth_filter.rst
@@ -62,7 +62,7 @@ An example configuration of the route filter may look like the following:
         route: { cluster: some_service }
         typed_per_filter_config:
           envoy.filters.http.basic_auth:
-            "@type": type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
+            "@type": type.googleapis.com/envoy.config.route.v3.FilterConfig
             disabled: true
       - match: { prefix: "/" }
         route: { cluster: some_service }

--- a/docs/root/configuration/http/http_filters/basic_auth_filter.rst
+++ b/docs/root/configuration/http/http_filters/basic_auth_filter.rst
@@ -26,10 +26,14 @@ An example configuration of the filter may look like the following:
 
 .. code-block:: yaml
 
-  users:
-    inline_string: |-
-        user1:{SHA}hashed_user1_password
-        user2:{SHA}hashed_user2_password
+  http_filters:
+  - name: envoy.filters.http.basic_auth
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuth
+      users:
+        inline_string: |-
+          user1:{SHA}hashed_user1_password
+          user2:{SHA}hashed_user2_password
 
 Note that only SHA format is currently supported. Other formats may be added in the future.
 

--- a/docs/root/configuration/http/http_filters/basic_auth_filter.rst
+++ b/docs/root/configuration/http/http_filters/basic_auth_filter.rst
@@ -37,6 +37,38 @@ An example configuration of the filter may look like the following:
 
 Note that only SHA format is currently supported. Other formats may be added in the future.
 
+Per-Route Configuration
+-----------------------
+
+An example configuration of the route filter may look like the following:
+
+.. code-block:: yaml
+
+  route_config:
+    name: local_route
+    virtual_hosts:
+    - name: local_service
+      domains: ["*"]
+      routes:
+      - match: { path: "/admin" }
+        route: { cluster: some_service }
+        typed_per_filter_config:
+          envoy.filters.http.basic_auth:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
+            users:
+              inline_string: |-
+                admin:{SHA}0DPiKuNIrrVmD8IUCuw1hQxNqZc=
+      - match: { prefix: "/static" }
+        route: { cluster: some_service }
+        typed_per_filter_config:
+          envoy.filters.http.basic_auth:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
+            disabled: true
+      - match: { prefix: "/" }
+        route: { cluster: some_service }
+
+In this example we customize users for ``/admin`` route, and disable authentication for ``/static`` prefixed routes.
+
 Statistics
 ----------
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -235,6 +235,7 @@ envoy.filters.http.basic_auth:
   status: alpha
   type_urls:
   - envoy.extensions.filters.http.basic_auth.v3.BasicAuth
+  - envoy.extensions.filters.http.basic_auth.v3.BasicAuthPerRoute
 envoy.filters.http.buffer:
   categories:
   - envoy.filters.http

--- a/source/extensions/filters/http/basic_auth/BUILD
+++ b/source/extensions/filters/http/basic_auth/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//source/common/http:header_utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy_api//envoy/extensions/filters/http/basic_auth/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -39,9 +39,6 @@ Http::FilterHeadersStatus BasicAuthFilter::decodeHeaders(Http::RequestHeaderMap&
       Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfigPerRoute>(decoder_callbacks_);
   auto users = config_->users();
   if (route_specific_settings != nullptr) {
-    if (route_specific_settings->disabled()) {
-      return Http::FilterHeadersStatus::Continue;
-    }
     users = route_specific_settings->users();
   }
 

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -84,7 +84,8 @@ Http::FilterHeadersStatus BasicAuthFilter::decodeHeaders(Http::RequestHeaderMap&
   return Http::FilterHeadersStatus::Continue;
 }
 
-bool BasicAuthFilter::validateUser(const UserMap& users, absl::string_view username, absl::string_view password) const {
+bool BasicAuthFilter::validateUser(const UserMap& users, absl::string_view username,
+                                   absl::string_view password) const {
   auto user = users.find(username);
   if (user == users.end()) {
     return false;

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -37,9 +37,9 @@ BasicAuthFilter::BasicAuthFilter(FilterConfigConstSharedPtr config) : config_(st
 Http::FilterHeadersStatus BasicAuthFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   const auto* route_specific_settings =
       Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfigPerRoute>(decoder_callbacks_);
-  auto users = config_->users();
+  const UserMap* users = &config_->users();
   if (route_specific_settings != nullptr) {
-    users = route_specific_settings->users();
+    users = &route_specific_settings->users();
   }
 
   auto auth_header = headers.get(Http::CustomHeaders::get().Authorization);
@@ -84,10 +84,10 @@ Http::FilterHeadersStatus BasicAuthFilter::decodeHeaders(Http::RequestHeaderMap&
   return Http::FilterHeadersStatus::Continue;
 }
 
-bool BasicAuthFilter::validateUser(const UserMap& users, absl::string_view username,
+bool BasicAuthFilter::validateUser(const UserMap* users, absl::string_view username,
                                    absl::string_view password) const {
-  auto user = users.find(username);
-  if (user == users.end()) {
+  auto user = users->find(username);
+  if (user == users->end()) {
     return false;
   }
 

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -71,7 +71,7 @@ Http::FilterHeadersStatus BasicAuthFilter::decodeHeaders(Http::RequestHeaderMap&
   absl::string_view username = decoded_view.substr(0, colon_pos);
   absl::string_view password = decoded_view.substr(colon_pos + 1);
 
-  if (!validateUser(users, username, password)) {
+  if (!validateUser(*users, username, password)) {
     return onDenied("User authentication failed. Invalid username/password combination.",
                     "invalid_credential_for_basic_auth");
   }
@@ -84,10 +84,10 @@ Http::FilterHeadersStatus BasicAuthFilter::decodeHeaders(Http::RequestHeaderMap&
   return Http::FilterHeadersStatus::Continue;
 }
 
-bool BasicAuthFilter::validateUser(const UserMap* users, absl::string_view username,
+bool BasicAuthFilter::validateUser(const UserMap& users, absl::string_view username,
                                    absl::string_view password) const {
-  auto user = users->find(username);
-  if (user == users->end()) {
+  auto user = users.find(username);
+  if (user == users.end()) {
     return false;
   }
 

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -90,8 +90,6 @@ public:
       : disabled_(config.disabled()) {
   }
 
-  // void merge(const FilterConfigPerRoute& other);
-
   bool disabled() const { return disabled_; }
 
 private:

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -75,7 +75,7 @@ public:
   const UserMap& users() const { return users_; }
 
 private:
-  UserMap users_;
+  const UserMap users_;
   bool disabled_;
 };
 

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -83,7 +83,7 @@ public:
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
-  bool validateUser(const UserMap* users, absl::string_view username,
+  bool validateUser(const UserMap& users, absl::string_view username,
                     absl::string_view password) const;
 
 private:

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -67,14 +67,11 @@ using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
  */
 class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
 public:
-  FilterConfigPerRoute(UserMap&& users, bool disabled):
-      users_(std::move(users)), disabled_(disabled) {}
-  bool disabled() const { return disabled_; }
+  FilterConfigPerRoute(UserMap&& users): users_(std::move(users)) {}
   const UserMap& users() const { return users_; }
 
 private:
   const UserMap users_;
-  bool disabled_;
 };
 
 // The Envoy filter to process HTTP basic auth.

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -83,7 +83,7 @@ public:
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
-  bool validateUser(const UserMap& users, absl::string_view username,
+  bool validateUser(const UserMap* users, absl::string_view username,
                     absl::string_view password) const;
 
 private:

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/extensions/filters/http/basic_auth/v3/basic_auth.pb.h"
 #include "envoy/stats/stats_macros.h"
 
 #include "source/common/common/logger.h"
@@ -75,6 +76,26 @@ private:
 
   // The callback function.
   FilterConfigConstSharedPtr config_;
+};
+
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
+
+/**
+ * Per route settings for BasicAuth. Allows customizing users on a virtualhost\route\weighted cluster level.
+ */
+class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
+public:
+  FilterConfigPerRoute(
+      const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& config)
+      : disabled_(config.disabled()) {
+  }
+
+  // void merge(const FilterConfigPerRoute& other);
+
+  bool disabled() const { return disabled_; }
+
+private:
+  bool disabled_;
 };
 
 } // namespace BasicAuth

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -7,8 +7,6 @@
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include "absl/container/flat_hash_map.h"
-#include <algorithm>
-#include <memory>
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -63,7 +63,8 @@ using FilterConfigConstSharedPtr = std::shared_ptr<const FilterConfig>;
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 /**
- * Per route settings for BasicAuth. Allows customizing users on a virtualhost\route\weighted cluster level.
+ * Per route settings for BasicAuth. Allows customizing users on a virtualhost\route\weighted
+ * cluster level.
  */
 class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
 public:

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -7,6 +7,8 @@
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include "absl/container/flat_hash_map.h"
+#include <algorithm>
+#include <memory>
 
 namespace Envoy {
 namespace Extensions {
@@ -47,8 +49,8 @@ public:
   FilterConfig(UserMap&& users, const std::string& forward_username_header,
                const std::string& stats_prefix, Stats::Scope& scope);
   const BasicAuthStats& stats() const { return stats_; }
-  bool validateUser(absl::string_view username, absl::string_view password) const;
   const std::string& forwardUsernameHeader() const { return forward_username_header_; }
+  const UserMap& users() const { return users_; }
 
 private:
   static BasicAuthStats generateStats(const std::string& prefix, Stats::Scope& scope) {
@@ -60,6 +62,22 @@ private:
   BasicAuthStats stats_;
 };
 using FilterConfigConstSharedPtr = std::shared_ptr<const FilterConfig>;
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
+
+/**
+ * Per route settings for BasicAuth. Allows customizing users on a virtualhost\route\weighted cluster level.
+ */
+class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
+public:
+  FilterConfigPerRoute(UserMap&& users, bool disabled):
+      users_(std::move(users)), disabled_(disabled) {}
+  bool disabled() const { return disabled_; }
+  const UserMap& users() const { return users_; }
+
+private:
+  UserMap users_;
+  bool disabled_;
+};
 
 // The Envoy filter to process HTTP basic auth.
 class BasicAuthFilter : public Http::PassThroughDecoderFilter,
@@ -69,6 +87,7 @@ public:
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
+  bool validateUser(const UserMap& users, absl::string_view username, absl::string_view password) const;
 
 private:
   Http::FilterHeadersStatus onDenied(absl::string_view body,
@@ -76,24 +95,6 @@ private:
 
   // The callback function.
   FilterConfigConstSharedPtr config_;
-};
-
-using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
-
-/**
- * Per route settings for BasicAuth. Allows customizing users on a virtualhost\route\weighted cluster level.
- */
-class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
-public:
-  FilterConfigPerRoute(
-      const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& config)
-      : disabled_(config.disabled()) {
-  }
-
-  bool disabled() const { return disabled_; }
-
-private:
-  bool disabled_;
 };
 
 } // namespace BasicAuth

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -67,7 +67,7 @@ using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
  */
 class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
 public:
-  FilterConfigPerRoute(UserMap&& users): users_(std::move(users)) {}
+  FilterConfigPerRoute(UserMap&& users) : users_(std::move(users)) {}
   const UserMap& users() const { return users_; }
 
 private:
@@ -82,7 +82,8 @@ public:
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
-  bool validateUser(const UserMap& users, absl::string_view username, absl::string_view password) const;
+  bool validateUser(const UserMap& users, absl::string_view username,
+                    absl::string_view password) const;
 
 private:
   Http::FilterHeadersStatus onDenied(absl::string_view body,

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -76,8 +76,11 @@ Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
 
 Router::RouteSpecificFilterConfigConstSharedPtr BasicAuthFilterFactory::createRouteSpecificFilterConfigTyped(
     const BasicAuthPerRoute& proto_config,
-    Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {
-  return std::make_shared<FilterConfigPerRoute>(proto_config);
+    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+  UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(
+      Config::DataSource::read(proto_config.users(), true, context.api()),
+      std::string));
+  return std::make_unique<FilterConfigPerRoute>(std::move(users), proto_config.disabled());
 }
 
 REGISTER_FACTORY(BasicAuthFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -9,6 +9,7 @@ namespace HttpFilters {
 namespace BasicAuth {
 
 using envoy::extensions::filters::http::basic_auth::v3::BasicAuth;
+using envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute;
 
 namespace {
 
@@ -71,6 +72,12 @@ Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<BasicAuthFilter>(config));
   };
+}
+
+Router::RouteSpecificFilterConfigConstSharedPtr BasicAuthFilterFactory::createRouteSpecificFilterConfigTyped(
+    const BasicAuthPerRoute& proto_config,
+    Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) {
+  return std::make_shared<FilterConfigPerRoute>(proto_config);
 }
 
 REGISTER_FACTORY(BasicAuthFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -80,7 +80,7 @@ Router::RouteSpecificFilterConfigConstSharedPtr BasicAuthFilterFactory::createRo
   UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(
       Config::DataSource::read(proto_config.users(), true, context.api()),
       std::string));
-  return std::make_unique<FilterConfigPerRoute>(std::move(users), proto_config.disabled());
+  return std::make_unique<FilterConfigPerRoute>(std::move(users));
 }
 
 REGISTER_FACTORY(BasicAuthFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -74,12 +74,12 @@ Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Router::RouteSpecificFilterConfigConstSharedPtr BasicAuthFilterFactory::createRouteSpecificFilterConfigTyped(
-    const BasicAuthPerRoute& proto_config,
-    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+Router::RouteSpecificFilterConfigConstSharedPtr
+BasicAuthFilterFactory::createRouteSpecificFilterConfigTyped(
+    const BasicAuthPerRoute& proto_config, Server::Configuration::ServerFactoryContext& context,
+    ProtobufMessage::ValidationVisitor&) {
   UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(
-      Config::DataSource::read(proto_config.users(), true, context.api()),
-      std::string));
+      Config::DataSource::read(proto_config.users(), true, context.api()), std::string));
   return std::make_unique<FilterConfigPerRoute>(std::move(users));
 }
 

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -11,7 +11,9 @@ namespace HttpFilters {
 namespace BasicAuth {
 
 class BasicAuthFilterFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::basic_auth::v3::BasicAuth> {
+    : public Common::FactoryBase<
+          envoy::extensions::filters::http::basic_auth::v3::BasicAuth,
+          envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute> {
 public:
   BasicAuthFilterFactory() : FactoryBase("envoy.filters.http.basic_auth") {}
 
@@ -19,6 +21,10 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& proto_config,
+      Server::Configuration::ServerFactoryContext&,
+      ProtobufMessage::ValidationVisitor&) override;
 };
 
 } // namespace BasicAuth

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -23,7 +23,7 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute& proto_config,
-      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor&) override;
 };
 

--- a/test/extensions/filters/http/basic_auth/BUILD
+++ b/test/extensions/filters/http/basic_auth/BUILD
@@ -18,7 +18,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/basic_auth:basic_auth_lib",
         "//test/mocks/server:server_mocks",
-        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/basic_auth/v3:pkg_cc_proto",
     ],
 )
@@ -30,6 +29,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/basic_auth:config",
         "//test/mocks/server:server_mocks",
+        "@envoy_api//envoy/extensions/filters/http/basic_auth/v3:pkg_cc_proto",
     ],
 )
 
@@ -42,5 +42,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/basic_auth:config",
         "//test/integration:http_protocol_integration_lib",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/basic_auth/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/basic_auth/BUILD
+++ b/test/extensions/filters/http/basic_auth/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/basic_auth:basic_auth_lib",
         "//test/mocks/server:server_mocks",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/basic_auth/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
+++ b/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
@@ -153,6 +153,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, NoneExistedUser) {
 TEST_P(BasicAuthIntegrationTestAllProtocols, ExistingUsernameHeader) {
   initializeFilter();
   codec_client_ = makeHttpConnection(lookupPort("http"));
+
   auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"},
       {":path", "/"},
@@ -168,7 +169,6 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, ExistingUsernameHeader) {
   EXPECT_FALSE(username_entry.empty());
   EXPECT_EQ(username_entry[0]->value().getStringView(), "user1");
 
-  waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());

--- a/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
+++ b/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
@@ -45,8 +45,9 @@ public:
 
   void initializePerRouteFilter(std::string yaml_config) {
     config_helper_.addConfigModifier(
-        [&yaml_config](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-               cfg) {
+        [&yaml_config](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                cfg) {
           envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute per_route_config;
           TestUtility::loadFromYaml(yaml_config, per_route_config);
 

--- a/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
+++ b/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
@@ -1,11 +1,12 @@
-#include "test/integration/http_protocol_integration.h"
-#include "test/test_common/utility.h"
+#include <string>
 
 #include "envoy/config/route/v3/route_components.pb.h"
 #include "envoy/extensions/filters/http/basic_auth/v3/basic_auth.pb.h"
 
+#include "test/integration/http_protocol_integration.h"
+#include "test/test_common/utility.h"
+
 #include "gtest/gtest.h"
-#include <string>
 
 namespace Envoy {
 namespace Extensions {
@@ -16,7 +17,7 @@ namespace {
 // user1, test1
 // user2, test2
 const std::string BasicAuthFilterConfig =
-  R"EOF(
+    R"EOF(
 name: envoy.filters.http.basic_auth
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.basic_auth.v3.BasicAuth
@@ -29,7 +30,7 @@ typed_config:
 
 // admin, admin
 const std::string AdminUsers =
-  R"EOF(
+    R"EOF(
 users:
   inline_string: |-
     admin:{SHA}0DPiKuNIrrVmD8IUCuw1hQxNqZc=
@@ -44,36 +45,36 @@ public:
 
   void initializePerRouteFilter(std::string yaml_config) {
     config_helper_.addConfigModifier(
-      [&yaml_config](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-             cfg) {
-        envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute per_route_config;
-        TestUtility::loadFromYaml(yaml_config, per_route_config);
+        [&yaml_config](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+               cfg) {
+          envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute per_route_config;
+          TestUtility::loadFromYaml(yaml_config, per_route_config);
 
-        auto* config = cfg.mutable_route_config()
-                           ->mutable_virtual_hosts()
-                           ->Mutable(0)
-                           ->mutable_typed_per_filter_config();
+          auto* config = cfg.mutable_route_config()
+                             ->mutable_virtual_hosts()
+                             ->Mutable(0)
+                             ->mutable_typed_per_filter_config();
 
-        (*config)["envoy.filters.http.basic_auth"].PackFrom(per_route_config);
-      });
+          (*config)["envoy.filters.http.basic_auth"].PackFrom(per_route_config);
+        });
     config_helper_.prependFilter(BasicAuthFilterConfig);
     initialize();
   }
 
   void disablePerRouteFilter() {
     config_helper_.addConfigModifier(
-      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-             cfg) {
-        envoy::config::route::v3::FilterConfig per_route_config;
-        per_route_config.set_disabled(true);
+        [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+               cfg) {
+          envoy::config::route::v3::FilterConfig per_route_config;
+          per_route_config.set_disabled(true);
 
-        auto* config = cfg.mutable_route_config()
-                           ->mutable_virtual_hosts()
-                           ->Mutable(0)
-                           ->mutable_typed_per_filter_config();
+          auto* config = cfg.mutable_route_config()
+                             ->mutable_virtual_hosts()
+                             ->Mutable(0)
+                             ->mutable_typed_per_filter_config();
 
-        (*config)["envoy.filters.http.basic_auth"].PackFrom(per_route_config);
-      });
+          (*config)["envoy.filters.http.basic_auth"].PackFrom(per_route_config);
+        });
     config_helper_.prependFilter(BasicAuthFilterConfig);
     initialize();
   }

--- a/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
+++ b/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
@@ -43,7 +43,7 @@ public:
     initialize();
   }
 
-  void initializePerRouteFilter(std::string yaml_config) {
+  void initializePerRouteFilter(const std::string& yaml_config) {
     config_helper_.addConfigModifier(
         [&yaml_config](
             envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/extensions/filters/http/basic_auth/v3/basic_auth.pb.h"
+
 #include "source/extensions/filters/http/basic_auth/basic_auth_filter.h"
 #include "source/extensions/filters/http/basic_auth/config.h"
 
@@ -11,6 +13,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace BasicAuth {
 
+using envoy::extensions::filters::http::basic_auth::v3::BasicAuth;
+
 TEST(Factory, ValidConfig) {
   const std::string yaml = R"(
   users:
@@ -21,12 +25,12 @@ TEST(Factory, ValidConfig) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  auto callback = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  auto callback = factory.createFilterFactoryFromProto(proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   callback.value()(filter_callback);
@@ -41,13 +45,13 @@ TEST(Factory, InvalidConfigNoColon) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException);
 }
 
@@ -60,13 +64,13 @@ TEST(Factory, InvalidConfigDuplicateUsers) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: duplicate users");
 }
 
@@ -79,13 +83,13 @@ TEST(Factory, InvalidConfigNoUser) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: empty user name or password");
 }
 
@@ -98,13 +102,13 @@ TEST(Factory, InvalidConfigNoPassword) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: empty user name or password");
 }
 
@@ -117,13 +121,13 @@ TEST(Factory, InvalidConfigNoHash) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: invalid htpasswd format, invalid SHA hash length");
 }
 
@@ -136,13 +140,13 @@ TEST(Factory, InvalidConfigNotSHA) {
   )";
 
   BasicAuthFilterFactory factory;
-  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
-  TestUtility::loadFromYaml(yaml, *proto_config);
+  BasicAuth proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
       EnvoyException, "basic auth: unsupported htpasswd format: please use {SHA}");
 }
 

--- a/test/extensions/filters/http/basic_auth/filter_test.cc
+++ b/test/extensions/filters/http/basic_auth/filter_test.cc
@@ -6,7 +6,6 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include <algorithm>
 
 namespace Envoy {
 namespace Extensions {
@@ -177,8 +176,7 @@ TEST_F(FilterTest, BasicAuthPerRouteEnabled) {
 
   Http::TestRequestHeaderMapImpl valid_credentials{{"Authorization", "Basic YWRtaW46YWRtaW4="}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(valid_credentials, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(valid_credentials, true));
 
   Http::TestRequestHeaderMapImpl invalid_credentials{{"Authorization", "Basic dXNlcjE6dGVzdDE="}};
 

--- a/test/extensions/filters/http/basic_auth/filter_test.cc
+++ b/test/extensions/filters/http/basic_auth/filter_test.cc
@@ -147,7 +147,7 @@ TEST_F(FilterTest, ExistingUsernameHeader) {
 TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
   Http::TestRequestHeaderMapImpl empty_request_headers;
   UserMap empty_users;
-  FilterConfigPerRoute basic_auth_per_route(std::move(empty_users), false);
+  FilterConfigPerRoute basic_auth_per_route(std::move(empty_users));
 
   ON_CALL(*decoder_filter_callbacks_.route_, mostSpecificPerFilterConfig(_))
       .WillByDefault(testing::Return(&basic_auth_per_route));
@@ -167,22 +167,10 @@ TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
             filter_->decodeHeaders(empty_request_headers, true));
 }
 
-TEST_F(FilterTest, BasicAuthPerRouteDisabled) {
-  Http::TestRequestHeaderMapImpl empty_request_headers;
-  UserMap empty_users;
-  FilterConfigPerRoute basic_auth_per_route(std::move(empty_users), true);
-
-  ON_CALL(*decoder_filter_callbacks_.route_, mostSpecificPerFilterConfig(_))
-      .WillByDefault(testing::Return(&basic_auth_per_route));
-
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(empty_request_headers, true));
-}
-
 TEST_F(FilterTest, BasicAuthPerRouteEnabled) {
   UserMap users_for_route;
   users_for_route.insert({"admin", {"admin", "0DPiKuNIrrVmD8IUCuw1hQxNqZc="}}); // admin:admin
-  FilterConfigPerRoute basic_auth_per_route(std::move(users_for_route), false);
+  FilterConfigPerRoute basic_auth_per_route(std::move(users_for_route));
 
   ON_CALL(*decoder_filter_callbacks_.route_, mostSpecificPerFilterConfig(_))
       .WillByDefault(testing::Return(&basic_auth_per_route));


### PR DESCRIPTION
Commit Message: "basic_auth: add support for per-route filter"
Additional Description:
Risk Level: medium
Testing: unit, integration, manual
Docs Changes: added
Release Notes: added
Platform Specific Features: -
Fixes #32550

[Here](https://github.com/jewertow/envoy-playground/tree/master/basic-auth-per-route) you can find configuration and steps for manual tests.
