### PR TITLE
api: add total_{active,new,error}_connections to UpstreamLocalityStats

### DIFF
--- a/api/envoy/config/endpoint/v3/BUILD
+++ b/api/envoy/config/endpoint/v3/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
+        "@com_github_cncf_xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/config/endpoint/v3/load_report.proto
+++ b/api/envoy/config/endpoint/v3/load_report.proto
@@ -8,6 +8,8 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
+import "xds/annotations/v3/status.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -23,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // These are stats Envoy reports to the management server at a frequency defined by
 // :ref:`LoadStatsResponse.load_reporting_interval<envoy_v3_api_field_service.load_stats.v3.LoadStatsResponse.load_reporting_interval>`.
 // Stats per upstream region/zone and optionally per subzone.
-// [#next-free-field: 9]
+// [#next-free-field: 12]
 message UpstreamLocalityStats {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.endpoint.UpstreamLocalityStats";
@@ -47,6 +49,23 @@ message UpstreamLocalityStats {
   // the last report. This information is aggregated over all the
   // upstream endpoints in the locality.
   uint64 total_issued_requests = 8;
+
+  // The total number of connections in an established state at the time of the
+  // report. This information is aggregated over all the upstream endpoints in
+  // the locality.
+  // [#not-implemented-hide:]
+  uint64 total_active_connections = 9 [(xds.annotations.v3.field_status).work_in_progress = true];
+
+  // The total number of connections opened since the last report. This
+  // information is aggregated over all the upstream endpoints in the locality.
+  // [#not-implemented-hide:]
+  uint64 total_new_connections = 10 [(xds.annotations.v3.field_status).work_in_progress = true];
+
+  // The total number of connections terminated abruptly (for example: due to
+  // connection refused, keepalive timeout). This information is aggregated over
+  // all the upstream endpoints in the locality.
+  // [#not-implemented-hide:]
+  uint64 total_error_connections = 11 [(xds.annotations.v3.field_status).work_in_progress = true];
 
   // Stats for multi-dimensional load balancing.
   repeated EndpointLoadMetricStats load_metric_stats = 5;


### PR DESCRIPTION
The new fields are marked with `[#not-implemented-hide:]` and `work_in_progress` per the guide.

Implementation will be added later in a separate PR.

Rationale: Current version of LRS protocol uses requests as a unit of load. L4 load balancers don't have information on the number of requests, but they can approximate it by the number of new and active connections.

Envoy already collects and exposes some of [the statistics](https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats#general) that can be used for the implementation of the new fields:
1. `total_new_connections` ~ `upstream_cx_total(now) - upstream_cx_total(now - load_report_interval)`
2. `total_active_connections` ~ `upstream_cx_active`
3. `total_error_connections` ~ `upstream_cx_connect_timeout + upstream_cx_idle_timeout + ...`

Please note that the linked stats are aggregated per cluster, while the new fields will correspond to `UpstreamLocality`, so the actual implementation will be more nuanced.

Commit Message: api: add total_{active,new,error}_connections to UpstreamLocalityStats
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
