### PR TITLE
mobile: Rename the enum values to PascalCase

### DIFF
--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -122,7 +122,7 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
   if (!success) {
     ENVOY_LOG(debug, result.error_details);
     postVerifyResultAndCleanUp(success, std::move(hostname), result.error_details, result.tls_alert,
-                               ValidationFailureType::FAIL_VERIFY_ERROR, dispatcher, parent);
+                               ValidationFailureType::FailVerifyError, dispatcher, parent);
     return;
   }
 
@@ -135,11 +135,11 @@ void PlatformBridgeCertValidator::verifyCertChainByPlatform(
     error_details = "PlatformBridgeCertValidator_verifySubjectAltName failed: SNI mismatch.";
     ENVOY_LOG(debug, error_details);
     postVerifyResultAndCleanUp(success, std::move(hostname), error_details, SSL_AD_BAD_CERTIFICATE,
-                               ValidationFailureType::FAIL_VERIFY_SAN, dispatcher, parent);
+                               ValidationFailureType::FailVerifySan, dispatcher, parent);
     return;
   }
   postVerifyResultAndCleanUp(success, std::move(hostname), error_details,
-                             SSL_AD_CERTIFICATE_UNKNOWN, ValidationFailureType::SUCCESS, dispatcher,
+                             SSL_AD_CERTIFICATE_UNKNOWN, ValidationFailureType::Success, dispatcher,
                              parent);
 }
 
@@ -184,14 +184,14 @@ void PlatformBridgeCertValidator::onVerificationComplete(const Thread::ThreadId&
 
   Ssl::ClientValidationStatus detailed_status = Envoy::Ssl::ClientValidationStatus::NotValidated;
   switch (failure_type) {
-  case ValidationFailureType::SUCCESS:
+  case ValidationFailureType::Success:
     detailed_status = Envoy::Ssl::ClientValidationStatus::Validated;
     break;
-  case ValidationFailureType::FAIL_VERIFY_ERROR:
+  case ValidationFailureType::FailVerifyError:
     detailed_status = Envoy::Ssl::ClientValidationStatus::Failed;
     stats_.fail_verify_error_.inc();
     break;
-  case ValidationFailureType::FAIL_VERIFY_SAN:
+  case ValidationFailureType::FailVerifySan:
     detailed_status = Envoy::Ssl::ClientValidationStatus::Failed;
     stats_.fail_verify_san_.inc();
     break;

--- a/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/mobile/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -62,9 +62,9 @@ private:
                               SslStats& stats, Thread::PosixThreadFactoryPtr thread_factory);
 
   enum class ValidationFailureType {
-    SUCCESS,
-    FAIL_VERIFY_ERROR,
-    FAIL_VERIFY_SAN,
+    Success,
+    FailVerifyError,
+    FailVerifySan,
   };
 
   // Calls into platform APIs in a stand-alone thread to verify the given certs.

--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -126,11 +126,11 @@ NetworkConfigurationFilter::resolveProxy(Http::RequestHeaderMap& request_headers
       });
 
   switch (proxy_resolution_result) {
-  case Network::ProxyResolutionResult::NO_PROXY_CONFIGURED:
+  case Network::ProxyResolutionResult::NoProxyConfigured:
     return Http::FilterHeadersStatus::Continue;
-  case Network::ProxyResolutionResult::RESULT_COMPLETED:
+  case Network::ProxyResolutionResult::ResultCompleted:
     return continueWithProxySettings(Network::ProxySettings::create(proxy_settings_));
-  case Network::ProxyResolutionResult::RESULT_IN_PROGRESS:
+  case Network::ProxyResolutionResult::ResultInProgress:
     // `onProxyResolutionComplete` method will be called once the proxy resolution completes
     return Http::FilterHeadersStatus::StopAllIterationAndWatermark;
   }

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -48,8 +48,8 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
   ENVOY_LOG(debug, "[S{}] response headers for stream (end_stream={}):\n{}",
             direct_stream_.stream_handle_, end_stream, headers);
 
