### PR TITLE
[bp/1.30] DynatraceResourceDetector: Change log level to debug

### DIFF
--- a/source/extensions/tracers/opentelemetry/resource_detectors/dynatrace/dynatrace_resource_detector.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/dynatrace/dynatrace_resource_detector.cc
@@ -38,7 +38,7 @@ Resource DynatraceResourceDetector::detect() {
     END_TRY catch (const EnvoyException& e) {
       failure_count++;
       ENVOY_LOG(
-          warn,
+          debug,
           "Failed to detect resource attributes from the Dynatrace enrichment file: {}, error: {}.",
           file_name, e.what());
     }


### PR DESCRIPTION
As discussed with @wbpcode I'm creating this backport to 1.30 for this small change. It just changes the log level to avoid unnecessary logs when the resource detector is added. Only back porting to 1.30 is enough, as we changed the error handling of the detector in after 1.29 

Commit Message: Backport from #33564

Risk Level: Low
Testing: Manual
Docs Changes: No
Release Notes: No
Platform Specific Features: No
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
