### PR TITLE
tools/notify: Add link to unassigned PRs

### DIFF
--- a/tools/repo/notify.py
+++ b/tools/repo/notify.py
@@ -33,7 +33,7 @@ ENVOY_REPO = "envoyproxy/envoy"
 CALENDAR = "https://calendar.google.com/calendar/ical/d6glc0l5rc3v235q9l2j29dgovh3dn48%40import.calendar.google.com/public/basic.ics"
 
 ISSUE_LINK = "https://github.com/envoyproxy/envoy/issues?q=is%3Aissue+is%3Aopen+label%3Atriage"
-PR_LINK = "https://github.com/envoyproxy/envoy/pulls?q=is%3Apr+is%3Aopen+no%3Aassignee+draft%3Afalse+-author%3Aapp%2Fdependabot"
+PR_LINK = "https://github.com/envoyproxy/envoy/pulls?q=is%3Apr+draft%3Afalse+-author%3Aapp%2Fdependabot"
 SLACK_EXPORT_URL = "https://api.slack.com/apps/A023NPQQ33K/oauth?"
 
 
@@ -158,6 +158,14 @@ class RepoNotifier(runner.Runner):
     def opsgenie_to_slack(self):
         return {v["opsgenie"]: v["slack"] for v in self.reviewers.values() if "opsgenie" in v}
 
+    @cached_property
+    def pr_link(self):
+        exclude_maintainers = "".join(
+            f"+-assignee%3A{assignee}"
+            for assignee
+            in self.maintainers)
+        return f"{PR_LINK}{exclude_maintainers}"
+
     @async_property(cache=True)
     async def tracked_prs(self):
         # A dict of maintainer : outstanding_pr_string to be sent to slack
@@ -270,7 +278,7 @@ class RepoNotifier(runner.Runner):
             await self.send_message(
                 channel='#envoy-maintainer-oncall',
                 text=(
-                    f"*'Unassigned' PRs* (PRs with no maintainer assigned)\n{unassigned}\n<{PR_LINK}|{PR_LINK}>"
+                    f"*'Unassigned' PRs* (PRs with no maintainer assigned)\n{unassigned}\n<{self.pr_link}|{self.pr_link}>"
                 ))
             await self.send_message(
                 channel='#envoy-maintainer-oncall',

--- a/tools/repo/notify.py
+++ b/tools/repo/notify.py
@@ -33,6 +33,7 @@ ENVOY_REPO = "envoyproxy/envoy"
 CALENDAR = "https://calendar.google.com/calendar/ical/d6glc0l5rc3v235q9l2j29dgovh3dn48%40import.calendar.google.com/public/basic.ics"
 
 ISSUE_LINK = "https://github.com/envoyproxy/envoy/issues?q=is%3Aissue+is%3Aopen+label%3Atriage"
+PR_LINK = "https://github.com/envoyproxy/envoy/pulls?q=is%3Apr+is%3Aopen+no%3Aassignee+draft%3Afalse+-author%3Aapp%2Fdependabot"
 SLACK_EXPORT_URL = "https://api.slack.com/apps/A023NPQQ33K/oauth?"
 
 
@@ -268,7 +269,9 @@ class RepoNotifier(runner.Runner):
                 channel='#envoy-maintainer-oncall', text=(f"Oncall now <@{oncall_handle}>"))
             await self.send_message(
                 channel='#envoy-maintainer-oncall',
-                text=(f"*'Unassigned' PRs* (PRs with no maintainer assigned)\n{unassigned}"))
+                text=(
+                    f"*'Unassigned' PRs* (PRs with no maintainer assigned)\n{unassigned}\n<{PR_LINK}|{PR_LINK}>"
+                ))
             await self.send_message(
                 channel='#envoy-maintainer-oncall',
                 text=(f"*Stalled PRs* (PRs with review out-SLO, please address)\n{stalled}"))


### PR DESCRIPTION
adds a link to unassigned PRs, excluding draft and dependabot PRs

https://github.com/envoyproxy/envoy/pulls?q=is%3Apr+is%3Aopen+no%3Aassignee+draft%3Afalse+-author%3Aapp%2Fdependabot

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
