### PR TITLE
mobile: Remove EnvoyFinalStreamIntelImpl's VisibleForTesting annotation

### DIFF
--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyFinalStreamIntelImpl.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyFinalStreamIntelImpl.java
@@ -3,7 +3,7 @@ package io.envoyproxy.envoymobile.engine;
 import io.envoyproxy.envoymobile.engine.types.EnvoyFinalStreamIntel;
 import androidx.annotation.VisibleForTesting;
 
-@VisibleForTesting
+// This class is made public for access in tests.
 public class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
   private final long streamStartMs;
   private final long dnsStartMs;


### PR DESCRIPTION
When a compiler has error-prone checks enabled, the VisibleForTesting annotation is not allowed on a public class.  This change removes the class-level annotation in favor of a comment.