### PR TITLE
upstream lb: remove unnecessary original dst lb config from cluster info

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1024,14 +1024,6 @@ public:
   clusterType() const PURE;
 
   /**
-   * @return const absl::optional<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>& the
-   * configuration for the Original Destination load balancing policy, only used if type is set to
-   *         ORIGINAL_DST_LB.
-   */
-  virtual OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
-  lbOriginalDstConfig() const PURE;
-
-  /**
    * @return const absl::optional<envoy::config::core::v3::TypedExtensionConfig>& the configuration
    *         for the upstream, if a custom upstream is configured.
    */

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1165,13 +1165,6 @@ ClusterInfoImpl::ClusterInfoImpl(
                                "HttpProtocolOptions can be specified");
   }
 
-  // Handle the original_dst_lb_config case first.
-  if (config.lb_config_case() == envoy::config::cluster::v3::Cluster::kOriginalDstLbConfig) {
-    original_dst_lb_config_ =
-        std::make_unique<envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
-            config.original_dst_lb_config());
-  }
-
   if (config.has_load_balancing_policy() ||
       config.lb_policy() == envoy::config::cluster::v3::Cluster::LOAD_BALANCING_POLICY_CONFIG) {
     // If load_balancing_policy is set we will use it directly, ignoring lb_policy.

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -883,10 +883,6 @@ public:
     }
     return *cluster_type_;
   }
-  OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
-  lbOriginalDstConfig() const override {
-    return makeOptRefFromPtr(original_dst_lb_config_.get());
-  }
   OptRef<const envoy::config::core::v3::TypedExtensionConfig> upstreamConfig() const override {
     if (upstream_config_ == nullptr) {
       return absl::nullopt;
@@ -1071,9 +1067,6 @@ private:
   std::unique_ptr<envoy::config::core::v3::TypedExtensionConfig> upstream_config_;
   std::unique_ptr<const envoy::config::core::v3::Metadata> metadata_;
   std::unique_ptr<ClusterTypedMetadata> typed_metadata_;
-  // The load balancing configuration for original dst cluster.
-  std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
-      original_dst_lb_config_;
   LoadBalancerConfigPtr load_balancer_config_;
   TypedLoadBalancerFactory* load_balancer_factory_ = nullptr;
   const std::shared_ptr<const envoy::config::cluster::v3::Cluster::CommonLbConfig>

--- a/source/extensions/clusters/original_dst/original_dst_cluster.cc
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.cc
@@ -196,17 +196,18 @@ OriginalDstCluster::OriginalDstCluster(const envoy::config::cluster::v3::Cluster
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, cleanup_interval, 5000))),
       cleanup_timer_(dispatcher_.createTimer([this]() -> void { cleanup(); })),
       host_map_(std::make_shared<HostMultiMap>()) {
-  if (const auto& config_opt = info_->lbOriginalDstConfig(); config_opt.has_value()) {
-    if (config_opt->use_http_header()) {
-      http_header_name_ = config_opt->http_header_name().empty()
+  if (config.has_original_dst_lb_config()) {
+    const auto& lb_config = config.original_dst_lb_config();
+    if (lb_config.use_http_header()) {
+      http_header_name_ = lb_config.http_header_name().empty()
                               ? Http::Headers::get().EnvoyOriginalDstHost
-                              : Http::LowerCaseString(config_opt->http_header_name());
+                              : Http::LowerCaseString(lb_config.http_header_name());
     }
-    if (config_opt->has_metadata_key()) {
-      metadata_key_ = Config::MetadataKey(config_opt->metadata_key());
+    if (lb_config.has_metadata_key()) {
+      metadata_key_ = Config::MetadataKey(lb_config.metadata_key());
     }
-    if (config_opt->has_upstream_port_override()) {
-      port_override_ = config_opt->upstream_port_override().value();
+    if (lb_config.has_upstream_port_override()) {
+      port_override_ = lb_config.upstream_port_override().value();
     }
   }
   cleanup_timer_->enableTimer(cleanup_interval_ms_);

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -131,13 +131,6 @@ MockClusterInfo::MockClusterInfo()
   ON_CALL(*this, resourceManager(_))
       .WillByDefault(Invoke(
           [this](ResourcePriority) -> Upstream::ResourceManager& { return *resource_manager_; }));
-  ON_CALL(*this, lbOriginalDstConfig())
-      .WillByDefault(Invoke(
-          [this]() -> OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig> {
-            return makeOptRefFromPtr<
-                const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>(
-                lb_original_dst_config_.get());
-          }));
   ON_CALL(*this, upstreamConfig())
       .WillByDefault(
           Invoke([this]() -> OptRef<const envoy::config::core::v3::TypedExtensionConfig> {

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -146,8 +146,6 @@ public:
   MOCK_METHOD(envoy::config::cluster::v3::Cluster::DiscoveryType, type, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>, clusterType, (),
               (const));
-  MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>,
-              lbOriginalDstConfig, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig, (),
               (const));
   MOCK_METHOD(bool, maintenanceMode, (), (const));
@@ -243,8 +241,6 @@ public:
       upstream_http_protocol_options_;
   absl::optional<const envoy::config::core::v3::AlternateProtocolsCacheOptions>
       alternate_protocols_cache_options_;
-  std::unique_ptr<const envoy::config::cluster::v3::Cluster::OriginalDstLbConfig>
-      lb_original_dst_config_;
   Upstream::TypedLoadBalancerFactory* lb_factory_ =
       Config::Utility::getFactoryByName<Upstream::TypedLoadBalancerFactory>(
           "envoy.load_balancing_policies.round_robin");


### PR DESCRIPTION
Commit Message: upstream lb: remove unnecessary original dst lb config from cluster info
Additional Description:

The orignal dst lb config is only used when we construct the original dst cluster. And we needn't store it in the cluster info because the constructor of original dst cluster could load the config directly.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.