### PR TITLE
thread: refactor the thread id getter to cache the id in thread local storage

### DIFF
--- a/source/common/common/macros.h
+++ b/source/common/common/macros.h
@@ -35,6 +35,12 @@ namespace Envoy {
     return *objectptr;                                                                             \
   } while (0)
 
+#define THREAD_LOCAL_CONSTRUCT_ON_FIRST_USE(type, ...)                                             \
+  do {                                                                                             \
+    static thread_local type* objectptr = new type{__VA_ARGS__};                                   \
+    return *objectptr;                                                                             \
+  } while (0)
+
 #define MUTABLE_CONSTRUCT_ON_FIRST_USE(type, ...)                                                  \
   do {                                                                                             \
     static type* objectptr = new type{__VA_ARGS__};                                                \

--- a/source/common/common/macros.h
+++ b/source/common/common/macros.h
@@ -35,12 +35,6 @@ namespace Envoy {
     return *objectptr;                                                                             \
   } while (0)
 
-#define THREAD_LOCAL_CONSTRUCT_ON_FIRST_USE(type, ...)                                             \
-  do {                                                                                             \
-    static thread_local type* objectptr = new type{__VA_ARGS__};                                   \
-    return *objectptr;                                                                             \
-  } while (0)
-
 #define MUTABLE_CONSTRUCT_ON_FIRST_USE(type, ...)                                                  \
   do {                                                                                             \
     static type* objectptr = new type{__VA_ARGS__};                                                \

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -28,8 +28,7 @@ int64_t getCurrentThreadIdBase() {
 }
 
 ThreadId getCurrentThreadId() {
-  static thread_local ThreadId cached_thread_id = ThreadId(getCurrentThreadIdBase());
-  return cached_thread_id;
+  THREAD_LOCAL_CONSTRUCT_ON_FIRST_USE(ThreadId, getCurrentThreadIdBase());
 }
 
 } // namespace

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -15,7 +15,7 @@ namespace Thread {
 
 namespace {
 
-int64_t getCurrentThreadId() {
+int64_t getCurrentThreadIdBase() {
 #ifdef __linux__
   return static_cast<int64_t>(syscall(SYS_gettid));
 #elif defined(__APPLE__)
@@ -25,6 +25,11 @@ int64_t getCurrentThreadId() {
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
+}
+
+ThreadId getCurrentThreadId() {
+  static thread_local ThreadId cached_thread_id = ThreadId(getCurrentThreadIdBase());
+  return cached_thread_id;
 }
 
 } // namespace
@@ -153,7 +158,7 @@ public:
     return std::make_unique<PosixThread>(thread_handle, options);
   };
 
-  ThreadId currentThreadId() override { return ThreadId(getCurrentThreadId()); };
+  ThreadId currentThreadId() override { return getCurrentThreadId(); };
 
   ThreadId currentPthreadId() override {
 #if defined(__linux__)


### PR DESCRIPTION
Commit Message: thread: refactor the thread id getter to cache the id in thread local storage
Additional Description:

In the current implementation of posix thread id getter, every `currentThreadId()` call will involves a system call. This make this call pretty expensive. And this also make the `Dispatcher::isThreadSafe()` call very expensive.

This PR refactor the implementation to cache the id in thread local storage to improve the performance.

Here is the benchmark result:

```
-------------------------------------------------------------
Benchmark                   Time             CPU   Iterations
-------------------------------------------------------------
bmThreadIdGetter/0       2595 ns         2595 ns       278564
bmThreadIdGetter/1       2.09 ns         2.09 ns    337318151

```

This should be safe and robust because the absl use similar way to get the thread id.

```
// GetCachedTID() caches the thread ID in thread-local storage (which is a
// userspace construct) to avoid unnecessary system calls. Without this caching,
// it can take roughly 98ns, while it takes roughly 1ns with this caching.
pid_t GetCachedTID() {
#ifdef ABSL_HAVE_THREAD_LOCAL
  static thread_local pid_t thread_id = GetTID();
  return thread_id;
#else
  return GetTID();
#endif  // ABSL_HAVE_THREAD_LOCAL
}

```

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
