### PR TITLE
mobile: Add a precondition to throw an exception when an engine has been terminated

### DIFF
--- a/mobile/test/kotlin/integration/EnvoyEngineSimpleIntegrationTest.kt
+++ b/mobile/test/kotlin/integration/EnvoyEngineSimpleIntegrationTest.kt
@@ -1,9 +1,11 @@
 package test.kotlin.integration
 
-import com.google.common.truth.Truth.assertThat
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.engine.JniLibrary
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class EnvoyEngineSimpleIntegrationTest {
@@ -13,10 +15,31 @@ class EnvoyEngineSimpleIntegrationTest {
 
   @Test
   fun `ensure engine build and termination succeeds with no errors`() {
+    val countDownLatch = CountDownLatch(1)
     val engine =
-      EngineBuilder().addLogLevel(LogLevel.DEBUG).setLogger { _, msg -> print(msg) }.build()
-    Thread.sleep(5000)
+      EngineBuilder()
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setOnEngineRunning { countDownLatch.countDown() }
+        .build()
+    countDownLatch.await(5, TimeUnit.SECONDS)
     engine.terminate()
-    assertThat(true).isTrue()
+  }
+
+  @Test
+  fun `ensure no other operations can be executed after a termination`() {
+    val countDownLatch = CountDownLatch(1)
+    val engine =
+      EngineBuilder()
+        .addLogLevel(LogLevel.DEBUG)
+        .setLogger { _, msg -> print(msg) }
+        .setOnEngineRunning { countDownLatch.countDown() }
+        .build()
+    countDownLatch.await(5, TimeUnit.SECONDS)
+    engine.terminate()
+
+    assertThrows(IllegalStateException::class.java) { engine.dumpStats() }
+    assertThrows(IllegalStateException::class.java) { engine.resetConnectivityState() }
+    assertThrows(IllegalStateException::class.java) { engine.terminate() }
   }
 }


### PR DESCRIPTION
Calling operations on a terminated engine can lead to a crash. This PR fixes the issue by having a check to ensure no other operations can be executed once the engine has been terminated.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
