### PR TITLE
load_shed: enable listener after client connections to ensure socket event once

### DIFF
--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -591,6 +591,7 @@ TEST_P(TcpListenerImplTest, EachQueuedConnectionShouldQueryTheLoadShedPoint) {
   EXPECT_CALL(overload_manager, getLoadShedPoint(testing::_))
       .WillRepeatedly(Return(&accept_connection_point));
   listener.configureLoadShedPoints(overload_manager);
+  listener.disable();
 
   // When accepting we'll reject the first connection, get queried again and accept the
   // second connection.
@@ -628,7 +629,8 @@ TEST_P(TcpListenerImplTest, EachQueuedConnectionShouldQueryTheLoadShedPoint) {
   client_connection2->addConnectionCallbacks(connection_callbacks2);
   client_connection2->connect();
 
-  EXPECT_CALL(listener_callbacks, recordConnectionsAcceptedOnSocketEvent(_));
+  listener.enable();
+  EXPECT_CALL(listener_callbacks, recordConnectionsAcceptedOnSocketEvent(_)).Times(1);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   // Now that we've seen that the connection hasn't been closed by the listener, make sure to

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -630,7 +630,7 @@ TEST_P(TcpListenerImplTest, EachQueuedConnectionShouldQueryTheLoadShedPoint) {
   client_connection2->connect();
 
   listener.enable();
-  EXPECT_CALL(listener_callbacks, recordConnectionsAcceptedOnSocketEvent(_)).Times(1);
+  EXPECT_CALL(listener_callbacks, recordConnectionsAcceptedOnSocketEvent(_));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   // Now that we've seen that the connection hasn't been closed by the listener, make sure to


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

enable listener after client connections to ensure socket event once to fix the flaky test #33704

```
bazel test //test/common/network:listener_impl_test --test_filter=*EachQueuedConnectionShouldQueryTheLoadShedPoint* --runs_per_test=10000
```


Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fix: #33704
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
