### PR TITLE
OTel AccessLogger: support log_written/dropped for OTel partial rejected log records

### DIFF
--- a/source/extensions/access_loggers/common/BUILD
+++ b/source/extensions/access_loggers/common/BUILD
@@ -56,9 +56,28 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "grpc_access_logger_clients_lib",
+    hdrs = ["grpc_access_logger_clients.h"],
+    deps = [
+        ":grpc_access_logger_utils_lib",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/grpc:async_client_manager_interface",
+        "//envoy/singleton:instance_interface",
+        "//envoy/stats:stats_interface",
+        "//envoy/thread_local:thread_local_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/grpc:typed_async_client_lib",
+        "//source/common/protobuf:utility_lib",
+        "@com_google_absl//absl/types:optional",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "grpc_access_logger",
     hdrs = ["grpc_access_logger.h"],
     deps = [
+        ":grpc_access_logger_clients_lib",
         ":grpc_access_logger_utils_lib",
         "//envoy/event:dispatcher_interface",
         "//envoy/grpc:async_client_manager_interface",

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -14,6 +14,7 @@
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/tracing/null_span_impl.h"
+#include "source/extensions/access_loggers/common/grpc_access_logger_clients.h"
 #include "source/extensions/access_loggers/common/grpc_access_logger_utils.h"
 
 #include "absl/container/flat_hash_map.h"
@@ -75,126 +76,6 @@ public:
   getOrCreateLogger(const ConfigProto& config, GrpcAccessLoggerType logger_type) PURE;
 };
 
-template <typename LogRequest, typename LogResponse> class GrpcAccessLogClient {
-public:
-  virtual ~GrpcAccessLogClient() = default;
-  virtual bool isConnected() PURE;
-  virtual bool log(const LogRequest& request) PURE;
-
-protected:
-  GrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
-                      const Protobuf::MethodDescriptor& service_method,
-                      OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
-      : client_(client), service_method_(service_method),
-        opts_(createRequestOptionsForRetry(retry_policy)) {}
-
-  Grpc::AsyncClient<LogRequest, LogResponse> client_;
-  const Protobuf::MethodDescriptor& service_method_;
-  const Http::AsyncClient::RequestOptions opts_;
-
-private:
-  Http::AsyncClient::RequestOptions
-  createRequestOptionsForRetry(OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy) {
-    auto opt = Http::AsyncClient::RequestOptions();
-
-    if (!retry_policy) {
-      return opt;
-    }
-
-    const auto grpc_retry_policy =
-        Http::Utility::convertCoreToRouteRetryPolicy(*retry_policy, "connect-failure");
-    opt.setBufferBodyForRetry(true);
-    opt.setRetryPolicy(grpc_retry_policy);
-    return opt;
-  }
-};
-
-template <typename LogRequest, typename LogResponse>
-class UnaryGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
-public:
-  UnaryGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
-                           const Protobuf::MethodDescriptor& service_method,
-                           OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
-      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method, retry_policy) {}
-
-  bool isConnected() override { return false; }
-
-  bool log(const LogRequest& request) override {
-    GrpcAccessLogClient<LogRequest, LogResponse>::client_->send(
-        GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, request, request_cb_,
-        Tracing::NullSpan::instance(), GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
-    return true;
-  }
-
-  struct RequestCallbacks : public Grpc::AsyncRequestCallbacks<LogResponse> {
-    // Grpc::AsyncRequestCallbacks
-    void onSuccess(Grpc::ResponsePtr<LogResponse>&&, Tracing::Span&) override {}
-    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
-    void onFailure(Grpc::Status::GrpcStatus, const std::string&, Tracing::Span&) override {}
-  };
-
-private:
-  RequestCallbacks request_cb_;
-};
-
-template <typename LogRequest, typename LogResponse>
-class StreamingGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
-public:
-  StreamingGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
-                               const Protobuf::MethodDescriptor& service_method,
-                               OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
-      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method, retry_policy) {}
-
-public:
-  struct LocalStream : public Grpc::AsyncStreamCallbacks<LogResponse> {
-    LocalStream(StreamingGrpcAccessLogClient& parent) : parent_(parent) {}
-
-    // Grpc::AsyncStreamCallbacks
-    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
-    void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
-    void onReceiveMessage(std::unique_ptr<LogResponse>&&) override {}
-    void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
-    void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override {
-      ASSERT(parent_.stream_ != nullptr);
-      if (parent_.stream_->stream_ != nullptr) {
-        // Only reset if we have a stream. Otherwise we had an inline failure and we will clear the
-        // stream data in send().
-        parent_.stream_.reset();
-      }
-    }
-
-    StreamingGrpcAccessLogClient& parent_;
-    Grpc::AsyncStream<LogRequest> stream_{};
-  };
-
-  bool isConnected() override { return stream_ != nullptr && stream_->stream_ != nullptr; }
-
-  bool log(const LogRequest& request) override {
-    if (!stream_) {
-      stream_ = std::make_unique<LocalStream>(*this);
-    }
-
-    if (stream_->stream_ == nullptr) {
-      stream_->stream_ = GrpcAccessLogClient<LogRequest, LogResponse>::client_->start(
-          GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, *stream_,
-          GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
-    }
-
-    if (stream_->stream_ != nullptr) {
-      if (stream_->stream_->isAboveWriteBufferHighWatermark()) {
-        return false;
-      }
-      stream_->stream_->sendMessage(request, false);
-    } else {
-      // Clear out the stream data due to stream creation failure.
-      stream_.reset();
-    }
-    return true;
-  }
-
-  std::unique_ptr<LocalStream> stream_;
-};
-
 } // namespace Detail
 
 /**
@@ -222,26 +103,22 @@ class GrpcAccessLogger : public Detail::GrpcAccessLogger<HttpLogProto, TcpLogPro
 public:
   using Interface = Detail::GrpcAccessLogger<HttpLogProto, TcpLogProto>;
   GrpcAccessLogger(
-      const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-      Event::Dispatcher& dispatcher, Stats::Scope& scope, std::string access_log_prefix,
-      const Protobuf::MethodDescriptor& service_method, bool stream = true)
-      : buffer_flush_interval_msec_(
-            PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),
+      Event::Dispatcher& dispatcher, Stats::Scope& scope,
+      std::optional<std::string> access_log_prefix,
+      std::unique_ptr<GrpcAccessLogClient<LogRequest, LogResponse>> client)
+      : client_(std::move(client)), buffer_flush_interval_msec_(PROTOBUF_GET_MS_OR_DEFAULT(
+                                        config, buffer_flush_interval, 1000)),
         flush_timer_(dispatcher.createTimer([this]() {
           flush();
           flush_timer_->enableTimer(buffer_flush_interval_msec_);
         })),
-        max_buffer_size_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384)),
-        stats_({ALL_GRPC_ACCESS_LOGGER_STATS(POOL_COUNTER_PREFIX(scope, access_log_prefix))}) {
-    if (stream) {
-      client_ = std::make_unique<Detail::StreamingGrpcAccessLogClient<LogRequest, LogResponse>>(
-          client, service_method, GrpcCommon::optionalRetryPolicy(config));
-    } else {
-      client_ = std::make_unique<Detail::UnaryGrpcAccessLogClient<LogRequest, LogResponse>>(
-          client, service_method, GrpcCommon::optionalRetryPolicy(config));
-    }
+        max_buffer_size_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384)) {
     flush_timer_->enableTimer(buffer_flush_interval_msec_);
+    if (access_log_prefix.has_value()) {
+      stats_ = std::make_unique<GrpcAccessLoggerStats>(GrpcAccessLoggerStats{
+          ALL_GRPC_ACCESS_LOGGER_STATS(POOL_COUNTER_PREFIX(scope, access_log_prefix.value()))});
+    }
   }
 
   void log(HttpLogProto&& entry) override {
@@ -264,7 +141,7 @@ public:
   }
 
 protected:
-  std::unique_ptr<Detail::GrpcAccessLogClient<LogRequest, LogResponse>> client_;
+  std::unique_ptr<GrpcAccessLogClient<LogRequest, LogResponse>> client_;
   LogRequest message_;
 
 private:
@@ -291,25 +168,45 @@ private:
     }
   }
 
+  // `canLogMore()` is only for streaming gRPC client only which could run into
+  // AboveWriteBufferHighWatermark during `flush()` so that we tracks the log entries dropped caused
+  // by that.
+  //
+  // For unary gRPC client, `canLogMore` always returns True[1][2] so `stats_` here is meaningless.
+  //
+  // [1]https://github.com/envoyproxy/envoy/blob/cd5ef906026160ec2cd766d8d18217e668c256d8/source/extensions/access_loggers/common/grpc_access_logger.h#L287.
+  // [2]https://github.com/envoyproxy/envoy/blob/cd5ef906026160ec2cd766d8d18217e668c256d8/source/extensions/access_loggers/common/grpc_access_logger.h#L126
   bool canLogMore() {
     if (max_buffer_size_bytes_ == 0 || approximate_message_size_bytes_ < max_buffer_size_bytes_) {
-      stats_.logs_written_.inc();
+      incLogsWrittenStats();
       return true;
     }
     flush();
     if (approximate_message_size_bytes_ < max_buffer_size_bytes_) {
-      stats_.logs_written_.inc();
+      incLogsWrittenStats();
       return true;
     }
-    stats_.logs_dropped_.inc();
+    incLogsDroppedStats();
     return false;
+  }
+
+  void incLogsDroppedStats() {
+    if (stats_) {
+      stats_->logs_dropped_.inc();
+    }
+  }
+
+  void incLogsWrittenStats() {
+    if (stats_) {
+      stats_->logs_written_.inc();
+    }
   }
 
   const std::chrono::milliseconds buffer_flush_interval_msec_;
   const Event::TimerPtr flush_timer_;
   const uint64_t max_buffer_size_bytes_;
   uint64_t approximate_message_size_bytes_ = 0;
-  GrpcAccessLoggerStats stats_;
+  std::unique_ptr<GrpcAccessLoggerStats> stats_ = nullptr;
 };
 
 /**

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -105,7 +105,7 @@ public:
   GrpcAccessLogger(
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
       Event::Dispatcher& dispatcher, Stats::Scope& scope,
-      std::optional<std::string> access_log_prefix,
+      absl::optional<std::string> access_log_prefix,
       std::unique_ptr<GrpcAccessLogClient<LogRequest, LogResponse>> client)
       : client_(std::move(client)), buffer_flush_interval_msec_(PROTOBUF_GET_MS_OR_DEFAULT(
                                         config, buffer_flush_interval, 1000)),

--- a/source/extensions/access_loggers/common/grpc_access_logger_clients.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger_clients.h
@@ -61,7 +61,7 @@ private:
 template <typename LogRequest, typename LogResponse>
 class UnaryGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
 public:
-  typedef std::function<Grpc::AsyncRequestCallbacks<LogResponse>*()> AsyncRequestCallbacksFactory;
+  typedef std::function<Grpc::AsyncRequestCallbacks<LogResponse>&()> AsyncRequestCallbacksFactory;
 
   UnaryGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
                            const Protobuf::MethodDescriptor& service_method,
@@ -75,7 +75,7 @@ public:
   bool log(const LogRequest& request) override {
     GrpcAccessLogClient<LogRequest, LogResponse>::client_->send(
         GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, request,
-        *callbacks_factory_(), Tracing::NullSpan::instance(),
+        callbacks_factory_(), Tracing::NullSpan::instance(),
         GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
     return true;
   }

--- a/source/extensions/access_loggers/common/grpc_access_logger_clients.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger_clients.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/grpc/async_client_manager.h"
+#include "envoy/singleton/instance.h"
+#include "envoy/stats/scope.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/grpc/typed_async_client.h"
+#include "source/common/http/utility.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/tracing/null_span_impl.h"
+#include "source/extensions/access_loggers/common/grpc_access_logger_utils.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace AccessLoggers {
+namespace Common {
+
+template <typename LogRequest, typename LogResponse> class GrpcAccessLogClient {
+public:
+  virtual ~GrpcAccessLogClient() = default;
+  virtual bool isConnected() PURE;
+  virtual bool log(const LogRequest& request) PURE;
+
+protected:
+  GrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
+                      const Protobuf::MethodDescriptor& service_method,
+                      OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
+      : client_(client), service_method_(service_method),
+        opts_(createRequestOptionsForRetry(retry_policy)) {}
+
+  Grpc::AsyncClient<LogRequest, LogResponse> client_;
+  const Protobuf::MethodDescriptor& service_method_;
+  const Http::AsyncClient::RequestOptions opts_;
+
+private:
+  Http::AsyncClient::RequestOptions
+  createRequestOptionsForRetry(OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy) {
+    auto opt = Http::AsyncClient::RequestOptions();
+
+    if (!retry_policy) {
+      return opt;
+    }
+
+    const auto grpc_retry_policy =
+        Http::Utility::convertCoreToRouteRetryPolicy(*retry_policy, "connect-failure");
+    opt.setBufferBodyForRetry(true);
+    opt.setRetryPolicy(grpc_retry_policy);
+    return opt;
+  }
+};
+
+template <typename LogRequest, typename LogResponse>
+class UnaryGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
+public:
+  UnaryGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
+                           const Protobuf::MethodDescriptor& service_method,
+                           OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy,
+                           Grpc::AsyncRequestCallbacks<LogResponse>& request_callbacks)
+      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method, retry_policy),
+        request_cb_(request_callbacks) {}
+
+  bool isConnected() override { return false; }
+
+  bool log(const LogRequest& request) override {
+    GrpcAccessLogClient<LogRequest, LogResponse>::client_->send(
+        GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, request, request_cb_,
+        Tracing::NullSpan::instance(), GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
+    return true;
+  }
+
+private:
+  Grpc::AsyncRequestCallbacks<LogResponse>& request_cb_;
+};
+
+template <typename LogRequest, typename LogResponse>
+class StreamingGrpcAccessLogClient : public GrpcAccessLogClient<LogRequest, LogResponse> {
+public:
+  StreamingGrpcAccessLogClient(const Grpc::RawAsyncClientSharedPtr& client,
+                               const Protobuf::MethodDescriptor& service_method,
+                               OptRef<const envoy::config::core::v3::RetryPolicy> retry_policy)
+      : GrpcAccessLogClient<LogRequest, LogResponse>(client, service_method, retry_policy) {}
+
+public:
+  struct LocalStream : public Grpc::AsyncStreamCallbacks<LogResponse> {
+    LocalStream(StreamingGrpcAccessLogClient& parent) : parent_(parent) {}
+
+    // Grpc::AsyncStreamCallbacks
+    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
+    void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
+    void onReceiveMessage(std::unique_ptr<LogResponse>&&) override {}
+    void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
+    void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override {
+      ASSERT(parent_.stream_ != nullptr);
+      if (parent_.stream_->stream_ != nullptr) {
+        // Only reset if we have a stream. Otherwise we had an inline failure and we will clear the
+        // stream data in send().
+        parent_.stream_.reset();
+      }
+    }
+
+    StreamingGrpcAccessLogClient& parent_;
+    Grpc::AsyncStream<LogRequest> stream_{};
+  };
+
+  bool isConnected() override { return stream_ != nullptr && stream_->stream_ != nullptr; }
+
+  bool log(const LogRequest& request) override {
+    if (!stream_) {
+      stream_ = std::make_unique<LocalStream>(*this);
+    }
+
+    if (stream_->stream_ == nullptr) {
+      stream_->stream_ = GrpcAccessLogClient<LogRequest, LogResponse>::client_->start(
+          GrpcAccessLogClient<LogRequest, LogResponse>::service_method_, *stream_,
+          GrpcAccessLogClient<LogRequest, LogResponse>::opts_);
+    }
+
+    if (stream_->stream_ != nullptr) {
+      if (stream_->stream_->isAboveWriteBufferHighWatermark()) {
+        return false;
+      }
+      stream_->stream_->sendMessage(request, false);
+    } else {
+      // Clear out the stream data due to stream creation failure.
+      stream_.reset();
+    }
+    return true;
+  }
+
+  std::unique_ptr<LocalStream> stream_;
+};
+
+} // namespace Common
+} // namespace AccessLoggers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/access_loggers/grpc/BUILD
+++ b/source/extensions/access_loggers/grpc/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/grpc:typed_async_client_lib",
         "//source/extensions/access_loggers/common:grpc_access_logger",
+        "//source/extensions/access_loggers/common:grpc_access_logger_clients_lib",
         "@envoy_api//envoy/data/accesslog/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/accesslog/v3:pkg_cc_proto",

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
@@ -7,6 +7,7 @@
 
 #include "source/common/config/utility.h"
 #include "source/common/grpc/typed_async_client.h"
+#include "source/extensions/access_loggers/common/grpc_access_logger_clients.h"
 
 const char GRPC_LOG_STATS_PREFIX[] = "access_logs.grpc_access_log.";
 
@@ -19,9 +20,14 @@ GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
     const Grpc::RawAsyncClientSharedPtr& client,
     const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
     Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope)
-    : GrpcAccessLogger(std::move(client), config, dispatcher, scope, GRPC_LOG_STATS_PREFIX,
-                       *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-                           "envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs")),
+    : GrpcAccessLogger(config, dispatcher, scope, GRPC_LOG_STATS_PREFIX,
+                       std::make_unique<Common::StreamingGrpcAccessLogClient<
+                           envoy::service::accesslog::v3::StreamAccessLogsMessage,
+                           envoy::service::accesslog::v3::StreamAccessLogsResponse>>(
+                           client,
+                           *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+                               "envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs"),
+                           GrpcCommon::optionalRetryPolicy(config))),
       log_name_(config.log_name()), local_info_(local_info) {}
 
 void GrpcAccessLoggerImpl::addEntry(envoy::data::accesslog::v3::HTTPAccessLogEntry&& entry) {

--- a/source/extensions/access_loggers/open_telemetry/BUILD
+++ b/source/extensions/access_loggers/open_telemetry/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//source/common/grpc:typed_async_client_lib",
         "//source/common/protobuf",
         "//source/extensions/access_loggers/common:grpc_access_logger",
+        "//source/extensions/access_loggers/common:grpc_access_logger_clients_lib",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/open_telemetry/v3:pkg_cc_proto",
         "@opentelemetry_proto//:logs_cc_proto",

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -56,8 +56,11 @@ std::function<GrpcAccessLoggerImpl::OTelLogRequestCallbacks*()>
 GrpcAccessLoggerImpl::genOTelCallbacksFactory() {
   return [this]() {
     OTelLogRequestCallbacks* ptr = new OTelLogRequestCallbacks(
-        this->stats_, this->batched_log_entries_,
-        [this](OTelLogRequestCallbacks* p) { this->callbacks_.erase(p); });
+        this->stats_, this->batched_log_entries_, [this](OTelLogRequestCallbacks* p) {
+          if (this->callbacks_.contains(p)) {
+            this->callbacks_.erase(p);
+          }
+        });
     this->batched_log_entries_ = 0;
     this->callbacks_.emplace(ptr, ptr);
     return ptr;

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -50,8 +50,8 @@ GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
               GrpcCommon::optionalRetryPolicy(config.common_config()),
               [this, &dispatcher]() {
                 // It will be deleted in the callbacks.
-                auto* callback = new OTelLogRequestCallbacks(dispatcher, this->stats_,
-                                                             this->batched_log_entries_);
+                auto* callback = new OTelLogRequestCallbacks(
+                    dispatcher, this->stats_, this->batched_log_entries_, this->destructing_);
                 this->batched_log_entries_ = 0;
                 return callback;
               })),

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
@@ -93,7 +93,7 @@ private:
   void initMessage() override;
   void clearMessage() override;
 
-  std::function<OTelLogRequestCallbacks*()> genOTelCallbacksFactory();
+  std::function<OTelLogRequestCallbacks&()> genOTelCallbacksFactory();
 
   opentelemetry::proto::logs::v1::ScopeLogs* root_;
   Common::GrpcAccessLoggerStats stats_;

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -67,7 +67,8 @@ public:
           client, service_method, GrpcCommon::optionalRetryPolicy(config));
     return std::make_unique<
         Common::UnaryGrpcAccessLogClient<ProtobufWkt::Struct, ProtobufWkt::Struct>>(
-        client, service_method, GrpcCommon::optionalRetryPolicy(config), [this]() { return this; });
+        client, service_method, GrpcCommon::optionalRetryPolicy(config),
+        [this]() -> MockGrpcAccessLoggerImpl& { return *this; });
   }
 
   int numInits() const { return num_inits_; }

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -67,7 +67,7 @@ public:
           client, service_method, GrpcCommon::optionalRetryPolicy(config));
     return std::make_unique<
         Common::UnaryGrpcAccessLogClient<ProtobufWkt::Struct, ProtobufWkt::Struct>>(
-        client, service_method, GrpcCommon::optionalRetryPolicy(config), *this);
+        client, service_method, GrpcCommon::optionalRetryPolicy(config), [this]() { return this; });
   }
 
   int numInits() const { return num_inits_; }

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -45,19 +45,39 @@ const Protobuf::MethodDescriptor& mockMethodDescriptor() {
 // standard Struct and Empty protos.
 class MockGrpcAccessLoggerImpl
     : public Common::GrpcAccessLogger<ProtobufWkt::Struct, ProtobufWkt::Empty, ProtobufWkt::Struct,
-                                      ProtobufWkt::Struct> {
+                                      ProtobufWkt::Struct>,
+      public Grpc::AsyncRequestCallbacks<ProtobufWkt::Struct> {
 public:
   MockGrpcAccessLoggerImpl(
       const Grpc::RawAsyncClientSharedPtr& client,
       const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
       Event::Dispatcher& dispatcher, Stats::Scope& scope, std::string access_log_prefix,
       const Protobuf::MethodDescriptor& service_method, bool stream)
-      : GrpcAccessLogger(std::move(client), config, dispatcher, scope, access_log_prefix,
-                         service_method, stream) {}
+      : GrpcAccessLogger(config, dispatcher, scope, access_log_prefix,
+                         createGrpcAccessLoggClient(stream, client, service_method, config)) {}
+
+  std::unique_ptr<Common::GrpcAccessLogClient<ProtobufWkt::Struct, ProtobufWkt::Struct>>
+  createGrpcAccessLoggClient(
+      bool stream, const Grpc::RawAsyncClientSharedPtr& client,
+      const Protobuf::MethodDescriptor& service_method,
+      const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config) {
+    if (stream)
+      return std::make_unique<
+          Common::StreamingGrpcAccessLogClient<ProtobufWkt::Struct, ProtobufWkt::Struct>>(
+          client, service_method, GrpcCommon::optionalRetryPolicy(config));
+    return std::make_unique<
+        Common::UnaryGrpcAccessLogClient<ProtobufWkt::Struct, ProtobufWkt::Struct>>(
+        client, service_method, GrpcCommon::optionalRetryPolicy(config), *this);
+  }
 
   int numInits() const { return num_inits_; }
 
   int numClears() const { return num_clears_; }
+
+  void onSuccess(Grpc::ResponsePtr<ProtobufWkt::Struct>&&, Tracing::Span&) override {}
+  void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
+
+  void onFailure(Grpc::Status::GrpcStatus, const std::string&, Tracing::Span&) override {}
 
 private:
   void mockAddEntry(const std::string& key) {

--- a/test/extensions/access_loggers/open_telemetry/access_log_integration_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_integration_test.cc
@@ -124,6 +124,10 @@ public:
 
     EXPECT_TRUE(TestUtility::protoEqual(request_msg, expected_request_msg,
                                         /*ignore_repeated_field_ordering=*/false));
