### PR TITLE
mobile: JNI code clean up

### DIFF
--- a/mobile/library/jni/android_jni_utility.cc
+++ b/mobile/library/jni/android_jni_utility.cc
@@ -13,16 +13,16 @@ namespace JNI {
 
 bool isCleartextPermitted(absl::string_view hostname) {
 #if defined(__ANDROID_API__)
-  envoy_data host = Envoy::Bridge::Utility::copyToBridgeData(hostname);
   JniHelper jni_helper(JniHelper::getThreadLocalEnv());
-  LocalRefUniquePtr<jstring> java_host = envoyDataToJavaString(jni_helper, host);
-  LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
+  LocalRefUniquePtr<jstring> java_host = cppStringToJavaString(jni_helper, std::string(hostname));
+  LocalRefUniquePtr<jclass> java_android_network_library_class =
       findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
-  jmethodID jmid_isCleartextTrafficPermitted = jni_helper.getStaticMethodId(
-      jcls_AndroidNetworkLibrary.get(), "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
+  jmethodID java_is_cleartext_traffic_permitted_method_id =
+      jni_helper.getStaticMethodId(java_android_network_library_class.get(),
+                                   "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
   jboolean result = jni_helper.callStaticBooleanMethod(
-      jcls_AndroidNetworkLibrary.get(), jmid_isCleartextTrafficPermitted, java_host.get());
-  release_envoy_data(host);
+      java_android_network_library_class.get(), java_is_cleartext_traffic_permitted_method_id,
+      java_host.get());
   return result == JNI_TRUE;
 #else
   UNREFERENCED_PARAMETER(hostname);
@@ -33,11 +33,12 @@ bool isCleartextPermitted(absl::string_view hostname) {
 void tagSocket(int ifd, int uid, int tag) {
 #if defined(__ANDROID_API__)
   JniHelper jni_helper(JniHelper::getThreadLocalEnv());
-  LocalRefUniquePtr<jclass> jcls_AndroidNetworkLibrary =
+  LocalRefUniquePtr<jclass> java_android_network_library_class =
       findClass("io.envoyproxy.envoymobile.utilities.AndroidNetworkLibrary");
-  jmethodID jmid_tagSocket =
-      jni_helper.getStaticMethodId(jcls_AndroidNetworkLibrary.get(), "tagSocket", "(III)V");
-  jni_helper.callStaticVoidMethod(jcls_AndroidNetworkLibrary.get(), jmid_tagSocket, ifd, uid, tag);
+  jmethodID java_tag_socket_method_id =
+      jni_helper.getStaticMethodId(java_android_network_library_class.get(), "tagSocket", "(III)V");
+  jni_helper.callStaticVoidMethod(java_android_network_library_class.get(),
+                                  java_tag_socket_method_id, ifd, uid, tag);
 #else
   UNREFERENCED_PARAMETER(ifd);
   UNREFERENCED_PARAMETER(uid);

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -266,7 +266,7 @@ jvm_http_filter_on_request_headers(envoy_headers input_headers, bool end_stream,
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 1);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_headers native_headers =
       Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_headers.get());
 
@@ -291,7 +291,7 @@ jvm_http_filter_on_response_headers(envoy_headers input_headers, bool end_stream
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_headers =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 1);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_headers native_headers =
       Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_headers.get());
 
@@ -346,7 +346,7 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_data =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 1);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_data native_data = Envoy::JNI::javaByteBufferToEnvoyData(jni_helper, j_data.get());
 
   envoy_headers* pending_headers = nullptr;
@@ -380,7 +380,7 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_data =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 1);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_data native_data = Envoy::JNI::javaByteBufferToEnvoyData(jni_helper, j_data.get());
 
   envoy_headers* pending_headers = nullptr;
@@ -443,7 +443,7 @@ jvm_http_filter_on_request_trailers(envoy_headers trailers, envoy_stream_intel s
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_trailers =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 1);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_headers native_trailers =
       Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_trailers.get());
 
@@ -485,7 +485,7 @@ jvm_http_filter_on_response_trailers(envoy_headers trailers, envoy_stream_intel 
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_trailers =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 1);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_headers native_trailers =
       Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeaders(jni_helper, j_trailers.get());
 
@@ -586,7 +586,7 @@ jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> j_trailers =
       jni_helper.getObjectArrayElement<jobjectArray>(result.get(), 3);
 
-  int unboxed_status = Envoy::JNI::javaIntegerTotInt(jni_helper, status.get());
+  int unboxed_status = Envoy::JNI::javaIntegerToCppInt(jni_helper, status.get());
   envoy_headers* pending_headers =
       Envoy::JNI::javaArrayOfObjectArrayToEnvoyHeadersPtr(jni_helper, j_headers.get());
   envoy_data* pending_data = Envoy::JNI::javaByteBufferToEnvoyDataPtr(jni_helper, j_data.get());

