### PR TITLE
http2: migrates DATA frame payloads to the visitor API

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -16,6 +16,10 @@ behavior_changes:
   change: |
     Changes the default value of ``envoy.reloadable_features.http2_use_oghttp2`` to true. This changes the codec used for HTTP/2
     requests and responses. This behavior can be reverted by setting the feature to false.
+- area: http2
+  change: |
+    Passes HTTP/2 DATA frames through a different codec API. This behavior can be temporarily disabled by setting the runtime
+    feature ``envoy.reloadable_features.http2_use_visitor_for_data`` to false.
 - area: proxy_protocol
   change: |
     Populate typed metadata by default in proxy protocol listener. Typed metadata can be consumed as

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -368,7 +368,7 @@ void ConnectionImpl::StreamImpl::processBufferedData() {
     // We only buffer the onStreamClose if we had no errors.
     if (Status status = parent_.onStreamClose(this, 0); !status.ok()) {
       ENVOY_CONN_LOG(debug, "error invoking onStreamClose: {}", parent_.connection_,
-                     status.message()); // GCOV_EXCL_LINE
+                     status.message()); // LCOV_EXCL_LINE
     }
   }
 }
@@ -787,7 +787,7 @@ void ConnectionImpl::StreamImpl::resetStream(StreamResetReason reason) {
     // its stream close.
     if (Status status = parent_.onStreamClose(this, 0); !status.ok()) {
       ENVOY_CONN_LOG(debug, "error invoking onStreamClose: {}", parent_.connection_,
-                     status.message()); // GCOV_EXCL_LINE
+                     status.message()); // LCOV_EXCL_LINE
     }
     return;
   }
@@ -985,7 +985,7 @@ Http::Status ConnectionImpl::dispatch(Buffer::Instance& data) {
     // protections that Envoy's codec does not have.
     if (rc == NGHTTP2_ERR_FLOODED) {
       return bufferFloodError(
-          "Flooding was detected in this HTTP/2 session, and it must be closed"); // GCOV_EXCL_LINE
+          "Flooding was detected in this HTTP/2 session, and it must be closed"); // LCOV_EXCL_LINE
     }
     if (rc != static_cast<ssize_t>(slice.len_)) {
       return codecProtocolError(nghttp2_strerror(rc));
@@ -1188,7 +1188,7 @@ Status ConnectionImpl::onHeaders(int32_t stream_id, size_t length, uint8_t flags
 
   default:
     // We do not currently support push.
-    ENVOY_BUG(false, "push not supported"); // GCOV_EXCL_LINE
+    ENVOY_BUG(false, "push not supported"); // LCOV_EXCL_LINE
   }
 
   stream->advanceHeadersState();
@@ -1312,7 +1312,7 @@ int ConnectionImpl::onInvalidFrame(int32_t stream_id, int error_code) {
 
   default:
     // Unknown error conditions. Trigger ENVOY_BUG and connection close.
-    ENVOY_BUG(false, absl::StrCat("Unexpected error_code: ", error_code)); // GCOV_EXCL_LINE
+    ENVOY_BUG(false, absl::StrCat("Unexpected error_code: ", error_code)); // LCOV_EXCL_LINE
     break;
   }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1704,11 +1704,11 @@ ConnectionImpl::Http2Visitor::OnReadyToSendDataForStream(Http2StreamId stream_id
                                                          size_t max_length) {
   StreamImpl* stream = connection_->getStream(stream_id);
   if (stream == nullptr) {
-    return {-1, false, false};
+    return {/*payload_length=*/-1, /*end_data=*/false, /*end_stream=*/false};
   }
   if (stream->pending_send_data_->length() == 0 && !stream->local_end_stream_) {
     stream->data_deferred_ = true;
-    return {0, false, false};
+    return {/*payload_length=*/0, /*end_data=*/false, /*end_stream=*/false};
   }
   const size_t length = std::min<size_t>(max_length, stream->pending_send_data_->length());
   bool end_data = false;

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -470,6 +470,8 @@ protected:
   };
 
   // Encapsulates the logic for sending DATA frames on a given stream.
+  // Deprecated. Remove when removing
+  // `envoy_reloadable_features_http2_use_visitor_for_data`.
   class StreamDataFrameSource : public http2::adapter::DataFrameSource {
   public:
     explicit StreamDataFrameSource(StreamImpl& stream) : stream_(stream) {}

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -176,6 +176,10 @@ protected:
       stream_close_listener_ = std::move(f);
     }
     int64_t OnReadyToSend(absl::string_view serialized) override;
+    DataFrameHeaderInfo OnReadyToSendDataForStream(Http2StreamId stream_id,
+                                                   size_t max_length) override;
+    bool SendDataFrame(Http2StreamId stream_id, absl::string_view frame_header,
+                       size_t payload_bytes) override;
     void OnConnectionError(ConnectionError /*error*/) override {}
     bool OnFrameHeader(Http2StreamId stream_id, size_t length, uint8_t type,
                        uint8_t flags) override;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -59,6 +59,7 @@ RUNTIME_GUARD(envoy_reloadable_features_http2_decode_metadata_with_quiche);
 RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year.
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
+RUNTIME_GUARD(envoy_reloadable_features_http2_use_visitor_for_data);
 RUNTIME_GUARD(envoy_reloadable_features_http2_validate_authority_with_quiche);
 RUNTIME_GUARD(envoy_reloadable_features_http_allow_partial_urls_in_referer);
 RUNTIME_GUARD(envoy_reloadable_features_http_filter_avoid_reentrant_local_reply);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -597,6 +597,51 @@ TEST_P(Http2CodecImplTest, SimpleRequestResponse) {
   }
 }
 
