### PR TITLE
api(route): vhds field doesn't contain an array of virtual hosts

### DIFF
--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -36,7 +36,7 @@ message RouteConfiguration {
   // An array of virtual hosts that make up the route table.
   repeated VirtualHost virtual_hosts = 2;
 
-  // An array of virtual hosts will be dynamically loaded via the VHDS API.
+  // Enable VHDS API for this route configuration.
   // Both ``virtual_hosts`` and ``vhds`` fields will be used when present. ``virtual_hosts`` can be used
   // for a base routing table or for infrequently changing virtual hosts. ``vhds`` is used for
   // on-demand discovery of virtual hosts. The contents of these two fields will be merged to


### PR DESCRIPTION

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: vhds field doesn't contain an array of virtual hosts
Additional Description: According to the https:
//www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/vhds.html#subscribing-to-resources, the VHDS is loaded lazily, and each time it loads one virtual host.
Risk Level: None
Testing: None
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
