### PR TITLE
mobile: Change C++ tests to not require YAML

### DIFF
--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -1,5 +1,4 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
-load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
@@ -7,10 +6,7 @@ envoy_mobile_package()
 
 envoy_cc_test(
     name = "engine_test",
-    srcs = envoy_select_enable_yaml(
-        ["engine_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["engine_test.cc"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -21,9 +21,8 @@ TEST(EngineTest, SetLogger) {
           .setEngineCallbacks(std::move(engine_callbacks))
           .addNativeFilter(
               "test_remote_response",
-              "{'@type': "
-              "type.googleapis.com/"
-              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+              "[type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}")
           .build();
   engine_running.WaitForNotification();
 
@@ -73,9 +72,8 @@ TEST(EngineTest, SetEngineCallbacks) {
           .setEngineCallbacks(std::move(engine_callbacks))
           .addNativeFilter(
               "test_remote_response",
-              "{'@type': "
-              "type.googleapis.com/"
-              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+              "[type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}")
           .build();
   engine_running.WaitForNotification();
 
@@ -137,9 +135,8 @@ TEST(EngineTest, SetEventTracker) {
           .setEventTracker(std::move(event_tracker))
           .addNativeFilter(
               "test_remote_response",
-              "{'@type': "
-              "type.googleapis.com/"
-              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}")
+              "[type.googleapis.com/"
+              "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}")
           .build();
   engine_running.WaitForNotification();
 

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -1,5 +1,4 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
-load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
@@ -7,10 +6,7 @@ envoy_mobile_package()
 
 envoy_cc_test(
     name = "send_headers_test",
-    srcs = envoy_select_enable_yaml(
-        ["send_headers_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["send_headers_test.cc"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
@@ -20,10 +16,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "lifetimes_test",
-    srcs = envoy_select_enable_yaml(
-        ["lifetimes_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["lifetimes_test.cc"],
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -46,9 +46,8 @@ void sendRequestEndToEnd() {
   Platform::EngineBuilder engine_builder;
   engine_builder.addNativeFilter(
       "test_remote_response",
-      "{'@type': "
-      "type.googleapis.com/"
-      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
+      "[type.googleapis.com/"
+      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}");
   absl::Notification engine_running;
   Platform::EngineSharedPtr engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
                                          .setOnEngineRunning([&]() { engine_running.Notify(); })

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -19,9 +19,8 @@ TEST(SendHeadersTest, CanSendHeaders) {
   Platform::EngineBuilder engine_builder;
   engine_builder.addNativeFilter(
       "test_remote_response",
-      "{'@type': "
-      "type.googleapis.com/"
-      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
+      "[type.googleapis.com/"
+      "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse]{}");
   absl::Notification engine_running;
   Platform::EngineSharedPtr engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
                                          .setOnEngineRunning([&]() { engine_running.Notify(); })

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -1,5 +1,4 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
-load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_yaml")
 
 licenses(["notice"])  # Apache 2
 
@@ -7,10 +6,7 @@ envoy_mobile_package()
 
 envoy_cc_test(
     name = "envoy_config_test",
-    srcs = envoy_select_enable_yaml(
-        ["envoy_config_test.cc"],
-        "@envoy",
-    ),
+    srcs = ["envoy_config_test.cc"],
     linkopts = select({
         "@envoy//bazel:apple": [
             # For the TestProxyResolutionApi test.

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -458,8 +458,8 @@ TEST(TestConfig, AddNativeFilters) {
   std::string filter_name1 = "envoy.filters.http.buffer1";
   std::string filter_name2 = "envoy.filters.http.buffer2";
   std::string filter_config =
-      "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\","
-      "\"max_request_bytes\":5242880}";
+      "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes { "
+      "value: 5242880 } }";
   engine_builder.addNativeFilter(filter_name1, filter_config);
   engine_builder.addNativeFilter(filter_name2, filter_config);
 


### PR DESCRIPTION
After this PR, only internal_engine_test.cc will be left with using YAML, which will be addressed in a follow up PR.
