### PR TITLE
getaddrinfo: Add host info in the debug log messages

### DIFF
--- a/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
+++ b/source/extensions/network/dns_resolver/getaddrinfo/getaddrinfo.cc
@@ -164,11 +164,12 @@ void GetAddrInfoDnsResolver::resolveThreadRoutine() {
         // the DNS query is retried.
         // NOTE: this is also how the c-ares resolver treats NONAME and NODATA:
         // https://github.com/envoyproxy/envoy/blob/099d85925b32ce8bf06e241ee433375a0a3d751b/source/extensions/network/dns_resolver/cares/dns_impl.h#L109-L111.
-        ENVOY_LOG(debug, "getaddrinfo no results rc={}", gai_strerror(rc.return_value_));
+        ENVOY_LOG(debug, "getaddrinfo for host={} has no results rc={}", next_query->dns_name_,
+                  gai_strerror(rc.return_value_));
         response = std::make_pair(ResolutionStatus::Success, std::list<DnsResponse>());
       } else {
-        ENVOY_LOG(debug, "getaddrinfo failed with rc={} errno={}", gai_strerror(rc.return_value_),
-                  errorDetails(rc.errno_));
+        ENVOY_LOG(debug, "getaddrinfo failed for host={} with rc={} errno={}",
+                  next_query->dns_name_, gai_strerror(rc.return_value_), errorDetails(rc.errno_));
         response = std::make_pair(ResolutionStatus::Failure, std::list<DnsResponse>());
       }
     }


### PR DESCRIPTION
This PR adds the host information in the debug log messages to make debugging easier.

Risk Level: low (updating debug log messages only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
