### PR TITLE
Adding integration test for match_delegate + composite + callout_filter in both downstrean and upstream

### DIFF
--- a/source/extensions/filters/http/ext_proc/config.h
+++ b/source/extensions/filters/http/ext_proc/config.h
@@ -24,7 +24,7 @@ private:
   static constexpr uint64_t DefaultMessageTimeoutMs = 200;
   static constexpr uint64_t DefaultMaxMessageTimeoutMs = 0;
 
-  virtual absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/test/extensions/filters/http/composite/composite_filter_integration_test.cc
+++ b/test/extensions/filters/http/composite/composite_filter_integration_test.cc
@@ -534,85 +534,127 @@ public:
     cleanupUpstreamAndDownstream();
   }
 
-  void initializeConfig() {
-    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // Ensure "HTTP2 with no prior knowledge." Necessary for gRPC and for headers
-      ConfigHelper::setHttp2(
-          *(bootstrap.mutable_static_resources()->mutable_clusters()->Mutable(0)));
+  void initializeConfig(bool downstream_filter, bool downstream) {
+    config_helper_.addConfigModifier(
+        [downstream_filter, downstream, this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+          // Ensure "HTTP2 with no prior knowledge." Necessary for gRPC and for headers
+          ConfigHelper::setHttp2(
+              *(bootstrap.mutable_static_resources()->mutable_clusters()->Mutable(0)));
 
-      // Clusters for test gRPC servers, starting by copying an existing cluster
-      for (size_t i = 0; i < grpc_upstreams_.size(); ++i) {
-        auto* server_cluster = bootstrap.mutable_static_resources()->add_clusters();
-        server_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-        std::string cluster_name = absl::StrCat("test_server_", i);
-        server_cluster->set_name(cluster_name);
-        server_cluster->mutable_load_assignment()->set_cluster_name(cluster_name);
-      }
-      // Load configuration of the server from YAML and use a helper to add a grpc_service
-      // stanza pointing to the cluster that we just made
-      setGrpcService(*filter_config_.mutable_grpc_service(), "test_server_0",
-                     grpc_upstreams_[0]->localAddress());
+          // Clusters for test gRPC servers, starting by copying an existing cluster
+          for (size_t i = 0; i < grpc_upstreams_.size(); ++i) {
+            auto* server_cluster = bootstrap.mutable_static_resources()->add_clusters();
+            server_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+            std::string cluster_name = absl::StrCat("test_server_", i);
+            server_cluster->set_name(cluster_name);
+            server_cluster->mutable_load_assignment()->set_cluster_name(cluster_name);
+          }
+          // Loading filter config from YAML.
+          prependServerFactoryContextFilter(downstream_filter, downstream);
 
-      addFilter();
-
-      // Parameterize with defer processing to prevent bit rot as filter made
-      // assumptions of data flow, prior relying on eager processing.
-      config_helper_.addRuntimeOverride(Runtime::defer_processing_backedup_streams,
-                                        deferredProcessing() ? "true" : "false");
-    });
+          // Parameterize with defer processing to prevent bit rot as filter made
+          // assumptions of data flow, prior relying on eager processing.
+          config_helper_.addRuntimeOverride(Runtime::defer_processing_backedup_streams,
+                                            deferredProcessing() ? "true" : "false");
+        });
 
     setUpstreamProtocol(Http::CodecType::HTTP2);
     setDownstreamProtocol(Http::CodecType::HTTP2);
   }
 
