### PR TITLE
mobile: Bump swift-async-await test timeout

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -137,6 +137,7 @@ jobs:
             expected: >-
               ${{ matrix.expected
                   || format('received headers with status {0}', matrix.expected-status) }}
+            timeout: ${{ matrix.timeout || '5m' }}
           env:
             ANDROID_NDK_HOME:
             ANDROID_HOME:
@@ -163,6 +164,7 @@ jobs:
           expected: >-
             \[2\] Uploaded 7 MB of data
           target: swift-async-await
+          timeout: 10m
         - name: Build objc hello world
           app: //examples/objective-c/hello_world:app
           expected-status: 301


### PR DESCRIPTION
This should hopefully fix the flakiness issue, such as https://github.com/envoyproxy/envoy/actions/runs/8636677357/job/23677319014

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