-  ASSERT(http_client_.getStream(direct_stream_.stream_handle_,
-                                GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  ASSERT(
+      http_client_.getStream(direct_stream_.stream_handle_, GetStreamFilters::AllowForAllStreams));
 
   // Capture some metadata before potentially closing the stream.
   absl::string_view alpn = "";
@@ -107,8 +107,8 @@ void Client::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_
   ENVOY_LOG(debug, "[S{}] response data for stream (length={} end_stream={})",
             direct_stream_.stream_handle_, data.length(), end_stream);
 
-  ASSERT(http_client_.getStream(direct_stream_.stream_handle_,
-                                GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  ASSERT(
+      http_client_.getStream(direct_stream_.stream_handle_, GetStreamFilters::AllowForAllStreams));
   direct_stream_.saveLatestStreamIntel();
   if (end_stream) {
     closeStream();
@@ -185,8 +185,8 @@ void Client::DirectStreamCallbacks::encodeTrailers(const ResponseTrailerMap& tra
   ENVOY_LOG(debug, "[S{}] response trailers for stream:\n{}", direct_stream_.stream_handle_,
             trailers);
 
-  ASSERT(http_client_.getStream(direct_stream_.stream_handle_,
-                                GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  ASSERT(
+      http_client_.getStream(direct_stream_.stream_handle_, GetStreamFilters::AllowForAllStreams));
   direct_stream_.saveLatestStreamIntel();
   closeStream(); // Trailers always indicate the end of the stream.
 
@@ -257,7 +257,8 @@ void Client::DirectStreamCallbacks::closeStream(bool end_stream) {
   }
 
   auto& client = direct_stream_.parent_;
-  auto stream = client.getStream(direct_stream_.stream_handle_, ALLOW_ONLY_FOR_OPEN_STREAMS);
+  auto stream =
+      client.getStream(direct_stream_.stream_handle_, GetStreamFilters::AllowOnlyForOpenStreams);
   ASSERT(stream != nullptr);
   if (stream) {
     ENVOY_LOG(debug, "[S{}] erased stream\n", direct_stream_.stream_handle_);
@@ -305,7 +306,7 @@ void Client::DirectStreamCallbacks::onError() {
     ENVOY_LOG(debug, "[S{}] defering remote reset stream due to explicit flow control",
               direct_stream_.stream_handle_);
     if (direct_stream_.parent_.getStream(direct_stream_.stream_handle_,
-                                         ALLOW_ONLY_FOR_OPEN_STREAMS)) {
+                                         GetStreamFilters::AllowOnlyForOpenStreams)) {
       closeStream(false);
     }
     return;
@@ -327,8 +328,8 @@ void Client::DirectStreamCallbacks::sendErrorToBridge() {
 
   // The stream should no longer be preset in the map, because onError() was either called from a
   // terminal callback that mapped to an error or it was called in response to a resetStream().
-  ASSERT(!http_client_.getStream(direct_stream_.stream_handle_,
-                                 GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  ASSERT(
+      !http_client_.getStream(direct_stream_.stream_handle_, GetStreamFilters::AllowForAllStreams));
 
   ENVOY_LOG(debug, "[S{}] dispatching to platform remote reset stream",
             direct_stream_.stream_handle_);
@@ -411,7 +412,7 @@ void Client::DirectStream::saveLatestStreamIntel() {
 }
 
 void Client::DirectStream::saveFinalStreamIntel() {
-  if (!parent_.getStream(stream_handle_, ALLOW_ONLY_FOR_OPEN_STREAMS)) {
+  if (!parent_.getStream(stream_handle_, GetStreamFilters::AllowOnlyForOpenStreams)) {
     return;
   }
   OptRef<RequestDecoder> request_decoder = requestDecoder();
@@ -464,7 +465,7 @@ Client::DirectStream::registerCodecEventCallbacks(CodecEventCallbacks* codec_cal
   // Envoy stream is going away. Make sure Envoy Mobile sees the stream as
   // closed as well.
   if (codec_callbacks == nullptr &&
-      parent_.getStream(stream_handle_, ALLOW_ONLY_FOR_OPEN_STREAMS)) {
+      parent_.getStream(stream_handle_, GetStreamFilters::AllowOnlyForOpenStreams)) {
     // Generally this only happens if Envoy closes the (virtual) downstream
     // connection, otherwise Envoy would inform the codec to send a reset.
     callbacks_->closeStream(false);
@@ -483,7 +484,7 @@ void Client::DirectStream::resetStream(StreamResetReason reason) {
   saveFinalStreamIntel();   // Take a snapshot now in case the stream gets destroyed.
   callbacks_->latchError(); // Latch the error in case the stream gets destroyed.
   runResetCallbacks(reason);
-  if (!parent_.getStream(stream_handle_, GetStreamFilters::ALLOW_FOR_ALL_STREAMS)) {
+  if (!parent_.getStream(stream_handle_, GetStreamFilters::AllowForAllStreams)) {
     // We don't assert here, because Envoy will issue a stream reset if a stream closes remotely
     // while still open locally. In this case the stream will already have been removed from
     // our stream maps due to the remote closure.
@@ -534,7 +535,7 @@ void Client::startStream(envoy_stream_t new_stream_handle, envoy_http_callbacks 
 void Client::sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, bool end_stream) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream =
-      getStream(stream, GetStreamFilters::ALLOW_ONLY_FOR_OPEN_STREAMS);
+      getStream(stream, GetStreamFilters::AllowOnlyForOpenStreams);
   // If direct_stream is not found, it means the stream has already closed or been reset
   // and the appropriate callback has been issued to the caller. There's nothing to do here
   // except silently swallow this.
@@ -586,7 +587,7 @@ void Client::readData(envoy_stream_t stream, size_t bytes_to_read) {
   // This is allowed for closed streams, else we could never send data up after
   // the FIN was received.
   Client::DirectStreamSharedPtr direct_stream =
-      getStream(stream, GetStreamFilters::ALLOW_FOR_ALL_STREAMS);
+      getStream(stream, GetStreamFilters::AllowForAllStreams);
   // If direct_stream is not found, it means the stream has already canceled or been reset
   // and the appropriate callback has been issued to the caller. There's nothing to do here
   // except silently swallow this.
@@ -598,7 +599,7 @@ void Client::readData(envoy_stream_t stream, size_t bytes_to_read) {
 void Client::sendData(envoy_stream_t stream, Buffer::InstancePtr buffer, bool end_stream) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream =
-      getStream(stream, GetStreamFilters::ALLOW_ONLY_FOR_OPEN_STREAMS);
+      getStream(stream, GetStreamFilters::AllowOnlyForOpenStreams);
 
   // If direct_stream is not found, it means the stream has already closed or been reset
   // and the appropriate callback has been issued to the caller. There's nothing to do here
@@ -645,7 +646,7 @@ void Client::sendMetadata(envoy_stream_t, envoy_headers) { PANIC("not implemente
 void Client::sendTrailers(envoy_stream_t stream, RequestTrailerMapPtr trailers) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream =
-      getStream(stream, GetStreamFilters::ALLOW_ONLY_FOR_OPEN_STREAMS);
+      getStream(stream, GetStreamFilters::AllowOnlyForOpenStreams);
   // If direct_stream is not found, it means the stream has already closed or been reset
   // and the appropriate callback has been issued to the caller. There's nothing to do here
   // except silently swallow this.
@@ -671,15 +672,14 @@ void Client::cancelStream(envoy_stream_t stream) {
   // for closed streams: if the client cancels the stream it should be canceled
   // whether it was closed or not.
   Client::DirectStreamSharedPtr direct_stream =
-      getStream(stream, GetStreamFilters::ALLOW_FOR_ALL_STREAMS);
+      getStream(stream, GetStreamFilters::AllowForAllStreams);
   scheduled_callback_ = nullptr;
   if (direct_stream) {
     // Attempt to latch the latest stream info. This will be a no-op if the stream
     // is already complete.
     ENVOY_LOG(debug, "[S{}] application cancelled stream", stream);
     direct_stream->saveFinalStreamIntel();
-    bool stream_was_open =
-        getStream(stream, GetStreamFilters::ALLOW_ONLY_FOR_OPEN_STREAMS) != nullptr;
+    bool stream_was_open = getStream(stream, GetStreamFilters::AllowOnlyForOpenStreams) != nullptr;
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     direct_stream->notifyAdapter(DirectStream::AdapterSignal::Cancel);
     removeStream(direct_stream->stream_handle_);
@@ -711,7 +711,7 @@ Client::DirectStreamSharedPtr Client::getStream(envoy_stream_t stream,
   if (direct_stream_pair_it != streams_.end()) {
     return direct_stream_pair_it->second;
   }
-  if (get_stream_filters == ALLOW_FOR_ALL_STREAMS) {
+  if (get_stream_filters == GetStreamFilters::AllowForAllStreams) {
     direct_stream_pair_it = closed_streams_.find(stream);
     if (direct_stream_pair_it != closed_streams_.end()) {
       return direct_stream_pair_it->second;
@@ -726,7 +726,7 @@ void Client::removeStream(envoy_stream_t stream_handle) {
       fmt::format("[S{}] stream removeStream must be performed on the dispatcher_'s thread.",
                   stream_handle));
   Client::DirectStreamSharedPtr direct_stream =
-      getStream(stream_handle, GetStreamFilters::ALLOW_FOR_ALL_STREAMS);
+      getStream(stream_handle, GetStreamFilters::AllowForAllStreams);
   RELEASE_ASSERT(
       direct_stream,
       fmt::format(

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -356,18 +356,18 @@ private:
 
   using DirectStreamWrapperPtr = std::unique_ptr<DirectStreamWrapper>;
 
-  enum GetStreamFilters {
+  enum class GetStreamFilters {
     // If a stream has been finished from upstream, but stream completion has
     // not yet been communicated, the downstream mobile library should not be
     // allowed to access the stream. getStream takes an argument to ensure that
     // the mobile client won't do things like send further request data for
     // streams in this state.
-    ALLOW_ONLY_FOR_OPEN_STREAMS,
+    AllowOnlyForOpenStreams,
     // If a stream has been finished from upstream, make sure that getStream
     // will continue to work for functions such as resumeData (pushing that data
     // to the mobile library) and cancelStream (the client not wanting further
     // data for the stream).
-    ALLOW_FOR_ALL_STREAMS,
+    AllowForAllStreams,
   };
   DirectStreamSharedPtr getStream(envoy_stream_t stream_handle, GetStreamFilters filters);
   void removeStream(envoy_stream_t stream_handle);

--- a/mobile/library/common/network/apple_proxy_resolver.cc
+++ b/mobile/library/common/network/apple_proxy_resolver.cc
@@ -33,17 +33,17 @@ AppleProxyResolver::resolveProxy(const std::string& target_url_string,
   {
     absl::MutexLock l(&mutex_);
     if (!proxy_settings_.has_value()) {
-      return ProxyResolutionResult::NO_PROXY_CONFIGURED;
+      return ProxyResolutionResult::NoProxyConfigured;
     }
 
     const auto proxy_settings = proxy_settings_.value();
     if (!proxy_settings.isPacEnabled()) {
       ProxySettings settings(proxy_settings.hostname(), proxy_settings.port());
       if (settings.isDirect()) {
-        return ProxyResolutionResult::NO_PROXY_CONFIGURED;
+        return ProxyResolutionResult::NoProxyConfigured;
       }
       proxies.emplace_back(std::move(settings));
-      return ProxyResolutionResult::RESULT_COMPLETED;
+      return ProxyResolutionResult::ResultCompleted;
     }
 
     pac_file_url = proxy_settings.pacFileUrl();
@@ -60,7 +60,7 @@ AppleProxyResolver::resolveProxy(const std::string& target_url_string,
       [proxy_resolution_completed](const std::vector<ProxySettings>& proxies) {
         proxy_resolution_completed(proxies);
       });
-  return ProxyResolutionResult::RESULT_IN_PROGRESS;
+  return ProxyResolutionResult::ResultInProgress;
 }
 
 } // namespace Network

--- a/mobile/library/common/network/connectivity_manager.h
+++ b/mobile/library/common/network/connectivity_manager.h
@@ -39,11 +39,14 @@
  */
 typedef uint16_t envoy_netconf_t;
 
+namespace Envoy {
+namespace Network {
+
 /**
  * These values specify the behavior of the network connectivity_manager with respect to the
  * upstream socket options it supplies.
  */
-typedef enum {
+enum class SocketMode : int {
   // In this mode, the connectivity_manager will provide socket options that result in the creation
   // of a
   // distinct connection pool for a given value of preferred network.
@@ -54,10 +57,7 @@ typedef enum {
   // options. Note this mode is experimental, and it will not be enabled at all unless
   // enable_interface_binding_ is set to true.
   AlternateBoundInterfaceMode = 1,
-} envoy_socket_mode_t;
-
-namespace Envoy {
-namespace Network {
+};
 
 using DnsCacheManagerSharedPtr = Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr;
 using InterfacePair = std::pair<const std::string, Address::InstanceConstSharedPtr>;
@@ -111,7 +111,7 @@ public:
   /**
    * @returns the current mode used to determine upstream socket options.
    */
-  virtual envoy_socket_mode_t getSocketMode() PURE;
+  virtual SocketMode getSocketMode() PURE;
 
   /**
    * @returns configuration key representing current network state.
@@ -170,7 +170,7 @@ public:
    * @returns the current socket options that should be used for connections.
    */
   virtual Socket::OptionsSharedPtr getUpstreamSocketOptions(NetworkType network,
-                                                            envoy_socket_mode_t socket_mode) PURE;
+                                                            SocketMode socket_mode) PURE;
 
   /**
    * @param options, upstream connection options to which additional options should be appended.
@@ -219,7 +219,7 @@ public:
   std::vector<InterfacePair> enumerateInterfaces(unsigned short family, unsigned int select_flags,
                                                  unsigned int reject_flags) override;
   NetworkType getPreferredNetwork() override;
-  envoy_socket_mode_t getSocketMode() override;
+  SocketMode getSocketMode() override;
   envoy_netconf_t getConfigurationKey() override;
   Envoy::Network::ProxySettingsConstSharedPtr getProxySettings() override;
   void reportNetworkUsage(envoy_netconf_t configuration_key, bool network_fault) override;
@@ -229,7 +229,7 @@ public:
   void refreshDns(envoy_netconf_t configuration_key, bool drain_connections) override;
   void resetConnectivityState() override;
   Socket::OptionsSharedPtr getUpstreamSocketOptions(NetworkType network,
-                                                    envoy_socket_mode_t socket_mode) override;
+                                                    SocketMode socket_mode) override;
   envoy_netconf_t addUpstreamSocketOptions(Socket::OptionsSharedPtr options) override;
   Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dnsCache() override;
 
@@ -240,7 +240,7 @@ private:
     envoy_netconf_t configuration_key_ ABSL_GUARDED_BY(mutex_);
     NetworkType network_ ABSL_GUARDED_BY(mutex_);
     uint8_t remaining_faults_ ABSL_GUARDED_BY(mutex_);
-    envoy_socket_mode_t socket_mode_ ABSL_GUARDED_BY(mutex_);
+    SocketMode socket_mode_ ABSL_GUARDED_BY(mutex_);
     Thread::MutexBasicLockable mutex_;
   };
   Socket::OptionsSharedPtr getAlternateInterfaceSocketOptions(NetworkType network);

--- a/mobile/library/common/network/proxy_resolver_interface.h
+++ b/mobile/library/common/network/proxy_resolver_interface.h
@@ -6,9 +6,9 @@ namespace Envoy {
 namespace Network {
 
 enum class ProxyResolutionResult {
-  NO_PROXY_CONFIGURED = 0,
-  RESULT_COMPLETED = 1,
-  RESULT_IN_PROGRESS = 2,
+  NoProxyConfigured = 0,
+  ResultCompleted = 1,
+  ResultInProgress = 2,
 };
 
 // An interface for resolving the system's proxy settings.

--- a/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
+++ b/mobile/test/common/extensions/filters/http/network_configuration/network_configuration_filter_test.cc
@@ -34,7 +34,7 @@ public:
   MOCK_METHOD(std::vector<Network::InterfacePair>, enumerateInterfaces,
               (unsigned short family, unsigned int select_flags, unsigned int reject_flags));
   MOCK_METHOD(NetworkType, getPreferredNetwork, ());
-  MOCK_METHOD(envoy_socket_mode_t, getSocketMode, ());
+  MOCK_METHOD(Network::SocketMode, getSocketMode, ());
   MOCK_METHOD(envoy_netconf_t, getConfigurationKey, ());
   MOCK_METHOD(Envoy::Network::ProxySettingsConstSharedPtr, getProxySettings, ());
   MOCK_METHOD(void, reportNetworkUsage, (envoy_netconf_t configuration_key, bool network_fault));
@@ -44,7 +44,7 @@ public:
   MOCK_METHOD(void, refreshDns, (envoy_netconf_t configuration_key, bool drain_connections));
   MOCK_METHOD(void, resetConnectivityState, ());
   MOCK_METHOD(Network::Socket::OptionsSharedPtr, getUpstreamSocketOptions,
-              (NetworkType network, envoy_socket_mode_t socket_mode));
+              (NetworkType network, Network::SocketMode socket_mode));
   MOCK_METHOD(envoy_netconf_t, addUpstreamSocketOptions,
               (Network::Socket::OptionsSharedPtr options));
 
@@ -222,7 +222,7 @@ public:
 TEST_F(NetworkConfigurationFilterProxyResolverApiTest, NoProxyConfigured) {
   std::vector<Network::ProxySettings> proxy_settings;
   EXPECT_CALL(getMockProxyResolver(), resolveProxy(_, proxy_settings, _))
-      .WillOnce(Return(Network::ProxyResolutionResult::NO_PROXY_CONFIGURED));
+      .WillOnce(Return(Network::ProxyResolutionResult::NoProxyConfigured));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_.decodeHeaders(default_request_headers_, false));
 }
@@ -230,7 +230,7 @@ TEST_F(NetworkConfigurationFilterProxyResolverApiTest, NoProxyConfigured) {
 TEST_F(NetworkConfigurationFilterProxyResolverApiTest, EmptyProxyConfigured) {
   std::vector<Network::ProxySettings> proxy_settings;
   EXPECT_CALL(getMockProxyResolver(), resolveProxy(_, proxy_settings, _))
-      .WillOnce(Return(Network::ProxyResolutionResult::RESULT_COMPLETED));
+      .WillOnce(Return(Network::ProxyResolutionResult::ResultCompleted));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_.decodeHeaders(default_request_headers_, false));
 }
@@ -242,7 +242,7 @@ TEST_F(NetworkConfigurationFilterProxyResolverApiTest, DirectProxyConfigured) {
                    std::vector<Network::ProxySettings>& proxies,
                    Network::ProxySettingsResolvedCallback /*proxy_resolution_completed*/) {
         proxies.emplace_back(Network::ProxySettings::direct());
-        return Network::ProxyResolutionResult::RESULT_COMPLETED;
+        return Network::ProxyResolutionResult::ResultCompleted;
       });
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_.decodeHeaders(default_request_headers_, false));
@@ -255,7 +255,7 @@ TEST_F(NetworkConfigurationFilterProxyResolverApiTest, ProxyWithIpAddressConfigu
                    std::vector<Network::ProxySettings>& proxies,
                    Network::ProxySettingsResolvedCallback /*proxy_resolution_completed*/) {
         proxies.emplace_back(Network::ProxySettings("127.0.0.1", 8080));
-        return Network::ProxyResolutionResult::RESULT_COMPLETED;
+        return Network::ProxyResolutionResult::ResultCompleted;
       });
   EXPECT_CALL(decoder_callbacks_.stream_info_, filterState());
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
@@ -271,7 +271,7 @@ TEST_F(NetworkConfigurationFilterProxyResolverApiTest, ProxyWithHostConfigured) 
                    std::vector<Network::ProxySettings>& proxies,
                    Network::ProxySettingsResolvedCallback /*proxy_resolution_completed*/) {
         proxies.emplace_back(Network::ProxySettings("foo.com", 8080));
-        return Network::ProxyResolutionResult::RESULT_COMPLETED;
+        return Network::ProxyResolutionResult::ResultCompleted;
       });
   EXPECT_CALL(decoder_callbacks_.stream_info_, filterState());
   EXPECT_CALL(*dns_cache_, loadDnsCacheEntry_(Eq("foo.com"), 8080, false, _))

--- a/mobile/test/common/network/connectivity_manager_test.cc
+++ b/mobile/test/common/network/connectivity_manager_test.cc
@@ -109,61 +109,61 @@ TEST_F(ConnectivityManagerTest,
        ReportNetworkUsageDoesntAlterNetworkConfigurationWhenBoundInterfacesAreDisabled) {
   envoy_netconf_t configuration_key = connectivity_manager_->getConfigurationKey();
   connectivity_manager_->setInterfaceBindingEnabled(false);
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
 
   EXPECT_EQ(configuration_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 }
 
 TEST_F(ConnectivityManagerTest,
        ReportNetworkUsageTriggersOverrideAfterFirstFaultAfterNetworkUpdate) {
   envoy_netconf_t configuration_key = connectivity_manager_->getConfigurationKey();
   connectivity_manager_->setInterfaceBindingEnabled(true);
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
 
   EXPECT_NE(configuration_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
 }
 
 TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisablesOverrideAfterFirstFaultAfterOverride) {
   envoy_netconf_t configuration_key = connectivity_manager_->getConfigurationKey();
   connectivity_manager_->setInterfaceBindingEnabled(true);
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
 
   EXPECT_NE(configuration_key, connectivity_manager_->getConfigurationKey());
   configuration_key = connectivity_manager_->getConfigurationKey();
-  EXPECT_EQ(AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
 
   EXPECT_NE(configuration_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 }
 
 TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisablesOverrideAfterThirdFaultAfterSuccess) {
   envoy_netconf_t configuration_key = connectivity_manager_->getConfigurationKey();
   connectivity_manager_->setInterfaceBindingEnabled(true);
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(configuration_key, false /* network_fault */);
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
 
   EXPECT_EQ(configuration_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
   connectivity_manager_->reportNetworkUsage(configuration_key, true /* network_fault */);
 
   EXPECT_NE(configuration_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
 }
 
 TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisregardsCallsWithStaleConfigurationKey) {
@@ -172,20 +172,20 @@ TEST_F(ConnectivityManagerTest, ReportNetworkUsageDisregardsCallsWithStaleConfig
   EXPECT_NE(stale_key, current_key);
 
   connectivity_manager_->setInterfaceBindingEnabled(true);
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(stale_key, true /* network_fault */);
   connectivity_manager_->reportNetworkUsage(stale_key, true /* network_fault */);
   connectivity_manager_->reportNetworkUsage(stale_key, true /* network_fault */);
 
   EXPECT_EQ(current_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::DefaultPreferredNetworkMode, connectivity_manager_->getSocketMode());
 
   connectivity_manager_->reportNetworkUsage(stale_key, false /* network_fault */);
   connectivity_manager_->reportNetworkUsage(current_key, true /* network_fault */);
 
   EXPECT_NE(current_key, connectivity_manager_->getConfigurationKey());
-  EXPECT_EQ(AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
+  EXPECT_EQ(SocketMode::AlternateBoundInterfaceMode, connectivity_manager_->getSocketMode());
 }
 
 TEST_F(ConnectivityManagerTest, EnumerateInterfacesFiltersByFlags) {


### PR DESCRIPTION
According to [Envoy C++ coding style](https://github.com/envoyproxy/envoy/blob/main/STYLE.md), enum values should use PascalCase. This PR also updates some enums to use `enum class`.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
