### PR TITLE
mobile: Remove the EngineBuilder::useDnsSystemResolver method

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -220,11 +220,6 @@ EngineBuilder& EngineBuilder::addMaxConnectionsPerHost(int max_connections_per_h
   return *this;
 }
 
-EngineBuilder& EngineBuilder::useDnsSystemResolver(bool use_system_resolver) {
-  use_system_resolver_ = use_system_resolver;
-  return *this;
-}
-
 EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
     int h2_connection_keepalive_idle_interval_milliseconds) {
   h2_connection_keepalive_idle_interval_milliseconds_ =

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -136,7 +136,6 @@ public:
   EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
   EngineBuilder& addDnsMinRefreshSeconds(int dns_min_refresh_seconds);
   EngineBuilder& addMaxConnectionsPerHost(int max_connections_per_host);
-  EngineBuilder& useDnsSystemResolver(bool use_system_resolver);
   EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       int h2_connection_keepalive_idle_interval_milliseconds);
   EngineBuilder&
@@ -230,7 +229,6 @@ private:
   int dns_failure_refresh_seconds_base_ = 2;
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 5;
-  bool use_system_resolver_ = true;
   int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
   int h2_connection_keepalive_timeout_seconds_ = 10;
   std::string app_version_ = "unspecified";

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -44,7 +44,6 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
   private final int mDnsCacheSaveIntervalSeconds = 1;
   private final List<String> mDnsFallbackNameservers = Collections.emptyList();
   private final boolean mEnableDnsFilterUnroutableFamilies = true;
-  private final boolean mDnsUseSystemResolver = true;
   private boolean mEnableDrainPostDnsRefresh = false;
   private final boolean mEnableGzipDecompression = true;
   private final boolean mEnableSocketTag = true;


### PR DESCRIPTION
Envoy Mobile uses the system resolver for both Apple and Android, and the use_system_resolver_ variable doesn't control any code, so just cleaning up the unused method.