### PR TITLE
test: Fix exit code check in corpus_from_config_impl helper script

### DIFF
--- a/test/common/router/corpus_from_config_impl.sh
+++ b/test/common/router/corpus_from_config_impl.sh
@@ -3,8 +3,7 @@
 # Helper shell script for :corpus_from_config_impl genrule in BUILD.
 
 # Set NORUNFILES so test/main doesn't fail when runfiles manifest is not found.
-TEXT=$(NORUNFILES=1 "$@" 2>&1)
-if [ ! $? ]; then
+if ! TEXT=$(NORUNFILES=1 "$@" 2>&1); then
    echo "$TEXT"
    echo "Router test failed to pass: debug logs above"
    exit 1


### PR DESCRIPTION
If the config_impl_test_static executable exited with a non-zero exit code, the output text and the log message were not being printed as expected, thus obscuring the failure reason.