### PR TITLE
route config: moving the route provider manager to its own file

### DIFF
--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -177,8 +177,14 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "rds_lib",
-    srcs = ["rds_impl.cc"],
-    hdrs = ["rds_impl.h"],
+    srcs = [
+        "rds_impl.cc",
+        "route_provider_manager.cc",
+    ],
+    hdrs = [
+        "rds_impl.h",
+        "route_provider_manager.h",
+    ],
     deps = [
         ":config_lib",
         "//envoy/config:subscription_interface",

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -180,10 +180,12 @@ envoy_cc_library(
     srcs = [
         "rds_impl.cc",
         "route_provider_manager.cc",
+        "static_route_provider_impl.cc",
     ],
     hdrs = [
         "rds_impl.h",
         "route_provider_manager.h",
+        "static_route_provider_impl.h",
     ],
     deps = [
         ":config_lib",

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -22,34 +22,6 @@
 namespace Envoy {
 namespace Router {
 
-RouteConfigProviderSharedPtr RouteConfigProviderUtil::create(
-    const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-        config,
-    Server::Configuration::ServerFactoryContext& factory_context,
-    ProtobufMessage::ValidationVisitor& validator, Init::Manager& init_manager,
-    const std::string& stat_prefix, RouteConfigProviderManager& route_config_provider_manager) {
-
-  switch (config.route_specifier_case()) {
-  case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
-      RouteSpecifierCase::kRouteConfig:
-    return route_config_provider_manager.createStaticRouteConfigProvider(
-        config.route_config(), factory_context, validator);
-  case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
-      RouteSpecifierCase::kRds:
-    return route_config_provider_manager.createRdsRouteConfigProvider(
-        // At the creation of a RDS route config provider, the factory_context's initManager is
-        // always valid, though the init manager may go away later when the listener goes away.
-        config.rds(), factory_context, stat_prefix, init_manager);
-  case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
-      RouteSpecifierCase::kScopedRoutes:
-    FALLTHRU; // PANIC
-  case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
-      RouteSpecifierCase::ROUTE_SPECIFIER_NOT_SET:
-    PANIC("not implemented");
-  }
-  PANIC_DUE_TO_CORRUPT_ENUM;
-}
-
 StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(
     const envoy::config::route::v3::RouteConfiguration& config, Rds::ConfigTraits& config_traits,
     Server::Configuration::ServerFactoryContext& factory_context,
@@ -218,45 +190,6 @@ void RdsRouteConfigProviderImpl::requestVirtualHostsUpdate(
       config_update_callbacks_.push_back({alias, thread_local_dispatcher, route_config_updated_cb});
     }
   });
-}
-
-RouteConfigProviderManagerImpl::RouteConfigProviderManagerImpl(OptRef<Server::Admin> admin)
-    : manager_(admin, "routes", proto_traits_) {}
-
-Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::createRdsRouteConfigProvider(
-    const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
-    Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
-    Init::Manager& init_manager) {
-  auto provider = manager_.addDynamicProvider(
-      rds, rds.route_config_name(), init_manager,
-      [&factory_context, &rds, &stat_prefix, this](uint64_t manager_identifier) {
-        auto config_update =
-            std::make_unique<RouteConfigUpdateReceiverImpl>(proto_traits_, factory_context);
-        auto resource_decoder = std::make_shared<
-            Envoy::Config::OpaqueResourceDecoderImpl<envoy::config::route::v3::RouteConfiguration>>(
-            factory_context.messageValidationContext().dynamicValidationVisitor(), "name");
-        auto subscription = std::make_shared<RdsRouteConfigSubscription>(
-            std::move(config_update), std::move(resource_decoder), rds, manager_identifier,
-            factory_context, stat_prefix, manager_);
-        auto provider =
-            std::make_shared<RdsRouteConfigProviderImpl>(std::move(subscription), factory_context);
-        return std::make_pair(provider, &provider->subscription().initTarget());
-      });
-  ASSERT(dynamic_cast<RouteConfigProvider*>(provider.get()));
-  return std::static_pointer_cast<RouteConfigProvider>(provider);
-}
-
-RouteConfigProviderPtr RouteConfigProviderManagerImpl::createStaticRouteConfigProvider(
-    const envoy::config::route::v3::RouteConfiguration& route_config,
-    Server::Configuration::ServerFactoryContext& factory_context,
-    ProtobufMessage::ValidationVisitor& validator) {
-  auto provider = manager_.addStaticProvider([&factory_context, &validator, &route_config, this]() {
-    ConfigTraitsImpl config_traits(validator);
-    return std::make_unique<StaticRouteConfigProviderImpl>(route_config, config_traits,
-                                                           factory_context, manager_);
-  });
-  ASSERT(dynamic_cast<RouteConfigProvider*>(provider.get()));
-  return RouteConfigProviderPtr(static_cast<RouteConfigProvider*>(provider.release()));
 }
 
 } // namespace Router

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -22,22 +22,6 @@
 namespace Envoy {
 namespace Router {
 
-StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(
-    const envoy::config::route::v3::RouteConfiguration& config, Rds::ConfigTraits& config_traits,
-    Server::Configuration::ServerFactoryContext& factory_context,
-    Rds::RouteConfigProviderManager& route_config_provider_manager)
-    : base_(config, config_traits, factory_context, route_config_provider_manager),
-      route_config_provider_manager_(route_config_provider_manager) {}
-
-StaticRouteConfigProviderImpl::~StaticRouteConfigProviderImpl() {
-  route_config_provider_manager_.eraseStaticProvider(this);
-}
-
-ConfigConstSharedPtr StaticRouteConfigProviderImpl::configCast() const {
-  ASSERT(dynamic_cast<const Config*>(StaticRouteConfigProviderImpl::config().get()));
-  return std::static_pointer_cast<const Config>(StaticRouteConfigProviderImpl::config());
-}
-
 // TODO(htuch): If support for multiple clusters is added per #1170 cluster_name_
 RdsRouteConfigSubscription::RdsRouteConfigSubscription(
     RouteConfigUpdatePtr&& config_update,

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -49,23 +49,6 @@ namespace Router {
 class ScopedRdsConfigSubscription;
 
 /**
- * Route configuration provider utilities.
- */
-class RouteConfigProviderUtil {
-public:
-  /**
-   * @return RouteConfigProviderSharedPtr a new route configuration provider based on the supplied
-   * proto configuration. Notes the provider object could be shared among multiple listeners.
-   */
-  static RouteConfigProviderSharedPtr create(
-      const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-          config,
-      Server::Configuration::ServerFactoryContext& factory_context,
-      ProtobufMessage::ValidationVisitor& validator, Init::Manager& init_manager,
-      const std::string& stat_prefix, RouteConfigProviderManager& route_config_provider_manager);
-};
-
-/**
  * Implementation of RouteConfigProvider that holds a static route configuration.
  */
 class StaticRouteConfigProviderImpl : public RouteConfigProvider {
@@ -173,37 +156,6 @@ private:
 };
 
 using RdsRouteConfigProviderImplSharedPtr = std::shared_ptr<RdsRouteConfigProviderImpl>;
-
-using ProtoTraitsImpl =
-    Rds::Common::ProtoTraitsImpl<envoy::config::route::v3::RouteConfiguration, 1>;
-
-class RouteConfigProviderManagerImpl : public RouteConfigProviderManager,
-                                       public Singleton::Instance {
-public:
-  RouteConfigProviderManagerImpl(OptRef<Server::Admin> admin);
-
-  std::unique_ptr<envoy::admin::v3::RoutesConfigDump>
-  dumpRouteConfigs(const Matchers::StringMatcher& name_matcher) const {
-    return manager_.dumpRouteConfigs(name_matcher);
-  }
-
-  // RouteConfigProviderManager
-  RouteConfigProviderSharedPtr createRdsRouteConfigProvider(
-      const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
-      Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
-      Init::Manager& init_manager) override;
-
-  RouteConfigProviderPtr
-  createStaticRouteConfigProvider(const envoy::config::route::v3::RouteConfiguration& route_config,
-                                  Server::Configuration::ServerFactoryContext& factory_context,
-                                  ProtobufMessage::ValidationVisitor& validator) override;
-
-private:
-  ProtoTraitsImpl proto_traits_;
-  Rds::RouteConfigProviderManager manager_;
-};
-
-using RouteConfigProviderManagerImplPtr = std::unique_ptr<RouteConfigProviderManagerImpl>;
 
 } // namespace Router
 } // namespace Envoy

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -49,31 +49,6 @@ namespace Router {
 class ScopedRdsConfigSubscription;
 
 /**
- * Implementation of RouteConfigProvider that holds a static route configuration.
- */
-class StaticRouteConfigProviderImpl : public RouteConfigProvider {
-public:
-  StaticRouteConfigProviderImpl(const envoy::config::route::v3::RouteConfiguration& config,
-                                Rds::ConfigTraits& config_traits,
-                                Server::Configuration::ServerFactoryContext& factory_context,
-                                Rds::RouteConfigProviderManager& route_config_provider_manager);
-  ~StaticRouteConfigProviderImpl() override;
-
-  // Router::RouteConfigProvider
-  Rds::ConfigConstSharedPtr config() const override { return base_.config(); }
-  const absl::optional<ConfigInfo>& configInfo() const override { return base_.configInfo(); }
-  SystemTime lastUpdated() const override { return base_.lastUpdated(); }
-  absl::Status onConfigUpdate() override { return base_.onConfigUpdate(); }
-  ConfigConstSharedPtr configCast() const override;
-  void requestVirtualHostsUpdate(const std::string&, Event::Dispatcher&,
-                                 std::weak_ptr<Http::RouteConfigUpdatedCallback>) override {}
-
-private:
-  Rds::StaticRouteConfigProviderImpl base_;
-  Rds::RouteConfigProviderManager& route_config_provider_manager_;
-};
-
-/**
  * A class that fetches the route configuration dynamically using the RDS API and updates them to
  * RDS config providers.
  */

--- a/source/common/router/route_provider_manager.cc
+++ b/source/common/router/route_provider_manager.cc
@@ -1,0 +1,66 @@
+#include "source/common/router/route_provider_manager.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/admin/v3/config_dump.pb.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/service/discovery/v3/discovery.pb.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/common/fmt.h"
+#include "source/common/config/api_version.h"
+#include "source/common/config/utility.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/router/config_impl.h"
+#include "source/common/router/rds_impl.h"
+#include "source/common/router/route_config_update_receiver_impl.h"
+
+namespace Envoy {
+namespace Router {
+
+RouteConfigProviderManagerImpl::RouteConfigProviderManagerImpl(OptRef<Server::Admin> admin)
+    : manager_(admin, "routes", proto_traits_) {}
+
+Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::createRdsRouteConfigProvider(
+    const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
+    Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
+    Init::Manager& init_manager) {
+  auto provider = manager_.addDynamicProvider(
+      rds, rds.route_config_name(), init_manager,
+      [&factory_context, &rds, &stat_prefix, this](uint64_t manager_identifier) {
+        auto config_update =
+            std::make_unique<RouteConfigUpdateReceiverImpl>(proto_traits_, factory_context);
+        auto resource_decoder = std::make_shared<
+            Envoy::Config::OpaqueResourceDecoderImpl<envoy::config::route::v3::RouteConfiguration>>(
+            factory_context.messageValidationContext().dynamicValidationVisitor(), "name");
+        auto subscription = std::make_shared<RdsRouteConfigSubscription>(
+            std::move(config_update), std::move(resource_decoder), rds, manager_identifier,
+            factory_context, stat_prefix, manager_);
+        auto provider =
+            std::make_shared<RdsRouteConfigProviderImpl>(std::move(subscription), factory_context);
+        return std::make_pair(provider, &provider->subscription().initTarget());
+      });
+  ASSERT(dynamic_cast<RouteConfigProvider*>(provider.get()));
+  return std::static_pointer_cast<RouteConfigProvider>(provider);
+}
+
+RouteConfigProviderPtr RouteConfigProviderManagerImpl::createStaticRouteConfigProvider(
+    const envoy::config::route::v3::RouteConfiguration& route_config,
+    Server::Configuration::ServerFactoryContext& factory_context,
+    ProtobufMessage::ValidationVisitor& validator) {
+  auto provider = manager_.addStaticProvider([&factory_context, &validator, &route_config, this]() {
+    ConfigTraitsImpl config_traits(validator);
+    return std::make_unique<StaticRouteConfigProviderImpl>(route_config, config_traits,
+                                                           factory_context, manager_);
+  });
+  ASSERT(dynamic_cast<RouteConfigProvider*>(provider.get()));
+  return RouteConfigProviderPtr(static_cast<RouteConfigProvider*>(provider.release()));
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/route_provider_manager.cc
+++ b/source/common/router/route_provider_manager.cc
@@ -19,6 +19,7 @@
 #include "source/common/router/config_impl.h"
 #include "source/common/router/rds_impl.h"
 #include "source/common/router/route_config_update_receiver_impl.h"
+#include "source/common/router/static_route_provider_impl.h"
 
 namespace Envoy {
 namespace Router {

--- a/source/common/router/route_provider_manager.h
+++ b/source/common/router/route_provider_manager.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <string>
+
+#include "envoy/admin/v3/config_dump.pb.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/config/route/v3/route.pb.validate.h"
+#include "envoy/config/subscription.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/http/codes.h"
+#include "envoy/local_info/local_info.h"
+#include "envoy/router/rds.h"
+#include "envoy/router/route_config_provider_manager.h"
+#include "envoy/router/route_config_update_receiver.h"
+#include "envoy/server/admin.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/service/discovery/v3/discovery.pb.h"
+#include "envoy/singleton/instance.h"
+#include "envoy/stats/scope.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "source/common/common/callback_impl.h"
+#include "source/common/common/cleanup.h"
+#include "source/common/common/logger.h"
+#include "source/common/init/manager_impl.h"
+#include "source/common/init/target_impl.h"
+#include "source/common/init/watcher_impl.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/rds/common/proto_traits_impl.h"
+#include "source/common/rds/rds_route_config_provider_impl.h"
+#include "source/common/rds/rds_route_config_subscription.h"
+#include "source/common/rds/route_config_provider_manager.h"
+#include "source/common/rds/route_config_update_receiver_impl.h"
+#include "source/common/rds/static_route_config_provider_impl.h"
+#include "source/common/router/vhds.h"
+
+#include "absl/container/node_hash_map.h"
+#include "absl/container/node_hash_set.h"
+
+namespace Envoy {
+namespace Router {
+
+using ProtoTraitsImpl =
+    Rds::Common::ProtoTraitsImpl<envoy::config::route::v3::RouteConfiguration, 1>;
+
+class RouteConfigProviderManagerImpl : public RouteConfigProviderManager,
+                                       public Singleton::Instance {
+public:
+  RouteConfigProviderManagerImpl(OptRef<Server::Admin> admin);
+
+  std::unique_ptr<envoy::admin::v3::RoutesConfigDump>
+  dumpRouteConfigs(const Matchers::StringMatcher& name_matcher) const {
+    return manager_.dumpRouteConfigs(name_matcher);
+  }
+
+  // RouteConfigProviderManager
+  RouteConfigProviderSharedPtr createRdsRouteConfigProvider(
+      const envoy::extensions::filters::network::http_connection_manager::v3::Rds& rds,
+      Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
+      Init::Manager& init_manager) override;
+
+  RouteConfigProviderPtr
+  createStaticRouteConfigProvider(const envoy::config::route::v3::RouteConfiguration& route_config,
+                                  Server::Configuration::ServerFactoryContext& factory_context,
+                                  ProtobufMessage::ValidationVisitor& validator) override;
+
+private:
+  ProtoTraitsImpl proto_traits_;
+  Rds::RouteConfigProviderManager manager_;
+};
+
+using RouteConfigProviderManagerImplPtr = std::unique_ptr<RouteConfigProviderManagerImpl>;
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/static_route_provider_impl.cc
+++ b/source/common/router/static_route_provider_impl.cc
@@ -1,0 +1,25 @@
+#include "source/common/router/static_route_provider_impl.h"
+
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+
+namespace Envoy {
+namespace Router {
+
+StaticRouteConfigProviderImpl::StaticRouteConfigProviderImpl(
+    const envoy::config::route::v3::RouteConfiguration& config, Rds::ConfigTraits& config_traits,
+    Server::Configuration::ServerFactoryContext& factory_context,
+    Rds::RouteConfigProviderManager& route_config_provider_manager)
+    : base_(config, config_traits, factory_context, route_config_provider_manager),
+      route_config_provider_manager_(route_config_provider_manager) {}
+
+StaticRouteConfigProviderImpl::~StaticRouteConfigProviderImpl() {
+  route_config_provider_manager_.eraseStaticProvider(this);
+}
+
+ConfigConstSharedPtr StaticRouteConfigProviderImpl::configCast() const {
+  ASSERT(dynamic_cast<const Config*>(StaticRouteConfigProviderImpl::config().get()));
+  return std::static_pointer_cast<const Config>(StaticRouteConfigProviderImpl::config());
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/static_route_provider_impl.h
+++ b/source/common/router/static_route_provider_impl.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <string>
+
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/config/route/v3/route.pb.validate.h"
+#include "envoy/config/subscription.h"
+#include "envoy/http/codes.h"
+#include "envoy/local_info/local_info.h"
+#include "envoy/rds/config_traits.h"
+#include "envoy/router/route_config_provider_manager.h"
+#include "envoy/router/route_config_update_receiver.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/service/discovery/v3/discovery.pb.h"
+#include "envoy/singleton/instance.h"
+#include "envoy/stats/scope.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/rds/static_route_config_provider_impl.h"
+
+namespace Envoy {
+namespace Router {
+
+/**
+ * Implementation of RouteConfigProvider that holds a static route configuration.
+ */
+class StaticRouteConfigProviderImpl : public RouteConfigProvider {
+public:
+  StaticRouteConfigProviderImpl(const envoy::config::route::v3::RouteConfiguration& config,
+                                Rds::ConfigTraits& config_traits,
+                                Server::Configuration::ServerFactoryContext& factory_context,
+                                Rds::RouteConfigProviderManager& route_config_provider_manager);
+  ~StaticRouteConfigProviderImpl() override;
+
+  // Router::RouteConfigProvider
+  Rds::ConfigConstSharedPtr config() const override { return base_.config(); }
+  const absl::optional<ConfigInfo>& configInfo() const override { return base_.configInfo(); }
+  SystemTime lastUpdated() const override { return base_.lastUpdated(); }
+  absl::Status onConfigUpdate() override { return base_.onConfigUpdate(); }
+  ConfigConstSharedPtr configCast() const override;
+  void requestVirtualHostsUpdate(const std::string&, Event::Dispatcher&,
+                                 std::weak_ptr<Http::RouteConfigUpdatedCallback>) override {}
+
+private:
+  Rds::StaticRouteConfigProviderImpl base_;
+  Rds::RouteConfigProviderManager& route_config_provider_manager_;
+};
+
+} // namespace Router
+} // namespace Envoy

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -352,7 +352,6 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       internal_address_config_(createInternalAddressConfig(config, creation_status)),
       xff_num_trusted_hops_(config.xff_num_trusted_hops()),
       skip_xff_append_(config.skip_xff_append()), via_(config.via()),
-      route_config_provider_manager_(route_config_provider_manager),
       scoped_routes_config_provider_manager_(scoped_routes_config_provider_manager),
       filter_config_provider_manager_(filter_config_provider_manager),
       http3_options_(Http3::Utility::initializeAndValidateOptions(

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -33,7 +33,7 @@
 #include "source/common/local_reply/local_reply.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/quic/server_connection_factory.h"
-#include "source/common/router/rds_impl.h"
+#include "source/common/router/route_provider_manager.h"
 #include "source/common/runtime/runtime_impl.h"
 #include "source/common/tracing/custom_tag_impl.h"
 #include "source/common/tracing/tracer_config_impl.h"
@@ -533,11 +533,16 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
   switch (config.route_specifier_case()) {
   case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       RouteSpecifierCase::kRds:
+    route_config_provider_ = route_config_provider_manager.createRdsRouteConfigProvider(
+        // At the creation of a RDS route config provider, the factory_context's initManager is
+        // always valid, though the init manager may go away later when the listener goes away.
+        config.rds(), context_.serverFactoryContext(), stats_prefix_, context_.initManager());
+    break;
   case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       RouteSpecifierCase::kRouteConfig:
-    route_config_provider_ = Router::RouteConfigProviderUtil::create(
-        config, context_.serverFactoryContext(), context_.messageValidationVisitor(),
-        context_.initManager(), stats_prefix_, route_config_provider_manager_);
+    route_config_provider_ = route_config_provider_manager.createStaticRouteConfigProvider(
+        config.route_config(), context_.serverFactoryContext(),
+        context_.messageValidationVisitor());
     break;
   case envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       RouteSpecifierCase::kScopedRoutes:

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -304,7 +304,6 @@ private:
   const std::string via_;
   Http::ForwardClientCertType forward_client_cert_;
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
-  Router::RouteConfigProviderManager& route_config_provider_manager_;
   Config::ConfigProviderManager* scoped_routes_config_provider_manager_;
   FilterConfigProviderManager& filter_config_provider_manager_;
   CodecType codec_type_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -34,7 +34,6 @@
 #include "source/common/json/json_loader.h"
 #include "source/common/local_reply/local_reply.h"
 #include "source/common/network/cidr_range.h"
-#include "source/common/router/rds_impl.h"
 #include "source/common/tracing/http_tracer_impl.h"
 #include "source/extensions/filters/network/common/factory_base.h"
 #include "source/extensions/filters/network/well_known_names.h"

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -454,7 +454,6 @@ envoy_cc_library(
         "//source/common/memory:stats_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/quic:quic_stat_names_lib",
-        "//source/common/router:rds_lib",
         "//source/common/runtime:runtime_keys_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/secret:secret_manager_impl_lib",

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -41,7 +41,6 @@
 #include "source/common/network/socket_interface.h"
 #include "source/common/network/socket_interface_impl.h"
 #include "source/common/protobuf/utility.h"
-#include "source/common/router/rds_impl.h"
 #include "source/common/runtime/runtime_impl.h"
 #include "source/common/runtime/runtime_keys.h"
 #include "source/common/signal/fatal_error_handler.h"

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -16,7 +16,9 @@
 #include "source/common/config/config_provider_impl.h"
 #include "source/common/config/null_grpc_mux_impl.h"
 #include "source/common/protobuf/message_validator_impl.h"
+#include "source/common/router/route_provider_manager.h"
 #include "source/common/router/scoped_rds.h"
+#include "source/common/router/static_route_provider_impl.h"
 
 #include "test/mocks/config/mocks.h"
 #include "test/mocks/matcher/mocks.h"

--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -11,6 +11,7 @@
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/rds_impl.h"
 #include "source/common/router/route_config_update_receiver_impl.h"
+#include "source/common/router/route_provider_manager.h"
 
 #ifdef ENVOY_ADMIN_FUNCTIONALITY
 #include "source/server/admin/admin.h"


### PR DESCRIPTION
This also removes a utility which had switch-and-panic calls in favor of explicitly calling the create functions inline.

Risk Level: low: mostly code move.
Testing: n/a
Docs Changes: n/a
Release Notes: n/a