### PR TITLE
Make findLongestPrefix less error-prone

### DIFF
--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -691,12 +691,11 @@ template <class Value> struct TrieLookupTable {
    * @param key the key used to find.
    * @return the value matching the longest prefix based on the key.
    */
-  Value findLongestPrefix(const char* key) const {
+  Value findLongestPrefix(absl::string_view key) const {
     const TrieEntry<Value>* current = &root_;
     const TrieEntry<Value>* result = current;
 
-    while (uint8_t c = *key) {
-      // https://github.com/facebook/mcrouter/blob/master/mcrouter/lib/fbi/cpp/Trie-inl.h#L126-L143
+    for (uint8_t c : key) {
       current = current->entries_[c].get();
 
       if (current == nullptr) {
@@ -704,7 +703,6 @@ template <class Value> struct TrieLookupTable {
       } else if (current->value_) {
         result = current;
       }
-      key++;
     }
     return result ? result->value_ : nullptr;
   }

--- a/source/common/matcher/prefix_map_matcher.h
+++ b/source/common/matcher/prefix_map_matcher.h
@@ -22,7 +22,7 @@ public:
 
 protected:
   absl::optional<OnMatch<DataType>> doMatch(const std::string& data) override {
-    const auto result = children_.findLongestPrefix(data.c_str());
+    const auto result = children_.findLongestPrefix(data);
     if (result) {
       return *result;
     }

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -98,9 +98,9 @@ RouteSharedPtr PrefixRoutes::upstreamPool(std::string& key,
   PrefixSharedPtr value = nullptr;
   if (case_insensitive_) {
     std::string copy = absl::AsciiStrToLower(key);
-    value = prefix_lookup_table_.findLongestPrefix(copy.c_str());
+    value = prefix_lookup_table_.findLongestPrefix(copy);
   } else {
-    value = prefix_lookup_table_.findLongestPrefix(key.c_str());
+    value = prefix_lookup_table_.findLongestPrefix(key);
   }
 
   if (value == nullptr) {


### PR DESCRIPTION
Commit Message: Make findLongestPrefix less error-prone
Additional Description: Old version assumes a null-terminated char* with no enforcement, and all callers were calling `c_str` on a `std::string` which can potentially provoke a performance cost depending on implementation. The code is also more readable with a string_view, and safer against e.g. a modification that breaks out of the loop, or that wants to do something with the key after the loop is over (key was previously modified and now is not). Also removes a comment citing external code where the link was broken anyway and the code now in place barely resembles the original code, after the bug fix #33478 and this change.
Also makes findLongestPrefix signature and behavior consistent with the signature and behavior of `find` right above it.
Example degenerate case with char* that would be fixed by this:
```
  auto trie = psuedocode_trie_factory({"foobar", "foo"});
  absl::string_view foobar = "foobar";
  absl::string_view foob = example.substr(0, 4);
  // before
  trie.findLongestPrefix(foob.begin());  // would return the foobar value
  // after
  trie.findLongestPrefix(foob);  // will return the foo value
```
An even more degenerate case would be to pass a non-zero-terminated char* foob that's followed by unallocated memory which would make asan cry.
Risk Level: Negligible. Same tests pass, behavior should be identical, just cleaner.
Testing: Existing tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
