### PR TITLE
iouring: fix the IoUringImpl tests for latest kernel

### DIFF
--- a/test/common/io/BUILD
+++ b/test/common/io/BUILD
@@ -10,25 +10,18 @@ envoy_package()
 
 envoy_cc_test(
     name = "io_uring_impl_test",
-    srcs = select({
-        "//bazel:linux_x86_64": ["io_uring_impl_test.cc"],
-        "//conditions:default": [],
-    }),
+    srcs = ["io_uring_impl_test.cc"],
     tags = [
         "nocompdb",
         "skip_on_windows",
     ],
     deps = [
+        "//source/common/io:io_uring_impl_lib",
         "//source/common/network:address_lib",
         "//test/mocks/io:io_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
-    ] + select({
-        "//bazel:linux": [
-            "//source/common/io:io_uring_impl_lib",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
 envoy_cc_test(

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -49,7 +49,8 @@ public:
     }
   }
 
-  void waitForCondition(Event::Dispatcher& dispatcher, WaitConditionFunc condition_func, std::chrono::milliseconds wait_timeout = TestUtility::DefaultTimeout) {
+  void waitForCondition(Event::Dispatcher& dispatcher, WaitConditionFunc condition_func,
+                        std::chrono::milliseconds wait_timeout = TestUtility::DefaultTimeout) {
     Event::TestTimeSystem::RealTimeBound bound(wait_timeout);
     while (!condition_func()) {
       if (!bound.withinBound()) {
@@ -120,7 +121,7 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 2; });
 }
 
 TEST_F(IoUringImplTest, InjectCompletion) {
@@ -150,7 +151,7 @@ TEST_F(IoUringImplTest, InjectCompletion) {
 
   file_event->activate(Event::FileReadyType::Read);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 1; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 1; });
 }
 
 TEST_F(IoUringImplTest, NestInjectCompletion) {
@@ -190,7 +191,7 @@ TEST_F(IoUringImplTest, NestInjectCompletion) {
 
   file_event->activate(Event::FileReadyType::Read);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 2; });
 }
 
 TEST_F(IoUringImplTest, RemoveInjectCompletion) {
@@ -225,7 +226,7 @@ TEST_F(IoUringImplTest, RemoveInjectCompletion) {
   EXPECT_EQ(-1, data2);
   file_event->activate(Event::FileReadyType::Read);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 1; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 1; });
 }
 
 TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
@@ -264,7 +265,7 @@ TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
 
   file_event->activate(Event::FileReadyType::Read);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 2; });
 }
 
 TEST_F(IoUringImplTest, RegisterEventfd) {
@@ -309,7 +310,7 @@ TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
   io_uring_->submit();
 
   // Check that the completion callback has been actually called.
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 1; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 1; });
   // The file's content is in the read buffer now.
   EXPECT_STREQ(static_cast<char*>(iov.iov_base), "test text");
 }
@@ -370,7 +371,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 2; });
   // Even though we haven't been notified about ops completion the buffers
   // are filled already.
   EXPECT_EQ(static_cast<char*>(iov1.iov_base)[0], 'a');
@@ -380,7 +381,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
 
   // Only 2 completions are expected because the completion queue can contain
   // no more than 2 entries.
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 2; });
 
   // Check a new event gets handled in the next dispatcher run.
   res = io_uring_->prepareReadv(fd, &iov3, 1, 4, &request3);
@@ -388,7 +389,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 3; });
+  waitForCondition(*dispatcher, [&completions_nr]() { return completions_nr == 3; });
 
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[0], 'e');
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[1], 'f');

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -1,3 +1,5 @@
+#include <functional>
+
 #include "source/common/io/io_uring_impl.h"
 #include "source/common/network/address_impl.h"
 
@@ -21,6 +23,8 @@ public:
   MockIoUringSocket mock_io_uring_socket_;
 };
 
+using WaitConditionFunc = std::function<bool()>;
+
 class IoUringImplTest : public ::testing::Test {
 public:
   IoUringImplTest() : api_(Api::createApiForTest()), should_skip_(!isIoUringSupported()) {
@@ -42,6 +46,17 @@ public:
 
     if (io_uring_->isEventfdRegistered()) {
       io_uring_->unregisterEventfd();
+    }
+  }
+
+  void waitForCondition(Event::Dispatcher& dispatcher, WaitConditionFunc condition_func, std::chrono::milliseconds wait_timeout = TestUtility::DefaultTimeout) {
+    Event::TestTimeSystem::RealTimeBound bound(wait_timeout);
+    while (!condition_func()) {
+      if (!bound.withinBound()) {
+        RELEASE_ASSERT(0, "Timed out waiting for the condition.");
+        break;
+      }
+      dispatcher.run(Event::Dispatcher::RunType::NonBlock);
     }
   }
 
@@ -105,9 +120,7 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  while (completions_nr < 2) {
-    dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  }
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
 }
 
 TEST_F(IoUringImplTest, InjectCompletion) {
@@ -137,8 +150,7 @@ TEST_F(IoUringImplTest, InjectCompletion) {
 
   file_event->activate(Event::FileReadyType::Read);
 
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(completions_nr, 1);
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 1; });
 }
 
 TEST_F(IoUringImplTest, NestInjectCompletion) {
@@ -178,8 +190,7 @@ TEST_F(IoUringImplTest, NestInjectCompletion) {
 
   file_event->activate(Event::FileReadyType::Read);
 
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(completions_nr, 2);
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
 }
 
 TEST_F(IoUringImplTest, RemoveInjectCompletion) {
@@ -214,8 +225,7 @@ TEST_F(IoUringImplTest, RemoveInjectCompletion) {
   EXPECT_EQ(-1, data2);
   file_event->activate(Event::FileReadyType::Read);
 
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(completions_nr, 1);
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 1; });
 }
 
 TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
