### PR TITLE
rbac: Add support for specifying a HTTP status code for RBAC denial responses

### DIFF
--- a/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -73,7 +73,7 @@ message RBAC {
   bool track_per_rule_stats = 7;
 
   // If specified, RBAC denies will use the given value as the response code. Defaults to 403 Forbidden.
-  uint32 deny_status = 8 [(validate.rules).uint32 = {ignore_empty: true lt: 600 gte: 200}];
+  uint32 deny_status = 8 [(validate.rules).uint32 = {lt: 600 gte: 200 ignore_empty: true}];
 }
 
 message RBACPerRoute {

--- a/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -10,6 +10,7 @@ import "xds/type/matcher/v3/matcher.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v3";
 option java_outer_classname = "RbacProto";
@@ -22,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.rbac]
 
 // RBAC filter config.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message RBAC {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.rbac.v2.RBAC";
@@ -70,6 +71,9 @@ message RBAC {
 
   // If track_per_rule_stats is true, counters will be published for each rule and shadow rule.
   bool track_per_rule_stats = 7;
+
+  // If specified, RBAC denies will use the given value as the response code. Defaults to 403 Forbidden.
+  uint32 deny_status = 8 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 }
 
 message RBACPerRoute {

--- a/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -73,7 +73,7 @@ message RBAC {
   bool track_per_rule_stats = 7;
 
   // If specified, RBAC denies will use the given value as the response code. Defaults to 403 Forbidden.
-  uint32 deny_status = 8 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+  uint32 deny_status = 8 [(validate.rules).uint32 = {ignore_empty: true lt: 600 gte: 200}];
 }
 
 message RBACPerRoute {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -127,6 +127,11 @@ new_features:
 - area: redis
   change: |
     Added support for `inline commands <https://redis.io/docs/reference/protocol-spec/#inline-commands>`_.
+- area: rbac
+  change: |
+    Added :ref:`deny_status
+    <envoy_v3_api_msg_extensions.filters.http.rbac.v3.RBAC.deny_status>`
+    to allow the HTTP status code for the RBAC denial response to be configured.
 
 deprecated:
 - area: tracing

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -130,7 +130,7 @@ new_features:
 - area: rbac
   change: |
     Added :ref:`deny_status
-    <envoy_v3_api_msg_extensions.filters.http.rbac.v3.RBAC.deny_status>`
+    <envoy_v3_api_field_extensions.filters.http.rbac.v3.RBAC.deny_status>`
     to allow the HTTP status code for the RBAC denial response to be configured.
 
 deprecated:

--- a/source/extensions/filters/http/rbac/rbac_filter.h
+++ b/source/extensions/filters/http/rbac/rbac_filter.h
@@ -65,6 +65,9 @@ public:
     return shadow_rules_stat_prefix_ +
            Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().ShadowEngineResultField;
   }
+  Http::Code denyStatus() const {
+    return deny_status_;
+  }
 
   const Filters::Common::RBAC::RoleBasedAccessControlEngine*
   engine(const Http::StreamFilterCallbacks* callbacks,
@@ -82,6 +85,7 @@ private:
   Filters::Common::RBAC::RoleBasedAccessControlFilterStats stats_;
   const std::string shadow_rules_stat_prefix_;
   const bool per_rule_stats_;
+  const Http::Code deny_status_;
 
   ActionValidationVisitor action_validation_visitor_;
   std::unique_ptr<const Filters::Common::RBAC::RoleBasedAccessControlEngine> engine_;

--- a/source/extensions/filters/http/rbac/rbac_filter.h
+++ b/source/extensions/filters/http/rbac/rbac_filter.h
@@ -65,9 +65,7 @@ public:
     return shadow_rules_stat_prefix_ +
            Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().ShadowEngineResultField;
   }
-  Http::Code denyStatus() const {
-    return deny_status_;
-  }
+  Http::Code denyStatus() const { return deny_status_; }
 
   const Filters::Common::RBAC::RoleBasedAccessControlEngine*
   engine(const Http::StreamFilterCallbacks* callbacks,

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -35,8 +35,7 @@ enum class LogResult { Yes, No, Undecided };
 
 class RoleBasedAccessControlFilterTest : public testing::Test {
 public:
-  void setupPolicy(envoy::config::rbac::v3::RBAC::Action action,
-                   std::string rules_stat_prefix = "",
+  void setupPolicy(envoy::config::rbac::v3::RBAC::Action action, std::string rules_stat_prefix = "",
                    uint32_t deny_status = 0) {
     envoy::extensions::filters::http::rbac::v3::RBAC config;
     config.set_deny_status(deny_status);


### PR DESCRIPTION
Commit Message: "rbac: Add support for specifying a HTTP status code for RBAC denial responses"
Additional Description: Added `deny_status` field to `extensions.filters.http.rbac.v3.RBAC` to allow the HTTP status code for the RBAC denial response to be configured.
Risk Level: low
Testing: Added unit and integration tests
Docs Changes: Updated comments in proto file.
Release Notes: Added :ref:`deny_status <envoy_v3_api_msg_extensions.filters.http.rbac.v3.RBAC.deny_status>` to allow the HTTP status code for the RBAC denial response to be configured.
Platform Specific Features: N/A
Fixes: #34127