### PR TITLE
mobile: Switch to absl::AnyInvocable for engine_types.h

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -171,8 +171,13 @@ EngineBuilder& EngineBuilder::setEngineCallbacks(std::unique_ptr<EngineCallbacks
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setOnEngineRunning(std::function<void()> closure) {
+EngineBuilder& EngineBuilder::setOnEngineRunning(absl::AnyInvocable<void()> closure) {
   callbacks_->on_engine_running_ = std::move(closure);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setOnEngineExit(absl::AnyInvocable<void()> closure) {
+  callbacks_->on_exit_ = std::move(closure);
   return *this;
 }
 

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -130,8 +130,8 @@ public:
   EngineBuilder& setLogLevel(Logger::Logger::Levels log_level);
   EngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
   EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
-  [[deprecated("Use EngineBuilder::setEngineCallbacks instead")]] EngineBuilder&
-  setOnEngineRunning(std::function<void()> closure);
+  EngineBuilder& setOnEngineRunning(absl::AnyInvocable<void()> closure);
+  EngineBuilder& setOnEngineExit(absl::AnyInvocable<void()> closure);
   EngineBuilder& setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker);
   EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
   EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);

--- a/mobile/library/common/BUILD
+++ b/mobile/library/common/BUILD
@@ -84,6 +84,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/functional:any_invocable",
         "@com_google_absl//absl/strings",
         "@envoy//source/common/common:base_logger_lib",
     ],

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -1,45 +1,35 @@
 #pragma once
 
-//==================================================================================================
-// READ THIS BEFORE UPDATING THIS FILE
-//==================================================================================================
-// Keep the code here (including the includes) as simple as possible given that this file will be
-// directly included by Swift and the Swift/C++ interop is far from complete. Including headers or
-// having code that is not supported by Swift may lead into weird compilation errors that can be
-// difficult to debug.
-// For more information, see
-// https://github.com/apple/swift/blob/swift-5.7.3-RELEASE/docs/CppInteroperability/CppInteroperabilityStatus.md
-
-#include <functional>
 #include <string>
 
 #include "source/common/common/base_logger.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/functional/any_invocable.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
 
 /** The callbacks for the Envoy Engine. */
 struct EngineCallbacks {
-  std::function<void()> on_engine_running_ = [] {};
-  std::function<void()> on_exit_ = [] {};
+  absl::AnyInvocable<void()> on_engine_running_ = [] {};
+  absl::AnyInvocable<void()> on_exit_ = [] {};
 };
 
 /** The callbacks for Envoy Logger. */
 struct EnvoyLogger {
-  std::function<void(Logger::Logger::Levels, const std::string&)> on_log_ =
+  absl::AnyInvocable<void(Logger::Logger::Levels, const std::string&)> on_log_ =
       [](Logger::Logger::Levels, const std::string&) {};
-  std::function<void()> on_exit_ = [] {};
+  absl::AnyInvocable<void()> on_exit_ = [] {};
 };
 
 inline constexpr absl::string_view ENVOY_EVENT_TRACKER_API_NAME = "event_tracker_api";
 
 /** The callbacks for Envoy Event Tracker. */
 struct EnvoyEventTracker {
-  std::function<void(const absl::flat_hash_map<std::string, std::string>&)> on_track_ =
+  absl::AnyInvocable<void(const absl::flat_hash_map<std::string, std::string>&)> on_track_ =
       [](const absl::flat_hash_map<std::string, std::string>&) {};
-  std::function<void()> on_exit_ = [] {};
+  absl::AnyInvocable<void()> on_exit_ = [] {};
 };
 
 } // namespace Envoy

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -77,8 +77,13 @@ class SendDataTest {
       .newStreamPrototype()
       .setOnResponseHeaders { headers, _, _ -> responseStatus = headers.httpStatus }
       .setOnResponseData { _, endStream, _ ->
+        // Sometimes Envoy Mobile may send an empty data (0 byte) with `endStream` set to true
+        // to indicate an end of stream. So, we should only do `expectation.countDown()`
+        // when the `endStream` is true.
         responseEndStream = endStream
-        expectation.countDown()
+        if (endStream) {
+          expectation.countDown()
+        }
       }
       .setOnError { _, _ -> fail("Unexpected error") }
       .start()


### PR DESCRIPTION
This PR switches from `std::function` to `absl::AnyInvocable` since `absl::AnyInvocable` is more flexible, such that it does not have a copyability requirement. The change should mostly be backward compatible.

This change also undeprecates `setOnEngineRunning` and introduces `setOnEngineExit` since it makes adding engine callbacks much nicer.

This PR also removes the comment about Swift/C++ interop since that support has been removed in https://github.com/envoyproxy/envoy/pull/33484.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
