### PR TITLE
OTel AccessLogger: cleanup and refactor for supporting log_written/dropped for partial failed log requests 

### DIFF
--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -159,7 +159,7 @@ public:
           flush();
           flush_timer_->enableTimer(buffer_flush_interval_msec_);
         })),
-        max_buffer_size_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384)){
+        max_buffer_size_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384)) {
 
     client_ = std::make_unique<Detail::UnaryGrpcAccessLogClient<LogRequest, LogResponse>>(
         client, service_method, GrpcCommon::optionalRetryPolicy(config));

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
@@ -22,6 +22,20 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace OpenTelemetry {
 
+/**
+ * All stats for the grpc access logger. @see stats_macros.h
+ */
+#define ALL_GRPC_ACCESS_LOGGER_STATS(COUNTER)                                                      \
+  COUNTER(logs_written)                                                                            \
+  COUNTER(logs_dropped)
+
+/**
+ * Wrapper struct for the access log stats. @see stats_macros.h
+ */
+struct GrpcAccessLoggerStats {
+  ALL_GRPC_ACCESS_LOGGER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
 // Note: OpenTelemetry protos are extra flexible and used also in the OT collector for batching and
 // so forth. As a result, some fields are repeated, but for our use case we assume the following
 // structure:
@@ -56,6 +70,7 @@ private:
   void clearMessage() override;
 
   opentelemetry::proto::logs::v1::ScopeLogs* root_;
+  GrpcAccessLoggerStats stats_;
 };
 
 class GrpcAccessLoggerCacheImpl

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -50,10 +50,8 @@ public:
   MockGrpcAccessLoggerImpl(
       const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-      Event::Dispatcher& dispatcher,
-      const Protobuf::MethodDescriptor& service_method)
-      : GrpcAccessLogger(std::move(client), config, dispatcher,
-                         service_method) {}
+      Event::Dispatcher& dispatcher, const Protobuf::MethodDescriptor& service_method)
+      : GrpcAccessLogger(std::move(client), config, dispatcher, service_method) {}
 
   int numInits() const { return num_inits_; }
 
@@ -119,7 +117,7 @@ public:
         std::chrono::duration_cast<std::chrono::nanoseconds>(buffer_flush_interval_msec).count());
 
     logger_ = std::make_unique<MockGrpcAccessLoggerImpl>(
-        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_,  mockMethodDescriptor());
+        Grpc::RawAsyncClientPtr{async_client_}, config_, dispatcher_, mockMethodDescriptor());
   }
 
   void expectFlushedLogEntriesCount(const std::string& key, int count) {

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -181,7 +181,7 @@ TEST_F(GrpcAccessLoggerImplTest, StatsWithOnFailure) {
                 .value(),
             0);
 
-    // TODO(TAOXUY): support record stats for failed otel requests.
+  // TODO(TAOXUY): support record stats for failed otel requests.
   // Here `log_written` should be 1 instead of 2 and `logs_dropped` should be 1 instead of 0.
   grpc_access_logger_impl_test_helper_.expectSentMessage(
       expected_message_yaml, Grpc::Status::WellKnownGrpcStatus::Internal, 1);

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -181,10 +181,11 @@ TEST_F(GrpcAccessLoggerImplTest, StatsWithOnFailure) {
                 .value(),
             0);
 
+    // TODO(TAOXUY): support record stats for failed otel requests.
+  // Here `log_written` should be 1 instead of 2 and `logs_dropped` should be 1 instead of 0.
   grpc_access_logger_impl_test_helper_.expectSentMessage(
       expected_message_yaml, Grpc::Status::WellKnownGrpcStatus::Internal, 1);
   logger_->log(opentelemetry::proto::logs::v1::LogRecord(entry));
-  // TODO(TAOXUY): support record stats for failed otel requests.
   EXPECT_EQ(store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
                 .value()
                 .get()


### PR DESCRIPTION
The OTel AccessLogger's existing stats log_written/log_dropped don't correctly record the case with gRPC failures. Currently, they were introduced for the log entries dropped by overFlowed gRPC stream.

https://github.com/open-telemetry/opentelemetry-proto/blob/b3060d2104df364136d75a35779e6bd48bac449a/opentelemetry/proto/collector/logs/v1/logs_service.proto#L69

**Cleanup**: in fact, right now only AsyncUnaryClient is used and the `StreamingGrpcAccessLogClient` is dead after https://github.com/envoyproxy/envoy/pull/24268 so clean it up. We can always add it back when needed.

**Refactor**: move log_written/log_dropped to `GrpcAccessLogImpl`, which we plan to make it inherit AsyncClientCallback, so that it can record  log_written/log_dropped in `onSuccess`/`onFailure` callback, which we will make in the followup changes.

No behavior change.