### PR TITLE
fuzz: slow-start prevent low min_weight_percent

### DIFF
--- a/test/common/upstream/least_request_load_balancer_corpus/zero_min_weight_percent
+++ b/test/common/upstream/least_request_load_balancer_corpus/zero_min_weight_percent
@@ -1,0 +1,26 @@
+zone_aware_load_balancer_test_case {
+  load_balancer_test_case {
+    common_lb_config {
+    }
+    setup_priority_levels {
+      num_hosts_in_priority_level: 48
+      random_bytestring: 0
+    }
+    seed_for_prng: 5
+  }
+  random_bytestring_for_weights: "\377q\377q"
+}
+least_request_lb_config {
+  slow_start_config {
+    slow_start_window {
+      seconds: 8
+    }
+    aggression {
+      default_value: 3.928881679110406e-27
+      runtime_key: "google.protobuf.UInt32Value"
+    }
+    min_weight_percent {
+    }
+  }
+}
+random_bytestring_for_requests: "#"

--- a/test/common/upstream/zone_aware_load_balancer_fuzz_base.cc
+++ b/test/common/upstream/zone_aware_load_balancer_fuzz_base.cc
@@ -72,6 +72,8 @@ bool ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
     uint32_t num_hosts) {
   if (slow_start_config.has_aggression()) {
     const auto& aggression = slow_start_config.aggression();
+    // If there are too many hosts, the call to the runtime mock will be too
+    // high, which will cause a timeout.
     if (num_hosts > 5000) {
       ENVOY_LOG_MISC(warn,
                      "Too many hosts ({} > 5000) with aggression will slow down the runtime loader "
@@ -79,11 +81,24 @@ bool ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
                      num_hosts);
       return false;
     }
+    // If the aggerssion is too small, the weights will essentially be 0.
     if (aggression.default_value() < 1e-30) {
       ENVOY_LOG_MISC(
           warn,
           "Aggression value ({}) cannot be smaller than 1e-30, error in slow-start validation",
           aggression.default_value());
+      return false;
+    }
+    // Getting non-zero weights fo slow-start is not-easy, and requires the
+    // correct configuration of the aggression and time-out factors. The
+    // alternative is to set a minimal min_weight_percent config when aggression
+    // is used, that will ensure that not all of the weights are 0.
+    if (slow_start_config.has_min_weight_percent() &&
+        slow_start_config.min_weight_percent().value() < 0.1) {
+      ENVOY_LOG_MISC(warn,
+                     "When aggression is used the min_weight_percent needs to be at least 0.1, and "
+                     "is currently {}, skipping test",
+                     slow_start_config.min_weight_percent().value());
       return false;
     }
   }

--- a/test/common/upstream/zone_aware_load_balancer_fuzz_base.cc
+++ b/test/common/upstream/zone_aware_load_balancer_fuzz_base.cc
@@ -81,7 +81,7 @@ bool ZoneAwareLoadBalancerFuzzBase::validateSlowStart(
                      num_hosts);
       return false;
     }
-    // If the aggerssion is too small, the weights will essentially be 0.
+    // If the aggression is too small, the weights will essentially be 0.
     if (aggression.default_value() < 1e-30) {
       ENVOY_LOG_MISC(
           warn,


### PR DESCRIPTION
Commit Message: fuzz: slow-start prevent low min_weight_percent
Additional Description:
Getting non-zero weights fo slow-start is not-easy, and requires the correct configuration of the aggression and time-out factors. The alternative is to set a minimal min_weight_percent config when aggression is used, that will ensure that not all of the weights are 0.

Risk Level: low - fuzz tests only
Testing: Added corpus
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Fixes fuzz issue [67870](https://oss-fuzz.com/testcase-detail/6146447478161408)