### PR TITLE
bazel: Shift ASAN flags to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,6 +86,8 @@ build:sanitizer --linkopt -ldl
 build:clang --action_env=BAZEL_COMPILER=clang
 build:clang --action_env=CC=clang --action_env=CXX=clang++
 build:clang --linkopt=-fuse-ld=lld
+build:clang --action_env=CC=clang --host_action_env=CC=clang
+build:clang --action_env=CXX=clang++ --host_action_env=CXX=clang++
 
 # Flags for Clang + PCH
 build:clang-pch --spawn_strategy=local
@@ -103,7 +105,6 @@ build:clang-tidy --output_groups=report
 build:clang-tidy --build_tag_filters=-notidy
 
 # Basic ASAN/UBSAN that works for gcc
-build:asan --action_env=ENVOY_ASAN=1
 build:asan --config=sanitizer
 # ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
 build:asan --define signal_trace=disabled
@@ -126,11 +127,18 @@ build:asan --copt -O1
 build:asan --copt -fno-optimize-sibling-calls
 
 # Clang ASAN/UBSAN
-build:clang-asan --config=clang
-build:clang-asan --config=asan
-build:clang-asan --linkopt -fuse-ld=lld
-build:clang-asan --linkopt --rtlib=compiler-rt
-build:clang-asan --linkopt --unwindlib=libgcc
+build:clang-asan-common --config=clang
+build:clang-asan-common --config=asan
+build:clang-asan-common --linkopt -fuse-ld=lld
+build:clang-asan-common --linkopt --rtlib=compiler-rt
+build:clang-asan-common --linkopt --unwindlib=libgcc
+
+build:clang-asan --config=clang-asan-common
+build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone.a
+build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx.a
+build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
+build:clang-asan --copt=-fsanitize=vptr,function
+build:clang-asan --linkopt=-fsanitize=vptr,function
 
 # macOS
 build:macos --cxxopt=-std=c++20 --host_cxxopt=-std=c++20

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -22,17 +22,10 @@ RT_LIBRARY_PATH="${LLVM_LIBDIR}/clang/${LLVM_VERSION}/lib/${LLVM_TARGET}"
 
 echo "# Generated file, do not edit. If you want to disable clang, just delete this file.
 build:clang --action_env='PATH=${PATH}' --host_action_env='PATH=${PATH}'
-build:clang --action_env=CC=clang --host_action_env=CC=clang
-build:clang --action_env=CXX=clang++ --host_action_env=CXX=clang++
 build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config' --host_action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --linkopt='-L$(llvm-config --libdir)'
 build:clang --linkopt='-Wl,-rpath,$(llvm-config --libdir)'
 
-build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
-build:clang-asan --copt=-fsanitize=vptr,function
-build:clang-asan --linkopt=-fsanitize=vptr,function
 build:clang-asan --linkopt='-L${RT_LIBRARY_PATH}'
-build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone.a
-build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx.a
 " >"${BAZELRC_FILE}"

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -100,8 +100,9 @@ build:mobile-asan-dev --copt -fsanitize=address
 build:mobile-asan-dev --linkopt -fsanitize=address
 build:mobile-asan-dev --platform_suffix=-asan
 
-build:clang-asan --linkopt --rtlib=compiler-rt
-build:clang-asan --linkopt --unwindlib=libgcc
+build:mobile-clang-asan --linkopt --rtlib=compiler-rt
+build:mobile-clang-asan --linkopt --unwindlib=libgcc
+build:mobile-clang-asan --config=clang-asan-common
 
 # Locally-runnable TSAN config
 build:mobile-tsan-dev --features=tsan
@@ -204,7 +205,7 @@ build:mobile-remote-ci-linux-clang --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 #############################################################################
 # mobile-remote-ci-linux-asan: These options are Linux-only using Clang and AddressSanitizer
 #############################################################################
-build:mobile-remote-ci-linux-asan --config=clang-asan
+build:mobile-remote-ci-linux-asan --config=mobile-clang-asan
 build:mobile-remote-ci-linux-asan --config=mobile-remote-ci-linux-clang
 build:mobile-remote-ci-linux-asan --config=remote-ci
 build:mobile-remote-ci-linux-asan --define=envoy_full_protos=disabled


### PR DESCRIPTION
This is a first step towards removing `bazel/setup_clang.sh` - it just removes the flags that have no reason to be there



<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
