### PR TITLE
mobile: Fix the test_binary_size program to use the InternalEngine

### DIFF
--- a/mobile/ci/test_size_regression.sh
+++ b/mobile/ci/test_size_regression.sh
@@ -5,10 +5,10 @@ set -o pipefail
 
 # Checks the absolute size and the relative size increase of a file.
 
-# As of Jan 11, 2024, the latest runs show that the test binary size is
-# 4273716 bytes:
-# https://github.com/envoyproxy/envoy/actions/runs/7497709450/job/20411963750
-MAX_SIZE=4500000 # 4.5MB
+# As of May 7, 2024, the latest runs show that the test binary size is
+# 5413199 bytes:
+# https://github.com/envoyproxy/envoy/actions/runs/8990218789/job/24695250246
+MAX_SIZE=5600000 # 5.6MB
 MAX_PERC=1.5
 
 if [ "$(uname)" == "Darwin" ]

--- a/mobile/test/performance/test_binary_size.cc
+++ b/mobile/test/performance/test_binary_size.cc
@@ -5,4 +5,9 @@
 // This binary is used to perform stripped down binary size investigations of the Envoy codebase.
 // Please refer to the development docs for more information:
 // https://envoymobile.io/docs/envoy-mobile/latest/development/performance/binary_size.html
-int main() { return reinterpret_cast<Envoy::InternalEngine*>(0)->run(nullptr, nullptr); }
+int main() {
+  Envoy::InternalEngine engine(nullptr, nullptr, nullptr);
+  const std::string config = "";
+  const std::string log_level = "";
+  engine.run(config, log_level);
+}


### PR DESCRIPTION
The previous test_binary_size code was:
```
reinterpret_cast<Envoy::InternalEngine*>(0)->run(nullptr, nullptr);
```

This code has a couple problems: (1) we don't actually create an InternalEngine; we just cast an arbitrary
integer value (in this case, 0) to a InternalEngine pointer and (2) the `run()` function takes const references,
not pointers.  The way this code was structured, it's believed that the binary size expectations were incorrect,
because the compiler could strip/elide code that this particular program setup would render unused code.

After changing the program structure, we do indeed see a size difference.  Instead of 4.5MB, as is the current
expectation, we are seeing the program size actually as 5.41MB.