### PR TITLE
[balsa] Add tests to document behavior when header value contains CR or LF.

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -5001,7 +5001,6 @@ TEST_P(Http1ServerConnectionImplTest, ValueStartsWithLF) {
   const absl::string_view expected_value = "value starts with line feed";
   testRequestWithValueExpectSuccess(value, expected_value);
 }
-}
 
 TEST_P(Http1ServerConnectionImplTest, ValueWithLFInTheMiddle) {
   const absl::string_view value = "value has \n line feed in the middle";

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -198,6 +198,7 @@ public:
 
   void testServerAllowChunkedContentLength(uint32_t content_length, bool allow_chunked_length);
 
+  void testRequestWithValueExpectSuccess(absl::string_view value, absl::string_view expected_value);
   void testRequestWithValueExpectFailure(absl::string_view value,
                                          absl::string_view expected_error_details,
                                          absl::string_view expected_error_message);
@@ -2555,6 +2556,7 @@ public:
   Http::ClientConnectionPtr codec_;
 
   void testClientAllowChunkedContentLength(uint32_t content_length, bool allow_chunked_length);
+  void testRequestWithValueExpectSuccess(absl::string_view value, absl::string_view expected_value);
   void testRequestWithValueExpectFailure(absl::string_view value,
                                          absl::string_view expected_error_message);
 
@@ -4888,6 +4890,26 @@ TEST_P(Http1ClientConnectionImplTest, ObsFold) {
   // SPELLCHECKER(on)
 }
 
+void Http1ServerConnectionImplTest::testRequestWithValueExpectSuccess(
+    absl::string_view value, absl::string_view expected_value) {
+  initialize();
+
+  StrictMock<MockRequestDecoder> decoder;
+  TestRequestHeaderMapImpl expected_headers{
+      {":path", "/"},
+      {":method", "GET"},
+      {"key", std::string(expected_value)},
+  };
+  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
+  EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
+
+  Buffer::OwnedImpl buffer(absl::StrCat("GET / HTTP/1.1\r\n"
+                                        "key: ",
+                                        value, "\r\n\r\n"));
+  auto status = codec_->dispatch(buffer);
+  EXPECT_TRUE(status.ok());
+}
+
 void Http1ServerConnectionImplTest::testRequestWithValueExpectFailure(
     absl::string_view value, absl::string_view expected_error_details,
     absl::string_view expected_error_message) {
@@ -4941,6 +4963,80 @@ TEST_P(Http1ServerConnectionImplTest, ValueEndsWithNullCharacter) {
   }
 }
 
+TEST_P(Http1ServerConnectionImplTest, ValueStartsWithCR) {
+  const absl::string_view value = "\r value starts with carriage return";
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    const absl::string_view expected_value = "value starts with carriage return";
+    testRequestWithValueExpectSuccess(value, expected_value);
+  } else {
+    testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_STRICT");
+  }
+}
+
+TEST_P(Http1ServerConnectionImplTest, ValueWithCRInTheMiddle) {
+  const absl::string_view value = "value has \r carriage return in the middle";
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    const absl::string_view expected_value = "value has  carriage return in the middle";
+    testRequestWithValueExpectSuccess(value, expected_value);
+  } else {
+    testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_LF_EXPECTED");
+  }
+}
+
+TEST_P(Http1ServerConnectionImplTest, ValueEndsWithCR) {
+  const absl::string_view value = "value ends in carriage return \r";
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    const absl::string_view expected_value = "value ends in carriage return";
+    testRequestWithValueExpectSuccess(value, expected_value);
+  } else {
+    testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_LF_EXPECTED");
+  }
+}
+
+TEST_P(Http1ServerConnectionImplTest, ValueStartsWithLF) {
+  const absl::string_view value = "\n value starts with line feed";
+  const absl::string_view expected_value = "value starts with line feed";
+  testRequestWithValueExpectSuccess(value, expected_value);
+}
+}
+
+TEST_P(Http1ServerConnectionImplTest, ValueWithLFInTheMiddle) {
+  const absl::string_view value = "value has \n line feed in the middle";
+  const absl::string_view expected_value = "value has  line feed in the middle";
+  testRequestWithValueExpectSuccess(value, expected_value);
+}
+
+TEST_P(Http1ServerConnectionImplTest, ValueEndsWithLF) {
+  const absl::string_view value = "value ends in line feed \n";
+  const absl::string_view expected_value = "value ends in line feed";
+  testRequestWithValueExpectSuccess(value, expected_value);
+}
+
+void Http1ClientConnectionImplTest::testRequestWithValueExpectSuccess(
+    absl::string_view value, absl::string_view expected_value) {
+  initialize();
+
+  NiceMock<MockResponseDecoder> response_decoder;
+  Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+  TestResponseHeaderMapImpl expected_headers{
+      {":status", "200"},
+      {"key", std::string(expected_value)},
+  };
+  EXPECT_CALL(response_decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
+
+  Buffer::OwnedImpl response(absl::StrCat("HTTP/1.1 200 OK\r\n"
+                                          "key: ",
+                                          value, "\r\n\r\n"));
+  auto status = codec_->dispatch(response);
+  EXPECT_TRUE(status.ok());
+}
+
 void Http1ClientConnectionImplTest::testRequestWithValueExpectFailure(
     absl::string_view value, absl::string_view expected_error_message) {
   initialize();
@@ -4987,6 +5083,57 @@ TEST_P(Http1ClientConnectionImplTest, ValueEndsWithNullCharacter) {
   } else {
     testRequestWithValueExpectFailure(value, "HPE_INVALID_HEADER_TOKEN");
   }
+}
+
+TEST_P(Http1ClientConnectionImplTest, ValueStartsWithCR) {
+  const absl::string_view value = "\r value starts with carriage return";
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    const absl::string_view expected_value = "value starts with carriage return";
+    testRequestWithValueExpectSuccess(value, expected_value);
+  } else {
+    testRequestWithValueExpectFailure(value, "HPE_STRICT");
+  }
+}
+
+TEST_P(Http1ClientConnectionImplTest, ValueWithCRInTheMiddle) {
+  const absl::string_view value = "value has \r carriage return in the middle";
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    const absl::string_view expected_value = "value has  carriage return in the middle";
+    testRequestWithValueExpectSuccess(value, expected_value);
+  } else {
+    testRequestWithValueExpectFailure(value, "HPE_LF_EXPECTED");
+  }
+}
+
+TEST_P(Http1ClientConnectionImplTest, ValueEndsWithCR) {
+  const absl::string_view value = "value ends in carriage return \r";
+
+  if (parser_impl_ == Http1ParserImpl::BalsaParser) {
+    const absl::string_view expected_value = "value ends in carriage return";
+    testRequestWithValueExpectSuccess(value, expected_value);
+  } else {
+    testRequestWithValueExpectFailure(value, "HPE_LF_EXPECTED");
+  }
+}
+
+TEST_P(Http1ClientConnectionImplTest, ValueStartsWithLF) {
+  const absl::string_view value = "\n value starts with line feed";
+  const absl::string_view expected_value = "value starts with line feed";
+  testRequestWithValueExpectSuccess(value, expected_value);
+}
+
+TEST_P(Http1ClientConnectionImplTest, ValueWithLFInTheMiddle) {
+  const absl::string_view value = "value has \n line feed in the middle";
+  const absl::string_view expected_value = "value has  line feed in the middle";
+  testRequestWithValueExpectSuccess(value, expected_value);
+}
+
+TEST_P(Http1ClientConnectionImplTest, ValueEndsWithLF) {
+  const absl::string_view value = "value ends in line feed \n";
+  const absl::string_view expected_value = "value ends in line feed";
+  testRequestWithValueExpectSuccess(value, expected_value);
 }
 
 } // namespace Http

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4970,7 +4970,11 @@ TEST_P(Http1ServerConnectionImplTest, ValueStartsWithCR) {
     const absl::string_view expected_value = "value starts with carriage return";
     testRequestWithValueExpectSuccess(value, expected_value);
   } else {
+#ifdef ENVOY_ENABLE_UHV
+    testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_INVALID_HEADER_TOKEN");
+#else
     testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_STRICT");
+#endif
   }
 }
 
