### PR TITLE
bazel/build: Extend `no-int` workaround to `pkgconfig` for all builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,12 @@ build --define envoy_mobile_listener=enabled
 build --experimental_repository_downloader_retries=2
 build --enable_platform_specific_config
 
+# Workaround issue with pkgconfig, see https://github.com/envoyproxy/envoy/issues/33225
+build --host_action_env=CXXFLAGS=-Wno-int-conversion
+build --action_env=CXXFLAGS=-Wno-int-conversion
+build --host_action_env=CFLAGS=-Wno-int-conversion
+build --action_env=CFLAGS=-Wno-int-conversion
+
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.
 build --action_env=CC --host_action_env=CC
@@ -147,12 +153,6 @@ build:macos --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
-
-# Workaround issue with pkgconfig, see https://github.com/envoyproxy/envoy/issues/33225
-build:macos --host_action_env=CXXFLAGS=-Wno-int-conversion
-build:macos --action_env=CXXFLAGS=-Wno-int-conversion
-build:macos --host_action_env=CFLAGS=-Wno-int-conversion
-build:macos --action_env=CFLAGS=-Wno-int-conversion
 
 # macOS ASAN/UBSAN
 build:macos-asan --config=asan

--- a/.bazelrc
+++ b/.bazelrc
@@ -26,12 +26,6 @@ build --define envoy_mobile_listener=enabled
 build --experimental_repository_downloader_retries=2
 build --enable_platform_specific_config
 
-# Workaround issue with pkgconfig, see https://github.com/envoyproxy/envoy/issues/33225
-build --host_action_env=CXXFLAGS=-Wno-int-conversion
-build --action_env=CXXFLAGS=-Wno-int-conversion
-build --host_action_env=CFLAGS=-Wno-int-conversion
-build --action_env=CFLAGS=-Wno-int-conversion
-
 # Pass CC, CXX and LLVM_CONFIG variables from the environment.
 # We assume they have stable values, so this won't cause action cache misses.
 build --action_env=CC --host_action_env=CC

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1455,7 +1455,13 @@ def _rules_ruby():
     external_http_archive("rules_ruby")
 
 def _foreign_cc_dependencies():
-    external_http_archive("rules_foreign_cc")
+    external_http_archive(
+        name = "rules_foreign_cc",
+        # This patch is needed to fix build on macos with xcode 15.3.
+        # remove this when https://github.com/bazelbuild/rules_foreign_cc/issues/1186 fixed.
+        patch_args = ["-p1"],
+        patches = ["@envoy//bazel:rules_foreign_cc.patch"],
+    )
 
 def _com_github_maxmind_libmaxminddb():
     external_http_archive(

--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -1,0 +1,20 @@
+diff --git a/foreign_cc/built_tools/pkgconfig_build.bzl b/foreign_cc/built_tools/pkgconfig_build.bzl
+index 64cb677..9a8c62c 100644
+--- a/foreign_cc/built_tools/pkgconfig_build.bzl
++++ b/foreign_cc/built_tools/pkgconfig_build.bzl
+@@ -9,6 +9,6 @@ load(
+     "built_tool_rule_impl",
+ )
+ load("//toolchains/native_tools:tool_access.bzl", "get_make_data")
+
+ def _pkgconfig_tool_impl(ctx):
+     make_data = get_make_data(ctx)
+@@ -18,6 +22,8 @@ def _pkgconfig_tool_impl(ctx):
+         "%s install" % make_data.path,
+     ]
+
++    script[0] = "CFLAGS=-Wno-int-conversion CXXFLAGS=-Wno-int-conversion ./configure --with-internal-glib --prefix=$$INSTALLDIR$$"
++
+     additional_tools = depset(transitive = [make_data.target.files])
+
+     return built_tool_rule_impl(


### PR DESCRIPTION
This extends the workaround that was added to macos to other builds

The need for the workaround wasnt macos specific - it relates more to the llvm/clang version used

fix #32426 

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
