### PR TITLE
Fix `clang-asan` config for non-RBE builds.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -136,6 +136,7 @@ build:clang-asan-common --linkopt --rtlib=compiler-rt
 build:clang-asan-common --linkopt --unwindlib=libgcc
 
 build:clang-asan --config=clang-asan-common
+build:clang-asan --linkopt='-L/opt/llvm/lib/clang/14.0.0/lib/x86_64-unknown-linux-gnu'
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone.a
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx.a
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1


### PR DESCRIPTION
Link `-L/opt/llvm/lib/clang/14.0.0/lib/x86_64-unknown-linux-gnu` when linking `libclang_rt.ubsan_standalone`.

For RBE builds this is achieved by the `build:rbe-toolchain-asan` config. This PR makes non-RBE builds that use `--config=clang-asan` work.

Commit Message: Fix `clang-asan` config for non-RBE builds.
Additional Description:
Risk Level: Low, Bazel flag changes only.
Testing: CI.
Docs Changes: none
Release Notes: n/a
Platform Specific Features: n/a