### PR TITLE
docs: add the link to term definition/explanation

### DIFF
--- a/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
@@ -10,7 +10,7 @@ SNI dynamic forward proxy
 Through the combination of :ref:`TLS inspector <config_listener_filters_tls_inspector>` listener filter,
 this network filter and the
 :ref:`dynamic forward proxy cluster <envoy_v3_api_msg_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig>`,
-Envoy supports SNI based dynamic forward proxy. The implementation works just like the
+Envoy supports `Server Name Indication https://en.wikipedia.org/wiki/Server_Name_Indication`_ (SNI) based dynamic forward proxy. The implementation works just like the
 :ref:`HTTP dynamic forward proxy <arch_overview_http_dynamic_forward_proxy>`, but using the value in
 SNI as target host instead.
 

--- a/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
@@ -10,7 +10,7 @@ SNI dynamic forward proxy
 Through the combination of :ref:`TLS inspector <config_listener_filters_tls_inspector>` listener filter,
 this network filter and the
 :ref:`dynamic forward proxy cluster <envoy_v3_api_msg_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig>`,
-Envoy supports `Server Name Indication https://en.wikipedia.org/wiki/Server_Name_Indication`_ (SNI) based dynamic forward proxy. The implementation works just like the
+Envoy supports `Server Name Indication <https://en.wikipedia.org/wiki/Server_Name_Indication>`_ (SNI) based dynamic forward proxy. The implementation works just like the
 :ref:`HTTP dynamic forward proxy <arch_overview_http_dynamic_forward_proxy>`, but using the value in
 SNI as target host instead.
 


### PR DESCRIPTION
I thought it would be a good idea to help people quickly understand what we are referring to