### PR TITLE
Add command line flag to skip hot restart stats transfer

### DIFF
--- a/api/envoy/admin/v3/server_info.proto
+++ b/api/envoy/admin/v3/server_info.proto
@@ -59,7 +59,7 @@ message ServerInfo {
   config.core.v3.Node node = 7;
 }
 
-// [#next-free-field: 40]
+// [#next-free-field: 41]
 message CommandLineOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.admin.v2alpha.CommandLineOptions";
@@ -100,6 +100,9 @@ message CommandLineOptions {
 
   // See :option:`--skip-hot-restart-on-no-parent` for details.
   bool skip_hot_restart_on_no_parent = 39;
+
+  // See :option:`--skip-hot-restart-parent-stats` for details.
+  bool skip_hot_restart_parent_stats = 40;
 
   // See :option:`--base-id-path` for details.
   string base_id_path = 32;

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -89,6 +89,9 @@ removed_config_or_runtime:
     Removed ``envoy.reloadable_features.copy_response_code_to_downstream_stream_info`` runtime flag and legacy code paths.
 
 new_features:
+- area: hot_restart
+  change: |
+    Added new command-line flag :option:`--skip-hot-restart-parent-stats`.
 - area: matching
   change: |
     Added :ref:`Filter State Input <envoy_v3_api_msg_extensions.matching.common_inputs.network.v3.FilterStateInput>`

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -77,6 +77,15 @@ following are the command line options that Envoy supports.
   an unexpected parent termination after interprocess communication is established will still cause
   the child instance to terminate due to failing communication.
 
+.. option:: --skip-hot-restart-parent-stats
+
+  *(optional)* In conjunction with :option:`--restart-epoch`, this flag allows for hot restart
+  to proceed without duplicating stats from the parent instance. Transferring stats can be an
+  expensive operation; skipping it can prevent overloading the main thread with this work, or
+  potentially dramatically increased memory load.
+
+  Has no effect if hot restarting is not in use.
+
 .. option:: --base-id-path <path_string>
 
   *(optional)* Writes the base ID to the given path. While this option is compatible with

--- a/envoy/server/options.h
+++ b/envoy/server/options.h
@@ -91,6 +91,12 @@ public:
   virtual bool skipHotRestartOnNoParent() const PURE;
 
   /**
+   * @return bool don't get stats from the parent. If there are a lot of stats, getting them
+   *         from the parent instance can be slow and require a lot of memory.
+   */
+  virtual bool skipHotRestartParentStats() const PURE;
+
+  /**
    * @return const std::string& the dynamic base id output file.
    */
   virtual const std::string& baseIdPath() const PURE;

--- a/source/exe/stripped_main_base.cc
+++ b/source/exe/stripped_main_base.cc
@@ -125,9 +125,9 @@ void StrippedMainBase::configureHotRestarter(Random::RandomGenerator& random_gen
         base_id = static_cast<uint32_t>(random_generator.random()) & 0x0FFFFFFF;
 
         TRY_ASSERT_MAIN_THREAD {
-          restarter = std::make_unique<Server::HotRestartImpl>(base_id, 0, options_.socketPath(),
-                                                               options_.socketMode(),
-                                                               options_.skipHotRestartOnNoParent());
+          restarter = std::make_unique<Server::HotRestartImpl>(
+              base_id, 0, options_.socketPath(), options_.socketMode(),
+              options_.skipHotRestartOnNoParent(), options_.skipHotRestartParentStats());
         }
         END_TRY
         CATCH(Server::HotRestartDomainSocketInUseException & ex, {
@@ -144,7 +144,7 @@ void StrippedMainBase::configureHotRestarter(Random::RandomGenerator& random_gen
     } else {
       restarter_ = std::make_unique<Server::HotRestartImpl>(
           base_id, options_.restartEpoch(), options_.socketPath(), options_.socketMode(),
-          options_.skipHotRestartOnNoParent());
+          options_.skipHotRestartOnNoParent(), options_.skipHotRestartParentStats());
     }
 
     // Write the base-id to the requested path whether we selected it

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -97,10 +97,10 @@ void initializeMutex(pthread_mutex_t& mutex) {
 // the socket names to entirely prevent collisions between consecutive base ids.
 HotRestartImpl::HotRestartImpl(uint32_t base_id, uint32_t restart_epoch,
                                const std::string& socket_path, mode_t socket_mode,
-                               bool skip_hot_restart_on_no_parent)
+                               bool skip_hot_restart_on_no_parent, bool skip_parent_stats)
     : base_id_(base_id), scaled_base_id_(base_id * 10),
       as_child_(HotRestartingChild(scaled_base_id_, restart_epoch, socket_path, socket_mode,
-                                   skip_hot_restart_on_no_parent)),
+                                   skip_hot_restart_on_no_parent, skip_parent_stats)),
       as_parent_(HotRestartingParent(scaled_base_id_, restart_epoch, socket_path, socket_mode)),
       shmem_(attachSharedMemory(scaled_base_id_, restart_epoch)), log_lock_(shmem_->log_lock_),
       access_log_lock_(shmem_->access_log_lock_) {

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -98,7 +98,7 @@ private:
 class HotRestartImpl : public HotRestart {
 public:
   HotRestartImpl(uint32_t base_id, uint32_t restart_epoch, const std::string& socket_path,
-                 mode_t socket_mode, bool skip_hot_restart_on_no_parent);
+                 mode_t socket_mode, bool skip_hot_restart_on_no_parent, bool skip_parent_stats);
 
   // Server::HotRestart
   void drainParentListeners() override;

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -50,10 +50,11 @@ HotRestartingChild::UdpForwardingContext::getListenerForDestination(
 // drained and terminated.
 HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
                                        const std::string& socket_path, mode_t socket_mode,
-                                       bool skip_hot_restart_on_no_parent)
+                                       bool skip_hot_restart_on_no_parent, bool skip_parent_stats)
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch),
       parent_terminated_(restart_epoch == 0), parent_drained_(restart_epoch == 0),
