### PR TITLE
[network]Add ip address family info to error details upon socket connect failure

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1037,7 +1037,11 @@ void ClientConnectionImpl::connect() {
   } else {
     immediate_error_event_ = ConnectionEvent::RemoteClose;
     connecting_ = false;
-    setFailureReason(absl::StrCat("immediate connect error: ", errorDetails(result.errno_)));
+    setFailureReason(absl::StrCat(
+        "immediate connect error: ", errorDetails(result.errno_), "remote address family:",
+        socket_->connectionInfoProvider().remoteAddress()->ip()->version() == Address::IpVersion::v4
+            ? "v4"
+            : "v6"));
     ENVOY_CONN_LOG_EVENT(debug, "connection_immediate_error", "{}", *this, failureReason());
 
     // Trigger a write event. This is needed on macOS and seems harmless on Linux.

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1038,10 +1038,8 @@ void ClientConnectionImpl::connect() {
     immediate_error_event_ = ConnectionEvent::RemoteClose;
     connecting_ = false;
     setFailureReason(absl::StrCat(
-        "immediate connect error: ", errorDetails(result.errno_), "|remote address family:",
-        socket_->connectionInfoProvider().remoteAddress()->ip()->version() == Address::IpVersion::v4
-            ? "v4"
-            : "v6"));
+        "immediate connect error: ", errorDetails(result.errno_),
+        "|remote address:", socket_->connectionInfoProvider().remoteAddress()->asString()));
     ENVOY_CONN_LOG_EVENT(debug, "connection_immediate_error", "{}", *this, failureReason());
 
     // Trigger a write event. This is needed on macOS and seems harmless on Linux.

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1038,7 +1038,7 @@ void ClientConnectionImpl::connect() {
     immediate_error_event_ = ConnectionEvent::RemoteClose;
     connecting_ = false;
     setFailureReason(absl::StrCat(
-        "immediate connect error: ", errorDetails(result.errno_), "remote address family:",
+        "immediate connect error: ", errorDetails(result.errno_), "|remote address family:",
         socket_->connectionInfoProvider().remoteAddress()->ip()->version() == Address::IpVersion::v4
             ? "v4"
             : "v6"));


### PR DESCRIPTION
Commit Message: Add ip address family info to error details upon socket connect failure
Additional Description: This helps reveal more info on why the socket connection fails immediately
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
