### PR TITLE
generic proxy: expose the codec error to upper layer

### DIFF
--- a/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
@@ -31,8 +31,9 @@ public:
 
   /**
    * If request decoding failure then this method will be called.
+   * @param reason the reason of decoding failure.
    */
-  virtual void onDecodingFailure() PURE;
+  virtual void onDecodingFailure(absl::string_view reason = {}) PURE;
 
   /**
    * Write specified data to the downstream connection. This is could be used to write
@@ -71,8 +72,9 @@ public:
 
   /**
    * If response decoding failure then this method will be called.
+   * @param reason the reason of decoding failure.
    */
-  virtual void onDecodingFailure() PURE;
+  virtual void onDecodingFailure(absl::string_view reason = {}) PURE;
 
   /**
    * Write specified data to the upstream connection. This is could be used to write
@@ -113,6 +115,12 @@ public:
    * @param end_stream if last frame is encoded.
    */
   virtual void onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) PURE;
+
+  /**
+   * If encoding failure then this method will be called.
+   * @param reason the reason of encoding failure.
+   */
+  virtual void onEncodingFailure(absl::string_view reason = {}) PURE;
 
   /**
    * The route that the request is matched to. This is optional when encoding the response

--- a/contrib/generic_proxy/filters/network/source/interface/stream.h
+++ b/contrib/generic_proxy/filters/network/source/interface/stream.h
@@ -285,18 +285,10 @@ using ResponseSharedPtr = std::shared_ptr<Response>;
 
 template <class T> class StreamFramePtrHelper {
 public:
-  StreamFramePtrHelper(StreamFramePtr frame) {
-    auto frame_ptr = frame.release();
-
-    auto typed_frame_ptr = dynamic_cast<T*>(frame_ptr);
-
-    if (typed_frame_ptr == nullptr) {
-      // If the frame is not the expected type, wrap it
-      // in the original StreamFramePtr.
-      frame_ = StreamFramePtr{frame_ptr};
-    } else {
-      // If the frame is the expected type, wrap it
-      // in the typed frame unique pointer.
+  StreamFramePtrHelper(StreamFramePtr frame) : frame_(std::move(frame)) {
+    if (auto typed_frame_ptr = dynamic_cast<T*>(frame_.get()); typed_frame_ptr != nullptr) {
+      // If the frame is the expected type, wrap it in the typed frame unique pointer.
+      frame_.release();
       typed_frame_ = std::unique_ptr<T>{typed_frame_ptr};
     }
   }

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -314,6 +314,11 @@ void ActiveStream::onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) 
   parent_.deferredStream(*this);
 }
 
+void ActiveStream::onEncodingFailure(absl::string_view reason) {
+  ENVOY_LOG(error, "Generic proxy: response encoding failure: {}", reason);
+  resetStream(DownstreamStreamResetReason::ProtocolError);
+}
+
 void ActiveStream::initializeFilterChain(FilterChainFactory& factory) {
   factory.createFilterChain(*this);
   // Reverse the encoder filter chain so that the first encoder filter is the last filter in the
@@ -390,9 +395,9 @@ void Filter::onDecodingSuccess(StreamFramePtr request) {
   onDecodingFailure();
 }
 
-void Filter::onDecodingFailure() {
+void Filter::onDecodingFailure(absl::string_view reason) {
+  ENVOY_LOG(error, "generic proxy: request decoding failure: {}", reason);
   stats_helper_.onRequestDecodingError();
-
   resetDownstreamAllStreams(DownstreamStreamResetReason::ProtocolError);
   closeDownstreamConnection();
 }

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -263,6 +263,7 @@ public:
 
   // ResponseEncoderCallback
   void onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) override;
+  void onEncodingFailure(absl::string_view reason = {}) override;
   OptRef<const RouteEntry> routeEntry() const override {
     return makeOptRefFromPtr<const RouteEntry>(cached_route_entry_.get());
   }
@@ -372,7 +373,7 @@ public:
 
   // RequestDecoderCallback
   void onDecodingSuccess(StreamFramePtr request) override;
-  void onDecodingFailure() override;
+  void onDecodingFailure(absl::string_view reason = {}) override;
   void writeToConnection(Buffer::Instance& buffer) override;
   OptRef<Network::Connection> connection() override;
 

--- a/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
@@ -195,7 +195,7 @@ TEST(DubboServerCodecTest, DubboServerCodecTest) {
     buffer.writeBEInt<int64_t>(0);
     buffer.writeBEInt<int64_t>(0);
 
-    EXPECT_CALL(callbacks, onDecodingFailure());
+    EXPECT_CALL(callbacks, onDecodingFailure(_));
     server_codec.decode(buffer, false);
   }
 
@@ -318,7 +318,7 @@ TEST(DubboClientCodecTest, DubboClientCodecTest) {
     buffer.writeBEInt<int64_t>(0);
     buffer.writeBEInt<int64_t>(0);
 
-    EXPECT_CALL(callbacks, onDecodingFailure());
+    EXPECT_CALL(callbacks, onDecodingFailure(_));
     client_codec.decode(buffer, false);
   }
 

--- a/contrib/generic_proxy/filters/network/test/codecs/http1/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/http1/config_test.cc
@@ -422,7 +422,7 @@ TEST_F(Http1ServerCodecTest, UnexpectedRequestTest) {
                "custom: value\r\n"
                "\r\n");
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 
@@ -444,7 +444,7 @@ TEST_F(Http1ServerCodecTest, UnexpectedRequestTest) {
                "0\r\n"  // Last chunk header.
                "\r\n"); // Last chunk footer.
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 
@@ -465,7 +465,7 @@ TEST_F(Http1ServerCodecTest, UnexpectedRequestTest) {
                "0\r\n"  // Last chunk header.
                "\r\n"); // Last chunk footer.
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 
@@ -479,7 +479,7 @@ TEST_F(Http1ServerCodecTest, UnexpectedRequestTest) {
                "custom: value\r\n"
                "\r\n");
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 
@@ -494,7 +494,7 @@ TEST_F(Http1ServerCodecTest, UnexpectedRequestTest) {
                "custom: value\r\n"
                "\r\n");
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 }
@@ -731,7 +731,7 @@ TEST_F(Http1ServerCodecTest, NewRequestBeforeFirstRequestCompleteTest) {
   codec_->decode(buffer, false);
 
   // First request is not complete, so the codec should close the connection.
-  EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+  EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
   codec_->decode(buffer2, false);
 }
 
@@ -786,7 +786,7 @@ TEST_F(Http1ServerCodecTest, SingleFrameModeRequestTooLargeTest) {
              "\r\n"
              "body~");
 
-  EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+  EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
   codec_->decode(buffer, false);
 }
 
@@ -1130,7 +1130,7 @@ TEST_F(Http1ClientCodecTest, UnexpectedResponseTest) {
                "0\r\n"  // Last chunk header.
                "\r\n"); // Last chunk footer.
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 
@@ -1152,7 +1152,7 @@ TEST_F(Http1ClientCodecTest, UnexpectedResponseTest) {
                "0\r\n"  // Last chunk header.
                "\r\n"); // Last chunk footer.
 
-    EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+    EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
     codec_->decode(buffer, false);
   }
 }
@@ -1309,9 +1309,9 @@ TEST_F(Http1ClientCodecTest, ResponseCompleteBeforeRequestCompleteTest) {
 
   // Decode the response.
   EXPECT_CALL(codec_callbacks_, onDecodingSuccess(_)).Times(3);
-  // Finally, the onDecodingFailure() is called because the request is not complete and the
+  // Finally, the onDecodingFailure(_) is called because the request is not complete and the
   // response is complete.
-  EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+  EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
   codec_->decode(buffer, false);
 }
 
@@ -1394,7 +1394,7 @@ TEST_F(Http1ClientCodecTest, SingleFrameModeResponseTooLargeTest) {
              "\r\n"
              "body~");
 
-  EXPECT_CALL(codec_callbacks_, onDecodingFailure());
+  EXPECT_CALL(codec_callbacks_, onDecodingFailure(_));
   codec_->decode(buffer, false);
 }
 

--- a/contrib/generic_proxy/filters/network/test/codecs/kafka/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/kafka/config_test.cc
@@ -68,7 +68,7 @@ TEST(KafkaCodecTest, KafkaRequestCallbacksTest) {
   }
 
   {
-    EXPECT_CALL(callbacks, onDecodingFailure());
+    EXPECT_CALL(callbacks, onDecodingFailure(_));
     request_callbacks.onFailedParse(nullptr);
   }
 }
@@ -91,7 +91,7 @@ TEST(KafkaCodecTest, KafkaResponseCallbacksTest) {
   }
 
   {
-    EXPECT_CALL(callbacks, onDecodingFailure());
+    EXPECT_CALL(callbacks, onDecodingFailure(_));
     response_callbacks.onFailedParse(nullptr);
   }
 }

--- a/contrib/generic_proxy/filters/network/test/integration_test.cc
+++ b/contrib/generic_proxy/filters/network/test/integration_test.cc
@@ -72,6 +72,7 @@ public:
   struct TestRequestEncoderCallback : public EncodingCallbacks {
     OptRef<const RouteEntry> routeEntry() const override { return {}; }
     void onEncodingSuccess(Buffer::Instance& buffer, bool) override { buffer_.move(buffer); }
+    void onEncodingFailure(absl::string_view) override {}
     Buffer::OwnedImpl buffer_;
   };
   using TestRequestEncoderCallbackSharedPtr = std::shared_ptr<TestRequestEncoderCallback>;
@@ -79,6 +80,7 @@ public:
   struct TestResponseEncoderCallback : public EncodingCallbacks {
     OptRef<const RouteEntry> routeEntry() const override { return {}; }
     void onEncodingSuccess(Buffer::Instance& buffer, bool) override { buffer_.move(buffer); }
+    void onEncodingFailure(absl::string_view) override {}
     Buffer::OwnedImpl buffer_;
   };
   using TestResponseEncoderCallbackSharedPtr = std::shared_ptr<TestResponseEncoderCallback>;
@@ -112,7 +114,7 @@ public:
         parent_.integration_->dispatcher_->exit();
       }
     }
-    void onDecodingFailure() override {}
+    void onDecodingFailure(absl::string_view) override {}
     void writeToConnection(Buffer::Instance&) override {}
     OptRef<Network::Connection> connection() override {
       if (parent_.upstream_connection_ != nullptr) {

--- a/contrib/generic_proxy/filters/network/test/mocks/codec.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/codec.h
@@ -11,7 +11,7 @@ namespace GenericProxy {
 class MockServerCodecCallbacks : public ServerCodecCallbacks {
 public:
   MOCK_METHOD(void, onDecodingSuccess, (StreamFramePtr request));
-  MOCK_METHOD(void, onDecodingFailure, ());
+  MOCK_METHOD(void, onDecodingFailure, (absl::string_view));
   MOCK_METHOD(void, writeToConnection, (Buffer::Instance & buffer));
   MOCK_METHOD(OptRef<Network::Connection>, connection, ());
 };
@@ -19,7 +19,7 @@ public:
 class MockClientCodecCallbacks : public ClientCodecCallbacks {
 public:
   MOCK_METHOD(void, onDecodingSuccess, (StreamFramePtr response));
-  MOCK_METHOD(void, onDecodingFailure, ());
+  MOCK_METHOD(void, onDecodingFailure, (absl::string_view));
   MOCK_METHOD(void, writeToConnection, (Buffer::Instance & buffer));
   MOCK_METHOD(OptRef<Network::Connection>, connection, ());
   MOCK_METHOD(OptRef<const Upstream::ClusterInfo>, upstreamCluster, (), (const));
@@ -28,6 +28,7 @@ public:
 class MockEncodingCallbacks : public EncodingCallbacks {
 public:
   MOCK_METHOD(void, onEncodingSuccess, (Buffer::Instance & buffer, bool end_stream));
+  MOCK_METHOD(void, onEncodingFailure, (absl::string_view));
   MOCK_METHOD(OptRef<const RouteEntry>, routeEntry, (), (const));
 };
 


### PR DESCRIPTION
Commit Message: generic proxy: expose the codec error to upper layer
Additional Description:

This PR extend the interface of generic codec to expose error from codecs to upper layer. Than the upper layer could use the error message to generate meaningful log or local response.

Risk Level: low, contrib only change.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.