### PR TITLE
basic_auth: add WWW-Authenticate header for 401 response

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -70,6 +70,9 @@ minor_behavior_changes:
 - area: quic
   change: |
     When a quic connection socket is created, the socket's detected transport protocol will be set to "quic".
+- area: filters
+  change: |
+    Set ``WWW-Authenticate`` header for 401 responses from the Basic Auth filter.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -104,7 +104,7 @@ Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,
         const auto request_headers = this->decoder_callbacks_->requestHeaders();
         const std::string uri = Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength);
         const std::string value = absl::StrCat("Basic realm=\"", uri, "\"");
-        headers.setCopy(Http::Headers::get().WWWAuthenticate, value);
+        headers.setReferenceKey(Http::Headers::get().WWWAuthenticate, value);
       },
       absl::nullopt, response_code_details);
   return Http::FilterHeadersStatus::StopIteration;

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -100,13 +100,13 @@ bool BasicAuthFilter::validateUser(const UserMap& users, absl::string_view usern
 Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,
                                                     absl::string_view response_code_details) {
   config_->stats().denied_.inc();
-  decoder_callbacks_->sendLocalReply(Http::Code::Unauthorized, body,
-                                     [uri = this->original_uri_](Http::ResponseHeaderMap& headers) {
-                                       std::string value =
-                                           absl::StrCat("Basic realm=\"", uri, "\"");
-                                       headers.setCopy(Http::Headers::get().WWWAuthenticate, value);
-                                     },
-                                     absl::nullopt, response_code_details);
+  decoder_callbacks_->sendLocalReply(
+      Http::Code::Unauthorized, body,
+      [uri = this->original_uri_](Http::ResponseHeaderMap& headers) {
+        std::string value = absl::StrCat("Basic realm=\"", uri, "\"");
+        headers.setCopy(Http::Headers::get().WWWAuthenticate, value);
+      },
+      absl::nullopt, response_code_details);
   return Http::FilterHeadersStatus::StopIteration;
 }
 

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -102,7 +102,7 @@ Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,
       Http::Code::Unauthorized, body,
       [this](Http::ResponseHeaderMap& headers) {
         const auto request_headers = this->decoder_callbacks_->requestHeaders();
-        std::string uri = Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength);
+        const std::string uri = Http::Utility::buildOriginalUri(*request_headers, MaximumUriLength);
         const std::string value = absl::StrCat("Basic realm=\"", uri, "\"");
         headers.setCopy(Http::Headers::get().WWWAuthenticate, value);
       },

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -92,6 +92,8 @@ private:
 
   // The callback function.
   FilterConfigConstSharedPtr config_;
+
+  std::string original_uri_;
 };
 
 } // namespace BasicAuth

--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.h
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.h
@@ -92,8 +92,6 @@ private:
 
   // The callback function.
   FilterConfigConstSharedPtr config_;
-
-  std::string original_uri_;
 };
 
 } // namespace BasicAuth

--- a/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
+++ b/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
@@ -130,6 +130,9 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, NoCredential) {
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("401", response->headers().getStatusValue());
   EXPECT_EQ("User authentication failed. Missing username and password.", response->body());
+  EXPECT_EQ(
+      "Basic realm=\"http://host/\"",
+      response->headers().get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 }
 
 // Request without wrong password
@@ -149,6 +152,9 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, WrongPasswrod) {
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("401", response->headers().getStatusValue());
   EXPECT_EQ("User authentication failed. Invalid username/password combination.", response->body());
+  EXPECT_EQ(
+      "Basic realm=\"http://host/\"",
+      response->headers().get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 }
 
 // Request with none-existed user
@@ -168,6 +174,9 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, NoneExistedUser) {
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("401", response->headers().getStatusValue());
   EXPECT_EQ("User authentication failed. Invalid username/password combination.", response->body());
+  EXPECT_EQ(
+      "Basic realm=\"http://host/\"",
+      response->headers().get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 }
 
 // Request with existing username header
@@ -249,6 +258,9 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, BasicAuthPerRouteEnabledInvalidCred
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("401", response->headers().getStatusValue());
   EXPECT_EQ("User authentication failed. Invalid username/password combination.", response->body());
+  EXPECT_EQ(
+      "Basic realm=\"http://host/\"",
+      response->headers().get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 }
 
 } // namespace

