### PR TITLE
mobile: Moves all Swift tests to EngineBuilder APIs

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -305,7 +305,6 @@ build:mobile-remote-ci-macos-ios --config=mobile-test-ios
 build:mobile-remote-ci-macos-ios-admin --config=mobile-remote-ci-macos-ios
 
 build:mobile-remote-ci-macos-ios-swift --config=mobile-remote-ci-macos-ios
-build:mobile-remote-ci-macos-ios-swift --define=envoy_yaml=enabled
 test:mobile-remote-ci-macos-ios-swift --build_tests_only
 
 build:mobile-remote-ci-macos-ios-obj-c --config=mobile-remote-ci-macos-ios

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -106,6 +106,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 
@@ -145,6 +146,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 

--- a/mobile/test/swift/integration/BUILD
+++ b/mobile/test/swift/integration/BUILD
@@ -120,6 +120,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 
@@ -160,6 +161,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 
@@ -173,6 +175,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 
@@ -186,6 +189,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 
@@ -199,6 +203,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 
@@ -212,6 +217,7 @@ envoy_mobile_swift_test(
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
+        "//test/objective-c:envoy_test_server",
     ],
 )
 

--- a/mobile/test/swift/integration/ReceiveDataTest.swift
+++ b/mobile/test/swift/integration/ReceiveDataTest.swift
@@ -1,5 +1,6 @@
 import Envoy
 import EnvoyEngine
+import EnvoyTestServer
 import Foundation
 import TestExtensions
 import XCTest
@@ -11,68 +12,25 @@ final class ReceiveDataTests: XCTestCase {
   }
 
   func testReceiveData() {
-    // swiftlint:disable:next line_length
-    let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
-    // swiftlint:disable:next line_length
-    let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-    let assertionResponseBody = "response_body"
-    let config =
-"""
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": \(emhcmType)
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-                      body:
-                        inline_string: \(assertionResponseBody)
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": \(assertionFilterType)
-                match_config:
-                  http_request_headers_match:
-                    headers:
-                      - name: ":authority"
-                        exact_match: example.com
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-"""
-    let engine = EngineBuilder(yaml: config)
+    let directResponseBody = "response_body"
+    EnvoyTestServer.startHttp1PlaintextServer()
+    EnvoyTestServer.setHeadersAndData(
+      "x-response-foo", header_value: "aaa", response_body: directResponseBody)
+
+    let engine = EngineBuilder()
       .addLogLevel(.debug)
       .build()
 
     let client = engine.streamClient()
 
-    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
-                                               authority: "example.com", path: "/test")
+    let port = String(EnvoyTestServer.getEnvoyPort())
+    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "http",
+                                               authority: "localhost:" + port, path: "/simple.txt")
       .build()
 
     let headersExpectation = self.expectation(description: "Run called with expected headers")
     let dataExpectation = self.expectation(description: "Run called with expected data")
+    var actualResponseBody: String = ""
 
     client
       .newStreamPrototype()
@@ -80,10 +38,11 @@ static_resources:
          XCTAssertEqual(200, responseHeaders.httpStatus)
          headersExpectation.fulfill()
       }
-      .setOnResponseData { data, _, _ in
-        let responseBody = String(data: data, encoding: .utf8)
-        XCTAssertEqual(assertionResponseBody, responseBody)
-        dataExpectation.fulfill()
+      .setOnResponseData { data, endStream, _ in
+        actualResponseBody.append(String(data: data, encoding: .utf8) ?? "")
+        if endStream {
+          dataExpectation.fulfill()
+        }
       }
       .setOnError { _, _ in
         XCTFail("Unexpected error")
@@ -95,6 +54,9 @@ static_resources:
                                   enforceOrder: true),
                    .completed)
 
+    XCTAssertEqual(actualResponseBody, directResponseBody)
+
     engine.terminate()
+    EnvoyTestServer.shutdownTestServer()
   }
 }

--- a/mobile/test/swift/integration/SendDataTest.swift
+++ b/mobile/test/swift/integration/SendDataTest.swift
@@ -1,5 +1,6 @@
 import Envoy
 import EnvoyEngine
+import EnvoyTestServer
 import Foundation
 import TestExtensions
 import XCTest
