### PR TITLE
mobile: fixing an error flush bug with explicit flow control

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -829,6 +829,40 @@ TEST_P(ClientIntegrationTest, ResetAfterDataExplicit) {
   ASSERT_EQ(cc_.on_error_calls_, 1);
 }
 
+TEST_P(ClientIntegrationTest, ResetAfterDataExplicitMultipleChunks) {
+  explicit_flow_control_ = true;
+
+  autonomous_allow_incomplete_streams_ = true;
+  initialize();
+
+  default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_RESPONSE_DATA, "yes");
+  default_request_headers_.addCopy(AutonomousStream::RESPONSE_DATA_BLOCKS, "1");
+
+  auto callbacks = createDefaultStreamCallbacks();
+  ConditionalInitializer initial_data;
+  callbacks.on_data_ = [this, &initial_data](const Buffer::Instance&, uint64_t /* length */,
+                                             bool /* end_stream */, envoy_stream_intel) {
+    if (!cc_.on_data_calls_) {
+      initial_data.setReady();
+    }
+    cc_.on_data_calls_++;
+  };
+
+  stream_ = createNewStream(std::move(callbacks));
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
+
+  // Default body size is 10 - this will force 2 reads.
+  stream_->readData(5);
+  initial_data.waitReady();
+  stream_->readData(5);
+  terminal_callback_.waitReady();
+
+  // Make sure we get both chunks before flushing the error.
+  ASSERT_EQ(cc_.on_data_calls_, 2);
+  ASSERT_EQ(cc_.on_error_calls_, 1);
+}
+
 TEST_P(ClientIntegrationTest, CancelBeforeRequestHeadersSent) {
   autonomous_upstream_ = false;
   initialize();

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -728,6 +728,21 @@ TEST_P(ClientIntegrationTest, BasicBeforeResponseHeaders) {
   ASSERT_EQ(cc_.on_headers_calls_, 0);
 }
 
+TEST_P(ClientIntegrationTest, ExplicitBeforeResponseHeaders) {
+  explicit_flow_control_ = true;
+  initialize();
+
+  default_request_headers_.addCopy(AutonomousStream::RESET_AFTER_REQUEST, "yes");
+
+  stream_ = createNewStream(createDefaultStreamCallbacks());
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
+                       true);
+  terminal_callback_.waitReady();
+
+  ASSERT_EQ(cc_.on_error_calls_, 1);
+  ASSERT_EQ(cc_.on_headers_calls_, 0);
+}
+
 TEST_P(ClientIntegrationTest, ResetAfterResponseHeaders) {
   autonomous_allow_incomplete_streams_ = true;
   initialize();


### PR DESCRIPTION
1) errors should be able to precede headers
2) if we flush buffered data, we should immediately send a deferred error up.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
