### PR TITLE
jwt_authn: Set metadata irrespective of success/failure of JWT Verification

### DIFF
--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -86,11 +86,7 @@ public:
       completion_state.status_ = status;
       return parent_->onComplete(status, context);
     }
-
-    if (Status::Ok == status) {
-      // We only set the extracted data to context when the JWT is verified.
-      context.setExtractedData();
-    }
+    context.setExtractedData();
     context.callback()->onComplete(status);
     context.cancel();
   }

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -111,6 +111,30 @@ TEST_F(ProviderVerifierTest, TestOkJWTWithExtractedHeaderAndPayload) {
   EXPECT_EQ(ExpectedPayloadValue, headers.get_("sec-istio-auth-userinfo"));
 }
 
+// Test to set dynamic metadata with the status of a failed JWT verification.
+TEST_F(ProviderVerifierTest, TestExpiredJWTWithFailedStatusInMetadata) {
+  TestUtility::loadFromYaml(ExampleConfig, proto_config_);
+  (*proto_config_.mutable_providers())[std::string(ProviderName)].set_failed_status_in_metadata(
+      "my_payload");
+  createVerifier();
+  MockUpstream mock_pubkey(mock_factory_ctx_.server_factory_context_.cluster_manager_, PublicKey);
+
+  EXPECT_CALL(mock_cb_, setExtractedData(_))
+      .WillOnce(Invoke([](const ProtobufWkt::Struct& payload) {
+        ProtobufWkt::Struct expected_payload;
+        MessageUtil::loadFromJson(ExpectedJWTExpiredStatusJSON, expected_payload);
+
+        EXPECT_TRUE(TestUtility::protoEqual(payload, expected_payload));
+      }));
+
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired));
+
+  auto headers =
+      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(ExpiredToken)}};
+  context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
+  verifier_->verify(context_);
+}
+
 TEST_F(ProviderVerifierTest, TestSpanPassedDown) {
   TestUtility::loadFromYaml(ExampleConfig, proto_config_);
   (*proto_config_.mutable_providers())[std::string(ProviderName)].set_payload_in_metadata(

--- a/test/extensions/filters/http/jwt_authn/test_common.h
+++ b/test/extensions/filters/http/jwt_authn/test_common.h
@@ -461,6 +461,15 @@ const char ExpectedPayloadAndHeaderJSON[] = R"(
 }
 )";
 
+const char ExpectedJWTExpiredStatusJSON[] = R"(
+{
+  "my_payload":{
+    "code": 3,
+    "message": "Jwt is expired"
+    }
+}
+)";
+
 // Token copied from https://github.com/google/jwt_verify_lib/blob/master/src/verify_jwk_ec_test.cc
 // Use jwt.io to modify payload as:
 // {


### PR DESCRIPTION
Commit Message: jwt_authn: Set metadata irrespective of success/failure of JWT Verification

Previously, metadata was only set for successful JWT verification, restricting "failed_status_in_metadata". This change removes the condition, allowing both "payload_in_metadata" and "failed_status_in_metadata" to be set as needed.

If this condition was added to restrict setting "payload_in_metadata" only on successful verification, it is unnecessary since "payload_in_metadata" is set only by AuthenticatorImpl:handleGoodJwt().

Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes:
Platform Specific Features: N/A
Fixes #32813