-  void addFilter() {
-    // Add the filter to the loaded hcm.
-    envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
-        hcm_config;
-    config_helper_.loadHttpConnectionManager(hcm_config);
-    auto* match_delegate_filter = hcm_config.add_http_filters();
-    match_delegate_filter->set_name("envoy.filters.http.match_delegate");
-
-    // Build extension config with composite filter inside.
-    envoy::extensions::common::matching::v3::ExtensionWithMatcher extension_config;
-    extension_config.mutable_extension_config()->set_name("composite");
-    envoy::extensions::filters::http::composite::v3::Composite composite_config;
-    extension_config.mutable_extension_config()->mutable_typed_config()->PackFrom(composite_config);
-    auto* matcher_tree = extension_config.mutable_xds_matcher()->mutable_matcher_tree();
-
-    // Set up the match input.
-    auto* matcher_input = matcher_tree->mutable_input();
-    matcher_input->set_name("request-headers");
-    envoy::type::matcher::v3::HttpRequestHeaderMatchInput request_header_match_input;
-    request_header_match_input.set_header_name("match-header");
-    matcher_input->mutable_typed_config()->PackFrom(request_header_match_input);
-
-    // Set up the match action with test filter as the delegated filter.
-    auto* exact_match_map = matcher_tree->mutable_exact_match_map()->mutable_map();
-    envoy::extensions::filters::http::composite::v3::ExecuteFilterAction test_filter_action;
-    test_filter_action.mutable_typed_config()->set_name("server-factory-context-filter");
-    test_filter_action.mutable_typed_config()->mutable_typed_config()->PackFrom(filter_config_);
-
-    ::xds::type::matcher::v3::Matcher_OnMatch on_match;
-    auto* on_match_action = on_match.mutable_action();
-    on_match_action->set_name("composite-action");
-    on_match_action->mutable_typed_config()->PackFrom(test_filter_action);
-
-    (*exact_match_map)["match"] = on_match;
-
-    // Finish up the construction of match_delegate_filter.
-    match_delegate_filter->mutable_typed_config()->PackFrom(extension_config);
-
-    // Now move the built filter to the front.
-    for (int i = hcm_config.http_filters_size() - 1; i > 0; --i) {
-      hcm_config.mutable_http_filters()->SwapElements(i, i - 1);
+  void
+  prependServerFactoryContextFilter(bool downstream_filter, bool downstream,
+                                    const std::string& name = "envoy.filters.http.match_delegate") {
+    std::string context_filter_config = "ServerFactoryContextFilterConfig";
+    if (!downstream_filter) {
+      context_filter_config = "ServerFactoryContextFilterConfigDual";
     }
 
-    // Store it to hcm.
-    config_helper_.storeHttpConnectionManager(hcm_config);
+    std::string address_prefix = "";
+    if (version_ == Network::Address::IpVersion::v6) {
+      address_prefix = "ipv6:///";
+    }
+
+    config_helper_.prependFilter(absl::StrFormat(R"EOF(
+      name: %s
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+        extension_config:
+          name: composite
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.composite.v3.Composite
+        xds_matcher:
+          matcher_tree:
+            input:
+              name: request-headers
+              typed_config:
+                "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                header_name: match-header
+            exact_match_map:
+              map:
+                match:
+                  action:
+                    name: composite-action
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.composite.v3.ExecuteFilterAction
+                      typed_config:
+                        name: server-factory-context-filter
+                        typed_config:
+                          "@type": type.googleapis.com/test.integration.filters.%s
+                          grpc_service:
+                            google_grpc:
+                              target_uri: %s%s
+                              stat_prefix: test_server_0
+    )EOF",
+                                                 name, context_filter_config, address_prefix,
+                                                 grpc_upstreams_[0]->localAddress()->asString()),
+                                 downstream);
   }
 
-  test::integration::filters::ServerFactoryContextFilterConfig filter_config_;
+  void serverContextBasicFlowTest() {
+    HttpIntegrationTest::initialize();
+
+    auto conn = makeClientConnection(lookupPort("http"));
+    codec_client_ = makeHttpConnection(std::move(conn));
+    const Http::TestRequestHeaderMapImpl request_headers = {{":method", "GET"},
+                                                            {":path", "/somepath"},
+                                                            {":scheme", "http"},
+                                                            {"match-header", "match"},
+                                                            {":authority", "blah"}};
+    // Send request from downstream to upstream.
+    auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+    // Wait for side stream request.
+    helloworld::HelloRequest request;
+    request.set_name("hello");
+    ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, connection_));
+    ASSERT_TRUE(connection_->waitForNewStream(*dispatcher_, stream_));
+    ASSERT_TRUE(stream_->waitForGrpcMessage(*dispatcher_, request));
+
+    // Start the grpc side stream.
+    stream_->startGrpcStream();
+
+    // Send the side stream response.
+    helloworld::HelloReply reply;
+    reply.set_message("ack");
+    stream_->sendGrpcMessage(reply);
+
+    // Handle the upstream request.
+    ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+    ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+    ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+    upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    upstream_request_->encodeData(100, true);
+
+    // Close the grpc stream.
+    stream_->finishGrpcStream(Grpc::Status::Ok);
+
+    // Verify the response from upstream to downstream.
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ(response->headers().getStatusValue(), "200");
+  }
+
   std::vector<FakeUpstream*> grpc_upstreams_;
   FakeHttpConnectionPtr connection_;
   FakeStreamPtr stream_;
