### PR TITLE
mobile: Use setLogger instead of addLogger in the C++ code

### DIFF
--- a/mobile/examples/cc/fetch_client/fetch_client.cc
+++ b/mobile/examples/cc/fetch_client/fetch_client.cc
@@ -3,14 +3,11 @@
 #include <iostream>
 
 #include "source/common/api/api_impl.h"
-#include "source/common/common/random_generator.h"
 #include "source/common/common/thread.h"
-#include "source/common/event/real_time_system.h"
 #include "source/common/http/utility.h"
 #include "source/common/stats/allocator_impl.h"
 #include "source/common/stats/thread_local_store.h"
 #include "source/exe/platform_impl.h"
-#include "source/exe/process_wide.h"
 
 #include "library/common/data/utility.h"
 
@@ -107,7 +104,7 @@ void Fetch::sendRequest(const absl::string_view url_string) {
 
 void Fetch::runEngine(absl::Notification& engine_running) {
   Platform::EngineBuilder engine_builder;
-  engine_builder.addLogLevel(Envoy::Platform::LogLevel::debug);
+  engine_builder.setLogLevel(Logger::Logger::debug);
   engine_builder.setOnEngineRunning([&engine_running]() { engine_running.Notify(); });
 
   {

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -50,7 +50,7 @@ void sendRequestEndToEnd() {
       "type.googleapis.com/"
       "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
   absl::Notification engine_running;
-  Platform::EngineSharedPtr engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
+  Platform::EngineSharedPtr engine = engine_builder.setLogLevel(Logger::Logger::debug)
                                          .setOnEngineRunning([&]() { engine_running.Notify(); })
                                          .build();
   engine_running.WaitForNotification();

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -23,7 +23,7 @@ TEST(SendHeadersTest, CanSendHeaders) {
       "type.googleapis.com/"
       "envoymobile.extensions.filters.http.test_remote_response.TestRemoteResponse}");
   absl::Notification engine_running;
-  Platform::EngineSharedPtr engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
+  Platform::EngineSharedPtr engine = engine_builder.setLogLevel(Logger::Logger::debug)
                                          .setOnEngineRunning([&]() { engine_running.Notify(); })
                                          .build();
   engine_running.WaitForNotification();

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -48,31 +48,6 @@ void validateStreamIntel(const envoy_final_stream_intel& final_intel, bool expec
   ASSERT_LE(final_intel.response_start_ms, final_intel.stream_end_ms);
 }
 
-// Gets the spdlog level from the test options and converts it to the Platform::LogLevel used by
-// the Envoy Mobile engine.
-Platform::LogLevel getPlatformLogLevelFromOptions() {
-  switch (TestEnvironment::getOptions().logLevel()) {
-  case spdlog::level::level_enum::trace:
-    return Platform::LogLevel::trace;
-  case spdlog::level::level_enum::debug:
-    return Platform::LogLevel::debug;
-  case spdlog::level::level_enum::info:
-    return Platform::LogLevel::info;
-  case spdlog::level::level_enum::warn:
-    return Platform::LogLevel::warn;
-  case spdlog::level::level_enum::err:
-    return Platform::LogLevel::error;
-  case spdlog::level::level_enum::critical:
-    return Platform::LogLevel::critical;
-  case spdlog::level::level_enum::off:
-    return Platform::LogLevel::off;
-  default:
-    ENVOY_LOG_MISC(warn, "Couldn't map spdlog level {}. Using `info` level.",
-                   TestEnvironment::getOptions().logLevel());
-    return Platform::LogLevel::info;
-  }
-}
-
 } // namespace
 
 // Use the Envoy mobile default config as much as possible in this test.
@@ -95,7 +70,8 @@ BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion
   defer_listener_finalization_ = true;
   memset(&last_stream_final_intel_, 0, sizeof(envoy_final_stream_intel));
 
-  builder_.addLogLevel(getPlatformLogLevelFromOptions());
+  builder_.setLogLevel(
+      static_cast<Logger::Logger::Levels>(TestEnvironment::getOptions().logLevel()));
   // The admin interface gets added by default in the ConfigHelper's constructor. Since the admin
   // interface gets compiled out by default in Envoy Mobile, remove it from the ConfigHelper's
   // bootstrap config.

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -925,8 +925,7 @@ TEST_P(ClientIntegrationTest, ResetWithBidiTraffic) {
 TEST_P(ClientIntegrationTest, ResetWithBidiTrafficExplicitData) {
   explicit_flow_control_ = true;
   autonomous_upstream_ = false;
-  // TODO(32024) remove trace logging.
-  builder_.addLogLevel(Platform::LogLevel::trace);
+  builder_.setLogLevel(Logger::Logger::debug);
   initialize();
   ConditionalInitializer headers_callback;
 


### PR DESCRIPTION
`EngineBuilder::addLogger` has been deprecated and it'll be removed in the future.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a