### PR TITLE
Drop overload runtim key

### DIFF
--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -77,6 +77,12 @@ message ClusterLoadAssignment {
     //
     // Envoy supports only one element and will NACK if more than one element is present.
     // Other xDS-capable data planes will not necessarily have this limitation.
+    //
+    // In Envoy, this **drop_overloads** config can be overridden by a runtime key
+    // "config.drop_overload_support". This runtime key can be set to any integer
+    // number between 0 and 100. 0 means 0%. 100 means 100%.
+    // In case an EDS update with **drop_overloads** setting, if this runtime key is
+    // enabled, then the smaller value between this two will be the actual drop_ratio.
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this

--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -79,10 +79,8 @@ message ClusterLoadAssignment {
     // Other xDS-capable data planes will not necessarily have this limitation.
     //
     // In Envoy, this **drop_overloads** config can be overridden by a runtime key
-    // "config.drop_overload_support". This runtime key can be set to any integer
-    // number between 0 and 100. 0 means 0%. 100 means 100%.
-    // In case an EDS update with **drop_overloads** setting, if this runtime key is
-    // enabled, then the smaller value between this two will be the actual drop_ratio.
+    // "config.drop_overload_support" setting. This runtime key can be set to any
+    // integer number between 0 and 100. 0 means drop 0%. 100 means drop 100%.
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this

--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -78,9 +78,11 @@ message ClusterLoadAssignment {
     // Envoy supports only one element and will NACK if more than one element is present.
     // Other xDS-capable data planes will not necessarily have this limitation.
     //
-    // In Envoy, this **drop_overloads** config can be overridden by a runtime key
-    // "config.drop_overload_support" setting. This runtime key can be set to any
-    // integer number between 0 and 100. 0 means drop 0%. 100 means drop 100%.
+    // In Envoy, this ``drop_overloads`` config can be overridden by a runtime key
+    // "load_balancing_policy.drop_overload_limit" setting. This runtime key can be set to
+    // any integer number between 0 and 100. 0 means drop 0%. 100 means drop 100%.
+    // When both ``drop_overloads`` config and "load_balancing_policy.drop_overload_limit"
+    // setting are in place, the min of these two wins.
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1702,12 +1702,14 @@ absl::Status ClusterImplBase::parseDropOverloadConfig(
         drop_percentage.denominator()));
   }
 
-  // If DropOverloadRuntimeKey is not enabled, honor the EDS drop_overload config.
-  // If it is enabled, choose the smaller one between it and the EDS config.
+  // If DropOverloadRuntimeKey is not enabled, take the EDS drop_overload config.
+  // If DropOverloadRuntimeKey is enabled, take it.
   float drop_ratio = float(drop_percentage.numerator()) / (denominator);
-  uint64_t drop_ratio_runtime =
-      runtime_.snapshot().getInteger(ClusterImplBase::DropOverloadRuntimeKey, 100);
-  drop_ratio = std::min(drop_ratio, float(drop_ratio_runtime) / float(100));
+  uint64_t drop_percent_runtime =
+      runtime_.snapshot().getInteger(ClusterImplBase::DropOverloadRuntimeKey, UINT32_MAX);
+  if (drop_percent_runtime != UINT32_MAX) {
+    drop_ratio = float(drop_percent_runtime) / float(100);
+  }
   drop_overload_ = UnitFloat(drop_ratio);
   return absl::OkStatus();
 }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1712,7 +1712,7 @@ absl::Status ClusterImplBase::parseDropOverloadConfig(
                     "Denominator {}). The valid range is 0~1.",
                     drop_ratio, drop_percentage.numerator(), denominator));
   }
-  const uint32_t MAX_DROP_OVERLOAD_RUNTIME = 100;
+  const uint64_t MAX_DROP_OVERLOAD_RUNTIME = 100;
   uint64_t drop_ratio_runtime = runtime_.snapshot().getInteger(
       ClusterImplBase::DropOverloadRuntimeKey, MAX_DROP_OVERLOAD_RUNTIME);
   if (drop_ratio_runtime > MAX_DROP_OVERLOAD_RUNTIME) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1278,6 +1278,7 @@ protected:
 
 private:
   static const absl::string_view DoNotValidateAlpnRuntimeKey;
+  static const absl::string_view DropOverloadRuntimeKey;
 
   void finishInitialization();
   void reloadHealthyHosts(const HostSharedPtr& host);

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -352,7 +352,7 @@ TEST_P(StrictDnsParamTest, DropOverLoadConfigTestMultipleCategory) {
 
 TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideSmall) { dropOverloadRuntimeTest(10, 0.1); }
 
-TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideLarge) { dropOverloadRuntimeTest(80, 0.5); }
+TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideLarge) { dropOverloadRuntimeTest(80, 0.8); }
 
 class StrictDnsClusterImplTest : public testing::Test, public UpstreamImplTestBase {
 protected:

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -193,8 +193,17 @@ public:
     Envoy::Upstream::ClusterFactoryContextImpl factory_context(
         server_context_, server_context_.cluster_manager_, nullptr, ssl_context_manager_, nullptr,
         false);
-    StrictDnsClusterImpl cluster(cluster_config, factory_context, dns_resolver);
-    EXPECT_EQ(drop_ratio, cluster.dropOverload().value());
+    if (numerator <= 100) {
+      StrictDnsClusterImpl cluster(cluster_config, factory_context, dns_resolver);
+      EXPECT_EQ(drop_ratio, cluster.dropOverload().value());
+    } else {
+      EXPECT_THROW_WITH_MESSAGE(
+          StrictDnsClusterImpl cluster(cluster_config, factory_context, dns_resolver),
+          EnvoyException,
+          fmt::format("load_balancing_policy.drop_overload_limit runtime key config {} is invalid. "
+                      "The valid range is 0~100",
+                      numerator));
+    }
   }
 };
 
@@ -320,6 +329,35 @@ TEST_P(StrictDnsParamTest, DropOverLoadConfigTestBadDenominator) {
       "Cluster drop_overloads config denominator setting is invalid : 4. Valid range 0~2.");
 }
 
+TEST_P(StrictDnsParamTest, DropOverLoadConfigTestBadNumerator) {
+  auto dns_resolver = std::make_shared<NiceMock<Network::MockDnsResolver>>();
+  ReadyWatcher initialized;
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: strict_dns
+    )EOF" + std::get<0>(GetParam()) +
+                           R"EOF(
+    lb_policy: round_robin
+    load_assignment:
+        policy:
+          drop_overloads:
+            category: test
+            drop_percentage:
+              numerator: 200
+              denominator: HUNDRED
+  )EOF";
+
+  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
+  Envoy::Upstream::ClusterFactoryContextImpl factory_context(
+      server_context_, server_context_.cluster_manager_, nullptr, ssl_context_manager_, nullptr,
+      false);
+  EXPECT_THROW_WITH_MESSAGE(
+      StrictDnsClusterImpl cluster(cluster_config, factory_context, dns_resolver), EnvoyException,
+      "Cluster drop_overloads config is invalid. drop_ratio=2(Numerator 200 / Denominator 100). "
+      "The valid range is 0~1.");
+}
+
 TEST_P(StrictDnsParamTest, DropOverLoadConfigTestMultipleCategory) {
   auto dns_resolver = std::make_shared<NiceMock<Network::MockDnsResolver>>();
   ReadyWatcher initialized;
@@ -350,9 +388,22 @@ TEST_P(StrictDnsParamTest, DropOverLoadConfigTestMultipleCategory) {
       "Cluster drop_overloads config has 2 categories. Envoy only support one.");
 }
 
+// Drop overload runtime key configuration test
 TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideSmall) { dropOverloadRuntimeTest(10, 0.1); }
 
 TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideLarge) { dropOverloadRuntimeTest(80, 0.5); }
+
+// Edge condition test
+TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideLowerBound) { dropOverloadRuntimeTest(0, 0); }
+
+TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideUpperBound) {
+  dropOverloadRuntimeTest(100, 0.5);
+}
+
+// Error configuration test
+TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideTooLarge) {
+  dropOverloadRuntimeTest(150, 0.5);
+}
 
 class StrictDnsClusterImplTest : public testing::Test, public UpstreamImplTestBase {
 protected:

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -352,7 +352,7 @@ TEST_P(StrictDnsParamTest, DropOverLoadConfigTestMultipleCategory) {
 
 TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideSmall) { dropOverloadRuntimeTest(10, 0.1); }
 
-TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideLarge) { dropOverloadRuntimeTest(80, 0.8); }
+TEST_P(StrictDnsParamTest, DropOverLoadRuntimeOverrideLarge) { dropOverloadRuntimeTest(80, 0.5); }
 
 class StrictDnsClusterImplTest : public testing::Test, public UpstreamImplTestBase {
 protected:


### PR DESCRIPTION
This is the 2nd attempt for the PR : https://github.com/envoyproxy/envoy/pull/32062.

Adding runtime key to protect drop overload feature.

The runtime key "load_balancing_policy.drop_overload_limit" can be configured with an integer 0 to 100. 0 means 0%. 100 means 100%. So, when there is an EDS update with drop_overloads configuration, if this runtime key is enabled, Envoy will pick up the smaller one between these two to perform the drops.


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