+TEST_P(Http2CodecImplTest, SimpleRequestResponseOldApi) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.http2_use_visitor_for_data", "false"}});
+  initialize();
+
+  InSequence s;
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  request_headers.setMethod("POST");
+
+  // Encode request headers.
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+
+  // Queue request body.
+  Buffer::OwnedImpl request_body(std::string(1024, 'a'));
+  request_encoder_->encodeData(request_body, true);
+
+  // Flush request body.
+  EXPECT_CALL(request_decoder_, decodeData(_, true)).Times(AtLeast(1));
+  driveToCompletion();
+
+  TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+
+  // Encode response headers.
+  EXPECT_CALL(response_decoder_, decodeHeaders_(_, false));
+  response_encoder_->encodeHeaders(response_headers, false);
+
+  // Queue response body.
+  Buffer::OwnedImpl response_body(std::string(1024, 'b'));
+  response_encoder_->encodeData(response_body, true);
+
+  // Flush response body.
+  EXPECT_CALL(response_decoder_, decodeData(_, true)).Times(AtLeast(1));
+  driveToCompletion();
+
+  EXPECT_TRUE(client_wrapper_->status_.ok());
+  EXPECT_TRUE(server_wrapper_->status_.ok());
+
+  if (http2_implementation_ == Http2Impl::Nghttp2) {
+    // Regression test for issue #19761.
+    EXPECT_EQ(0, getClientDataSourcesSize());
+    EXPECT_EQ(0, getServerDataSourcesSize());
+  }
+}
+
 TEST_P(Http2CodecImplTest, ShutdownNotice) {
   initialize();
   EXPECT_EQ(absl::nullopt, request_encoder_->http1StreamEncoderOptions());

--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -423,6 +423,19 @@ Http2Frame Http2Frame::makeDataFrame(uint32_t stream_index, absl::string_view da
   return frame;
 }
 
+Http2Frame Http2Frame::makeDataFrameWithPadding(uint32_t stream_index, absl::string_view data,
+                                                uint8_t padding_size) {
+  ASSERT(padding_size > 0);
+  Http2Frame frame;
+  frame.buildHeader(Type::Data, 0, 0x08, makeNetworkOrderStreamId(stream_index));
+  frame.appendData({static_cast<uint8_t>(padding_size - 1u)});
+  frame.appendData(data);
+  std::vector<uint8_t> padding(padding_size - 1);
+  frame.appendData(padding);
+  frame.adjustPayloadSize();
+  return frame;
+}
+
 } // namespace Http2
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -184,6 +184,8 @@ public:
                                     const std::vector<Header> extra_headers);
   static Http2Frame makeDataFrame(uint32_t stream_index, absl::string_view data,
                                   DataFlags flags = DataFlags::None);
+  static Http2Frame makeDataFrameWithPadding(uint32_t stream_index, absl::string_view data,
+                                             uint8_t padding_size);
 
   /**
    * Creates a frame with the given contents. This frame can be

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -258,6 +258,7 @@ KiB
 Kille
 LBs
 LC
+LCOV
 LDS
 LEDS
 LEV


### PR DESCRIPTION
This slightly simplifies the flow of DATA frame payloads; after this change, the `StreamDataFrameSource` class can be removed.

* `Http2Visitor::OnReadyToSendDataForStream()` is substantially the same implementation as `StreamDataFrameSource::SelectPayloadLength()`.
* `Http2Visitor::SendDataFrame()` is substantially the same as `StreamDataFrameSource::Send()`.

Commit Message: http2: migrates DATA frame payloads to the visitor API
Additional Description:
Risk Level: low
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes: added a note with the runtime feature to disable in case of problems
Runtime guard: `envoy_reloadable_features_http2_use_visitor_for_data`
