### PR TITLE
load shed: add total count metrics for lsp in overload manager

### DIFF
--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -382,4 +382,5 @@ with the following statistics:
   :widths: 1, 1, 2
 
   scale_percent, Gauge, "Scaled value of the action as a percent (0-99=scaling, 100=saturated)"
+  shed_load_count, Counter, "Total count the load is sheded"
 

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -317,7 +317,7 @@ LoadShedPointImpl::LoadShedPointImpl(const envoy::config::overload::v3::LoadShed
                                      Random::RandomGenerator& random_generator)
     : scale_percent_(makeGauge(stats_scope, config.name(), "scale_percent",
                                Stats::Gauge::ImportMode::NeverImport)),
-      shed_load_counter_(makeCounter(stats_scope, config.name(), "load_shed_count")),
+      shed_load_counter_(makeCounter(stats_scope, config.name(), "shed_load_count")),
       random_generator_(random_generator) {
   for (const auto& trigger_config : config.triggers()) {
     if (!triggers_.try_emplace(trigger_config.name(), createTriggerFromConfig(trigger_config))

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -317,6 +317,7 @@ LoadShedPointImpl::LoadShedPointImpl(const envoy::config::overload::v3::LoadShed
                                      Random::RandomGenerator& random_generator)
     : scale_percent_(makeGauge(stats_scope, config.name(), "scale_percent",
                                Stats::Gauge::ImportMode::NeverImport)),
+      shed_load_counter_(makeCounter(stats_scope, config.name(), "load_shed_count")),
       random_generator_(random_generator) {
   for (const auto& trigger_config : config.triggers()) {
     if (!triggers_.try_emplace(trigger_config.name(), createTriggerFromConfig(trigger_config))
@@ -354,10 +355,15 @@ bool LoadShedPointImpl::shouldShedLoad() {
   float unit_float_probability_shed_load = probability_shed_load_.load();
   // This should be ok as we're using unit float which saturates at 1.0f.
   if (unit_float_probability_shed_load == 1.0f) {
+    shed_load_counter_.inc();
     return true;
   }
 
-  return random_generator_.bernoulli(UnitFloat(unit_float_probability_shed_load));
+  if (random_generator_.bernoulli(UnitFloat(unit_float_probability_shed_load))) {
+    shed_load_counter_.inc();
+    return true;
+  }
+  return false;
 }
 
 OverloadManagerImpl::OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -90,6 +90,7 @@ private:
   absl::flat_hash_map<std::string, TriggerPtr> triggers_;
   std::atomic<float> probability_shed_load_{0};
   Stats::Gauge& scale_percent_;
+  Stats::Counter& shed_load_counter_;
   Random::RandomGenerator& random_generator_;
 };
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -1002,6 +1002,50 @@ TEST_F(OverloadManagerLoadShedPointImplTest, PointUsesTriggerToDetermineWhetherT
   EXPECT_EQ(0, scale_percent.value());
 }
 
+TEST_F(OverloadManagerLoadShedPointImplTest, TriggerLoadShedCunterTest) {
+  setDispatcherExpectation();
+  const std::string config = R"EOF(
+    resource_monitors:
+      - name: envoy.resource_monitors.fake_resource1
+    loadshed_points:
+      - name: "test_point"
+        triggers:
+          - name: "envoy.resource_monitors.fake_resource1"
+            scaled:
+              scaling_threshold: 0.8
+              saturation_threshold: 0.9
+  )EOF";
+
+  auto manager{createOverloadManager(config)};
+  manager->start();
+
+  LoadShedPoint* point = manager->getLoadShedPoint("test_point");
+  ASSERT_NE(point, nullptr);
+
+  Stats::Counter& shed_load_count = stats_.counter("overload.test_point.load_shed_count");
+
+  EXPECT_EQ(0, shed_load_count.value());
+  EXPECT_FALSE(point->shouldShedLoad());
+
+  factory1_.monitor_->setPressure(0.65);
+  timer_cb_();
+  EXPECT_EQ(0, shed_load_count.value());
+  EXPECT_FALSE(point->shouldShedLoad());
+
+  factory1_.monitor_->setPressure(0.95);
+  timer_cb_();
+  EXPECT_TRUE(point->shouldShedLoad());
+  EXPECT_EQ(1, shed_load_count.value());
+
+  factory1_.monitor_->setPressure(0.85);
+  timer_cb_();
+  if (point->shouldShedLoad()) {
+    EXPECT_EQ(2, shed_load_count.value());
+  } else {
+    EXPECT_EQ(1, shed_load_count.value());
+  }
+}
+
 TEST_F(OverloadManagerLoadShedPointImplTest, PointWithMultipleTriggers) {
   setDispatcherExpectation();
   const std::string config = R"EOF(

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -1022,7 +1022,7 @@ TEST_F(OverloadManagerLoadShedPointImplTest, TriggerLoadShedCunterTest) {
   LoadShedPoint* point = manager->getLoadShedPoint("test_point");
   ASSERT_NE(point, nullptr);
 
-  Stats::Counter& shed_load_count = stats_.counter("overload.test_point.load_shed_count");
+  Stats::Counter& shed_load_count = stats_.counter("overload.test_point.shed_load_count");
 
   EXPECT_EQ(0, shed_load_count.value());
   EXPECT_FALSE(point->shouldShedLoad());


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Added one counter stats that will +1 when `shouldShedLoad()` is true.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
