### PR TITLE
mobile: Remove --build_tests_only from the build targets

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -253,7 +253,6 @@ build:mobile-remote-ci-cc --config=mobile-remote-ci
 # Temporary revert to C++17 for mobile NDK builds.
 build:mobile-remote-ci-cc --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build:mobile-remote-ci-cc --define=envoy_full_protos=disabled
-build:mobile-remote-ci-cc --build_tests_only
 test:mobile-remote-ci-cc --action_env=LD_LIBRARY_PATH
 
 build:mobile-remote-ci-cc-no-exceptions --config=mobile-remote-ci-cc
@@ -273,7 +272,6 @@ build:mobile-remote-ci-macos-swift --@envoy//bazel:http3=False
 
 build:mobile-remote-ci-core --config=mobile-remote-ci
 build:mobile-remote-ci-core --define=envoy_full_protos=disabled
-build:mobile-remote-ci-core --build_tests_only
 test:mobile-remote-ci-core --action_env=LD_LIBRARY_PATH
 test:mobile-remote-ci-core --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 


### PR DESCRIPTION
`//test/performance:test_binary_size` and `//library/cc/...` are not test targets, so passing `--build_tests_only` will not build those targets. That means the `cc-no-build-exceptions` CI will always have 0 targets. This PR fixes https://github.com/envoyproxy/envoy/issues/34114 by removing `--build_tests_only` from the build targets.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
