### PR TITLE
mobile: Cache the jclass objects

### DIFF
--- a/mobile/library/jni/jni_helper.cc
+++ b/mobile/library/jni/jni_helper.cc
@@ -89,13 +89,7 @@ jmethodID JniHelper::getStaticMethodId(jclass clazz, const char* name, const cha
   return method_id;
 }
 
-LocalRefUniquePtr<jclass> JniHelper::findClass(const char* class_name) {
-  LocalRefUniquePtr<jclass> result(env_->FindClass(class_name), LocalRefDeleter(env_));
-  rethrowException();
-  return result;
-}
-
-jclass JniHelper::findClassFromCache(const char* class_name) {
+jclass JniHelper::findClass(const char* class_name) {
   if (auto i = JCLASS_CACHES.find(class_name); i != JCLASS_CACHES.end()) {
     return i->second;
   }
@@ -108,9 +102,9 @@ LocalRefUniquePtr<jclass> JniHelper::getObjectClass(jobject object) {
 }
 
 void JniHelper::throwNew(const char* java_class_name, const char* message) {
-  LocalRefUniquePtr<jclass> java_class = findClass(java_class_name);
+  jclass java_class = findClass(java_class_name);
   if (java_class != nullptr) {
-    jint error = env_->ThrowNew(java_class.get(), message);
+    jint error = env_->ThrowNew(java_class, message);
     ASSERT(error == JNI_OK, "Failed calling ThrowNew.");
   }
 }

--- a/mobile/library/jni/jni_helper.h
+++ b/mobile/library/jni/jni_helper.h
@@ -230,18 +230,11 @@ public:
   jmethodID getStaticMethodId(jclass clazz, const char* name, const char* signature);
 
   /**
-   * Finds the given `class_name` using Java classloader.
+   * Finds the given `class_name` using from the cache.
    *
    * https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#findclass
    */
-  [[nodiscard]] LocalRefUniquePtr<jclass> findClass(const char* class_name);
-
-  /**
-   * Finds the given `class_name` from the cache.
-   *
-   * https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#findclass
-   */
-  [[nodiscard]] jclass findClassFromCache(const char* class_name);
+  [[nodiscard]] jclass findClass(const char* class_name);
 
   /**
    * Returns the class of a given `object`.

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -21,6 +21,18 @@ using Envoy::Platform::EngineBuilder;
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
   Envoy::JNI::JniHelper::initialize(vm);
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Object");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Integer");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/ClassLoader");
+  Envoy::JNI::JniHelper::addClassToCache("java/nio/ByteBuffer");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Throwable");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/UnsupportedOperationException");
+  Envoy::JNI::JniHelper::addClassToCache("[B");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/LinkedHashMap");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/HashMap");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/List");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/ArrayList");
   Envoy::JNI::JniHelper::addClassToCache("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel");
   Envoy::JNI::JniHelper::addClassToCache(
       "io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");
@@ -229,15 +241,13 @@ jvm_on_headers(const char* method, const Envoy::Types::ManagedEnvoyHeaders& head
   // Create a "no operation" result:
   //  1. Tell the filter chain to continue the iteration.
   //  2. Return headers received on as method's input as part of the method's output.
-  Envoy::JNI::LocalRefUniquePtr<jclass> jcls_object_array =
-      jni_helper.findClass("java/lang/Object");
+  jclass jcls_object_array = jni_helper.findClass("java/lang/Object");
   Envoy::JNI::LocalRefUniquePtr<jobjectArray> noopResult =
-      jni_helper.newObjectArray(2, jcls_object_array.get(), NULL);
+      jni_helper.newObjectArray(2, jcls_object_array, NULL);
 
-  Envoy::JNI::LocalRefUniquePtr<jclass> jcls_int = jni_helper.findClass("java/lang/Integer");
-  jmethodID jmid_intInit = jni_helper.getMethodId(jcls_int.get(), "<init>", "(I)V");
-  Envoy::JNI::LocalRefUniquePtr<jobject> j_status =
-      jni_helper.newObject(jcls_int.get(), jmid_intInit, 0);
+  jclass jcls_int = jni_helper.findClass("java/lang/Integer");
+  jmethodID jmid_intInit = jni_helper.getMethodId(jcls_int, "<init>", "(I)V");
+  Envoy::JNI::LocalRefUniquePtr<jobject> j_status = jni_helper.newObject(jcls_int, jmid_intInit, 0);
   // Set status to "0" (FilterHeadersStatus::Continue). Signal that the intent
   // is to continue the iteration of the filter chain.
   jni_helper.setObjectArrayElement(noopResult.get(), 0, j_status.get());

--- a/mobile/library/jni/jni_utility.h
+++ b/mobile/library/jni/jni_utility.h
@@ -134,12 +134,12 @@ LocalRefUniquePtr<jstring> cppStringToJavaString(JniHelper& jni_helper,
 /** Converts from C++'s map-type<std::string, std::string> to Java `HashMap<String, String>`. */
 template <typename MapType>
 LocalRefUniquePtr<jobject> cppMapToJavaMap(JniHelper& jni_helper, const MapType& cpp_map) {
-  auto java_map_class = jni_helper.findClass("java/util/HashMap");
-  auto java_map_init_method_id = jni_helper.getMethodId(java_map_class.get(), "<init>", "(I)V");
+  jclass java_map_class = jni_helper.findClass("java/util/HashMap");
+  auto java_map_init_method_id = jni_helper.getMethodId(java_map_class, "<init>", "(I)V");
   auto java_map_put_method_id = jni_helper.getMethodId(
-      java_map_class.get(), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+      java_map_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
   auto java_map_object =
-      jni_helper.newObject(java_map_class.get(), java_map_init_method_id, cpp_map.size());
+      jni_helper.newObject(java_map_class, java_map_init_method_id, cpp_map.size());
   for (const auto& [cpp_key, cpp_value] : cpp_map) {
     auto java_key = cppStringToJavaString(jni_helper, cpp_key);
     auto java_value = cppStringToJavaString(jni_helper, cpp_value);

--- a/mobile/test/jni/jni_helper_test.cc
+++ b/mobile/test/jni/jni_helper_test.cc
@@ -11,6 +11,8 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Exception");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/RuntimeException");
   return Envoy::JNI::JniHelper::getVersion();
 }
 
@@ -75,8 +77,7 @@ extern "C" JNIEXPORT jclass JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelper
     JNIEnv* env, jclass, jstring class_name) {
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::JNI::StringUtfUniquePtr class_name_ptr = jni_helper.getStringUtfChars(class_name, nullptr);
-  Envoy::JNI::LocalRefUniquePtr<jclass> clazz = jni_helper.findClass(class_name_ptr.get());
-  return clazz.release();
+  return jni_helper.findClass(class_name_ptr.get());
 }
 
 extern "C" JNIEXPORT jclass JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getObjectClass(

--- a/mobile/test/jni/jni_http_proxy_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_proxy_test_server_factory.cc
@@ -7,6 +7,14 @@
 
 // NOLINT(namespace-envoy)
 
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
+  Envoy::JNI::JniHelper::initialize(vm);
+  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
+  Envoy::JNI::JniHelper::addClassToCache(
+      "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
+  return Envoy::JNI::JniHelper::getVersion();
+}
+
 extern "C" JNIEXPORT jobject JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_start(JNIEnv* env, jclass,
                                                                                jint type) {
@@ -16,13 +24,13 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_start(J
   Envoy::TestServer* test_server = new Envoy::TestServer();
   test_server->start(static_cast<Envoy::TestServerType>(type));
 
-  auto java_http_proxy_server_factory_class = jni_helper.findClass(
+  jclass java_http_proxy_server_factory_class = jni_helper.findClass(
       "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
   auto java_init_method_id =
-      jni_helper.getMethodId(java_http_proxy_server_factory_class.get(), "<init>", "(JI)V");
+      jni_helper.getMethodId(java_http_proxy_server_factory_class, "<init>", "(JI)V");
   int port = test_server->getPort();
   return jni_helper
-      .newObject(java_http_proxy_server_factory_class.get(), java_init_method_id,
+      .newObject(java_http_proxy_server_factory_class, java_init_method_id,
                  reinterpret_cast<jlong>(test_server), static_cast<jint>(port))
       .release();
 }

--- a/mobile/test/jni/jni_http_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_test_server_factory.cc
@@ -8,6 +8,14 @@
 
 // NOLINT(namespace-envoy)
 
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
+  Envoy::JNI::JniHelper::initialize(vm);
+  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
+  Envoy::JNI::JniHelper::addClassToCache(
+      "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer");
+  return Envoy::JNI::JniHelper::getVersion();
+}
+
 extern "C" JNIEXPORT jobject JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_start(
     JNIEnv* env, jclass, jint type, jobject headers, jstring body, jobject trailers) {
@@ -22,15 +30,15 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_start(
   auto cpp_trailers = Envoy::JNI::javaMapToCppMap(jni_helper, trailers);
   test_server->setResponse(cpp_headers, cpp_body, cpp_trailers);
 
-  auto java_http_server_factory_class = jni_helper.findClass(
+  jclass java_http_server_factory_class = jni_helper.findClass(
       "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer");
-  auto java_init_method_id = jni_helper.getMethodId(java_http_server_factory_class.get(), "<init>",
+  auto java_init_method_id = jni_helper.getMethodId(java_http_server_factory_class, "<init>",
                                                     "(JLjava/lang/String;ILjava/lang/String;)V");
   auto ip_address = Envoy::JNI::cppStringToJavaString(jni_helper, test_server->getIpAddress());
   int port = test_server->getPort();
   auto address = Envoy::JNI::cppStringToJavaString(jni_helper, test_server->getAddress());
   return jni_helper
-      .newObject(java_http_server_factory_class.get(), java_init_method_id,
+      .newObject(java_http_server_factory_class, java_init_method_id,
                  reinterpret_cast<jlong>(test_server), ip_address.get(), static_cast<jint>(port),
                  address.get())
       .release();

--- a/mobile/test/jni/jni_utility_test.cc
+++ b/mobile/test/jni/jni_utility_test.cc
@@ -13,6 +13,17 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Object");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Integer");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/ClassLoader");
+  Envoy::JNI::JniHelper::addClassToCache("java/nio/ByteBuffer");
+  Envoy::JNI::JniHelper::addClassToCache("java/lang/Throwable");
+  Envoy::JNI::JniHelper::addClassToCache("[B");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/LinkedHashMap");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/HashMap");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/List");
+  Envoy::JNI::JniHelper::addClassToCache("java/util/ArrayList");
   Envoy::JNI::JniHelper::addClassToCache("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel");
   Envoy::JNI::JniHelper::addClassToCache(
       "io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");

--- a/mobile/test/jni/jni_xds_test_server_factory.cc
+++ b/mobile/test/jni/jni_xds_test_server_factory.cc
@@ -8,6 +8,14 @@
 
 // NOLINT(namespace-envoy)
 
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
+  Envoy::JNI::JniHelper::initialize(vm);
+  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
+  Envoy::JNI::JniHelper::addClassToCache(
+      "io/envoyproxy/envoymobile/engine/testing/XdsTestServerFactory$XdsTestServer");
+  return Envoy::JNI::JniHelper::getVersion();
+}
+
 extern "C" JNIEXPORT jobject JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_XdsTestServerFactory_create(JNIEnv* env, jclass) {
   // This is called via JNI from kotlin tests, and Envoy doesn't consider it a test thread
@@ -18,14 +26,14 @@ Java_io_envoyproxy_envoymobile_engine_testing_XdsTestServerFactory_create(JNIEnv
   Envoy::ExtensionRegistry::registerFactories();
   Envoy::XdsTestServer* test_server = new Envoy::XdsTestServer();
 
-  auto java_xds_server_factory_class = jni_helper.findClass(
+  jclass java_xds_server_factory_class = jni_helper.findClass(
       "io/envoyproxy/envoymobile/engine/testing/XdsTestServerFactory$XdsTestServer");
-  auto java_init_method_id = jni_helper.getMethodId(java_xds_server_factory_class.get(), "<init>",
-                                                    "(JLjava/lang/String;I)V");
+  auto java_init_method_id =
+      jni_helper.getMethodId(java_xds_server_factory_class, "<init>", "(JLjava/lang/String;I)V");
   auto host = Envoy::JNI::cppStringToJavaString(jni_helper, test_server->getHost());
   jint port = static_cast<jint>(test_server->getPort());
   return jni_helper
-      .newObject(java_xds_server_factory_class.get(), java_init_method_id,
+      .newObject(java_xds_server_factory_class, java_init_method_id,
                  reinterpret_cast<jlong>(test_server), host.get(), port)
       .release();
 }


### PR DESCRIPTION
Caching `jclass` should help with the performance as per https://developer.android.com/training/articles/perf-jni#jclass,-jmethodid,-and-jfieldid.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
