### PR TITLE
aws: fix assertion failure in debug due to timer access outside of main thread

### DIFF
--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -138,6 +138,8 @@ protected:
   const std::string uri_;
   // The cache duration of the fetched credentials.
   const std::chrono::seconds cache_duration_;
+  // Metadata receiver state
+  MetadataFetcher::MetadataReceiver::ReceiverState receiver_state_;
   // The thread local slot for cache.
   ThreadLocal::TypedSlotPtr<ThreadLocalCredentialsCache> tls_;
   // The timer to trigger fetch due to cache duration.

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -140,7 +140,8 @@ protected:
   const std::chrono::seconds cache_duration_;
   // Metadata receiver state
   MetadataFetcher::MetadataReceiver::ReceiverState receiver_state_;
-  // Metadata receiver initialisation timer - number of seconds between retries before initialization is complete
+  // Metadata receiver initialization timer - number of seconds between retries before
+  // initialization is complete
   std::chrono::seconds initialization_timer_;
   // The thread local slot for cache.
   ThreadLocal::TypedSlotPtr<ThreadLocalCredentialsCache> tls_;

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -140,6 +140,8 @@ protected:
   const std::chrono::seconds cache_duration_;
   // Metadata receiver state
   MetadataFetcher::MetadataReceiver::ReceiverState receiver_state_;
+  // Metadata receiver initialisation timer - number of seconds between retries before initialization is complete
+  std::chrono::seconds initialization_timer_;
   // The thread local slot for cache.
   ThreadLocal::TypedSlotPtr<ThreadLocalCredentialsCache> tls_;
   // The timer to trigger fetch due to cache duration.

--- a/source/extensions/common/aws/metadata_fetcher.h
+++ b/source/extensions/common/aws/metadata_fetcher.h
@@ -40,8 +40,9 @@ public:
       MissingConfig,
     };
 
-    // Metadata fetcher begins in initializing state and stays there until first success, then reverts to standard cache duration timing
-    // Initializing state will cause credential refresh at 2 sec, doubling to a maximum of 30 sec until successful.
+    // Metadata fetcher begins in initializing state and stays there until first success, then
+    // reverts to standard cache duration timing Initializing state will cause credential refresh at
+    // 2 sec, doubling to a maximum of 30 sec until successful.
     enum class ReceiverState {
       Initializing,
       Ready,

--- a/source/extensions/common/aws/metadata_fetcher.h
+++ b/source/extensions/common/aws/metadata_fetcher.h
@@ -40,6 +40,11 @@ public:
       MissingConfig,
     };
 
+    enum class ReceiverState {
+      Initializing,
+      Ready,
+    };
+
     virtual ~MetadataReceiver() = default;
 
     /**

--- a/source/extensions/common/aws/metadata_fetcher.h
+++ b/source/extensions/common/aws/metadata_fetcher.h
@@ -40,6 +40,8 @@ public:
       MissingConfig,
     };
 
+    // Metadata fetcher begins in initializing state and stays there until first success, then reverts to standard cache duration timing
+    // Initializing state will cause credential refresh at 2 sec, doubling to a maximum of 30 sec until successful.
     enum class ReceiverState {
       Initializing,
       Ready,

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -825,7 +825,6 @@ TEST_F(InstanceProfileCredentialsProviderTest, FailedDocumentSecure) {
   // Trigger refresh, which should then validate the previous two expectations
   timer_->invokeCallback();
 
-
   const auto credentials = provider_->getCredentials();
   EXPECT_FALSE(credentials.accessKeyId().has_value());
   EXPECT_FALSE(credentials.secretAccessKey().has_value());
@@ -841,7 +840,7 @@ TEST_F(InstanceProfileCredentialsProviderTest, MissingDocumentUnsecure) {
   // init_watcher ready is called.
   init_watcher_.expectReady();
 
-    // Cancel is called twice.
+  // Cancel is called twice.
   EXPECT_CALL(*raw_metadata_fetcher_, cancel()).Times(2);
 
   // Expect refresh timer to be started as a result of completing the init callback
@@ -871,7 +870,7 @@ TEST_F(InstanceProfileCredentialsProviderTest, MissingDocumentSecure) {
   // init_watcher ready is called.
   init_watcher_.expectReady();
 
-    // Cancel is called twice.
+  // Cancel is called twice.
   EXPECT_CALL(*raw_metadata_fetcher_, cancel()).Times(2);
 
   // Expect refresh timer to be started as a result of completing the init callback
@@ -902,8 +901,8 @@ TEST_F(InstanceProfileCredentialsProviderTest, MalformedDocumentUnsecure) {
  )EOF"));
   // init_watcher ready is called.
   init_watcher_.expectReady();
-  
-    // Cancel is called twice.
+
+  // Cancel is called twice.
   EXPECT_CALL(*raw_metadata_fetcher_, cancel()).Times(2);
 
   // Expect refresh timer to be started as a result of completing the init callback
@@ -934,8 +933,8 @@ TEST_F(InstanceProfileCredentialsProviderTest, MalformedDocumentSecure) {
  )EOF"));
   // init_watcher ready is called.
   init_watcher_.expectReady();
-  
-    // Cancel is called twice.
+
+  // Cancel is called twice.
   EXPECT_CALL(*raw_metadata_fetcher_, cancel()).Times(2);
 
   // Expect refresh timer to be started as a result of completing the init callback
@@ -949,7 +948,7 @@ TEST_F(InstanceProfileCredentialsProviderTest, MalformedDocumentSecure) {
   EXPECT_CALL(*timer_, enableTimer(timer_duration, nullptr));
   // Trigger refresh, which should then validate the previous two expectations
   timer_->invokeCallback();
-  
+
   const auto credentials = provider_->getCredentials();
   EXPECT_FALSE(credentials.accessKeyId().has_value());
   EXPECT_FALSE(credentials.secretAccessKey().has_value());

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -2928,10 +2928,6 @@ public:
 
 TEST_F(DefaultCredentialsProviderChainTest, NoEnvironmentVars) {
   EXPECT_CALL(factories_, createCredentialsFileCredentialsProvider(Ref(*api_)));
-  ENVOY_LOG_MISC(debug, "env var AWS_CONTAINER_CREDENTIALS_FULL_URI = {}",
-                 getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"));
-  ENVOY_LOG_MISC(debug, "env var AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = {}",
-                 getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"));
   EXPECT_CALL(factories_, createInstanceProfileCredentialsProvider(Ref(*api_), _, _, _, _));
 
   DefaultCredentialsProviderChain chain(*api_, context_, "region", DummyMetadataFetcher(),


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: aws: fix assertion failure in debug due to timer access outside of main thread
Additional Description: 

Patch to ensure async credential providers do not access main thread timers when credentials are requested.

This patch performs the following:
- Moves refreshIfNeeded() to within if statement to verify that refresh will not be triggered during signing if this is an async credential provider and the runtime guard is enabled.
- Changes refresh behaviour for async providers to refresh with a timer beginning at 2 seconds and doubling until < 30 seconds. This allows async providers to finish cluster setup successfully but still refresh at least once.

Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] #33962
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