--- a/test/extensions/filters/http/basic_auth/filter_test.cc
+++ b/test/extensions/filters/http/basic_auth/filter_test.cc
@@ -61,7 +61,7 @@ TEST_F(FilterTest, UserNotExist) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                           std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
@@ -69,10 +69,9 @@ TEST_F(FilterTest, UserNotExist) {
 
         Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
         modify_headers(response_headers);
-        EXPECT_EQ("Basic realm=\"http://host/\"",
-                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
-                  ->value()
-                  .getStringView());
+        EXPECT_EQ(
+            "Basic realm=\"http://host/\"",
+            response_headers.get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_credential_for_basic_auth");
@@ -90,7 +89,7 @@ TEST_F(FilterTest, InvalidPassword) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                           std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
@@ -98,10 +97,9 @@ TEST_F(FilterTest, InvalidPassword) {
 
         Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
         modify_headers(response_headers);
-        EXPECT_EQ("Basic realm=\"http://host/\"",
-                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
-                  ->value()
-                  .getStringView());
+        EXPECT_EQ(
+            "Basic realm=\"http://host/\"",
+            response_headers.get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_credential_for_basic_auth");
@@ -118,7 +116,7 @@ TEST_F(FilterTest, NoAuthHeader) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                           std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
@@ -126,10 +124,9 @@ TEST_F(FilterTest, NoAuthHeader) {
 
         Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
         modify_headers(response_headers);
-        EXPECT_EQ("Basic realm=\"http://host/\"",
-                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
-                  ->value()
-                  .getStringView());
+        EXPECT_EQ(
+            "Basic realm=\"http://host/\"",
+            response_headers.get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "no_credential_for_basic_auth");
@@ -146,7 +143,7 @@ TEST_F(FilterTest, HasAuthHeaderButNotForBasic) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                           std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
@@ -154,10 +151,9 @@ TEST_F(FilterTest, HasAuthHeaderButNotForBasic) {
 
         Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
         modify_headers(response_headers);
-        EXPECT_EQ("Basic realm=\"http://host/\"",
-                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
-                  ->value()
-                  .getStringView());
+        EXPECT_EQ(
+            "Basic realm=\"http://host/\"",
+            response_headers.get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_scheme_for_basic_auth");
@@ -174,7 +170,7 @@ TEST_F(FilterTest, HasAuthHeaderButNoColon) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                           std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
@@ -182,10 +178,9 @@ TEST_F(FilterTest, HasAuthHeaderButNoColon) {
 
         Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
         modify_headers(response_headers);
-        EXPECT_EQ("Basic realm=\"http://host/\"",
-                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
-                  ->value()
-                  .getStringView());
+        EXPECT_EQ(
+            "Basic realm=\"http://host/\"",
+            response_headers.get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_format_for_basic_auth");
@@ -220,7 +215,7 @@ TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                           std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
@@ -228,10 +223,9 @@ TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
 
         Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
         modify_headers(response_headers);
-        EXPECT_EQ("Basic realm=\"http://host/\"",
-                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
-                  ->value()
-                  .getStringView());
+        EXPECT_EQ(
+            "Basic realm=\"http://host/\"",
+            response_headers.get(Http::Headers::get().WWWAuthenticate)[0]->value().getStringView());
 
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "no_credential_for_basic_auth");

--- a/test/extensions/filters/http/basic_auth/filter_test.cc
+++ b/test/extensions/filters/http/basic_auth/filter_test.cc
@@ -33,6 +33,9 @@ public:
 TEST_F(FilterTest, BasicAuth) {
   // user1:test1
   Http::TestRequestHeaderMapImpl request_headers_user1{{"Authorization", "Basic dXNlcjE6dGVzdDE="}};
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(request_headers_user1, true));
@@ -40,6 +43,9 @@ TEST_F(FilterTest, BasicAuth) {
 
   // user2:test2
   Http::TestRequestHeaderMapImpl request_headers_user2{{"Authorization", "Basic dXNlcjI6dGVzdDI="}};
+  request_headers_user2.setScheme("http");
+  request_headers_user2.setHost("host");
+  request_headers_user2.setPath("/");
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(request_headers_user2, true));
@@ -49,14 +55,25 @@ TEST_F(FilterTest, BasicAuth) {
 TEST_F(FilterTest, UserNotExist) {
   // user3:test2
   Http::TestRequestHeaderMapImpl request_headers_user1{{"Authorization", "Basic dXNlcjM6dGVzdDI="}};
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap & headers)>,
+                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
         EXPECT_EQ("User authentication failed. Invalid username/password combination.", body);
+
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+        modify_headers(response_headers);
+        EXPECT_EQ("Basic realm=\"http://host/\"",
+                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
+                  ->value()
+                  .getStringView());
+
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_credential_for_basic_auth");
       }));
@@ -67,14 +84,25 @@ TEST_F(FilterTest, UserNotExist) {
 TEST_F(FilterTest, InvalidPassword) {
   // user1:test2
   Http::TestRequestHeaderMapImpl request_headers_user1{{"Authorization", "Basic dXNlcjE6dGVzdDI="}};
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap & headers)>,
+                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
         EXPECT_EQ("User authentication failed. Invalid username/password combination.", body);
+
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+        modify_headers(response_headers);
+        EXPECT_EQ("Basic realm=\"http://host/\"",
+                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
+                  ->value()
+                  .getStringView());
+
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_credential_for_basic_auth");
       }));
@@ -84,14 +112,25 @@ TEST_F(FilterTest, InvalidPassword) {
 
 TEST_F(FilterTest, NoAuthHeader) {
   Http::TestRequestHeaderMapImpl request_headers_user1;
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap & headers)>,
+                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
         EXPECT_EQ("User authentication failed. Missing username and password.", body);
+
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+        modify_headers(response_headers);
+        EXPECT_EQ("Basic realm=\"http://host/\"",
+                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
+                  ->value()
+                  .getStringView());
+
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "no_credential_for_basic_auth");
       }));
@@ -101,14 +140,25 @@ TEST_F(FilterTest, NoAuthHeader) {
 
 TEST_F(FilterTest, HasAuthHeaderButNotForBasic) {
   Http::TestRequestHeaderMapImpl request_headers_user1{{"Authorization", "Bearer xxxxxxx"}};
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap & headers)>,
+                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
         EXPECT_EQ("User authentication failed. Expected 'Basic' authentication scheme.", body);
+
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+        modify_headers(response_headers);
+        EXPECT_EQ("Basic realm=\"http://host/\"",
+                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
+                  ->value()
+                  .getStringView());
+
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_scheme_for_basic_auth");
       }));
