### PR TITLE
Adaptation of the log format of hot-restarter.py to the format of Envoy

### DIFF
--- a/restarter/hot-restarter.py
+++ b/restarter/hot-restarter.py
@@ -17,7 +17,8 @@ TERM_WAIT_SECONDS = 30
 restart_epoch = 0
 pid_list = []
 
-LOG_FORMAT = "[%(asctime)s][%(process)d][%(levelname)s][%(filename)s:%(lineno)d] %(message)s"
+LOG_FORMAT = "[%(asctime)s.%(msecs)03d][%(process)d][%(levelname)s][core] [%(filename)s:%(lineno)d] %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 LOG_LEVEL = logging.INFO
 logger = logging.getLogger(__name__)
 
@@ -196,7 +197,7 @@ def fork_and_exec():
 def init_logger():
     """init logger"""
     stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    stream_handler.setFormatter(logging.Formatter(LOG_FORMAT, DATE_FORMAT))
     logger.setLevel(LOG_LEVEL)
     logger.addHandler(stream_handler)
 


### PR DESCRIPTION
**Current Behavior:**

The _hot-restarter.py_ script logs timestamps with a comma (,) separating seconds from milliseconds.

```
[2024-05-13 14:03:31,880][1][INFO][hot-restarter.py:210] starting hot-restarter with target: /usr/local/bin/start_envoy.sh
[2024-05-13 14:03:31,880][1][INFO][hot-restarter.py:183] forking and execing new child process at epoch 0
[2024-05-13 14:03:31,881][1][INFO][hot-restarter.py:192] forked new child process with PID=12
```
In addition, no category ID is output.

**Envoy's Format:**

Envoy, on the other hand, uses a dot (.) as the separator for milliseconds and outputs a category ID for each log entry.

```
[2024-05-13 15:25:30.105][12][debug][dns] [source/extensions/network/dns_resolver/cares/dns_impl.cc:369] dns resolution for filebrowser started
[2024-05-13 15:25:30.105][12][trace][dns] [source/extensions/network/dns_resolver/cares/dns_impl.cc:332] Setting DNS resolution timer for 5000 milliseconds
[2024-05-13 15:25:30.108][12][debug][dns] [source/extensions/network/dns_resolver/cares/dns_impl.cc:289] dns resolution for filebrowser completed with status 0
```

**This Pull Request:**

This pull request modifies the _hot-restarter.py_ script to align its log format with Envoy's format, using a period (.) as the separator for milliseconds and using the category ID _core_ for all it's log entries. This ensures consistency in post-processing/parsing of log data.