### PR TITLE
async_client: Add option to disable internal headers on async client path.

### DIFF
--- a/envoy/http/async_client.h
+++ b/envoy/http/async_client.h
@@ -251,6 +251,10 @@ public:
       send_xff = v;
       return *this;
     }
+    StreamOptions& setSendInternal(bool v) {
+      send_internal = v;
+      return *this;
+    }
     StreamOptions& setHashPolicy(
         const Protobuf::RepeatedPtrField<envoy::config::route::v3::RouteAction::HashPolicy>& v) {
       hash_policy = v;
@@ -320,7 +324,7 @@ public:
     // For gmock test
     bool operator==(const StreamOptions& src) const {
       return timeout == src.timeout && buffer_body_for_retry == src.buffer_body_for_retry &&
-             send_xff == src.send_xff;
+             send_xff == src.send_xff && send_internal == src.send_internal;
     }
 
     // The timeout supplies the stream timeout, measured since when the frame with
@@ -335,6 +339,9 @@ public:
 
     // If true, x-forwarded-for header will be added.
     bool send_xff{true};
+
+    // If true, x-envoy-internal header will be added.
+    bool send_internal{true};
 
     // Provides the hash policy for hashing load balancing strategies.
     Protobuf::RepeatedPtrField<envoy::config::route::v3::RouteAction::HashPolicy> hash_policy;
@@ -378,6 +385,10 @@ public:
     }
     RequestOptions& setSendXff(bool v) {
       StreamOptions::setSendXff(v);
+      return *this;
+    }
+    RequestOptions& setSendInternal(bool v) {
+      StreamOptions::setSendInternal(v);
       return *this;
     }
     RequestOptions& setHashPolicy(

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -111,8 +111,8 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
           parent_.cluster_->name(),
           retry_policy_ != nullptr ? *retry_policy_ : *options.parsed_retry_policy,
           parent_.factory_context_.regexEngine(), options.timeout, options.hash_policy)),
-      account_(options.account_), buffer_limit_(options.buffer_limit_),
-      send_xff_(options.send_xff) {
+      account_(options.account_), buffer_limit_(options.buffer_limit_), send_xff_(options.send_xff),
+      send_internal_(options.send_internal) {
   stream_info_.dynamicMetadata().MergeFrom(options.metadata);
   stream_info_.setIsShadow(options.is_shadow);
   stream_info_.setUpstreamClusterInfo(parent_.cluster_);
@@ -173,7 +173,10 @@ void AsyncStreamImpl::sendHeaders(RequestHeaderMap& headers, bool end_stream) {
   }
 
   is_grpc_request_ = Grpc::Common::isGrpcRequestHeaders(headers);
-  headers.setReferenceEnvoyInternalRequest(Headers::get().EnvoyInternalRequestValues.True);
+  if (send_internal_) {
+    headers.setReferenceEnvoyInternalRequest(Headers::get().EnvoyInternalRequestValues.True);
+  }
+
   if (send_xff_) {
     Utility::appendXff(headers, *parent_.config_->local_info_.address());
   }

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -291,6 +291,7 @@ private:
   bool is_grpc_request_{};
   bool is_head_request_{false};
   bool send_xff_{true};
+  bool send_internal_{true};
 
   friend class AsyncClientImpl;
   friend class AsyncClientImplUnitTest;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -177,6 +177,59 @@ TEST_F(AsyncClientImplTest, BasicStream) {
                      .value());
 }
 
+TEST_F(AsyncClientImplTest, BasicStreamWithInternalHeadersDisabled) {
+  Buffer::InstancePtr body{new Buffer::OwnedImpl("test body")};
+
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _, _))
+      .WillOnce(Invoke(
+          [&](ResponseDecoder& decoder, ConnectionPool::Callbacks& callbacks,
+              const ConnectionPool::Instance::StreamOptions&) -> ConnectionPool::Cancellable* {
+            // The backing object of 'decoder' should also implemented the
+            // Router::UpstreamToDownstream.
+            const auto* upstream_to_downstream =
+                dynamic_cast<Router::UpstreamToDownstream*>(&decoder);
+            EXPECT_NE(nullptr, upstream_to_downstream);
+            // Ensure the route() is populated and valid.
+            EXPECT_NE(nullptr, upstream_to_downstream->route().routeEntry());
+
+            callbacks.onPoolReady(stream_encoder_, cm_.thread_local_cluster_.conn_pool_.host_,
+                                  stream_info_, {});
+            response_decoder_ = &decoder;
+            return nullptr;
+          }));
+
+  // Create the headers without x-envoy-internal and x-forwarded-for.
+  TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+
+  EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&headers), false));
+  EXPECT_CALL(stream_encoder_, encodeData(BufferEqual(body.get()), true));
+
+  expectResponseHeaders(stream_callbacks_, 200, false);
+  EXPECT_CALL(stream_callbacks_, onData(BufferEqual(body.get()), true));
+  EXPECT_CALL(stream_callbacks_, onComplete());
+
+  AsyncClient::StreamOptions option = AsyncClient::StreamOptions();
+  // Set stream option to disable x-envoy-internal and x-forwarded-for headers.
+  option.setSendInternal(false);
+  option.setSendXff(false);
+  AsyncClient::Stream* stream = client_.start(stream_callbacks_, option);
+
+  TestRequestHeaderMapImpl send_headers = headers;
+  stream->sendHeaders(send_headers, false);
+  stream->sendData(*body, true);
+
+  response_decoder_->decode1xxHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "100"}}));
+  response_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
+  response_decoder_->decodeData(*body, true);
+
+  EXPECT_EQ(
+      1UL,
+      cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_200").value());
+}
+
 TEST_F(AsyncClientImplTest, Basic) {
   message_->body().add("test body");
   Buffer::Instance& data = message_->body();


### PR DESCRIPTION
Add option to disable `x-envoy-internal` on the async client path.
