### PR TITLE
Fix QUIC deferred access logging for aborted client connection

### DIFF
--- a/source/common/quic/quic_stats_gatherer.cc
+++ b/source/common/quic/quic_stats_gatherer.cc
@@ -7,6 +7,12 @@
 namespace Envoy {
 namespace Quic {
 
+QuicStatsGatherer::~QuicStatsGatherer() {
+  if (!logging_done_) {
+    maybeDoDeferredLog(false);
+  }
+}
+
 void QuicStatsGatherer::OnPacketAcked(int acked_bytes,
                                       quic::QuicTime::Delta /* delta_largest_observed */) {
   bytes_outstanding_ -= acked_bytes;

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -18,6 +18,8 @@ class QuicStatsGatherer : public quic::QuicAckListenerInterface {
 public:
   explicit QuicStatsGatherer(Envoy::TimeSource* time_source) : time_source_(time_source) {}
 
+  ~QuicStatsGatherer();
+
   // QuicAckListenerInterface
   void OnPacketAcked(int acked_bytes, quic::QuicTime::Delta delta_largest_observed) override;
   void OnPacketRetransmitted(int retransmitted_bytes) override;

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -1597,6 +1597,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithAbortedClientConnection) {
   waitForNextUpstreamRequest(0, TestUtility::DefaultTimeout);
   upstream_request_->encodeHeaders(default_response_headers_, true);
 
+  // Abruptly close the client connection.
   codec_client_->close(Envoy::Network::ConnectionCloseType::Abort);
 
   std::string log = waitForAccessLog(access_log_name_);
@@ -1604,6 +1605,7 @@ TEST_P(QuicHttpIntegrationTest, DeferredLoggingWithAbortedClientConnection) {
   std::vector<std::string> metrics = absl::StrSplit(log, ',');
   ASSERT_EQ(metrics.size(), 21);
   EXPECT_EQ(/* PROTOCOL */ metrics.at(0), "HTTP/3");
+  // No roundtrip duration is logged; we never received a final ack from client.
   EXPECT_EQ(/* ROUNDTRIP_DURATION */ metrics.at(1), "-");
   EXPECT_GE(/* REQUEST_DURATION */ std::stoi(metrics.at(2)), 0);
   EXPECT_GE(/* RESPONSE_DURATION */ std::stoi(metrics.at(3)), 0);


### PR DESCRIPTION
Commit Message: Fix QUIC deferred access logging when client terminates connection before final ack
Additional Description: Addresses bug reported in https://github.com/envoyproxy/envoy/issues/29930. 
Risk Level: Low
Testing: Integration test
Docs Changes: N/A