@@ -118,14 +168,25 @@ TEST_F(FilterTest, HasAuthHeaderButNotForBasic) {
 
 TEST_F(FilterTest, HasAuthHeaderButNoColon) {
   Http::TestRequestHeaderMapImpl request_headers_user1{{"Authorization", "Basic dXNlcjE="}};
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap & headers)>,
+                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
         EXPECT_EQ("User authentication failed. Invalid basic credential format.", body);
+
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+        modify_headers(response_headers);
+        EXPECT_EQ("Basic realm=\"http://host/\"",
+                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
+                  ->value()
+                  .getStringView());
+
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "invalid_format_for_basic_auth");
       }));
@@ -137,6 +198,9 @@ TEST_F(FilterTest, ExistingUsernameHeader) {
   // user1:test1
   Http::TestRequestHeaderMapImpl request_headers_user1{{"Authorization", "Basic dXNlcjE6dGVzdDE="},
                                                        {"x-username", "existingUsername"}};
+  request_headers_user1.setScheme("http");
+  request_headers_user1.setHost("host");
+  request_headers_user1.setPath("/");
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(request_headers_user1, true));
@@ -145,6 +209,9 @@ TEST_F(FilterTest, ExistingUsernameHeader) {
 
 TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
   Http::TestRequestHeaderMapImpl empty_request_headers;
+  empty_request_headers.setScheme("http");
+  empty_request_headers.setHost("host");
+  empty_request_headers.setPath("/");
   UserMap empty_users;
   FilterConfigPerRoute basic_auth_per_route(std::move(empty_users));
 
@@ -153,11 +220,19 @@ TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
-                           std::function<void(Http::ResponseHeaderMap & headers)>,
+                           std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                            const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                            absl::string_view details) {
         EXPECT_EQ(Http::Code::Unauthorized, code);
         EXPECT_EQ("User authentication failed. Missing username and password.", body);
+
+        Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+        modify_headers(response_headers);
+        EXPECT_EQ("Basic realm=\"http://host/\"",
+                  response_headers.get(Http::Headers::get().WWWAuthenticate)[0]
+                  ->value()
+                  .getStringView());
+
         EXPECT_EQ(grpc_status, absl::nullopt);
         EXPECT_EQ(details, "no_credential_for_basic_auth");
       }));
