### PR TITLE
access log: change the factory context of log filter to generic one

### DIFF
--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -30,7 +30,7 @@ public:
    */
   virtual FilterBasePtr<Context>
   createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-               Server::Configuration::FactoryContext& context) PURE;
+               Server::Configuration::GenericFactoryContext& context) PURE;
 
   std::string category() const override { return category_; }
 

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -54,7 +54,7 @@ bool ComparisonFilter::compareAgainstValue(uint64_t lhs) const {
 }
 
 FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                                   Server::Configuration::FactoryContext& context) {
+                                   Server::Configuration::GenericFactoryContext& context) {
   Runtime::Loader& runtime = context.serverFactoryContext().runtime();
   Random::RandomGenerator& random = context.serverFactoryContext().api().randomGenerator();
   ProtobufMessage::ValidationVisitor& validation_visitor = context.messageValidationVisitor();
@@ -157,7 +157,7 @@ bool RuntimeFilter::evaluate(const Formatter::HttpFormatterContext&,
 
 OperatorFilter::OperatorFilter(
     const Protobuf::RepeatedPtrField<envoy::config::accesslog::v3::AccessLogFilter>& configs,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   for (const auto& config : configs) {
     auto filter = FilterFactory::fromProto(config, context);
     if (filter != nullptr) {
@@ -167,11 +167,11 @@ OperatorFilter::OperatorFilter(
 }
 
 OrFilter::OrFilter(const envoy::config::accesslog::v3::OrFilter& config,
-                   Server::Configuration::FactoryContext& context)
+                   Server::Configuration::GenericFactoryContext& context)
     : OperatorFilter(config.filters(), context) {}
 
 AndFilter::AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
-                     Server::Configuration::FactoryContext& context)
+                     Server::Configuration::GenericFactoryContext& context)
     : OperatorFilter(config.filters(), context) {}
 
 bool OrFilter::evaluate(const Formatter::HttpFormatterContext& context,

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -35,7 +35,7 @@ public:
    * Read a filter definition from proto and instantiate a concrete filter class.
    */
   static FilterPtr fromProto(const envoy::config::accesslog::v3::AccessLogFilter& config,
-                             Server::Configuration::FactoryContext& context);
+                             Server::Configuration::GenericFactoryContext& context);
 };
 
 /**
@@ -87,7 +87,7 @@ class OperatorFilter : public Filter {
 public:
   OperatorFilter(
       const Protobuf::RepeatedPtrField<envoy::config::accesslog::v3::AccessLogFilter>& configs,
-      Server::Configuration::FactoryContext& context);
+      Server::Configuration::GenericFactoryContext& context);
 
 protected:
   std::vector<FilterPtr> filters_;
@@ -99,7 +99,7 @@ protected:
 class AndFilter : public OperatorFilter {
 public:
   AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
-            Server::Configuration::FactoryContext& context);
+            Server::Configuration::GenericFactoryContext& context);
 
   // AccessLog::Filter
   bool evaluate(const Formatter::HttpFormatterContext& context,
@@ -112,7 +112,7 @@ public:
 class OrFilter : public OperatorFilter {
 public:
   OrFilter(const envoy::config::accesslog::v3::OrFilter& config,
-           Server::Configuration::FactoryContext& context);
+           Server::Configuration::GenericFactoryContext& context);
 
   // AccessLog::Filter
   bool evaluate(const Formatter::HttpFormatterContext& context,

--- a/source/extensions/access_loggers/filters/cel/config.cc
+++ b/source/extensions/access_loggers/filters/cel/config.cc
@@ -16,7 +16,7 @@ namespace CEL {
 
 Envoy::AccessLog::FilterPtr CELAccessLogExtensionFilterFactory::createFilter(
     const envoy::config::accesslog::v3::ExtensionFilter& config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
 
   auto factory_config =
       Config::Utility::translateToFactoryConfig(config, context.messageValidationVisitor(), *this);

--- a/source/extensions/access_loggers/filters/cel/config.h
+++ b/source/extensions/access_loggers/filters/cel/config.h
@@ -22,7 +22,7 @@ class CELAccessLogExtensionFilterFactory : public Envoy::AccessLog::ExtensionFil
 public:
   Envoy::AccessLog::FilterPtr
   createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-               Server::Configuration::FactoryContext& context) override;
+               Server::Configuration::GenericFactoryContext& context) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override { return "envoy.access_loggers.extension_filters.cel"; }
 };

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1643,7 +1643,7 @@ public:
   ~TestHeaderFilterFactory() override = default;
 
   FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::FactoryContext& context) override {
+                         Server::Configuration::GenericFactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
     const auto& header_config =
@@ -1739,7 +1739,7 @@ public:
   ~SampleExtensionFilterFactory() override = default;
 
   FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::FactoryContext& context) override {
+                         Server::Configuration::GenericFactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
 


### PR DESCRIPTION
Commit Message: access log: change the factory context of log filter to generic one
Additional Description:

See slack discussion: https://envoyproxy.slack.com/archives/C78HA81DH/p1715658162300489

NOTE: I am not sure is that OK to merge this to main. It's harmless (or senseless?) to the community extensions because all community log filters have no `FactoryContext` requirement. (We use `FactoryContext` in previous implementation just for simplication.)

This change could let the third party developers to create log filters with only `ServerFactoryContext`. But will affect the third party developers who create a custom log filter which require `FactoryContext`. But considering the fact that before #31012, only `CommonFactoryContext` (it was removed) is provided to the log factory. So I guess this change is OK? Anyway, let the community to make the decision.


Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
