### PR TITLE
Stats: Add the ability to add a StatName to a StatNamePool directly.

### DIFF
--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -640,6 +640,11 @@ const uint8_t* StatNamePool::addReturningStorage(absl::string_view str) {
   return storage_vector_.back().bytes();
 }
 
+StatName StatNamePool::add(StatName name) {
+  storage_vector_.push_back(Stats::StatNameStorage(name, symbol_table_));
+  return storage_vector_.back().statName();
+}
+
 StatName StatNamePool::add(absl::string_view str) { return StatName(addReturningStorage(str)); }
 
 StatName StatNameDynamicPool::add(absl::string_view str) {

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -636,12 +636,12 @@ void StatNamePool::clear() {
 }
 
 const uint8_t* StatNamePool::addReturningStorage(absl::string_view str) {
-  storage_vector_.push_back(Stats::StatNameStorage(str, symbol_table_));
+  storage_vector_.emplace_back(str, symbol_table_);
   return storage_vector_.back().bytes();
 }
 
 StatName StatNamePool::add(StatName name) {
-  storage_vector_.push_back(Stats::StatNameStorage(name, symbol_table_));
+  storage_vector_.emplace_back(name, symbol_table_);
   return storage_vector_.back().statName();
 }
 

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -755,6 +755,16 @@ public:
   StatName add(absl::string_view name);
 
   /**
+   * Adds the StatName to the pool preserving the representation.
+   * This avoids stringifying if we already have a StatName object
+   * and is useful if parts of the StatName are dynamically encoded.
+   * @param name the stat name to add the container.
+   * @return the StatName held in the container for this name.
+   *
+   */
+  StatName add(StatName name);
+
+  /**
    * Does essentially the same thing as add(), but returns the storage as a
    * pointer which can later be used to create a StatName. This can be used
    * to accumulate a vector of uint8_t* which can later be used to create

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -652,12 +652,40 @@ TEST_F(StatNameTest, StatNameSet) {
 }
 
 TEST_F(StatNameTest, StorageCopy) {
-  StatName a = pool_.add("stat.name");
+  const StatName a = pool_.add("stat.name");
   StatNameStorage b_storage(a, table_);
-  StatName b = b_storage.statName();
+  const StatName b = b_storage.statName();
   EXPECT_EQ(a, b);
   EXPECT_NE(a.data(), b.data());
   b_storage.free(table_);
+
+  const StatName c = pool_.add(a);
+  EXPECT_EQ(a, c);
+  EXPECT_NE(a.data(), c.data());
+}
+
+TEST_F(StatNameTest, AddingToPoolViaStatNamePreservesDynamicSegments) {
+  const StatNameDynamicStorage tag_name("tag", table_);
+  const StatNameDynamicStorage tag_value("value", table_);
+  const StatNameTagVector tag_vector{{tag_name.statName(), tag_value.statName()}};
+
+  const StatName empty_prefix = pool_.add("");
+  const StatName basename = pool_.add("stat.name");
+
+  TagUtility::TagStatNameJoiner joiner(empty_prefix, basename, tag_vector, table_);
+  const StatName tagged_name = joiner.nameWithTags();
+
+  const StatName copy_via_statname = pool_.add(tagged_name);
+  EXPECT_EQ(tagged_name, copy_via_statname);
+  EXPECT_NE(tagged_name.data(), copy_via_statname.data());
+
+  // When adding the statname via strings it will be encoded in the symbol
+  // table. It will not be comparable to the statname that is a mix of
+  // encoded symbols from the symbol table and dynamic strings.
+  const std::string tagged_name_str = table_.toString(tagged_name);
+  const StatName copy_via_string = pool_.add(tagged_name_str);
+  EXPECT_NE(tagged_name, copy_via_string);
+  EXPECT_EQ(table_.toString(tagged_name), table_.toString(copy_via_string));
 }
 
 TEST_F(StatNameTest, RecentLookups) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add the ability to add a StatName to a StatNamePool directly.
Additional Description: If one maintains a StatNamePool to reference count symbols, provide a way to add to the pool directly vs needing to stringify. 
Risk Level: low / medium
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
