### PR TITLE
Add support for boolean type to Envoy::Json::Streamer

### DIFF
--- a/source/common/json/json_streamer.cc
+++ b/source/common/json/json_streamer.cc
@@ -137,7 +137,7 @@ void Streamer::Map::addEntries(const Entries& entries) {
 }
 
 void Streamer::Level::addValue(const Value& value) {
-  switch (int idx = value.index()) {
+  switch (value.index()) {
   case 0:
     static_assert(std::is_same<decltype(absl::get<0>(value)), const absl::string_view&>::value,
                   "value at index 0 must be an absl::string_vlew");

--- a/source/common/json/json_streamer.cc
+++ b/source/common/json/json_streamer.cc
@@ -1,5 +1,7 @@
 #include "source/common/json/json_streamer.h"
 
+#include <type_traits>
+
 #include "source/common/buffer/buffer_util.h"
 #include "source/common/json/json_sanitizer.h"
 
@@ -135,20 +137,30 @@ void Streamer::Map::addEntries(const Entries& entries) {
 }
 
 void Streamer::Level::addValue(const Value& value) {
-  switch (value.index()) {
+  switch (int idx = value.index()) {
   case 0:
+    static_assert(std::is_same<decltype(absl::get<0>(value)), const absl::string_view&>::value,
+                  "value at index 0 must be an absl::string_vlew");
     addString(absl::get<absl::string_view>(value));
     break;
   case 1:
+    static_assert(std::is_same<decltype(absl::get<1>(value)), const double&>::value,
+                  "value at index 1 must be a double");
     addNumber(absl::get<double>(value));
     break;
   case 2:
+    static_assert(std::is_same<decltype(absl::get<2>(value)), const uint64_t&>::value,
+                  "value at index 2 must be a uint64_t");
     addNumber(absl::get<uint64_t>(value));
     break;
   case 3:
+    static_assert(std::is_same<decltype(absl::get<3>(value)), const int64_t&>::value,
+                  "value at index 3 must be an int64_t");
     addNumber(absl::get<int64_t>(value));
     break;
   case 4:
+    static_assert(std::is_same<decltype(absl::get<4>(value)), const bool&>::value,
+                  "value at index 4 must be a bool");
     addBool(absl::get<bool>(value));
     break;
   default:

--- a/source/common/json/json_streamer.cc
+++ b/source/common/json/json_streamer.cc
@@ -82,6 +82,12 @@ void Streamer::Level::addNumber(int64_t number) {
   streamer_.addNumber(number);
 }
 
+void Streamer::Level::addBool(bool b) {
+  ASSERT_THIS_IS_TOP_LEVEL;
+  nextField();
+  streamer_.addBool(b);
+}
+
 void Streamer::Level::addString(absl::string_view str) {
   ASSERT_THIS_IS_TOP_LEVEL;
   nextField();
@@ -142,6 +148,9 @@ void Streamer::Level::addValue(const Value& value) {
   case 3:
     addNumber(absl::get<int64_t>(value));
     break;
+  case 4:
+    addBool(absl::get<bool>(value));
+    break;
   default:
     IS_ENVOY_BUG(absl::StrCat("addValue invalid index: ", value.index()));
     break;
@@ -165,6 +174,8 @@ void Streamer::addNumber(double number) {
 void Streamer::addNumber(uint64_t number) { response_.addFragments({absl::StrCat(number)}); }
 
 void Streamer::addNumber(int64_t number) { response_.addFragments({absl::StrCat(number)}); }
+
+void Streamer::addBool(bool b) { response_.addFragments({b ? "true" : "false"}); }
 
 void Streamer::addSanitized(absl::string_view prefix, absl::string_view str,
                             absl::string_view suffix) {

--- a/source/common/json/json_streamer.h
+++ b/source/common/json/json_streamer.h
@@ -21,7 +21,7 @@ namespace Json {
  */
 class Streamer {
 public:
-  using Value = absl::variant<absl::string_view, double, uint64_t, int64_t>;
+  using Value = absl::variant<absl::string_view, double, uint64_t, int64_t, bool>;
 
   /**
    * @param response The buffer in which to stream output. Note: this buffer can
@@ -84,6 +84,14 @@ public:
      * isn't expecting a value. You must call Map::addKey prior to calling this.
      */
     void addString(absl::string_view str);
+
+    /**
+     * Adds a bool constant value to the current array or map. It's a programming
+     * error to call this method on a map or array that's not the top level.
+     * It's also a programming error to call this on map that isn't expecting
+     * a value. You must call Map::addKey prior to calling this.
+     */
+    void addBool(bool b);
 
   protected:
     /**
@@ -201,6 +209,7 @@ private:
   void addNumber(double d);
   void addNumber(uint64_t u);
   void addNumber(int64_t i);
+  void addBool(bool b);
 
   /**
    * Flushes out any pending fragments.

--- a/test/common/json/json_streamer_test.cc
+++ b/test/common/json/json_streamer_test.cc
@@ -65,6 +65,22 @@ TEST_F(JsonStreamerTest, MapOneString) {
   EXPECT_EQ(R"EOF({"a":"b"})EOF", buffer_.toString());
 }
 
+TEST_F(JsonStreamerTest, MapOneBool) {
+  {
+    Streamer::MapPtr map = streamer_.makeRootMap();
+    map->addEntries({{"a", true}});
+  }
+  EXPECT_EQ(R"EOF({"a":true})EOF", buffer_.toString());
+}
+
+TEST_F(JsonStreamerTest, MapTwoBools) {
+  {
+    Streamer::MapPtr map = streamer_.makeRootMap();
+    map->addEntries({{"a", true}, {"b", false}});
+  }
+  EXPECT_EQ(R"EOF({"a":true,"b":false})EOF", buffer_.toString());
+}
+
 TEST_F(JsonStreamerTest, MapOneSanitized) {
   {
     Streamer::MapPtr map = streamer_.makeRootMap();
@@ -89,19 +105,20 @@ TEST_F(JsonStreamerTest, SubArray) {
   Streamer::MapPtr map = streamer_.makeRootMap();
   map->addKey("a");
   Streamer::ArrayPtr array = map->addArray();
-  array->addEntries({1.0, "two", 3.5, std::nan("")});
+  array->addEntries({1.0, "two", 3.5, true, false, std::nan("")});
   array.reset();
   map->addEntries({{"embedded\"quote", "value"}});
   map.reset();
-  EXPECT_EQ(R"EOF({"a":[1,"two",3.5,null],"embedded\"quote":"value"})EOF", buffer_.toString());
+  EXPECT_EQ(R"EOF({"a":[1,"two",3.5,true,false,null],"embedded\"quote":"value"})EOF",
+            buffer_.toString());
 }
 
 TEST_F(JsonStreamerTest, TopArray) {
   {
     Streamer::ArrayPtr array = streamer_.makeRootArray();
-    array->addEntries({1.0, "two", 3.5, std::nan("")});
+    array->addEntries({1.0, "two", 3.5, true, false, std::nan("")});
   }
-  EXPECT_EQ(R"EOF([1,"two",3.5,null])EOF", buffer_.toString());
+  EXPECT_EQ(R"EOF([1,"two",3.5,true,false,null])EOF", buffer_.toString());
 }
 
 TEST_F(JsonStreamerTest, SubMap) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Add support for boolean type to Envoy::Json::Streamer
Additional Description: Fixes #33752
Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: Add support for boolean type to Envoy::Json::Streamer
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

@tonya11en @jmarantz 
