### PR TITLE
Implement setOperation for the opentelemetry provider

### DIFF
--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -84,6 +84,8 @@ void Span::finishSpan() {
   }
 }
 
+void Span::setOperation(absl::string_view operation) { span_.set_name(operation); };
+
 void Span::injectContext(Tracing::TraceContext& trace_context, const Tracing::UpstreamContext&) {
   std::string trace_id_hex = absl::BytesToHexString(span_.trace_id());
   std::string span_id_hex = absl::BytesToHexString(span_.span_id());

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -85,7 +85,7 @@ public:
        Tracer& parent_tracer, OTelSpanKind span_kind);
 
   // Tracing::Span functions
-  void setOperation(absl::string_view /*operation*/) override{};
+  void setOperation(absl::string_view /*operation*/) override;
   void setTag(absl::string_view /*name*/, absl::string_view /*value*/) override;
   void log(SystemTime /*timestamp*/, const std::string& /*event*/) override{};
   void finishSpan() override;

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -122,6 +122,11 @@ public:
   OTelSpanKind spankind() const { return span_.kind(); }
 
   /**
+   * @return the operation name set on the span
+   */
+  std::string name() const { return span_.name(); }
+
+  /**
    * Sets the span's id.
    */
   void setId(const absl::string_view& span_id_hex) {

--- a/test/extensions/tracers/opentelemetry/BUILD
+++ b/test/extensions/tracers/opentelemetry/BUILD
@@ -101,3 +101,19 @@ envoy_extension_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "operation_name_test",
+    srcs = ["operation_name_test.cc"],
+    extension_names = ["envoy.tracers.opentelemetry"],
+    deps = [
+        "//source/extensions/tracers/opentelemetry:config",
+        "//source/extensions/tracers/opentelemetry:opentelemetry_tracer_lib",
+        "//test/mocks/server:tracer_factory_context_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/mocks/thread_local:thread_local_mocks",
+        "//test/mocks/tracing:tracing_mocks",
+        "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/tracers/opentelemetry/operation_name_test.cc
+++ b/test/extensions/tracers/opentelemetry/operation_name_test.cc
@@ -1,0 +1,71 @@
+#include "source/extensions/tracers/opentelemetry/config.h"
+#include "source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.h"
+#include "source/extensions/tracers/opentelemetry/tracer.h"
+
+#include "test/mocks/server/tracer_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/mocks/tracing/mocks.h"
+#include "test/mocks/upstream/cluster_manager.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Tracers {
+namespace OpenTelemetry {
+
+class OpenTelemetryTracerOperationNameTest : public testing::Test {
+public:
+  OpenTelemetryTracerOperationNameTest();
+
+protected:
+  NiceMock<Tracing::MockConfig> config;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Tracing::TestTraceContextImpl trace_context{};
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  NiceMock<Upstream::MockClusterManager> cluster_manager_;
+};
+
+OpenTelemetryTracerOperationNameTest::OpenTelemetryTracerOperationNameTest() {
+  cluster_manager_.initializeClusters({"fake-cluster"}, {});
+  cluster_manager_.thread_local_cluster_.cluster_.info_->name_ = "fake-cluster";
+  cluster_manager_.initializeThreadLocalClusters({"fake-cluster"});
+}
+
+TEST_F(OpenTelemetryTracerOperationNameTest, OperationName) {
+  // Checks:
+  //
+  // - The span returned by `Tracer::startSpan` has as its name the
+  //   operation name passed to `Tracer::startSpan`
+  // - `Span::setOperation` sets the name of the span
+
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: test-service-name
+    )EOF";
+
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  auto driver = std::make_unique<Driver>(opentelemetry_config, context);
+
+  const std::string operation_name = "initial_operation_name";
+  Tracing::SpanPtr tracing_span = driver->startSpan(
+      config, trace_context, stream_info, operation_name, {Tracing::Reason::Sampling, true});
+
+  EXPECT_EQ(dynamic_cast<Span*>(tracing_span.get())->name(), operation_name);
+
+  const std::string new_operation_name = "the_new_operation_name";
+  tracing_span->setOperation(new_operation_name);
+  EXPECT_EQ(dynamic_cast<Span*>(tracing_span.get())->name(), new_operation_name);
+}
+
+} // namespace OpenTelemetry
+} // namespace Tracers
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: implement setOperation for the opentelemetry provider

Additional Description:
The detailed description is provided in [issue#34063](https://github.com/envoyproxy/envoy/issues/34063). In short, the MR implements a method for the OpenTelemetry tracing provider that was left empty and thus made the [`setOperation`](https://github.com/envoyproxy/envoy/blob/main/source/common/router/config_impl.cc#L460) method a no-op.

Risk Level: Low

Testing: Unit testing and the [sandbox](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/opentelemetry).

Fixes [issue#34063](https://github.com/envoyproxy/envoy/issues/34063)

