### PR TITLE
mobile: Adds the ability to pass error details into Cronvoy exceptions

### DIFF
--- a/mobile/library/java/org/chromium/net/impl/CronvoyBidirectionalStreamNetworkException.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyBidirectionalStreamNetworkException.java
@@ -8,7 +8,13 @@ import org.chromium.net.impl.Errors.NetError;
 public final class CronvoyBidirectionalStreamNetworkException extends CronvoyNetworkExceptionImpl {
   public CronvoyBidirectionalStreamNetworkException(String message, int errorCode,
                                                     int cronetInternalErrorCode) {
-    super(message, errorCode, cronetInternalErrorCode);
+    this(message, errorCode, cronetInternalErrorCode, "");
+  }
+
+  public CronvoyBidirectionalStreamNetworkException(String message, int errorCode,
+                                                    int cronetInternalErrorCode,
+                                                    String errorDetails) {
+    super(message, errorCode, cronetInternalErrorCode, errorDetails);
   }
 
   @Override

--- a/mobile/library/java/org/chromium/net/impl/CronvoyNetworkExceptionImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyNetworkExceptionImpl.java
@@ -10,6 +10,7 @@ public class CronvoyNetworkExceptionImpl extends NetworkException {
   protected final int mErrorCode;
   // Cronet internal error code.
   protected final int mCronetInternalErrorCode;
+  protected final String mErrorDetails;
 
   /**
    * Constructs an exception with a specific error.
@@ -17,15 +18,33 @@ public class CronvoyNetworkExceptionImpl extends NetworkException {
    * @param message explanation of failure.
    * @param errorCode error code, one of {@link #ERROR_HOSTNAME_NOT_RESOLVED ERROR_*}.
    * @param cronetInternalErrorCode Cronet internal error code, one of
-   * <a href=https://chromium.googlesource.com/chromium/src/+/master/net/base/net_error_list.h>
+   * <a
+   * href=https://github.com/envoyproxy/envoy/blob/5451efd9b8f8a444431197050e45ba974ed4e9d8/mobile/library/java/org/chromium/net/impl/Errors.java#L43>
    * these</a>.
    */
   public CronvoyNetworkExceptionImpl(String message, int errorCode, int cronetInternalErrorCode) {
+    this(message, errorCode, cronetInternalErrorCode, "");
+  }
+
+  /**
+   * Constructs an exception with a specific error and a details string.
+   *
+   * @param message explanation of failure.
+   * @param errorCode error code, one of {@link #ERROR_HOSTNAME_NOT_RESOLVED ERROR_*}.
+   * @param cronetInternalErrorCode Cronet internal error code, one of
+   * <a
+   * href=https://github.com/envoyproxy/envoy/blob/5451efd9b8f8a444431197050e45ba974ed4e9d8/mobile/library/java/org/chromium/net/impl/Errors.java#L43>
+   * these</a>.
+   * @param errorDetails a string of error details.
+   */
+  public CronvoyNetworkExceptionImpl(String message, int errorCode, int cronetInternalErrorCode,
+                                     String errorDetails) {
     super(message, null);
     assert errorCode > 0 && errorCode < 12;
     assert cronetInternalErrorCode < 0;
     mErrorCode = errorCode;
     mCronetInternalErrorCode = cronetInternalErrorCode;
+    mErrorDetails = errorDetails;
   }
 
   @Override
@@ -67,4 +86,6 @@ public class CronvoyNetworkExceptionImpl extends NetworkException {
     b.append(", Retryable=").append(immediatelyRetryable());
     return b.toString();
   }
+
+  public String getErrorDetails() { return mErrorDetails; }
 }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyQuicExceptionImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyQuicExceptionImpl.java
@@ -14,7 +14,8 @@ public class CronvoyQuicExceptionImpl extends QuicException {
    *
    * @param message explanation of failure.
    * @param netErrorCode Error code from
-   * <a href=https://chromium.googlesource.com/chromium/src/+/master/net/base/net_error_list.h>
+   * <a
+   * href=https://github.com/envoyproxy/envoy/blob/5451efd9b8f8a444431197050e45ba974ed4e9d8/mobile/library/java/org/chromium/net/impl/Errors.java#L43>
    * this list</a>.
    * @param quicDetailedErrorCode Detailed <a href="https://www.chromium.org/quic">QUIC</a> error
    * code from <a
@@ -23,8 +24,28 @@ public class CronvoyQuicExceptionImpl extends QuicException {
    */
   public CronvoyQuicExceptionImpl(String message, int errorCode, int netErrorCode,
                                   int quicDetailedErrorCode) {
+    this(message, errorCode, netErrorCode, quicDetailedErrorCode, "");
+  }
+
+  /**
+   * Constructs an exception with a specific error and error details.
+   *
+   * @param message explanation of failure.
+   * @param netErrorCode Error code from
+   * <a
+   * href=https://github.com/envoyproxy/envoy/blob/5451efd9b8f8a444431197050e45ba974ed4e9d8/mobile/library/java/org/chromium/net/impl/Errors.java#L43>
+   * this list</a>.
+   * @param quicDetailedErrorCode Detailed <a href="https://www.chromium.org/quic">QUIC</a> error
+   * code from <a
+   * href="https://cs.chromium.org/search/?q=symbol:%5CbQuicErrorCode%5Cb">
+   * QuicErrorCode</a>.
+   * @param errorDetails a string of error details.
+   */
+  public CronvoyQuicExceptionImpl(String message, int errorCode, int netErrorCode,
+                                  int quicDetailedErrorCode, String errorDetails) {
     super(message, null);
-    mNetworkException = new CronvoyNetworkExceptionImpl(message, errorCode, netErrorCode);
+    mNetworkException =
+        new CronvoyNetworkExceptionImpl(message, errorCode, netErrorCode, errorDetails);
     mQuicDetailedErrorCode = quicDetailedErrorCode;
   }
 
@@ -52,4 +73,6 @@ public class CronvoyQuicExceptionImpl extends QuicException {
   public int getQuicDetailedErrorCode() {
     return mQuicDetailedErrorCode;
   }
+
+  public String getErrorDetails() { return mNetworkException.getErrorDetails(); }
 }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
@@ -944,14 +944,18 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
       int javaError = mapNetErrorToCronetApiErrorCode(netError);
 
       if (isQuicException(javaError)) {
+        // `message` is populated from StreamInfo::responseCodeDetails(), so `message` is used to
+        // populate the error details in the exception.
         enterErrorState(new CronvoyQuicExceptionImpl("Exception in CronvoyUrlRequest: " + netError,
                                                      javaError, netError.getErrorCode(),
-                                                     Errors.QUIC_INTERNAL_ERROR));
+                                                     Errors.QUIC_INTERNAL_ERROR, message));
         return;
       }
 
+      // `message` is populated from StreamInfo::responseCodeDetails(), so `message` is used to
+      // populate the error details in the exception.
       enterErrorState(new CronvoyNetworkExceptionImpl("Exception in CronvoyUrlRequest: " + netError,
-                                                      javaError, netError.getErrorCode()));
+                                                      javaError, netError.getErrorCode(), message));
     }
 
     @Override

