### PR TITLE
[bp/1.29] admin: fix broken UI pages when called with empty query params (#33044)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -12,7 +12,10 @@ bug_fixes:
   change: |
     Fix a RELEASE_ASSERT when using :ref:`auto_sni <envoy_v3_api_field_config.core.v3.UpstreamHttpProtocolOptions.auto_sni>`
     if the downstream request ``:authority`` was longer than 255 characters.
-
+- area: admin
+  change: |
+    Fixed a bug where the config_dump & init_dump admin endpoint would return an empty response when called with empty
+    query parameters (e.g. ``/config_dump?resource=&mask=&name_regex=``).
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/server/admin/config_dump_handler.cc
+++ b/source/server/admin/config_dump_handler.cc
@@ -151,8 +151,9 @@ Http::Code ConfigDumpHandler::handlerConfigDump(Http::ResponseHeaderMap& respons
                                                 Buffer::Instance& response,
                                                 AdminStream& admin_stream) const {
   Http::Utility::QueryParamsMulti query_params = admin_stream.queryParams();
-  const auto resource = query_params.getFirstValue("resource");
-  const auto mask = query_params.getFirstValue("mask");
+  const absl::optional<std::string> resource =
+      Utility::nonEmptyQueryParam(query_params, "resource");
+  const absl::optional<std::string> mask = Utility::nonEmptyQueryParam(query_params, "mask");
   const bool include_eds = shouldIncludeEdsInDump(query_params);
   const absl::StatusOr<Matchers::StringMatcherPtr> name_matcher = buildNameMatcher(query_params);
   if (!name_matcher.ok()) {

--- a/source/server/admin/init_dump_handler.cc
+++ b/source/server/admin/init_dump_handler.cc
@@ -13,7 +13,8 @@ InitDumpHandler::InitDumpHandler(Server::Instance& server) : HandlerContextBase(
 Http::Code InitDumpHandler::handlerInitDump(Http::ResponseHeaderMap& response_headers,
                                             Buffer::Instance& response,
                                             AdminStream& admin_stream) const {
-  const auto mask = admin_stream.queryParams().getFirstValue("mask");
+  const absl::optional<std::string> mask =
+      Utility::nonEmptyQueryParam(admin_stream.queryParams(), "mask");
 
   envoy::admin::v3::UnreadyTargetsDumps dump = *dumpUnreadyTargets(mask);
   MessageUtil::redact(dump);

--- a/source/server/admin/utils.cc
+++ b/source/server/admin/utils.cc
@@ -29,7 +29,7 @@ void populateFallbackResponseHeaders(Http::Code code, Http::ResponseHeaderMap& h
 absl::Status histogramBucketsParam(const Http::Utility::QueryParamsMulti& params,
                                    HistogramBucketsMode& histogram_buckets_mode) {
   absl::optional<std::string> histogram_buckets_query_param =
-      params.getFirstValue("histogram_buckets");
+      nonEmptyQueryParam(params, "histogram_buckets");
   histogram_buckets_mode = HistogramBucketsMode::NoBuckets;
   if (histogram_buckets_query_param.has_value()) {
     if (histogram_buckets_query_param.value() == "cumulative") {
@@ -46,9 +46,21 @@ absl::Status histogramBucketsParam(const Http::Utility::QueryParamsMulti& params
   return absl::OkStatus();
 }
 
+// Helper method to get a query parameter.
+// Returns the first value for that query parameter, unless that value is empty.
+// In that case, it returns nullopt.
+absl::optional<std::string> nonEmptyQueryParam(const Http::Utility::QueryParamsMulti& params,
+                                               const std::string& key) {
+  const auto data = params.getFirstValue(key);
+  if (data.has_value() && data.value().empty()) {
+    return absl::nullopt;
+  }
+  return data;
+}
+
 // Helper method to get the format parameter.
 absl::optional<std::string> formatParam(const Http::Utility::QueryParamsMulti& params) {
-  return params.getFirstValue("format");
+  return nonEmptyQueryParam(params, "format");
 }
 
 } // namespace Utility

--- a/source/server/admin/utils.h
+++ b/source/server/admin/utils.h
@@ -25,6 +25,9 @@ absl::Status histogramBucketsParam(const Http::Utility::QueryParamsMulti& params
 
 absl::optional<std::string> formatParam(const Http::Utility::QueryParamsMulti& params);
 
+absl::optional<std::string> nonEmptyQueryParam(const Http::Utility::QueryParamsMulti& params,
+                                               const std::string& key);
+
 } // namespace Utility
 } // namespace Server
 } // namespace Envoy

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -41,6 +41,7 @@ void addHostInfo(NiceMock<Upstream::MockHost>& host, const std::string& hostname
 
 TEST_P(AdminInstanceTest, ConfigDump) {
   Buffer::OwnedImpl response;
+  Buffer::OwnedImpl response2;
   Http::TestResponseHeaderMapImpl header_map;
   auto entry = admin_.getConfigTracker().add("foo", [](const Matchers::StringMatcher&) {
     auto msg = std::make_unique<ProtobufWkt::StringValue>();
@@ -57,8 +58,10 @@ TEST_P(AdminInstanceTest, ConfigDump) {
 }
 )EOF";
   EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
-  std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_EQ(Http::Code::OK,
+            getCallback("/config_dump?resource=&mask=&name_regex=", header_map, response2));
+  EXPECT_EQ(expected_json, response.toString());
+  EXPECT_EQ(expected_json, response2.toString());
 }
 
 TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {

--- a/test/server/admin/utils_test.cc
+++ b/test/server/admin/utils_test.cc
@@ -50,5 +50,14 @@ TEST_F(UtilsTest, QueryParam) {
   EXPECT_EQ("value", query_.getFirstValue("key").value());
 }
 
+TEST_F(UtilsTest, NonEmptyQueryParam) {
+  EXPECT_FALSE(Utility::nonEmptyQueryParam(query_, "key").has_value());
+  query_.overwrite("key", "");
+  EXPECT_FALSE(Utility::nonEmptyQueryParam(query_, "key").has_value());
+  query_.overwrite("key", "value");
+  EXPECT_TRUE(Utility::nonEmptyQueryParam(query_, "key").has_value());
+  EXPECT_EQ("value", Utility::nonEmptyQueryParam(query_, "key").value());
+}
+
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
Fix #33435

Backport of #33044

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
