### PR TITLE
OAuth2 Client Credential: Fix test flake

### DIFF
--- a/source/extensions/http/injected_credentials/oauth2/token_provider.cc
+++ b/source/extensions/http/injected_credentials/oauth2/token_provider.cc
@@ -93,11 +93,13 @@ void TokenProvider::onGetAccessTokenSuccess(const std::string& access_token,
   auto token = absl::StrCat("Bearer ", access_token);
   ThreadLocalOauth2ClientCredentialsTokenSharedPtr value(
       new ThreadLocalOauth2ClientCredentialsToken(token));
+
+  tls_->set(
+      [value](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr { return value; });
+
   stats_.token_fetched_.inc();
   ENVOY_LOG(debug, "onGetAccessTokenSuccess: Token fetched successfully, expires in {} seconds.",
             expires_in.count());
-  tls_->set(
-      [value](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr { return value; });
   if (timer_->enabled()) {
     return;
   }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
fixes: https://github.com/envoyproxy/envoy/issues/34040
Commit Message: OAuth2 Client Credential: Fix test flake
Additional Description:

In tests, before firing http traffic request, make sure through stats that token is fetched. Since token fetching happens on main thread in async, without ensuring it is possible that before tls slot is set by main thread, worker thread attempts to inject the request, which would fail.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
