### PR TITLE
HCM supports configuring keepalive header timeout

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -37,7 +37,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 58]
+// [#next-free-field: 59]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -895,6 +895,14 @@ message HttpConnectionManager {
   // This should be set to ``false`` in cases where Envoy's view of the downstream address may not correspond to the
   // actual client address, for example, if there's another proxy in front of the Envoy.
   google.protobuf.BoolValue add_proxy_protocol_connection_state = 53;
+
+  // The timeout seconds configured here will be set in the "Keep-Alive" response header.
+  // For example, configuring 10s will return the response header "Connection: keep-alive" and "Keep-Alive: timeout=10".
+  // If not specified, the default is 0, which means this behavior is disabled.
+  // The "Keep-Alive" header field is recognized by Mozilla, Konqueror and Apache HTTPClient.
+  // Note that the "Connection" and "Keep-Alive" response headers will only be added when the downstream protocol is HTTP1.0 or HTTP1.1
+  // and it is not an upgrade connection scenario.
+  google.protobuf.Duration keepalive_header_timeout = 58;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -544,6 +544,12 @@ public:
    *         Connection Lifetime.
    */
   virtual bool addProxyProtocolConnectionState() const PURE;
+
+  /**
+   * @return the timeout seconds will be set in the "Keep-Alive" response header.
+   * Zero indicates this behavior is disabled.
+   */
+  virtual std::chrono::seconds keepaliveHeaderTimeout() const PURE;
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -416,7 +416,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       append_local_overload_(config.append_local_overload()),
       append_x_forwarded_port_(config.append_x_forwarded_port()),
       add_proxy_protocol_connection_state_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, add_proxy_protocol_connection_state, true)) {
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, add_proxy_protocol_connection_state, true)),
+      keepalive_header_timeout_(PROTOBUF_GET_SECONDS_OR_DEFAULT(config, keepalive_header_timeout,
+                                                                KeepaliveHeaderTimeoutSeconds)) {
   if (!creation_status.ok()) {
     return;
   }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -271,6 +271,7 @@ public:
   bool addProxyProtocolConnectionState() const override {
     return add_proxy_protocol_connection_state_;
   }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return keepalive_header_timeout_; }
 
 private:
   enum class CodecType { HTTP1, HTTP2, HTTP3, AUTO };
@@ -357,6 +358,8 @@ private:
   static const uint64_t RequestTimeoutMs = 0;
   // request header timeout is disabled by default
   static const uint64_t RequestHeaderTimeoutMs = 0;
+  // keep-alive response header is disabled by default
+  static const uint64_t KeepaliveHeaderTimeoutSeconds = 0;
   const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       PathWithEscapedSlashesAction path_with_escaped_slashes_action_;
   const bool strip_trailing_host_dot_;
@@ -366,6 +369,7 @@ private:
   const bool append_local_overload_;
   const bool append_x_forwarded_port_;
   const bool add_proxy_protocol_connection_state_;
+  std::chrono::seconds keepalive_header_timeout_;
 };
 
 /**

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -235,6 +235,7 @@ public:
   bool appendLocalOverload() const override { return false; }
   bool appendXForwardedPort() const override { return false; }
   bool addProxyProtocolConnectionState() const override { return true; }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return {}; }
 
 private:
   friend class AdminTestingPeer;

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -177,6 +177,7 @@ public:
   bool addProxyProtocolConnectionState() const override {
     return add_proxy_protocol_connection_state_;
   }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return keepalive_header_timeout_; }
 
   // Simple helper to wrapper filter to the factory function.
   FilterFactoryCb createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr filter) {
@@ -282,6 +283,7 @@ public:
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
   std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_{};
   bool add_proxy_protocol_connection_state_ = true;
+  std::chrono::seconds keepalive_header_timeout_{};
 
   const LocalReply::LocalReplyPtr local_reply_;
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

fixes #33593 

HCM supports configuring keepalive header timeout

Risk Level: low
Testing:  UT
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

