### PR TITLE
Fix flaky integration test

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1018,7 +1018,7 @@ TEST_P(ExtAuthzGrpcIntegrationTest, DownstreamHeadersOnSuccess) {
 TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailClosed) {
   GrpcInitializeConfigOpts opts;
   opts.failure_mode_allow = false;
-  opts.timeout_ms = 10;
+  opts.timeout_ms = 1;
   initializeConfig(opts);
 
   // Use h1, set up the test.
@@ -1027,9 +1027,6 @@ TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailClosed) {
 
   // Start a client connection and request.
   initiateClientConnection(0);
-
-  // Wait for the ext_authz request as a result of the client request.
-  waitForExtAuthzRequest(expectedCheckRequest(Http::CodecType::HTTP1));
 
   // Do not sendExtAuthzResponse(). Envoy should reject the request after 1 second.
   ASSERT_TRUE(response_->waitForEndStream());
@@ -1042,7 +1039,7 @@ TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailClosed) {
 TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailOpen) {
   GrpcInitializeConfigOpts init_opts;
   init_opts.failure_mode_allow = true;
-  init_opts.timeout_ms = 10;
+  init_opts.timeout_ms = 1;
   initializeConfig(init_opts);
 
   // Use h1, set up the test.
@@ -1051,9 +1048,6 @@ TEST_P(ExtAuthzGrpcIntegrationTest, TimeoutFailOpen) {
 
   // Start a client connection and request.
   initiateClientConnection(0);
-
-  // Wait for the ext_authz request as a result of the client request.
-  waitForExtAuthzRequest(expectedCheckRequest(Http::CodecType::HTTP1));
 
   // Do not sendExtAuthzResponse(). Envoy should eventually proxy the request upstream as if the
   // authz service approved the request.
@@ -1273,10 +1267,9 @@ TEST_P(ExtAuthzHttpIntegrationTest, RedirectResponse) {
 }
 
 TEST_P(ExtAuthzHttpIntegrationTest, TimeoutFailClosed) {
-  initializeConfig(false, /*failure_mode_allow=*/false, /*timeout_ms=*/10);
+  initializeConfig(false, /*failure_mode_allow=*/false, /*timeout_ms=*/1);
   HttpIntegrationTest::initialize();
   initiateClientConnection();
-  waitForExtAuthzRequest();
 
   // Do not sendExtAuthzResponse(). Envoy should reject the request after 1 second.
   ASSERT_TRUE(response_->waitForEndStream(Envoy::Seconds(10)));
@@ -1287,10 +1280,9 @@ TEST_P(ExtAuthzHttpIntegrationTest, TimeoutFailClosed) {
 }
 
 TEST_P(ExtAuthzHttpIntegrationTest, TimeoutFailOpen) {
-  initializeConfig(false, /*failure_mode_allow=*/true, /*timeout_ms=*/10);
+  initializeConfig(false, /*failure_mode_allow=*/true, /*timeout_ms=*/1);
   HttpIntegrationTest::initialize();
   initiateClientConnection();
-  waitForExtAuthzRequest();
 
   // Do not sendExtAuthzResponse(). Envoy should eventually proxy the request upstream as if the
   // authz service approved the request.


### PR DESCRIPTION
Commit Message: fix flaky integration tests
Additional Description: The ext_authz timeout integration tests were calling `waitForExtAuthzRequest` when it wasn't necessary. This, combined with a short timeout duration (10ms), led to very rare flakes where the request would timeout before the stream was established or before the grpc message was sent. The request would then get cancelled and `waitForExtAuthzRequest` would fail.

This PR removes all side stream expectations from the timeout integration tests since they are unnecessary. The HTTP tests weren't not flaky, but out of principle I did the same to them.

Risk Level: none
Testing: test-only PR
Docs Changes: none
Release Notes: none
Platform Specific Features: none
Fixes #33510

[Optional Runtime guard:]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