--- a/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
+++ b/mobile/test/java/org/chromium/net/BidirectionalStreamTest.java
@@ -1486,26 +1486,28 @@ public class BidirectionalStreamTest {
   public void testErrorCodes() throws Exception {
     // Non-BidirectionalStream specific error codes.
     checkSpecificErrorCode(NetError.ERR_NAME_NOT_RESOLVED,
-                           NetworkException.ERROR_HOSTNAME_NOT_RESOLVED, false);
+                           NetworkException.ERROR_HOSTNAME_NOT_RESOLVED, "", false);
     checkSpecificErrorCode(NetError.ERR_INTERNET_DISCONNECTED,
-                           NetworkException.ERROR_INTERNET_DISCONNECTED, false);
-    checkSpecificErrorCode(NetError.ERR_NETWORK_CHANGED, NetworkException.ERROR_NETWORK_CHANGED,
+                           NetworkException.ERROR_INTERNET_DISCONNECTED, "bad error", false);
+    checkSpecificErrorCode(NetError.ERR_NETWORK_CHANGED, NetworkException.ERROR_NETWORK_CHANGED, "",
                            true);
     checkSpecificErrorCode(NetError.ERR_CONNECTION_CLOSED, NetworkException.ERROR_CONNECTION_CLOSED,
-                           true);
+                           "", true);
     checkSpecificErrorCode(NetError.ERR_CONNECTION_REFUSED,
-                           NetworkException.ERROR_CONNECTION_REFUSED, false);
+                           NetworkException.ERROR_CONNECTION_REFUSED, "", false);
     checkSpecificErrorCode(NetError.ERR_CONNECTION_RESET, NetworkException.ERROR_CONNECTION_RESET,
-                           true);
+                           "", true);
     checkSpecificErrorCode(NetError.ERR_CONNECTION_TIMED_OUT,
-                           NetworkException.ERROR_CONNECTION_TIMED_OUT, true);
-    checkSpecificErrorCode(NetError.ERR_TIMED_OUT, NetworkException.ERROR_TIMED_OUT, true);
+                           NetworkException.ERROR_CONNECTION_TIMED_OUT, "", true);
+    checkSpecificErrorCode(NetError.ERR_TIMED_OUT, NetworkException.ERROR_TIMED_OUT, "", true);
     checkSpecificErrorCode(NetError.ERR_ADDRESS_UNREACHABLE,
-                           NetworkException.ERROR_ADDRESS_UNREACHABLE, false);
+                           NetworkException.ERROR_ADDRESS_UNREACHABLE, "", false);
 
     // BidirectionalStream specific retryable error codes.
