### PR TITLE
mobile: Update a comment about on_data_ callback

### DIFF
--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -64,6 +64,7 @@ struct EnvoyStreamCallbacks {
    *
    * The callback function pases the following parameters.
    * - buffer: the data received.
+   * - length: the length of data to read. It will always be <= `buffer.length()`
    * - end_stream: whether the data is the last data frame.
    * - stream_intel: contains internal stream metrics.
    */


### PR DESCRIPTION
This PR updates the comment for `on_data_` callback related to the `length`.

Risk Level: low (comment update only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a