@@ -5091,7 +5095,11 @@ TEST_P(Http1ClientConnectionImplTest, ValueStartsWithCR) {
     const absl::string_view expected_value = "value starts with carriage return";
     testRequestWithValueExpectSuccess(value, expected_value);
   } else {
+#ifdef ENVOY_ENABLE_UHV
+    testRequestWithValueExpectFailure(value, "HPE_INVALID_HEADER_TOKEN");
+#else
     testRequestWithValueExpectFailure(value, "HPE_STRICT");
+#endif
   }
 }
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -198,8 +198,9 @@ public:
 
   void testServerAllowChunkedContentLength(uint32_t content_length, bool allow_chunked_length);
 
-  void testValueHasNullCharacter(absl::string_view value, absl::string_view expected_error_details,
-                                 absl::string_view expected_error_message);
+  void testRequestWithValueExpectFailure(absl::string_view value,
+                                         absl::string_view expected_error_details,
+                                         absl::string_view expected_error_message);
 
   // Send the request, and validate the received request headers.
   // Then send a response just to clean up.
@@ -2554,7 +2555,8 @@ public:
   Http::ClientConnectionPtr codec_;
 
   void testClientAllowChunkedContentLength(uint32_t content_length, bool allow_chunked_length);
-  void testValueHasNullCharacter(absl::string_view value, absl::string_view expected_error_message);
+  void testRequestWithValueExpectFailure(absl::string_view value,
+                                         absl::string_view expected_error_message);
 
 protected:
   Stats::TestUtil::TestStore store_;
