### PR TITLE
dlb: disable domain server

### DIFF
--- a/contrib/dlb/source/BUILD
+++ b/contrib/dlb/source/BUILD
@@ -15,6 +15,7 @@ envoy_contrib_package()
 
 make(
     name = "dlb",
+    env = {"DLB_DISABLE_DOMAIN_SERVER": "TRUE"},
     includes = [],
     lib_source = "@intel_dlb//:libdlb",
     out_static_libs = ["libdlb.a"],


### PR DESCRIPTION
In the high kernel like 6.8, it would raise an error:

```
[dlb_domain_server()] Error: failed to share domain fd
[2024-04-16 04:55:50.055][7055][critical][backtrace] [./source/server/backtrace.h:127] Caught Segmentation fault, suspect faulting address 0x10
```

The dlb connection balancer does not need it, so disable it and make it work in high kernel.

Commit Message:
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
