### PR TITLE
readme: remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ involved and how Envoy plays a role, read the CNCF
 * [Official documentation](https://www.envoyproxy.io/)
 * [FAQ](https://www.envoyproxy.io/docs/envoy/latest/faq/overview)
 * [Unofficial Chinese documentation](https://cloudnative.to/envoy/)
-* Watch [a video overview of Envoy](https://www.youtube.com/watch?v=RVZX4CwKhGE)
-([transcript](https://www.microservices.com/talks/lyfts-envoy-monolith-service-mesh-matt-klein/))
-to find out more about the origin story and design philosophy of Envoy
 * [Blog](https://medium.com/@mattklein123/envoy-threading-model-a8d44b922310) about the threading model
 * [Blog](https://medium.com/@mattklein123/envoy-hot-restart-1d16b14555b5) about hot restart
 * [Blog](https://medium.com/@mattklein123/envoy-stats-b65c7f363342) about stats architecture


### PR DESCRIPTION
Commit Message: readme: remove dead link
Additional Description:
The original video was removed from: https://www.microservices.com/talks/lyfts-envoy-monolith-service-mesh-matt-klein/
I couldn't find the original video on youtube or anywhere.

I guess we can also add a link to https://www.youtube.com/watch?v=uaksVVHDhYU but will leave it up to the reviewer to decide.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
