### PR TITLE
tls_inspector: Fix invalid ALPN extension in test

### DIFF
--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -117,6 +117,18 @@ std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja
                                                // algorithm
                                                0x04, 0x03};
 
+  // ALPN extension
+  const uint16_t alpn_id = 0x10;
+  std::vector<uint8_t> alpn_extension = {(alpn_id & 0xff00) >> 8, alpn_id & 0xff,
+                                         // length
+                                         0x00, 0x0b,
+                                         // list length
+                                         0x00, 0x09,
+                                         // protocol length
+                                         0x08,
+                                         // protocol name
+                                         'H', 'T', 'T', 'P', '/', '1', '.', '1'};
+
   // extensions
   values = absl::StrSplit(fingerprint[2], '-', absl::SkipEmpty());
   std::vector<uint8_t> extensions;
@@ -139,6 +151,10 @@ std::vector<uint8_t> generateClientHelloFromJA3Fingerprint(const std::string& ja
     case signature_algorithms_id: {
       extensions.insert(std::end(extensions), std::begin(signature_algorithms),
                         std::end(signature_algorithms));
+      break;
+    }
+    case alpn_id: {
+      extensions.insert(std::end(extensions), std::begin(alpn_extension), std::end(alpn_extension));
       break;
     }
     default: {


### PR DESCRIPTION
This commit stops `generateClientHelloFromJA3Fingerprint()` generating client hellos containing an invalid ALPN extension. It also updates relevant `tls_inspector_test` functions to check the ALPN value, if expected.

When the `generateClientHelloFromJA3Fingerprint()` function was asked to include an ALPN extension (16) in the generated client hello, it was generating a default empty extension with the correct id (16) but a zero length. While this is technically a valid extension, it is not a valid ALPN extension, which must include a list of the client's preferred protocol(s).

This was causing test failures in the `envoyproxy/envoy-openssl` repo because OpenSSL responds to the malformed ALPN extension by sending a TLS alert 50 (Decode Error) which causes many of the `tls_inspector_test` functions to fail.

Risk Level: Low
Testing: Modifies existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