+    opentelemetry::proto::collector::logs::v1::ExportLogsServiceResponse response;
+    access_log_request_->startGrpcStream();
+    access_log_request_->sendGrpcMessage(response);
+    access_log_request_->finishGrpcStream(Grpc::Status::Ok);
     return AssertionSuccess();
   }
 

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -128,7 +128,6 @@ TEST_F(GrpcAccessLoggerImplTest, Log) {
   )EOF");
   opentelemetry::proto::logs::v1::LogRecord entry;
   entry.set_severity_text("test-severity-text");
-  EXPECT_CALL(dispatcher_, deferredDelete_(_));
   logger_->log(opentelemetry::proto::logs::v1::LogRecord(entry));
   EXPECT_EQ(stats_store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
                 .value()
@@ -168,7 +167,6 @@ TEST_F(GrpcAccessLoggerImplTest, LogWithStats) {
   grpc_access_logger_impl_test_helper_.expectSentMessage(expected_message_yaml);
   opentelemetry::proto::logs::v1::LogRecord entry;
   entry.set_severity_text("test-severity-text");
-  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(2);
   logger_->log(opentelemetry::proto::logs::v1::LogRecord(entry));
   EXPECT_EQ(stats_store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
                 .value()

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -128,6 +128,7 @@ TEST_F(GrpcAccessLoggerImplTest, Log) {
   )EOF");
   opentelemetry::proto::logs::v1::LogRecord entry;
   entry.set_severity_text("test-severity-text");
+  EXPECT_CALL(dispatcher_, deferredDelete_(_));
   logger_->log(opentelemetry::proto::logs::v1::LogRecord(entry));
   EXPECT_EQ(stats_store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
                 .value()
@@ -167,6 +168,7 @@ TEST_F(GrpcAccessLoggerImplTest, LogWithStats) {
   grpc_access_logger_impl_test_helper_.expectSentMessage(expected_message_yaml);
   opentelemetry::proto::logs::v1::LogRecord entry;
   entry.set_severity_text("test-severity-text");
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(2);
   logger_->log(opentelemetry::proto::logs::v1::LogRecord(entry));
   EXPECT_EQ(stats_store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
                 .value()


### PR DESCRIPTION
This PR makes the OTel access logger to support log_written/log_dropped tracking
- failed gRPC requests
- partial rejected log entries, which is supported by [OTel protocol](https://github.com/open-telemetry/opentelemetry-proto/blob/b3060d2104df364136d75a35779e6bd48bac449a/opentelemetry/proto/collector/logs/v1/logs_service.proto#L69)

**Context**:
- After https://github.com/envoyproxy/envoy/pull/24268, OTel AccessLogger uses unary async client.
- The current `log_written/log_dropped` tracked in GrpcAccessLogger doesn't make sense for unary gRPC client, which always increment log_written for each incoming log entry. It couldn't record the 2 cases mentioned above.


**What this PR contains**:
- move grpc access loggers clients to a new file and make them DI for GrpcAccessLogger
- for unary async case, move `log_written/log_dropped` from GrpcAccessLogger to OpenTelemetry::GrpcAccessLoggerImpl while no changes for streaming case.
- add an AsyncUnaryRequestCallbacks so that it can record the number of log entries on the fly and record correctly in the callback
