### PR TITLE
generic proxy: fix possible infinite loop 

### DIFF
--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -290,6 +290,7 @@ public:
     return {};
   }
 
+  void deferredDelete();
   void completeRequest();
 
   uint64_t requestStreamId() const {
@@ -407,13 +408,6 @@ public:
    * @param start_time the start time of the request.
    */
   void newDownstreamRequest(StreamRequestPtr request, absl::optional<StartTime> start_time = {});
-
-  /**
-   * Move the stream to the deferred delete stream list. This is called when the stream is reset
-   * or completed.
-   * @param stream the stream to be deferred deleted.
-   */
-  void deferredStream(ActiveStream& stream);
 
   static const std::string& name() {
     CONSTRUCT_ON_FIRST_USE(std::string, "envoy.filters.network.generic_proxy");

--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -250,8 +250,10 @@ public:
 
     if (config_->bindUpstreamConnection()) {
       // If upstream connection binding is enabled, the downstream connection will be closed
-      // when the upstream connection is closed.
-      EXPECT_CALL(mock_downstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
+      // when the upstream connection is closed and will clean up all active streams and
+      // L7 filter chains.
+      EXPECT_CALL(mock_downstream_connection_, close(Network::ConnectionCloseType::FlushWrite))
+          .WillOnce(Invoke([this](Network::ConnectionCloseType) { filter_->onDestroy(); }));
     }
 
     EXPECT_CALL(mock_upstream_connection_, close(Network::ConnectionCloseType::FlushWrite))


### PR DESCRIPTION
[generic proxy: fix possible infinite loop](https://github.com/envoyproxy/envoy/commit/d7347f72831a8a59faaf0be1ead970a47f04ca56)

Commit Message: generic proxy: fix possible infinite loop
Additional Description:

The generic proxy will fall in infinite loop when the upstream connection is bound to downstream connection and the upstream request is reset because protocol error (or some other reasons), then the generic proxy router will fall in infinite loop because it can never complete the cleaning up of upstream request list.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
