### PR TITLE
grpc: fix maximum gRPC message size changelogs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -458,6 +458,11 @@ new_features:
   change: |
     The ``/stats/prometheus`` endpoint can now emit prometheus ``summary`` metric types by explicitly setting the
     ``histogram_buckets`` query parameter to ``summary``.
+- area: grpc
+  change: |
+    Added maximum gRPC message size that is allowed to be received in Envoy gRPC. If a message over this limit is received,
+    the gRPC stream is terminated with the RESOURCE_EXHAUSTED error. This limit is applied to individual messages in the
+    streaming response and not the total size of streaming response. Defaults to 0, which means unlimited.
 
 deprecated:
 - area: listener
@@ -469,8 +474,4 @@ deprecated:
     deprecated :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>`
     in favor of :ref:`spawn_upstream_span
     <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.
-- area: grpc
-  change: |
-    Added maximum gRPC message size that is allowed to be received in Envoy gRPC. If a message over this limit is received,
-    the gRPC stream is terminated with the RESOURCE_EXHAUSTED error. This limit is applied to individual messages in the
-    streaming response and not the total size of streaming response. Defaults to 0, which means unlimited.
+

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -474,4 +474,3 @@ deprecated:
     deprecated :ref:`split_spans_for_request <envoy_v3_api_field_config.trace.v3.ZipkinConfig.split_spans_for_request>`
     in favor of :ref:`spawn_upstream_span
     <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.Tracing.spawn_upstream_span>`.
-


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Move it from deprecated to new feature  introduced from #32711

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
