### PR TITLE
mobile: Use setLogLevel in the gcp_traffic_director_integration_test.cc

### DIFF
--- a/mobile/test/non_hermetic/gcp_traffic_director_integration_test.cc
+++ b/mobile/test/non_hermetic/gcp_traffic_director_integration_test.cc
@@ -70,7 +70,7 @@ public:
     xds_builder.addInitialStreamHeader("x-goog-api-key", std::string(api_key))
         .setSslRootCerts(std::move(root_certs))
         .addClusterDiscoveryService();
-    builder_.addLogLevel(Platform::LogLevel::trace)
+    builder_.setLogLevel(Logger::Logger::Levels::trace)
         .setNodeId(absl::Substitute("projects/$0/networks/default/nodes/111222333444", PROJECT_ID))
         .setXds(std::move(xds_builder));
 


### PR DESCRIPTION
This fixes the compilation error in `gcp_traffic_director_integration_test.cc`.

Risk Level: low
Testing: `bazel build --define=envoy_mobile_xds=enabled test/non_hermetic:gcp_traffic_director_integration_test`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
