### PR TITLE
quic: turn off prefer gro by default

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -77,7 +77,6 @@ RUNTIME_GUARD(envoy_reloadable_features_oauth_make_token_cookie_httponly);
 RUNTIME_GUARD(envoy_reloadable_features_oauth_use_standard_max_age_value);
 RUNTIME_GUARD(envoy_reloadable_features_oauth_use_url_encoding);
 RUNTIME_GUARD(envoy_reloadable_features_original_dst_rely_on_idle_timeout);
-RUNTIME_GUARD(envoy_reloadable_features_prefer_quic_client_udp_gro);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_status_mapping_more_core_response_flags);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_status_upstream_request_timeout);
 RUNTIME_GUARD(envoy_reloadable_features_quic_fix_filter_manager_uaf);
@@ -153,6 +152,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_enable_universal_header_validator)
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_defer_logging_to_ack_listener);
 // TODO(panting): flip this to true after some test time.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_config_in_happy_eyeballs);
+// TODO(danzh) removed it once GRO MSG_TRUNC is fixed.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_prefer_quic_client_udp_gro);
 
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.


### PR DESCRIPTION
Commit Message: flip runtime guard envoy_reloadable_features_prefer_quic_client_udp_gro to false
Additional Description: it has caused performance regression because of massive MSG_TRUNC in recvmsg call. Each call is supplied with a 24kB read buffer (~16 packets), which is probably not enough if more than 16 packets with the same network 5-tuple are concatenated by GRO. 
  
Risk Level: low
Testing: existing test pass.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Related issue #33474