### PR TITLE
lua: add new methods to access network connection streamInfo() & dynamicMetadata()

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -480,6 +480,10 @@ new_features:
   change: |
     Added :ref:`per-route configuration support to the Basic Auth filter
     <envoy_v3_api_msg_extensions.filters.http.basic_auth.v3.BasicAuthPerRoute>`.
+- area: lua
+  change: |
+    Added a new ``connectionStreamInfo()`` which could be used to access the streamInfo object on the connection. This addition
+    is helpful in scenarios requiring the retrieval of dynamic metadata from network filters, such as the Proxy Protocol, etc.
 
 deprecated:
 - area: listener

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -545,6 +545,17 @@ Returns the current request's underlying :repo:`connection <envoy/network/connec
 
 Returns a :ref:`connection object <config_http_filters_lua_connection_wrapper>`.
 
+connectionStreamInfo()
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  local connectionStreamInfo = handle:connectionStreamInfo()
+
+Returns connection-level :repo:`information <envoy/stream_info/stream_info.h>` related to the current request.
+
+Returns a connection-level :ref:`stream info object <config_http_filters_lua_cx_stream_info_wrapper>`.
+
 importPublicKey()
 ^^^^^^^^^^^^^^^^^
 
@@ -847,6 +858,20 @@ requestedServerName()
 
 Returns the string representation of :repo:`requested server name <envoy/stream_info/stream_info.h>`
 (e.g. SNI in TLS) for the current request if present.
+
+.. _config_http_filters_lua_cx_stream_info_wrapper:
+
+Connection stream info object API
+---------------------------------
+
+dynamicMetadata()
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  connectionStreamInfo:dynamicMetadata()
+
+Returns a :ref:`dynamic metadata object <config_http_filters_lua_stream_info_dynamic_metadata_wrapper>`.
 
 Dynamic metadata object API
 ---------------------------

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -202,6 +202,9 @@ PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotA
   lua_state_.registerType<DynamicMetadataMapIterator>();
   lua_state_.registerType<StreamHandleWrapper>();
   lua_state_.registerType<PublicKeyWrapper>();
+  lua_state_.registerType<ConnectionStreamInfoWrapper>();
+  lua_state_.registerType<ConnectionDynamicMetadataMapWrapper>();
+  lua_state_.registerType<ConnectionDynamicMetadataMapIterator>();
 
   const Filters::Common::Lua::InitializerList initializers(
       // EnvoyTimestampResolution "enum".
@@ -622,6 +625,17 @@ int StreamHandleWrapper::luaStreamInfo(lua_State* state) {
     stream_info_wrapper_.pushStack();
   } else {
     stream_info_wrapper_.reset(StreamInfoWrapper::create(state, callbacks_.streamInfo()), true);
+  }
+  return 1;
+}
+
+int StreamHandleWrapper::luaConnectionStreamInfo(lua_State* state) {
+  ASSERT(state_ == State::Running);
+  if (connection_stream_info_wrapper_.get() != nullptr) {
+    connection_stream_info_wrapper_.pushStack();
+  } else {
+    connection_stream_info_wrapper_.reset(
+        ConnectionStreamInfoWrapper::create(state, callbacks_.connection()->streamInfo()), true);
   }
   return 1;
 }

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -185,7 +185,8 @@ public:
             {"verifySignature", static_luaVerifySignature},
             {"base64Escape", static_luaBase64Escape},
             {"timestamp", static_luaTimestamp},
-            {"timestampString", static_luaTimestampString}};
+            {"timestampString", static_luaTimestampString},
+            {"connectionStreamInfo", static_luaConnectionStreamInfo}};
   }
 
 private:
