### PR TITLE
mobile: Switch to using a large runner for running iOS tests

### DIFF
--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -42,7 +42,7 @@ jobs:
       command: ./bazelw
       container-command:
       request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12
+      runs-on: macos-12-large
       source: |
         source ./ci/mac_ci_setup.sh
       steps-post: ${{ matrix.steps-post }}


### PR DESCRIPTION
An attempt to fix https://github.com/envoyproxy/envoy/issues/33488. We suspect that the tests run slow because it has [tags = ["no-remote-exec"]](https://github.com/envoyproxy/envoy/blob/a048435d6fca8f2541cd41cbf809f9890c8a744c/mobile/test/swift/integration/BUILD#L13-L14), which means the tests will be executed locally, which currently runs on a standard runner.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a