-    checkSpecificErrorCode(NetError.ERR_HTTP2_PING_FAILED, NetworkException.ERROR_OTHER, true);
-    checkSpecificErrorCode(NetError.ERR_QUIC_HANDSHAKE_FAILED, NetworkException.ERROR_OTHER, true);
+    checkSpecificErrorCode(NetError.ERR_HTTP2_PING_FAILED, NetworkException.ERROR_OTHER,
+                           "bad error", true);
+    checkSpecificErrorCode(NetError.ERR_QUIC_HANDSHAKE_FAILED, NetworkException.ERROR_OTHER, "",
+                           true);
   }
 
   // Returns the contents of byteBuffer, from its position() to its limit(),
@@ -1520,13 +1522,15 @@ public class BidirectionalStreamTest {
     return new String(contents);
   }
 
-  private static void checkSpecificErrorCode(NetError netError, int errorCode,
+  private static void checkSpecificErrorCode(NetError netError, int errorCode, String errorDetails,
                                              boolean immediatelyRetryable) throws Exception {
-    NetworkException exception =
-        new CronvoyBidirectionalStreamNetworkException("", errorCode, netError.getErrorCode());
+    CronvoyBidirectionalStreamNetworkException exception =
+        new CronvoyBidirectionalStreamNetworkException("", errorCode, netError.getErrorCode(),
+                                                       errorDetails);
     assertEquals(immediatelyRetryable, exception.immediatelyRetryable());
     assertEquals(netError.getErrorCode(), exception.getCronetInternalErrorCode());
     assertEquals(errorCode, exception.getErrorCode());
+    assertEquals(errorDetails, exception.getErrorDetails());
   }
 
   @Test

--- a/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import io.envoyproxy.envoymobile.engine.AndroidNetworkMonitor;
+import org.chromium.net.impl.CronvoyNetworkExceptionImpl;
 import org.chromium.net.impl.CronvoyUrlRequest;
 import org.chromium.net.impl.CronvoyUrlRequestContext;
 import org.chromium.net.impl.Errors.EnvoyMobileError;
@@ -1769,6 +1770,7 @@ public class CronetUrlRequestTest {
     assertNull(callback.mResponseInfo);
     assertContains("Exception in CronetUrlRequest: net::ERR_CONNECTION_REFUSED",
                    callback.mError.getMessage());
+    assertEquals("", ((CronvoyNetworkExceptionImpl)callback.mError).getErrorDetails());
   }
 
   private TestUrlRequestCallback throwOrCancel(FailureType failureType, ResponseStep failureStep,
@@ -2219,6 +2221,7 @@ public class CronetUrlRequestTest {
     assertEquals(0, callback.mRedirectCount);
     assertTrue(callback.mOnErrorCalled);
     assertEquals(ResponseStep.ON_FAILED, callback.mResponseStep);
+    assertEquals("", ((CronvoyNetworkExceptionImpl)callback.mError).getErrorDetails());
   }
 
   // Returns the contents of byteBuffer, from its position() to its limit(),


### PR DESCRIPTION
These details will be used by error consumers to add error details to logging pipelines.
