### PR TITLE
mobile: Allow the Kotlin XdsTest to accept untrusted certs

### DIFF
--- a/mobile/test/kotlin/integration/XdsTest.kt
+++ b/mobile/test/kotlin/integration/XdsTest.kt
@@ -7,6 +7,7 @@ import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.XdsBuilder
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.XdsTestServerFactory
 import java.io.File
@@ -31,8 +32,6 @@ class XdsTest {
 
   @Before
   fun setUp() {
-    val upstreamCert: String =
-      File("../envoy/test/config/integration/certs/upstreamcacert.pem").readText()
     xdsTestServer = XdsTestServerFactory.create()
     val latch = CountDownLatch(1)
     engine =
@@ -40,12 +39,12 @@ class XdsTest {
         .addLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> print(msg) }
         .setOnEngineRunning { latch.countDown() }
+        .setTrustChainVerification(TrustChainVerification.ACCEPT_UNTRUSTED)
         .setXds(
           XdsBuilder(
               xdsTestServer.host,
               xdsTestServer.port,
             )
-            .setSslRootCerts(upstreamCert)
             .addClusterDiscoveryService()
         )
         .build()

--- a/mobile/test/kotlin/integration/XdsTest.kt
+++ b/mobile/test/kotlin/integration/XdsTest.kt
@@ -10,7 +10,6 @@ import io.envoyproxy.envoymobile.engine.AndroidJniLibrary
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification
 import io.envoyproxy.envoymobile.engine.JniLibrary
 import io.envoyproxy.envoymobile.engine.testing.XdsTestServerFactory
-import java.io.File
 import java.util.concurrent.CountDownLatch
 import org.junit.After
 import org.junit.Before


### PR DESCRIPTION
The test only sends requests to a local server.  Unfortunately, `upstreamcacert.pem` has expired as of Apr 6, 2024[1].  While we work out generating a new cert, this solves a current permafail in the XdsTest, and `ACCEPT_UNTRUSTED` is used in other mobile integration tests (e.g. https://github.com/envoyproxy/envoy/blob/f580ed067db0f2a48085aa33e45a3a9cf5e36bfe/mobile/test/kotlin/integration/ReceiveTrailersTest.kt#L55).

[1] Determined by running `openssl x509 -in test/config/integration/certs/upstreamcacert.pem -text -noout`