### PR TITLE
docs: fix typo

### DIFF
--- a/docs/root/configuration/http/http_filters/grpc_field_extraction_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_field_extraction_filter.rst
@@ -1,4 +1,4 @@
-.._config_http_filters_grpc_field_extraction:
+.. _config_http_filters_grpc_field_extraction:
 
 gRPC Field Extraction
 =====================


### PR DESCRIPTION
https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_field_extraction_filter.html was showing the literal string `.._config_http_filters_grpc_field_extraction:`.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
