### PR TITLE
Add `load()` statements for the Bazel builtin top-level java symbols

### DIFF
--- a/mobile/bazel/dokka.bzl
+++ b/mobile/bazel/dokka.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_common")
+
 def _sources_javadocs_impl(ctx):
     javabase = ctx.attr._javabase[java_common.JavaRuntimeInfo]
     plugins_classpath = ";".join([


### PR DESCRIPTION
Loads are being added in preparation for moving the symbols out of Bazel and into `@rules_java`.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add `load()` statements for the Bazel builtin top-level java symbols
Additional Description: Loads are being added in preparation for moving the symbols out of Bazel and into `@rules_java`.
Risk Level: Low
Testing: `bazel build //library/kotlin/io/envoyproxy/envoymobile:envoy_aar_android_javadocs` 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