@@ -254,8 +264,7 @@ TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
 
   file_event->activate(Event::FileReadyType::Read);
 
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(completions_nr, 2);
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
 }
 
 TEST_F(IoUringImplTest, RegisterEventfd) {
@@ -299,10 +308,8 @@ TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
   EXPECT_STREQ(static_cast<char*>(iov.iov_base), "");
   io_uring_->submit();
 
-  dispatcher->run(Event::Dispatcher::RunType::Block);
-
   // Check that the completion callback has been actually called.
-  EXPECT_EQ(completions_nr, 1);
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 1; });
   // The file's content is in the read buffer now.
   EXPECT_STREQ(static_cast<char*>(iov.iov_base), "test text");
 }
@@ -363,9 +370,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  while (completions_nr < 2) {
-    dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  }
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
   // Even though we haven't been notified about ops completion the buffers
   // are filled already.
   EXPECT_EQ(static_cast<char*>(iov1.iov_base)[0], 'a');
@@ -373,11 +378,9 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   EXPECT_EQ(static_cast<char*>(iov2.iov_base)[0], 'c');
   EXPECT_EQ(static_cast<char*>(iov2.iov_base)[1], 'd');
 
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-
   // Only 2 completions are expected because the completion queue can contain
   // no more than 2 entries.
-  EXPECT_EQ(completions_nr, 2);
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 2; });
 
   // Check a new event gets handled in the next dispatcher run.
   res = io_uring_->prepareReadv(fd, &iov3, 1, 4, &request3);
@@ -385,16 +388,10 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  while (completions_nr < 3) {
-    dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  }
+  waitForCondition(*dispatcher, [&completions_nr](){ return completions_nr == 3; });
 
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[0], 'e');
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[1], 'f');
-
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  // Check the completion callback was called actually.
-  EXPECT_EQ(completions_nr, 3);
 }
 
 } // namespace

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -346,7 +346,6 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
           EXPECT_TRUE(user_data != nullptr);
           EXPECT_EQ(res, 2);
           completions_nr++;
-          ENVOY_LOG_MISC(info, "get uring request completion {}", completions_nr);
           // Note: generally events are not guaranteed to complete in the same order
           // we submit them, but for this case of reading from a single file it's ok
           // to expect the same order.

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -337,6 +337,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
           EXPECT_TRUE(user_data != nullptr);
           EXPECT_EQ(res, 2);
           completions_nr++;
+          ENVOY_LOG_MISC(info, "get uring request completion {}", completions_nr);
           // Note: generally events are not guaranteed to complete in the same order
           // we submit them, but for this case of reading from a single file it's ok
           // to expect the same order.
@@ -361,6 +362,9 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
+  while (completions_nr < 2) {
+    dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+  } 
   // Even though we haven't been notified about ops completion the buffers
   // are filled already.
   EXPECT_EQ(static_cast<char*>(iov1.iov_base)[0], 'a');

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -105,8 +105,9 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
 
-  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(completions_nr, 2);
+  while (completions_nr < 2) {
+    dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+  }
 }
 
 TEST_F(IoUringImplTest, InjectCompletion) {
@@ -383,6 +384,10 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   EXPECT_EQ(res, IoUringResult::Ok);
   res = io_uring_->submit();
   EXPECT_EQ(res, IoUringResult::Ok);
+
+  while (completions_nr < 3) {
+    dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+  }
 
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[0], 'e');
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[1], 'f');

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -364,7 +364,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
 
   while (completions_nr < 2) {
     dispatcher->run(Event::Dispatcher::RunType::NonBlock);
-  } 
+  }
   // Even though we haven't been notified about ops completion the buffers
   // are filled already.
   EXPECT_EQ(static_cast<char*>(iov1.iov_base)[0], 'a');


### PR DESCRIPTION
Commit Message: iouring: fix the IoUringImpl tests for the arm CI
Additional Description:
The existing tests assume that the I/O request can be finished right after the request submission. Add waiting function before checking the I/O request completion, making those tests more reliable.

Risk Level: low
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #33829
