### PR TITLE
mobile: Replace envoy_network_t with Envoy::NetWorkType enum class

### DIFF
--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -32,4 +32,14 @@ struct EnvoyEventTracker {
   absl::AnyInvocable<void()> on_exit_ = [] {};
 };
 
+/** Networks classified by the physical link. */
+enum class NetworkType : int {
+  // This is the default and includes cases where network characteristics are unknown.
+  Generic = 0,
+  // This includes WiFi and other local area wireless networks.
+  WLAN = 1,
+  // This includes all mobile phone networks.
+  WWAN = 2,
+};
+
 } // namespace Envoy

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -268,10 +268,10 @@ envoy_status_t InternalEngine::resetConnectivityState() {
   return dispatcher_->post([&]() -> void { connectivity_manager_->resetConnectivityState(); });
 }
 
-envoy_status_t InternalEngine::setPreferredNetwork(envoy_network_t network) {
+envoy_status_t InternalEngine::setPreferredNetwork(NetworkType network) {
   return dispatcher_->post([&, network]() -> void {
     envoy_netconf_t configuration_key =
-        Envoy::Network::ConnectivityManagerImpl::setPreferredNetwork(network);
+        Network::ConnectivityManagerImpl::setPreferredNetwork(network);
     connectivity_manager_->refreshDns(configuration_key, true);
   });
 }

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -97,7 +97,7 @@ public:
   // to networkConnectivityManager after doing a dispatcher post (thread context switch)
   envoy_status_t setProxySettings(const char* host, const uint16_t port);
   envoy_status_t resetConnectivityState();
-  envoy_status_t setPreferredNetwork(envoy_network_t network);
+  envoy_status_t setPreferredNetwork(NetworkType network);
 
   /**
    * Increment a counter with a given string of elements and by the given count.

--- a/mobile/library/common/network/BUILD
+++ b/mobile/library/common/network/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":proxy_settings_lib",
+        "//library/common:engine_types_lib",
         "//library/common/network:src_addr_socket_option_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/network:socket_interface",

--- a/mobile/library/common/network/connectivity_manager.h
+++ b/mobile/library/common/network/connectivity_manager.h
@@ -10,6 +10,7 @@
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache.h"
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
 
+#include "library/common/engine_types.h"
 #include "library/common/network/proxy_settings.h"
 #include "library/common/types/c_types.h"
 
@@ -105,7 +106,7 @@ public:
   /**
    * @returns the current OS default/preferred network class.
    */
-  virtual envoy_network_t getPreferredNetwork() PURE;
+  virtual NetworkType getPreferredNetwork() PURE;
 
   /**
    * @returns the current mode used to determine upstream socket options.
@@ -168,7 +169,7 @@ public:
   /**
    * @returns the current socket options that should be used for connections.
    */
-  virtual Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network,
+  virtual Socket::OptionsSharedPtr getUpstreamSocketOptions(NetworkType network,
                                                             envoy_socket_mode_t socket_mode) PURE;
 
   /**
@@ -197,7 +198,7 @@ public:
    * @param network, the OS-preferred network.
    * @returns configuration key to associate with any related calls.
    */
-  static envoy_netconf_t setPreferredNetwork(envoy_network_t network);
+  static envoy_netconf_t setPreferredNetwork(NetworkType network);
 
   ConnectivityManagerImpl(Upstream::ClusterManager& cluster_manager,
                           DnsCacheManagerSharedPtr dns_cache_manager)
@@ -217,7 +218,7 @@ public:
   std::vector<InterfacePair> enumerateV6Interfaces() override;
   std::vector<InterfacePair> enumerateInterfaces(unsigned short family, unsigned int select_flags,
                                                  unsigned int reject_flags) override;
-  envoy_network_t getPreferredNetwork() override;
+  NetworkType getPreferredNetwork() override;
   envoy_socket_mode_t getSocketMode() override;
   envoy_netconf_t getConfigurationKey() override;
   Envoy::Network::ProxySettingsConstSharedPtr getProxySettings() override;
@@ -227,7 +228,7 @@ public:
   void setInterfaceBindingEnabled(bool enabled) override;
   void refreshDns(envoy_netconf_t configuration_key, bool drain_connections) override;
   void resetConnectivityState() override;
-  Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network,
+  Socket::OptionsSharedPtr getUpstreamSocketOptions(NetworkType network,
                                                     envoy_socket_mode_t socket_mode) override;
   envoy_netconf_t addUpstreamSocketOptions(Socket::OptionsSharedPtr options) override;
   Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dnsCache() override;
@@ -237,13 +238,13 @@ private:
     // The configuration key is passed through calls dispatched on the run loop to determine if
     // they're still valid/relevant at time of execution.
     envoy_netconf_t configuration_key_ ABSL_GUARDED_BY(mutex_);
-    envoy_network_t network_ ABSL_GUARDED_BY(mutex_);
+    NetworkType network_ ABSL_GUARDED_BY(mutex_);
     uint8_t remaining_faults_ ABSL_GUARDED_BY(mutex_);
     envoy_socket_mode_t socket_mode_ ABSL_GUARDED_BY(mutex_);
     Thread::MutexBasicLockable mutex_;
   };