@@ -250,6 +251,11 @@ private:
    * @return a handle to the network connection.
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnection);
+
+  /**
+   * @return a handle to the network connection's stream info.
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnectionStreamInfo);
 
   /**
    * Log a message to the Envoy log.
@@ -333,6 +339,7 @@ private:
     stream_info_wrapper_.reset();
     connection_wrapper_.reset();
     public_key_wrapper_.reset();
+    connection_stream_info_wrapper_.reset();
   }
 
   // Http::AsyncClient::Callbacks
@@ -357,6 +364,7 @@ private:
   Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> trailers_wrapper_;
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> stream_info_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<ConnectionStreamInfoWrapper> connection_stream_info_wrapper_;
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::ConnectionWrapper> connection_wrapper_;
   Filters::Common::Lua::LuaDeathRef<PublicKeyWrapper> public_key_wrapper_;
   State state_{State::Running};

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -170,6 +170,16 @@ int StreamInfoWrapper::luaDynamicMetadata(lua_State* state) {
   return 1;
 }
 
+int ConnectionStreamInfoWrapper::luaConnectionDynamicMetadata(lua_State* state) {
+  if (connection_dynamic_metadata_wrapper_.get() != nullptr) {
+    connection_dynamic_metadata_wrapper_.pushStack();
+  } else {
+    connection_dynamic_metadata_wrapper_.reset(
+        ConnectionDynamicMetadataMapWrapper::create(state, *this), true);
+  }
+  return 1;
+}
+
 int StreamInfoWrapper::luaDownstreamSslConnection(lua_State* state) {
   const auto& ssl = stream_info_.downstreamAddressProvider().sslConnection();
   if (ssl != nullptr) {
@@ -218,7 +228,29 @@ DynamicMetadataMapIterator::DynamicMetadataMapIterator(DynamicMetadataMapWrapper
 
 StreamInfo::StreamInfo& DynamicMetadataMapWrapper::streamInfo() { return parent_.stream_info_; }
 
+ConnectionDynamicMetadataMapIterator::ConnectionDynamicMetadataMapIterator(
+    ConnectionDynamicMetadataMapWrapper& parent)
+    : parent_{parent}, current_{parent_.streamInfo().dynamicMetadata().filter_metadata().begin()} {}
+
+const StreamInfo::StreamInfo& ConnectionDynamicMetadataMapWrapper::streamInfo() {
+  return parent_.connection_stream_info_;
+}
+
 int DynamicMetadataMapIterator::luaPairsIterator(lua_State* state) {
+  if (current_ == parent_.streamInfo().dynamicMetadata().filter_metadata().end()) {
+    parent_.iterator_.reset();
+    return 0;
+  }
+
+  lua_pushlstring(state, current_->first.data(), current_->first.size());
+  Filters::Common::Lua::MetadataMapHelper::createTable(state, current_->second.fields());
+
+  current_++;
+  return 2;
+}
+
+int ConnectionDynamicMetadataMapIterator::luaConnectionDynamicMetadataPairsIterator(
+    lua_State* state) {
   if (current_ == parent_.streamInfo().dynamicMetadata().filter_metadata().end()) {
     parent_.iterator_.reset();
     return 0;
@@ -271,6 +303,30 @@ int DynamicMetadataMapWrapper::luaPairs(lua_State* state) {
 
   iterator_.reset(DynamicMetadataMapIterator::create(state, *this), true);
   lua_pushcclosure(state, DynamicMetadataMapIterator::static_luaPairsIterator, 1);
+  return 1;
+}
+
+int ConnectionDynamicMetadataMapWrapper::luaConnectionDynamicMetadataGet(lua_State* state) {
+  const char* filter_name = luaL_checkstring(state, 2);
+  const auto& metadata = streamInfo().dynamicMetadata().filter_metadata();
+  const auto filter_it = metadata.find(filter_name);
+  if (filter_it == metadata.end()) {
+    return 0;
+  }
+
+  Filters::Common::Lua::MetadataMapHelper::createTable(state, filter_it->second.fields());
+  return 1;
+}
+
+int ConnectionDynamicMetadataMapWrapper::luaConnectionDynamicMetadataPairs(lua_State* state) {
+  if (iterator_.get() != nullptr) {
+    luaL_error(state, "cannot create a second iterator before completing the first");
+  }
+
+  iterator_.reset(ConnectionDynamicMetadataMapIterator::create(state, *this), true);
+  lua_pushcclosure(
+      state, ConnectionDynamicMetadataMapIterator::static_luaConnectionDynamicMetadataPairsIterator,
+      1);
   return 1;
 }
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -2090,6 +2090,57 @@ TEST_F(LuaHttpFilterTest, GetRequestedServerName) {
   EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
 }
 
+// Verify that network connection level streamInfo():dynamicMetadata() could be accessed using LUA.
+TEST_F(LuaHttpFilterTest, GetConnectionDynamicMetadata) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      local cx_metadata = request_handle:connectionStreamInfo():dynamicMetadata()
+      local filters_count = 0
+      for filter_name, _ in pairs(cx_metadata) do
+        filters_count = filters_count + 1
+      end
+      request_handle:logTrace('Filters Count: ' .. filters_count)
+
+      local pp_metadata_entries = cx_metadata:get("envoy.proxy_protocol")
+      for key, value in pairs(pp_metadata_entries) do
+        request_handle:logTrace('Key: ' .. key .. ', Value: ' .. value)
+      end
+
+      local lb_version = cx_metadata:get("envoy.lb")["version"]
+      request_handle:logTrace('Key: version, Value: ' .. lb_version)
+    end
+  )EOF"};
+
+  // Proxy Protocol Filter Metadata
+  ProtobufWkt::Value tlv_ea_value;
+  tlv_ea_value.set_string_value("vpce-064c279a4001a055f");
+  ProtobufWkt::Struct proxy_protocol_metadata;
+  proxy_protocol_metadata.mutable_fields()->insert({"tlv_ea", tlv_ea_value});
+  (*stream_info_.metadata_.mutable_filter_metadata())["envoy.proxy_protocol"] =
+      proxy_protocol_metadata;
+
+  // LB Filter Metadata
+  ProtobufWkt::Value lb_version_value;
+  lb_version_value.set_string_value("v1.0");
+  ProtobufWkt::Struct lb_metadata;
+  lb_metadata.mutable_fields()->insert({"version", lb_version_value});
+  (*stream_info_.metadata_.mutable_filter_metadata())["envoy.lb"] = lb_metadata;
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_CALL(decoder_callbacks_, connection())
+      .WillOnce(Return(OptRef<const Network::Connection>{connection_}));
+  EXPECT_CALL(Const(connection_), streamInfo()).WillOnce(ReturnRef(stream_info_));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("Filters Count: 2")));
+  EXPECT_CALL(*filter_,
+              scriptLog(spdlog::level::trace, StrEq("Key: tlv_ea, Value: vpce-064c279a4001a055f")));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("Key: version, Value: v1.0")));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(0, stats_store_.counter("test.lua.errors").value());
+}
+
 // Verify that binary values could also be extracted from dynamicMetadata() in LUA filter.
 TEST_F(LuaHttpFilterTest, GetDynamicMetadataBinaryData) {
   const std::string SCRIPT{R"EOF(


### PR DESCRIPTION
**Previous PR:** https://github.com/envoyproxy/envoy/pull/22246

### Background

Currently, there seems to be no way to access the dynamic metadata set by any network filters in LUA or any other HTTP filters. `streamInfo()` is accessible on the connection and could be used to fetch the `dynamicMetadata()` from the network filters but it's is currently not exposed in HTTP LUA filter.

### Use Case

We want to read the TLV values set by the `proxy_protocol` filter in the dynamic metadata in the LUA filter so that we can propagate these TLV pairs to the upstream services for some further processing. 

### Changes

This PR adds a new `connectionStreamInfo()` methods to LUA filter that could be used to access the Stream Info object on the connection and then fetch the dynamic metadata from network filters like this:
```
connectionStreamInfo():dynamicMetadata():get("envoy.proxy_protocol")
```
---
**Commit Message:** add new methods to access network connection streamInfo() & dynamicMetadata().
**Additional Description:** See Background Section.
**Risk Level:** Low
**Testing:** Unit Tests
**Docs Changes:** Added the description of the new methods added in LUA. 
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>