### PR TITLE
router: set upstream host from the conn pool

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -113,7 +113,7 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
 
   // The router checks that the connection pool is non-null and valid before creating an
   // UpstreamRequest.
-  ASSERT(conn_pool_->valid() && upstream_host_ != nullptr, "Invalid connection pool");
+  ASSERT(upstream_host_ != nullptr, "Invalid connection pool");
   upstream_info_->upstream_host_ = upstream_host_;
 
   Tracing::HttpTraceContext trace_context(*parent_.downstreamHeaders());

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -129,9 +129,9 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
     parent_.callbacks()->activeSpan().injectContext(trace_context, upstream_context);
   }
 
-  stream_info_.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());
+  stream_info_.setUpstreamInfo(upstream_info_);
   stream_info_.route_ = parent_.callbacks()->route();
-  parent_.callbacks()->streamInfo().setUpstreamInfo(stream_info_.upstreamInfo());
+  parent_.callbacks()->streamInfo().setUpstreamInfo(upstream_info_);
 
   stream_info_.healthCheck(parent_.callbacks()->streamInfo().healthCheck());
   stream_info_.setIsShadow(parent_.callbacks()->streamInfo().isShadow());

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -195,6 +195,7 @@ private:
   std::unique_ptr<GenericUpstream> upstream_;
   absl::optional<Http::StreamResetReason> deferred_reset_reason_;
   Upstream::HostDescriptionConstSharedPtr upstream_host_;
+  std::shared_ptr<StreamInfo::UpstreamInfoImpl> upstream_info_;
   DownstreamWatermarkManager downstream_watermark_manager_{*this};
   Tracing::SpanPtr span_;
   StreamInfo::StreamInfoImpl stream_info_;

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -85,7 +85,7 @@ public:
   virtual void resetStream();
   void setupPerTryTimeout();
   void maybeEndDecode(bool end_stream);
-  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host, bool pool_success);
+  void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr real_host, bool success);
 
   // Http::StreamDecoder
   void decodeData(Buffer::Instance& data, bool end_stream) override;

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -334,7 +334,7 @@ public:
     EXPECT_CALL(*mock_host_, createConnection_(_, _)).WillRepeatedly(Return(connection_data));
     EXPECT_CALL(*mock_host_, cluster())
         .WillRepeatedly(ReturnRef(*cm_.thread_local_cluster_.cluster_.info_));
-    EXPECT_CALL(*mock_host_description_, locality()).WillRepeatedly(ReturnRef(host_locality_));
+    EXPECT_CALL(*mock_host_, locality()).WillRepeatedly(ReturnRef(host_locality_));
     http_conn_pool_ = Http::Http2::allocateConnPool(*dispatcher_, api_->randomGenerator(),
                                                     host_ptr_, Upstream::ResourcePriority::Default,
                                                     nullptr, nullptr, state_);
@@ -570,11 +570,11 @@ public:
     auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
         tls_context, factory_context_);
 
-    mock_host_description_->socket_factory_ =
+    mock_host_->socket_factory_ =
         std::make_unique<Extensions::TransportSockets::Tls::ClientSslSocketFactory>(
             std::move(cfg), context_manager_, *stats_store_.rootScope());
     async_client_transport_socket_ =
-        mock_host_description_->socket_factory_->createTransportSocket(nullptr, nullptr);
+        mock_host_->socket_factory_->createTransportSocket(nullptr, nullptr);
     FakeUpstreamConfig config(test_time_.timeSystem());
     config.upstream_protocol_ = Http::CodecType::HTTP2;
     fake_upstream_ =

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -669,7 +669,7 @@ TEST_P(LoadStatsIntegrationTest, Dropped) {
   EXPECT_EQ("503", response_->headers().getStatusValue());
   cleanupUpstreamAndDownstream();
 
-  ASSERT_TRUE(waitForLoadStatsRequest({}, 1));
+  ASSERT_TRUE(waitForLoadStatsRequest({localityStats("winter", 0, 1, 0, 0)}, 1));
 
   EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(2, test_server_->counter("load_reporter.responses")->value());


### PR DESCRIPTION
Commit Message: router: set upstream host from the conn pool
Additional Description:

The `host()` method of connection pool will return a host in current implementation. We can set the host at constructor of `UpstreamRequest` and needn't to wait the pool callbacks.

Considering a scenario like this, if the request is timeout before any pool callbacks are called, then the upstream host will never be set and we can even cannot know which host is selected for this request from the access log.

Risk Level: mid, core logic change.
Testing: wait.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.