### PR TITLE
OTel Access Logger: support additional stat prefix

### DIFF
--- a/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
@@ -47,7 +47,7 @@ message OpenTelemetryAccessLogConfig {
   // Example: ``attributes { values { key: "user_agent" value { string_value: "%REQ(USER-AGENT)%" } } }``.
   opentelemetry.proto.common.v1.KeyValueList attributes = 3;
 
-  // Optional prefix to use on OpenTelemetry access logger stats. If empty, the stats will be rooted at
+  // Optional. Additional prefix to use on OpenTelemetry access logger stats. If empty, the stats will be rooted at
   // ``access_logs.open_telemetry_access_log.``. If non-empty, stats will be rooted at
   // ``access_logs.open_telemetry_access_log.<stat_prefix>.``.
   string stat_prefix = 6;

--- a/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // populate `opentelemetry.proto.collector.v1.logs.ExportLogsServiceRequest.resource_logs <https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto>`_.
 // In addition, the request start time is set in the dedicated field.
 // [#extension: envoy.access_loggers.open_telemetry]
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message OpenTelemetryAccessLogConfig {
   // [#comment:TODO(itamarkam): add 'filter_state_objects_to_log' to logs.]
   grpc.v3.CommonGrpcAccessLogConfig common_config = 1 [(validate.rules).message = {required: true}];
@@ -46,7 +46,7 @@ message OpenTelemetryAccessLogConfig {
   // See 'attributes' in the LogResource proto for more details.
   // Example: ``attributes { values { key: "user_agent" value { string_value: "%REQ(USER-AGENT)%" } } }``.
   opentelemetry.proto.common.v1.KeyValueList attributes = 3;
-  
+
   // Optional prefix to use on OpenTelemetry access logger stats. If empty, the stats will be rooted at
   // ``access_logs.open_telemetry_access_log.``. If non-empty, stats will be rooted at
   // ``access_logs.open_telemetry_access_log.<stat_prefix>.``.

--- a/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v3/logs_service.proto
@@ -46,4 +46,9 @@ message OpenTelemetryAccessLogConfig {
   // See 'attributes' in the LogResource proto for more details.
   // Example: ``attributes { values { key: "user_agent" value { string_value: "%REQ(USER-AGENT)%" } } }``.
   opentelemetry.proto.common.v1.KeyValueList attributes = 3;
+  
+  // Optional prefix to use on OpenTelemetry access logger stats. If empty, the stats will be rooted at
+  // ``access_logs.open_telemetry_access_log.``. If non-empty, stats will be rooted at
+  // ``access_logs.open_telemetry_access_log.<stat_prefix>.``.
+  string stat_prefix = 6;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -169,9 +169,9 @@ new_features:
     :ref:`health_check_config <envoy_v3_api_field_config.core.v3.HealthCheck.TcpHealthCheck.proxy_protocol_config>`.
 - area: open_telemetry
   change: |
-    added :ref:`stats_prefix
-    <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.stats_prefix>`
-    configuration to support additional stats prefix.
+    added :ref:`stat_prefix
+    <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.stat_prefix>`
+    configuration to support additional stat prefix.
 
 deprecated:
 - area: tracing

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -167,6 +167,11 @@ new_features:
   change: |
     Added support to healthcheck with ProxyProtocol in TCP Healthcheck by setting
     :ref:`health_check_config <envoy_v3_api_field_config.core.v3.HealthCheck.TcpHealthCheck.proxy_protocol_config>`.
+- area: open_telemetry
+  change: |
+    added :ref:`stats_prefix
+    <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.stats_prefix>`
+    configuration to support additional stats prefix.
 
 deprecated:
 - area: tracing

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -171,7 +171,7 @@ new_features:
   change: |
     added :ref:`stat_prefix
     <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.stat_prefix>`
-    configuration to support additional stat prefix.
+    configuration to support additional stat prefix for the OpenTelemetry logger.
 
 deprecated:
 - area: tracing

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -48,7 +48,8 @@ GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
               *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
                   "opentelemetry.proto.collector.logs.v1.LogsService.Export"),
               GrpcCommon::optionalRetryPolicy(config.common_config()), genOTelCallbacksFactory())),
-      stats_({ALL_GRPC_ACCESS_LOGGER_STATS(POOL_COUNTER_PREFIX(scope, GRPC_LOG_STATS_PREFIX))}) {
+      stats_({ALL_GRPC_ACCESS_LOGGER_STATS(
+          POOL_COUNTER_PREFIX(scope, absl::StrCat(GRPC_LOG_STATS_PREFIX, config.stat_prefix())))}) {
   initMessageRoot(config, local_info);
 }
 

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -197,11 +197,6 @@ TEST_F(GrpcAccessLoggerImplTest, LogWithStats) {
                 .get()
                 .value(),
             1);
-  EXPECT_EQ(stats_store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
-                .value()
-                .get()
-                .value(),
-            1);
 }
 
 TEST_F(GrpcAccessLoggerImplTest, StatsWithCustomPrefix) {

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -90,9 +90,6 @@ public:
     config_.mutable_common_config()->mutable_buffer_size_bytes()->set_value(BUFFER_SIZE_BYTES);
     config_.mutable_common_config()->mutable_buffer_flush_interval()->set_nanos(
         std::chrono::duration_cast<std::chrono::nanoseconds>(FlushInterval).count());
-    logger_ =
-        std::make_unique<GrpcAccessLoggerImpl>(Grpc::RawAsyncClientPtr{async_client_}, config_,
-                                               dispatcher_, local_info_, *stats_store_.rootScope());
   }
 
   Grpc::MockAsyncClient* async_client_;
@@ -103,9 +100,16 @@ public:
   std::unique_ptr<GrpcAccessLoggerImpl> logger_;
   GrpcAccessLoggerImplTestHelper grpc_access_logger_impl_test_helper_;
   envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig config_;
+
+  void setUpLogger() {
+    logger_ =
+        std::make_unique<GrpcAccessLoggerImpl>(Grpc::RawAsyncClientPtr{async_client_}, config_,
+                                               dispatcher_, local_info_, *stats_store_.rootScope());
+  }
 };
 
 TEST_F(GrpcAccessLoggerImplTest, Log) {
+  setUpLogger();
   grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
   resource_logs:
     resource:
@@ -144,6 +148,7 @@ TEST_F(GrpcAccessLoggerImplTest, Log) {
 }
 
 TEST_F(GrpcAccessLoggerImplTest, LogWithStats) {
+  setUpLogger();
   std::string expected_message_yaml = R"EOF(
   resource_logs:
     resource:
@@ -192,6 +197,45 @@ TEST_F(GrpcAccessLoggerImplTest, LogWithStats) {
                 .get()
                 .value(),
             1);
+  EXPECT_EQ(stats_store_.findCounterByString("access_logs.open_telemetry_access_log.logs_written")
+                .value()
+                .get()
+                .value(),
+            1);
+}
+
+TEST_F(GrpcAccessLoggerImplTest, StatsWithCustomPrefix) {
+  *config_.mutable_stat_prefix() = "custom.";
+  setUpLogger();
+  grpc_access_logger_impl_test_helper_.expectSentMessage(R"EOF(
+  resource_logs:
+    resource:
+      attributes:
+        - key: "log_name"
+          value:
+            string_value: "test_log_name"
+        - key: "zone_name"
+          value:
+            string_value: "zone_name"
+        - key: "cluster_name"
+          value:
+            string_value: "cluster_name"
+        - key: "node_name"
+          value:
+            string_value: "node_name"
+    scope_logs:
+      - log_records:
+          - severity_text: "test-severity-text"
+  )EOF");
+  opentelemetry::proto::logs::v1::LogRecord entry;
+  entry.set_severity_text("test-severity-text");
+  logger_->log(opentelemetry::proto::logs::v1::LogRecord(entry));
+  EXPECT_EQ(
+      stats_store_.findCounterByString("access_logs.open_telemetry_access_log.custom.logs_written")
+          .value()
+          .get()
+          .value(),
+      1);
 }
 
 class GrpcAccessLoggerCacheImplTest : public testing::Test {


### PR DESCRIPTION
As described in the API, this allows to distinguish emitted statistics between configured open telemetry access loggers in the logger chain. If empty, the default `access_logs.open_telemetry_access_log.` will be used.

It is based on https://github.com/envoyproxy/envoy/pull/34072 so please review from the 4th commit.