-      skip_hot_restart_on_no_parent_(skip_hot_restart_on_no_parent) {
+      skip_hot_restart_on_no_parent_(skip_hot_restart_on_no_parent),
+      skip_parent_stats_(skip_parent_stats) {
   main_rpc_stream_.initDomainSocketAddress(&parent_address_);
   std::string socket_path_udp = socket_path + "_udp";
   udp_forwarding_rpc_stream_.initDomainSocketAddress(&parent_address_udp_forwarding_);
@@ -144,7 +145,7 @@ int HotRestartingChild::duplicateParentListenSocket(const std::string& address,
 }
 
 std::unique_ptr<HotRestartMessage> HotRestartingChild::getParentStats() {
-  if (parent_terminated_) {
+  if (parent_terminated_ || skip_parent_stats_) {
     return nullptr;
   }
 

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -43,7 +43,8 @@ public:
   };
 
   HotRestartingChild(int base_id, int restart_epoch, const std::string& socket_path,
-                     mode_t socket_mode, bool skip_hot_restart_on_no_parent);
+                     mode_t socket_mode, bool skip_hot_restart_on_no_parent,
+                     bool skip_parent_stats);
   ~HotRestartingChild() override = default;
 
   void initialize(Event::Dispatcher& dispatcher);
@@ -76,6 +77,7 @@ private:
   bool parent_terminated_;
   bool parent_drained_ ABSL_GUARDED_BY(registry_mu_);
   const bool skip_hot_restart_on_no_parent_;
+  const bool skip_parent_stats_;
   sockaddr_un parent_address_;
   sockaddr_un parent_address_udp_forwarding_;
   std::unique_ptr<Stats::StatMerger> stat_merger_{};

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -71,6 +71,12 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       " connection to the parent cannot be established. Set this to true to instead continue with"
       " a regular startup, while retaining the new epoch value.",
       cmd, false);
+  TCLAP::SwitchArg skip_hot_restart_parent_stats(
+      "", "skip-hot-restart-parent-stats",
+      "When hot restarting, by default the child instance copies stats from the parent"
+      " instance periodically during the draining period. This can potentially be an"
+      " expensive operation; set this to true to just use new stats.",
+      cmd, false);
   TCLAP::ValueArg<std::string> base_id_path(
       "", "base-id-path", "Path to which the base ID is written", false, "", "string", cmd);
   TCLAP::ValueArg<uint32_t> concurrency("", "concurrency", "# of worker threads to run", false,
@@ -235,6 +241,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   base_id_ = base_id.getValue();
   use_dynamic_base_id_ = use_dynamic_base_id.getValue();
   skip_hot_restart_on_no_parent_ = skip_hot_restart_on_no_parent.getValue();
+  skip_hot_restart_parent_stats_ = skip_hot_restart_parent_stats.getValue();
   base_id_path_ = base_id_path.getValue();
   restart_epoch_ = restart_epoch.getValue();
 
@@ -380,6 +387,7 @@ Server::CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_base_id(baseId());
   command_line_options->set_use_dynamic_base_id(useDynamicBaseId());
   command_line_options->set_skip_hot_restart_on_no_parent(skipHotRestartOnNoParent());
+  command_line_options->set_skip_hot_restart_parent_stats(skipHotRestartParentStats());
   command_line_options->set_base_id_path(baseIdPath());
   command_line_options->set_concurrency(concurrency());
   command_line_options->set_config_path(configPath());

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -75,7 +75,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
       "", "skip-hot-restart-parent-stats",
       "When hot restarting, by default the child instance copies stats from the parent"
       " instance periodically during the draining period. This can potentially be an"
-      " expensive operation; set this to true to just use new stats.",
+      " expensive operation; set this to true to reset all stats in child process.",
       cmd, false);
   TCLAP::ValueArg<std::string> base_id_path(
       "", "base-id-path", "Path to which the base ID is written", false, "", "string", cmd);

--- a/source/server/options_impl_base.h
+++ b/source/server/options_impl_base.h
@@ -33,6 +33,7 @@ public:
   void setBaseId(uint64_t base_id) { base_id_ = base_id; };
   void setUseDynamicBaseId(bool use_dynamic_base_id) { use_dynamic_base_id_ = use_dynamic_base_id; }
   void setSkipHotRestartOnNoParent(bool skip) { skip_hot_restart_on_no_parent_ = skip; }
+  void setSkipHotRestartParentStats(bool skip) { skip_hot_restart_parent_stats_ = skip; }
   void setBaseIdPath(const std::string& base_id_path) { base_id_path_ = base_id_path; }
   void setConcurrency(uint32_t concurrency) { concurrency_ = concurrency; }
   void setConfigPath(const std::string& config_path) { config_path_ = config_path; }
@@ -98,6 +99,7 @@ public:
   uint64_t baseId() const override { return base_id_; }
   bool useDynamicBaseId() const override { return use_dynamic_base_id_; }
   bool skipHotRestartOnNoParent() const override { return skip_hot_restart_on_no_parent_; }
+  bool skipHotRestartParentStats() const override { return skip_hot_restart_parent_stats_; }
   const std::string& baseIdPath() const override { return base_id_path_; }
   uint32_t concurrency() const override { return concurrency_; }
   const std::string& configPath() const override { return config_path_; }
@@ -170,6 +172,7 @@ private:
   uint64_t base_id_{0};
   bool use_dynamic_base_id_{false};
   bool skip_hot_restart_on_no_parent_{false};
+  bool skip_hot_restart_parent_stats_{false};
   std::string base_id_path_;
   uint32_t concurrency_{1};
   std::string config_path_;

--- a/test/mocks/server/options.h
+++ b/test/mocks/server/options.h
@@ -18,6 +18,7 @@ public:
   MOCK_METHOD(uint64_t, baseId, (), (const));
   MOCK_METHOD(bool, useDynamicBaseId, (), (const));
   MOCK_METHOD(bool, skipHotRestartOnNoParent, (), (const));
+  MOCK_METHOD(bool, skipHotRestartParentStats, (), (const));
   MOCK_METHOD(const std::string&, baseIdPath, (), (const));
   MOCK_METHOD(uint32_t, concurrency, (), (const));
   MOCK_METHOD(const std::string&, configPath, (), (const));

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -67,7 +67,7 @@ public:
     EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(4);
 
     // Test we match the correct stat with empty-slots before, after, or both.
-    hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false);
+    hot_restart_ = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false);
     hot_restart_->drainParentListeners();
 
     // We close both sockets, both ends, totaling 4.
