### PR TITLE
ext-proc: fallback to 'value', if 'raw_value' is not set

### DIFF
--- a/source/extensions/filters/http/ext_proc/mutation_utils.cc
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.cc
@@ -170,6 +170,9 @@ absl::Status MutationUtils::applyHeaderMutations(const HeaderMutation& mutation,
     absl::string_view header_value;
     if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.send_header_raw_value")) {
       header_value = sh.header().raw_value();
+      if (header_value.empty()) {
+        header_value = sh.header().value();
+      }
     } else {
       header_value = sh.header().value();
     }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: ext-proc: fallback to 'value', if 'raw_value' is not set
Additional Description:
Enabling `envoy.reloadable_features.send_header_raw_value` by default is a **breaking change** in current form. If ext server was setting `value` it would be ignored because now feature is enable by default and it looks for `raw_value` only. For backward compatibility, fallback to `value` if `raw_value` is not set by service

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