@@ -175,10 +250,16 @@ TEST_F(FilterTest, BasicAuthPerRouteEnabled) {
       .WillByDefault(testing::Return(&basic_auth_per_route));
 
   Http::TestRequestHeaderMapImpl valid_credentials{{"Authorization", "Basic YWRtaW46YWRtaW4="}};
+  valid_credentials.setScheme("http");
+  valid_credentials.setHost("host");
+  valid_credentials.setPath("/");
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(valid_credentials, true));
 
   Http::TestRequestHeaderMapImpl invalid_credentials{{"Authorization", "Basic dXNlcjE6dGVzdDE="}};
+  invalid_credentials.setScheme("http");
+  invalid_credentials.setHost("host");
+  invalid_credentials.setPath("/");
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(invalid_credentials, true));

--- a/test/extensions/filters/http/basic_auth/filter_test.cc
+++ b/test/extensions/filters/http/basic_auth/filter_test.cc
@@ -59,7 +59,7 @@ TEST_F(FilterTest, UserNotExist) {
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
+      .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -88,7 +88,7 @@ TEST_F(FilterTest, InvalidPassword) {
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
+      .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -117,7 +117,7 @@ TEST_F(FilterTest, NoAuthHeader) {
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
+      .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -146,7 +146,7 @@ TEST_F(FilterTest, HasAuthHeaderButNotForBasic) {
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
+      .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -175,7 +175,7 @@ TEST_F(FilterTest, HasAuthHeaderButNoColon) {
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
+      .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -217,7 +217,7 @@ TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
   empty_request_headers.setHost("host");
   empty_request_headers.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(empty_request_headers)));
+      .WillOnce(testing::Return(makeOptRef(empty_request_headers)));
   UserMap empty_users;
   FilterConfigPerRoute basic_auth_per_route(std::move(empty_users));
 
@@ -266,7 +266,7 @@ TEST_F(FilterTest, BasicAuthPerRouteEnabled) {
   invalid_credentials.setHost("host");
   invalid_credentials.setPath("/");
   EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
-            .WillOnce(testing::Return(makeOptRef(invalid_credentials)));
+      .WillOnce(testing::Return(makeOptRef(invalid_credentials)));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(invalid_credentials, true));

--- a/test/extensions/filters/http/basic_auth/filter_test.cc
+++ b/test/extensions/filters/http/basic_auth/filter_test.cc
@@ -58,7 +58,8 @@ TEST_F(FilterTest, UserNotExist) {
   request_headers_user1.setScheme("http");
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
-
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
@@ -86,6 +87,8 @@ TEST_F(FilterTest, InvalidPassword) {
   request_headers_user1.setScheme("http");
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -113,6 +116,8 @@ TEST_F(FilterTest, NoAuthHeader) {
   request_headers_user1.setScheme("http");
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -140,6 +145,8 @@ TEST_F(FilterTest, HasAuthHeaderButNotForBasic) {
   request_headers_user1.setScheme("http");
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -167,6 +174,8 @@ TEST_F(FilterTest, HasAuthHeaderButNoColon) {
   request_headers_user1.setScheme("http");
   request_headers_user1.setHost("host");
   request_headers_user1.setPath("/");
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(request_headers_user1)));
 
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(Invoke([&](Http::Code code, absl::string_view body,
@@ -207,6 +216,8 @@ TEST_F(FilterTest, BasicAuthPerRouteDefaultSettings) {
   empty_request_headers.setScheme("http");
   empty_request_headers.setHost("host");
   empty_request_headers.setPath("/");
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(empty_request_headers)));
   UserMap empty_users;
   FilterConfigPerRoute basic_auth_per_route(std::move(empty_users));
 
@@ -254,6 +265,8 @@ TEST_F(FilterTest, BasicAuthPerRouteEnabled) {
   invalid_credentials.setScheme("http");
   invalid_credentials.setHost("host");
   invalid_credentials.setPath("/");
+  EXPECT_CALL(decoder_filter_callbacks_, requestHeaders())
+            .WillOnce(testing::Return(makeOptRef(invalid_credentials)));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(invalid_credentials, true));


### PR DESCRIPTION
Commit Message: Adds valid WWW-Authenticate header for 401 response in Basic Auth filter
Additional Description:
Risk Level: Low
Testing: unit test, integration
Docs Changes: N/A
Release Notes: Set ``WWW-Authenticate`` header for 401 responses from the Basic Auth filter.
Platform Specific Features: N/A
Fixes #34015
