### PR TITLE
golang: cache log level at Go side

### DIFF
--- a/contrib/golang/common/go/api/logger.go
+++ b/contrib/golang/common/go/api/logger.go
@@ -17,7 +17,9 @@
 
 package api
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func (c *commonCApiImpl) Log(level LogType, message string) {
 	panic("To implement")
@@ -28,51 +30,87 @@ func (c *commonCApiImpl) LogLevel() LogType {
 }
 
 func LogTrace(message string) {
+	if cAPI.LogLevel() > Trace {
+		return
+	}
 	cAPI.Log(Trace, message)
 }
 
 func LogDebug(message string) {
+	if cAPI.LogLevel() > Debug {
+		return
+	}
 	cAPI.Log(Debug, message)
 }
 
 func LogInfo(message string) {
+	if cAPI.LogLevel() > Info {
+		return
+	}
 	cAPI.Log(Info, message)
 }
 
 func LogWarn(message string) {
+	if cAPI.LogLevel() > Warn {
+		return
+	}
 	cAPI.Log(Warn, message)
 }
 
 func LogError(message string) {
+	if cAPI.LogLevel() > Error {
+		return
+	}
 	cAPI.Log(Error, message)
 }
 
 func LogCritical(message string) {
+	if cAPI.LogLevel() > Critical {
+		return
+	}
 	cAPI.Log(Critical, message)
 }
 
 func LogTracef(format string, v ...any) {
-	LogTrace(fmt.Sprintf(format, v...))
+	if cAPI.LogLevel() > Trace {
+		return
+	}
+	cAPI.Log(Trace, fmt.Sprintf(format, v...))
 }
 
 func LogDebugf(format string, v ...any) {
-	LogDebug(fmt.Sprintf(format, v...))
+	if cAPI.LogLevel() > Debug {
+		return
+	}
+	cAPI.Log(Debug, fmt.Sprintf(format, v...))
 }
 
 func LogInfof(format string, v ...any) {
-	LogInfo(fmt.Sprintf(format, v...))
+	if cAPI.LogLevel() > Info {
+		return
+	}
+	cAPI.Log(Info, fmt.Sprintf(format, v...))
 }
 
 func LogWarnf(format string, v ...any) {
-	LogWarn(fmt.Sprintf(format, v...))
+	if cAPI.LogLevel() > Warn {
+		return
+	}
+	cAPI.Log(Warn, fmt.Sprintf(format, v...))
 }
 
 func LogErrorf(format string, v ...any) {
-	LogError(fmt.Sprintf(format, v...))
+	if cAPI.LogLevel() > Error {
+		return
+	}
+	cAPI.Log(Error, fmt.Sprintf(format, v...))
 }
 
 func LogCriticalf(format string, v ...any) {
-	LogCritical(fmt.Sprintf(format, v...))
+	if cAPI.LogLevel() > Critical {
+		return
+	}
+	cAPI.Log(Critical, fmt.Sprintf(format, v...))
 }
 
 func GetLogLevel() LogType {

--- a/contrib/golang/common/go/api_impl/capi_impl.go
+++ b/contrib/golang/common/go/api_impl/capi_impl.go
@@ -32,9 +32,16 @@ package api_impl
 */
 import "C"
 import (
+	"os"
+	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+)
+
+var (
+	currLogLevel atomic.Int32
 )
 
 type commonCApiImpl struct{}
@@ -47,9 +54,31 @@ func (c *commonCApiImpl) Log(level api.LogType, message string) {
 }
 
 func (c *commonCApiImpl) LogLevel() api.LogType {
-	return api.LogType(C.envoyGoFilterLogLevel())
+	lv := currLogLevel.Load()
+	return api.LogType(lv)
 }
 
 func init() {
 	api.SetCommonCAPI(&commonCApiImpl{})
+
+	interval := time.Second
+	envInterval := os.Getenv("ENVOY_GOLANG_LOG_LEVEL_SYNC_INTERVAL")
+	if envInterval != "" {
+		dur, err := time.ParseDuration(envInterval)
+		if err == nil && dur >= time.Millisecond {
+			// protect against too frequent sync
+			interval = dur
+		}
+	}
+
+	currLogLevel.Store(int32(C.envoyGoFilterLogLevel()))
+	ticker := time.NewTicker(interval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				currLogLevel.Store(int32(C.envoyGoFilterLogLevel()))
+			}
+		}
+	}()
 }


### PR DESCRIPTION
Log lower than the configured level doesn't call into Envoy anymore.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: golang: cache log level at Go side
Additional Description: Log lower than the configured level doesn't call into Envoy anymore.
Risk Level: Low
Testing: pass the current log tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