@@ -623,49 +665,19 @@ INSTANTIATE_TEST_SUITE_P(
     GRPC_CLIENT_INTEGRATION_DEFERRED_PROCESSING_PARAMS,
     Grpc::GrpcClientIntegrationParamTestWithDeferredProcessing::protocolTestParamsToString);
 
-TEST_P(CompositeFilterSeverContextIntegrationTest, BasicFlow) {
-  initializeConfig();
-  HttpIntegrationTest::initialize();
+TEST_P(CompositeFilterSeverContextIntegrationTest, BasicFlowDownstreamFilterInDownstream) {
+  initializeConfig(/*downstream_filter*/ true, /*downstream*/ true);
+  serverContextBasicFlowTest();
+}
 
-  auto conn = makeClientConnection(lookupPort("http"));
-  codec_client_ = makeHttpConnection(std::move(conn));
-  const Http::TestRequestHeaderMapImpl request_headers = {{":method", "GET"},
-                                                          {":path", "/somepath"},
-                                                          {":scheme", "http"},
-                                                          {"match-header", "match"},
-                                                          {":authority", "blah"}};
-  // Send request from downstream to upstream.
-  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+TEST_P(CompositeFilterSeverContextIntegrationTest, BasicFlowDualFilterInDownstream) {
+  initializeConfig(/*downstream_filter*/ false, /*downstream*/ true);
+  serverContextBasicFlowTest();
+}
 
-  // Wait for side stream request.
-  helloworld::HelloRequest request;
-  request.set_name("hello");
-  ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, connection_));
-  ASSERT_TRUE(connection_->waitForNewStream(*dispatcher_, stream_));
-  ASSERT_TRUE(stream_->waitForGrpcMessage(*dispatcher_, request));
-
-  // Start the grpc side stream.
-  stream_->startGrpcStream();
-
-  // Send the side stream response.
-  helloworld::HelloReply reply;
-  reply.set_message("ack");
-  stream_->sendGrpcMessage(reply);
-
-  // Handle the upstream request.
-  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
-  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
-  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-  upstream_request_->encodeData(100, true);
-
-  // Close the grpc stream.
-  stream_->finishGrpcStream(Grpc::Status::Ok);
-
-  // Verify the response from upstream to downstream.
-  ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ(response->headers().getStatusValue(), "200");
+TEST_P(CompositeFilterSeverContextIntegrationTest, BasicFlowDualFilterInUpstream) {
+  initializeConfig(/*downstream_filter*/ false, /*downstream*/ false);
+  serverContextBasicFlowTest();
 }
 
 } // namespace

--- a/test/integration/filters/server_factory_context_filter_config.proto
+++ b/test/integration/filters/server_factory_context_filter_config.proto
@@ -4,6 +4,12 @@ package test.integration.filters;
 
 import "envoy/config/core/v3/grpc_service.proto";
 
+// Message for downstream only filter factory.
 message ServerFactoryContextFilterConfig {
+  envoy.config.core.v3.GrpcService grpc_service = 1;
+}
+
+// Message for dual filter factory.
+message ServerFactoryContextFilterConfigDual {
   envoy.config.core.v3.GrpcService grpc_service = 1;
 }


### PR DESCRIPTION
This PR adding integration test to verify match_delegate + composite + callout_filter works in both downstream and upstream. 

It addresses this comments: https://github.com/envoyproxy/envoy/pull/33273#pullrequestreview-1998264437
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
