### PR TITLE
Fix layering issue in TransportSocket mocks.

### DIFF
--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -16,9 +16,11 @@
 
 #include "absl/types/optional.h"
 
+#ifdef ENVOY_ENABLE_QUIC
 namespace quic {
 class QuicCryptoClientConfig;
 }
+#endif
 
 namespace Envoy {
 
@@ -344,10 +346,12 @@ public:
    */
   virtual OptRef<const Ssl::ClientContextConfig> clientContextConfig() const { return {}; }
 
+#ifdef ENVOY_ENABLE_QUIC
   /*
    * @return the QuicCryptoClientConfig or nullptr for non-QUIC factories.
    */
   virtual std::shared_ptr<quic::QuicCryptoClientConfig> getCryptoConfig() { return nullptr; }
+#endif
 };
 
 /**

--- a/source/extensions/transport_sockets/common/passthrough.h
+++ b/source/extensions/transport_sockets/common/passthrough.h
@@ -35,9 +35,11 @@ public:
   OptRef<const Ssl::ClientContextConfig> clientContextConfig() const override {
     return transport_socket_factory_->clientContextConfig();
   }
+#ifdef ENVOY_ENABLE_QUIC
   std::shared_ptr<quic::QuicCryptoClientConfig> getCryptoConfig() override {
     return transport_socket_factory_->getCryptoConfig();
   }
+#endif
 
 protected:
   // The wrapped factory.

--- a/test/extensions/transport_sockets/common/passthrough_test.cc
+++ b/test/extensions/transport_sockets/common/passthrough_test.cc
@@ -145,10 +145,12 @@ TEST(PassthroughFactoryTest, TestDelegation) {
     EXPECT_CALL(*inner_factory, clientContextConfig());
     factory->clientContextConfig();
   }
+#ifdef ENVOY_ENABLE_QUIC
   {
     EXPECT_CALL(*inner_factory, getCryptoConfig());
     factory->getCryptoConfig();
   }
+#endif
 }
 
 class DownstreamTestFactory : public DownstreamPassthroughFactory {

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -88,5 +88,6 @@ envoy_cc_mock(
         "//envoy/network:transport_socket_interface",
         "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
+        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
     ],
 )

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -88,6 +88,7 @@ envoy_cc_mock(
         "//envoy/network:transport_socket_interface",
         "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
+    ] + envoy_select_enable_http3([
         "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
-    ],
+    ]),
 )

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -89,6 +89,6 @@ envoy_cc_mock(
         "//source/common/network:listen_socket_lib",
         "//source/common/network:utility_lib",
     ] + envoy_select_enable_http3([
-        "@com_github_google_quiche//:quic_core_crypto_crypto_handshake_lib",
+        "@com_github_google_quiche//:quic_client_crypto_crypto_handshake_lib",
     ]),
 )

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -9,9 +9,8 @@
 
 #include "source/common/network/listen_socket_impl.h"
 
-#include "quiche/quic/core/crypto/quic_crypto_client_config.h"
-
 #include "gmock/gmock.h"
+#include "quiche/quic/core/crypto/quic_crypto_client_config.h"
 
 namespace Envoy {
 namespace Network {

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -9,6 +9,8 @@
 
 #include "source/common/network/listen_socket_impl.h"
 
+#include "quiche/quic/core/crypto/quic_crypto_client_config.h"
+
 #include "gmock/gmock.h"
 
 namespace Envoy {

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -10,7 +10,9 @@
 #include "source/common/network/listen_socket_impl.h"
 
 #include "gmock/gmock.h"
+#ifdef ENVOY_ENABLE_QUIC
 #include "quiche/quic/core/crypto/quic_crypto_client_config.h"
+#endif
 
 namespace Envoy {
 namespace Network {
@@ -47,7 +49,9 @@ public:
   MOCK_METHOD(absl::string_view, defaultServerNameIndication, (), (const));
   MOCK_METHOD(Envoy::Ssl::ClientContextSharedPtr, sslCtx, ());
   MOCK_METHOD(OptRef<const Ssl::ClientContextConfig>, clientContextConfig, (), (const));
+#ifdef ENVOY_ENABLE_QUIC
   MOCK_METHOD(std::shared_ptr<quic::QuicCryptoClientConfig>, getCryptoConfig, ());
+#endif
 
   MOCK_METHOD(TransportSocketPtr, createTransportSocket,
               (TransportSocketOptionsConstSharedPtr,

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -10,6 +10,7 @@
 #include "source/common/network/listen_socket_impl.h"
 
 #include "gmock/gmock.h"
+
 #ifdef ENVOY_ENABLE_QUIC
 #include "quiche/quic/core/crypto/quic_crypto_client_config.h"
 #endif


### PR DESCRIPTION
We're planning to make some changes to GoogleTest that requires having the definition of various types available in order to detect whether they're protobufs or not.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix layering issue in TransportSocket mocks.
Additional Description:
Risk Level: n/a
Testing: n/a
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
