### PR TITLE
Clean up remaining streams in TcpConnPool dtor

### DIFF
--- a/source/extensions/upstreams/http/tcp/upstream_request.h
+++ b/source/extensions/upstreams/http/tcp/upstream_request.h
@@ -26,7 +26,10 @@ public:
               Upstream::ResourcePriority priority, Upstream::LoadBalancerContext* ctx) {
     conn_pool_data_ = thread_local_cluster.tcpConnPool(priority, ctx);
   }
-  ~TcpConnPool() override { cancelAnyPendingStream(); }
+  ~TcpConnPool() override {
+    cancelAnyPendingStream();
+    ENVOY_BUG(upstream_handle_ == nullptr, "upstream_handle not null");
+  }
   // Router::GenericConnPool
   void newStream(Router::GenericConnectionPoolCallbacks* callbacks) override {
     callbacks_ = callbacks;

--- a/source/extensions/upstreams/http/tcp/upstream_request.h
+++ b/source/extensions/upstreams/http/tcp/upstream_request.h
@@ -27,8 +27,8 @@ public:
     conn_pool_data_ = thread_local_cluster.tcpConnPool(priority, ctx);
   }
   ~TcpConnPool() override {
-    cancelAnyPendingStream();
     ENVOY_BUG(upstream_handle_ == nullptr, "upstream_handle not null");
+    cancelAnyPendingStream();
   }
   // Router::GenericConnPool
   void newStream(Router::GenericConnectionPoolCallbacks* callbacks) override {

--- a/source/extensions/upstreams/http/tcp/upstream_request.h
+++ b/source/extensions/upstreams/http/tcp/upstream_request.h
@@ -26,6 +26,7 @@ public:
               Upstream::ResourcePriority priority, Upstream::LoadBalancerContext* ctx) {
     conn_pool_data_ = thread_local_cluster.tcpConnPool(priority, ctx);
   }
+  ~TcpConnPool() override { cancelAnyPendingStream(); }
   // Router::GenericConnPool
   void newStream(Router::GenericConnectionPoolCallbacks* callbacks) override {
     callbacks_ = callbacks;

--- a/source/extensions/upstreams/http/tcp/upstream_request.h
+++ b/source/extensions/upstreams/http/tcp/upstream_request.h
@@ -28,21 +28,14 @@ public:
   }
   ~TcpConnPool() override {
     ENVOY_BUG(upstream_handle_ == nullptr, "upstream_handle not null");
-    cancelAnyPendingStream();
+    resetUpstreamHandleIfSet();
   }
   // Router::GenericConnPool
   void newStream(Router::GenericConnectionPoolCallbacks* callbacks) override {
     callbacks_ = callbacks;
     upstream_handle_ = conn_pool_data_.value().newConnection(*this);
   }
-  bool cancelAnyPendingStream() override {
-    if (upstream_handle_) {
-      upstream_handle_->cancel(Envoy::Tcp::ConnectionPool::CancelPolicy::Default);
-      upstream_handle_ = nullptr;
-      return true;
-    }
-    return false;
-  }
+  bool cancelAnyPendingStream() override { return resetUpstreamHandleIfSet(); }
   Upstream::HostDescriptionConstSharedPtr host() const override {
     return conn_pool_data_.value().host();
   }
@@ -60,6 +53,15 @@ public:
                    Upstream::HostDescriptionConstSharedPtr host) override;
 
 private:
+  bool resetUpstreamHandleIfSet() {
+    if (upstream_handle_) {
+      upstream_handle_->cancel(Envoy::Tcp::ConnectionPool::CancelPolicy::Default);
+      upstream_handle_ = nullptr;
+      return true;
+    }
+    return false;
+  }
+
   absl::optional<Envoy::Upstream::TcpPoolData> conn_pool_data_;
   Envoy::Tcp::ConnectionPool::Cancellable* upstream_handle_{};
   Router::GenericConnectionPoolCallbacks* callbacks_{};


### PR DESCRIPTION
Commit Message: Fix for heap-use-after-free issue in Envoy::Tcp::ConnPoolImpl::onPoolReady (see #34055)
Risk Level: Low