@@ -11,78 +12,46 @@ final class SendDataTests: XCTestCase {
   }
 
   func testSendData() throws {
-    // swiftlint:disable:next line_length
-    let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
+    EnvoyTestServer.startHttp1PlaintextServer()
+    EnvoyTestServer.setHeadersAndData("x-response-foo", header_value: "aaa", response_body: "data")
+
     // swiftlint:disable:next line_length
     let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
     let requestStringMatch = "match_me"
-    let config =
-"""
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": \(emhcmType)
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": \(assertionFilterType)
-                match_config:
-                  http_request_generic_body_match:
-                    patterns:
-                      - string_match: \(requestStringMatch)
-            - name: envoy.filters.http.buffer
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
-                max_request_bytes: 65000
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-"""
+
     let expectation = self.expectation(description: "Run called with expected http status")
-    let engine = EngineBuilder(yaml: config)
+    let engine = EngineBuilder()
       .addLogLevel(.debug)
+      .addNativeFilter(
+        name: "test_logger",
+        // swiftlint:disable:next line_length
+        typedConfig: "[\(assertionFilterType)] { match_config { http_request_generic_body_match: { patterns: { string_match: '\(requestStringMatch)'}}}}"
+      )
       .build()
 
     let client = engine.streamClient()
 
-    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
-                                               authority: "example.com", path: "/test")
+    let port = String(EnvoyTestServer.getEnvoyPort())
+    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "http",
+                                               authority: "localhost:" + port, path: "/simple.txt")
       .build()
     let body = try XCTUnwrap(requestStringMatch.data(using: .utf8))
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, endStream, _ in
+      .setOnResponseHeaders { responseHeaders, _, _ in
          XCTAssertEqual(200, responseHeaders.httpStatus)
-         XCTAssertTrue(endStream)
-         expectation.fulfill()
+      }
+      .setOnResponseData { _, endStream, _ in
+        if endStream {
+          expectation.fulfill()
+        }
       }
       .setOnError { _, _ in
         XCTFail("Unexpected error")
+      }
+      .setOnCancel { _ in
+        XCTFail("Unexpected cancel")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: false)
@@ -91,5 +60,6 @@ static_resources:
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
 
     engine.terminate()
+    EnvoyTestServer.shutdownTestServer()
   }
 }

--- a/mobile/test/swift/integration/SendHeadersTest.swift
+++ b/mobile/test/swift/integration/SendHeadersTest.swift
@@ -14,7 +14,8 @@ final class SendHeadersTests: XCTestCase {
   func testSendHeaders() {
     EnvoyTestServer.startHttp1PlaintextServer()
 
-    let headersExpectation = self.expectation(description: "Run called with expected http headers status")
+    let headersExpectation = self.expectation(
+      description: "Run called with expected http headers status")
     let endStreamExpectation = self.expectation(description: "End stream encountered")
     let engine = EngineBuilder()
       .addLogLevel(.debug)

--- a/mobile/test/swift/integration/SendHeadersTest.swift
+++ b/mobile/test/swift/integration/SendHeadersTest.swift
@@ -1,5 +1,6 @@
 import Envoy
 import EnvoyEngine
+import EnvoyTestServer
 import Foundation
 import TestExtensions
 import XCTest
@@ -11,69 +12,34 @@ final class SendHeadersTests: XCTestCase {
   }
 
   func testSendHeaders() {
-    // swiftlint:disable:next line_length
-    let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
-    // swiftlint:disable:next line_length
-    let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
-    let config =
-"""
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": \(emhcmType)
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": \(assertionFilterType)
-                match_config:
-                  http_request_headers_match:
-                    headers:
-                      - name: ":authority"
-                        exact_match: example.com
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-"""
-    let expectation = self.expectation(description: "Run called with expected http status")
-    let engine = EngineBuilder(yaml: config)
+    EnvoyTestServer.startHttp1PlaintextServer()
+
+    let headersExpectation = self.expectation(description: "Run called with expected http headers status")
+    let endStreamExpectation = self.expectation(description: "End stream encountered")
+    let engine = EngineBuilder()
       .addLogLevel(.debug)
       .build()
 
     let client = engine.streamClient()
 
-    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
-                                               authority: "example.com", path: "/test")
+    let port = String(EnvoyTestServer.getEnvoyPort())
+    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "http",
+                                               authority: "localhost:" + port, path: "/simple.txt")
       .build()
+
     client
       .newStreamPrototype()
       .setOnResponseHeaders { responseHeaders, endStream, _ in
          XCTAssertEqual(200, responseHeaders.httpStatus)
-         XCTAssertTrue(endStream)
-         expectation.fulfill()
+         headersExpectation.fulfill()
+         if endStream {
+           endStreamExpectation.fulfill()
+         }
+      }
+      .setOnResponseData { _, endStream, _ in
+         if endStream {
+           endStreamExpectation.fulfill()
+         }
       }
       .setOnError { _, _ in
         XCTFail("Unexpected error")
@@ -81,8 +47,10 @@ static_resources:
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
+    let expectations = [headersExpectation, endStreamExpectation]
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 10), .completed)
 
     engine.terminate()
+    EnvoyTestServer.shutdownTestServer()
   }
 }

--- a/mobile/test/swift/integration/SendTrailersTest.swift
+++ b/mobile/test/swift/integration/SendTrailersTest.swift
@@ -1,5 +1,6 @@
 import Envoy
 import EnvoyEngine
+import EnvoyTestServer
 import Foundation
 import TestExtensions
 import XCTest
