### PR TITLE
mobile: Fix flaky ReceiveTrailersTest.kt

### DIFF
--- a/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveTrailersTest.kt
@@ -89,12 +89,13 @@ class ReceiveTrailersTest {
       .sendHeaders(requestHeadersDefault, false)
       .sendData(body)
       .close(requestTrailers)
+
     expectation.await(10, TimeUnit.SECONDS)
+    trailersReceived.await(10, TimeUnit.SECONDS)
 
     engine.terminate()
 
     assertThat(trailersReceived.count).isEqualTo(0)
-    trailersReceived.await(10, TimeUnit.SECONDS)
     assertThat(expectation.count).isEqualTo(0)
     assertThat(responseStatus).isEqualTo(200)
     assertThat(trailerValues).contains(TRAILER_VALUE)


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/33429.

Before this PR, the test would do this.

```
assertThat(trailersReceived.count).isEqualTo(0)
trailersReceived.await(10, TimeUnit.SECONDS) 
```
It was problematic because if the `setOnResponseTrailers` hadn't finished, the `trailersReceived.count` would still be set to 1. This PR fixes it by calling `trailersReceived.await` first and then doing an assert on `trailersReceived.count`.

Risk Level: low
Testing: ` bazel test --runs_per_test=100 //test/kotlin/integration:receive_trailers_test`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
