### PR TITLE
[extension inplace change the ImmediateResponse::body type from string to bytes

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -339,7 +339,7 @@ message ImmediateResponse {
 
   // The message body to return with the response which is sent using the
   // text/plain content type, or encoded in the grpc-message header.
-  string body = 3;
+  bytes body = 3;
 
   // If set, then include a gRPC status trailer.
   GrpcStatus grpc_status = 4;


### PR DESCRIPTION
Commit Message: inplace change the ImmediateResponse::body type from string to bytes
Additional Description: in issue https://github.com/envoyproxy/envoy/issues/32071 Folks found the immediateResponse::body was a string, which fails Envoy ext_proc filter to receive a non-utf8 payload 
Risk Level: LOW  (the in-place type change only drops the utf8 verification in generated code).
Testing: existing tests. 
Docs Changes:
Release Notes:
Platform Specific Features: