### PR TITLE
mobile: Add sendHeaders and close with Envoy::Http::HeaderMap types

### DIFF
--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -115,6 +115,7 @@ envoy_cc_library(
         "//library/common/api:c_types",
         "//library/common/data:utility_lib",
         "//library/common/extensions/key_value/platform:config",
+        "@envoy//source/common/http:header_map_lib",
         "@envoy//source/common/http:utility_lib",
     ],
 )

--- a/mobile/library/cc/stream.cc
+++ b/mobile/library/cc/stream.cc
@@ -8,8 +8,7 @@
 namespace Envoy {
 namespace Platform {
 
-Stream::Stream(Envoy::InternalEngine* engine, envoy_stream_t handle)
-    : engine_(engine), handle_(handle) {}
+Stream::Stream(InternalEngine* engine, envoy_stream_t handle) : engine_(engine), handle_(handle) {}
 
 Stream& Stream::sendHeaders(RequestHeadersSharedPtr headers, bool end_stream) {
   auto request_header_map = Http::Utility::createRequestHeaderMapPtr();
@@ -24,6 +23,11 @@ Stream& Stream::sendHeaders(RequestHeadersSharedPtr headers, bool end_stream) {
     }
   }
   engine_->sendHeaders(handle_, std::move(request_header_map), end_stream);
+  return *this;
+}
+
+Stream& Stream::sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream) {
+  engine_->sendHeaders(handle_, std::move(headers), end_stream);
   return *this;
 }
 
@@ -45,6 +49,10 @@ void Stream::close(RequestTrailersSharedPtr trailers) {
     }
   }
   engine_->sendTrailers(handle_, std::move(request_trailer_map));
+}
+
+void Stream::close(Http::RequestTrailerMapPtr trailers) {
+  engine_->sendTrailers(handle_, std::move(trailers));
 }
 
 void Stream::close(envoy_data data) { engine_->sendData(handle_, data, true); }

--- a/mobile/library/cc/stream.h
+++ b/mobile/library/cc/stream.h
@@ -2,9 +2,10 @@
 
 #include <vector>
 
+#include "envoy/http/header_map.h"
+
 #include "library/cc/request_headers.h"
 #include "library/cc/request_trailers.h"
-#include "library/cc/stream_callbacks.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -13,17 +14,39 @@ namespace Platform {
 
 class Stream {
 public:
-  Stream(Envoy::InternalEngine* engine, envoy_stream_t handle);
+  Stream(InternalEngine* engine, envoy_stream_t handle);
 
-  Stream& sendHeaders(RequestHeadersSharedPtr headers, bool end_stream);
+  [[deprecated]] Stream& sendHeaders(RequestHeadersSharedPtr headers, bool end_stream);
+
+  /**
+   * Send the headers over an open HTTP stream. This function can be invoked
+   * once and needs to be called before `sendData`.
+   *
+   * @param headers the headers to send.
+   * @param end_stream indicates whether to close the stream locally after sending this frame.
+   */
+  Stream& sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream);
+
   Stream& sendData(envoy_data data);
+
   Stream& readData(size_t bytes_to_read);
-  void close(RequestTrailersSharedPtr trailers);
+
+  [[deprecated]] void close(RequestTrailersSharedPtr trailers);
+
+  /**
+   * Send trailers over an open HTTP stream. This method can only be invoked once per stream.
+   * Note that this method implicitly closes the stream locally.
+   *
+   * @param trailers the trailers to send.send
+   */
+  void close(Http::RequestTrailerMapPtr trailers);
+
   void close(envoy_data data);
+
   void cancel();
 
 private:
