### PR TITLE
mobile: Remove the deprecated Stream::sendHeaders and Stream::sendTrailers

### DIFF
--- a/mobile/library/cc/stream.cc
+++ b/mobile/library/cc/stream.cc
@@ -1,6 +1,5 @@
 #include "stream.h"
 
-#include "library/cc/bridge_utility.h"
 #include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/internal_engine.h"
@@ -10,22 +9,6 @@ namespace Envoy {
 namespace Platform {
 
 Stream::Stream(InternalEngine* engine, envoy_stream_t handle) : engine_(engine), handle_(handle) {}
-
-Stream& Stream::sendHeaders(RequestHeadersSharedPtr headers, bool end_stream) {
-  auto request_header_map = Http::Utility::createRequestHeaderMapPtr();
-  for (const auto& [key, values] : headers->allHeaders()) {
-    if (request_header_map->formatter().has_value()) {
-      Http::StatefulHeaderKeyFormatter& formatter = request_header_map->formatter().value();
-      // Make sure the formatter knows the original case.
-      formatter.processKey(key);
-    }
-    for (const auto& value : values) {
-      request_header_map->addCopy(Http::LowerCaseString(key), value);
-    }
-  }
-  engine_->sendHeaders(handle_, std::move(request_header_map), end_stream);
-  return *this;
-}
 
 Stream& Stream::sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream) {
   engine_->sendHeaders(handle_, std::move(headers), end_stream);
@@ -45,16 +28,6 @@ Stream& Stream::sendData(Buffer::InstancePtr buffer) {
 Stream& Stream::readData(size_t bytes_to_read) {
   engine_->readData(handle_, bytes_to_read);
   return *this;
-}
-
-void Stream::close(RequestTrailersSharedPtr trailers) {
-  auto request_trailer_map = Http::Utility::createRequestTrailerMapPtr();
-  for (const auto& [key, values] : trailers->allHeaders()) {
-    for (const auto& value : values) {
-      request_trailer_map->addCopy(Http::LowerCaseString(key), value);
-    }
-  }
-  engine_->sendTrailers(handle_, std::move(request_trailer_map));
 }
 
 void Stream::close(Http::RequestTrailerMapPtr trailers) {

--- a/mobile/library/cc/stream.h
+++ b/mobile/library/cc/stream.h
@@ -5,8 +5,6 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/http/header_map.h"
 
-#include "library/cc/request_headers.h"
-#include "library/cc/request_trailers.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -16,8 +14,6 @@ namespace Platform {
 class Stream {
 public:
   Stream(InternalEngine* engine, envoy_stream_t handle);
-
-  [[deprecated]] Stream& sendHeaders(RequestHeadersSharedPtr headers, bool end_stream);
 
   /**
    * Send the headers over an open HTTP stream. This function can be invoked
@@ -38,8 +34,6 @@ public:
   Stream& sendData(Buffer::InstancePtr buffer);
 
   Stream& readData(size_t bytes_to_read);
-
-  [[deprecated]] void close(RequestTrailersSharedPtr trailers);
 
   /**
    * Send trailers over an open HTTP stream. This method can only be invoked once per stream.

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -6,6 +6,7 @@
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 #include "library/cc/engine_builder.h"
+#include "library/common/http/header_utility.h"
 
 namespace Envoy {
 
@@ -49,11 +50,13 @@ TEST(EngineTest, SetLogger) {
                     })
                     .start();
 
-  auto request_headers =
-      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https",
-                                      engine_with_test_server.testServer().getAddress(), "/")
-          .build();
-  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"), "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
   stream_complete.WaitForNotification();
 
   EXPECT_EQ(actual_status_code, 200);
@@ -96,11 +99,13 @@ TEST(EngineTest, SetEngineCallbacks) {
                     })
                     .start();
 
-  auto request_headers =
-      Platform::RequestHeadersBuilder(Platform::RequestMethod::GET, "https",
-                                      engine_with_test_server.testServer().getAddress(), "/")
-          .build();
-  stream->sendHeaders(std::make_shared<Platform::RequestHeaders>(request_headers), true);
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  headers->addCopy(Http::LowerCaseString(":method"), "GET");
+  headers->addCopy(Http::LowerCaseString(":scheme"), "https");
+  headers->addCopy(Http::LowerCaseString(":authority"),
+                   engine_with_test_server.testServer().getAddress());
+  headers->addCopy(Http::LowerCaseString(":path"), "/");
+  stream->sendHeaders(std::move(headers), true);
   stream_complete.WaitForNotification();
 
   EXPECT_EQ(actual_status_code, 200);

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -49,6 +49,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:engine_builder_lib",
+        "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -1,13 +1,10 @@
 #include "test/common/integration/engine_with_test_server.h"
 #include "test/common/integration/test_server.h"
 
-#include "absl/strings/str_format.h"
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 #include "library/cc/engine_builder.h"
 #include "library/cc/envoy_error.h"
-#include "library/cc/request_headers_builder.h"
-#include "library/cc/request_method.h"
 #include "library/common/http/header_utility.h"
 
 namespace Envoy {
@@ -66,51 +63,6 @@ TEST(SendHeadersTest, Success) {
                    engine_with_test_server.testServer().getAddress());
   headers->addCopy(Http::LowerCaseString(":path"), "/");
   stream->sendHeaders(std::move(headers), true);
-  stream_complete.WaitForNotification();
-
-  EXPECT_EQ(actual_status_code, 200);
-  EXPECT_TRUE(actual_end_stream);
-}
-
-TEST(SendHeadersTest, SuccessWithDeprecatedFunction) {
-  absl::Notification engine_running;
-  Platform::EngineBuilder engine_builder;
-  engine_builder.enforceTrustChainVerification(false)
-      .setLogLevel(Logger::Logger::debug)
-      .setOnEngineRunning([&]() { engine_running.Notify(); });
-  EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);
-  engine_running.WaitForNotification();
-
-  int actual_status_code;
-  bool actual_end_stream;
-  absl::Notification stream_complete;
-  auto stream_prototype = engine_with_test_server.engine()->streamClient()->newStreamPrototype();
-  Platform::StreamSharedPtr stream =
-      (*stream_prototype)
-          .setOnHeaders(
-              [&](Platform::ResponseHeadersSharedPtr headers, bool end_stream, envoy_stream_intel) {
-                actual_status_code = headers->httpStatus();
-                actual_end_stream = end_stream;
-              })
-          .setOnData([&](envoy_data data, bool end_stream) {
-            actual_end_stream = end_stream;
-            data.release(data.context);
-          })
-          .setOnComplete(
-              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
-          .setOnError([&](Platform::EnvoyErrorSharedPtr, envoy_stream_intel,
-                          envoy_final_stream_intel) { stream_complete.Notify(); })
-          .setOnCancel(
-              [&](envoy_stream_intel, envoy_final_stream_intel) { stream_complete.Notify(); })
-          .start();
-
-  Platform::RequestHeadersBuilder request_headers_builder(
-      Platform::RequestMethod::GET, "https", engine_with_test_server.testServer().getAddress(),
-      "/");
-  auto request_headers = request_headers_builder.build();
-  auto request_headers_ptr =
-      Platform::RequestHeadersSharedPtr(new Platform::RequestHeaders(request_headers));
-  stream->sendHeaders(request_headers_ptr, true);
   stream_complete.WaitForNotification();
 
   EXPECT_EQ(actual_status_code, 200);

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -121,32 +121,6 @@ void BaseClientIntegrationTest::initialize() {
   default_request_headers_.setHost(fake_upstreams_[0]->localAddress()->asStringView());
 }
 
-std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobileHeaders(
-    const Http::TestRequestHeaderMapImpl& request_headers) {
-
-  Platform::RequestHeadersBuilder builder(
-      Platform::RequestMethod::GET,
-      std::string(default_request_headers_.Scheme()->value().getStringView()),
-      std::string(default_request_headers_.Host()->value().getStringView()),
-      std::string(default_request_headers_.Path()->value().getStringView()));
-
-  request_headers.iterate(
-      [&request_headers, &builder](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
-        std::string key = std::string(header.key().getStringView());
-        if (request_headers.formatter().has_value()) {
-          const Envoy::Http::StatefulHeaderKeyFormatter& formatter =
-              request_headers.formatter().value();
-          key = formatter.format(key);
-        }
-        auto value = std::vector<std::string>();
-        value.push_back(std::string(header.value().getStringView()));
-        builder.set(key, value);
-        return Http::HeaderMap::Iterate::Continue;
-      });
-
-  return std::make_shared<Platform::RequestHeaders>(builder.build());
-}
-
 void BaseClientIntegrationTest::threadRoutine(absl::Notification& engine_running) {
   builder_.setOnEngineRunning([&]() { engine_running.Notify(); });
   {

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -54,10 +54,6 @@ protected:
   void createEnvoy() override;
   void threadRoutine(absl::Notification& engine_running);
 
-  // Converts TestRequestHeaderMapImpl to Envoy::Platform::RequestHeadersSharedPtr
-  Envoy::Platform::RequestHeadersSharedPtr
-  envoyToMobileHeaders(const Http::TestRequestHeaderMapImpl& request_headers);
-
   // Get the value of a Counter in the Envoy instance.
   uint64_t getCounterValue(const std::string& name);
   // Wait until the Counter specified by `name` is >= `value`.

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -7,6 +7,7 @@
 #include "source/extensions/quic/proof_source/envoy_quic_proof_source_factory_impl.h"
 #include "source/extensions/udp_packet_writer/default/config.h"
 
+#include "test/common/http/common.h"
 #include "test/common/integration/base_client_integration_test.h"
 #include "test/common/mocks/common/mocks.h"
 #include "test/integration/autonomous_upstream.h"
@@ -14,6 +15,7 @@
 
 #include "extension_registry.h"
 #include "library/common/data/utility.h"
+#include "library/common/http/header_utility.h"
 #include "library/common/internal_engine.h"
 #include "library/common/network/proxy_settings.h"
 #include "library/common/types/c_types.h"
@@ -200,15 +202,13 @@ void ClientIntegrationTest::basicTest() {
     release_envoy_data(c_data);
   });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
 
   envoy_data c_data = Data::Utility::toBridgeData(request_data);
   stream_->sendData(c_data);
 
-  Platform::RequestTrailersBuilder builder;
-  std::shared_ptr<Platform::RequestTrailers> trailers =
-      std::make_shared<Platform::RequestTrailers>(builder.build());
-  stream_->close(trailers);
+  stream_->close(Http::Utility::createRequestTrailerMapPtr());
 
   terminal_callback_.waitReady();
 
@@ -274,7 +274,8 @@ void ClientIntegrationTest::trickleTest() {
     cc_.on_data_calls++;
     release_envoy_data(c_data);
   });
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
   if (explicit_flow_control_) {
     // Allow reading up to 100 bytes
     stream_->readData(100);
@@ -282,10 +283,7 @@ void ClientIntegrationTest::trickleTest() {
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
   envoy_data c_data = Data::Utility::toBridgeData(request_data);
   stream_->sendData(c_data);
-  Platform::RequestTrailersBuilder builder;
-  std::shared_ptr<Platform::RequestTrailers> trailers =
-      std::make_shared<Platform::RequestTrailers>(builder.build());
-  stream_->close(trailers);
+  stream_->close(Http::Utility::createRequestTrailerMapPtr());
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -342,7 +340,8 @@ TEST_P(ClientIntegrationTest, ManyStreamExplicitFlowControl) {
       stream->readData(100);
       release_envoy_data(c_data);
     });
-    stream->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+    stream->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                        true);
     stream->readData(100);
     prototype_streams.push_back(stream_prototype);
     streams.push_back(stream);
@@ -401,7 +400,8 @@ void ClientIntegrationTest::explicitFlowControlWithCancels(const uint32_t body_s
           RELEASE_ASSERT(0, "unexpected");
         });
 
-    stream->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+    stream->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                        true);
     prototype_streams.push_back(stream_prototype);
     streams.push_back(stream);
     if (i % 2 == 0) {
@@ -469,7 +469,8 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
     release_envoy_data(c_data);
   });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
 
   terminal_callback_.waitReady();
 
@@ -505,15 +506,13 @@ TEST_P(ClientIntegrationTest, BasicHttps) {
     release_envoy_data(c_data);
   });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
 
   envoy_data c_data = Data::Utility::toBridgeData(request_data);
   stream_->sendData(c_data);
 
-  Platform::RequestTrailersBuilder builder;
-  std::shared_ptr<Platform::RequestTrailers> trailers =
-      std::make_shared<Platform::RequestTrailers>(builder.build());
-  stream_->close(trailers);
+  stream_->close(Http::Utility::createRequestTrailerMapPtr());
 
   terminal_callback_.waitReady();
 
@@ -534,7 +533,8 @@ TEST_P(ClientIntegrationTest, BasicNon2xx) {
       ->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(
           Http::TestResponseHeaderMapImpl({{":status", "503"}})));
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 0);
@@ -547,7 +547,8 @@ TEST_P(ClientIntegrationTest, InvalidDomain) {
   initialize();
 
   default_request_headers_.setHost("www.doesnotexist.com");
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 1);
@@ -559,7 +560,8 @@ TEST_P(ClientIntegrationTest, BasicBeforeResponseHeaders) {
 
   default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_REQUEST, "yes");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 1);
@@ -573,7 +575,8 @@ TEST_P(ClientIntegrationTest, ResetAfterResponseHeaders) {
   default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_HEADERS, "yes");
   default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "1");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 1);
@@ -587,7 +590,8 @@ TEST_P(ClientIntegrationTest, ResetAfterResponseHeadersExplicit) {
   default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_HEADERS, "yes");
   default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "1");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   // Read the body chunk. This releases the error.
   stream_->readData(100);
 
@@ -603,7 +607,8 @@ TEST_P(ClientIntegrationTest, ResetAfterHeaderOnlyResponse) {
   default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_HEADERS, "yes");
   default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "0");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 1);
@@ -616,7 +621,8 @@ TEST_P(ClientIntegrationTest, ResetBetweenDataChunks) {
   default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_DATA, "yes");
   default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "2");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 1);
@@ -629,7 +635,8 @@ TEST_P(ClientIntegrationTest, ResetAfterData) {
   default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_DATA, "yes");
   default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "1");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
 
   ASSERT_EQ(cc_.on_error_calls, 1);
@@ -651,7 +658,8 @@ TEST_P(ClientIntegrationTest, CancelAfterRequestHeadersSent) {
 
   default_request_headers_.addCopy(AutonomousStream::RESPOND_AFTER_REQUEST_HEADERS, "yes");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
   stream_->cancel();
   terminal_callback_.waitReady();
   ASSERT_EQ(cc_.on_cancel_calls, 1);
@@ -661,7 +669,8 @@ TEST_P(ClientIntegrationTest, CancelAfterRequestComplete) {
   autonomous_upstream_ = false;
   initialize();
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   stream_->cancel();
   terminal_callback_.waitReady();
   ASSERT_EQ(cc_.on_cancel_calls, 1);
@@ -681,7 +690,8 @@ TEST_P(ClientIntegrationTest, CancelDuringResponse) {
         return nullptr;
       });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -728,7 +738,8 @@ TEST_P(ClientIntegrationTest, BasicCancelWithCompleteStream) {
 
   initialize();
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -761,7 +772,8 @@ TEST_P(ClientIntegrationTest, CancelWithPartialStream) {
         return nullptr;
       });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -799,14 +811,12 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   autonomous_upstream_ = false;
   initialize();
 
-  default_request_headers_.header_map_->setFormatter(
-      std::make_unique<
-          Extensions::Http::HeaderFormatters::PreserveCase::PreserveCaseHeaderFormatter>(
-          false, envoy::extensions::http::header_formatters::preserve_case::v3::
-                     PreserveCaseFormatterConfig::DEFAULT));
-
-  default_request_headers_.addCopy("FoO", "bar");
-  default_request_headers_.header_map_->formatter().value().get().processKey("FoO");
+  auto headers = Http::Utility::createRequestHeaderMapPtr();
+  HttpTestUtility::addDefaultHeaders(*headers);
+  headers->setHost(fake_upstreams_[0]->localAddress()->asStringView());
+  Http::StatefulHeaderKeyFormatter& formatter = headers->formatter().value();
+  formatter.processKey("FoO");
+  headers->addCopy(Http::LowerCaseString("FoO"), "bar");
 
   stream_prototype_->setOnHeaders(
       [this](Platform::ResponseHeadersSharedPtr headers, bool, envoy_stream_intel) {
@@ -816,7 +826,7 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
         EXPECT_TRUE((*headers)["My-ResponsE-Header"][0] == "foo");
         return nullptr;
       });
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::move(headers), true);
 
   Envoy::FakeRawConnectionPtr upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream_connection));
@@ -845,7 +855,8 @@ TEST_P(ClientIntegrationTest, TimeoutOnRequestPath) {
   autonomous_upstream_ = false;
   initialize();
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -871,7 +882,8 @@ TEST_P(ClientIntegrationTest, TimeoutOnResponsePath) {
   autonomous_upstream_ = false;
   initialize();
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -909,7 +921,8 @@ TEST_P(ClientIntegrationTest, ResetWithBidiTraffic) {
         return nullptr;
       });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -947,7 +960,8 @@ TEST_P(ClientIntegrationTest, ResetWithBidiTrafficExplicitData) {
         return nullptr;
       });
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), false);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       false);
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
                                                         upstream_connection_));
@@ -980,7 +994,8 @@ TEST_P(ClientIntegrationTest, Proxying) {
                                         fake_upstreams_[0]->localAddress()->ip()->port());
   }
   // The initial request will do the DNS lookup.
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
   ASSERT_EQ(cc_.status, "200");
   ASSERT_EQ(cc_.on_complete_calls, 1);
@@ -988,7 +1003,8 @@ TEST_P(ClientIntegrationTest, Proxying) {
 
   // The second request will use the cached DNS entry and should succeed as well.
   stream_ = (*stream_prototype_).start(explicit_flow_control_);
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
   ASSERT_EQ(cc_.status, "200");
   ASSERT_EQ(cc_.on_complete_calls, 2);
@@ -1008,7 +1024,8 @@ TEST_P(ClientIntegrationTest, DirectResponse) {
   default_request_headers_.setHost("127.0.0.1");
   default_request_headers_.setPath("/");
 
-  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
   terminal_callback_.waitReady();
   ASSERT_EQ(cc_.status, "404");
   ASSERT_EQ(cc_.on_headers_calls, 1);

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -38,9 +38,9 @@ public:
 
   void runReloadTest() {
     // Send a request on the data plane.
-    stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
+    stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                         true);
     terminal_callback_.waitReady();
-
     EXPECT_EQ(cc_.on_headers_calls, 1);
     EXPECT_EQ(cc_.status, "200");
     EXPECT_EQ(cc_.on_data_calls, 2);


### PR DESCRIPTION
Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
