### PR TITLE
opencensus: Disable by default

### DIFF
--- a/api/envoy/config/trace/v3/opencensus.proto
+++ b/api/envoy/config/trace/v3/opencensus.proto
@@ -49,69 +49,95 @@ message OpenCensusConfig {
 
   // Configures tracing, e.g. the sampler, max number of annotations, etc.
   opencensus.proto.trace.v1.TraceConfig trace_config = 1
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // Enables the stdout exporter if set to true. This is intended for debugging
   // purposes.
   bool stdout_exporter_enabled = 2
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // Enables the Stackdriver exporter if set to true. The project_id must also
   // be set.
   bool stackdriver_exporter_enabled = 3
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // The Cloud project_id to use for Stackdriver tracing.
   string stackdriver_project_id = 4
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // (optional) By default, the Stackdriver exporter will connect to production
   // Stackdriver. If stackdriver_address is non-empty, it will instead connect
   // to this address, which is in the gRPC format:
   // https://github.com/grpc/grpc/blob/master/doc/naming.md
   string stackdriver_address = 10
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // (optional) The gRPC server that hosts Stackdriver tracing service. Only
   // Google gRPC is supported. If :ref:`target_uri <envoy_v3_api_field_config.core.v3.GrpcService.GoogleGrpc.target_uri>`
   // is not provided, the default production Stackdriver address will be used.
   core.v3.GrpcService stackdriver_grpc_service = 13
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // Enables the Zipkin exporter if set to true. The url and service name must
   // also be set. This is deprecated, prefer to use Envoy's :ref:`native Zipkin
   // tracer <envoy_v3_api_msg_config.trace.v3.ZipkinConfig>`.
   bool zipkin_exporter_enabled = 5
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // The URL to Zipkin, e.g. "http://127.0.0.1:9411/api/v2/spans". This is
   // deprecated, prefer to use Envoy's :ref:`native Zipkin tracer
   // <envoy_v3_api_msg_config.trace.v3.ZipkinConfig>`.
   string zipkin_url = 6
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // Enables the OpenCensus Agent exporter if set to true. The ocagent_address or
   // ocagent_grpc_service must also be set.
   bool ocagent_exporter_enabled = 11
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // The address of the OpenCensus Agent, if its exporter is enabled, in gRPC
   // format: https://github.com/grpc/grpc/blob/master/doc/naming.md
   // [#comment:TODO: deprecate this field]
   string ocagent_address = 12
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // (optional) The gRPC server hosted by the OpenCensus Agent. Only Google gRPC is supported.
   // This is only used if the ocagent_address is left empty.
   core.v3.GrpcService ocagent_grpc_service = 14
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // List of incoming trace context headers we will accept. First one found
   // wins.
   repeated TraceContext incoming_trace_context = 8
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 
   // List of outgoing trace context headers we will produce.
   repeated TraceContext outgoing_trace_context = 9
-      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+      [deprecated = true,
+       (envoy.annotations.deprecated_at_minor_version) = "3.0",
+       (envoy.annotations.disallowed_by_default) = true];
 }

