### PR TITLE
mobile: Use TestServer instead of TestRemoteResponse native filter

### DIFF
--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -10,6 +10,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
         "@envoy//source/common/common:assert_lib",
         "@envoy_build_config//:test_extensions",

--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -1,5 +1,4 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
-load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
@@ -7,13 +6,11 @@ envoy_mobile_package()
 
 envoy_cc_test(
     name = "engine_test",
-    srcs = envoy_select_enable_yaml(
-        ["engine_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["engine_test.cc"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//test/common/integration:test_server_lib",
         "@envoy//source/common/common:assert_lib",
         "@envoy_build_config//:test_extensions",
     ],

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -10,6 +10,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",
     ],
@@ -21,6 +22,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",
     ],

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -1,5 +1,4 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
-load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
@@ -7,26 +6,22 @@ envoy_mobile_package()
 
 envoy_cc_test(
     name = "send_headers_test",
-    srcs = envoy_select_enable_yaml(
-        ["send_headers_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["send_headers_test.cc"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",
     ],
 )
 
 envoy_cc_test(
     name = "lifetimes_test",
-    srcs = envoy_select_enable_yaml(
-        ["lifetimes_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["lifetimes_test.cc"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",
     ],
 )

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -1,31 +1,39 @@
-#include "test/test_common/utility.h"
+#include "test/common/integration/test_server.h"
 
+#include "absl/strings/str_format.h"
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 #include "library/cc/engine_builder.h"
 #include "library/cc/envoy_error.h"
-#include "library/cc/log_level.h"
 #include "library/cc/request_headers_builder.h"
 #include "library/cc/request_method.h"
 
 namespace Envoy {
 namespace {
 
-struct Status {
-  int status_code;
-  bool end_stream;
-};
+void sendRequest() {
+  TestServer test_server;
+  test_server.startTestServer(TestServerType::HTTP2_WITH_TLS);
 
-void sendRequest(Platform::EngineSharedPtr engine, Status& status,
-                 absl::Notification& stream_complete) {
+  absl::Notification engine_running;
+  Platform::EngineBuilder engine_builder;
+  Platform::EngineSharedPtr engine = engine_builder.enforceTrustChainVerification(false)
+                                         .setLogLevel(Logger::Logger::debug)
+                                         .setOnEngineRunning([&]() { engine_running.Notify(); })
+                                         .build();
+  engine_running.WaitForNotification();
+
+  absl::Notification stream_complete;
+  int actual_status_code;
+  bool actual_end_stream;
   auto stream_prototype = engine->streamClient()->newStreamPrototype();
   auto stream = (*stream_prototype)
                     .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool end_stream,
                                       envoy_stream_intel) {
-                      status.status_code = headers->httpStatus();
-                      status.end_stream = end_stream;
+                      actual_status_code = headers->httpStatus();
+                      actual_end_stream = end_stream;
                     })
-                    .setOnData([&](envoy_data, bool end_stream) { status.end_stream = end_stream; })
+                    .setOnData([&](envoy_data, bool end_stream) { actual_end_stream = end_stream; })
                     .setOnComplete([&](envoy_stream_intel, envoy_final_stream_intel) {
                       stream_complete.Notify();
                     })
@@ -36,41 +44,30 @@ void sendRequest(Platform::EngineSharedPtr engine, Status& status,
                     })
                     .start();
 
-  auto request_headers =
-      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https", "example.com", "/")
-          .build();
+  auto request_headers = Platform::RequestHeadersBuilder(
+                             Platform::RequestMethod::GET, "https",
+                             absl::StrFormat("localhost:%d", test_server.getServerPort()), "/")
+                             .build();
   stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
-}
-
-void sendRequestEndToEnd() {
-  Platform::EngineBuilder engine_builder;
-  engine_builder.addNativeFilter(
-      "test_remote_response",
-      "{'@type': "
-      "type.googleapis.com/"
-      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
-  absl::Notification engine_running;
-  Platform::EngineSharedPtr engine = engine_builder.setLogLevel(Logger::Logger::debug)
-                                         .setOnEngineRunning([&]() { engine_running.Notify(); })
-                                         .build();
-  engine_running.WaitForNotification();
-
-  Status status;
-  absl::Notification stream_complete;
-  sendRequest(engine, status, stream_complete);
   stream_complete.WaitForNotification();
 
-  EXPECT_EQ(status.status_code, 200);
-  EXPECT_EQ(status.end_stream, true);
+  // It is important that the we shutdown the TestServer first before terminating the Engine. This
+  // is because when the Engine is terminated, the Logger::Context will be destroyed and
+  // Logger::Context is a global variable that is used by both Engine and TestServer. By shutting
+  // down the TestServer first, the TestServer will no longer access a Logger::Context that has been
+  // destroyed.
+  test_server.shutdownTestServer();
 
-  engine->terminate();
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_TRUE(actual_end_stream);
+  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
 }
 
 // this test attempts to elicit race conditions deriving from
 // the semantics of ownership on StreamCallbacks
-TEST(TestLifetimes, CallbacksStayAlive) {
+TEST(LifetimesTest, CallbacksStayAlive) {
   for (size_t i = 0; i < 10; i++) {
-    sendRequestEndToEnd();
+    sendRequest();
   }
 }
 

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -1,5 +1,6 @@
-#include "test/test_common/utility.h"
+#include "test/common/integration/test_server.h"
 
+#include "absl/strings/str_format.h"
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 #include "library/cc/engine_builder.h"
@@ -10,36 +11,31 @@
 namespace Envoy {
 namespace {
 
-struct Status {
-  int status_code;
-  bool end_stream;
-};
-
 TEST(SendHeadersTest, CanSendHeaders) {
-  Platform::EngineBuilder engine_builder;
-  engine_builder.addNativeFilter(
-      "test_remote_response",
-      "{'@type': "
-      "type.googleapis.com/"
-      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
+  TestServer test_server;
+  test_server.startTestServer(TestServerType::HTTP2_WITH_TLS);
+
   absl::Notification engine_running;
-  Platform::EngineSharedPtr engine = engine_builder.setLogLevel(Logger::Logger::debug)
+  Platform::EngineBuilder engine_builder;
+  Platform::EngineSharedPtr engine = engine_builder.enforceTrustChainVerification(false)
+                                         .setLogLevel(Logger::Logger::debug)
                                          .setOnEngineRunning([&]() { engine_running.Notify(); })
                                          .build();
   engine_running.WaitForNotification();
 
-  Status status;
+  int actual_status_code;
+  bool actual_end_stream;
   absl::Notification stream_complete;
   auto stream_prototype = engine->streamClient()->newStreamPrototype();
   Platform::StreamSharedPtr stream =
       (*stream_prototype)
           .setOnHeaders(
               [&](Platform::ResponseHeadersSharedPtr headers, bool end_stream, envoy_stream_intel) {
-                status.status_code = headers->httpStatus();
-                status.end_stream = end_stream;
+                actual_status_code = headers->httpStatus();
+                actual_end_stream = end_stream;
               })
           .setOnData([&](envoy_data data, bool end_stream) {
-            status.end_stream = end_stream;
+            actual_end_stream = end_stream;
             data.release(data.context);
           })
           .setOnComplete(
@@ -50,18 +46,25 @@ TEST(SendHeadersTest, CanSendHeaders) {
               [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
           .start();
 
-  Platform::RequestHeadersBuilder request_headers_builder(Platform::RequestMethod::GET, "https",
-                                                          "example.com", "/");
+  Platform::RequestHeadersBuilder request_headers_builder(
+      Platform::RequestMethod::GET, "https",
+      absl::StrFormat("localhost:%d", test_server.getServerPort()), "/");
   auto request_headers = request_headers_builder.build();
   auto request_headers_ptr =
       Platform::RequestHeadersSharedPtr(new Platform::RequestHeaders(request_headers));
   stream->sendHeaders(request_headers_ptr, true);
   stream_complete.WaitForNotification();
 
-  EXPECT_EQ(status.status_code, 200);
-  EXPECT_EQ(status.end_stream, true);
+  // It is important that the we shutdown the TestServer first before terminating the Engine. This
+  // is because when the Engine is terminated, the Logger::Context will be destroyed and
+  // Logger::Context is a global variable that is used by both Engine and TestServer. By shutting
+  // down the TestServer first, the TestServer will no longer access a Logger::Context that has been
+  // destroyed.
+  test_server.shutdownTestServer();
 
-  engine->terminate();
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_TRUE(actual_end_stream);
+  EXPECT_EQ(engine->terminate(), ENVOY_SUCCESS);
 }
 
 } // namespace

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -235,3 +235,18 @@ envoy_cc_test_library(
         "@envoy",
     ),
 )
+
+envoy_cc_test_library(
+    name = "engine_with_test_server",
+    srcs = [
+        "engine_with_test_server.cc",
+    ],
+    hdrs = [
+        "engine_with_test_server.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":test_server_lib",
+        "//library/cc:engine_builder_lib",
+    ],
+)

--- a/mobile/test/common/integration/engine_with_test_server.cc
+++ b/mobile/test/common/integration/engine_with_test_server.cc
@@ -1,0 +1,25 @@
+#include "test/common/integration/engine_with_test_server.h"
+
+namespace Envoy {
+
+EngineWithTestServer::EngineWithTestServer(Platform::EngineBuilder& engine_builder,
+                                           TestServerType type) {
+  test_server_.startTestServer(type);
+  engine_ = engine_builder.build();
+}
+
+EngineWithTestServer::~EngineWithTestServer() {
+  engine_->terminate();
+  // It is important that the we shutdown the TestServer first before terminating the Engine. This
+  // is because when the Engine is terminated, the Logger::Context will be destroyed and
+  // Logger::Context is a global variable that is used by both Engine and TestServer. By shutting
+  // down the TestServer first, the TestServer will no longer access a Logger::Context that has been
+  // destroyed.
+  test_server_.shutdownTestServer();
+}
+
+Platform::EngineSharedPtr& EngineWithTestServer::engine() { return engine_; }
+
+TestServer& EngineWithTestServer::testServer() { return test_server_; }
+
+} // namespace Envoy

--- a/mobile/test/common/integration/engine_with_test_server.cc
+++ b/mobile/test/common/integration/engine_with_test_server.cc
@@ -9,13 +9,13 @@ EngineWithTestServer::EngineWithTestServer(Platform::EngineBuilder& engine_build
 }
 
 EngineWithTestServer::~EngineWithTestServer() {
-  engine_->terminate();
   // It is important that the we shutdown the TestServer first before terminating the Engine. This
   // is because when the Engine is terminated, the Logger::Context will be destroyed and
   // Logger::Context is a global variable that is used by both Engine and TestServer. By shutting
   // down the TestServer first, the TestServer will no longer access a Logger::Context that has been
   // destroyed.
   test_server_.shutdownTestServer();
+  engine_->terminate();
 }
 
 Platform::EngineSharedPtr& EngineWithTestServer::engine() { return engine_; }

--- a/mobile/test/common/integration/engine_with_test_server.h
+++ b/mobile/test/common/integration/engine_with_test_server.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "test/common/integration/test_server.h"
+
+#include "library/cc/engine_builder.h"
+
+namespace Envoy {
+
+/**
+ * This class starts `TestServer` and build the `Engine` and ensures that the `TestServer` is
+ * shutdown first before terminating the `Engine` in order to avoid accessing the destroyed
+ * `Logger::Context` given that the `Logger::Context` is a global variable used by both the
+ * `TestServer` and `Engine`.
+ */
+class EngineWithTestServer {
+public:
+  EngineWithTestServer(Platform::EngineBuilder& engine_builder, TestServerType type);
+  ~EngineWithTestServer();
+
+  /** Returns the reference of `Engine` created. */
+  Platform::EngineSharedPtr& engine();
+
+  /** Returns the reference of `TestServer` started. */
+  TestServer& testServer();
+
+private:
+  Platform::EngineSharedPtr engine_;
+  TestServer test_server_;
+};
+
+} // namespace Envoy

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -1,11 +1,9 @@
 #include "test_server.h"
 
-#include "source/common/common/random_generator.h"
 #include "source/common/listener_manager/connection_handler_impl.h"
 #include "source/common/listener_manager/listener_manager_impl.h"
 #include "source/common/quic/quic_server_transport_socket_factory.h"
 #include "source/common/quic/server_codec_impl.h"
-#include "source/common/stats/allocator_impl.h"
 #include "source/common/stats/thread_local_store.h"
 #include "source/common/thread_local/thread_local_impl.h"
 #include "source/common/tls/context_config_impl.h"
@@ -19,6 +17,8 @@
 
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
+
+#include "extension_registry.h"
 
 namespace Envoy {
 
@@ -80,6 +80,8 @@ TestServer::TestServer()
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
   ON_CALL(factory_context_, sslContextManager())
       .WillByDefault(testing::ReturnRef(context_manager_));
+
+  Envoy::ExtensionRegistry::registerFactories();
 }
 
 void TestServer::startTestServer(TestServerType test_server_type) {

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -1,4 +1,4 @@
-#include "test_server.h"
+#include "test/common/integration/test_server.h"
 
 #include "source/common/listener_manager/connection_handler_impl.h"
 #include "source/common/listener_manager/listener_manager_impl.h"

--- a/mobile/test/common/integration/test_server_interface.cc
+++ b/mobile/test/common/integration/test_server_interface.cc
@@ -1,7 +1,5 @@
 #include "test/common/integration/test_server_interface.h"
 
-#include "extension_registry.h"
-
 // NOLINT(namespace-envoy)
 
 static std::shared_ptr<Envoy::TestServer> strong_test_server_;
@@ -10,7 +8,6 @@ static std::weak_ptr<Envoy::TestServer> weak_test_server_;
 static std::shared_ptr<Envoy::TestServer> test_server() { return weak_test_server_.lock(); }
 
 void start_server(Envoy::TestServerType test_server_type) {
-  Envoy::ExtensionRegistry::registerFactories();
   strong_test_server_ = std::make_shared<Envoy::TestServer>();
   weak_test_server_ = strong_test_server_;
 


### PR DESCRIPTION
This PR updates some C++ tests to use `TestServer` instead of `TestRemoteResponse` native filter to make the tests more realistic. This PR also removes the `envoy_select_enable_yaml` so that the tests run since Envoy Mobile build has no YAML enabled by default.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
