### PR TITLE
xds: add use_system_root_certs to CertificateValidationContext

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -339,6 +339,9 @@ message CertificateValidationContext {
     ACCEPT_UNTRUSTED = 1;
   }
 
+  message SystemRootCerts {
+  }
+
   reserved 4, 5;
 
   reserved "verify_subject_alt_name";
@@ -390,10 +393,10 @@ message CertificateValidationContext {
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
   // Use system root certs for validation.
-  // If true, system root certs are used only if neither of the ``trusted_ca``
+  // If present, system root certs are used only if neither of the ``trusted_ca``
   // or ``ca_certificate_provider_instance`` fields are set.
   // [#not-implemented-hide:]
-  bool use_system_root_certs = 17;
+  SystemRootCerts system_root_certs = 17;
 
   // If specified, updates of a file-based ``trusted_ca`` source will be triggered
   // by this watch. This allows explicit control over the path watched, by

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -323,7 +323,7 @@ message SubjectAltNameMatcher {
   type.matcher.v3.StringMatcher matcher = 2 [(validate.rules).message = {required: true}];
 }
 
-// [#next-free-field: 17]
+// [#next-free-field: 18]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -388,6 +388,12 @@ message CertificateValidationContext {
   // [#not-implemented-hide:]
   CertificateProviderPluginInstance ca_certificate_provider_instance = 13
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
+
+  // Use system root certs for validation.
+  // If true, system root certs are used only if neither of the ``trusted_ca``
+  // or ``ca_certificate_provider_instance`` fields are set.
+  // [#not-implemented-hide:]
+  bool use_system_root_certs = 17;
 
   // If specified, updates of a file-based ``trusted_ca`` source will be triggered
   // by this watch. This allows explicit control over the path watched, by


### PR DESCRIPTION
Commit Message: xds: add use_system_root_certs to CertificateValidationContext
Additional Description: This allows using system root certs in gRPC.  For details, see https://github.com/grpc/proposal/pull/436.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A