### PR TITLE
config: no longer require transport_api_version

### DIFF
--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -28,12 +28,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // xDS API and non-xDS services version. This is used to describe both resource and transport
 // protocol versions (in distinct configuration fields).
 enum ApiVersion {
-  // When not specified, we assume v2, to ease migration to Envoy's stable API
-  // versioning. If a client does not support v2 (e.g. due to deprecation), this
-  // is an invalid value.
-  AUTO = 0 [deprecated = true, (envoy.annotations.deprecated_at_minor_version_enum) = "3.0"];
+  // When not specified, we assume v3; it is the only supported version.
+  AUTO = 0;
 
-  // Use xDS v2 API.
+  // Use xDS v2 API. This is no longer supported.
   V2 = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version_enum) = "3.0"];
 
   // Use xDS v3 API.

--- a/api/envoy/config/metrics/v3/metrics_service.proto
+++ b/api/envoy/config/metrics/v3/metrics_service.proto
@@ -43,7 +43,6 @@ enum HistogramEmitMode {
 //       - name: envoy.stat_sinks.metrics_service
 //         typed_config:
 //           "@type": type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
-//           transport_api_version: V3
 //
 // [#extension: envoy.stat_sinks.metrics_service]
 // [#next-free-field: 6]

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -74,6 +74,11 @@ minor_behavior_changes:
 - area: quic
   change: |
     When a quic connection socket is created, the socket's detected transport protocol will be set to "quic".
+- area: config
+  change: |
+    In xDS configuration, the :ref:`AUTO <envoy_v3_api_enum_value_config.core.v3.ApiVersion.AUTO>` value now means
+    :ref:`V3 <envoy_v3_api_enum_value_config.core.v3.ApiVersion.V3>`. :ref:`AUTO <envoy_v3_api_enum_value_config.core.v3.ApiVersion.AUTO>`
+    is the default value of the enum, so this field may be omitted from all configurations now.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/configs/envoy_front_proxy.template.yaml
+++ b/configs/envoy_front_proxy.template.yaml
@@ -66,7 +66,6 @@
             domain: envoy_front
             request_type: external
             rate_limit_service:
-              transport_api_version: V3
               grpc_service:
                 envoy_grpc:
                   cluster_name: ratelimit

--- a/configs/envoy_service_to_service.template.yaml
+++ b/configs/envoy_service_to_service.template.yaml
@@ -162,7 +162,6 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
               domain: envoy_service_to_service
               rate_limit_service:
-                 transport_api_version: V3
                  grpc_service:
                     envoy_grpc:
                        cluster_name: ratelimit
@@ -187,10 +186,8 @@ static_resources:
           stat_prefix: egress_http
           rds:
             config_source:
-               resource_api_version: V3
                api_config_source:
                  api_type: GRPC
-                 transport_api_version: V3
                  grpc_services:
                    envoy_grpc:
                      cluster_name: "rds"
@@ -227,7 +224,6 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
               domain: envoy_service_to_service
               rate_limit_service:
-                 transport_api_version: V3
                  grpc_service:
                     envoy_grpc:
                        cluster_name: ratelimit
@@ -533,10 +529,8 @@ static_resources:
                 protocol: TCP
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     api_config_source:
       api_type: REST
-      transport_api_version: V3
       cluster_names:
       - cds_cluster
       refresh_delay: 30s

--- a/configs/routing_helper.template.yaml
+++ b/configs/routing_helper.template.yaml
@@ -15,10 +15,8 @@
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: REST
-        transport_api_version: V3
         cluster_names:
         - sds
         refresh_delay: 30s

--- a/contrib/config/test/kv_store_xds_delegate_integration_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_integration_test.cc
@@ -494,10 +494,8 @@ public:
 
       auto* cds = bootstrap.mutable_dynamic_resources()->mutable_cds_config();
       const std::string cds_yaml = fmt::format(R"EOF(
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: {}

--- a/contrib/generic_proxy/filters/network/test/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/config_test.cc
@@ -96,7 +96,7 @@ TEST(FactoryTest, GenericRds) {
         type_url: envoy.generic_proxy.codecs.fake.type
         value: {}
     generic_rds:
-      config_source: { resource_api_version: V3, ads: {} }
+      config_source: { ads: {} }
       route_config_name: test_route
     )EOF";
 
@@ -152,8 +152,7 @@ TEST(FactoryTest, GenericRdsApiConfigSource) {
         value: {}
     generic_rds:
       config_source:
-        resource_api_version: V3
-        api_config_source: { api_type: GRPC, transport_api_version: V3 }
+        api_config_source: { api_type: GRPC }
       route_config_name: test_route
     )EOF";
 
@@ -186,7 +185,7 @@ TEST(FactoryTest, CustomReadFilterFactory) {
         type_url: envoy.generic_proxy.codecs.mock.type
         value: {}
     generic_rds:
-      config_source: { resource_api_version: V3, ads: {} }
+      config_source: { ads: {} }
       route_config_name: test_route
     )EOF";
 
@@ -366,7 +365,7 @@ TEST(BasicFilterConfigTest, TestConfigurationWithTracing) {
         type_url: envoy.generic_proxy.codecs.mock.type
         value: {}
     generic_rds:
-      config_source: { resource_api_version: V3, ads: {} }
+      config_source: { ads: {} }
       route_config_name: test_route
     tracing:
       max_path_tag_length: 128
@@ -420,7 +419,7 @@ TEST(BasicFilterConfigTest, TestConfigurationWithAccessLog) {
         type_url: envoy.generic_proxy.codecs.mock.type
         value: {}
     generic_rds:
-      config_source: { resource_api_version: V3, ads: {} }
+      config_source: { ads: {} }
       route_config_name: test_route
     access_log:
     - name: envoy.generic_proxy.access_loggers.file

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -73,7 +73,6 @@ public:
                  envoy_grpc:
                    cluster_name: tra_service
                timeout: 2s
-               transport_api_version: V3
 )EOF";
       TestUtility::loadFromYaml(sip_proxy_yaml1, sip_proxy_config_);
     } else {

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -39,7 +39,6 @@ public:
                  envoy_grpc:
                    cluster_name: tra_service
                timeout: 2s
-               transport_api_version: V3
 )EOF";
 
     auto tra_config = std::make_shared<

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -100,12 +100,10 @@ certificate:
   name: certificate
   sds_config:
     path: "xxxx"
-    resource_api_version: V3
 private_key:
   name: private_key
   sds_config:
     path: "xxxx"
-    resource_api_version: V3
 cbor_url: "/.sxg/cert.cbor"
 validity_url: "/.sxg/validity.msg"
 )YAML";

--- a/docs/root/_include/ads.yaml
+++ b/docs/root/_include/ads.yaml
@@ -7,15 +7,12 @@ node:
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    transport_api_version: V3
     grpc_services:
     - envoy_grpc:
         cluster_name: ads_cluster
   cds_config:
-    resource_api_version: V3
     ads: {}
   lds_config:
-    resource_api_version: V3
     ads: {}
 
 static_resources:

--- a/docs/root/configuration/overview/_include/extensions/with-type-url.yaml
+++ b/docs/root/configuration/overview/_include/extensions/with-type-url.yaml
@@ -21,10 +21,8 @@ static_resources:
             rds:
               route_config_name: local_route
               config_source:
-                resource_api_version: V3
                 api_config_source:
                   api_type: GRPC
-                  transport_api_version: V3
                   grpc_services:
                   - envoy_grpc:
                       cluster_name: xds_cluster

--- a/docs/root/configuration/overview/_include/extensions/without-type-url.yaml
+++ b/docs/root/configuration/overview/_include/extensions/without-type-url.yaml
@@ -19,10 +19,8 @@ static_resources:
           rds:
             route_config_name: local_route
             config_source:
-              resource_api_version: V3
               api_config_source:
                 api_type: GRPC
-                transport_api_version: V3
                 grpc_services:
                 - envoy_grpc:
                     cluster_name: xds_cluster

--- a/docs/root/configuration/overview/_include/xds_api/dynamic-resources.yaml
+++ b/docs/root/configuration/overview/_include/xds_api/dynamic-resources.yaml
@@ -5,23 +5,18 @@ node:
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    transport_api_version: V3
     grpc_services:
     - envoy_grpc:
         cluster_name: xds_cluster
   cds_config:
-    resource_api_version: V3
     api_config_source:
       api_type: GRPC
-      transport_api_version: V3
       grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster
   lds_config:
-    resource_api_version: V3
     api_config_source:
       api_type: GRPC
-      transport_api_version: V3
       grpc_services:
       - envoy_grpc:
           cluster_name: xds_cluster

--- a/docs/root/configuration/overview/_include/xds_api/oauth-sds-example.yaml
+++ b/docs/root/configuration/overview/_include/xds_api/oauth-sds-example.yaml
@@ -48,20 +48,16 @@ static_resources:
                   token_secret:
                     name: token
                     sds_config:
-                      resource_api_version: V3
                       api_config_source:
                         api_type: GRPC
-                        transport_api_version: V3
                         grpc_services:
                         - envoy_grpc:
                             cluster_name: sds_server_uds
                   hmac_secret:
                     name: hmac
                     sds_config:
-                      resource_api_version: V3
                       api_config_source:
                         api_type: GRPC
-                        transport_api_version: V3
                         grpc_services:
                         - envoy_grpc:
                             cluster_name: sds_server_uds

--- a/docs/root/configuration/overview/examples.rst
+++ b/docs/root/configuration/overview/examples.rst
@@ -101,10 +101,8 @@ on 127.0.0.1:5678 is provided below:
       type: EDS
       eds_cluster_config:
         eds_config:
-          resource_api_version: V3
           api_config_source:
             api_type: GRPC
-            transport_api_version: V3
             grpc_services:
               - envoy_grpc:
                   cluster_name: xds_cluster
@@ -181,18 +179,14 @@ below:
 
   dynamic_resources:
     lds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: GRPC
-        transport_api_version: V3
         grpc_services:
           - envoy_grpc:
               cluster_name: xds_cluster
     cds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: GRPC
-        transport_api_version: V3
         grpc_services:
           - envoy_grpc:
               cluster_name: xds_cluster
@@ -245,10 +239,8 @@ The management server could respond to LDS requests with:
           rds:
             route_config_name: local_route
             config_source:
-              resource_api_version: V3
               api_config_source:
                 api_type: GRPC
-                transport_api_version: V3
                 grpc_services:
                   - envoy_grpc:
                       cluster_name: xds_cluster
@@ -285,10 +277,8 @@ The management server could respond to CDS requests with:
     type: EDS
     eds_cluster_config:
       eds_config:
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             - envoy_grpc:
                 cluster_name: xds_cluster

--- a/docs/root/configuration/overview/xds_api.rst
+++ b/docs/root/configuration/overview/xds_api.rst
@@ -41,10 +41,8 @@ for the service definition. This is used by Envoy as a client when
 .. code-block:: yaml
 
     eds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: GRPC
-        transport_api_version: V3
         grpc_services:
         - envoy_grpc:
             cluster_name: some_xds_cluster
@@ -80,10 +78,8 @@ for the service definition. This is used by Envoy as a client when
 
     route_config_name: some_route_name
     config_source:
-      resource_api_version: V3
       api_config_source:
         api_type: GRPC
-        transport_api_version: V3
         grpc_services:
         - envoy_grpc:
             cluster_name: some_xds_cluster
@@ -103,11 +99,9 @@ for the service definition. This is used by Envoy as a client when
 
     name: some_scoped_route_name
     scoped_rds:
-      resource_api_version: V3
       config_source:
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
           - envoy_grpc:
               cluster_name: some_xds_cluster
@@ -143,10 +137,8 @@ for the service definition. This is used by Envoy as a client when
 
     name: some_runtime_layer_name
     config_source:
-      resource_api_version: V3
       api_config_source:
         api_type: GRPC
-        transport_api_version: V3
         grpc_services:
         - envoy_grpc:
             cluster_name: some_xds_cluster
@@ -167,10 +159,8 @@ for the service definition. This is used by Envoy as a client when
 .. code-block:: yaml
 
     cds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: REST
-        transport_api_version: V3
         cluster_names: [some_xds_cluster]
 
 is set in the :ref:`dynamic_resources
@@ -186,10 +176,8 @@ for the service definition. This is used by Envoy as a client when
 .. code-block:: yaml
 
     eds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: REST
-        transport_api_version: V3
         cluster_names: [some_xds_cluster]
 
 is set in the :ref:`eds_cluster_config
@@ -205,10 +193,8 @@ for the service definition. This is used by Envoy as a client when
 .. code-block:: yaml
 
     lds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: REST
-        transport_api_version: V3
         cluster_names: [some_xds_cluster]
 
 is set in the :ref:`dynamic_resources
@@ -225,10 +211,8 @@ for the service definition. This is used by Envoy as a client when
 
     route_config_name: some_route_name
     config_source:
-      resource_api_version: V3
       api_config_source:
         api_type: REST
-        transport_api_version: V3
         cluster_names: [some_xds_cluster]
 
 is set in the :ref:`rds
@@ -295,10 +279,8 @@ be set to use the ADS channel. For example, a LDS config could be changed from
 .. code-block:: yaml
 
     lds_config:
-      resource_api_version: V3
       api_config_source:
         api_type: REST
-        transport_api_version: V3
         cluster_names: [some_xds_cluster]
 
 to

--- a/docs/root/configuration/security/_include/sds-source-example.yaml
+++ b/docs/root/configuration/security/_include/sds-source-example.yaml
@@ -18,20 +18,16 @@ static_resources:
             tls_certificate_sds_secret_configs:
             - name: server_cert
               sds_config:
-                resource_api_version: V3
                 api_config_source:
                   api_type: GRPC
-                  transport_api_version: V3
                   grpc_services:
                   - envoy_grpc:
                       cluster_name: sds_server_mtls
             validation_context_sds_secret_config:
               name: validation_context
               sds_config:
-                resource_api_version: V3
                 api_config_source:
                   api_type: GRPC
-                  transport_api_version: V3
                   grpc_services:
                   - envoy_grpc:
                       cluster_name: sds_server_uds
@@ -93,10 +89,8 @@ static_resources:
           tls_certificate_sds_secret_configs:
           - name: client_cert
             sds_config:
-              resource_api_version: V3
               api_config_source:
                 api_type: GRPC
-                transport_api_version: V3
                 grpc_services:
                 - google_grpc:
                     target_uri: unix:/tmp/uds_path

--- a/docs/root/configuration/security/secret.rst
+++ b/docs/root/configuration/security/secret.rst
@@ -131,7 +131,7 @@ This example shows how to configure secrets fetched from remote SDS servers:
 
 .. literalinclude:: _include/sds-source-example.yaml
    :language: yaml
-   :lines: 1-103
+   :lines: 1-97
    :linenos:
    :lineno-start: 1
    :caption: :download:`sds-source-example.yaml <_include/sds-source-example.yaml>`

--- a/docs/root/start/quick-start/_include/envoy-dynamic-control-plane-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-control-plane-demo.yaml
@@ -5,15 +5,12 @@ node:
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    transport_api_version: V3
     grpc_services:
     - envoy_grpc:
         cluster_name: xds_cluster
   cds_config:
-    resource_api_version: V3
     ads: {}
   lds_config:
-    resource_api_version: V3
     ads: {}
 
 static_resources:

--- a/docs/root/start/quick-start/_include/envoy-dynamic-filesystem-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-filesystem-demo.yaml
@@ -4,10 +4,8 @@ node:
 
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     path: /var/lib/envoy/cds.yaml
   lds_config:
-    resource_api_version: V3
     path: /var/lib/envoy/lds.yaml
 
 

--- a/examples/dynamic-config-cp/envoy.yaml
+++ b/examples/dynamic-config-cp/envoy.yaml
@@ -5,15 +5,12 @@ node:
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    transport_api_version: V3
     grpc_services:
     - envoy_grpc:
         cluster_name: xds_cluster
   cds_config:
-    resource_api_version: V3
     ads: {}
   lds_config:
-    resource_api_version: V3
     ads: {}
 
 static_resources:

--- a/examples/dynamic-config-fs/envoy.yaml
+++ b/examples/dynamic-config-fs/envoy.yaml
@@ -4,11 +4,9 @@ node:
 
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     path_config_source:
       path: /var/lib/envoy/cds.yaml
   lds_config:
-    resource_api_version: V3
     path_config_source:
       path: /var/lib/envoy/lds.yaml
 

--- a/examples/ext_authz/config/grpc-service/v3.yaml
+++ b/examples/ext_authz/config/grpc-service/v3.yaml
@@ -30,7 +30,6 @@ static_resources:
                 envoy_grpc:
                   cluster_name: ext_authz-grpc-service
                 timeout: 0.250s
-              transport_api_version: V3
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/examples/ext_authz/config/http-service.yaml
+++ b/examples/ext_authz/config/http-service.yaml
@@ -26,7 +26,6 @@ static_resources:
           - name: envoy.filters.http.ext_authz
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-              transport_api_version: V3
               http_service:
                 server_uri:
                   uri: ext_authz

--- a/examples/ext_authz/config/opa-service/v3.yaml
+++ b/examples/ext_authz/config/opa-service/v3.yaml
@@ -30,7 +30,6 @@ static_resources:
                 envoy_grpc:
                   cluster_name: ext_authz-opa-service
                 timeout: 0.250s
-              transport_api_version: V3
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/examples/load-reporting-service/envoy.yaml
+++ b/examples/load-reporting-service/envoy.yaml
@@ -59,7 +59,6 @@ static_resources:
 cluster_manager:
   load_stats_config:
     api_type: GRPC
-    transport_api_version: V3
     grpc_services:
     - envoy_grpc:
         cluster_name: load_reporting_cluster

--- a/examples/single-page-app/envoy.yml
+++ b/examples/single-page-app/envoy.yml
@@ -4,7 +4,6 @@ node:
 
 dynamic_resources:
   lds_config:
-    resource_api_version: V3
     path_config_source:
       path: /var/lib/envoy/lds.yml
 
@@ -54,13 +53,11 @@ static_resources:
                   token_secret:
                     name: token
                     sds_config:
-                      resource_api_version: V3
                       path_config_source:
                         path: /etc/envoy/secrets/myhub-token-secret.yml
                   hmac_secret:
                     name: hmac
                     sds_config:
-                      resource_api_version: V3
                       path_config_source:
                         path: /etc/envoy/secrets/hmac-secret.yml
                 auth_scopes:
@@ -135,13 +132,11 @@ static_resources:
                   token_secret:
                     name: token
                     sds_config:
-                      resource_api_version: V3
                       path_config_source:
                         path: /etc/envoy/secrets/myhub-token-secret.yml
                   hmac_secret:
                     name: hmac
                     sds_config:
-                      resource_api_version: V3
                       path_config_source:
                         path: /etc/envoy/secrets/hmac-secret.yml
                 auth_scopes:

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -155,12 +155,12 @@ public:
   template <class Proto> static absl::Status checkTransportVersion(const Proto& api_config_source) {
     const auto transport_api_version = api_config_source.transport_api_version();
     ASSERT_IS_MAIN_OR_TEST_THREAD();
-    if (transport_api_version != envoy::config::core::v3::ApiVersion::V3) {
+    if (transport_api_version != envoy::config::core::v3::ApiVersion::AUTO &&
+        transport_api_version != envoy::config::core::v3::ApiVersion::V3) {
       const std::string& warning = fmt::format(
-          "V2 (and AUTO) xDS transport protocol versions are deprecated in {}. "
+          "V2 xDS transport protocol version is deprecated in {}. "
           "The v2 xDS major version has been removed and is no longer supported. "
-          "You may be missing explicit V3 configuration of the transport API version, "
-          "see the advice in https://www.envoyproxy.io/docs/envoy/latest/faq/api/envoy_v3.",
+          "See the advice in https://www.envoyproxy.io/docs/envoy/latest/faq/api/envoy_v3.",
           api_config_source.DebugString());
       ENVOY_LOG_MISC(warn, warning);
       return absl::InvalidArgumentError(warning);

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -654,10 +654,8 @@ TEST_F(RdsImplTest, VirtualHostUpdateWhenProviderHasBeenDeallocated) {
 rds:
   route_config_name: my_route
   config_source:
-    resource_api_version: V3
     api_config_source:
       api_type: GRPC
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: xds_cluster
@@ -715,10 +713,8 @@ TEST_F(RdsRouteConfigSubscriptionTest, CreatesNoopInitManager) {
   const std::string rds_config = R"EOF(
   route_config_name: my_route
   config_source:
-    resource_api_version: V3
     api_config_source:
       api_type: GRPC
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: xds_cluster

--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -91,7 +91,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 )EOF";
@@ -265,7 +264,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -273,7 +271,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 )EOF";
@@ -299,7 +296,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -307,7 +303,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 )EOF";
@@ -340,7 +335,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -348,7 +342,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: eds path
 )EOF";

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -740,7 +740,6 @@ TEST_F(ClusterManagerImplTest, AdsCluster) {
   const std::string yaml = R"EOF(
   dynamic_resources:
     ads_config:
-      transport_api_version: V3
       api_type: GRPC
       set_node_on_first_message_only: true
       grpc_services:
@@ -773,7 +772,6 @@ TEST_F(ClusterManagerImplTest, AdsClusterStartsMuxOnlyOnce) {
   const std::string yaml = R"EOF(
   dynamic_resources:
     ads_config:
-      transport_api_version: V3
       api_type: GRPC
       set_node_on_first_message_only: true
       grpc_services:
@@ -1010,10 +1008,8 @@ static_resources:
     type: eds
     eds_cluster_config:
       eds_config:
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: static_cluster

--- a/test/common/upstream/deferred_cluster_initialization_test.cc
+++ b/test/common/upstream/deferred_cluster_initialization_test.cc
@@ -484,7 +484,6 @@ TEST_P(EdsTest, ShouldMergeAddingHosts) {
         eds_config:
           api_config_source:
             api_type: REST
-            transport_api_version: V3
             cluster_names:
             - eds
             refresh_delay: 1s
@@ -556,7 +555,6 @@ TEST_P(EdsTest, ShouldNotMergeAddingHostsForDifferentClustersWithSameName) {
         eds_config:
           api_config_source:
             api_type: REST
-            transport_api_version: V3
             cluster_names:
             - eds
             refresh_delay: 1s
@@ -629,7 +627,6 @@ TEST_P(EdsTest, ShouldNotHaveRemovedHosts) {
         eds_config:
           api_config_source:
             api_type: REST
-            transport_api_version: V3
             cluster_names:
             - eds
             refresh_delay: 1s
@@ -702,7 +699,6 @@ TEST_P(EdsTest, ShouldHaveHostThatWasAddedAfterRemoval) {
         eds_config:
           api_config_source:
             api_type: REST
-            transport_api_version: V3
             cluster_names:
             - eds
             refresh_delay: 1s
@@ -779,7 +775,6 @@ TEST_P(EdsTest, MultiplePrioritiesShouldMergeCorrectly) {
         eds_config:
           api_config_source:
             api_type: REST
-            transport_api_version: V3
             cluster_names:
             - eds
             refresh_delay: 1s
@@ -852,7 +847,6 @@ TEST_P(EdsTest, ActiveClusterGetsUpdated) {
         eds_config:
           api_config_source:
             api_type: REST
-            transport_api_version: V3
             cluster_names:
             - eds
             refresh_delay: 1s

--- a/test/config/integration/server_xds.bootstrap.udpa.yaml
+++ b/test/config/integration/server_xds.bootstrap.udpa.yaml
@@ -1,7 +1,6 @@
 dynamic_resources:
   lds_resources_locator: "file:///{{ lds_json_path }}"
   cds_config:
-    resource_api_version: V3
     path_config_source:
       path: "{{ cds_json_path }}"
 admin:

--- a/test/config/integration/server_xds.bootstrap.yml
+++ b/test/config/integration/server_xds.bootstrap.yml
@@ -1,10 +1,8 @@
 dynamic_resources:
   lds_config:
-    resource_api_version: V3
     path_config_source:
       path: "{{ lds_json_path }}"
   cds_config:
-    resource_api_version: V3
     path_config_source:
       path: "{{ cds_json_path }}"
 admin:

--- a/test/config/integration/server_xds.cds.with_unknown_field.yaml
+++ b/test/config/integration/server_xds.cds.with_unknown_field.yaml
@@ -6,7 +6,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: "{{ eds_json_path }}"
   lb_policy: ROUND_ROBIN

--- a/test/config/integration/server_xds.cds.yaml
+++ b/test/config/integration/server_xds.cds.yaml
@@ -6,7 +6,6 @@ resources:
   type: EDS
   eds_cluster_config:
     eds_config:
-      resource_api_version: V3
       path_config_source:
         path: "{{ eds_json_path }}"
   lb_policy: ROUND_ROBIN

--- a/test/config/integration/server_xds.lds.typed_struct.yaml
+++ b/test/config/integration/server_xds.lds.typed_struct.yaml
@@ -19,7 +19,6 @@ resources:
           rds:
             route_config_name: route_config_0
             config_source:
-              resource_api_version: V3
               path_config_source:
                 path: "{{ rds_json_path }}"
           http_filters:

--- a/test/config/integration/server_xds.lds.udpa.list_collection.yaml
+++ b/test/config/integration/server_xds.lds.udpa.list_collection.yaml
@@ -23,7 +23,6 @@ resource:
               rds:
                 route_config_name: route_config_0
                 config_source:
-                  resource_api_version: V3
                   path_config_source:
                     path: "{{ rds_json_path }}"
               http_filters:

--- a/test/config/integration/server_xds.lds.with_unknown_field.typed_struct.yaml
+++ b/test/config/integration/server_xds.lds.with_unknown_field.typed_struct.yaml
@@ -19,7 +19,6 @@ resources:
           rds:
             route_config_name: route_config_0
             config_source:
-              resource_api_version: V3
               path_config_source:
                 path: "{{ rds_json_path }}"
           http_filters:

--- a/test/config/integration/server_xds.lds.with_unknown_field.yaml
+++ b/test/config/integration/server_xds.lds.with_unknown_field.yaml
@@ -16,9 +16,7 @@ resources:
         stat_prefix: router
         rds:
           route_config_name: route_config_0
-          transport_api_version: V3
           config_source:
-            resource_api_version: V3
             path_config_source:
               path: "{{ rds_json_path }}"
         http_filters:

--- a/test/config/integration/server_xds.lds.yaml
+++ b/test/config/integration/server_xds.lds.yaml
@@ -17,7 +17,6 @@ resources:
         rds:
           route_config_name: route_config_0
           config_source:
-            resource_api_version: V3
             path_config_source:
               path: "{{ rds_json_path }}"
         http_filters:

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -58,7 +58,6 @@ admin:
       port_value: 0
 dynamic_resources:
   lds_config:
-    resource_api_version: V3
     path_config_source:
       path: {}
 static_resources:
@@ -376,10 +375,8 @@ admin:
       port_value: 0
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     api_config_source:
       api_type: {}
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: my_cds_cluster
@@ -451,13 +448,10 @@ std::string ConfigHelper::adsBootstrap(const std::string& api_type) {
   return fmt::format(R"EOF(
 dynamic_resources:
   lds_config:
-    resource_api_version: V3
     ads: {{}}
   cds_config:
-    resource_api_version: V3
     ads: {{}}
   ads_config:
-    transport_api_version: V3
     api_type: {0}
     set_node_on_first_message_only: true
 static_resources:
@@ -664,7 +658,6 @@ envoy::config::listener::v3::Listener ConfigHelper::buildListener(const std::str
             rds:
               route_config_name: {}
               config_source:
-                resource_api_version: V3
                 ads: {{}}
             http_filters:
             - name: envoy.filters.http.router

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
@@ -267,7 +267,6 @@ typed_config:
       "@type": type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
       common_config:
         log_name: foo
-        transport_api_version: V3
         grpc_service:
           envoy_grpc:
             cluster_name: cluster_0
@@ -304,7 +303,6 @@ TEST_P(AccessLogIntegrationTest, GrpcLoggerSurvivesAfterReloadConfig) {
       "@type": type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig
       common_config:
         log_name: bar
-        transport_api_version: V3
         grpc_service:
           envoy_grpc:
             cluster_name: cluster_0

--- a/test/extensions/clusters/aggregate/cluster_integration_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_integration_test.cc
@@ -43,10 +43,8 @@ admin:
       port_value: 0
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     api_config_source:
       api_type: GRPC
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: my_cds_cluster

--- a/test/extensions/clusters/eds/leds_test.cc
+++ b/test/extensions/clusters/eds/leds_test.cc
@@ -144,7 +144,6 @@ public:
         grpc_services:
           envoy_grpc:
             cluster_name: xds_cluster
-      resource_api_version: V3
     leds_collection_name: xdstp://test/envoy.config.endpoint.v3.LbEndpoint/foo-endpoints/*
   )EOF"};
 

--- a/test/extensions/filters/http/composite/composite_filter_integration_test.cc
+++ b/test/extensions/filters/http/composite/composite_filter_integration_test.cc
@@ -206,7 +206,6 @@ public:
                           name: set-response-code
                           config_discovery:
                             config_source:
-                                resource_api_version: V3
                                 path_config_source:
                                   path: "{{ test_tmpdir }}/%s"
                             type_urls:
@@ -254,10 +253,8 @@ resources:
                           name: missing-config
                           config_discovery:
                             config_source:
-                                resource_api_version: V3
                                 api_config_source:
                                   api_type: GRPC
-                                  transport_api_version: V3
                                   grpc_services:
                                     envoy_grpc:
                                       cluster_name: "ecds_cluster"

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -319,7 +319,6 @@ TEST(ConfigTest, TestConfig) {
         name: set-response-code
         config_discovery:
           config_source:
-              resource_api_version: V3
               path_config_source:
                 path: "{{ test_tmpdir }}/set_response_code.yaml"
           type_urls:
@@ -353,7 +352,6 @@ TEST(ConfigTest, TestDynamicConfigInDownstream) {
         name: set-response-code
         config_discovery:
           config_source:
-              resource_api_version: V3
               path_config_source:
                 path: "{{ test_tmpdir }}/set_response_code.yaml"
           type_urls:
@@ -384,7 +382,6 @@ TEST(ConfigTest, TestDynamicConfigInUpstream) {
         name: set-response-code
         config_discovery:
           config_source:
-              resource_api_version: V3
               path_config_source:
                 path: "{{ test_tmpdir }}/set_response_code.yaml"
           type_urls:
@@ -524,7 +521,6 @@ TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingActionForDynamicConf
         name: actionName
         config_discovery:
           config_source:
-              resource_api_version: V3
               path_config_source:
                 path: "{{ test_tmpdir }}/set_response_code.yaml"
           type_urls:

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -123,7 +123,6 @@ public:
 TEST_F(ExtAuthzFilterHttpTest, ExtAuthzFilterFactoryTestHttp) {
   const std::string ext_authz_config_yaml = R"EOF(
   stat_prefix: "wall"
-  transport_api_version: V3
   allowed_headers:
       patterns:
       - exact: baz
@@ -231,7 +230,6 @@ private:
 
 TEST_F(ExtAuthzFilterGrpcTest, EnvoyGrpc) {
   const std::string ext_authz_config_yaml = R"EOF(
-   transport_api_version: V3
    grpc_service:
      envoy_grpc:
        cluster_name: test_cluster
@@ -242,7 +240,6 @@ TEST_F(ExtAuthzFilterGrpcTest, EnvoyGrpc) {
 
 TEST_F(ExtAuthzFilterGrpcTest, GoogleGrpc) {
   const std::string ext_authz_config_yaml = R"EOF(
-  transport_api_version: V3
   grpc_service:
     google_grpc:
       target_uri: ext_authz_server

--- a/test/extensions/filters/http/ext_authz/ext_authz.yaml
+++ b/test/extensions/filters/http/ext_authz/ext_authz.yaml
@@ -26,7 +26,6 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
               failure_mode_allow: false
-              transport_api_version: V3
               status_on_error:
                 code: 503
               grpc_service:

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -848,7 +848,6 @@ public:
   const Http::LowerCaseString case_sensitive_header_name_{"x-case-sensitive-header"};
   const std::string case_sensitive_header_value_{"Case-Sensitive"};
   const std::string legacy_default_config_ = R"EOF(
-  transport_api_version: V3
   disallowed_headers:
     patterns:
     - prefix: allowed-prefix-denied
@@ -878,7 +877,6 @@ public:
         - prefix: x-append
   )EOF";
   const std::string default_config_ = R"EOF(
-  transport_api_version: V3
   allowed_headers:
     patterns:
     - exact: X-Case-Sensitive-Header
@@ -1426,7 +1424,6 @@ TEST_P(ExtAuthzLocalReplyIntegrationTest, DeniedHeaderTest) {
 
     envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config;
     const std::string ext_authz_config = R"EOF(
-  transport_api_version: V3
   http_service:
     server_uri:
       uri: "ext_authz:9000"

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -87,7 +87,6 @@ public:
     )EOF";
 
     const std::string grpc_config = R"EOF(
-    transport_api_version: V3
     failure_mode_allow_header_add: true
     grpc_service:
       envoy_grpc:
@@ -206,7 +205,6 @@ public:
     InSequence s;
 
     initialize(R"(
-        transport_api_version: V3
         grpc_service:
           envoy_grpc:
             cluster_name: "ext_authz_server"
@@ -435,7 +433,6 @@ TEST_F(HttpFilterTest, StatsWithPrefix) {
 
   initialize(fmt::format(R"EOF(
   stat_prefix: "{}"
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -482,7 +479,6 @@ TEST_F(HttpFilterTest, ErrorFailClose) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -521,7 +517,6 @@ TEST_F(HttpFilterTest, ErrorCustomStatusCode) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -565,7 +560,6 @@ TEST_F(HttpFilterTest, ErrorFailOpen) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -603,7 +597,6 @@ TEST_F(HttpFilterTest, ImmediateErrorOpen) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -648,7 +641,6 @@ TEST_F(HttpFilterTest, ErrorOpenWithHeaderAddClose) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -686,7 +678,6 @@ TEST_F(HttpFilterTest, ImmediateErrorOpenWithHeaderAddClose) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -728,7 +719,6 @@ TEST_F(HttpFilterTest, ImmediateErrorOpenWithHeaderAddClose) {
 // Check a bad configuration results in validation exception.
 TEST_F(HttpFilterTest, BadConfig) {
   const std::string filter_config = R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc: {}
   failure_mode_allow: true
@@ -746,7 +736,6 @@ TEST_F(HttpFilterTest, RequestDataIsTooLarge) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -776,7 +765,6 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -824,7 +812,6 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessageThenContinueDecoding) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -887,7 +874,6 @@ TEST_F(HttpFilterTest, RequestDataWithSmallBuffer) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -921,7 +907,6 @@ TEST_F(HttpFilterTest, AuthWithRequestData) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -965,7 +950,6 @@ TEST_F(HttpFilterTest, AuthWithNonUtf8RequestData) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1013,7 +997,6 @@ TEST_F(HttpFilterTest, AuthWithNonUtf8RequestHeaders) {
 
   // N.B. encode_raw_headers is set to true.
   initialize(R"EOF(
-  transport_api_version: V3
   encode_raw_headers: true
   grpc_service:
     envoy_grpc:
@@ -1058,7 +1041,6 @@ TEST_F(HttpFilterTest, HeaderOnlyRequest) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1083,7 +1065,6 @@ TEST_F(HttpFilterTest, UpgradeWebsocketRequest) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1113,7 +1094,6 @@ TEST_F(HttpFilterTest, H2UpgradeRequest) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1143,7 +1123,6 @@ TEST_F(HttpFilterTest, HeaderOnlyRequestWithStream) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1179,7 +1158,6 @@ TEST_F(HttpFilterTest, HeadersToRemoveRemovesHeadersExceptSpecialHeaders) {
   request_headers_.addCopy("remove-me", "upstream-should-not-see-me");
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1236,7 +1214,6 @@ TEST_F(HttpFilterTest, ClearCache) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1282,7 +1259,6 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAppendOnly) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1326,7 +1302,6 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAddOnly) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1370,7 +1345,6 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToRemoveOnly) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1414,7 +1388,6 @@ TEST_F(HttpFilterTest, NoClearCacheRoute) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1453,7 +1426,6 @@ TEST_F(HttpFilterTest, NoClearCacheRouteConfig) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1493,7 +1465,6 @@ TEST_F(HttpFilterTest, NoClearCacheRouteDeniedResponse) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1531,7 +1502,6 @@ TEST_F(HttpFilterTest, NoClearCacheRouteDeniedResponse) {
 // Verifies that specified metadata is passed along in the check request
 TEST_F(HttpFilterTest, MetadataContext) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1629,7 +1599,6 @@ TEST_F(HttpFilterTest, MetadataContext) {
 // Verifies that specified connection metadata is passed along in the check request
 TEST_F(HttpFilterTest, ConnectionMetadataContext) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1765,7 +1734,6 @@ TEST_F(HttpFilterTest, ConnectionMetadataContext) {
 // Verifies that specified route metadata is passed along in the check request
 TEST_F(HttpFilterTest, RouteMetadataContext) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1933,7 +1901,6 @@ TEST_F(HttpFilterTest, RouteMetadataContext) {
 // Test that filter can be disabled via the filter_enabled field.
 TEST_F(HttpFilterTest, FilterDisabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1958,7 +1925,6 @@ TEST_F(HttpFilterTest, FilterDisabled) {
 // Test that filter can be enabled via the filter_enabled field.
 TEST_F(HttpFilterTest, FilterEnabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -1986,7 +1952,6 @@ TEST_F(HttpFilterTest, FilterEnabled) {
 // Test that filter can be disabled via the filter_enabled_metadata field.
 TEST_F(HttpFilterTest, MetadataDisabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2019,7 +1984,6 @@ TEST_F(HttpFilterTest, MetadataDisabled) {
 // Test that filter can be enabled via the filter_enabled_metadata field.
 TEST_F(HttpFilterTest, MetadataEnabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2056,7 +2020,6 @@ TEST_F(HttpFilterTest, MetadataEnabled) {
 // is disabled.
 TEST_F(HttpFilterTest, FilterEnabledButMetadataDisabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2101,7 +2064,6 @@ TEST_F(HttpFilterTest, FilterEnabledButMetadataDisabled) {
 // is disabled.
 TEST_F(HttpFilterTest, FilterDisabledButMetadataEnabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2146,7 +2108,6 @@ TEST_F(HttpFilterTest, FilterDisabledButMetadataEnabled) {
 // is enabled.
 TEST_F(HttpFilterTest, FilterEnabledAndMetadataEnabled) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2193,7 +2154,6 @@ TEST_F(HttpFilterTest, FilterEnabledAndMetadataEnabled) {
 // Test that filter can deny for protected path when filter is disabled via filter_enabled field.
 TEST_F(HttpFilterTest, FilterDenyAtDisable) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2227,7 +2187,6 @@ TEST_F(HttpFilterTest, FilterDenyAtDisable) {
 // Test that filter allows for protected path when filter is disabled via filter_enabled field.
 TEST_F(HttpFilterTest, FilterAllowAtDisable) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2352,7 +2311,6 @@ TEST_P(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
 
   auto test_disable = [&](bool disabled) {
     initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -2436,7 +2394,6 @@ TEST_P(HttpFilterTestParam, OkResponse) {
 
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcService) {
   initialize(R"EOF(
-    transport_api_version: V3
     grpc_service:
       envoy_grpc:
         cluster_name: "ext_authz_server"
@@ -2447,7 +2404,6 @@ TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcService) {
 
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForHttpService) {
   initialize(R"EOF(
-    transport_api_version: V3
     http_service:
       server_uri:
         uri: "ext_authz:9000"
@@ -2466,7 +2422,6 @@ TEST_P(HttpFilterTestParam, RequestHeaderMatchersForHttpService) {
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcServiceWithAllowedHeaders) {
   const Http::LowerCaseString foo{"foo"};
   initialize(R"EOF(
-    transport_api_version: V3
     grpc_service:
       envoy_grpc:
         cluster_name: "ext_authz_server"
@@ -2483,7 +2438,6 @@ TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcServiceWithAllowedHeader
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcServiceWithDisallowedHeaders) {
   const Http::LowerCaseString foo{"foo"};
   initialize(R"EOF(
-    transport_api_version: V3
     grpc_service:
       envoy_grpc:
         cluster_name: "ext_authz_server"
@@ -2500,7 +2454,6 @@ TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcServiceWithDisallowedHea
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForHttpServiceWithAllowedHeaders) {
   const Http::LowerCaseString foo{"foo"};
   initialize(R"EOF(
-    transport_api_version: V3
     http_service:
       server_uri:
         uri: "ext_authz:9000"
@@ -2524,7 +2477,6 @@ TEST_P(HttpFilterTestParam, RequestHeaderMatchersForHttpServiceWithAllowedHeader
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForHttpServiceWithDisallowedHeaders) {
   const Http::LowerCaseString foo{"foo"};
   initialize(R"EOF(
-    transport_api_version: V3
     http_service:
       server_uri:
         uri: "ext_authz:9000"
@@ -2544,7 +2496,6 @@ TEST_P(HttpFilterTestParam,
        DEPRECATED_FEATURE_TEST(RequestHeaderMatchersForHttpServiceWithLegacyAllowedHeaders)) {
   const Http::LowerCaseString foo{"foo"};
   initialize(R"EOF(
-    transport_api_version: V3
     http_service:
       server_uri:
         uri: "ext_authz:9000"
@@ -2915,7 +2866,6 @@ TEST_P(HttpFilterTestParam, DeniedResponseWith401) {
 // Test that a denied response results in the connection closing with a 401 response to the client.
 TEST_P(HttpFilterTestParam, DeniedResponseWith401NoClusterResponseCodeStats) {
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -3133,7 +3083,6 @@ TEST_F(HttpFilterTest, EmitDynamicMetadata) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -3195,7 +3144,6 @@ TEST_F(HttpFilterTest, EmitDynamicMetadataWhenDenied) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -3249,7 +3197,6 @@ TEST_F(HttpFilterTest, EmittingMetadataWhenError) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -3358,7 +3305,6 @@ TEST_F(HttpFilterTest, PerRouteCheckSettingsWorks) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -3415,7 +3361,6 @@ TEST_F(HttpFilterTest, PerRouteCheckSettingsOverrideWorks) {
   InSequence s;
 
   initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"
@@ -3480,7 +3425,6 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
 
   auto test_disable_request_body_buffering = [&](bool bypass) {
     initialize(R"EOF(
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: "ext_authz_server"

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -217,13 +217,11 @@ typed_config:
         sds_config:
           path_config_source:
             path: "{{ test_tmpdir }}/token_secret.yaml"
-          resource_api_version: V3
       hmac_secret:
         name: hmac
         sds_config:
           path_config_source:
             path: "{{ test_tmpdir }}/hmac_secret.yaml"
-          resource_api_version: V3
     use_refresh_token: true
     auth_scopes:
     - user
@@ -561,13 +559,11 @@ typed_config:
         sds_config:
           path_config_source:
             path: "{{ test_tmpdir }}/token_secret.yaml"
-          resource_api_version: V3
       hmac_secret:
         name: hmac
         sds_config:
           path_config_source:
             path: "{{ test_tmpdir }}/hmac_secret.yaml"
-          resource_api_version: V3
     auth_scopes:
     - user
     - openid

--- a/test/extensions/filters/http/on_demand/odcds_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/odcds_integration_test.cc
@@ -86,10 +86,8 @@ public:
   createOdCdsConfigSource(absl::string_view cluster_name) {
     envoy::config::core::v3::ConfigSource source;
     TestUtility::loadFromYaml(fmt::format(R"EOF(
-      resource_api_version: V3
       api_config_source:
         api_type: DELTA_GRPC
-        transport_api_version: V3
         grpc_services:
           envoy_grpc:
             cluster_name: {}
@@ -102,7 +100,6 @@ public:
   static envoy::config::core::v3::ConfigSource createAdsOdCdsConfigSource() {
     envoy::config::core::v3::ConfigSource source;
     TestUtility::loadFromYaml(R"EOF(
-      resource_api_version: V3
       ads: {}
 )EOF",
                               source);
@@ -781,10 +778,8 @@ key:
               "@type": type.googleapis.com/envoy.extensions.filters.http.on_demand.v3.PerRouteConfig
               odcds:
                 source:
-                  resource_api_version: V3
                   api_config_source:
                     api_type: DELTA_GRPC
-                    transport_api_version: V3
                     grpc_services:
                       envoy_grpc:
                         cluster_name: odcds_cluster
@@ -801,10 +796,8 @@ key:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.on_demand.v3.PerRouteConfig
                 odcds:
                   source:
-                    resource_api_version: V3
                     api_config_source:
                       api_type: DELTA_GRPC
-                      transport_api_version: V3
                       grpc_services:
                         envoy_grpc:
                           cluster_name: odcds_cluster

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -33,7 +33,6 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   domain: test
   timeout: 2s
   rate_limit_service:
-    transport_api_version: V3
     grpc_service:
       envoy_grpc:
         cluster_name: ratelimit_cluster

--- a/test/extensions/filters/network/dubbo_proxy/config_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/config_test.cc
@@ -185,7 +185,7 @@ TEST_F(DubboFilterConfigTest, DubboProxyDrds) {
   const std::string config_yaml = R"EOF(
 stat_prefix: ingress
 drds:
-  config_source: { resource_api_version: V3, ads: {} }
+  config_source: { ads: {} }
   route_config_name: test_route
 )EOF";
 
@@ -223,7 +223,7 @@ stat_prefix: ingress
 route_config:
 - name: local_route
 drds:
-  config_source: { resource_api_version: V3, ads: {} }
+  config_source: { ads: {} }
   route_config_name: test_route
 )EOF";
 
@@ -257,8 +257,7 @@ TEST_F(DubboFilterConfigTest, DubboProxyDrdsApiConfigSource) {
 stat_prefix: ingress
 drds:
   config_source:
-    resource_api_version: V3
-    api_config_source: { api_type: GRPC, transport_api_version: V3 }
+    api_config_source: { api_type: GRPC }
   route_config_name: test_route
 )EOF";
 

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -28,7 +28,6 @@ void expectCorrectProto() {
       stat_prefix: google
   failure_mode_allow: false
   stat_prefix: name
-  transport_api_version: V3
 )EOF";
 
   ExtAuthzConfigFactory factory;

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -141,7 +141,6 @@ public:
   Network::Address::InstanceConstSharedPtr addr_;
   Filters::Common::ExtAuthz::RequestCallbacks* request_callbacks_{};
   const std::string default_yaml_string_ = R"EOF(
-transport_api_version: V3
 grpc_service:
   envoy_grpc:
     cluster_name: ext_authz_server
@@ -150,7 +149,6 @@ failure_mode_allow: true
 stat_prefix: name
   )EOF";
   const std::string metadata_yaml_string_ = R"EOF(
-transport_api_version: V3
 grpc_service:
   envoy_grpc:
     cluster_name: ext_authz_server
@@ -168,7 +166,6 @@ filter_enabled_metadata:
 
 TEST_F(ExtAuthzFilterTest, BadExtAuthzConfig) {
   std::string yaml_string = R"EOF(
-transport_api_version: V3
 grpc_service: {}
 stat_prefix: name
   )EOF";

--- a/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
@@ -136,12 +136,12 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     type_urls:
     - type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
 - name: bar
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     type_urls:
     - type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
 - name: envoy.filters.http.router

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -2611,7 +2611,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     apply_default_config_without_warming: true
     type_urls:
     - type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -2639,7 +2639,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     default_config:
       "@type": type.googleapis.com/google.protobuf.Value
     type_urls:
@@ -2669,7 +2669,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     default_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
       pass_through_mode: false
@@ -2700,7 +2700,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     default_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
     type_urls:
@@ -2732,7 +2732,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     default_config:
       "@type": type.googleapis.com/xds.type.v3.TypedStruct
       type_url: type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -2766,7 +2766,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     default_config:
       "@type": type.googleapis.com/udpa.type.v1.TypedStruct
       type_url: type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -2800,7 +2800,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     type_urls:
     - type.googleapis.com/google.protobuf.Value
   )EOF";
@@ -2827,7 +2827,7 @@ route_config:
 http_filters:
 - name: foo
   config_discovery:
-    config_source: { resource_api_version: V3, ads: {} }
+    config_source: { ads: {} }
     default_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
       pass_through_mode: false

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -38,7 +38,6 @@ TEST(RateLimitFilterConfigTest, CorrectProto) {
        value: my_value
   timeout: 2s
   rate_limit_service:
-    transport_api_version: V3
     grpc_service:
       envoy_grpc:
         cluster_name: ratelimit_cluster

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -259,7 +259,7 @@ TEST_F(ThriftFilterConfigTest, ThriftProxyTrds) {
   const std::string config_yaml = R"EOF(
 stat_prefix: ingress
 trds:
-  config_source: { resource_api_version: V3, ads: {} }
+  config_source: { ads: {} }
   route_config_name: test_route
 )EOF";
 
@@ -296,7 +296,7 @@ stat_prefix: ingress
 route_config:
   name: local_route
 trds:
-  config_source: { resource_api_version: V3, ads: {} }
+  config_source: { ads: {} }
   route_config_name: test_route
 )EOF";
 
@@ -311,8 +311,7 @@ TEST_F(ThriftFilterConfigTest, ThriftProxyTrdsApiConfigSource) {
 stat_prefix: ingress
 trds:
   config_source:
-    resource_api_version: V3
-    api_config_source: { api_type: GRPC, transport_api_version: V3 }
+    api_config_source: { api_type: GRPC }
   route_config_name: test_route
 )EOF";
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
@@ -41,7 +41,6 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterCorrectProto) {
 domain: "test"
 timeout: "1.337s"
 rate_limit_service:
-  transport_api_version: V3
   grpc_service:
     envoy_grpc:
       cluster_name: ratelimit_cluster

--- a/test/extensions/filters/network/thrift_proxy/trds_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/trds_integration_test.cc
@@ -27,7 +27,6 @@ admin:
       port_value: 0
 dynamic_resources:
   ads_config:
-    transport_api_version: V3
     api_type: GRPC
     grpc_services:
       envoy_grpc:
@@ -78,7 +77,6 @@ static_resources:
             stat_prefix: thrift_stats
             trds:
               config_source:
-                resource_api_version: V3
                 ads: {{}}
               route_config_name: test_route
 

--- a/test/extensions/http/credential_injector/generic/credential_injector_integration_test.cc
+++ b/test/extensions/http/credential_injector/generic/credential_injector_integration_test.cc
@@ -92,7 +92,6 @@ typed_config:
       credential:
         name: credential
         sds_config:
-          resource_api_version: V3
           path_config_source:
             path: "{{ test_tmpdir }}/credential.yaml"
 )EOF";
@@ -132,7 +131,6 @@ typed_config:
       credential:
         name: credential
         sds_config:
-          resource_api_version: V3
           path_config_source:
             path: "{{ test_tmpdir }}/credential.yaml"
 )EOF";
@@ -175,7 +173,6 @@ typed_config:
       credential:
         name: credential
         sds_config:
-          resource_api_version: V3
           path_config_source:
             path: "{{ test_tmpdir }}/credential.yaml"
 )EOF";

--- a/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
@@ -201,7 +201,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -247,7 +246,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -304,7 +302,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -360,7 +357,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/initial_secret.yaml"
 )EOF";
@@ -431,7 +427,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -494,7 +489,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -554,7 +548,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -587,7 +580,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -620,7 +612,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";
@@ -654,7 +645,6 @@ typed_config:
         client_secret:
           name: client-secret
           sds_config:
-            resource_api_version: V3
             path_config_source:
               path: "{{ test_tmpdir }}/client_secret.yaml"
 )EOF";

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -260,7 +260,6 @@ TEST_P(AdsIntegrationTest, DeltaSdsRemovals) {
           validation_context_sds_secret_config:
             name: validation_context
             sds_config:
-              resource_api_version: V3
               initial_fetch_timeout: 5s
               ads: {}
   )EOF",
@@ -345,7 +344,6 @@ TEST_P(AdsIntegrationTest, ClusterSharingSecretWarming) {
           validation_context_sds_secret_config:
             name: validation_context
             sds_config:
-              resource_api_version: V3
               ads: {}
   )EOF",
                             sds_transport_socket);
@@ -402,7 +400,6 @@ TEST_P(AdsIntegrationTest, SecretsPausedDuringCDS) {
             validation_context_sds_secret_config:
               name: validation_context_{}
               sds_config:
-                resource_api_version: V3
                 ads: {{}}
     )EOF",
                                           i),
@@ -2693,11 +2690,9 @@ TEST_P(AdsIntegrationTest, SrdsPausedDuringLds) {
                       separator: =
                       key: vip
               rds_config_source:
-                resource_api_version: V3
                 ads: {}
               scoped_rds:
                 scoped_rds_config_source:
-                  resource_api_version: V3
                   ads: {}
             http_filters:
             - name: envoy.filters.http.router

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -224,10 +224,8 @@ public:
                   type: EDS
                   eds_cluster_config:
                     eds_config:
-                      resource_api_version: V3
                       api_config_source:
                         api_type: GRPC
-                        transport_api_version: V3
                         grpc_services:
                           envoy_grpc:
                             cluster_name: "eds-cluster"

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -56,10 +56,8 @@ layered_runtime:
     rtds_layer:
       name: some_rtds_layer
       rtds_config:
-        resource_api_version: V3
         api_config_source:
           api_type: {}
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: rtds_cluster

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -1018,10 +1018,8 @@ public:
 
       // Set up the Bootstrap's CDS config to fetch from the CDS cluster.
       const std::string cds_yaml = R"EOF(
-    resource_api_version: V3
     api_config_source:
       api_type: GRPC
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: cds_cluster

--- a/test/integration/tcp_proxy_odcds_integration_test.cc
+++ b/test/integration/tcp_proxy_odcds_integration_test.cc
@@ -60,10 +60,8 @@ public:
           TestUtility::parseYaml<
               envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy_OnDemand>(R"EOF(
           odcds_config:
-            resource_api_version: V3
             api_config_source:
               api_type: DELTA_GRPC
-              transport_api_version: V3
               grpc_services:
                 envoy_grpc:
                   cluster_name: cluster_0

--- a/test/integration/vhds.h
+++ b/test/integration/vhds.h
@@ -87,10 +87,8 @@ static_resources:
           rds:
             route_config_name: my_route
             config_source:
-              resource_api_version: V3
               api_config_source:
                 api_type: GRPC
-                transport_api_version: V3
                 grpc_services:
                   envoy_grpc:
                     cluster_name: xds_cluster
@@ -112,10 +110,8 @@ const char RdsConfig[] = R"EOF(
 name: my_route
 vhds:
   config_source:
-    resource_api_version: V3
     api_config_source:
       api_type: DELTA_GRPC
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: xds_cluster
@@ -131,10 +127,8 @@ virtual_hosts:
     route: { cluster: my_service }
 vhds:
   config_source:
-    resource_api_version: V3
     api_config_source:
       api_type: DELTA_GRPC
-      transport_api_version: V3
       grpc_services:
         envoy_grpc:
           cluster_name: xds_cluster

--- a/test/integration/xds_config_tracker_integration_test.cc
+++ b/test/integration/xds_config_tracker_integration_test.cc
@@ -249,10 +249,8 @@ TEST_P(XdsConfigTrackerIntegrationTest, XdsConfigTrackerFailureCount) {
     name: my_route
     vhds:
       config_source:
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: xds_cluster

--- a/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-4788023076847616
+++ b/test/server/server_corpus/clusterfuzz-testcase-config_fuzz_test-4788023076847616
@@ -177,7 +177,6 @@ static_resources {
 }
 cluster_manager {
   load_stats_config {
-    transport_api_version: V3
   }
 }
 stats_sinks {

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-5146513187667968
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-5146513187667968
@@ -40,6 +40,5 @@ static_resources {
 }
 hds_config {
   api_type: REST
-  transport_api_version: V3
 }
 enable_dispatcher_stats: true

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-6612746286268416
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-6612746286268416
@@ -231,7 +231,6 @@ cluster_manager {
     request_timeout {
       nanos: 14024704
     }
-    transport_api_version: V3
   }
 }
 stats_flush_interval {

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5674078337236992
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5674078337236992
@@ -85,7 +85,6 @@ cluster_manager {
   }
   load_stats_config {
     api_type: REST
-    transport_api_version: V3
     refresh_delay {
       seconds: 4611686018427387903
     }
@@ -118,7 +117,6 @@ watchdogs {
 }
 hds_config {
   api_type: REST
-  transport_api_version: V3
 }
 layered_runtime {
 }

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5754548048625664
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5754548048625664
@@ -1,3 +1,2 @@
-node {   id: "    "   cluster: "             " } dynamic_resources {   ads_config {    api_type: REST	transport_api_version: V3	grpc_services {       google_grpc {         target_uri: " "         stat_prefix: "                                        "       }     }   } } admin {   
   profile_path: "p"
 }

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5762646786179072
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5762646786179072
@@ -1,4 +1,3 @@
-node {   id: "    "   cluster: "             " } static_resources {   listeners {     address {       pipe {         path: " "       }     }     filter_chains {       tls_context {         common_tls_context {           tls_params {             tls_minimum_protocol_version: TLSv1_2             tls_maximum_protocol_version: TLSv1_3             cipher_suites: "    "             ecdh_curves: "                                                                                                              "           }           tls_certificate_sds_secret_configs {             sds_config {               api_config_source {	api_type: REST	transport_api_version: V3                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""                 cluster_names: ""               }             }           }           validation_context_sds_secret_config {             sds_config {               ads {               }             }           }         }         require_client_certificate {           value: true         }       }     }     metadata {       filter_metadata {         key: ""         value {
         }
       }
       filter_metadata {
@@ -267,7 +266,6 @@ node {   id: "    "   cluster: "             " } static_resources {   listeners 
 dynamic_resources {
   ads_config {
     api_type: GRPC
-    transport_api_version: V3
     grpc_services {
       google_grpc {
         target_uri: "*"
@@ -385,7 +383,6 @@ stats_sinks {
 }
 hds_config {
   api_type: REST
-  transport_api_version: V3
   cluster_names: ""
   cluster_names: ""
   cluster_names: ""

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5633109961998336
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5633109961998336
@@ -38,7 +38,6 @@ static_resources {
 cluster_manager {
   load_stats_config {
     api_type: REST
-    transport_api_version: V3
     rate_limit_settings {
       fill_rate {
         value: 2.36453327863576e-312

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5665272556158976
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5665272556158976
@@ -1,1 +1,0 @@
-cluster_manager {   load_stats_config {     api_type: REST	transport_api_version: V3	grpc_services {       google_grpc {         target_uri: " "         call_credentials {           sts_service {           }         }       }     }   } } 

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5714049408172032
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5714049408172032
@@ -1,7 +1,6 @@
 cluster_manager {
   load_stats_config {
     api_type: GRPC
-    transport_api_version: V3
     grpc_services {
       google_grpc {
         target_uri: "18446744073709551617"

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5809171076218880
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-5809171076218880
@@ -7,6 +7,5 @@ admin {
 }
 hds_config {
   api_type: REST
-  transport_api_version: V3
   cluster_names: "+"
 }

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6036175623028736
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6036175623028736
@@ -1,7 +1,6 @@
 dynamic_resources {
   ads_config {
     api_type: GRPC
-    transport_api_version: V3
     grpc_services {
       google_grpc {
         target_uri: "\177\177"

--- a/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6236930453798912
+++ b/test/server/server_corpus/clusterfuzz-testcase-server_fuzz_test-6236930453798912
@@ -18,7 +18,6 @@ static_resources {
 cluster_manager {
   load_stats_config {
     api_type: REST
-    transport_api_version: V3
     cluster_names: "www.google.com"
   }
 }

--- a/test/server/server_corpus/grpc_arg_pointer
+++ b/test/server/server_corpus/grpc_arg_pointer
@@ -1,7 +1,6 @@
 cluster_manager {
   load_stats_config {
     api_type: GRPC
-    transport_api_version: V3
     grpc_services {
       google_grpc {
         target_uri: "2"

--- a/test/server/server_corpus/grpc_illegal_characters
+++ b/test/server/server_corpus/grpc_illegal_characters
@@ -1,7 +1,6 @@
 cluster_manager {
   load_stats_config {
     api_type: GRPC
-    transport_api_version: V3
     grpc_services {
       google_grpc {
         target_uri: "48?"

--- a/test/server/server_corpus/low_fill_rate
+++ b/test/server/server_corpus/low_fill_rate
@@ -18,7 +18,6 @@ dynamic_resources {
         value: 2.47032822920623e-323
       }
     }
-    transport_api_version: V3
   }
 }
 flags_path: "`"
@@ -30,7 +29,6 @@ layered_runtime {
       rtds_config {
         ads {
         }
-        resource_api_version: V3
       }
     }
   }

--- a/test/server/server_corpus/rate_limit_nan
+++ b/test/server/server_corpus/rate_limit_nan
@@ -18,7 +18,6 @@ dynamic_resources {
         value: nan
       }
     }
-    transport_api_version: V3
   }
 }
 layered_runtime {

--- a/test/server/server_corpus/start_async_client_when_validate_config
+++ b/test/server/server_corpus/start_async_client_when_validate_config
@@ -173,7 +173,6 @@ dynamic_resources {
       }
     }
     set_node_on_first_message_only: true
-    transport_api_version: V3
   }
 }
 flags_path: "+"
@@ -224,6 +223,5 @@ stats_sinks {
 }
 config_sources {
   path: "+"
-  resource_api_version: V3
 }
 

--- a/test/server/test_data/server/bad_sds_config_source.yaml
+++ b/test/server/test_data/server/bad_sds_config_source.yaml
@@ -23,10 +23,8 @@ static_resources:
           tls_certificate_sds_secret_configs:
           - name: default
             sds_config:
-              resource_api_version: V3
               api_config_source:
                 api_type: GRPC
-                transport_api_version: V3
                 grpc_services:
                   envoy_grpc:
                     cluster_name: "sds-grpc"

--- a/test/server/test_data/server/hds_exception.yaml
+++ b/test/server/test_data/server/hds_exception.yaml
@@ -22,6 +22,5 @@
 hdsConfig:
   apiType: GRPC
   requestTimeout: 0.014024704s
-  transportApiVersion: V3
 
 enableDispatcherStats: true

--- a/test/server/test_data/server/health_check_nullptr.yaml
+++ b/test/server/test_data/server/health_check_nullptr.yaml
@@ -19,5 +19,4 @@ clusterManager:
   loadStatsConfig:
     apiType: GRPC
     requestTimeout: 0.014024704s
-    transportApiVersion: V3
 statsFlushInterval: 0.002097152s

--- a/test/server/test_data/server/runtime_bootstrap_ads_eds.yaml
+++ b/test/server/test_data/server/runtime_bootstrap_ads_eds.yaml
@@ -16,17 +16,14 @@ static_resources:
     type: EDS
     eds_cluster_config:
       eds_config:
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: "dummy_cluster"
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    transport_api_version: V3
     grpc_services:
       envoy_grpc:
         cluster_name: ads_cluster
@@ -37,5 +34,4 @@ layered_runtime:
     rtds_layer:
       name: foobar
       rtds_config:
-        resource_api_version: V3
         ads: {}

--- a/test/server/test_data/server/runtime_bootstrap_eds.yaml
+++ b/test/server/test_data/server/runtime_bootstrap_eds.yaml
@@ -16,10 +16,8 @@ static_resources:
     type: EDS
     eds_cluster_config:
       eds_config:
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: "dummy_cluster"
@@ -29,10 +27,8 @@ layered_runtime:
     rtds_layer:
       name: foobar
       rtds_config:
-        resource_api_version: V3
         api_config_source:
           api_type: GRPC
-          transport_api_version: V3
           grpc_services:
             envoy_grpc:
               cluster_name: rtds_cluster

--- a/test/tools/schema_validator/test/config/bootstrap.yaml
+++ b/test/tools/schema_validator/test/config/bootstrap.yaml
@@ -15,7 +15,6 @@ layered_runtime:
     rtds_layer:
       name: rtds
       rtds_config:
-        resource_api_version: V3
         path_config_source:
           path: /config_map/rtds/rtds.yaml
           watched_directory:
@@ -23,13 +22,11 @@ layered_runtime:
 
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     path_config_source:
       path: /config_map/cds/cds.yaml
       watched_directory:
         path: /config_map/cds
   lds_config:
-    resource_api_version: V3
     path_config_source:
       path: /config_map/lds/lds.yaml
       watched_directory:

--- a/test/tools/schema_validator/test/config/bootstrap_pgv_fail.yaml
+++ b/test/tools/schema_validator/test/config/bootstrap_pgv_fail.yaml
@@ -17,7 +17,6 @@ layered_runtime:
     rtds_layer:
       name: rtds
       rtds_config:
-        resource_api_version: V3
         path_config_source:
           path: /config_map/rtds/rtds.yaml
           watched_directory:
@@ -25,13 +24,11 @@ layered_runtime:
 
 dynamic_resources:
   cds_config:
-    resource_api_version: V3
     path_config_source:
       path: /config_map/cds/cds.yaml
       watched_directory:
         path: /config_map/cds
   lds_config:
-    resource_api_version: V3
     path_config_source:
       path: /config_map/lds/lds.yaml
       watched_directory:

--- a/test/tools/schema_validator/test/config/lds.yaml
+++ b/test/tools/schema_validator/test/config/lds.yaml
@@ -16,7 +16,6 @@ resources:
         rds:
           route_config_name: ingress_http
           config_source:
-            resource_api_version: V3
             path_config_source:
               path: /config_map/rds/rds.yaml
               watched_directory:

--- a/test/tools/schema_validator/test/config/lds_deprecated.yaml
+++ b/test/tools/schema_validator/test/config/lds_deprecated.yaml
@@ -19,7 +19,6 @@ resources:
           rds:
             route_config_name: ingress_http
             config_source:
-              resource_api_version: V3
               path_config_source:
                 path: /config_map/rds/rds.yaml
                 watched_directory:

--- a/test/tools/schema_validator/test/config/lds_unknown.yaml
+++ b/test/tools/schema_validator/test/config/lds_unknown.yaml
@@ -17,7 +17,6 @@ resources:
         rds:
           route_config_name: ingress_http
           config_source:
-            resource_api_version: V3
             path_config_source:
               path: /config_map/rds/rds.yaml
               watched_directory:

--- a/test/tools/schema_validator/test/config/lds_wip.yaml
+++ b/test/tools/schema_validator/test/config/lds_wip.yaml
@@ -18,7 +18,6 @@ resources:
         rds:
           route_config_name: ingress_http
           config_source:
-            resource_api_version: V3
             path_config_source:
               path: /config_map/rds/rds.yaml
               watched_directory:


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: resource_api_version has also been removed from all tests and examples, as it isn't used for anything.
Additional Description:
Risk Level: 
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