@@ -133,7 +133,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketAlreadyInUse) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false),
+  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false),
                Server::HotRestartDomainSocketInUseException);
 }
 
@@ -149,7 +149,8 @@ TEST_P(DomainSocketErrorTest, DomainSocketError) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false), EnvoyException);
+  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false),
+               EnvoyException);
 }
 
 class HotRestartUdpForwardingContextTest : public HotRestartImplTest {

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -91,8 +91,8 @@ public:
     EXPECT_CALL(os_sys_calls_, bind(_, _, _)).Times(4);
     EXPECT_CALL(os_sys_calls_, close(_)).Times(4);
     fake_parent_ = std::make_unique<FakeHotRestartingParent>(os_sys_calls_, 0, 0, socket_path_);
-    hot_restarting_child_ =
-        std::make_unique<HotRestartingChild>(0, 1, socket_path_, 0, skipHotRestartOnNoParent());
+    hot_restarting_child_ = std::make_unique<HotRestartingChild>(
+        0, 1, socket_path_, 0, skipHotRestartOnNoParent(), skipParentStats());
     if (skipHotRestartOnNoParent()) {
       if (hotRestartIsSkipped()) {
         // A message is attempted to be sent to the parent and returns ECONNREFUSED.
@@ -121,6 +121,7 @@ public:
   std::unique_ptr<HotRestartingChild> hot_restarting_child_;
   virtual bool skipHotRestartOnNoParent() const { return false; }
   virtual bool hotRestartIsSkipped() const { return false; }
+  virtual bool skipParentStats() const { return false; }
 };
 
 class HotRestartingChildWithSkipTest : public HotRestartingChildTest {

--- a/test/server/hot_restarting_parent_test.cc
+++ b/test/server/hot_restarting_parent_test.cc
@@ -299,7 +299,7 @@ TEST_F(HotRestartingParentTest, RetainDynamicStats) {
     Stats::Gauge& g2 = child_store.rootScope()->gaugeFromStatName(
         dynamic.add("g2"), Stats::Gauge::ImportMode::Accumulate);
 
-    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0, false);
+    HotRestartingChild hot_restarting_child(0, 0, testDomainSocketName(), 0, false, false);
     hot_restarting_child.mergeParentStats(child_store, stats_proto);
     EXPECT_EQ(1, c1.value());
     EXPECT_EQ(1, c2.value());

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -96,6 +96,8 @@ TEST_F(OptionsImplTest, All) {
       "--local-address-ip-version v6 -l info --component-log-level upstream:debug,connection:trace "
       "--service-cluster cluster --service-node node --service-zone zone "
       "--file-flush-interval-msec 9000 "
+      "--skip-hot-restart-on-no-parent "
+      "--skip-hot-restart-parent-stats "
       "--drain-time-s 60 --log-format [%v] --enable-fine-grain-logging --parent-shutdown-time-s 90 "
       "--log-path "
       "/foo/bar "
@@ -114,6 +116,8 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(2, options->componentLogLevels().size());
   EXPECT_EQ("[%v]", options->logFormat());
   EXPECT_TRUE(options->logFormatSet());
+  EXPECT_TRUE(options->skipHotRestartParentStats());
+  EXPECT_TRUE(options->skipHotRestartOnNoParent());
   EXPECT_EQ("/foo/bar", options->logPath());
   EXPECT_EQ(true, options->enableFineGrainLogging());
   EXPECT_EQ("cluster", options->serviceClusterName());
@@ -517,6 +521,12 @@ TEST_F(OptionsImplTest, LogFormatDefault) {
   std::unique_ptr<OptionsImpl> options = createOptionsImpl({"envoy", "-c", "hello"});
   EXPECT_EQ(options->logFormat(), "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v");
   EXPECT_FALSE(options->logFormatSet());
+}
+
+TEST_F(OptionsImplTest, SkipHotRestartDefaults) {
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl({"envoy", "-c", "hello"});
+  EXPECT_FALSE(options->skipHotRestartOnNoParent());
+  EXPECT_FALSE(options->skipHotRestartParentStats());
 }
 
 TEST_F(OptionsImplTest, LogFormatOverride) {


### PR DESCRIPTION
Commit Message: Add command line flag to skip hot restart stats transfer
Additional Description: We had a number of issues with production servers having their main thread stuck trying to get stats from the parent instance. We're not entirely sure what the cause was, but we know stats can get big, we know that's where it was stuck, and we know there was 3 minutes of spare time during which the drain *should have* completed before the parent instance was hard-killed. It's possible that an out of memory occurred, it's possible the stream had a problem with the volume of data, it's possible there's a bug that causes the parent instance to lock up or crash during the stats retrieval, but one thing we can be confident of is that if we don't go down that branch at all then none of those things will happen.
Risk Level: Extremely small; no change to the usual behavior, only a change if a new command-line flag is set.
Testing: Minimal. The coverage is the same as it was before, or very slightly better.
Docs Changes: Added documentation for the command line option.
Release Notes: Yes.
Platform Specific Features: Not relevant to Windows because hot restart isn't supported there.
Relevant to: #33446