### PR TITLE
arm/tests: Temporarily disable failing `io_uring` test

### DIFF
--- a/test/common/io/BUILD
+++ b/test/common/io/BUILD
@@ -10,18 +10,25 @@ envoy_package()
 
 envoy_cc_test(
     name = "io_uring_impl_test",
-    srcs = ["io_uring_impl_test.cc"],
+    srcs = select({
+        "//bazel:linux_x86_64": ["io_uring_impl_test.cc"],
+        "//conditions:default": [],
+    }),
     tags = [
         "nocompdb",
         "skip_on_windows",
     ],
     deps = [
-        "//source/common/io:io_uring_impl_lib",
         "//source/common/network:address_lib",
         "//test/mocks/io:io_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
-    ],
+    ] + select({
+        "//bazel:linux": [
+            "//source/common/io:io_uring_impl_lib",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 envoy_cc_test(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
