### PR TITLE
Add static lookup benchmarks for header_map_impl

### DIFF
--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -347,7 +347,7 @@ protected:
   const uint32_t max_headers_count_ = UINT32_MAX;
 
   // For benchmarking to access non-public methods to test staticLookup.
-  template <class T> friend class StaticLookupBenchmarker;
+  friend class StaticLookupBenchmarker;
 };
 
 /**

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -345,6 +345,8 @@ protected:
   const uint32_t max_headers_kb_ = UINT32_MAX;
   // This holds the max count of the headers in the HeaderMap.
   const uint32_t max_headers_count_ = UINT32_MAX;
+
+  template <class T> friend class StaticLookupBenchmarker;
 };
 
 /**

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -346,6 +346,7 @@ protected:
   // This holds the max count of the headers in the HeaderMap.
   const uint32_t max_headers_count_ = UINT32_MAX;
 
+  // For benchmarking to access non-public methods to test staticLookup.
   template <class T> friend class StaticLookupBenchmarker;
 };
 

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -338,6 +338,10 @@ static std::vector<std::string> makeMismatchedHeaders() {
   };
 }
 
+// Macro is used in the two functions below to populate an array of the common
+// set of keys, to use for benchmarking. The INLINE_REQ_HEADERS and
+// INLINE_RESP_HEADERS macros do a macro "callback" with just one argument, so
+// we can't parameterize `keys` into the macro.
 #define ADD_HEADER_TO_KEYS(name) keys.emplace_back(Http::Headers::get().name);
 static void bmHeaderMapImplRequestStaticLookupHits(benchmark::State& state) {
   std::vector<std::string> keys;

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -1,6 +1,8 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 
+#include "test/test_common/utility.h"
+
 #include "benchmark/benchmark.h"
 
 namespace Envoy {
@@ -302,7 +304,10 @@ public:
   }
 
 private:
-  std::unique_ptr<RequestHeaderMapImpl> ignored_ = RequestHeaderMapImpl::create();
+  // We create both kinds of table so the entries that get registered dynamically
+  // are included in the static tables.
+  std::unique_ptr<HeaderMapImpl> ignored_ = RequestHeaderMapImpl::create();
+  std::unique_ptr<HeaderMapImpl> also_ignored_ = ResponseHeaderMapImpl::create();
   HeaderMapImpl::StaticLookupTable<HeaderMapType> table_;
 };
 


### PR DESCRIPTION
Commit Message: Add static lookup benchmarks for header_map_impl
Additional Description: This aspect of header maps is not currently benchmarked and is apparently performance critical.

Output of the new benchmarks:

Benchmark | time | cpu | iterations
--- | --- | --- | ---
bmHeaderMapImplRequestStaticLookupHits        |  47.0 ns     |    47.0 ns  |  308763840
bmHeaderMapImplResponseStaticLookupHits      |   32.8 ns    |     32.8 ns |   428130226
bmHeaderMapImplRequestStaticLookupMisses     |   5.56 ns    |     5.56 ns |  1000000000
bmHeaderMapImplResponseStaticLookupMisses   |    5.85 ns   |      5.85 ns |  1000000000

Risk Level: None, test-only.
Testing: It is.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