-  Socket::OptionsSharedPtr getAlternateInterfaceSocketOptions(envoy_network_t network);
-  InterfacePair getActiveAlternateInterface(envoy_network_t network, unsigned short family);
+  Socket::OptionsSharedPtr getAlternateInterfaceSocketOptions(NetworkType network);
+  InterfacePair getActiveAlternateInterface(NetworkType network, unsigned short family);
 
   bool enable_drain_post_dns_refresh_{false};
   bool enable_interface_binding_{false};

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -61,18 +61,6 @@ typedef enum {
   ENVOY_REQUEST_TIMEOUT,
 } envoy_error_code_t;
 
-/**
- * Networks classified by last physical link.
- * ENVOY_NET_GENERIC is default and includes cases where network characteristics are unknown.
- * ENVOY_NET_WLAN includes WiFi and other local area wireless networks.
- * ENVOY_NET_WWAN includes all mobile phone networks.
- */
-typedef enum {
-  ENVOY_NET_GENERIC = 0,
-  ENVOY_NET_WLAN = 1,
-  ENVOY_NET_WWAN = 2,
-} envoy_network_t;
-
 #ifdef __cplusplus
 extern "C" { // release function
 #endif

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -30,9 +30,6 @@ import java.util.Collections;
 public class AndroidNetworkMonitor extends BroadcastReceiver {
   private static final String PERMISSION_DENIED_STATS_ELEMENT =
       "android_permissions.network_state_denied";
-  private static final int ENVOY_NET_GENERIC = 0;
-  private static final int ENVOY_NET_WWAN = 1;
-  private static final int ENVOY_NET_WLAN = 2;
 
   private static volatile AndroidNetworkMonitor instance = null;
 
@@ -138,13 +135,13 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
 
     switch (networkType) {
     case ConnectivityManager.TYPE_MOBILE:
-      envoyEngine.setPreferredNetwork(EnvoyNetworkType.ENVOY_NETWORK_TYPE_WWAN);
+      envoyEngine.setPreferredNetwork(EnvoyNetworkType.WWAN);
       return;
     case ConnectivityManager.TYPE_WIFI:
-      envoyEngine.setPreferredNetwork(EnvoyNetworkType.ENVOY_NETWORK_TYPE_WLAN);
+      envoyEngine.setPreferredNetwork(EnvoyNetworkType.WLAN);
       return;
     default:
-      envoyEngine.setPreferredNetwork(EnvoyNetworkType.ENVOY_NETWORK_TYPE_GENERIC);
+      envoyEngine.setPreferredNetwork(EnvoyNetworkType.GENERIC);
     }
   }
 

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -164,19 +164,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   @Override
   public void setPreferredNetwork(EnvoyNetworkType network) {
     checkIsTerminated();
-    switch (network) {
-    case ENVOY_NETWORK_TYPE_WWAN:
-      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WWAN);
-      return;
-    case ENVOY_NETWORK_TYPE_WLAN:
-      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WLAN);
-      return;
-    case ENVOY_NETWORK_TYPE_GENERIC:
-      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_GENERIC);
-      return;
-    default:
-      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_GENERIC);
-    }
+    JniLibrary.setPreferredNetwork(engineHandle, network.getValue());
   }
 
   public void setProxySettings(String host, int port) {

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
@@ -2,10 +2,15 @@ package io.envoyproxy.envoymobile.engine.types;
 
 // Network interface type
 public enum EnvoyNetworkType {
-  // WWAN
-  ENVOY_NETWORK_TYPE_WWAN,
-  // WLAN
-  ENVOY_NETWORK_TYPE_WLAN,
-  // GENERIC
-  ENVOY_NETWORK_TYPE_GENERIC
+  GENERIC(0),
+  WLAN(1),
+  WWAN(2),
+  ;
+
+  private final int value;
+
+  EnvoyNetworkType(int value) { this.value = value; }
+
+  /** Gets the numerical value of this enum. */
+  public int getValue() { return value; }
 }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -1297,7 +1297,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_setPreferredNetwork(JNIEnv* /*e
                                                                      jclass, // class
                                                                      jlong engine, jint network) {
   return reinterpret_cast<Envoy::InternalEngine*>(engine)->setPreferredNetwork(
-      static_cast<envoy_network_t>(network));
+      static_cast<Envoy::NetworkType>(network));
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_setProxySettings(

--- a/mobile/library/objective-c/EnvoyNetworkMonitor.mm
+++ b/mobile/library/objective-c/EnvoyNetworkMonitor.mm
@@ -42,7 +42,7 @@
       dispatch_queue_create("io.envoyproxy.envoymobile.EnvoyNetworkMonitor", attrs);
   nw_path_monitor_set_queue(_path_monitor, queue);
 
-  __block envoy_network_t previousNetworkType = (envoy_network_t)-1;
+  __block Envoy::NetworkType previousNetworkType = (Envoy::NetworkType)-1;
   Envoy::InternalEngine *engine = _engine;
   nw_path_monitor_set_update_handler(_path_monitor, ^(nw_path_t _Nonnull path) {
     BOOL isSatisfied = nw_path_get_status(path) == nw_path_status_satisfied;
@@ -58,10 +58,10 @@
     }
 
     BOOL isCellular = nw_path_uses_interface_type(path, nw_interface_type_cellular);
-    envoy_network_t network = ENVOY_NET_WWAN;
+    Envoy::NetworkType network = Envoy::NetworkType::WWAN;
     if (!isCellular) {
       BOOL isWifi = nw_path_uses_interface_type(path, nw_interface_type_wifi);
-      network = isWifi ? ENVOY_NET_WLAN : ENVOY_NET_GENERIC;
+      network = isWifi ? Envoy::NetworkType::WLAN : Envoy::NetworkType::Generic;
     }
 
     if (network != previousNetworkType) {
@@ -135,7 +135,8 @@ static void _reachability_callback(SCNetworkReachabilityRef target,
 
   NSLog(@"[Envoy] setting preferred network to %@", isUsingWWAN ? @"WWAN" : @"WLAN");
   EnvoyNetworkMonitor *monitor = (__bridge EnvoyNetworkMonitor *)info;
-  monitor->_engine->setPreferredNetwork(isUsingWWAN ? ENVOY_NET_WWAN : ENVOY_NET_WLAN);
+  monitor->_engine->setPreferredNetwork(isUsingWWAN ? Envoy::NetworkType::WWAN
+                                                    : Envoy::NetworkType::WLAN);
 }
 
 @end

--- a/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
+++ b/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
@@ -33,7 +33,7 @@ public:
   MOCK_METHOD(std::vector<Network::InterfacePair>, enumerateV6Interfaces, ());
   MOCK_METHOD(std::vector<Network::InterfacePair>, enumerateInterfaces,
               (unsigned short family, unsigned int select_flags, unsigned int reject_flags));
-  MOCK_METHOD(envoy_network_t, getPreferredNetwork, ());
+  MOCK_METHOD(NetworkType, getPreferredNetwork, ());
   MOCK_METHOD(envoy_socket_mode_t, getSocketMode, ());
   MOCK_METHOD(envoy_netconf_t, getConfigurationKey, ());
   MOCK_METHOD(Envoy::Network::ProxySettingsConstSharedPtr, getProxySettings, ());
@@ -44,7 +44,7 @@ public:
   MOCK_METHOD(void, refreshDns, (envoy_netconf_t configuration_key, bool drain_connections));
   MOCK_METHOD(void, resetConnectivityState, ());
   MOCK_METHOD(Network::Socket::OptionsSharedPtr, getUpstreamSocketOptions,
-              (envoy_network_t network, envoy_socket_mode_t socket_mode));
+              (NetworkType network, envoy_socket_mode_t socket_mode));
   MOCK_METHOD(envoy_netconf_t, addUpstreamSocketOptions,
               (Network::Socket::OptionsSharedPtr options));
 

--- a/mobile/test/common/network/connectivity_manager_test.cc
+++ b/mobile/test/common/network/connectivity_manager_test.cc
@@ -22,8 +22,8 @@ public:
         connectivity_manager_(std::make_shared<ConnectivityManagerImpl>(cm_, dns_cache_manager_)) {
     ON_CALL(*dns_cache_manager_, lookUpCacheByName(_)).WillByDefault(Return(dns_cache_));
     // Toggle network to reset network state.
-    ConnectivityManagerImpl::setPreferredNetwork(ENVOY_NET_GENERIC);
-    ConnectivityManagerImpl::setPreferredNetwork(ENVOY_NET_WLAN);
+    ConnectivityManagerImpl::setPreferredNetwork(NetworkType::Generic);
+    ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WLAN);
   }
 
   std::shared_ptr<NiceMock<Extensions::Common::DynamicForwardProxy::MockDnsCacheManager>>
@@ -35,7 +35,7 @@ public:
 
 TEST_F(ConnectivityManagerTest, SetPreferredNetworkWithNewNetworkChangesConfigurationKey) {
   envoy_netconf_t original_key = connectivity_manager_->getConfigurationKey();
-  envoy_netconf_t new_key = ConnectivityManagerImpl::setPreferredNetwork(ENVOY_NET_WWAN);
+  envoy_netconf_t new_key = ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WWAN);
   EXPECT_NE(original_key, new_key);
   EXPECT_EQ(new_key, connectivity_manager_->getConfigurationKey());
 }
@@ -43,7 +43,7 @@ TEST_F(ConnectivityManagerTest, SetPreferredNetworkWithNewNetworkChangesConfigur
 TEST_F(ConnectivityManagerTest,
        DISABLED_SetPreferredNetworkWithUnchangedNetworkReturnsStaleConfigurationKey) {
   envoy_netconf_t original_key = connectivity_manager_->getConfigurationKey();
-  envoy_netconf_t stale_key = ConnectivityManagerImpl::setPreferredNetwork(ENVOY_NET_WLAN);
+  envoy_netconf_t stale_key = ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WLAN);
   EXPECT_NE(original_key, stale_key);
   EXPECT_EQ(original_key, connectivity_manager_->getConfigurationKey());
 }
@@ -168,7 +168,7 @@ TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisablesOverrideAfterThirdFaul
 
 TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisregardsCallsWithStaleConfigurationKey) {
   envoy_netconf_t stale_key = connectivity_manager_->getConfigurationKey();
-  envoy_netconf_t current_key = ConnectivityManagerImpl::setPreferredNetwork(ENVOY_NET_WWAN);
+  envoy_netconf_t current_key = ConnectivityManagerImpl::setPreferredNetwork(NetworkType::WWAN);
   EXPECT_NE(stale_key, current_key);
 
   connectivity_manager_->setInterfaceBindingEnabled(true);


### PR DESCRIPTION
This PR removes `envoy_network_t` and replaces it with `Envoy::NetworkType` as an effort to get rid of `c_types.h`.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a