-  Envoy::InternalEngine* engine_;
+  InternalEngine* engine_;
   envoy_stream_t handle_;
 };
 

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -10,6 +10,20 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//library/common/http:header_utility_lib",
+        "//test/common/integration:engine_with_test_server",
+        "//test/common/integration:test_server_lib",
+        "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test(
+    name = "send_trailers_test",
+    srcs = ["send_trailers_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:engine_builder_lib",
+        "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -8,11 +8,56 @@
 #include "library/cc/envoy_error.h"
 #include "library/cc/request_headers_builder.h"
 #include "library/cc/request_method.h"
+#include "library/common/http/header_utility.h"
 
 namespace Envoy {
-namespace {
 
-TEST(SendHeadersTest, CanSendHeaders) {
+TEST(SendHeadersTest, Success) {
+  absl::Notification engine_running;
+  Platform::EngineBuilder engine_builder;
+  engine_builder.enforceTrustChainVerification(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);
+  engine_running.WaitForNotification();
+
+  int actual_status_code;
+  bool actual_end_stream;
+  absl::Notification stream_complete;
+  auto stream_prototype = engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream =
+      (*stream_prototype)
+          .setOnHeaders(
+              [&](Platform::ResponseHeadersSharedPtr headers, bool end_stream, envoy_stream_intel) {
+                actual_status_code = headers->httpStatus();
+                actual_end_stream = end_stream;
+              })
+          .setOnData([&](envoy_data data, bool end_stream) {
+            actual_end_stream = end_stream;
+            data.release(data.context);
+          })
+          .setOnComplete(
+              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
+          .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                          envoy_final_stream_intel) { stream_complete.Notify(); })
+          .setOnCancel(
+              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
+          .start();
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"), "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getPort()));
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_TRUE(actual_end_stream);
+}
+
+TEST(SendHeadersTest, SuccessWithDeprecatedFunction) {
   absl::Notification engine_running;
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
@@ -57,5 +102,4 @@ TEST(SendHeadersTest, CanSendHeaders) {
   EXPECT_TRUE(actual_end_stream);
 }
 
-} // namespace
 } // namespace Envoy

--- a/mobile/test/cc/integration/send_trailers_test.cc
+++ b/mobile/test/cc/integration/send_trailers_test.cc
@@ -1,0 +1,63 @@
+#include "test/common/integration/engine_with_test_server.h"
+#include "test/common/integration/test_server.h"
+
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/engine_builder.h"
+#include "library/cc/envoy_error.h"
+#include "library/common/http/header_utility.h"
+
+namespace Envoy {
+
+TEST(SendTrailersTest, Success) {
+  absl::Notification engine_running;
+  Platform::EngineBuilder engine_builder;
+  engine_builder.enforceTrustChainVerification(false)
+      .setLogLevel(Logger::Logger::debug)
+      .setOnEngineRunning([&]() { engine_running.Notify(); });
+  EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);
+  engine_running.WaitForNotification();
+
+  engine_with_test_server.testServer().setResponse({}, "body", {{"trailer-key", "trailer-value"}});
+
+  int actual_status_code;
+  std::string actual_trailer_value;
+  absl::Notification stream_complete;
+  auto stream_prototype = engine_with_test_server.engine()->streamClient()->newStreamPrototype();
+  Platform::StreamSharedPtr stream =
+      (*stream_prototype)
+          .setOnHeaders([&](Platform::ResponseHeadersSharedPtr headers, bool, envoy_stream_intel) {
+            actual_status_code = headers->httpStatus();
+          })
+          .setOnTrailers([&](Platform::ResponseTrailersSharedPtr trailers, envoy_stream_intel) {
+            ASSERT_TRUE(trailers->contains("trailer-key"));
+            actual_trailer_value = (*trailers)["trailer-key"][0];
+          })
+          .setOnComplete(
+              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
+          .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
+                          envoy_final_stream_intel) { stream_complete.Notify(); })
+          .setOnCancel(
+              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
+          .start();
+
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"), "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   absl::StrFormat("localhost:%d", engine_with_test_server.testServer().getPort()));
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), false);
+
+  auto trailers = Http::Utility::createRequestTrailerMapPtr();
+  trailers->addCopy(Http::LowerCaseString("trailer-key"), "trailer-value");
+  stream->close(std::move(trailers));
+
+  stream_complete.WaitForNotification();
+
+  EXPECT_EQ(actual_status_code, 200);
+  EXPECT_EQ(actual_trailer_value, "trailer-value");
+}
+
+} // namespace Envoy


### PR DESCRIPTION
This PR adds `Stream::sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream)` and `close(Http::RequestTrailerMapPtr trailers)` that use Envoy Core types and deprecates the `sendHeaders(RequestHeadersSharedPtr headers, bool end_stream)` and `close(RequestTrailersSharedPtr trailers)` that use wrapper types. This change will eliminate unnecessary copies and indirection.

This PR also adds a missing a unit test for sending a trailer.

Risk Level: low (new functions)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
