### PR TITLE
Manage wasm invalid grpc code

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1695,9 +1695,11 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, std::string_view b
       // which should be mapped to nullopt in Envoy to prevent it from sending a grpc-status trailer
       // at all.
       absl::optional<Grpc::Status::GrpcStatus> grpc_status_code =
-          grpc_status == static_cast<uint32_t>(Grpc::Status::WellKnownGrpcStatus::InvalidCode)
+          Grpc::Status::WellKnownGrpcStatus(grpc_status) ==
+                  Grpc::Status::WellKnownGrpcStatus::InvalidCode
               ? absl::nullopt
-              : absl::optional<Grpc::Status::GrpcStatus>(grpc_status);
+              : absl::optional<Grpc::Status::GrpcStatus>(
+                    Grpc::Status::WellKnownGrpcStatus(grpc_status));
       decoder_callbacks_->sendLocalReply(static_cast<Envoy::Http::Code>(response_code), body_text,
                                          modify_headers, grpc_status_code, details);
       local_reply_sent_ = true;

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1691,8 +1691,14 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, std::string_view b
       if (local_reply_sent_) {
         return;
       }
+      // In case -1 is send from sdk, as an invalid value, nullopt is sent to allows envoy to
+      // set the grpc status code
+      absl::optional<Grpc::Status::GrpcStatus> grpc_status_code =
+          grpc_status == static_cast<uint32_t>(Grpc::Status::WellKnownGrpcStatus::InvalidCode)
+              ? absl::nullopt
+              : absl::optional<Grpc::Status::GrpcStatus>(grpc_status);
       decoder_callbacks_->sendLocalReply(static_cast<Envoy::Http::Code>(response_code), body_text,
-                                         modify_headers, grpc_status, details);
+                                         modify_headers, grpc_status_code, details);
       local_reply_sent_ = true;
     });
   }

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1691,8 +1691,9 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, std::string_view b
       if (local_reply_sent_) {
         return;
       }
-      // In case -1 is send from sdk, as an invalid value, nullopt is sent to allows envoy to
-      // set the grpc status code
+      // C++, Rust and other SDKs use -1 (InvalidCode) as the default value if gRPC code is not set,
+      // which should be mapped to nullopt in Envoy to prevent it from sending a grpc-status trailer
+      // at all.
       absl::optional<Grpc::Status::GrpcStatus> grpc_status_code =
           grpc_status == static_cast<uint32_t>(Grpc::Status::WellKnownGrpcStatus::InvalidCode)
               ? absl::nullopt

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1694,12 +1694,11 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, std::string_view b
       // C++, Rust and other SDKs use -1 (InvalidCode) as the default value if gRPC code is not set,
       // which should be mapped to nullopt in Envoy to prevent it from sending a grpc-status trailer
       // at all.
-      absl::optional<Grpc::Status::GrpcStatus> grpc_status_code =
-          Grpc::Status::WellKnownGrpcStatus(grpc_status) ==
-                  Grpc::Status::WellKnownGrpcStatus::InvalidCode
-              ? absl::nullopt
-              : absl::optional<Grpc::Status::GrpcStatus>(
-                    Grpc::Status::WellKnownGrpcStatus(grpc_status));
+      absl::optional<Grpc::Status::GrpcStatus> grpc_status_code = absl::nullopt;
+      if (grpc_status >= Grpc::Status::WellKnownGrpcStatus::Ok &&
+          grpc_status <= Grpc::Status::WellKnownGrpcStatus::MaximumKnown) {
+        grpc_status_code = Grpc::Status::WellKnownGrpcStatus(grpc_status);
+      }
       decoder_callbacks_->sendLocalReply(static_cast<Envoy::Http::Code>(response_code), body_text,
                                          modify_headers, grpc_status_code, details);
       local_reply_sent_ = true;

--- a/test/extensions/common/wasm/test_data/test_context_cpp.cc
+++ b/test/extensions/common/wasm/test_data/test_context_cpp.cc
@@ -110,11 +110,30 @@ FilterDataStatus PanicReplyContext::onRequestBody(size_t, bool) {
   return FilterDataStatus::Continue;
 }
 
+class InvalidGrpcStatusReplyContext : public Context {
+public:
+  explicit InvalidGrpcStatusReplyContext(uint32_t id, RootContext* root) : Context(id, root) {}
+  FilterDataStatus onRequestBody(size_t body_buffer_length, bool end_of_stream) override;
+
+private:
+  EnvoyRootContext* root() { return static_cast<EnvoyRootContext*>(Context::root()); }
+};
+
+FilterDataStatus InvalidGrpcStatusReplyContext::onRequestBody(size_t size, bool) {
+  sendLocalResponse(200, "ok", "body", {}, size == 0 ? GrpcStatus::InvalidCode : GrpcStatus::PermissionDenied);
+  return FilterDataStatus::Continue;
+}
+
 static RegisterContextFactory register_DupReplyContext(CONTEXT_FACTORY(DupReplyContext),
                                                        ROOT_FACTORY(EnvoyRootContext),
                                                        "send local reply twice");
 static RegisterContextFactory register_PanicReplyContext(CONTEXT_FACTORY(PanicReplyContext),
                                                          ROOT_FACTORY(EnvoyRootContext),
                                                          "panic after sending local reply");
+
+static RegisterContextFactory register_InvalidGrpcStatusReplyContext(CONTEXT_FACTORY(InvalidGrpcStatusReplyContext),
+                                                         ROOT_FACTORY(EnvoyRootContext),
+                                                         "send local reply grpc");
+
 
 END_WASM_PLUGIN


### PR DESCRIPTION
Commit Message: wasm: Manage wasm invalid grpc code

Additional Description: In the scenario when the wasm generate a local reply with unset (invalid) grpc code. instead of propagate the -1, now the context will check and propagate the nullopt to let envoy populate it correctly.


Risk Level: Low
Testing: yes
Docs Changes: no
Release Notes: no
Platform Specific Features: n/a