### PR TITLE
ci/docker: Increase timeouts to handle broken Ubuntu repos

### DIFF
--- a/.azure-pipelines/stage/publish.yml
+++ b/.azure-pipelines/stage/publish.yml
@@ -10,12 +10,12 @@ parameters:
 - name: timeoutDockerPublish
   displayName: "Timout Docker publish"
   type: number
-  # in seconds
-  default: 15
+  # in minutes
+  default: 18
 - name: timeoutDockerBuild
   displayName: "Timout Docker build"
   type: number
-  default: 400
+  default: 500
 
 # Auth
 - name: authGCP

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -21,7 +21,7 @@ set -e
 ##
 
 # Workaround for https://github.com/envoyproxy/envoy/issues/26634
-DOCKER_BUILD_TIMEOUT="${DOCKER_BUILD_TIMEOUT:-400}"
+DOCKER_BUILD_TIMEOUT="${DOCKER_BUILD_TIMEOUT:-500}"
 
 DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/arm64,linux/amd64}"
 


### PR DESCRIPTION
Ubuntu repos have been ~broken for the last day or so - the ppas have had major outages, but it seems to be affecting their other repos as just doing `apt update` is currently ridiculously slow

Trying to repro with a minimal example locally and it passes but after a very long time - this increases the timeout to handle that and workaround the issue

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
