### PR TITLE
filter-network-redis: add support for single-key STREAM commands

### DIFF
--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -29,10 +29,11 @@ struct SupportedCommands {
         "ltrim", "persist", "pexpire", "pexpireat", "pfadd", "pfcount", "psetex", "pttl", "restore",
         "rpop", "rpush", "rpushx", "sadd", "scard", "set", "setbit", "setex", "setnx", "setrange",
         "sismember", "smembers", "spop", "srandmember", "srem", "sscan", "strlen", "ttl", "type",
-        "watch", "zadd", "zcard", "zcount", "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange",
-        "zrangebylex", "zrangebyscore", "zrank", "zrem", "zremrangebylex", "zremrangebyrank",
-        "zremrangebyscore", "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan",
-        "zscore");
+        "watch", "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xlen", "xpending", "xrange",
+        "xrevrange", "xtrim", "zadd", "zcard", "zcount", "zincrby", "zlexcount","zpopmin",
+        "zpopmax", "zrange", "zrangebylex", "zrangebyscore", "zrank", "zrem", "zremrangebylex",
+        "zremrangebyrank", "zremrangebyscore", "zrevrange", "zrevrangebylex", "zrevrangebyscore",
+        "zrevrank", "zscan", "zscore");
   }
 
   /**


### PR DESCRIPTION
Commit Message:
Add support for all the stream commands which are hashable on their first argument (the key)

Additional Description:
As above, it does lack support for the remaining stream commands which someone else can look at adding.
Is a partial fix for https://github.com/envoyproxy/envoy/issues/32928

Risk Level: Low
Testing: Manual (unsure what is needed)

Docs Changes:
Probably should add to the supported command list, but want to ensure if the process is needed.

Release Notes:
Add support for xack, xadd, xautoclaim, xclaim, xdel, xlen, xrange, xrevrange, xtrim to the redis proxy.

Platform Specific Features: N/A