@@ -12,67 +13,33 @@ final class SendTrailersTests: XCTestCase {
 
   func testSendTrailers() throws {
     // swiftlint:disable:next line_length
-    let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
-    // swiftlint:disable:next line_length
     let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+    let bufferFilterType = "type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer"
     let matcherTrailerName = "test-trailer"
     let matcherTrailerValue = "test.code"
-    let config =
-"""
-listener_manager:
-    name: envoy.listener_manager_impl.api
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.listener.v3.ApiListenerManager
-static_resources:
-  listeners:
-  - name: base_api_listener
-    address:
-      socket_address:
-        protocol: TCP
-        address: 0.0.0.0
-        port_value: 10000
-    api_listener:
-      api_listener:
-        "@type": \(emhcmType)
-        config:
-          stat_prefix: hcm
-          route_config:
-            name: api_router
-            virtual_hosts:
-              - name: api
-                domains:
-                  - "*"
-                routes:
-                  - match:
-                      prefix: "/"
-                    direct_response:
-                      status: 200
-          http_filters:
-            - name: envoy.filters.http.assertion
-              typed_config:
-                "@type": \(assertionFilterType)
-                match_config:
-                  http_request_trailers_match:
-                    headers:
-                      - name: \(matcherTrailerName)
-                        exact_match: \(matcherTrailerValue)
-            - name: envoy.filters.http.buffer
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
-                max_request_bytes: 65000
-            - name: envoy.router
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-"""
+
     let expectation = self.expectation(description: "Run called with expected http status")
-    let engine = EngineBuilder(yaml: config)
+
+    EnvoyTestServer.startHttp1PlaintextServer()
+
+    let engine = EngineBuilder()
       .addLogLevel(.debug)
+      .addNativeFilter(
+        name: "envoy.filters.http.assertion",
+        // swiftlint:disable:next line_length
+        typedConfig: "[\(assertionFilterType)] {match_config: {http_request_trailers_match: {headers: [{name: '\(matcherTrailerName)', exact_match: '\(matcherTrailerValue)'}]}}}"
+      )
+      .addNativeFilter(
+        name: "envoy.filters.http.buffer",
+        typedConfig: "[\(bufferFilterType)] { max_request_bytes: { value: 65000 } }"
+      )
       .build()
 
     let client = engine.streamClient()
 
-    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
-                                               authority: "example.com", path: "/test")
+    let port = String(EnvoyTestServer.getEnvoyPort())
+    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "http",
+                                               authority: "localhost:" + port, path: "/simple.txt")
       .build()
     let body = try XCTUnwrap("match_me".data(using: .utf8))
     let requestTrailers = RequestTrailersBuilder()
@@ -96,5 +63,6 @@ static_resources:
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
 
     engine.terminate()
+    EnvoyTestServer.shutdownTestServer()
   }
 }

--- a/mobile/test/swift/integration/SetEventTrackerTestNoTracker.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTestNoTracker.swift
@@ -1,5 +1,6 @@
 import Envoy
 import EnvoyEngine
+import EnvoyTestServer
 import Foundation
 import TestExtensions
 import XCTest
@@ -10,8 +11,9 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
     register_test_extensions()
   }
 
-  // Skipping because this test currently attempts to connect to an invalid remote (example.com)
-  func skipped_testSetEventTracker() throws {
+  func testSetEventTracker() throws {
+    EnvoyTestServer.startHttp1PlaintextServer()
+
     let expectation = self.expectation(description: "Response headers received")
 
     let engine = EngineBuilder()
@@ -19,13 +21,14 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
       .addNativeFilter(
         name: "envoy.filters.http.test_event_tracker",
         // swiftlint:disable:next line_length
-        typedConfig: "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker\",\"attributes\":{\"foo\":\"bar\"}}")
+        typedConfig: "[type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker] { attributes: { key: 'foo' value: 'bar'}}")
       .build()
 
     let client = engine.streamClient()
 
-    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
-                                               authority: "example.com", path: "/test")
+    let port = String(EnvoyTestServer.getEnvoyPort())
+    let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "http",
+                                               authority: "localhost:" + port, path: "/simple.txt")
       .build()
 
     client
@@ -39,5 +42,6 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
 
     engine.terminate()
+    EnvoyTestServer.shutdownTestServer()
   }
 }

--- a/mobile/test/swift/integration/SetLoggerTest.swift
+++ b/mobile/test/swift/integration/SetLoggerTest.swift
@@ -25,7 +25,7 @@ final class LoggerTests: XCTestCase {
       .addNativeFilter(
         name: "test_logger",
         // swiftlint:disable:next line_length
-        typedConfig: "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger\"}")
+        typedConfig: "[type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger]{}")
       .setLogger { _, msg in
         if msg.contains("starting main dispatch loop") {
           loggingExpectation.fulfill()


### PR DESCRIPTION
As part of this change, the native filters that get added on the EngineBuilder use the proto format, not YAML.
As a result, iOS CI is also updated to build without YAML enabled.