### PR TITLE
build: Add router_check_tool to tools container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,10 @@
 !/configs/*yaml
 !/linux/amd64/release.tar.zst
 !/linux/amd64/schema_validator_tool
+!/linux/amd64/router_check_tool
 !/linux/arm64/release.tar.zst
 !/linux/arm64/schema_validator_tool
+!/linux/arm64/router_check_tool
 !/local
 !/test/config/integration/certs
 !/windows

--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -54,7 +54,7 @@ FROM envoy AS envoy-tools
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM="${TARGETPLATFORM:-linux/amd64}"
 COPY --chown=0:0 --chmod=755 \
-    "${TARGETPLATFORM}/schema_validator_tool" /usr/local/bin/schema_validator_tool
+    "${TARGETPLATFORM}/schema_validator_tool" "${TARGETPLATFORM}/router_check_tool" /usr/local/bin/
 
 
 # STAGE: envoy-distroless

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -134,6 +134,8 @@ function cp_binary_for_image_build() {
   # Tools for the tools image. Strip to save size.
   strip bazel-bin/test/tools/schema_validator/schema_validator_tool \
     -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"/schema_validator_tool
+  strip bazel-bin/test/tools/router_check/router_check_tool \
+    -o "${BASE_TARGET_DIR}"/"${TARGET_DIR}"/router_check_tool
 
   # Copy the su-exec utility binary into the image
   cp -f bazel-bin/external/com_github_ncopa_suexec/su-exec "${BASE_TARGET_DIR}"/"${TARGET_DIR}"
@@ -199,6 +201,8 @@ function bazel_binary_build() {
   # Validation tools for the tools image.
   bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c "${COMPILE_TYPE}" \
     //test/tools/schema_validator:schema_validator_tool "${CONFIG_ARGS[@]}"
+  bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c "${COMPILE_TYPE}" \
+    //test/tools/router_check:router_check_tool "${CONFIG_ARGS[@]}"
 
   # Build su-exec utility
   bazel build "${BAZEL_BUILD_OPTIONS[@]}" --remote_download_toplevel -c "${COMPILE_TYPE}" external:su-exec
@@ -853,6 +857,12 @@ case $CI_TARGET in
         cp -a \
            bazel-bin/test/tools/schema_validator/schema_validator_tool.stripped \
            "${ENVOY_BINARY_DIR}/schema_validator_tool"
+        bazel build "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_RELEASE_OPTIONS[@]}" \
+              --remote_download_toplevel \
+              //test/tools/router_check:router_check_tool.stripped
+        cp -a \
+           bazel-bin/test/tools/router_check/router_check_tool.stripped \
+           "${ENVOY_BINARY_DIR}/router_check_tool"
         echo "Release files created in ${ENVOY_BINARY_DIR}"
         ;;
 

--- a/docs/root/operations/tools/route_table_check_tool.rst
+++ b/docs/root/operations/tools/route_table_check_tool.rst
@@ -72,6 +72,8 @@ Output
   If the ``--only-show-failures`` flag is provided, only the failed test cases are written to a file.
 
 Building
+  The tool is included in the :ref:`tools image <install_tools>`.
+
   The tool can be built locally using Bazel. ::
 
     bazel build //test/tools/router_check:router_check_tool


### PR DESCRIPTION
This change adds `router_check_tool` binary to tools image.

Fixes #32032

Commit Message: Add router_check_tool to tools container image
Additional Description: 
Risk Level: Low
Testing: Manual container build was executed
Docs Changes: update [doc](https://www.envoyproxy.io/docs/envoy/latest/operations/tools/route_table_check_tool) about availability in tools image.
Release Notes: N/A
Platform Specific Features: N/A
