### PR TITLE
mobile: Clean up TestServer code

### DIFF
--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -53,8 +53,7 @@ TEST(EngineTest, SetLogger) {
   auto request_headers =
       Platform::RequestHeadersBuilder(
           Platform::RequestMethod::GET, "https",
-          absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getServerPort()),
-          "/")
+          absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getPort()), "/")
           .build();
   stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
   stream_complete.WaitForNotification();
@@ -66,7 +65,7 @@ TEST(EngineTest, SetLogger) {
 
 TEST(EngineTest, SetEngineCallbacks) {
   TestServer test_server;
-  test_server.startTestServer(TestServerType::HTTP2_WITH_TLS);
+  test_server.start(TestServerType::HTTP2_WITH_TLS);
 
   absl::Notification engine_running;
   auto engine_callbacks = std::make_unique<EngineCallbacks>();
@@ -105,8 +104,7 @@ TEST(EngineTest, SetEngineCallbacks) {
   auto request_headers =
       Platform::RequestHeadersBuilder(
           Platform::RequestMethod::GET, "https",
-          absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getServerPort()),
-          "/")
+          absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getPort()), "/")
           .build();
   stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
   stream_complete.WaitForNotification();

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -45,8 +45,7 @@ void sendRequest() {
   auto request_headers =
       Platform::RequestHeadersBuilder(
           Platform::RequestMethod::GET, "https",
-          absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getServerPort()),
-          "/")
+          absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getPort()), "/")
           .build();
   stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
   stream_complete.WaitForNotification();

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -46,7 +46,7 @@ TEST(SendHeadersTest, CanSendHeaders) {
 
   Platform::RequestHeadersBuilder request_headers_builder(
       Platform::RequestMethod::GET, "https",
-      absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getServerPort()), "/");
+      absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getPort()), "/");
   auto request_headers = request_headers_builder.build();
   auto request_headers_ptr =
       Platform::RequestHeadersSharedPtr(new Platform::RequestHeaders(request_headers));

