### PR TITLE
async_client: add support for filter state

### DIFF
--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -9,6 +9,7 @@
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/http/message.h"
+#include "envoy/stream_info/filter_state.h"
 #include "envoy/stream_info/stream_info.h"
 #include "envoy/tracing/tracer.h"
 
@@ -266,6 +267,12 @@ public:
       return *this;
     }
 
+    // Set FilterState on async stream allowing upstream filters to access it.
+    StreamOptions& setFilterState(Envoy::StreamInfo::FilterStateSharedPtr fs) {
+      filter_state = fs;
+      return *this;
+    }
+
     // Set buffer restriction and accounting for the stream.
     StreamOptions& setBufferAccount(const Buffer::BufferMemoryAccountSharedPtr& account) {
       account_ = account;
@@ -330,6 +337,7 @@ public:
     ParentContext parent_context;
 
     envoy::config::core::v3::Metadata metadata;
+    Envoy::StreamInfo::FilterStateSharedPtr filter_state;
 
     // Buffer memory account for tracking bytes.
     Buffer::BufferMemoryAccountSharedPtr account_{nullptr};
@@ -375,6 +383,10 @@ public:
     }
     RequestOptions& setMetadata(const envoy::config::core::v3::Metadata& m) {
       StreamOptions::setMetadata(m);
+      return *this;
+    }
+    RequestOptions& setFilterState(Envoy::StreamInfo::FilterStateSharedPtr fs) {
+      StreamOptions::setFilterState(fs);
       return *this;
     }
     RequestOptions& setRetryPolicy(const envoy::config::route::v3::RetryPolicy& p) {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -10,6 +10,7 @@
 #include "source/common/http/null_route_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
+#include "source/common/stream_info/filter_state_impl.h"
 #include "source/common/tracing/http_tracer_impl.h"
 #include "source/common/upstream/retry_factory.h"
 
@@ -98,7 +99,10 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
       router_(options.filter_config_ ? *options.filter_config_ : parent.config_,
               parent.config_.async_stats_),
       stream_info_(Protocol::Http11, parent.dispatcher().timeSource(), nullptr,
-                   StreamInfo::FilterState::LifeSpan::FilterChain),
+                   options.filter_state != nullptr
+                       ? options.filter_state
+                       : std::make_shared<StreamInfo::FilterStateImpl>(
+                             StreamInfo::FilterState::LifeSpan::FilterChain)),
       tracing_config_(Tracing::EgressConfig::get()),
       retry_policy_(createRetryPolicy(parent, options, parent_.factory_context_)),
       route_(std::make_shared<NullRouteImpl>(

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -133,6 +133,18 @@ struct StreamInfoImpl : public StreamInfo {
                                                   std::move(parent_filter_state), parent_life_span),
                                               life_span)) {}
 
+  StreamInfoImpl(
+      absl::optional<Http::Protocol> protocol, TimeSource& time_source,
+      const Network::ConnectionInfoProviderSharedPtr& downstream_connection_info_provider,
+      FilterStateSharedPtr filter_state)
+      : time_source_(time_source), start_time_(time_source.systemTime()),
+        start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
+        filter_state_(std::move(filter_state)),
+        downstream_connection_info_provider_(downstream_connection_info_provider != nullptr
+                                                 ? downstream_connection_info_provider
+                                                 : emptyDownstreamAddressProvider()),
+        trace_reason_(Tracing::Reason::NotTraceable) {}
+
   SystemTime startTime() const override { return start_time_; }
 
   MonotonicTime startTimeMonotonic() const override { return start_time_monotonic_; }
@@ -459,18 +471,6 @@ private:
         Network::ConnectionInfoProviderSharedPtr,
         std::make_shared<Network::ConnectionInfoSetterImpl>(nullptr, nullptr));
   }
-
-  StreamInfoImpl(
-      absl::optional<Http::Protocol> protocol, TimeSource& time_source,
-      const Network::ConnectionInfoProviderSharedPtr& downstream_connection_info_provider,
-      FilterStateSharedPtr filter_state)
-      : time_source_(time_source), start_time_(time_source.systemTime()),
-        start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
-        filter_state_(std::move(filter_state)),
-        downstream_connection_info_provider_(downstream_connection_info_provider != nullptr
-                                                 ? downstream_connection_info_provider
-                                                 : emptyDownstreamAddressProvider()),
-        trace_reason_(Tracing::Reason::NotTraceable) {}
 
   std::shared_ptr<UpstreamInfo> upstream_info_;
   uint64_t bytes_received_{};


### PR DESCRIPTION
Commit Message: Add support for FilterState to AsyncClient
Additional Description: This allows upstream filters used in an AsyncClient request to access the FilterState.
Risk Level: low
Testing: Updated unit tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
