### PR TITLE
[bp/1.28] tests: fixed & expanded checking of ocsp response (#33030)

### DIFF
--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -1078,7 +1078,12 @@ TEST_P(SslCertficateIntegrationTest, BothEcdsaAndRsaOnlyEcdsaOcspResponse) {
   const uint8_t* resp;
   size_t resp_len;
   SSL_get0_ocsp_response(socket->ssl(), &resp, &resp_len);
-  EXPECT_NE(0, resp_len);
+  ASSERT_GT(resp_len, 0);
+  ASSERT_NE(resp, nullptr);
+  std::string ocsp_resp{reinterpret_cast<const char*>(resp), resp_len};
+  std::string expected_ocsp_resp{TestEnvironment::readFileToStringForTest(
+      TestEnvironment::runfilesPath("test/config/integration/certs/server_ecdsa_ocsp_resp.der"))};
+  EXPECT_EQ(ocsp_resp, expected_ocsp_resp);
 }
 
 // Server has ECDSA and RSA certificates with OCSP responses and stapling required policy works.


### PR DESCRIPTION
Commit Message: tests: fixed & expanded checking of ocsp response
Additional Description: Expand the checking of OCSP response to check for expected length and bytes, to prevent false positive results.

Backport of #33030 