### PR TITLE
mobile: Remove homebrew caches and unused packages

### DIFF
--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -51,6 +51,11 @@ do
     is_installed "${DEP}" || install "${DEP}"
 done
 
+# This is to save some disk space.
+# https://mac.install.guide/homebrew/8
+brew autoremove
+brew cleanup --prune=all
+
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
 sudo xcode-select --switch /Applications/Xcode_14.1.app
 


### PR DESCRIPTION
This is an attempt to salvage some disk space since the iOS related tests are consistently running out of disk space.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
