### PR TITLE
Add disallowed_headers knob to ext_authz config

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -28,7 +28,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -219,7 +219,16 @@ message ExtAuthz {
   //  <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
   //  consequently the value of *Content-Length* of the authorization request reflects the size of
   //  its payload size.
+  //
+  // .. note::
+  //
+  //  3. This can be overridden by the field ``disallowed_headers`` below. That is, if a header
+  //  matches for both ``allowed_headers`` and ``disallowed_headers``, the header will NOT be sent.
   type.matcher.v3.ListStringMatcher allowed_headers = 17;
+
+  // If set, specifically disallow any header in this list to be forwarded to the external
+  // authentication server. This overrides the above ``allowed_headers`` if a header matches both.
+  type.matcher.v3.ListStringMatcher disallowed_headers = 25;
 
   // Specifies if the TLS session level details like SNI are sent to the external service.
   //

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -101,6 +101,12 @@ new_features:
   change: |
     Added :ref:`Filter State Input <envoy_v3_api_msg_extensions.matching.common_inputs.network.v3.FilterStateInput>`
     for matching http input based on filter state objects.
+- area: ext_authz
+  change: |
+    Added :ref:`disallowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.disallowed_headers>`
+    to specify headers that should never be sent to the external authentication service. Overrides
+    :ref:`allowed_headers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.allowed_headers>`
+    if a header matches both.
 - area: quic
   change: |
     Added support for QUIC server preferred address when there is a DNAT between the client and Envoy. See

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -128,7 +128,8 @@ void CheckRequestUtils::setHttpRequest(
     envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq, uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
     const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
-    bool encode_raw_headers, const MatcherSharedPtr& request_header_matchers) {
+    bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
+    const MatcherSharedPtr& disallowed_headers_matcher) {
   httpreq.set_id(std::to_string(stream_id));
   httpreq.set_method(getHeaderStr(headers.Method()));
   httpreq.set_path(getHeaderStr(headers.Path()));
@@ -145,15 +146,18 @@ void CheckRequestUtils::setHttpRequest(
   // Calling mutable_header_map() creates the field in the request; only do so when necessary.
   auto* mutable_header_map = encode_raw_headers ? httpreq.mutable_header_map() : nullptr;
 
-  headers.iterate([encode_raw_headers, request_header_matchers, mutable_headers,
-                   mutable_header_map](const Envoy::Http::HeaderEntry& e) {
+  headers.iterate([encode_raw_headers, allowed_headers_matcher, disallowed_headers_matcher,
+                   mutable_headers, mutable_header_map](const Envoy::Http::HeaderEntry& e) {
     // Skip any client EnvoyAuthPartialBody header, which could interfere with internal use.
     if (e.key().getStringView() == Headers::get().EnvoyAuthPartialBody.get()) {
       return Envoy::Http::HeaderMap::Iterate::Continue;
     }
 
     const std::string key(e.key().getStringView());
-    if (request_header_matchers != nullptr && !request_header_matchers->matches(key)) {
+    if (allowed_headers_matcher != nullptr && !allowed_headers_matcher->matches(key)) {
+      return Envoy::Http::HeaderMap::Iterate::Continue;
+    }
+    if (disallowed_headers_matcher != nullptr && disallowed_headers_matcher->matches(key)) {
       return Envoy::Http::HeaderMap::Iterate::Continue;
     }
 
@@ -208,10 +212,12 @@ void CheckRequestUtils::setAttrContextRequest(
     envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
     const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
-    bool encode_raw_headers, const MatcherSharedPtr& request_header_matchers) {
+    bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
+    const MatcherSharedPtr& disallowed_headers_matcher) {
   setRequestTime(req, stream_info);
   setHttpRequest(*req.mutable_http(), stream_id, stream_info, decoding_buffer, headers,
-                 max_request_bytes, pack_as_bytes, encode_raw_headers, request_header_matchers);
+                 max_request_bytes, pack_as_bytes, encode_raw_headers, allowed_headers_matcher,
+                 disallowed_headers_matcher);
 }
 
 void CheckRequestUtils::setTLSSession(
@@ -232,7 +238,8 @@ void CheckRequestUtils::createHttpCheck(
     envoy::service::auth::v3::CheckRequest& request, uint64_t max_request_bytes, bool pack_as_bytes,
     bool encode_raw_headers, bool include_peer_certificate, bool include_tls_session,
     const Protobuf::Map<std::string, std::string>& destination_labels,
-    const MatcherSharedPtr& request_header_matchers) {
+    const MatcherSharedPtr& allowed_headers_matcher,
+    const MatcherSharedPtr& disallowed_headers_matcher) {
 
   auto attrs = request.mutable_attributes();
   const std::string service = getHeaderStr(headers.EnvoyDownstreamServiceCluster());
@@ -246,7 +253,7 @@ void CheckRequestUtils::createHttpCheck(
                      include_peer_certificate);
   setAttrContextRequest(*attrs->mutable_request(), cb->streamId(), cb->streamInfo(),
                         cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes,
-                        encode_raw_headers, request_header_matchers);
+                        encode_raw_headers, allowed_headers_matcher, disallowed_headers_matcher);
 
   if (include_tls_session && cb->connection()->ssl() != nullptr) {
     setTLSSession(*attrs->mutable_tls_session(), cb->connection()->ssl());

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -154,10 +154,11 @@ void CheckRequestUtils::setHttpRequest(
     }
 
     const std::string key(e.key().getStringView());
-    if (allowed_headers_matcher != nullptr && !allowed_headers_matcher->matches(key)) {
+    if (disallowed_headers_matcher != nullptr && disallowed_headers_matcher->matches(key)) {
       return Envoy::Http::HeaderMap::Iterate::Continue;
     }
-    if (disallowed_headers_matcher != nullptr && disallowed_headers_matcher->matches(key)) {
+
+    if (allowed_headers_matcher != nullptr && !allowed_headers_matcher->matches(key)) {
       return Envoy::Http::HeaderMap::Iterate::Continue;
     }
 

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -100,7 +100,8 @@ public:
                               bool encode_raw_headers, bool include_peer_certificate,
                               bool include_tls_session,
                               const Protobuf::Map<std::string, std::string>& destination_labels,
-                              const MatcherSharedPtr& request_header_matchers);
+                              const MatcherSharedPtr& allowed_headers_matcher,
+                              const MatcherSharedPtr& disallowed_headers_matcher);
 
   /**
    * createTcpCheck is used to extract the attributes from the network layer and fill them up
@@ -133,12 +134,14 @@ private:
                              const Envoy::Http::RequestHeaderMap& headers,
                              uint64_t max_request_bytes, bool pack_as_bytes,
                              bool encode_raw_headers,
-                             const MatcherSharedPtr& request_header_matchers);
+                             const MatcherSharedPtr& allowed_headers_matcher,
+                             const MatcherSharedPtr& disallowed_headers_matcher);
   static void setAttrContextRequest(
       envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
       const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
       const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
-      bool encode_raw_headers, const MatcherSharedPtr& request_header_matchers);
+      bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
+      const MatcherSharedPtr& disallowed_headers_matcher);
   static void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
                             const Ssl::ConnectionInfoConstSharedPtr ssl_info);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -106,7 +106,8 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
       decoder_callbacks_, headers, std::move(context_extensions), std::move(metadata_context),
       std::move(route_metadata_context), check_request_, max_request_bytes_, config_->packAsBytes(),
       config_->headersAsBytes(), config_->includePeerCertificate(), config_->includeTLSSession(),
-      config_->destinationLabels(), config_->requestHeaderMatchers());
+      config_->destinationLabels(), config_->allowedHeadersMatcher(),
+      config_->disallowedHeadersMatcher());
 
   ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server", *decoder_callbacks_);
   // Store start time of ext_authz filter call

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -129,16 +129,20 @@ public:
     // HTTP authz servers only and defaults to blocking all but a few headers (i.e. Authorization,
     // Method, Path and Host).
     if (config.has_grpc_service() && config.has_allowed_headers()) {
-      request_header_matchers_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
+      allowed_headers_matcher_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
           config.allowed_headers(), false, factory_context);
     } else if (config.has_http_service()) {
       if (config.http_service().authorization_request().has_allowed_headers()) {
-        request_header_matchers_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
+        allowed_headers_matcher_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
             config.http_service().authorization_request().allowed_headers(), true, factory_context);
       } else {
-        request_header_matchers_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
+        allowed_headers_matcher_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
             config.allowed_headers(), true, factory_context);
       }
+    }
+    if (config.has_disallowed_headers()) {
+      disallowed_headers_matcher_ = Filters::Common::ExtAuthz::CheckRequestUtils::toRequestMatchers(
+          config.disallowed_headers(), false, factory_context);
     }
   }
 
@@ -205,8 +209,12 @@ public:
 
   bool chargeClusterResponseStats() const { return charge_cluster_response_stats_; }
 
-  const Filters::Common::ExtAuthz::MatcherSharedPtr& requestHeaderMatchers() const {
-    return request_header_matchers_;
+  const Filters::Common::ExtAuthz::MatcherSharedPtr& allowedHeadersMatcher() const {
+    return allowed_headers_matcher_;
+  }
+
+  const Filters::Common::ExtAuthz::MatcherSharedPtr& disallowedHeadersMatcher() const {
+    return disallowed_headers_matcher_;
   }
 
 private:
@@ -267,7 +275,8 @@ private:
   // The stats for the filter.
   ExtAuthzFilterStats stats_;
 
-  Filters::Common::ExtAuthz::MatcherSharedPtr request_header_matchers_;
+  Filters::Common::ExtAuthz::MatcherSharedPtr allowed_headers_matcher_;
+  Filters::Common::ExtAuthz::MatcherSharedPtr disallowed_headers_matcher_;
 
 public:
   // TODO(nezdolik): deprecate cluster scope stats counters in favor of filter scope stats


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add disallowed_headers knob to ext_authz config
Additional Description: This PR adds a config field to ext_authz that will prevent the specified headers from being sent to the external authentication service. This new field (disallowed_headers) will always override the allowed_headers field.
Risk Level: low
Testing: unit tests & integration tests
Docs Changes: none
Release Notes: added to changelog
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
