### PR TITLE
allow configuring max request buffer size without buffering it per route

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -360,7 +360,8 @@ message Route {
   string stat_prefix = 19;
 
   // Sets the maximum size of a request body that will be buffered in memory. Envoy will return
-  // ``HTTP 413`` when buffer reaches the number set in this field.
+  // ``HTTP 413`` or trigger the ``onDecoderFilterAboveWriteBufferHighWatermark`` callback
+  // when buffer reaches the number set in this field.
   // This option will be ignored if the current maximum buffer size is already larger than
   // the value set in this field.
   // Unlike the ``max_request_bytes`` in the ``buffer`` filter, setting this field won't force

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -245,7 +245,7 @@ message RouteList {
 //
 //   Envoy supports routing on HTTP method via :ref:`header matching
 //   <envoy_v3_api_msg_config.route.v3.HeaderMatcher>`.
-// [#next-free-field: 20]
+// [#next-free-field: 21]
 message Route {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.Route";
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -358,6 +358,14 @@ message Route {
   //    every application endpoint. This is both not easily maintainable and
   //    statistics use a non-trivial amount of memory(approximately 1KiB per route).
   string stat_prefix = 19;
+
+  // Sets the maximum size of a request body that will be buffered in memory. Envoy will return
+  // ``HTTP 413`` when buffer reaches the number set in this field.
+  // This option will be ignored if the current maximum buffer size is already larger than
+  // the value set in this field.
+  // Unlike the ``max_request_bytes`` in the ``buffer`` filter, setting this field won't force
+  // Envoy to buffer the request.
+  uint32 max_request_buffer_bytes = 20;
 }
 
 // Compared to the :ref:`cluster <envoy_v3_api_field_config.route.v3.RouteAction.cluster>` field that specifies a

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -989,6 +989,11 @@ public:
   virtual const std::vector<ShadowPolicyPtr>& shadowPolicies() const PURE;
 
   /**
+   * @return uint32_t the route's configured max request buffer bytes.
+   */
+  virtual uint32_t maxRequestBufferBytes() const PURE;
+
+  /**
    * @return std::chrono::milliseconds the route's timeout.
    */
   virtual std::chrono::milliseconds timeout() const PURE;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -315,6 +315,7 @@ private:
 
     void refreshCachedRoute(const Router::RouteCallback& cb);
 
+    void refreshRequestLimit();
     void refreshCachedTracingCustomTags();
     void refreshDurationTimeout();
     void refreshIdleTimeout();

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -796,6 +796,10 @@ public:
 
   // Possibly increases buffer_limit_ to the value of limit.
   void setBufferLimit(uint32_t limit);
+  /**
+   * @return uint32_t the current buffer limit
+   */
+  uint32_t bufferLimit() const { return buffer_limit_; }
 
   /**
    * @return bool whether any above high watermark triggers are currently active

--- a/source/common/http/null_route_impl.h
+++ b/source/common/http/null_route_impl.h
@@ -140,6 +140,7 @@ struct RouteEntryImpl : public Router::RouteEntry {
   const std::vector<Router::ShadowPolicyPtr>& shadowPolicies() const override {
     return shadow_policies_;
   }
+  uint32_t maxRequestBufferBytes() const override { return 0; }
   std::chrono::milliseconds timeout() const override {
     if (timeout_) {
       return timeout_.value();

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -536,6 +536,7 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
       route_name_(route.name()), time_source_(factory_context.mainThreadDispatcher().timeSource()),
       retry_shadow_buffer_limit_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           route, per_request_buffer_limit_bytes, vhost->retryShadowBufferLimit())),
+      max_request_buffer_bytes_(route.max_request_buffer_bytes()),
       direct_response_code_(ConfigUtility::parseDirectResponseCode(route)),
       cluster_not_found_response_code_(ConfigUtility::parseClusterNotFoundResponseCode(
           route.route().cluster_not_found_response_code())),

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -722,6 +722,7 @@ public:
   const VirtualCluster* virtualCluster(const Http::HeaderMap& headers) const override {
     return vhost_->virtualClusterFromEntries(headers);
   }
+  uint32_t maxRequestBufferBytes() const override { return max_request_buffer_bytes_; }
   std::chrono::milliseconds timeout() const override { return timeout_; }
   bool usingNewTimeouts() const override { return using_new_timeouts_; }
 
@@ -858,6 +859,7 @@ public:
     const std::vector<ShadowPolicyPtr>& shadowPolicies() const override {
       return parent_->shadowPolicies();
     }
+    uint32_t maxRequestBufferBytes() const override { return parent_->maxRequestBufferBytes(); }
     std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
     absl::optional<std::chrono::milliseconds> idleTimeout() const override {
       return parent_->idleTimeout();
@@ -1222,6 +1224,7 @@ private:
 
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   uint32_t retry_shadow_buffer_limit_{std::numeric_limits<uint32_t>::max()};
+  uint32_t max_request_buffer_bytes_;
   const absl::optional<Http::Code> direct_response_code_;
   const Http::Code cluster_not_found_response_code_;
   const Upstream::ResourcePriority priority_;

--- a/source/common/router/delegating_route_impl.cc
+++ b/source/common/router/delegating_route_impl.cc
@@ -96,6 +96,10 @@ const std::vector<Router::ShadowPolicyPtr>& DelegatingRouteEntry::shadowPolicies
   return base_route_->routeEntry()->shadowPolicies();
 }
 
+uint32_t DelegatingRouteEntry::maxRequestBufferBytes() const {
+  return base_route_->routeEntry()->maxRequestBufferBytes();
+}
+
 std::chrono::milliseconds DelegatingRouteEntry::timeout() const {
   return base_route_->routeEntry()->timeout();
 }

--- a/source/common/router/delegating_route_impl.h
+++ b/source/common/router/delegating_route_impl.h
@@ -93,6 +93,7 @@ public:
   const InternalRedirectPolicy& internalRedirectPolicy() const override;
   uint32_t retryShadowBufferLimit() const override;
   const std::vector<Router::ShadowPolicyPtr>& shadowPolicies() const override;
+  uint32_t maxRequestBufferBytes() const override;
   std::chrono::milliseconds timeout() const override;
   absl::optional<std::chrono::milliseconds> idleTimeout() const override;
   bool usingNewTimeouts() const override;

--- a/test/common/router/delegating_route_impl_test.cc
+++ b/test/common/router/delegating_route_impl_test.cc
@@ -66,6 +66,7 @@ TEST(DelegatingRouteEntry, DelegatingRouteEntryTest) {
   TEST_METHOD(internalRedirectPolicy);
   TEST_METHOD(retryShadowBufferLimit);
   TEST_METHOD(shadowPolicies);
+  TEST_METHOD(maxRequestBufferBytes);
   TEST_METHOD(timeout);
   TEST_METHOD(idleTimeout);
   TEST_METHOD(usingNewTimeouts);

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -433,7 +433,7 @@ public:
   MOCK_METHOD(const PathRewriterSharedPtr&, pathRewriter, (), (const));
   MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
   MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
-  MOCK_METHOD(uint32_t, maxRequestBytes, (), (const));
+  MOCK_METHOD(uint32_t, maxRequestBufferBytes, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
   MOCK_METHOD(bool, usingNewTimeouts, (), (const));

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -433,6 +433,7 @@ public:
   MOCK_METHOD(const PathRewriterSharedPtr&, pathRewriter, (), (const));
   MOCK_METHOD(uint32_t, retryShadowBufferLimit, (), (const));
   MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
+  MOCK_METHOD(uint32_t, maxRequestBytes, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
   MOCK_METHOD(bool, usingNewTimeouts, (), (const));


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: allow configuring max request buffer size without buffering it per route
Additional Description: With this feature, we can increase the buffer size for some routes which has filters that buffers the request optionally, for example, a WAF filter.
Risk Level: Low
Testing: Unit & Integration
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #32205
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
