### PR TITLE
Skip filter state update when composite filter is in upstream

### DIFF
--- a/docs/root/configuration/http/http_filters/composite_filter.rst
+++ b/docs/root/configuration/http/http_filters/composite_filter.rst
@@ -20,6 +20,7 @@ incremented.
 
 This filter adds a map of the delegated filter name (of the action that is matched )and the root config filter name to the filter state with key
 ``envoy.extensions.filters.http.composite.matched_actions``
+This filter state is not emitted when the filter is configed in the upstream filter chain.
 
 Contains a map of pairs `FILTER_CONFIG_NAME:ACTION_NAME`:
 

--- a/docs/root/configuration/http/http_filters/composite_filter.rst
+++ b/docs/root/configuration/http/http_filters/composite_filter.rst
@@ -20,7 +20,7 @@ incremented.
 
 This filter adds a map of the delegated filter name (of the action that is matched )and the root config filter name to the filter state with key
 ``envoy.extensions.filters.http.composite.matched_actions``
-This filter state is not emitted when the filter is configed in the upstream filter chain.
+This filter state is not emitted when the filter is configured in the upstream filter chain.
 
 Contains a map of pairs `FILTER_CONFIG_NAME:ACTION_NAME`:
 

--- a/source/extensions/filters/http/composite/config.cc
+++ b/source/extensions/filters/http/composite/config.cc
@@ -19,8 +19,8 @@ absl::StatusOr<Http::FilterFactoryCb> CompositeFilterFactory::createFilterFactor
   auto stats = std::make_shared<FilterStats>(
       FilterStats{ALL_COMPOSITE_FILTER_STATS(POOL_COUNTER_PREFIX(dual_info.scope, prefix))});
 
-  return [stats](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    auto filter = std::make_shared<Filter>(*stats, callbacks.dispatcher());
+  return [stats, dual_info](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    auto filter = std::make_shared<Filter>(*stats, callbacks.dispatcher(), dual_info.is_upstream);
     callbacks.addStreamFilter(filter);
     callbacks.addAccessLogHandler(filter);
   };

--- a/source/extensions/filters/http/composite/filter.cc
+++ b/source/extensions/filters/http/composite/filter.cc
@@ -142,6 +142,9 @@ void Filter::onMatchCallback(const Matcher::Action& action) {
 
 void Filter::updateFilterState(Http::StreamFilterCallbacks* callback,
                                const std::string& filter_name, const std::string& action_name) {
+  if (isUpstream()) {
+    return;
+  }
   auto* info = callback->streamInfo().filterState()->getDataMutable<MatchedActionInfo>(
       MatchedActionsFilterStateKey);
   if (info != nullptr) {

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -56,8 +56,9 @@ class Filter : public Http::StreamFilter,
                public AccessLog::Instance,
                Logger::Loggable<Logger::Id::filter> {
 public:
-  Filter(FilterStats& stats, Event::Dispatcher& dispatcher)
-      : dispatcher_(dispatcher), decoded_headers_(false), stats_(stats) {}
+  Filter(FilterStats& stats, Event::Dispatcher& dispatcher, bool is_upstream)
+      : dispatcher_(dispatcher), decoded_headers_(false), stats_(stats), is_upstream_(is_upstream) {
+  }
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
@@ -108,6 +109,8 @@ public:
       log->log(log_context, info);
     }
   }
+
+  bool isUpstream() { return is_upstream_; }
 
 private:
   friend FactoryCallbacksWrapper;
@@ -165,6 +168,8 @@ private:
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   FilterStats& stats_;
+  // Filter in the upstream filter chain.
+  bool is_upstream_;
 };
 
 } // namespace Composite

--- a/source/extensions/filters/http/composite/filter.h
+++ b/source/extensions/filters/http/composite/filter.h
@@ -110,7 +110,7 @@ public:
     }
   }
 
-  bool isUpstream() { return is_upstream_; }
+  bool isUpstream() const { return is_upstream_; }
 
 private:
   friend FactoryCallbacksWrapper;


### PR DESCRIPTION
This is to address issue: https://github.com/envoyproxy/envoy/issues/33343

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