--- a/mobile/library/jni/jni_utility.cc
+++ b/mobile/library/jni/jni_utility.cc
@@ -42,7 +42,7 @@ void jniDeleteConstGlobalRef(const void* context) {
   jniDeleteGlobalRef(const_cast<void*>(context));
 }
 
-int javaIntegerTotInt(JniHelper& jni_helper, jobject boxed_integer) {
+int javaIntegerToCppInt(JniHelper& jni_helper, jobject boxed_integer) {
   LocalRefUniquePtr<jclass> jcls_Integer = jni_helper.findClass("java/lang/Integer");
   jmethodID jmid_intValue = jni_helper.getMethodId(jcls_Integer.get(), "intValue", "()I");
   return jni_helper.callIntMethod(boxed_integer, jmid_intValue);
@@ -59,12 +59,6 @@ envoy_data javaByteArrayToEnvoyData(JniHelper& jni_helper, jbyteArray j_data, si
       jni_helper.getPrimitiveArrayCritical(j_data, nullptr);
   memcpy(native_bytes, critical_data.get(), data_length); // NOLINT(safe-memcpy)
   return {data_length, native_bytes, free, native_bytes};
-}
-
-LocalRefUniquePtr<jstring> envoyDataToJavaString(JniHelper& jni_helper, envoy_data data) {
-  // Ensure we get a null-terminated string, the data coming in via envoy_data might not be.
-  std::string str(reinterpret_cast<const char*>(data.bytes), data.length);
-  return jni_helper.newStringUtf(str.c_str());
 }
 
 LocalRefUniquePtr<jbyteArray> envoyDataToJavaByteArray(JniHelper& jni_helper, envoy_data data) {
@@ -119,22 +113,6 @@ envoyFinalStreamIntelToJavaLongArray(JniHelper& jni_helper,
   critical_array.get()[14] = static_cast<jlong>(final_stream_intel.response_flags);
   critical_array.get()[15] = static_cast<jlong>(final_stream_intel.upstream_protocol);
   return j_array;
-}
-
-LocalRefUniquePtr<jobject> envoyMapToJavaMap(JniHelper& jni_helper, envoy_map map) {
-  LocalRefUniquePtr<jclass> jcls_hashMap = jni_helper.findClass("java/util/HashMap");
-  jmethodID jmid_hashMapInit = jni_helper.getMethodId(jcls_hashMap.get(), "<init>", "(I)V");
-  LocalRefUniquePtr<jobject> j_hashMap =
-      jni_helper.newObject(jcls_hashMap.get(), jmid_hashMapInit, map.length);
-  jmethodID jmid_hashMapPut = jni_helper.getMethodId(
-      jcls_hashMap.get(), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-  for (envoy_map_size_t i = 0; i < map.length; i++) {
-    LocalRefUniquePtr<jstring> key = envoyDataToJavaString(jni_helper, map.entries[i].key);
-    LocalRefUniquePtr<jstring> value = envoyDataToJavaString(jni_helper, map.entries[i].value);
-    LocalRefUniquePtr<jobject> ignored =
-        jni_helper.callObjectMethod(j_hashMap.get(), jmid_hashMapPut, key.get(), value.get());
-  }
-  return j_hashMap;
 }
 
 envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data) {

--- a/mobile/library/jni/jni_utility.h
+++ b/mobile/library/jni/jni_utility.h
@@ -45,7 +45,7 @@ void jniDeleteGlobalRef(void* context);
 void jniDeleteConstGlobalRef(const void* context);
 
 /** Converts `java.lang.Integer` to C++ `int`. */
-int javaIntegerTotInt(JniHelper& jni_helper, jobject boxed_integer);
+int javaIntegerToCppInt(JniHelper& jni_helper, jobject boxed_integer);
 
 /** Converts from Java byte array to `envoy_data`. */
 envoy_data javaByteArrayToEnvoyData(JniHelper& jni_helper, jbyteArray j_data);
@@ -67,12 +67,6 @@ LocalRefUniquePtr<jlongArray> envoyStreamIntelToJavaLongArray(JniHelper& jni_hel
 LocalRefUniquePtr<jlongArray>
 envoyFinalStreamIntelToJavaLongArray(JniHelper& jni_helper,
                                      envoy_final_stream_intel final_stream_intel);
-
-/** Converts from Java `Map` to `envoy_map`. */
-LocalRefUniquePtr<jobject> envoyMapToJavaMap(JniHelper& jni_helper, envoy_map map);
-
-/** Converts from `envoy_data` to Java `String`. */
-LocalRefUniquePtr<jstring> envoyDataToJavaString(JniHelper& jni_helper, envoy_data data);
 
 /** Converts from Java `ByteBuffer` to `envoy_data`. */
 envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data);


### PR DESCRIPTION
This PR does the following:
- Removes unused functions.
- Fixes typo in the function name.
- Updates  `isClearTextPermitted` implementation by converting from C++ String to `jstring` instead of going through an intermediate `envoy_data`.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
