### PR TITLE
mobile: Fix clang-format

### DIFF
--- a/mobile/.clang-format
+++ b/mobile/.clang-format
@@ -4,7 +4,7 @@ AccessModifierOffset: -2
 ColumnLimit: 100
 DerivePointerAlignment: false
 PointerAlignment: Left
-SortIncludes: false
+SortIncludes: Never
 ...
 
 ---
@@ -14,7 +14,7 @@ ColumnLimit: 100
 DerivePointerAlignment: false
 IndentWidth: 2
 PointerAlignment: Left
-SortIncludes: false
+SortIncludes: Never
 ...
 
 ---
@@ -27,12 +27,12 @@ ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
 PointerAlignment: Right
-SortIncludes: false
+SortIncludes: Never
 ...
 
 ---
 Language: Proto
 ColumnLimit: 100
 SpacesInContainerLiterals: false
-AllowShortFunctionsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
 ...


### PR DESCRIPTION
This fixes the values that are not correct. See https://clang.llvm.org/docs/ClangFormatStyleOptions.html

Risk Level: low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
