### PR TITLE
router: add use_upstream_scheme to router filter

### DIFF
--- a/api/envoy/extensions/filters/http/router/v3/router.proto
+++ b/api/envoy/extensions/filters/http/router/v3/router.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Router :ref:`configuration overview <config_http_filters_router>`.
 // [#extension: envoy.filters.http.router]
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message Router {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.router.v2.Router";
@@ -103,6 +103,9 @@ message Router {
       }
     }
   }];
+
+  // If set, override the :scheme header to correspond with the upstream transport protocol.
+  bool use_upstream_scheme = 10;
 
   // If not set, ingress Envoy will ignore
   // :ref:`config_http_filters_router_x-envoy-expected-rq-timeout-ms` header, populated by egress

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -25,7 +25,8 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
       config_(factory_context, http_context.asyncClientStatPrefix(), factory_context.localInfo(),
               *stats_store.rootScope(), cm, factory_context.runtime(),
               factory_context.api().randomGenerator(), std::move(shadow_writer), true, false, false,
-              false, false, false, {}, dispatcher.timeSource(), http_context, router_context),
+              false, false, false, false, {}, dispatcher.timeSource(), http_context,
+              router_context),
       dispatcher_(dispatcher) {}
 
 AsyncClientImpl::~AsyncClientImpl() {

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -119,11 +119,13 @@ public:
 
   /**
    * Set the :scheme header using the best information available. In order this is
+   * - security of upstream connection if provided
    * - existing scheme header if valid
    * - x-forwarded-proto header if valid
    * - security of downstream connection
    */
-  static void setUpstreamScheme(Http::RequestHeaderMap& headers, bool downstream_secure);
+  static void setUpstreamScheme(Http::RequestHeaderMap& headers,
+                                absl::optional<bool> upstream_secure, bool downstream_secure);
 
   /**
    * Determine whether a request should be shadowed.
@@ -204,7 +206,7 @@ public:
                Random::RandomGenerator& random, ShadowWriterPtr&& shadow_writer,
                bool emit_dynamic_stats, bool start_child_span, bool suppress_envoy_headers,
                bool respect_expected_rq_timeout, bool suppress_grpc_request_failure_code_stats,
-               bool flush_upstream_log_on_upstream_stream,
+               bool use_upstream_scheme, bool flush_upstream_log_on_upstream_stream,
                const Protobuf::RepeatedPtrField<std::string>& strict_check_headers,
                TimeSource& time_source, Http::Context& http_context,
                Router::Context& router_context)
@@ -216,6 +218,7 @@ public:
         start_child_span_(start_child_span), suppress_envoy_headers_(suppress_envoy_headers),
         respect_expected_rq_timeout_(respect_expected_rq_timeout),
         suppress_grpc_request_failure_code_stats_(suppress_grpc_request_failure_code_stats),
+        use_upstream_scheme_(use_upstream_scheme),
         flush_upstream_log_on_upstream_stream_(flush_upstream_log_on_upstream_stream),
         http_context_(http_context), zone_name_(local_info_.zoneStatName()),
         shadow_writer_(std::move(shadow_writer)), time_source_(time_source) {
@@ -271,6 +274,7 @@ public:
   const bool suppress_envoy_headers_;
   const bool respect_expected_rq_timeout_;
   const bool suppress_grpc_request_failure_code_stats_;
+  const bool use_upstream_scheme_;
   // TODO(xyu-stripe): Make this a bitset to keep cluster memory footprint down.
   HeaderVectorPtr strict_check_headers_;
   const bool flush_upstream_log_on_upstream_stream_;

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -693,7 +693,7 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
                      context.serverFactoryContext().api().randomGenerator(),
                      std::make_unique<Router::ShadowWriterImpl>(
                          context.serverFactoryContext().clusterManager()),
-                     true, false, false, false, false, false, {},
+                     true, false, false, false, false, false, false, {},
                      context.serverFactoryContext().api().timeSource(),
                      context.serverFactoryContext().httpContext(),
                      context.serverFactoryContext().routerContext()),

--- a/source/extensions/health_checkers/grpc/health_checker_impl.cc
+++ b/source/extensions/health_checkers/grpc/health_checker_impl.cc
@@ -223,7 +223,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
       headers_message->headers(),
       // Here there is no downstream connection so scheme will be based on
       // upstream crypto
-      host_->transportSocketFactory().implementsSecureTransport());
+      absl::optional<bool>(host_->transportSocketFactory().implementsSecureTransport()), false);
 
   auto status = request_encoder_->encodeHeaders(headers_message->headers(), false);
   // Encoding will only fail if required headers are missing.

--- a/source/extensions/health_checkers/http/health_checker_impl.cc
+++ b/source/extensions/health_checkers/http/health_checker_impl.cc
@@ -267,7 +267,7 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
       *request_headers,
       // Here there is no downstream connection so scheme will be based on
       // upstream crypto
-      host_->transportSocketFactory().implementsSecureTransport());
+      absl::optional<bool>(host_->transportSocketFactory().implementsSecureTransport()), false);
   StreamInfo::StreamInfoImpl stream_info(protocol_, parent_.dispatcher_.timeSource(),
                                          local_connection_info_provider_,
                                          StreamInfo::FilterState::LifeSpan::FilterChain);

--- a/test/common/http/hcm_router_fuzz_test.cc
+++ b/test/common/http/hcm_router_fuzz_test.cc
@@ -444,7 +444,7 @@ public:
             runtime_, random_, Router::ShadowWriterPtr{shadow_writer_}, true /*emit_dynamic_stats*/,
             false /*start_child_span*/, true /*suppress_envoy_headers*/,
             false /*respect_expected_rq_timeout*/,
-            true /*suppress_grpc_request_failure_code_stats*/,
+            true /*suppress_grpc_request_failure_code_stats*/, false /*use_upstream_scheme*/,
             false /*flush_upstream_log_on_upstream_stream*/, std::move(strict_headers_to_check),
             time_system_.timeSystem(), http_context_, router_context_) {
     cluster_manager_.createDefaultClusters(*this);

--- a/test/common/router/router_test_base.cc
+++ b/test/common/router/router_test_base.cc
@@ -12,16 +12,16 @@ using ::testing::ReturnRef;
 
 RouterTestBase::RouterTestBase(bool start_child_span, bool suppress_envoy_headers,
                                bool suppress_grpc_request_failure_code_stats,
-                               bool flush_upstream_log_on_upstream_stream,
+                               bool use_upstream_scheme, bool flush_upstream_log_on_upstream_stream,
                                Protobuf::RepeatedPtrField<std::string> strict_headers_to_check)
     : pool_(stats_store_.symbolTable()), http_context_(stats_store_.symbolTable()),
       router_context_(stats_store_.symbolTable()), shadow_writer_(new MockShadowWriter()),
       config_(factory_context_, pool_.add("test"), factory_context_.local_info_,
               *stats_store_.rootScope(), cm_, runtime_, random_, ShadowWriterPtr{shadow_writer_},
               true, start_child_span, suppress_envoy_headers, false,
-              suppress_grpc_request_failure_code_stats, flush_upstream_log_on_upstream_stream,
-              std::move(strict_headers_to_check), test_time_.timeSystem(), http_context_,
-              router_context_),
+              suppress_grpc_request_failure_code_stats, use_upstream_scheme,
+              flush_upstream_log_on_upstream_stream, std::move(strict_headers_to_check),
+              test_time_.timeSystem(), http_context_, router_context_),
       router_(std::make_unique<RouterTestFilter>(config_, config_.default_stats_)) {
   router_->setDecoderFilterCallbacks(callbacks_);
   upstream_locality_.set_zone("to_az");

--- a/test/common/router/router_test_base.h
+++ b/test/common/router/router_test_base.h
@@ -61,7 +61,7 @@ public:
 class RouterTestBase : public testing::Test {
 public:
   RouterTestBase(bool start_child_span, bool suppress_envoy_headers,
-                 bool suppress_grpc_request_failure_code_stats,
+                 bool suppress_grpc_request_failure_code_stats, bool use_upstream_scheme,
                  bool flush_upstream_log_on_upstream_stream,
                  Protobuf::RepeatedPtrField<std::string> strict_headers_to_check);
 


### PR DESCRIPTION
Commit Message: add use_upstream_scheme field to router config
Additional Description: Use a router config toggle to override the scheme of a request. Useful for when HTTP2 servers expect the scheme header to match the transport and the downstream/upstream transport protocols don't match (see PR for more details).
Risk Level: low
Testing: unit testing
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes envoyproxy#33020
