### PR TITLE
[bp/1.30] cryptomb: add `BN_bn2lebinpad` definition for fips build (#33756)

### DIFF
--- a/bazel/foreign_cc/ipp-crypto-bn2lebinpad.patch
+++ b/bazel/foreign_cc/ipp-crypto-bn2lebinpad.patch
@@ -1,0 +1,19 @@
+diff --git a/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c b/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
+index e6db178c..0a1ecc49 100644
+--- a/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
++++ b/sources/ippcp/crypto_mb/src/common/ifma_cvt52.c
+@@ -16,9 +16,14 @@
+ 
+ #include <internal/common/ifma_defs.h>
+ #include <internal/common/ifma_math.h>
++#include <openssl/bn.h>
+ 
+ #include <assert.h>
+ 
++static int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen) {
++    return BN_bn2le_padded(to, tolen, a);
++}
++
+ #if defined(_MSC_VER) && (_MSC_VER < 1920)
+   // Disable optimization for VS2017 due to AVX512 masking bug
+   #define DISABLE_OPTIMIZATION __pragma(optimize( "", off ))

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -310,6 +310,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_rules_proto_grpc()
     _com_github_unicode_org_icu()
     _com_github_intel_ipp_crypto_crypto_mb()
+    _com_github_intel_ipp_crypto_crypto_mb_fips()
     _com_github_intel_qatlib()
     _com_github_intel_qatzip()
     _com_github_qat_zstd()
@@ -547,6 +548,19 @@ def _com_github_intel_ipp_crypto_crypto_mb():
     external_http_archive(
         name = "com_github_intel_ipp_crypto_crypto_mb",
         build_file_content = BUILD_ALL_CONTENT,
+    )
+
+def _com_github_intel_ipp_crypto_crypto_mb_fips():
+    # Temporary fix for building ipp-crypto when boringssl-fips is used.
+    # Build will fail if bn2lebinpad patch is applied. Remove this archive
+    # when upstream dependency fixes this issue.
+    external_http_archive(
+        name = "com_github_intel_ipp_crypto_crypto_mb_fips",
+        patches = ["@envoy//bazel/foreign_cc:ipp-crypto-bn2lebinpad.patch"],
+        patch_args = ["-p1"],
+        build_file_content = BUILD_ALL_CONTENT,
+        # Use existing ipp-crypto repository location name to avoid redefinition.
+        location_name = "com_github_intel_ipp_crypto_crypto_mb",
     )
 
 def _com_github_intel_qatlib():

--- a/contrib/cryptomb/private_key_providers/source/BUILD
+++ b/contrib/cryptomb/private_key_providers/source/BUILD
@@ -24,7 +24,10 @@ envoy_cmake(
     defines = [
         "OPENSSL_USE_STATIC_LIBS=TRUE",
     ],
-    lib_source = "@com_github_intel_ipp_crypto_crypto_mb//:all",
+    lib_source = select({
+        "//bazel:boringssl_fips": "@com_github_intel_ipp_crypto_crypto_mb_fips//:all",
+        "//conditions:default": "@com_github_intel_ipp_crypto_crypto_mb//:all",
+    }),
     out_lib_dir = "lib/intel64",
     out_static_libs = ["libcrypto_mb.a"],
     tags = ["skip_on_windows"],


### PR DESCRIPTION
Commit Message: cryptomb: add `BN_bn2lebinpad` definition for fips build (#33756)
Additional Description:
The fips verison boringSSL is old. so it doesn't have the definition of BN_bn2lebinpad, so patch ipp-crypto to give a definition.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes https://github.com/envoyproxy/envoy/issues/33585
