### PR TITLE
runtime_guard: deprecate http proxy_status_upstream_request_timeout

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -11,6 +11,9 @@ bug_fixes:
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
+- area: http
+  change: |
+    Removed ``envoy.reloadable_features.proxy_status_upstream_request_timeout`` runtime flag and lagacy code paths.
 
 new_features:
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -78,7 +78,6 @@ RUNTIME_GUARD(envoy_reloadable_features_oauth_use_standard_max_age_value);
 RUNTIME_GUARD(envoy_reloadable_features_oauth_use_url_encoding);
 RUNTIME_GUARD(envoy_reloadable_features_original_dst_rely_on_idle_timeout);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_status_mapping_more_core_response_flags);
-RUNTIME_GUARD(envoy_reloadable_features_proxy_status_upstream_request_timeout);
 RUNTIME_GUARD(envoy_reloadable_features_quic_fix_filter_manager_uaf);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year. Confirm with
 // @danzh2010 or @RyanTheOptimist before removing.

--- a/source/common/stream_info/utility.cc
+++ b/source/common/stream_info/utility.cc
@@ -434,10 +434,6 @@ ProxyStatusUtils::fromStreamInfo(const StreamInfo& stream_info) {
   } else if (stream_info.hasResponseFlag(CoreResponseFlag::NoHealthyUpstream)) {
     return ProxyStatusError::DestinationUnavailable;
   } else if (stream_info.hasResponseFlag(CoreResponseFlag::UpstreamRequestTimeout)) {
-    if (!Runtime::runtimeFeatureEnabled(
-            "envoy.reloadable_features.proxy_status_upstream_request_timeout")) {
-      return ProxyStatusError::ConnectionTimeout;
-    }
     return ProxyStatusError::HttpResponseTimeout;
   }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -4409,9 +4409,6 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCodeAndServerNa
 }
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetailsAndResponseCode) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
   proxy_status_config_->set_remove_details(false);
   proxy_status_config_->set_set_recommended_response_code(true);
@@ -4469,8 +4466,6 @@ TEST_F(ProxyStatusTest, NoPopulateUnauthorizedProxyStatus) {
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
   proxy_status_config_->set_remove_details(false);
   proxy_status_config_->set_remove_connection_termination_details(false);
@@ -4494,8 +4489,6 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithDetails) {
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
   proxy_status_config_->set_remove_details(true);
   proxy_status_config_->set_set_recommended_response_code(false);
@@ -4518,8 +4511,6 @@ TEST_F(ProxyStatusTest, PopulateProxyStatusWithoutDetails) {
 
 TEST_F(ProxyStatusTest, PopulateProxyStatusAppendToPreviousValue) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
   proxy_status_config_ = std::make_unique<HttpConnectionManagerProto::ProxyStatusConfig>();
   proxy_status_config_->set_remove_details(false);
 

--- a/test/common/stream_info/utility_test.cc
+++ b/test/common/stream_info/utility_test.cc
@@ -367,8 +367,6 @@ TEST(ProxyStatusErrorToString, TestAll) {
 TEST(ProxyStatusFromStreamInfo, TestAll) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
-  scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.proxy_status_mapping_more_core_response_flags", "false"}});
   for (const auto& [response_flag, proxy_status_error] :
        std::vector<std::pair<ResponseFlag, ProxyStatusError>>{
@@ -402,8 +400,6 @@ TEST(ProxyStatusFromStreamInfo, TestAll) {
 
 TEST(ProxyStatusFromStreamInfo, TestNewAll) {
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.proxy_status_mapping_more_core_response_flags", "true"}});
   for (const auto& [response_flag, proxy_status_error] :
@@ -442,16 +438,6 @@ TEST(ProxyStatusFromStreamInfo, TestNewAll) {
     ON_CALL(stream_info, hasResponseFlag(response_flag)).WillByDefault(Return(true));
     EXPECT_THAT(ProxyStatusUtils::fromStreamInfo(stream_info), proxy_status_error);
   }
-}
-
-TEST(ProxyStatusFromStreamInfo, TestUpstreamRequestTimeout) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "false"}});
-  NiceMock<MockStreamInfo> stream_info;
-  ON_CALL(stream_info, hasResponseFlag(ResponseFlag(CoreResponseFlag::UpstreamRequestTimeout)))
-      .WillByDefault(Return(true));
-  EXPECT_THAT(ProxyStatusUtils::fromStreamInfo(stream_info), ProxyStatusError::ConnectionTimeout);
 }
 
 } // namespace

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -18,10 +18,6 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
   config_helper_.addConfigModifier(configureProxyStatus());
   initialize();
 
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.proxy_status_upstream_request_timeout", "true"}});
-
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
       Http::TestRequestHeaderMapImpl{{":method", "POST"},


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

deprecate http proxy_status_upstream_request_timeout

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes: #33625 
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
