### PR TITLE
Recommend the Clang-14 tarball

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -98,7 +98,9 @@ for how to update or override dependencies.
     ```
 
     ### Linux
-    On Linux, we recommend using the prebuilt Clang+LLVM package from [LLVM official site](http://releases.llvm.org/download.html).
+    On Linux, we recommend using the prebuilt Clang+LLVM package from [LLVM official site](http://releases.llvm.org/download.html) for Clang 14.
+    Note that newer versions of Clang do not include this package for Linux, but neither are newer versions of Clang able to build the Envoy dependencies.
+
     Extract the tar.xz and run the following:
     ```console
     bazel/setup_clang.sh <PATH_TO_EXTRACTED_CLANG_LLVM>

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -99,7 +99,6 @@ for how to update or override dependencies.
 
     ### Linux
     On Linux, we recommend using the prebuilt Clang+LLVM package from [LLVM official site](http://releases.llvm.org/download.html) for Clang 14.
-    Note that newer versions of Clang do not include this package for Linux, but neither are newer versions of Clang able to build the Envoy dependencies.
 
     Extract the tar.xz and run the following:
     ```console


### PR DESCRIPTION
Newer versions of this Clang+LLVM budnel are not available in the Clang releases, and other means of installing Clang-16 suggest that it fails building various Envoy dependencies. Clang-14 is used in CI, so recommend that version.

This is based on my experience trying to build Envoy from source (without using the docker image).