### PR TITLE
Clarify DOWNSTREAM_LOCAL_ADDRESS.

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -695,6 +695,12 @@ UDP
   If the original connection was redirected by iptables TPROXY, and the listener's transparent
   option was set to true, this represents the original destination address and port.
 
+  .. note::
+
+    This may not be the physical remote address of the peer if the address has been inferred from
+    :ref:`Proxy Protocol filter <config_listener_filters_proxy_protocol>` or :ref:`x-forwarded-for
+    <config_http_conn_man_headers_x-forwarded-for>`.
+
 %DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%
   Local address of the downstream connection, without any port component.
   IP addresses are the only address type with a port component.


### PR DESCRIPTION
To make the doc aligned with the actual behavior when proxy protocol filter is used on listener. We consistently set this in various places.
https://github.com/search?q=repo%3Aenvoyproxy%2Fenvoy%20Network%3A%3AProxyProtocolFilterState%3A%3Akey()&type=code

Commit Message:
Additional Description:
Risk Level: N/A
Testing:
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
