### PR TITLE
docs: fix RESPONSE_FLAGS_LONG description

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -498,7 +498,7 @@ The following command operators are supported:
 
 %RESPONSE_FLAGS% / %RESPONSE_FLAGS_LONG%
   Additional details about the response or connection, if any. For TCP connections, the response codes mentioned in
-  the descriptions do not apply. %RESPONSE_FLAGS% will outout a short string. %RESPONSE_FLAGS% will outout a Pascal case string.
+  the descriptions do not apply. %RESPONSE_FLAGS% will output a short string. %RESPONSE_FLAGS_LONG% will output a Pascal case string.
   Possible values are:
 
 HTTP and TCP


### PR DESCRIPTION
Fix `%RESPONSE_FLAGS_LONG%` command operator description.


