### PR TITLE
tracer: implement zipkin getTraceIdAsHex

### DIFF
--- a/source/extensions/access_loggers/open_telemetry/access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/access_log_impl.cc
@@ -90,8 +90,15 @@ void AccessLog::emitLog(const Formatter::HttpFormatterContext& log_context,
   }
   const auto formatted_attributes = attributes_formatter_->format(log_context, stream_info);
   *log_entry.mutable_attributes() = formatted_attributes.values();
-  *log_entry.mutable_trace_id() =
-      absl::HexStringToBytes(log_context.activeSpan().getTraceIdAsHex());
+
+  // Setting the trace id if available.
+  std::string trace_id_hex = log_context.activeSpan().getTraceIdAsHex();
+  if (trace_id_hex.size() == 32) {
+    *log_entry.mutable_trace_id() = absl::HexStringToBytes(trace_id_hex);
+  } else if (trace_id_hex.size() == 16) {
+    auto trace_id = absl::StrCat(Hex::uint64ToHex(0), trace_id_hex);
+    *log_entry.mutable_trace_id() = absl::HexStringToBytes(trace_id);
+  }
 
   tls_slot_->getTyped<ThreadLocalLogger>().logger_->log(std::move(log_entry));
 }

--- a/source/extensions/access_loggers/open_telemetry/access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/access_log_impl.cc
@@ -92,6 +92,9 @@ void AccessLog::emitLog(const Formatter::HttpFormatterContext& log_context,
   *log_entry.mutable_attributes() = formatted_attributes.values();
 
   // Setting the trace id if available.
+  // OpenTelemetry trace id is a [16]byte array, backend(e.g. OTel-collector) will reject the
+  // request if the length is not 16. Some trace provider(e.g. zipkin) may return it as a 64-bit hex
+  // string. In this case, we need to convert it to a 128-bit hex string, padding left with zeros.
   std::string trace_id_hex = log_context.activeSpan().getTraceIdAsHex();
   if (trace_id_hex.size() == 32) {
     *log_entry.mutable_trace_id() = absl::HexStringToBytes(trace_id_hex);

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -83,8 +83,7 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override;
   std::string getBaggage(absl::string_view) override;
 
-  // TODO: This method is unimplemented for Zipkin.
-  std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  std::string getTraceIdAsHex() const override { return span_.traceIdAsHexString(); };
 
   /**
    * @return a reference to the Zipkin::Span object.

--- a/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
@@ -185,6 +185,26 @@ TEST_F(AccessLogTest, TraceId) {
       stream_info);
 }
 
+TEST_F(AccessLogTest, ZipkinTraceId) {
+  InSequence s;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  stream_info.start_time_ = SystemTime(1h);
+  Http::TestRequestHeaderMapImpl request_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
+  auto access_log = makeAccessLog({}, {});
+
+  NiceMock<Tracing::MockSpan> active_span;
+
+  EXPECT_CALL(active_span, getTraceIdAsHex()).WillOnce(Return("0ccce09bf12e94df"));
+  expectLog(R"EOF(
+      trace_id: "AAAAAAAAAAAMzOCb8S6U3w=="
+      time_unix_nano: 3600000000000
+    )EOF");
+  access_log->log(
+      {&request_headers, &response_headers, nullptr, {}, AccessLogType::NotSet, &active_span},
+      stream_info);
+}
+
 } // namespace
 } // namespace OpenTelemetry
 } // namespace AccessLoggers

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -725,7 +725,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
   // ====
   Tracing::SpanPtr span6 = driver_->startSpan(config_, request_headers_, stream_info_,
                                               operation_name_, {Tracing::Reason::Sampling, true});
-  EXPECT_EQ(span6->getTraceIdAsHex(), "");
+  EXPECT_EQ(span6->getTraceIdAsHex(), "0000000000000000");
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersTest) {
@@ -798,6 +798,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3Headers128TraceIdTest) {
   EXPECT_EQ(span_id, zipkin_span->span().idAsHexString());
   EXPECT_EQ(parent_id, zipkin_span->span().parentIdAsHexString());
   EXPECT_TRUE(zipkin_span->span().sampled());
+  EXPECT_EQ(trace_id, zipkin_span->getTraceIdAsHex());
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromInvalidTraceIdB3HeadersTest) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: make zipkin tracer work with opentelemetry accesslogger
Additional Description: follow up https://github.com/envoyproxy/envoy/pull/33281
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
