### PR TITLE
[bp/1.28] Fix build error with `maxmind` if http3 is disabled (#33638)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1410,7 +1410,3 @@ def _com_github_maxmind_libmaxminddb():
         name = "com_github_maxmind_libmaxminddb",
         build_file_content = BUILD_ALL_CONTENT,
     )
-    native.bind(
-        name = "maxmind",
-        actual = "@envoy//bazel/foreign_cc:maxmind_linux",
-    )

--- a/source/extensions/geoip_providers/maxmind/BUILD
+++ b/source/extensions/geoip_providers/maxmind/BUILD
@@ -37,9 +37,9 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     hdrs = ["geoip_provider.h"],
-    external_deps = ["maxmind"],
     tags = ["skip_on_windows"],
     deps = [
+        "//bazel/foreign_cc:maxmind_linux",
         "//envoy/geoip:geoip_provider_driver_interface",
         "@envoy_api//envoy/extensions/geoip_providers/maxmind/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
`maxmind` is causing the build to not honor the flag `--//bazel:http3=False`: The define `ENVOY_ENABLE_QUIC` is still being passed to the compiler. This causes code that rely on the presence (or not) of that define to behave wrongly.

I am not 100% sure of what causes it, but Bazel doc says 1) to not use `bind` and 2) that `bind` and `select` do not play well together: https://bazel.build/reference/be/workspace#bind

By removing the `bind` and pointing directly to the actual dependency in `maxmind` BUILD file, we fix this issue.

Backport of https://github.com/envoyproxy/envoy/pull/33638
