### PR TITLE
quic: Use expected_server_preferred_address instead of sent_server_pr…

### DIFF
--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -203,8 +203,8 @@ void EnvoyQuicServerSession::ProcessUdpPacket(const quic::QuicSocketAddress& sel
   // is the time to actually close the connection.
   maybeHandleCloseDuringInitialize();
   quic::QuicServerSessionBase::ProcessUdpPacket(self_address, peer_address, packet);
-  if (connection()->sent_server_preferred_address().IsInitialized() &&
-      self_address == connection()->sent_server_preferred_address()) {
+  if (connection()->expected_server_preferred_address().IsInitialized() &&
+      self_address == connection()->expected_server_preferred_address()) {
     connection_stats_.num_packets_rx_on_preferred_address_.inc();
   }
   maybeApplyDelayedClose();


### PR DESCRIPTION
A recent QUICHE change renamed the method sent_server_preferred_address to expected_server_preferred_address, but left the old method around. This PR removes a call to the old method which will allow the QUICHE old method to be removed.

Risk Level: N/A - No behavior change
Testing: N/A 
Docs Changes: N/A
Release Notes: N/A