### PR TITLE
support config keep-alive header timeout

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -899,7 +899,7 @@ message HttpConnectionManager {
   // The timeout seconds configured here will be set in the "Keep-Alive" response header.
   // For example, configuring 10s will return the response header "Connection: keep-alive" and "Keep-Alive: timeout=10".
   // If not specified, the default is 0, which means this behavior is disabled.
-  // The "Keep-Alive" header field is recognized by Mozilla, Konqueror and Apache HTTPClient.
+  // The "Keep-Alive" header field is recognized by Mozilla and Apache HTTPClient.
   // Note that the "Connection" and "Keep-Alive" response headers will only be added when the downstream protocol is HTTP1.0 or HTTP1.1
   // and it is not an upgrade connection scenario.
   google.protobuf.Duration keepalive_header_timeout = 58;

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -37,7 +37,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 58]
+// [#next-free-field: 59]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -895,6 +895,14 @@ message HttpConnectionManager {
   // This should be set to ``false`` in cases where Envoy's view of the downstream address may not correspond to the
   // actual client address, for example, if there's another proxy in front of the Envoy.
   google.protobuf.BoolValue add_proxy_protocol_connection_state = 53;
+
+  // The timeout seconds configured here will be set in the "Keep-Alive" response header.
+  // For example, configuring 10s will return the response header "Connection: keep-alive" and "Keep-Alive: timeout=10".
+  // If not specified, the default is 0, which means this behavior is disabled.
+  // The "Keep-Alive" header field is recognized by Mozilla, Konqueror and Apache HTTPClient.
+  // Note that the "Connection" and "Keep-Alive" response headers will only be added when the downstream protocol is HTTP1.0 or HTTP1.1
+  // and it is not an upgrade connection scenario.
+  google.protobuf.Duration keepalive_header_timeout = 58;
 }
 
 // The configuration to customize local reply returned by Envoy.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -544,6 +544,12 @@ public:
    *         Connection Lifetime.
    */
   virtual bool addProxyProtocolConnectionState() const PURE;
+
+  /**
+   * @return the timeout seconds will be set in the "Keep-Alive" response header.
+   * Zero indicates this behavior is disabled.
+   */
+  virtual std::chrono::seconds keepaliveHeaderTimeout() const PURE;
 };
 
 using ConnectionManagerConfigSharedPtr = std::shared_ptr<ConnectionManagerConfig>;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1799,10 +1799,10 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& heade
       // Do not do this for H2 (which drains via GOAWAY) or Upgrade or CONNECT (as the
       // payload is no longer HTTP/1.1)
       headers.setReferenceConnection(Headers::get().ConnectionValues.Close);
-    } else if (connection_manager_.config_.keepaliveHeaderTimeout().count() != 0) {
+    } else if (connection_manager_.config_->keepaliveHeaderTimeout().count() != 0) {
       headers.setKeepAlive(absl::StrCat(
           "timeout=",
-          std::to_string(connection_manager_.config_.keepaliveHeaderTimeout().count())));
+          std::to_string(connection_manager_.config_->keepaliveHeaderTimeout().count())));
       headers.setReferenceConnection(Headers::get().ConnectionValues.KeepAlive);
     }
   }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -416,7 +416,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       append_local_overload_(config.append_local_overload()),
       append_x_forwarded_port_(config.append_x_forwarded_port()),
       add_proxy_protocol_connection_state_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, add_proxy_protocol_connection_state, true)) {
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, add_proxy_protocol_connection_state, true)),
+      keepalive_header_timeout_(PROTOBUF_GET_SECONDS_OR_DEFAULT(config, keepalive_header_timeout,
+                                                                KeepaliveHeaderTimeoutSeconds)) {
   if (!creation_status.ok()) {
     return;
   }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -271,6 +271,7 @@ public:
   bool addProxyProtocolConnectionState() const override {
     return add_proxy_protocol_connection_state_;
   }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return keepalive_header_timeout_; }
 
 private:
   enum class CodecType { HTTP1, HTTP2, HTTP3, AUTO };
@@ -357,6 +358,8 @@ private:
   static const uint64_t RequestTimeoutMs = 0;
   // request header timeout is disabled by default
   static const uint64_t RequestHeaderTimeoutMs = 0;
+  // keep-alive response header is disabled by default
+  static const uint64_t KeepaliveHeaderTimeoutSeconds = 0;
   const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       PathWithEscapedSlashesAction path_with_escaped_slashes_action_;
   const bool strip_trailing_host_dot_;
@@ -366,6 +369,7 @@ private:
   const bool append_local_overload_;
   const bool append_x_forwarded_port_;
   const bool add_proxy_protocol_connection_state_;
+  std::chrono::seconds keepalive_header_timeout_;
 };
 
 /**

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -236,6 +236,7 @@ public:
   bool appendLocalOverload() const override { return false; }
   bool appendXForwardedPort() const override { return false; }
   bool addProxyProtocolConnectionState() const override { return true; }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return {}; }
 
 private:
   friend class AdminTestingPeer;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -296,7 +296,7 @@ public:
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
   std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_;
   std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
-  std::chrono::seconds keepalive_header_timeout_;
+  std::chrono::seconds keepalive_header_timeout_{};
 };
 
 // Internal representation of stream state. Encapsulates the stream state, mocks

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -242,6 +242,7 @@ public:
   bool appendLocalOverload() const override { return false; }
   bool appendXForwardedPort() const override { return false; }
   bool addProxyProtocolConnectionState() const override { return true; }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return keepalive_header_timeout_; }
 
   const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
       config_;
@@ -295,6 +296,7 @@ public:
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
   std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_;
   std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
+  std::chrono::seconds keepalive_header_timeout_;
 };
 
 // Internal representation of stream state. Encapsulates the stream state, mocks

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -138,6 +138,9 @@ public:
   bool addProxyProtocolConnectionState() const override {
     return parent_.addProxyProtocolConnectionState();
   }
+  std::chrono::seconds keepaliveHeaderTimeout() const override {
+    return parent_.keepaliveHeaderTimeout();
+  }
 
 private:
   ConnectionManagerConfig& parent_;

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -177,6 +177,7 @@ public:
   bool addProxyProtocolConnectionState() const override {
     return add_proxy_protocol_connection_state_;
   }
+  std::chrono::seconds keepaliveHeaderTimeout() const override { return keepalive_header_timeout_; }
 
   // Simple helper to wrapper filter to the factory function.
   FilterFactoryCb createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr filter) {
@@ -282,6 +283,7 @@ public:
   std::vector<Http::OriginalIPDetectionSharedPtr> ip_detection_extensions_{};
   std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_{};
   bool add_proxy_protocol_connection_state_ = true;
+  std::chrono::seconds keepalive_header_timeout_{};
 
   const LocalReply::LocalReplyPtr local_reply_;
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -683,6 +683,7 @@ public:
   MOCK_METHOD(bool, appendLocalOverload, (), (const));
   MOCK_METHOD(bool, appendXForwardedPort, (), (const));
   MOCK_METHOD(bool, addProxyProtocolConnectionState, (), (const));
+  MOCK_METHOD(std::chrono::seconds, keepaliveHeaderTimeout, (), (const));
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =
       std::make_unique<DefaultInternalAddressConfig>();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

fixes #33593 

HCM supports configuring keepalive header timeout.

Refer to the [keepalive_timeout](https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout) directive in Nginx. the "Connection" and "Keep-Alive" response headers will only be added when the downstream protocol is HTTP1.0 or HTTP1.1 and it is not an upgrade connection scenario.

Risk Level: low
Testing:  UT
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
