### PR TITLE
external authorization: set the SNI value from server name if it isn't available on the connection/socket

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -91,6 +91,11 @@ bug_fixes:
   change: |
     Fix BalsaParser resetting state too early, guarded by default-true
     ``envoy.reloadable_features.http1_balsa_delay_reset``.
+- area: ext_authz
+  change: |
+    Set the SNI value from the requested server name if it isn't available on the connection/socket. This applies when
+    ``include_tls_session`` is true. The requested server name is set on a connection when filters such as the TLS
+    inspector are used.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -222,7 +222,7 @@ void CheckRequestUtils::setAttrContextRequest(
 }
 
 void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
-                   OptRef<const Network::Connection> connection) {
+                   OptRef<const Envoy::Network::Connection> connection) {
   if (connection.has_value()) {
     const Ssl::ConnectionInfoConstSharedPtr ssl_info = connection->ssl();
     if (ssl_info != nullptr && !ssl_info->sni().empty()) {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -224,15 +224,13 @@ void CheckRequestUtils::setAttrContextRequest(
 void CheckRequestUtils::setTLSSession(
     envoy::service::auth::v3::AttributeContext::TLSSession& session,
     const Envoy::Network::Connection& connection) {
-  if (connection.has_value()) {
-    const Ssl::ConnectionInfoConstSharedPtr ssl_info = connection.ssl();
-    if (ssl_info != nullptr && !ssl_info->sni().empty()) {
-      const std::string server_name(ssl_info->sni());
-      session.set_sni(server_name);
-    } else if (!connection.requestedServerName().empty()) {
-      const std::string server_name(connection.requestedServerName());
-      session.set_sni(server_name);
-    }
+  const Ssl::ConnectionInfoConstSharedPtr ssl_info = connection.ssl();
+  if (ssl_info != nullptr && !ssl_info->sni().empty()) {
+    const std::string server_name(ssl_info->sni());
+    session.set_sni(server_name);
+  } else if (!connection.requestedServerName().empty()) {
+    const std::string server_name(connection.requestedServerName());
+    session.set_sni(server_name);
   }
 }
 
@@ -264,7 +262,7 @@ void CheckRequestUtils::createHttpCheck(
                         encode_raw_headers, allowed_headers_matcher, disallowed_headers_matcher);
 
   if (include_tls_session) {
-    setTLSSession(*attrs->mutable_tls_session(), cb->connection()->ref());
+    setTLSSession(*attrs->mutable_tls_session(), *cb->connection());
   }
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
   // Fill in the context extensions and metadata context.

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -221,15 +221,16 @@ void CheckRequestUtils::setAttrContextRequest(
                  disallowed_headers_matcher);
 }
 
-void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
-                   OptRef<const Envoy::Network::Connection> connection) {
+void CheckRequestUtils::setTLSSession(
+    envoy::service::auth::v3::AttributeContext::TLSSession& session,
+    const Envoy::Network::Connection& connection) {
   if (connection.has_value()) {
-    const Ssl::ConnectionInfoConstSharedPtr ssl_info = connection->ssl();
+    const Ssl::ConnectionInfoConstSharedPtr ssl_info = connection.ssl();
     if (ssl_info != nullptr && !ssl_info->sni().empty()) {
       const std::string server_name(ssl_info->sni());
       session.set_sni(server_name);
-    } else if (!connection->requestedServerName().empty()) {
-      const std::string server_name(connection->requestedServerName());
+    } else if (!connection.requestedServerName().empty()) {
+      const std::string server_name(connection.requestedServerName());
       session.set_sni(server_name);
     }
   }
@@ -263,7 +264,7 @@ void CheckRequestUtils::createHttpCheck(
                         encode_raw_headers, allowed_headers_matcher, disallowed_headers_matcher);
 
   if (include_tls_session) {
-    setTLSSession(*attrs->mutable_tls_session(), cb->connection());
+    setTLSSession(*attrs->mutable_tls_session(), cb->connection()->ref());
   }
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
   // Fill in the context extensions and metadata context.
@@ -288,7 +289,7 @@ void CheckRequestUtils::createTcpCheck(
                      include_peer_certificate);
 
   if (include_tls_session) {
-    setTLSSession(*attrs->mutable_tls_session(), makeOptRef(cb->connection()));
+    setTLSSession(*attrs->mutable_tls_session(), cb->connection());
   }
   (*attrs->mutable_destination()->mutable_labels()) = destination_labels;
 }

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -143,7 +143,7 @@ private:
       bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
       const MatcherSharedPtr& disallowed_headers_matcher);
   static void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
-                            const Ssl::ConnectionInfoConstSharedPtr ssl_info);
+                            OptRef<const Network::Connection> connection);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);
 };

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -143,7 +143,7 @@ private:
       bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
       const MatcherSharedPtr& disallowed_headers_matcher);
   static void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