@@ -4886,7 +4888,7 @@ TEST_P(Http1ClientConnectionImplTest, ObsFold) {
   // SPELLCHECKER(on)
 }
 
-void Http1ServerConnectionImplTest::testValueHasNullCharacter(
+void Http1ServerConnectionImplTest::testRequestWithValueExpectFailure(
     absl::string_view value, absl::string_view expected_error_details,
     absl::string_view expected_error_message) {
   initialize();
@@ -4908,11 +4910,11 @@ TEST_P(Http1ServerConnectionImplTest, ValueStartsWithNullCharacter) {
   const std::string value = absl::StrCat(kNullCharacter, "value starts with null character");
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    testValueHasNullCharacter(value, "http1.invalid_characters",
-                              "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "http1.invalid_characters",
+                                      "header value contains invalid chars");
   } else {
-    testValueHasNullCharacter(value, "http1.invalid_characters",
-                              "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "http1.invalid_characters",
+                                      "header value contains invalid chars");
   }
 }
 
@@ -4921,10 +4923,10 @@ TEST_P(Http1ServerConnectionImplTest, ValueWithNullCharacterInTheMiddle) {
       absl::StrCat("value has", kNullCharacter, "null character in the middle");
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    testValueHasNullCharacter(value, "http1.invalid_characters",
-                              "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "http1.invalid_characters",
+                                      "header value contains invalid chars");
   } else {
-    testValueHasNullCharacter(value, "http1.codec_error", "HPE_INVALID_HEADER_TOKEN");
+    testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_INVALID_HEADER_TOKEN");
   }
 }
 
@@ -4932,14 +4934,14 @@ TEST_P(Http1ServerConnectionImplTest, ValueEndsWithNullCharacter) {
   const std::string value = absl::StrCat("value ends in null character", kNullCharacter);
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    testValueHasNullCharacter(value, "http1.invalid_characters",
-                              "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "http1.invalid_characters",
+                                      "header value contains invalid chars");
   } else {
-    testValueHasNullCharacter(value, "http1.codec_error", "HPE_INVALID_HEADER_TOKEN");
+    testRequestWithValueExpectFailure(value, "http1.codec_error", "HPE_INVALID_HEADER_TOKEN");
   }
 }
 
-void Http1ClientConnectionImplTest::testValueHasNullCharacter(
+void Http1ClientConnectionImplTest::testRequestWithValueExpectFailure(
     absl::string_view value, absl::string_view expected_error_message) {
   initialize();
 
@@ -4960,9 +4962,9 @@ TEST_P(Http1ClientConnectionImplTest, ValueStartsWithNullCharacter) {
   const std::string value = absl::StrCat(kNullCharacter, "value starts with null character");
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    testValueHasNullCharacter(value, "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "header value contains invalid chars");
   } else {
-    testValueHasNullCharacter(value, "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "header value contains invalid chars");
   }
 }
 
@@ -4971,9 +4973,9 @@ TEST_P(Http1ClientConnectionImplTest, ValueWithNullCharacterInTheMiddle) {
       absl::StrCat("value has", kNullCharacter, "null character in the middle");
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    testValueHasNullCharacter(value, "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "header value contains invalid chars");
   } else {
-    testValueHasNullCharacter(value, "HPE_INVALID_HEADER_TOKEN");
+    testRequestWithValueExpectFailure(value, "HPE_INVALID_HEADER_TOKEN");
   }
 }
 
@@ -4981,9 +4983,9 @@ TEST_P(Http1ClientConnectionImplTest, ValueEndsWithNullCharacter) {
   const std::string value = absl::StrCat("value ends in null character", kNullCharacter);
 
   if (parser_impl_ == Http1ParserImpl::BalsaParser) {
-    testValueHasNullCharacter(value, "header value contains invalid chars");
+    testRequestWithValueExpectFailure(value, "header value contains invalid chars");
   } else {
-    testValueHasNullCharacter(value, "HPE_INVALID_HEADER_TOKEN");
+    testRequestWithValueExpectFailure(value, "HPE_INVALID_HEADER_TOKEN");
   }
 }
 


### PR DESCRIPTION
These characters are invalid according to RFC9110 Section 5.5 [1].
Either the message must be rejected, or the characters replaced by SP
according to the RFC. These tests confirm that both http-parser and
BalsaParser indeed either reject the message or remove the forbidden
characters, though neither of them seem to insert a SP in their place.

Balsa implementation tracking issue: #21245

[1] https://www.rfc-editor.org/rfc/rfc9110.html#name-field-values

Commit Message: Add tests to document behavior when header value contains CR or LF.
Additional Description:
Risk Level: low, test-only change
Testing: test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a