### PR TITLE
admission control filter: Fix average RPS calculation

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -61,6 +61,12 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: admission control
+  change: |
+    Fixed the thread-local controller's average RPS calculation to be calculated over the full
+    lookback window. Previously, the controller would calculate the average RPS over the amount of
+    time elapsed since the oldest valid request sample. This change brings the behavior in line with
+    the documentation.
 - area: outlier detection
   change: |
     Fixed :ref:`successful_active_health_check_uneject_host

--- a/source/extensions/filters/http/admission_control/thread_local_controller.cc
+++ b/source/extensions/filters/http/admission_control/thread_local_controller.cc
@@ -22,7 +22,8 @@ uint32_t ThreadLocalControllerImpl::averageRps() const {
     return 0;
   }
   using std::chrono::seconds;
-  seconds secs = std::max(seconds(1), std::chrono::duration_cast<seconds>(ageOfOldestSample()));
+  seconds secs =
+      std::max(sampling_window_, std::chrono::duration_cast<seconds>(ageOfOldestSample()));
   return global_data_.requests / secs.count();
 }
 

--- a/source/extensions/filters/http/admission_control/thread_local_controller.h
+++ b/source/extensions/filters/http/admission_control/thread_local_controller.h
@@ -41,7 +41,7 @@ public:
   // Returns the average RPS across the sampling window.
   virtual uint32_t averageRps() const PURE;
 
-  // Returns the lookback window for this controller.
+  // Returns the sample window for this controller.
   virtual std::chrono::seconds samplingWindow() const PURE;
 };
 

--- a/source/extensions/filters/http/admission_control/thread_local_controller.h
+++ b/source/extensions/filters/http/admission_control/thread_local_controller.h
@@ -38,8 +38,11 @@ public:
   // Returns the current number of requests and how many of them are successful.
   virtual RequestData requestCounts() PURE;
 
-  // return the average RPS across the sampling window
+  // Returns the average RPS across the sampling window.
   virtual uint32_t averageRps() const PURE;
+
+  // Returns the lookback window for this controller.
+  virtual std::chrono::seconds samplingWindow() const PURE;
 };
 
 /**
@@ -67,6 +70,8 @@ public:
   }
 
   uint32_t averageRps() const override;
+
+  std::chrono::seconds samplingWindow() const override { return sampling_window_; }
 
 private:
   void recordRequest(bool success);

--- a/test/extensions/filters/http/admission_control/admission_control_filter_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_filter_test.cc
@@ -37,6 +37,7 @@ public:
   MOCK_METHOD(void, recordSuccess, ());
   MOCK_METHOD(void, recordFailure, ());
   MOCK_METHOD(uint32_t, averageRps, (), (const));
+  MOCK_METHOD(std::chrono::seconds, samplingWindow, (), (const));
 };
 
 class MockResponseEvaluator : public ResponseEvaluator {

--- a/test/extensions/filters/http/admission_control/controller_test.cc
+++ b/test/extensions/filters/http/admission_control/controller_test.cc
@@ -100,35 +100,33 @@ TEST_F(ThreadLocalControllerTest, VerifyMemoryUsage) {
   EXPECT_EQ(RequestData(3, 3), tlc_.requestCounts());
 }
 
-// Test for function: averageRps.
+// Verify the average RPS is calculated properly.
 TEST_F(ThreadLocalControllerTest, AverageRps) {
-  // Validate that historical_data_ is empty.
+  // Lookback window is 5s by default in these tests.
+  constexpr auto test_window = std::chrono::seconds(5);
+  EXPECT_EQ(test_window, tlc_.samplingWindow());
+
+  // We expect the RPS to be 0 after instantiation.
   EXPECT_EQ(0, tlc_.averageRps());
 
-  // Validate that global_data_.requests equals to zero.
-  tlc_.requestCounts();
-  EXPECT_EQ(0, tlc_.averageRps());
-
-  // Validate the value in one second.
+  // Validate the average RPS value is calculated over the entire lookback window.
   tlc_.recordSuccess();
   tlc_.recordFailure();
-  EXPECT_EQ(2, tlc_.averageRps());
-
-  // Validate that the sampling window is not full.
-  time_system_.advanceTimeWait(std::chrono::seconds(1));
+  // We had 2 requests, so this would be 0.4 RPS over the full window.
+  EXPECT_EQ(2, tlc_.requestCounts().requests);
+  EXPECT_EQ(0, tlc_.averageRps());
+  // At 5 requests, this should be 1 RPS even if 0s have elapsed.
   tlc_.recordSuccess();
-  EXPECT_EQ(3, tlc_.averageRps());
+  tlc_.recordFailure();
+  tlc_.recordSuccess();
+  EXPECT_EQ(5, tlc_.requestCounts().requests);
+  EXPECT_EQ(1, tlc_.averageRps());
 
-  // Now clean up the sampling window to validate that the sampling window is full.
-  time_system_.advanceTimeWait(std::chrono::seconds(10));
-  for (int tick = 0; tick < window_.count(); ++tick) {
-    // 1 + 3 + 5 + 7 + 9
-    for (int record_count = 0; record_count <= tick * 2; ++record_count) {
-      tlc_.recordSuccess();
-    }
-    time_system_.advanceTimeWait(std::chrono::seconds(1));
-  }
-  EXPECT_EQ(5, tlc_.averageRps());
+  // After enough time, the requests that are outside the window should not count towards the
+  // average RPS calculation.
+  time_system_.advanceTimeWait(test_window);
+  EXPECT_EQ(0, tlc_.requestCounts().requests);
+  EXPECT_EQ(0, tlc_.averageRps());
 }
 
 } // namespace

--- a/test/extensions/filters/http/admission_control/controller_test.cc
+++ b/test/extensions/filters/http/admission_control/controller_test.cc
@@ -102,14 +102,14 @@ TEST_F(ThreadLocalControllerTest, VerifyMemoryUsage) {
 
 // Verify the average RPS is calculated properly.
 TEST_F(ThreadLocalControllerTest, AverageRps) {
-  // Lookback window is 5s by default in these tests.
+  // Sample window is 5s by default in these tests.
   constexpr auto test_window = std::chrono::seconds(5);
   EXPECT_EQ(test_window, tlc_.samplingWindow());
 
   // We expect the RPS to be 0 after instantiation.
   EXPECT_EQ(0, tlc_.averageRps());
 
-  // Validate the average RPS value is calculated over the entire lookback window.
+  // Validate the average RPS value is calculated over the entire sample window.
   tlc_.recordSuccess();
   tlc_.recordFailure();
   // We had 2 requests, so this would be 0.4 RPS over the full window.


### PR DESCRIPTION
This patch fixes a bug in the thread-local controller's average RPS
calculation. The controller was erroneously calculating the average over
the time elapsed since the oldest valid sample, which is incorrect. This
can result in erratic load shedding behavior for bursty request
distributions.

The correct behavior is to calculate the average RPS over the full
lookback window.

Risk Level: Low
Testing: Unit test
Docs Changes: n/a
Release Notes: Documented the bugfix.
Fixes #33739
