### PR TITLE
[bp/1.29] build(deps): bump distroless/base-nossl-debian12 from `312c829` to `8…

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -58,7 +58,7 @@ COPY --chown=0:0 --chmod=755 \
 
 
 # STAGE: envoy-distroless
-FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:312c829b02cb4270e64e72973dfc15164e3fbbd6c1d685da55b6f0de2a99a2b2 AS envoy-distroless
+FROM gcr.io/distroless/base-nossl-debian12:nonroot@sha256:8a09e5752fb3ab9c9534fcc627eb1f451cd9bcfe66a6b149df62dcb84fb841a6 AS envoy-distroless
 EXPOSE 10000
 ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
…a09e57` in /ci (#33956)

build(deps): bump distroless/base-nossl-debian12 in /ci

Bumps distroless/base-nossl-debian12 from `312c829` to `8a09e57`.

---
updated-dependencies:
- dependency-name: distroless/base-nossl-debian12 dependency-type: direct:production ...

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