-                            OptRef<const Network::Connection> connection);
+                            OptRef<const Envoy::Network::Connection> connection);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);
 };

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -143,7 +143,7 @@ private:
       bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
       const MatcherSharedPtr& disallowed_headers_matcher);
   static void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
-                            OptRef<const Envoy::Network::Connection> connection);
+                            const Envoy::Network::Connection& connection);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);
   static Envoy::Http::HeaderMap::Iterate fillHttpHeaders(const Envoy::Http::HeaderEntry&, void*);
 };

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -247,7 +247,9 @@ TEST_F(CheckRequestUtilsTest, TcpTlsSessionNoSessionSni) {
   EXPECT_CALL(net_callbacks_, connection()).Times(4).WillRepeatedly(ReturnRef(connection_));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(connection_, requestedServerName()).WillOnce(Return(requested_server_name_));
+  EXPECT_CALL(connection_, requestedServerName())
+      .Time(2)
+      .WillRepeatedly(Return(requested_server_name_));
   EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
@@ -258,7 +260,7 @@ TEST_F(CheckRequestUtilsTest, TcpTlsSessionNoSessionSni) {
   CheckRequestUtils::createTcpCheck(&net_callbacks_, request, false, true,
                                     Protobuf::Map<std::string, std::string>());
   EXPECT_TRUE(request.attributes().has_tls_session());
-  EXPECT_EQ(sni_, request.attributes().tls_session().sni());
+  EXPECT_EQ(requested_server_name_, request.attributes().tls_session().sni());
 }
 
 // Verify that createHttpCheck's dependencies are invoked when it's called.

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -248,7 +248,7 @@ TEST_F(CheckRequestUtilsTest, TcpTlsSessionNoSessionSni) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(connection_, requestedServerName())
-      .Times(2)
+      .Times(3)
       .WillRepeatedly(Return(requested_server_name_));
   EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -767,6 +767,9 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNIEqualServe
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(connection_, requestedServerName())
+      .Times(2)
+      .WillRepeatedly(Return(requested_server_name_));
   EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
   EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
   EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -734,7 +734,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
   want_tls_session.set_sni(sni_);
-  EXPECT_CALL(*ssl_, sni()).Times(3).WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
@@ -757,7 +757,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
@@ -784,7 +784,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNIEqualServe
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -248,7 +248,7 @@ TEST_F(CheckRequestUtilsTest, TcpTlsSessionNoSessionSni) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(connection_, requestedServerName())
-      .Time(2)
+      .Times(2)
       .WillRepeatedly(Return(requested_server_name_));
   EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -223,10 +223,10 @@ TEST_F(CheckRequestUtilsTest, TcpPeerCertificate) {
 // Verify that createTcpCheck populates the tls session details correctly.
 TEST_F(CheckRequestUtilsTest, TcpTlsSession) {
   envoy::service::auth::v3::CheckRequest request;
-  EXPECT_CALL(net_callbacks_, connection()).Times(5).WillRepeatedly(ReturnRef(connection_));
+  EXPECT_CALL(net_callbacks_, connection()).Times(4).WillRepeatedly(ReturnRef(connection_));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
@@ -691,11 +691,11 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerCertificate) {
 // Verify that the SNI is populated correctly.
 TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
   EXPECT_CALL(callbacks_, connection())
-      .Times(4)
+      .Times(3)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
   EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
   EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
@@ -715,11 +715,11 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
 // Verify that the SNI is populated correctly.
 TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(callbacks_, connection())
-      .Times(4)
+      .Times(3)
       .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(Const(connection_), ssl()).Times(4).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
   EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
   EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -768,7 +768,6 @@ TEST_F(CheckRequestUtilsTest, HttpTlsSessionNoSessionSni) {
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
-  expectBasicHttp();
   CheckRequestUtils::createHttpCheck(
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request, size,

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -747,30 +747,6 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
   connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
   EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
-  EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
-  EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
-  EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
-  EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
-  EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
-
-  EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
-  EXPECT_CALL(*ssl_, uriSanLocalCertificate())
-      .WillOnce(Return(std::vector<std::string>{"destination"}));
-  envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
-
-  callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
-}
-
-// Verify that createHttpCheck populates the tls session details correctly from the connection when
-// TLS session information isn't present.
-TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNIEqualServerName) {
-  EXPECT_CALL(callbacks_, connection())
-      .Times(3)
-      .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
-  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
-  connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
-  EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(connection_, requestedServerName())
       .Times(2)
       .WillRepeatedly(Return(requested_server_name_));

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -241,7 +241,7 @@ TEST_F(CheckRequestUtilsTest, TcpTlsSession) {
 }
 
 // Verify that createTcpCheck populates the tls session details correctly from the connection when
-// TLS session information isn't present
+// TLS session information isn't present.
 TEST_F(CheckRequestUtilsTest, TcpTlsSessionNoSessionSni) {
   envoy::service::auth::v3::CheckRequest request;
   EXPECT_CALL(net_callbacks_, connection()).Times(4).WillRepeatedly(ReturnRef(connection_));
@@ -756,6 +756,28 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
+}
+
+// Verify that createHttpCheck populates the tls session details correctly from the connection when
+// TLS session information isn't present.
+TEST_F(CheckRequestUtilsTest, HttpTlsSessionNoSessionSni) {
+  envoy::service::auth::v3::CheckRequest request_;
+
+  // A client supplied EnvoyAuthPartialBody header should be ignored.
+  Http::TestRequestHeaderMapImpl request_headers{{Headers::get().EnvoyAuthPartialBody.get(), "1"}};
+
+  EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
+  EXPECT_CALL(*ssl_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"destination"}));
+  expectBasicHttp();
+  CheckRequestUtils::createHttpCheck(
+      &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
+      envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
+      /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
+      /*include_tls_session=*/true, Protobuf::Map<std::string, std::string>(), nullptr);
+  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
+  EXPECT_TRUE(request.attributes().has_tls_session());
+  EXPECT_EQ(requested_server_name_, request.attributes().tls_session().sni());
 }
 
 } // namespace

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -758,10 +758,9 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
 
-// Verify that createHttpCheck populates the tls session details correctly from the connection when
-// TLS session information isn't present.
 TEST_F(CheckRequestUtilsTest, HttpTlsSessionNoSessionSni) {
-  envoy::service::auth::v3::CheckRequest request_;
+  const uint64_t size = 0;
+  envoy::service::auth::v3::CheckRequest request;
 
   // A client supplied EnvoyAuthPartialBody header should be ignored.
   Http::TestRequestHeaderMapImpl request_headers{{Headers::get().EnvoyAuthPartialBody.get(), "1"}};
@@ -772,9 +771,10 @@ TEST_F(CheckRequestUtilsTest, HttpTlsSessionNoSessionSni) {
   expectBasicHttp();
   CheckRequestUtils::createHttpCheck(
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
-      envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
+      envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
       /*include_tls_session=*/true, Protobuf::Map<std::string, std::string>(), nullptr);
+  envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
   EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
   EXPECT_TRUE(request.attributes().has_tls_session());
   EXPECT_EQ(requested_server_name_, request.attributes().tls_session().sni());

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -242,7 +242,7 @@ TEST_F(CheckRequestUtilsTest, TcpTlsSession) {
 
 // Verify that createTcpCheck populates the tls session details correctly from the connection when
 // TLS session information isn't present
-TEST_F(CheckRequestUtilsTest, TcpTlsSession) {
+TEST_F(CheckRequestUtilsTest, TcpTlsSessionNoSessionSni) {
   envoy::service::auth::v3::CheckRequest request;
   EXPECT_CALL(net_callbacks_, connection()).Times(4).WillRepeatedly(ReturnRef(connection_));
   connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -758,25 +758,28 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
 
-TEST_F(CheckRequestUtilsTest, HttpTlsSessionNoSessionSni) {
-  const uint64_t size = 0;
-  envoy::service::auth::v3::CheckRequest request;
-
-  // A client supplied EnvoyAuthPartialBody header should be ignored.
-  Http::TestRequestHeaderMapImpl request_headers{{Headers::get().EnvoyAuthPartialBody.get(), "1"}};
+// Verify that createHttpCheck populates the tls session details correctly from the connection when
+// TLS session information isn't present.
+TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNIEqualServerName) {
+  EXPECT_CALL(callbacks_, connection())
+      .Times(3)
+      .WillRepeatedly(Return(OptRef<const Network::Connection>{connection_}));
+  connection_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_);
+  connection_.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_);
+  EXPECT_CALL(Const(connection_), ssl()).Times(3).WillRepeatedly(Return(ssl_));
+  EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
+  EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
+  EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
+  EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
 
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
-  CheckRequestUtils::createHttpCheck(
-      &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
-      envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request, size,
-      /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/true, Protobuf::Map<std::string, std::string>(), nullptr);
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
   EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
-  EXPECT_TRUE(request.attributes().has_tls_session());
-  EXPECT_EQ(requested_server_name_, request.attributes().tls_session().sni());
+
+  callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
 
 } // namespace

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -98,7 +98,11 @@ public:
 
     EXPECT_EQ(want_tls_session != nullptr, request.attributes().has_tls_session());
     if (want_tls_session != nullptr) {
-      EXPECT_EQ(want_tls_session->sni(), request.attributes().tls_session().sni());
+      if (!want_tls_session->sni().empty()) {
+        EXPECT_EQ(want_tls_session->sni(), request.attributes().tls_session().sni());
+      } else {
+        EXPECT_EQ(requested_server_name_, request.attributes().tls_session().sni());
+      }
     }
   }
 
@@ -730,7 +734,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSession) {
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
   want_tls_session.set_sni(sni_);
-  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).Times(3).WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
@@ -753,7 +757,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }
@@ -780,7 +784,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNIEqualServe
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())
       .WillOnce(Return(std::vector<std::string>{"destination"}));
   envoy::service::auth::v3::AttributeContext_TLSSession want_tls_session;
-  EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
+  EXPECT_CALL(*ssl_, sni()).Times(2).WillRepeatedly(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
 }


### PR DESCRIPTION
This is my first commit to the Envoy project and I haven't written C++ in many years. I'm still navigating the types and hierarchy and best practices for obtaining the data I need to complete this pull request. I have started in `draft` first to see the CI processes and look at how the tests run and if my changes cause any issues with current tests.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: external authorization: set the SNI value from server name if it isn't available on the connection/socket
Additional Description: Leverages the TLS inspectors server name value, if one was set.
Risk Level: low
Testing: Will test that the SNI value is set from the server name of a connection when the TLS session doesn't have the SNI.
Docs Changes: N/A
Release Notes: exterbal authorization
Platform Specific Features: N/A
[Optional Runtime guard:]
Fixes https://github.com/envoyproxy/envoy/issues/34002
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
