### PR TITLE
[cache filter] Add option to ignore cache-control directives from request

### DIFF
--- a/api/envoy/extensions/filters/http/cache/v3/cache.proto
+++ b/api/envoy/extensions/filters/http/cache/v3/cache.proto
@@ -20,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: HTTP Cache Filter]
 
 // [#extension: envoy.filters.http.cache]
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message CacheConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.cache.v2alpha.CacheConfig";
@@ -88,4 +88,9 @@ message CacheConfig {
   // Max body size the cache filter will insert into a cache. 0 means unlimited (though the cache
   // storage implementation may have its own limit beyond which it will reject insertions).
   uint32 max_body_bytes = 4;
+
+  // By default, a ``cache-control: no-cache`` or ``pragma: no-cache`` header in the request
+  // causes the cache to validate with its upstream even if the lookup is a hit. Setting this
+  // to true will ignore these headers.
+  bool ignore_request_cache_control_header = 6;
 }

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -9,7 +9,7 @@ namespace Cache {
 
 Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
   std::shared_ptr<HttpCache> cache;
   if (!config.disabled().value()) {
     if (!config.has_typed_config()) {
@@ -26,10 +26,9 @@ Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
     cache = http_cache_factory->getCache(config, context);
   }
 
-  return [config, stats_prefix, &context,
+  return [config = std::make_shared<CacheFilterConfig>(config, context.serverFactoryContext()),
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, stats_prefix, context.scope(),
-                                                            context.serverFactoryContext(), cache));
+    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, cache));
   };
 }
 

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -24,7 +24,8 @@ namespace HttpFilters {
 namespace Cache {
 
 LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, SystemTime timestamp,
-                             const VaryAllowList& vary_allow_list)
+                             const VaryAllowList& vary_allow_list,
+                             bool ignore_request_cache_control_header)
     : request_headers_(Http::createHeaderMap<Http::RequestHeaderMapImpl>(request_headers)),
       vary_allow_list_(vary_allow_list), timestamp_(timestamp) {
   // These ASSERTs check prerequisites. A request without these headers can't be looked up in cache;
@@ -36,7 +37,9 @@ LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, Syst
   absl::string_view scheme = request_headers.getSchemeValue();
   ASSERT(Http::Utility::schemeIsValid(request_headers.getSchemeValue()));
 
-  initializeRequestCacheControl(request_headers);
+  if (!ignore_request_cache_control_header) {
+    initializeRequestCacheControl(request_headers);
+  }
   // TODO(toddmgreer): Let config determine whether to include scheme, host, and
   // query params.
 

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -78,7 +78,8 @@ class LookupRequest {
 public:
   // Prereq: request_headers's Path(), Scheme(), and Host() are non-null.
   LookupRequest(const Http::RequestHeaderMap& request_headers, SystemTime timestamp,
-                const VaryAllowList& vary_allow_list);
+                const VaryAllowList& vary_allow_list,
+                bool ignore_request_cache_control_header = false);
 
   const RequestCacheControl& requestCacheControl() const { return request_cache_control_; }
 

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -30,9 +30,8 @@ protected:
   // The filter has to be created as a shared_ptr to enable shared_from_this() which is used in the
   // cache callbacks.
   CacheFilterSharedPtr makeFilter(std::shared_ptr<HttpCache> cache, bool auto_destroy = true) {
-    std::shared_ptr<CacheFilter> filter(new CacheFilter(config_, /*stats_prefix=*/"",
-                                                        context_.scope(),
-                                                        context_.server_factory_context_, cache),
+    auto config = std::make_shared<CacheFilterConfig>(config_, context_.server_factory_context_);
+    std::shared_ptr<CacheFilter> filter(new CacheFilter(config, cache),
                                         [auto_destroy](CacheFilter* f) {
                                           if (auto_destroy) {
                                             f->onDestroy();


### PR DESCRIPTION
Commit Message: [cache filter] Add option to ignore cache-control directives from request
Additional Description: We noticed that, versus nginx cache, upstream was issuing many 304 responses. After some delving into what was happening, I tried commenting out the line that this change makes controllable, and the cache behaved more like our expectations. This PR makes it so we can have that sort of control via an option rather than via a patch.

Also addresses #12901 to make configuration more shared rather than initialized per-filter.
Risk Level: Low, it's a WIP filter and the behavior should be the same before and after unless the new option is set.
Testing: Added some.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
