### PR TITLE
mobile/test: Fix SetEventTracker test flakes

### DIFF
--- a/mobile/test/swift/integration/SetEventTrackerTest.swift
+++ b/mobile/test/swift/integration/SetEventTrackerTest.swift
@@ -18,9 +18,14 @@ final class SetEventTrackerTest: XCTestCase {
       self.expectation(description: "Passed event tracker receives an event")
 
     let engine = EngineBuilder()
+      .addLogLevel(.debug)
+      .setLogger { _, msg in
+          print(msg, terminator: "")
+      }
       .setEventTracker { event in
-        XCTAssertEqual("bar", event["foo"])
-        eventExpectation.fulfill()
+        if event["foo"] == "bar" {
+          eventExpectation.fulfill()
+        }
       }
       .addNativeFilter(
         name: "envoy.filters.http.test_event_tracker",


### PR DESCRIPTION
The event tracker callback can get called multiple times at different junctures in the code, not just from the TestEventTracker filter. This PR ensures that we only fulfill the test expectation when the TestEventTracker filter's events appear in the callback.