--- a/mobile/test/common/integration/engine_with_test_server.cc
+++ b/mobile/test/common/integration/engine_with_test_server.cc
@@ -4,7 +4,7 @@ namespace Envoy {
 
 EngineWithTestServer::EngineWithTestServer(Platform::EngineBuilder& engine_builder,
                                            TestServerType type) {
-  test_server_.startTestServer(type);
+  test_server_.start(type);
   engine_ = engine_builder.build();
 }
 
@@ -14,7 +14,7 @@ EngineWithTestServer::~EngineWithTestServer() {
   // Logger::Context is a global variable that is used by both Engine and TestServer. By shutting
   // down the TestServer first, the TestServer will no longer access a Logger::Context that has been
   // destroyed.
-  test_server_.shutdownTestServer();
+  test_server_.shutdown();
   engine_->terminate();
 }
 

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -21,198 +21,9 @@
 #include "extension_registry.h"
 
 namespace Envoy {
+namespace {
 
-Network::DownstreamTransportSocketFactoryPtr TestServer::createQuicUpstreamTlsContext(
-    testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>& factory_context) {
-  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
-  Extensions::TransportSockets::Tls::ContextManagerImpl context_manager{server_factory_context_};
-  tls_context.mutable_common_tls_context()->add_alpn_protocols("h3");
-  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* certs =
-      tls_context.mutable_common_tls_context()->add_tls_certificates();
-  certs->mutable_certificate_chain()->set_filename(
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
-  certs->mutable_private_key()->set_filename(
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
-  envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport quic_config;
-  quic_config.mutable_downstream_tls_context()->MergeFrom(tls_context);
-
-  std::vector<std::string> server_names;
-  auto& config_factory = Config::Utility::getAndCheckFactoryByName<
-      Server::Configuration::DownstreamTransportSocketConfigFactory>(
-      "envoy.transport_sockets.quic");
-
-  return config_factory.createTransportSocketFactory(quic_config, factory_context, server_names);
-}
-
-Network::DownstreamTransportSocketFactoryPtr TestServer::createUpstreamTlsContext(
-    testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>& factory_context) {
-  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
-  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* certs =
-      tls_context.mutable_common_tls_context()->add_tls_certificates();
-  certs->mutable_certificate_chain()->set_filename(
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
-  certs->mutable_private_key()->set_filename(
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
-  auto* ctx = tls_context.mutable_common_tls_context()->mutable_validation_context();
-  ctx->mutable_trusted_ca()->set_filename(
-      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
-  tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
-  auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
-      tls_context, factory_context);
-  static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
-  return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
-      std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
-      std::vector<std::string>{});
-}
-
-TestServer::TestServer()
-    : api_(Api::createApiForTest(stats_store_, time_system_)),
-      version_(Network::Address::IpVersion::v4), upstream_config_(time_system_), port_(0) {
-  std::string runfiles_error;
-  runfiles_ = std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles>{
-      bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&runfiles_error)};
-  RELEASE_ASSERT(TestEnvironment::getOptionalEnvVar("NORUNFILES").has_value() ||
-                     runfiles_ != nullptr,
-                 runfiles_error);
-  TestEnvironment::setRunfiles(runfiles_.get());
-  ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
-  ON_CALL(factory_context_, statsScope())
-      .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
-  ON_CALL(factory_context_, sslContextManager())
-      .WillByDefault(testing::ReturnRef(context_manager_));
-
-  Envoy::ExtensionRegistry::registerFactories();
-}
-
-void TestServer::startTestServer(TestServerType test_server_type) {
-  ASSERT(!upstream_);
-  // pre-setup: see https://github.com/envoyproxy/envoy/blob/main/test/test_runner.cc
-  Logger::Context logging_state(spdlog::level::level_enum::err,
-                                "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v", lock, false, false);
-  // end pre-setup
-  Network::DownstreamTransportSocketFactoryPtr factory;
-
-  switch (test_server_type) {
-  case TestServerType::HTTP3:
-    // Make sure if extensions aren't statically linked QUIC will work.
-    Quic::forceRegisterQuicServerTransportSocketConfigFactory();
-    Network::forceRegisterUdpDefaultWriterFactoryFactory();
-    Quic::forceRegisterQuicHttpServerConnectionFactoryImpl();
-    Quic::forceRegisterEnvoyQuicCryptoServerStreamFactoryImpl();
-    Quic::forceRegisterQuicServerTransportSocketConfigFactory();
-    Quic::forceRegisterEnvoyQuicProofSourceFactoryImpl();
-    Quic::forceRegisterEnvoyDeterministicConnectionIdGeneratorConfigFactory();
-
-    // envoy.quic.crypto_stream.server.quiche
-    upstream_config_.upstream_protocol_ = Http::CodecType::HTTP3;
-    upstream_config_.udp_fake_upstream_ = FakeUpstreamConfig::UdpConfig();
-    factory = createQuicUpstreamTlsContext(factory_context_);
-    break;
-  case TestServerType::HTTP2_WITH_TLS:
-    upstream_config_.upstream_protocol_ = Http::CodecType::HTTP2;
-    factory = createUpstreamTlsContext(factory_context_);
-    break;
-  case TestServerType::HTTP1_WITHOUT_TLS:
-    upstream_config_.upstream_protocol_ = Http::CodecType::HTTP1;
-    factory = Network::Test::createRawBufferDownstreamSocketFactory();
-    break;
-  case TestServerType::HTTP_PROXY: {
-    Server::forceRegisterDefaultListenerManagerFactoryImpl();
-    Extensions::TransportSockets::RawBuffer::forceRegisterDownstreamRawBufferSocketFactory();
-    Server::forceRegisterConnectionHandlerFactoryImpl();
-
-    std::string config_path =
-        TestEnvironment::writeStringToFileForTest("config.pb_text", http_proxy_config);
-    test_server_ = IntegrationTestServer::create(config_path, Network::Address::IpVersion::v4,
-                                                 nullptr, nullptr, {}, time_system_, *api_);
-    test_server_->waitUntilListenersReady();
-    ENVOY_LOG_MISC(debug, "Http proxy is now running");
-    return;
-  }
-  case TestServerType::HTTPS_PROXY: {
-    Server::forceRegisterDefaultListenerManagerFactoryImpl();
-    Extensions::TransportSockets::RawBuffer::forceRegisterDownstreamRawBufferSocketFactory();
-    Server::forceRegisterConnectionHandlerFactoryImpl();
-    std::string config_path =
-        TestEnvironment::writeStringToFileForTest("config.pb_text", https_proxy_config);
-    test_server_ = IntegrationTestServer::create(config_path, Network::Address::IpVersion::v4,
-                                                 nullptr, nullptr, {}, time_system_, *api_);
-    test_server_->waitUntilListenersReady();
-    ENVOY_LOG_MISC(debug, "Https proxy is now running");
-    return;
-  }
-  }
-
-  upstream_ = std::make_unique<AutonomousUpstream>(std::move(factory), port_, version_,
-                                                   upstream_config_, true);
-
-  // Legacy behavior for cronet tests.
-  if (test_server_type == TestServerType::HTTP3) {
-    upstream_->setResponseHeaders(
-        std::make_unique<Http::TestResponseHeaderMapImpl>(Http::TestResponseHeaderMapImpl(
-            {{":status", "200"},
-             {"Cache-Control", "max-age=0"},
-             {"Content-Type", "text/plain"},
-             {"X-Original-Url", "https://test.example.com:6121/simple.txt"}})));
-    upstream_->setResponseBody("This is a simple text file served by QUIC.\n");
-  }
-
-  ENVOY_LOG_MISC(debug, "Upstream now listening on {}", upstream_->localAddress()->asString());
-}
-
-void TestServer::shutdownTestServer() {
-  ASSERT(upstream_ || test_server_);
-  upstream_.reset();
-  test_server_.reset();
-}
-
-int TestServer::getServerPort() {
-  ASSERT(upstream_ || test_server_);
-  if (upstream_) {
-    return upstream_->localAddress()->ip()->port();
-  }
-  std::atomic<uint32_t> port = 0;
-  absl::Notification port_set;
-  test_server_->server().dispatcher().post([&]() {
-    auto listeners = test_server_->server().listenerManager().listeners();
-    auto listener_it = listeners.cbegin();
-    auto socket_factory_it = listener_it->get().listenSocketFactories().begin();
-    const auto listen_addr = (*socket_factory_it)->localAddress();
-    port = listen_addr->ip()->port();
-    port_set.Notify();
-  });
-  port_set.WaitForNotification();
-  return port;
-}
-
-void TestServer::setHeadersAndData(absl::string_view header_key, absl::string_view header_value,
-                                   absl::string_view response_body) {
-  ASSERT(upstream_);
-  upstream_->setResponseHeaders(
-      std::make_unique<Http::TestResponseHeaderMapImpl>(Http::TestResponseHeaderMapImpl(
-          {{std::string(header_key), std::string(header_value)}, {":status", "200"}})));
-  upstream_->setResponseBody(std::string(response_body));
-}
-
-void TestServer::setResponse(const absl::flat_hash_map<std::string, std::string>& headers,
-                             absl::string_view body,
-                             const absl::flat_hash_map<std::string, std::string>& trailers) {
-  ASSERT(upstream_);
-  Http::TestResponseHeaderMapImpl new_headers;
-  for (const auto& [key, value] : headers) {
-    new_headers.addCopy(key, value);
-  }
-  new_headers.addCopy(":status", "200");
-  upstream_->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(new_headers));
-  upstream_->setResponseBody(std::string(body));
-  Http::TestResponseTrailerMapImpl new_trailers;
-  for (const auto& [key, value] : trailers) {
-    new_trailers.addCopy(key, value);
-  }
-  upstream_->setResponseTrailers(std::make_unique<Http::TestResponseTrailerMapImpl>(new_trailers));
-}
-
-const std::string TestServer::http_proxy_config = R"EOF(
+inline constexpr absl::string_view HTTP_PROXY_CONFIG = R"EOF(
 static_resources {
   listeners {
     name: "listener_proxy"
@@ -376,7 +187,7 @@ layered_runtime {
 }
 )EOF";
 
-const std::string TestServer::https_proxy_config = R"EOF(
+inline constexpr absl::string_view HTTPS_PROXY_CONFIG = R"EOF(
 static_resources {
   listeners {
     name: "listener_proxy"
@@ -543,5 +354,196 @@ layered_runtime {
   }
 }
 )EOF";
+} // namespace
+
+TestServer::TestServer()
+    : api_(Api::createApiForTest(stats_store_, time_system_)),
+      version_(Network::Address::IpVersion::v4), upstream_config_(time_system_), port_(0) {
+  std::string runfiles_error;
+  runfiles_ = std::unique_ptr<bazel::tools::cpp::runfiles::Runfiles>{
+      bazel::tools::cpp::runfiles::Runfiles::CreateForTest(&runfiles_error)};
+  RELEASE_ASSERT(TestEnvironment::getOptionalEnvVar("NORUNFILES").has_value() ||
+                     runfiles_ != nullptr,
+                 runfiles_error);
+  TestEnvironment::setRunfiles(runfiles_.get());
+  ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
+  ON_CALL(factory_context_, statsScope())
+      .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
+  ON_CALL(factory_context_, sslContextManager())
+      .WillByDefault(testing::ReturnRef(context_manager_));
+
+  Envoy::ExtensionRegistry::registerFactories();
+}
+
+void TestServer::start(TestServerType type) {
+  ASSERT(!upstream_);
+  // pre-setup: see https://github.com/envoyproxy/envoy/blob/main/test/test_runner.cc
+  Logger::Context logging_state(spdlog::level::level_enum::err,
+                                "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v", lock_, false, false);
+  // end pre-setup
+  Network::DownstreamTransportSocketFactoryPtr factory;
+
+  switch (type) {
+  case TestServerType::HTTP3:
+    // Make sure if extensions aren't statically linked QUIC will work.
+    Quic::forceRegisterQuicServerTransportSocketConfigFactory();
+    Network::forceRegisterUdpDefaultWriterFactoryFactory();
+    Quic::forceRegisterQuicHttpServerConnectionFactoryImpl();
+    Quic::forceRegisterEnvoyQuicCryptoServerStreamFactoryImpl();
+    Quic::forceRegisterQuicServerTransportSocketConfigFactory();
+    Quic::forceRegisterEnvoyQuicProofSourceFactoryImpl();
+    Quic::forceRegisterEnvoyDeterministicConnectionIdGeneratorConfigFactory();
+
+    // envoy.quic.crypto_stream.server.quiche
+    upstream_config_.upstream_protocol_ = Http::CodecType::HTTP3;
+    upstream_config_.udp_fake_upstream_ = FakeUpstreamConfig::UdpConfig();
+    factory = createQuicUpstreamTlsContext(factory_context_);
+    break;
+  case TestServerType::HTTP2_WITH_TLS:
+    upstream_config_.upstream_protocol_ = Http::CodecType::HTTP2;
+    factory = createUpstreamTlsContext(factory_context_);
+    break;
+  case TestServerType::HTTP1_WITHOUT_TLS:
+    upstream_config_.upstream_protocol_ = Http::CodecType::HTTP1;
+    factory = Network::Test::createRawBufferDownstreamSocketFactory();
+    break;
+  case TestServerType::HTTP_PROXY: {
+    Server::forceRegisterDefaultListenerManagerFactoryImpl();
+    Extensions::TransportSockets::RawBuffer::forceRegisterDownstreamRawBufferSocketFactory();
+    Server::forceRegisterConnectionHandlerFactoryImpl();
+
+    std::string config_path =
+        TestEnvironment::writeStringToFileForTest("config.pb_text", std::string(HTTP_PROXY_CONFIG));
+    test_server_ = IntegrationTestServer::create(config_path, Network::Address::IpVersion::v4,
+                                                 nullptr, nullptr, {}, time_system_, *api_);
+    test_server_->waitUntilListenersReady();
+    ENVOY_LOG_MISC(debug, "Http proxy is now running");
+    return;
+  }
+  case TestServerType::HTTPS_PROXY: {
+    Server::forceRegisterDefaultListenerManagerFactoryImpl();
+    Extensions::TransportSockets::RawBuffer::forceRegisterDownstreamRawBufferSocketFactory();
+    Server::forceRegisterConnectionHandlerFactoryImpl();
+    std::string config_path = TestEnvironment::writeStringToFileForTest(
+        "config.pb_text", std::string(HTTPS_PROXY_CONFIG));
+    test_server_ = IntegrationTestServer::create(config_path, Network::Address::IpVersion::v4,
+                                                 nullptr, nullptr, {}, time_system_, *api_);
+    test_server_->waitUntilListenersReady();
+    ENVOY_LOG_MISC(debug, "Https proxy is now running");
+    return;
+  }
+  }
+
+  upstream_ = std::make_unique<AutonomousUpstream>(std::move(factory), port_, version_,
+                                                   upstream_config_, true);
+
+  // Legacy behavior for cronet tests.
+  if (type == TestServerType::HTTP3) {
+    upstream_->setResponseHeaders(
+        std::make_unique<Http::TestResponseHeaderMapImpl>(Http::TestResponseHeaderMapImpl(
+            {{":status", "200"},
+             {"Cache-Control", "max-age=0"},
+             {"Content-Type", "text/plain"},
+             {"X-Original-Url", "https://test.example.com:6121/simple.txt"}})));
+    upstream_->setResponseBody("This is a simple text file served by QUIC.\n");
+  }
+
+  ENVOY_LOG_MISC(debug, "Upstream now listening on {}", upstream_->localAddress()->asString());
+}
+
+void TestServer::shutdown() {
+  ASSERT(upstream_ || test_server_);
+  upstream_.reset();
+  test_server_.reset();
+}
+
+int TestServer::getPort() {
+  ASSERT(upstream_ || test_server_);
+  if (upstream_) {
+    return upstream_->localAddress()->ip()->port();
+  }
+  std::atomic<uint32_t> port = 0;
+  absl::Notification port_set;
+  test_server_->server().dispatcher().post([&]() {
+    auto listeners = test_server_->server().listenerManager().listeners();
+    auto listener_it = listeners.cbegin();
+    auto socket_factory_it = listener_it->get().listenSocketFactories().begin();
+    const auto listen_addr = (*socket_factory_it)->localAddress();
+    port = listen_addr->ip()->port();
+    port_set.Notify();
+  });
+  port_set.WaitForNotification();
+  return port;
+}
+
+void TestServer::setHeadersAndData(absl::string_view header_key, absl::string_view header_value,
+                                   absl::string_view response_body) {
+  ASSERT(upstream_);
+  upstream_->setResponseHeaders(
+      std::make_unique<Http::TestResponseHeaderMapImpl>(Http::TestResponseHeaderMapImpl(
+          {{std::string(header_key), std::string(header_value)}, {":status", "200"}})));
+  upstream_->setResponseBody(std::string(response_body));
+}
+
+void TestServer::setResponse(const absl::flat_hash_map<std::string, std::string>& headers,
+                             absl::string_view body,
+                             const absl::flat_hash_map<std::string, std::string>& trailers) {
+  ASSERT(upstream_);
+  Http::TestResponseHeaderMapImpl new_headers;
+  for (const auto& [key, value] : headers) {
+    new_headers.addCopy(key, value);
+  }
+  new_headers.addCopy(":status", "200");
+  upstream_->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(new_headers));
+  upstream_->setResponseBody(std::string(body));
+  Http::TestResponseTrailerMapImpl new_trailers;
+  for (const auto& [key, value] : trailers) {
+    new_trailers.addCopy(key, value);
+  }
+  upstream_->setResponseTrailers(std::make_unique<Http::TestResponseTrailerMapImpl>(new_trailers));
+}
+
+Network::DownstreamTransportSocketFactoryPtr TestServer::createQuicUpstreamTlsContext(
+    testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>& factory_context) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  Extensions::TransportSockets::Tls::ContextManagerImpl context_manager{server_factory_context_};
+  tls_context.mutable_common_tls_context()->add_alpn_protocols("h3");
+  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* certs =
+      tls_context.mutable_common_tls_context()->add_tls_certificates();
+  certs->mutable_certificate_chain()->set_filename(
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
+  certs->mutable_private_key()->set_filename(
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
+  envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport quic_config;
+  quic_config.mutable_downstream_tls_context()->MergeFrom(tls_context);
+
+  std::vector<std::string> server_names;
+  auto& config_factory = Config::Utility::getAndCheckFactoryByName<
+      Server::Configuration::DownstreamTransportSocketConfigFactory>(
+      "envoy.transport_sockets.quic");
+
+  return config_factory.createTransportSocketFactory(quic_config, factory_context, server_names);
+}
+
+Network::DownstreamTransportSocketFactoryPtr TestServer::createUpstreamTlsContext(
+    testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>& factory_context) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* certs =
+      tls_context.mutable_common_tls_context()->add_tls_certificates();
+  certs->mutable_certificate_chain()->set_filename(
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
+  certs->mutable_private_key()->set_filename(
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
+  auto* ctx = tls_context.mutable_common_tls_context()->mutable_validation_context();
+  ctx->mutable_trusted_ca()->set_filename(
+      TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
+  tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
+  auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
+      tls_context, factory_context);
+  static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
+  return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
+      std::move(cfg), context_manager_, *upstream_stats_store->rootScope(),
+      std::vector<std::string>{});
+}
 
 } // namespace Envoy

--- a/mobile/test/common/integration/test_server_interface.cc
+++ b/mobile/test/common/integration/test_server_interface.cc
@@ -12,7 +12,7 @@ void start_server(Envoy::TestServerType test_server_type) {
   weak_test_server_ = strong_test_server_;
 
   if (auto server = test_server()) {
-    server->startTestServer(test_server_type);
+    server->start(test_server_type);
   }
 }
 
@@ -21,12 +21,12 @@ void shutdown_server() {
   // but retain it long enough to synchronously shutdown.
   auto server = strong_test_server_;
   strong_test_server_.reset();
-  server->shutdownTestServer();
+  server->shutdown();
 }
 
 int get_server_port() {
   if (auto server = test_server()) {
-    return server->getServerPort();
+    return server->getPort();
   }
   return -1; // failure
 }

--- a/mobile/test/jni/jni_http_proxy_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_proxy_test_server_factory.cc
@@ -14,13 +14,13 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_start(J
 
   Envoy::ExtensionRegistry::registerFactories();
   Envoy::TestServer* test_server = new Envoy::TestServer();
-  test_server->startTestServer(static_cast<Envoy::TestServerType>(type));
+  test_server->start(static_cast<Envoy::TestServerType>(type));
 
   auto java_http_proxy_server_factory_class = jni_helper.findClass(
       "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
   auto java_init_method_id =
       jni_helper.getMethodId(java_http_proxy_server_factory_class.get(), "<init>", "(JI)V");
-  int port = test_server->getServerPort();
+  int port = test_server->getPort();
   return jni_helper
       .newObject(java_http_proxy_server_factory_class.get(), java_init_method_id,
                  reinterpret_cast<jlong>(test_server), static_cast<jint>(port))
@@ -35,6 +35,6 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_00024Ht
   auto java_handle_field_id = jni_helper.getFieldId(java_class.get(), "handle", "J");
   jlong java_handle = jni_helper.getLongField(instance, java_handle_field_id);
   Envoy::TestServer* test_server = reinterpret_cast<Envoy::TestServer*>(java_handle);
-  test_server->shutdownTestServer();
+  test_server->shutdown();
   delete test_server;
 }

--- a/mobile/test/jni/jni_http_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_test_server_factory.cc
@@ -15,7 +15,7 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_start(
 
   Envoy::ExtensionRegistry::registerFactories();
   Envoy::TestServer* test_server = new Envoy::TestServer();
-  test_server->startTestServer(static_cast<Envoy::TestServerType>(type));
+  test_server->start(static_cast<Envoy::TestServerType>(type));
 
   auto cpp_headers = Envoy::JNI::javaMapToCppMap(jni_helper, headers);
   auto cpp_body = Envoy::JNI::javaStringToCppString(jni_helper, body);
@@ -26,7 +26,7 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_start(
       "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer");
   auto java_init_method_id =
       jni_helper.getMethodId(java_http_server_factory_class.get(), "<init>", "(JI)V");
-  int port = test_server->getServerPort();
+  int port = test_server->getPort();
   return jni_helper
       .newObject(java_http_server_factory_class.get(), java_init_method_id,
                  reinterpret_cast<jlong>(test_server), static_cast<jint>(port))
@@ -41,6 +41,6 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_00024HttpTes
   auto java_handle_field_id = jni_helper.getFieldId(java_class.get(), "handle", "J");
   jlong java_handle = jni_helper.getLongField(instance, java_handle_field_id);
   Envoy::TestServer* test_server = reinterpret_cast<Envoy::TestServer*>(java_handle);
-  test_server->shutdownTestServer();
+  test_server->shutdown();
   delete test_server;
 }


### PR DESCRIPTION
This PR cleans up the `TestServer` code to follow Envoy naming convention as well as some C++ best practices.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
