### PR TITLE
mobile: Fix Kotlin warning

### DIFF
--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import io.envoyproxy.envoymobile.engine.AndroidEngineImpl
 
 /** The engine builder to use to create Envoy engine on Android. */
-class AndroidEngineBuilder @JvmOverloads constructor(context: Context) : EngineBuilder() {
+class AndroidEngineBuilder(context: Context) : EngineBuilder() {
   init {
     addEngineType {
       AndroidEngineImpl(


### PR DESCRIPTION
This fixes the following warning.

```
library/kotlin/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt:7:28: warning: '@JvmOverloads' annotation has no effect for methods without default arguments
class AndroidEngineBuilder @JvmOverloads constructor(context: Context) : EngineBuilder() {
```

Risk Level: low
Testing: bazel build
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
