### PR TITLE
mobile: Remove [2] from the swift-async-await expected check

### DIFF
--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -162,7 +162,7 @@ jobs:
         - name: Build swift async await
           app: //examples/swift/async_await:app
           expected: >-
-            \[2\] Uploaded 7 MB of data
+            Uploaded 7 MB of data
           target: swift-async-await
           timeout: 10m
         - name: Build objc hello world


### PR DESCRIPTION
It is not clear to me why the test expects to see `[2]` when seeing `Uploaded 7 MB of data` should be sufficient. This PR removes the `[2]` from the expected check.

This should make the swift-async-await test less flaky.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
