### PR TITLE
upstream: set host on stream info for upstream filters

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -573,6 +573,7 @@ Host::CreateConnectionData HostImplBase::createConnection(
       cluster.setLocalInterfaceNameOnUpstreamConnections());
   connection->setBufferLimits(cluster.perConnectionBufferLimitBytes());
   cluster.createNetworkFilterChain(*connection);
+  connection->streamInfo().upstreamInfo()->setUpstreamHost(host);
   return {std::move(connection), std::move(host)};
 }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -572,8 +572,10 @@ Host::CreateConnectionData HostImplBase::createConnection(
   connection->connectionInfoSetter().enableSettingInterfaceName(
       cluster.setLocalInterfaceNameOnUpstreamConnections());
   connection->setBufferLimits(cluster.perConnectionBufferLimitBytes());
+  if (auto upstream_info = connection->streamInfo().upstreamInfo(); upstream_info) {
+    upstream_info->setUpstreamHost(host);
+  }
   cluster.createNetworkFilterChain(*connection);
-  connection->streamInfo().upstreamInfo()->setUpstreamHost(host);
   return {std::move(connection), std::move(host)};
 }
 

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -285,7 +285,7 @@ public:
     EXPECT_CALL(*connection_, connect());
     EXPECT_CALL(*connection_, setConnectionStats(_));
     EXPECT_CALL(*connection_, noDelay(true));
-    EXPECT_CALL(*connection_, streamInfo());
+    EXPECT_CALL(*connection_, streamInfo()).Times(AnyNumber());
     EXPECT_CALL(*connection_, id()).Times(AnyNumber());
     EXPECT_CALL(*connection_, readDisable(_)).Times(AnyNumber());
     EXPECT_CALL(*connection_, initializeReadFilters());

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1624,9 +1624,11 @@ TEST_F(HostImplTest, CreateConnection) {
   EXPECT_CALL(*connection, setBufferLimits(0));
   EXPECT_CALL(dispatcher, createClientConnection_(_, _, _, _)).WillOnce(Return(connection));
   EXPECT_CALL(*connection, connectionInfoSetter());
+  EXPECT_CALL(*connection, streamInfo());
   Envoy::Upstream::Host::CreateConnectionData connection_data =
       host->createConnection(dispatcher, options, transport_socket_options);
   EXPECT_EQ(connection, connection_data.connection_.get());
+  EXPECT_EQ(host, connection->stream_info_.upstreamInfo()->upstreamHost());
 }
 
 TEST_F(HostImplTest, CreateConnectionHappyEyeballs) {
@@ -1664,11 +1666,13 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballs) {
   EXPECT_CALL(dispatcher, createClientConnection_(address_list[0], _, _, _))
       .WillOnce(Return(connection));
   EXPECT_CALL(dispatcher, createTimer_(_));
+  EXPECT_CALL(*connection, streamInfo());
 
   Envoy::Upstream::Host::CreateConnectionData connection_data =
       host->createConnection(dispatcher, options, transport_socket_options);
   // The created connection will be wrapped in a HappyEyeballsConnectionImpl.
   EXPECT_NE(connection, connection_data.connection_.get());
+  EXPECT_EQ(host, connection->stream_info_.upstreamInfo()->upstreamHost());
 }
 
 TEST_F(HostImplTest, ProxyOverridesHappyEyeballs) {
@@ -1712,12 +1716,14 @@ TEST_F(HostImplTest, ProxyOverridesHappyEyeballs) {
   // The underlying connection should be created to the proxy address.
   EXPECT_CALL(dispatcher, createClientConnection_(proxy_address, _, _, _))
       .WillOnce(Return(connection));
+  EXPECT_CALL(*connection, streamInfo());
 
   Envoy::Upstream::Host::CreateConnectionData connection_data =
       host->createConnection(dispatcher, options, transport_socket_options);
   // The created connection will be a raw connection to the proxy address rather
   // than a happy eyeballs connection.
   EXPECT_EQ(connection, connection_data.connection_.get());
+  EXPECT_EQ(host, connection->stream_info_.upstreamInfo()->upstreamHost());
 }
 
 TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithConfig) {
@@ -1768,11 +1774,13 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithConfig) {
   EXPECT_CALL(dispatcher, createClientConnection_(address_list[1], _, _, _))
       .WillOnce(Return(connection));
   EXPECT_CALL(dispatcher, createTimer_(_));
+  EXPECT_CALL(*connection, streamInfo());
 
   Envoy::Upstream::Host::CreateConnectionData connection_data =
       host->createConnection(dispatcher, options, transport_socket_options);
   // The created connection will be wrapped in a HappyEyeballsConnectionImpl.
   EXPECT_NE(connection, connection_data.connection_.get());
+  EXPECT_EQ(host, connection->stream_info_.upstreamInfo()->upstreamHost());
 }
 
 TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithEmptyConfig) {
@@ -1820,11 +1828,13 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithEmptyConfig) {
   EXPECT_CALL(dispatcher, createClientConnection_(address_list[0], _, _, _))
       .WillOnce(Return(connection));
   EXPECT_CALL(dispatcher, createTimer_(_));
+  EXPECT_CALL(*connection, streamInfo());
 
   Envoy::Upstream::Host::CreateConnectionData connection_data =
       host->createConnection(dispatcher, options, transport_socket_options);
   // The created connection will be wrapped in a HappyEyeballsConnectionImpl.
   EXPECT_NE(connection, connection_data.connection_.get());
+  EXPECT_EQ(host, connection->stream_info_.upstreamInfo()->upstreamHost());
 }
 
 TEST_F(HostImplTest, HealthFlags) {

--- a/test/extensions/clusters/eds/eds_test.cc
+++ b/test/extensions/clusters/eds/eds_test.cc
@@ -428,6 +428,7 @@ TEST_F(EdsTest, DualStackEndpoint) {
   EXPECT_CALL(dispatcher, createClientConnection_(hosts[0]->address(), _, _, _))
       .WillOnce(Return(connection));
   EXPECT_CALL(dispatcher, createTimer_(_));
+  EXPECT_CALL(*connection, streamInfo());
 
   Envoy::Upstream::Host::CreateConnectionData connection_data =
       hosts[0]->createConnection(dispatcher, options, transport_socket_options);


### PR DESCRIPTION
Change-Id: Ia868bb4d9cbf78de23bc43b6a162edcc065aa762

Commit Message: set host info on stream info for upstream filters. This is useful in upstream filters since the host is known.
Risk Level: low
Testing: regression