### PR TITLE
docs: clarify Windows build status

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -27,6 +27,10 @@ main commit at which the binary was compiled, and `latest` corresponds to a bina
 
 ## Windows 2019 Envoy image
 
+On August 31, 2023 the Envoy project ended official Windows support due to a lack of resources.
+We will continue to accept patches related to the Windows build. Until further notice, Windows
+builds are excluded from Envoy CI, as well as the Envoy release and security processes.
+
 The Windows 2019 based Envoy Docker image at [`envoyproxy/envoy-build-windows2019:<hash>`](https://hub.docker.com/r/envoyproxy/envoy-build-windows2019/)
 is used for CI checks, where `<hash>` is specified in [`envoy_build_sha.sh`](https://github.com/envoyproxy/envoy/blob/main/ci/envoy_build_sha.sh).
 Developers may work with the most recent `envoyproxy/envoy-build-windows2019` image to provide a self-contained environment for building Envoy binaries and

--- a/docs/root/_include/windows_support_ended.rst
+++ b/docs/root/_include/windows_support_ended.rst
@@ -1,0 +1,5 @@
+.. note::
+
+  On August 31, 2023 the Envoy project ended official Windows support due to a lack of resources.
+  We will continue to accept patches related to the Windows build. Until further notice, Windows
+  builds are excluded from Envoy CI, as well as the Envoy release and security processes.

--- a/docs/root/faq/overview.rst
+++ b/docs/root/faq/overview.rst
@@ -87,6 +87,8 @@ Extensions
 Windows
 -------
 
+.. include:: ../_include/windows_support_ended.rst
+
 .. toctree::
   :maxdepth: 2
 

--- a/docs/root/faq/windows/win_fips_support.rst
+++ b/docs/root/faq/windows/win_fips_support.rst
@@ -1,6 +1,8 @@
 Does Envoy on Windows support FIPS?
 ===================================
 
+.. include:: ../../_include/windows_support_ended.rst
+
 Envoy uses `BoringSSL <https://boringssl.googlesource.com/boringssl/>`_  which is a slimmed down TLS implementation. At the time of writing,
 BoringSSL does not support a FIPS mode on Windows. As a result, Envoy does not offer support for FIPS on Windows.
 

--- a/docs/root/faq/windows/win_not_supported_features.rst
+++ b/docs/root/faq/windows/win_not_supported_features.rst
@@ -1,6 +1,8 @@
 Which Envoy features are not supported on Windows?
 ==================================================
 
+.. include:: ../../_include/windows_support_ended.rst
+
 The vast majority of Envoy features are supported on Windows. There are few exceptions that are documented explicitly.
 The most notable features that are not supported on Windows are:
 

--- a/docs/root/faq/windows/win_performance.rst
+++ b/docs/root/faq/windows/win_performance.rst
@@ -1,6 +1,8 @@
 How fast is Envoy on Windows?
 =============================
 
+.. include:: ../../_include/windows_support_ended.rst
+
 Everything that is mentioned in :ref:`How fast is Envoy? <faq_how_fast_is_envoy>` applies to Windows. We have
 done some work to improve the event loop on Windows. That being said, we have observed that the tail performance of Envoy on Windows
 tends to be worse compared to Linux, especially when TLS is involved.

--- a/docs/root/faq/windows/win_requirements.rst
+++ b/docs/root/faq/windows/win_requirements.rst
@@ -1,7 +1,9 @@
 What are the requirements to run on Envoy on Windows?
 =====================================================
 
-Envoy is tested on Windows Server Core 2019 (Long-Term Servicing Channel). This corresponds to OS version 10.0.17763.1879. We have also tested a few more recent versions of Windows Server
+.. include:: ../../_include/windows_support_ended.rst
+
+Envoy was tested on Windows Server Core 2019 (Long-Term Servicing Channel). This corresponds to OS version 10.0.17763.1879. We have also tested a few more recent versions of Windows Server
 and in general higher versions will be fully supported. For more info please see `Windows Server Core <https://hub.docker.com/_/microsoft-windows-servercore>`_.
 To build Envoy from source you will need to have at least Windows 10 SDK, version 1803 (10.0.17134.12).
 Earlier versions will not compile because the ``afunix.h`` header is not available.

--- a/docs/root/faq/windows/win_run_as_service.rst
+++ b/docs/root/faq/windows/win_run_as_service.rst
@@ -1,6 +1,8 @@
 Can I run Envoy on Windows under SCM?
 =====================================
 
+.. include:: ../../_include/windows_support_ended.rst
+
 .. note::
 
     This feature is still in Experimental state.

--- a/docs/root/faq/windows/win_security.rst
+++ b/docs/root/faq/windows/win_security.rst
@@ -1,4 +1,6 @@
 What is the security release process?
 =====================================
 
+.. include:: ../../_include/windows_support_ended.rst
+
 We follow the process described at `Security Reporting Process <https://github.com/envoyproxy/envoy/blob/main/SECURITY.md#security-reporting-process>`_.

--- a/docs/root/start/building.rst
+++ b/docs/root/start/building.rst
@@ -6,8 +6,8 @@ Building
 
 The Envoy build system uses `Bazel <https://bazel.build/>`_.
 
-In order to ease initial building and for a quick start, we provide an Ubuntu 16 and a Windows based docker containers
-that have everything needed inside of it to build and *statically link* Envoy, see :repo:`ci/README.md`.
+In order to ease initial building and for a quick start, we provide a recent Ubuntu-based docker container
+that has everything needed inside of it to build and *statically link* Envoy, see :repo:`ci/README.md`.
 
 In order to build without using the Docker container, follow the instructions at :repo:`bazel/README.md`.
 
@@ -33,7 +33,9 @@ as the new tcmalloc code is not guaranteed to compile with lower versions of Cla
 Windows Target Requirements
 ---------------------------
 
-Envoy now suports Windows as a target platform. The requirements below only apply if you want to build the Windows
+.. include:: ../_include/windows_support_ended.rst
+
+Envoy supports Windows as a target platform. The requirements below only apply if you want to build the Windows
 native executable. If you want to build the Linux version of Envoy on Windows either with WSL or Linux containers
 please see the Linux requirements above.
 

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -73,18 +73,6 @@ You can install Envoy on Mac OSX using the official brew repositories.
       $ brew update
       $ brew install envoy
 
-.. _start_install_windows:
-
-Install Envoy on Windows
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can run Envoy using the official Windows Docker image.
-
-.. substitution-code-block:: console
-
-   $ docker pull envoyproxy/|envoy_windows_docker_image|
-   $ docker run --rm envoyproxy/|envoy_windows_docker_image| --version
-
 .. _start_install_docker:
 
 Install Envoy using Docker
@@ -214,25 +202,6 @@ The following table shows the available Docker tag variants for the latest
      - :dockerhub_envoy:`tools`
      - :dockerhub_envoy:`tools-dev`
 
-
-`envoyproxy/envoy-windows <https://hub.docker.com/r/envoyproxy/envoy-windows>`__, `envoyproxy/envoy-windows-dev <https://hub.docker.com/r/envoyproxy/envoy-windows-dev>`__
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-Release binary with symbols stripped on top of a Windows Server 1809 base.
-
-The ``windows-dev`` image also contains build tools.
-
-.. list-table::
-   :widths: auto
-   :header-rows: 1
-   :stub-columns: 1
-
-   * - variant
-     - latest stable (amd64)
-     - main dev (amd64)
-   * - envoy-windows
-     - :dockerhub_envoy:`windows`
-     - :dockerhub_envoy:`windows-dev`
 
 .. _install_tools:
 

--- a/docs/root/start/quick-start/run-envoy.rst
+++ b/docs/root/start/quick-start/run-envoy.rst
@@ -31,14 +31,6 @@ Once you have :ref:`installed Envoy <install>`, you can check the version inform
                envoyproxy/|envoy_docker_image| \
                    --version
          ...
-   .. tab:: Docker (Windows Image)
-
-      .. substitution-code-block:: powershell
-
-         PS> docker run --rm
-               'envoyproxy/|envoy_windows_docker_image|'
-                  --version
-         ...
 
 .. _start_quick_start_help:
 
@@ -64,15 +56,6 @@ flag:
          $ docker run --rm \
                envoyproxy/|envoy_docker_image| \
                    --help
-         ...
-
-   .. tab:: Docker (Windows Image)
-
-      .. substitution-code-block:: powershell
-
-         PS> docker run --rm
-               'envoyproxy/|envoy_windows_docker_image|'
-                    --help
          ...
 
 .. _start_quick_start_config:
@@ -122,33 +105,6 @@ Envoy will parse the config file according to the file extension, please see the
                -p 10000:10000 \
                envoyproxy/|envoy_docker_image| \
                    -c /envoy-custom.yaml
-         ...
-
-   .. tab:: Docker (Windows Image)
-
-      You can start the Envoy Docker image without specifying a configuration file, and
-      it will use the demo config by default.
-
-      .. substitution-code-block:: powershell
-
-         PS> docker run --rm -it
-               -p '9901:9901'
-               -p '10000:10000'
-               'envoyproxy/|envoy_windows_docker_image|'
-         ...
-
-      To specify a custom configuration you can mount the config into the container, and specify the path with ``-c``.
-
-      Assuming you have a custom configuration in the current directory named ``envoy-custom.yaml``, from PowerShell run:
-
-      .. substitution-code-block:: powershell
-
-         PS> docker run --rm -it
-               -v "$PWD\:`"C:\envoy-configs`""
-               -p '9901:9901'
-               -p '10000:10000'
-               'envoyproxy/|envoy_windows_docker_image|'
-                   -c 'C:\envoy-configs\envoy-custom.yaml'
          ...
 
 Check Envoy is proxying on http://localhost:10000.
@@ -201,6 +157,8 @@ Next, start the Envoy server using the override configuration:
 
       On Windows run:
 
+      .. include:: ../../_include/windows_support_ended.rst
+
       .. code-block:: powershell
 
          $ envoy -c envoy-demo.yaml --config-yaml "$(Get-Content -Raw envoy-override.yaml)"
@@ -216,18 +174,6 @@ Next, start the Envoy server using the override configuration:
                envoyproxy/|envoy_docker_image| \
                    -c /etc/envoy/envoy.yaml \
                    --config-yaml "$(cat envoy-override.yaml)"
-         ...
-
-   .. tab:: Docker (Windows Image)
-
-      .. substitution-code-block:: powershell
-
-         PS> docker run --rm -it
-               -p '9902:9902'
-               -p '10000:10000'
-               'envoyproxy/|envoy_windows_docker_image|'
-                  -c 'C:\ProgramData\envoy.yaml'
-                  --config-yaml "$(Get-Content -Raw envoy-override.yaml)"
          ...
 
 The Envoy admin interface should now be available on http://localhost:9902.
@@ -303,20 +249,6 @@ For invalid configuration the process will print the errors and exit with ``1``.
          [2020-11-08 12:36:06.549][11][info][config] [source/server/configuration_impl.cc:121] loading stats sink configuration
          configuration 'my-envoy-config.yaml' OK
 
-   .. tab:: Docker (Windows Image)
-
-      .. substitution-code-block:: powershell
-
-         PS> docker run --rm -it
-               -v "$PWD\:`"C:\envoy-configs`""
-               -p '9901:9901'
-               -p '10000:10000'
-               'envoyproxy/|envoy_windows_docker_image|'
-                  --mode validate
-                  -c 'C:\envoy-configs\my-envoy-config.yaml'
-
-         configuration 'my-envoy-config.yaml' OK
-
 Envoy logging
 -------------
 
@@ -345,24 +277,6 @@ This can be overridden using :option:`--log-path`.
                envoyproxy/|envoy_docker_image| \
                    -c /etc/envoy/envoy.yaml \
                    --log-path logs/custom.log
-
-   .. tab:: Docker (Windows Image)
-
-      .. substitution-code-block:: powershell
-
-            PS> mkdir logs
-            PS> docker run --rm -it
-                  -p '10000:10000'
-                  -v "$PWD\logs\:`"C:\logs`""
-                  'envoyproxy/|envoy_windows_docker_image|'
-                     -c 'C:\ProgramData\envoy.yaml'
-                     --log-path 'C:\logs\custom.log'
-
-      .. note::
-
-         Envoy on a Windows system Envoy will output to ``CON`` by default.
-
-         This can also be used as a logging path when configuring logging.
 
 :ref:`Access log <arch_overview_access_logs>` paths can be set for the
 :ref:`admin interface <start_quick_start_admin>`, and for configured
@@ -453,19 +367,6 @@ which are set to ``debug`` and ``trace`` respectively.
                    -l off \
                    --component-log-level upstream:debug,connection:trace
          ...
-
-   .. tab:: Docker (Windows Image)
-
-      .. substitution-code-block:: powershell
-
-            PS> mkdir logs
-            PS> docker run --rm -it
-                  -p '10000:10000'
-                  envoyproxy/|envoy_windws_docker_image|
-                     -c 'C:\ProgramData\envoy.yaml'
-                     -l off
-                     --component-log-level 'upstream:debug,connection:trace'
-            ...
 
 .. tip::
 

--- a/docs/root/start/sandboxes/setup.rst
+++ b/docs/root/start/sandboxes/setup.rst
@@ -37,9 +37,6 @@ The user account running the examples will need to have permission to use Docker
 
 Full instructions for installing Docker can be found on the `Docker website <https://docs.docker.com/get-docker/>`_
 
-If you want to use the Windows based Envoy images make sure that you
-`switch Docker to use Windows containers <https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers>`_.
-
 .. _start_sandboxes_setup_docker_compose:
 
 Install ``docker compose``

--- a/docs/root/start/sandboxes/win32_front_proxy.rst
+++ b/docs/root/start/sandboxes/win32_front_proxy.rst
@@ -1,6 +1,8 @@
 Windows based Front proxy
 =========================
 
+.. include:: ../../_include/windows_support_ended.rst
+
 .. sidebar:: Requirements
 
    .. include:: _include/docker-env-setup-link.rst


### PR DESCRIPTION
Per #28588, Windows builds are unsupported. Make that clear in the documentation.
Additionally, remove references to the Windows docker image, which has not been updated
since 1.28.0 with the intention of not directing Windows operators towards a version missing
important security updates.

Risk Level: low, docs only
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
