### PR TITLE
[cleanup] deflaky ExtProcIntegrationTest.RetryOnDifferentHost: cleanup connection before closing the test

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -3927,7 +3927,7 @@ TEST_P(ExtProcIntegrationTest, RetryOnDifferentHost) {
   ASSERT_OK_AND_ASSIGN(host_id_2, FakeUpstream::waitForHttpConnection(
                                       *dispatcher_, fake_upstreams_, processor_connection_2,
                                       std::chrono::milliseconds(5000)));
-  absl::Cleanup close_connection2{[&processor_connection_2]() {
+  Cleanup close_connection2{[&processor_connection_2]() {
     if (processor_connection_2 != nullptr) {
       ASSERT_TRUE(processor_connection_2->close());
       ASSERT_TRUE(processor_connection_2->waitForDisconnect());

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -3927,6 +3927,13 @@ TEST_P(ExtProcIntegrationTest, RetryOnDifferentHost) {
   ASSERT_OK_AND_ASSIGN(host_id_2, FakeUpstream::waitForHttpConnection(
                                       *dispatcher_, fake_upstreams_, processor_connection_2,
                                       std::chrono::milliseconds(5000)));
+  absl::Cleanup close_connection2{[&processor_connection_2]() {
+    if (processor_connection_2 != nullptr) {
+      ASSERT_TRUE(processor_connection_2->close());
+      ASSERT_TRUE(processor_connection_2->waitForDisconnect());
+    }
+  }};
+
   // Retry happens on a new host.
   ASSERT_NE(host_id_2, first_host_id);
   FakeStreamPtr processor_stream_2;
@@ -3945,6 +3952,7 @@ TEST_P(ExtProcIntegrationTest, RetryOnDifferentHost) {
   new_header->mutable_header()->set_raw_value("bluh");
   processor_stream_2->sendGrpcMessage(processing_response);
   processor_stream_2->finishGrpcStream(Grpc::Status::Ok);
+  ASSERT_TRUE(processor_stream_2->waitForReset());
 
   handleUpstreamRequest();
   EXPECT_EQ(upstream_request_->headers()


### PR DESCRIPTION
Commit Message: deflaky ExtProcIntegrationTest.RetryOnDifferentHost: cleanup connection before closing the test
Additional Description:
Risk Level: LOW, test cleanup
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/32849
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
