### PR TITLE
mobile: Wrap the direct ByteBuffer created by the JVM with a GlobalRef

### DIFF
--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -214,6 +214,7 @@ cc_library(
     deps = [
         "//library/common/http:header_utility_lib",
         "//library/jni:jni_utility_lib",
+        "//library/jni/types:jni_javavm_lib",
         "@envoy//test/test_common:utility_lib",
     ],
     alwayslink = True,

--- a/mobile/test/jni/jni_utility_test.cc
+++ b/mobile/test/jni/jni_utility_test.cc
@@ -5,11 +5,20 @@
 #include "absl/container/flat_hash_map.h"
 #include "library/common/http/header_utility.h"
 #include "library/jni/jni_utility.h"
+#include "library/jni/types/java_virtual_machine.h"
 
 // NOLINT(namespace-envoy)
 
 // This file contains JNI implementation used by
 // `test/java/io/envoyproxy/envoymobile/jni/JniUtilityTest.java` unit tests.
+
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
+  const auto result = Envoy::JNI::JavaVirtualMachine::initialize(vm);
+  if (result != JNI_OK) {
+    return result;
+  }
+  return Envoy::JNI::JavaVirtualMachine::getJNIVersion();
+}
 
 extern "C" JNIEXPORT jbyteArray JNICALL
 Java_io_envoyproxy_envoymobile_jni_JniUtilityTest_protoJavaByteArrayConversion(JNIEnv* env, jclass,


### PR DESCRIPTION
This is to tell the JVM to not garbage collect the `ByteBuffer` until it's no longer used or else we might end up with a use-after-free. The `GlobalRef` will be deleted inside the `BufferFragmentImpl` releasor.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile