### PR TITLE
mobile: Link the test servers with test_extensions

### DIFF
--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -53,6 +53,8 @@ cc_library(
         "//test/common/integration:test_server_lib",
         "@envoy//test/test_common:test_version_linkstamp",
         "@envoy_build_config//:extension_registry",
+        # This is needed since some tests use test extensions.
+        "@envoy_build_config//:test_extensions",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,
@@ -84,6 +86,8 @@ cc_library(
         "//test/common/integration:test_server_lib",
         "@envoy//test/test_common:test_version_linkstamp",
         "@envoy_build_config//:extension_registry",
+        # This is needed since some tests use test extensions.
+        "@envoy_build_config//:test_extensions",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,
@@ -116,6 +120,8 @@ cc_library(
         "//test/common/integration:xds_test_server_lib",
         "@envoy//test/test_common:test_version_linkstamp",
         "@envoy_build_config//:extension_registry",
+        # This is needed since some tests use test extensions.
+        "@envoy_build_config//:test_extensions",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.
     alwayslink = True,


### PR DESCRIPTION
Occasionally I have seen test failures due to missing cluster factory implementation, such as

```
Didn't find a registered cluster factory implementation for name: 'envoy.cluster.static
```

This PR fixes the issue by linking the JNI test servers with `@envoy_build_config//:test_extensions` to force the factory registrations.

Risk Level: low (tests only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
