### PR TITLE
stats: Extract route names with forward-slash

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -23,9 +23,9 @@ std::string expandRegex(const std::string& regex) {
               {"<TLS_VERSION>", R"(TLSv\d\.\d)"},
               // A generic name can contain any character except dots.
               {"<TAG_VALUE>", TAG_VALUE_REGEX},
-              // Route names may contain dots in addition to alphanumerics and
-              // dashes with underscores.
-              {"<ROUTE_CONFIG_NAME>", R"([\w-\.]+)"},
+              // Route names may contain dots and slashes in addition to
+              // alphanumerics, underscores, and dashes.
+              {"<ROUTE_CONFIG_NAME>", R"([\w-\./]+)"},
               // Match a prefix that is either a listener plus name or cluster plus name
               {"<LISTENER_OR_CLUSTER_WITH_NAME>", R"((?:listener|cluster)\..*?)"}});
 }

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -393,15 +393,16 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
                          "http.fault.aborts_injected",
                          {fault_connection_manager, fault_downstream_cluster});
 
+  // HTTP Connection Manager and Route
   Tag rds_hcm;
   rds_hcm.name_ = tag_names.HTTP_CONN_MANAGER_PREFIX;
   rds_hcm.value_ = "rds_connection_manager";
 
   Tag rds_route_config;
   rds_route_config.name_ = tag_names.RDS_ROUTE_CONFIG;
-  rds_route_config.value_ = "route_config.123";
+  rds_route_config.value_ = "agg/route_config.1-23";
 
-  regex_tester.testRegex("http.rds_connection_manager.rds.route_config.123.update_success",
+  regex_tester.testRegex("http.rds_connection_manager.rds.agg/route_config.1-23.update_success",
                          "http.rds.update_success", {rds_hcm, rds_route_config});
 
   // Listener manager worker id


### PR DESCRIPTION
Commit Message: Extract route names with forward-slash.
Additional Description:  RDS protocol allows almost any route name, and stats are lightly sanitized before emitting to statsd and prometheus endpoints. This change slightly relaxes the capture group for RDS route names in stats, instead of opening the floodgates to everything, because YAGNI.
Risk Level: Low
Testing: Updated unit test
Docs Changes: None
Release Notes: N/A 
Platform Specific Features: None
Fixes: #32976