--- a/api/envoy/config/trace/v3/opencensus.proto
+++ b/api/envoy/config/trace/v3/opencensus.proto
@@ -48,96 +48,109 @@ message OpenCensusConfig {
   reserved 7;
 
   // Configures tracing, e.g. the sampler, max number of annotations, etc.
-  opencensus.proto.trace.v1.TraceConfig trace_config = 1
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  opencensus.proto.trace.v1.TraceConfig trace_config = 1 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Enables the stdout exporter if set to true. This is intended for debugging
   // purposes.
-  bool stdout_exporter_enabled = 2
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  bool stdout_exporter_enabled = 2 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Enables the Stackdriver exporter if set to true. The project_id must also
   // be set.
-  bool stackdriver_exporter_enabled = 3
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  bool stackdriver_exporter_enabled = 3 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // The Cloud project_id to use for Stackdriver tracing.
-  string stackdriver_project_id = 4
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  string stackdriver_project_id = 4 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // (optional) By default, the Stackdriver exporter will connect to production
   // Stackdriver. If stackdriver_address is non-empty, it will instead connect
   // to this address, which is in the gRPC format:
   // https://github.com/grpc/grpc/blob/master/doc/naming.md
-  string stackdriver_address = 10
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  string stackdriver_address = 10 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // (optional) The gRPC server that hosts Stackdriver tracing service. Only
   // Google gRPC is supported. If :ref:`target_uri <envoy_v3_api_field_config.core.v3.GrpcService.GoogleGrpc.target_uri>`
   // is not provided, the default production Stackdriver address will be used.
-  core.v3.GrpcService stackdriver_grpc_service = 13
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  core.v3.GrpcService stackdriver_grpc_service = 13 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Enables the Zipkin exporter if set to true. The url and service name must
   // also be set. This is deprecated, prefer to use Envoy's :ref:`native Zipkin
   // tracer <envoy_v3_api_msg_config.trace.v3.ZipkinConfig>`.
-  bool zipkin_exporter_enabled = 5
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  bool zipkin_exporter_enabled = 5 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // The URL to Zipkin, e.g. "http://127.0.0.1:9411/api/v2/spans". This is
   // deprecated, prefer to use Envoy's :ref:`native Zipkin tracer
   // <envoy_v3_api_msg_config.trace.v3.ZipkinConfig>`.
-  string zipkin_url = 6
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  string zipkin_url = 6 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // Enables the OpenCensus Agent exporter if set to true. The ocagent_address or
   // ocagent_grpc_service must also be set.
-  bool ocagent_exporter_enabled = 11
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  bool ocagent_exporter_enabled = 11 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // The address of the OpenCensus Agent, if its exporter is enabled, in gRPC
   // format: https://github.com/grpc/grpc/blob/master/doc/naming.md
   // [#comment:TODO: deprecate this field]
-  string ocagent_address = 12
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  string ocagent_address = 12 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // (optional) The gRPC server hosted by the OpenCensus Agent. Only Google gRPC is supported.
   // This is only used if the ocagent_address is left empty.
-  core.v3.GrpcService ocagent_grpc_service = 14
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  core.v3.GrpcService ocagent_grpc_service = 14 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // List of incoming trace context headers we will accept. First one found
   // wins.
-  repeated TraceContext incoming_trace_context = 8
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  repeated TraceContext incoming_trace_context = 8 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 
   // List of outgoing trace context headers we will produce.
-  repeated TraceContext outgoing_trace_context = 9
-      [deprecated = true,
-       (envoy.annotations.deprecated_at_minor_version) = "3.0",
-       (envoy.annotations.disallowed_by_default) = true];
+  repeated TraceContext outgoing_trace_context = 9 [
+    deprecated = true,
+    (envoy.annotations.deprecated_at_minor_version) = "3.0",
+    (envoy.annotations.disallowed_by_default) = true
+  ];
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -81,6 +81,6 @@ new_features:
 deprecated:
 - area: tracing
   change: |
-    Disable opencensus by default, as it is no longer supported/maintained upstream
-    (see `https://opentelemetry.io/blog/2023/sunsetting-opencensus/`_). Users of this extension can use the OpenTelemetry
-    tracer instead, and the OpenTelemetry collector can be used to convert traces.
+    Disable OpenCensus by default, as it is
+    `no longer supported/maintained upstream <https://opentelemetry.io/blog/2023/sunsetting-opencensus/>`_.
+    This extension can be replaced with the OpenTelemetry tracer and collector.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -79,3 +79,6 @@ new_features:
     for disabling appending of the ``-shadow`` suffix to the shadowed host/authority header.
 
 deprecated:
+- area: tracing
+  change: |
+    Disable opencensus by default, as it is no longer supported/maintained upstream.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -81,4 +81,6 @@ new_features:
 deprecated:
 - area: tracing
   change: |
-    Disable opencensus by default, as it is no longer supported/maintained upstream.
+    Disable opencensus by default, as it is no longer supported/maintained upstream
+    (see `https://opentelemetry.io/blog/2023/sunsetting-opencensus/`_). Users of this extension can use the OpenTelemetry
+    tracer instead, and the OpenTelemetry collector can be used to convert traces.


### PR DESCRIPTION
Opencensus has been archived for some time upstream, i believe because it was folded in to opentelemetry.

The plan was to remove opencensus and opentracing altogether in the 1.31 release cycle, and both were set to deprecated.

Only opentracing had the `disabled_by_default` set in time for the release cycle, so this sets it for opencensus.

Original tracking issue is https://github.com/envoyproxy/envoy/issues/9958 bu there have been quite a few conversations around this since

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
