### PR TITLE
generic proxy: split the upstream to different module to simply test and mock

### DIFF
--- a/contrib/generic_proxy/filters/network/source/router/BUILD
+++ b/contrib/generic_proxy/filters/network/source/router/BUILD
@@ -13,9 +13,11 @@ envoy_cc_library(
     name = "router_lib",
     srcs = [
         "router.cc",
+        "upstream.cc",
     ],
     hdrs = [
         "router.h",
+        "upstream.h",
     ],
     deps = [
         "//contrib/generic_proxy/filters/network/source:tracing_lib",
@@ -30,6 +32,7 @@ envoy_cc_library(
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tracing:tracer_lib",
         "//source/common/upstream:load_balancer_context_base_lib",
+        "@com_github_google_quiche//:quiche_common_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/generic_proxy/router/v3:pkg_cc_proto",
     ],
 )

--- a/contrib/generic_proxy/filters/network/source/router/router.h
+++ b/contrib/generic_proxy/filters/network/source/router/router.h
@@ -15,6 +15,8 @@
 #include "contrib/generic_proxy/filters/network/source/interface/codec.h"
 #include "contrib/generic_proxy/filters/network/source/interface/filter.h"
 #include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+#include "contrib/generic_proxy/filters/network/source/router/upstream.h"
+#include "quiche/common/quiche_linked_hash_map.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -40,166 +42,14 @@ enum class StreamResetReason : uint32_t {
 };
 
 class RouterFilter;
-class UpstreamRequest;
 
-class GenericUpstream : public ClientCodecCallbacks,
-                        public Envoy::Event::DeferredDeletable,
-                        public Tcp::ConnectionPool::Callbacks,
-                        public Tcp::ConnectionPool::UpstreamCallbacks,
-                        public Envoy::Logger::Loggable<Envoy::Logger::Id::upstream> {
-public:
-  GenericUpstream(Upstream::TcpPoolData&& tcp_pool_data, ClientCodecPtr&& client_codec)
-      : tcp_pool_data_(std::move(tcp_pool_data)), client_codec_(std::move(client_codec)),
-        upstream_host_(tcp_pool_data_.host()) {
-    client_codec_->setCodecCallbacks(*this);
-  }
-  ~GenericUpstream() override;
-
-  void initialize();
-  virtual void cleanUp(bool close_connection);
-
-  // Tcp::ConnectionPool::Callbacks
-  void onPoolFailure(ConnectionPool::PoolFailureReason, absl::string_view,
-                     Upstream::HostDescriptionConstSharedPtr) override;
-  void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
-                   Upstream::HostDescriptionConstSharedPtr host) override;
-
-  // Tcp::ConnectionPool::UpstreamCallbacks
-  void onAboveWriteBufferHighWatermark() override {}
-  void onBelowWriteBufferLowWatermark() override {}
-  void onUpstreamData(Buffer::Instance& data, bool end_stream) override;
-  void onEvent(Network::ConnectionEvent event) override { onEventImpl(event); }
-
-  ClientCodec& clientCodec() { return *client_codec_; }
-  void mayUpdateUpstreamHost(Upstream::HostDescriptionConstSharedPtr real_host) {
-    if (real_host == nullptr || real_host == upstream_host_) {
-      return;
-    }
-
-    // Update the upstream host iff the connection pool callbacks provide a different
-    // value.
-    upstream_host_ = std::move(real_host);
-  }
-  Upstream::HostDescriptionConstSharedPtr upstreamHost() const { return upstream_host_; }
-
-  // ResponseDecoderCallback
-  void writeToConnection(Buffer::Instance& buffer) override;
-  OptRef<Network::Connection> connection() override;
-  OptRef<const Upstream::ClusterInfo> upstreamCluster() const override {
-    ASSERT(upstream_host_ != nullptr);
-    return upstream_host_->cluster();
-  }
-
-  virtual void onEventImpl(Network::ConnectionEvent event) PURE;
-  virtual void onPoolSuccessImpl() PURE;
-  virtual void onPoolFailureImpl(ConnectionPool::PoolFailureReason reason,
-                                 absl::string_view transport_failure_reason) PURE;
-  virtual void insertUpstreamRequest(uint64_t stream_id, UpstreamRequest* pending_request) PURE;
-  virtual void removeUpstreamRequest(uint64_t stream_id) PURE;
-
-protected:
-  Upstream::TcpPoolData tcp_pool_data_;
-  ClientCodecPtr client_codec_;
-  Upstream::HostDescriptionConstSharedPtr upstream_host_;
-
-  // Whether the upstream connection is created. This will be set to true when the initialize()
-  // is called.
-  bool initialized_{};
-
-  Tcp::ConnectionPool::Cancellable* tcp_pool_handle_{};
-  Tcp::ConnectionPool::ConnectionDataPtr owned_conn_data_;
-};
-using GenericUpstreamSharedPtr = std::shared_ptr<GenericUpstream>;
-
-class BoundGenericUpstream : public GenericUpstream,
-                             public StreamInfo::FilterState::Object,
-                             public std::enable_shared_from_this<BoundGenericUpstream> {
-public:
-  BoundGenericUpstream(const CodecFactory& codec_factory,
-                       Envoy::Upstream::TcpPoolData&& tcp_pool_data,
-                       Network::Connection& downstream_connection);
-
-  void onDownstreamConnectionEvent(Network::ConnectionEvent event);
-
-  // UpstreamConnection
-  void onPoolSuccessImpl() override;
-  void onPoolFailureImpl(ConnectionPool::PoolFailureReason reason,
-                         absl::string_view transport_failure_reason) override;
-  void onEventImpl(Network::ConnectionEvent event) override;
-  void cleanUp(bool close_connection) override;
-
-  // ClientCodecCallbacks
-  void onDecodingSuccess(ResponseHeaderFramePtr response_header_frame,
-                         absl::optional<StartTime> start_time = {}) override;
-  void onDecodingSuccess(ResponseCommonFramePtr response_common_frame) override;
-  void onDecodingFailure(absl::string_view reason = {}) override;
-
-  // GenericUpstream
-  void insertUpstreamRequest(uint64_t stream_id, UpstreamRequest* pending_request) override;
-  void removeUpstreamRequest(uint64_t stream_id) override;
-
-  const auto& waitingResponseRequestsForTest() const { return waiting_response_requests_; }
-  const auto& waitingUpstreamRequestsForTest() const { return waiting_upstream_requests_; }
-
-private:
-  struct EventWatcher : public Network::ConnectionCallbacks {
-    EventWatcher(BoundGenericUpstream& parent) : parent_(parent) {}
-    BoundGenericUpstream& parent_;
-
-    // Network::ConnectionCallbacks
-    void onAboveWriteBufferHighWatermark() override {}
-    void onBelowWriteBufferLowWatermark() override {}
-    void onEvent(Network::ConnectionEvent downstream_event) override {
-      parent_.onDownstreamConnectionEvent(downstream_event);
-    }
-  };
-
-  Network::Connection& downstream_connection_;
-
-  std::unique_ptr<EventWatcher> connection_event_watcher_;
-
-  absl::optional<bool> upstream_connection_ready_;
-  bool prevent_clean_up_{};
-
-  // Pending upstream requests that are waiting for the upstream response to be received.
-  absl::flat_hash_map<uint64_t, UpstreamRequest*> waiting_response_requests_;
-  // Pending upstream requests that are waiting for the upstream connection to be ready.
-  absl::flat_hash_map<uint64_t, UpstreamRequest*> waiting_upstream_requests_;
-};
-
-class OwnedGenericUpstream : public GenericUpstream {
-public:
-  OwnedGenericUpstream(const CodecFactory& codec_factory,
-                       Envoy::Upstream::TcpPoolData&& tcp_pool_data);
-
-  void setResponseCallback();
-
-  // UpstreamConnection
-  void onEventImpl(Network::ConnectionEvent event) override;
-  void onPoolSuccessImpl() override;
-  void onPoolFailureImpl(ConnectionPool::PoolFailureReason reason,
-                         absl::string_view transport_failure_reason) override;
-
-  // ClientCodecCallbacks
-  void onDecodingSuccess(ResponseHeaderFramePtr response_header_frame,
-                         absl::optional<StartTime> start_time = {}) override;
-  void onDecodingSuccess(ResponseCommonFramePtr response_common_frame) override;
-  void onDecodingFailure(absl::string_view reason = {}) override;
-
-  // GenericUpstream
-  void insertUpstreamRequest(uint64_t stream_id, UpstreamRequest* pending_request) override;
-  void removeUpstreamRequest(uint64_t) override {}
-
-private:
-  UpstreamRequest* upstream_request_{};
-};
-
-class UpstreamRequest : public LinkedObject<UpstreamRequest>,
-                        public Envoy::Event::DeferredDeletable,
+class UpstreamRequest : public UpstreamRequestCallbacks,
+                        public LinkedObject<UpstreamRequest>,
                         public EncodingCallbacks,
                         Logger::Loggable<Envoy::Logger::Id::filter> {
 public:
-  UpstreamRequest(RouterFilter& parent, GenericUpstreamSharedPtr generic_upstream);
+  UpstreamRequest(RouterFilter& parent, StreamFlags stream_flags,
+                  GenericUpstreamSharedPtr generic_upstream);
 
   void startStream();
   void resetStream(StreamResetReason reason, absl::string_view reason_detail);
@@ -208,16 +58,15 @@ public:
   // Called when the stream has been reset or completed.
   void deferredDelete();
 
+  // UpstreamRequestCallbacks
   void onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
-                         absl::string_view transport_failure_reason);
-  void onUpstreamSuccess();
-
-  void onConnectionClose(Network::ConnectionEvent event);
-
+                         absl::string_view transport_failure_reason) override;
+  void onUpstreamSuccess() override;
+  void onConnectionClose(Network::ConnectionEvent event) override;
   void onDecodingSuccess(ResponseHeaderFramePtr response_header_frame,
-                         absl::optional<StartTime> start_time = {});
-  void onDecodingSuccess(ResponseCommonFramePtr response_common_frame);
-  void onDecodingFailure(absl::string_view reason);
+                         absl::optional<StartTime> start_time = {}) override;
+  void onDecodingSuccess(ResponseCommonFramePtr response_common_frame) override;
+  void onDecodingFailure(absl::string_view reason) override;
 
   // RequestEncoderCallback
   void onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) override;
@@ -234,11 +83,7 @@ public:
   void onUpstreamResponseComplete(bool drain_close);
 
   RouterFilter& parent_;
-  uint64_t stream_id_{};
-
   GenericUpstreamSharedPtr generic_upstream_;
-
-  Buffer::OwnedImpl upstream_request_buffer_;
 
   StreamInfo::StreamInfoImpl stream_info_;
   std::shared_ptr<StreamInfo::UpstreamInfoImpl> upstream_info_;
@@ -247,10 +92,11 @@ public:
 
   absl::optional<MonotonicTime> connecting_start_time_;
 
+  const uint64_t stream_id_{};
+  const bool expects_response_{};
+
   // One of these flags should be set to true when the request is complete.
   bool reset_or_response_complete_{};
-
-  bool expects_response_{};
 
   bool request_stream_header_sent_{};
   bool response_stream_header_received_{};
@@ -274,10 +120,15 @@ class RouterFilter : public DecoderFilter,
                      public RequestFramesHandler,
                      Logger::Loggable<Envoy::Logger::Id::filter> {
 public:
-  RouterFilter(RouterConfigSharedPtr config, Server::Configuration::FactoryContext& context)
-      : config_(std::move(config)),
+  RouterFilter(RouterConfigSharedPtr config, Server::Configuration::FactoryContext& context,
+               GenericUpstreamFactory* upstream_factory = nullptr)
+      : config_(std::move(config)), generic_upstream_factory_(upstream_factory),
         cluster_manager_(context.serverFactoryContext().clusterManager()),
-        time_source_(context.serverFactoryContext().timeSource()) {}
+        time_source_(context.serverFactoryContext().timeSource()) {
+    if (generic_upstream_factory_ == nullptr) {
+      generic_upstream_factory_ = &DefaultGenericUpstreamFactory::get();
+    }
+  }
 
   // DecoderFilter
   void onDestroy() override;
@@ -358,6 +209,8 @@ private:
   DecoderFilterCallback* callbacks_{};
 
   RouterConfigSharedPtr config_;
+  const GenericUpstreamFactory* generic_upstream_factory_{};
+
   Upstream::ClusterManager& cluster_manager_;
   TimeSource& time_source_;
 };

--- a/contrib/generic_proxy/filters/network/source/router/router.h
+++ b/contrib/generic_proxy/filters/network/source/router/router.h
@@ -153,7 +153,7 @@ public:
     max_retries_ = route_entry_ ? route_entry->retryPolicy().numRetries() : 1;
   }
 
-  std::list<UpstreamRequestPtr>& upstreamRequestsForTest() { return upstream_requests_; }
+  size_t upstreamRequestsSize() { return upstream_requests_.size(); }
 
   // Upstream::LoadBalancerContextBase
   const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() override;

--- a/contrib/generic_proxy/filters/network/source/router/upstream.cc
+++ b/contrib/generic_proxy/filters/network/source/router/upstream.cc
@@ -1,0 +1,361 @@
+#include "contrib/generic_proxy/filters/network/source/router/upstream.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+namespace Router {
+
+void SharedRequestManager::appendUpstreamRequest(uint64_t stream_id,
+                                                 UpstreamRequestCallbacks* pending_request) {
+  pending_requests_[stream_id] = pending_request;
+}
+
+void SharedRequestManager::removeUpstreamRequest(uint64_t stream_id) {
+  pending_requests_.erase(stream_id);
+}
+
+void SharedRequestManager::onConnectionClose(Network::ConnectionEvent event) {
+  while (!pending_requests_.empty()) {
+    // Remove then notify.
+    auto it = pending_requests_.begin();
+    auto cb = it->second;
+    pending_requests_.erase(it);
+    cb->onConnectionClose(event);
+  }
+}
+
+void SharedRequestManager::onDecodingSuccess(ResponseHeaderFramePtr header_frame,
+                                             absl::optional<StartTime> start_time) {
+
+  const uint64_t stream_id = header_frame->frameFlags().streamFlags().streamId();
+  const bool end_stream = header_frame->frameFlags().endStream();
+
+  auto it = pending_requests_.find(stream_id);
+  auto cb = it->second;
+
+  if (it == pending_requests_.end()) {
+    ENVOY_LOG(error, "generic proxy: id {} not found for frame", stream_id);
+    return;
+  }
+
+  // If the response stream is end, remove the callbacks from the map because we
+  // no longer need to track the response.
+  if (end_stream) {
+    pending_requests_.erase(it);
+  }
+
+  cb->onDecodingSuccess(std::move(header_frame), std::move(start_time));
+}
+void SharedRequestManager::onDecodingSuccess(ResponseCommonFramePtr common_frame) {
+  const uint64_t stream_id = common_frame->frameFlags().streamFlags().streamId();
+  const bool end_stream = common_frame->frameFlags().endStream();
+
+  auto it = pending_requests_.find(stream_id);
+  auto cb = it->second;
+
+  if (it == pending_requests_.end()) {
+    ENVOY_LOG(error, "generic proxy: id {} not found for frame", stream_id);
+    return;
+  }
+
+  // If the response stream is end, remove the callbacks from the map because we
+  // no longer need to track the response.
+  if (end_stream) {
+    pending_requests_.erase(it);
+  }
+
+  cb->onDecodingSuccess(std::move(common_frame));
+}
+
+void SharedRequestManager::onDecodingFailure(absl::string_view reason) {
+  ENVOY_LOG(error, "generic proxy shared encoder decoder: decoding failure ({})", reason);
+
+  // Notify all pending requests that the decoding is failed.
+  while (!pending_requests_.empty()) {
+    // Remove then notify.
+    auto it = pending_requests_.begin();
+    auto cb = it->second;
+    pending_requests_.erase(it);
+    cb->onDecodingFailure(reason);
+  }
+}
+
+void UniqueRequestManager::appendUpstreamRequest(uint64_t,
+                                                 UpstreamRequestCallbacks* pending_request) {
+  ASSERT(pending_request_ == nullptr);
+  pending_request_ = pending_request;
+}
+
+void UniqueRequestManager::removeUpstreamRequest(uint64_t) {
+  ASSERT(pending_request_ != nullptr);
+  pending_request_ = nullptr;
+}
+
+void UniqueRequestManager::onConnectionClose(Network::ConnectionEvent event) {
+  if (pending_request_ != nullptr) {
+    // Remove then notify.
+    auto cb = pending_request_;
+    pending_request_ = nullptr;
+
+    cb->onConnectionClose(event);
+  }
+}
+
+void UniqueRequestManager::onDecodingSuccess(ResponseHeaderFramePtr header_frame,
+                                             absl::optional<StartTime> start_time) {
+  if (pending_request_ != nullptr) {
+    auto cb = pending_request_;
+
+    // If the response is end, reset the pending request because we no longer need
+    // to track the response.
+    if (header_frame->frameFlags().endStream()) {
+      pending_request_ = nullptr;
+    }
+
+    cb->onDecodingSuccess(std::move(header_frame), std::move(start_time));
+  }
+}
+void UniqueRequestManager::onDecodingSuccess(ResponseCommonFramePtr common_frame) {
+  if (pending_request_ != nullptr) {
+    auto cb = pending_request_;
+
+    // If the response is end, reset the pending request because we no longer need
+    // to track the response.
+    if (common_frame->frameFlags().endStream()) {
+      pending_request_ = nullptr;
+    }
+
+    cb->onDecodingSuccess(std::move(common_frame));
+  }
+}
+
+void UniqueRequestManager::onDecodingFailure(absl::string_view reason) {
+  if (pending_request_ != nullptr) {
+    // Remove then notify.
+    auto cb = pending_request_;
+    pending_request_ = nullptr;
+    cb->onDecodingFailure(reason);
+  }
+}
+
+BoundGenericUpstream::BoundGenericUpstream(Envoy::Upstream::TcpPoolData tcp_pool_data,
+                                           const CodecFactory& codec_factory,
+                                           Network::Connection& downstream_connection)
+    : UpstreamBase(std::move(tcp_pool_data), codec_factory),
+      downstream_conn_(downstream_connection),
+      connection_event_watcher_(
+          [this](Network::ConnectionEvent event) { onDownstreamConnectionEvent(event); }) {
+  downstream_conn_.addConnectionCallbacks(connection_event_watcher_);
+}
+
+void BoundGenericUpstream::onDownstreamConnectionEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::LocalClose ||
+      event == Network::ConnectionEvent::RemoteClose) {
+    // The event should be handled first by the generic proxy first. So all pending
+    // requests will be cleaned up by the downstream connection close event.
+    ASSERT(pending_requests_.empty());
+    ASSERT(encoder_decoder_ == nullptr || encoder_decoder_->requestsSize() == 0);
+
+    // Close upstream connection and this will trigger the upstream connection close event.
+    cleanUp(true);
+  }
+}
+
+void BoundGenericUpstream::appendUpstreamRequest(uint64_t stream_id,
+                                                 UpstreamRequestCallbacks* pending_request) {
+
+  if (upstream_conn_ready_.has_value()) {
+    // Upstream connection is already ready. If the upstream connection is failed then
+    // all pending requests will be reset and no new upstream request will be created.
+    if (!upstream_conn_ready_.value()) {
+      return;
+    }
+
+    ASSERT(encoder_decoder_ != nullptr);
+
+    if (encoder_decoder_->containsRequest(stream_id)) {
+      ENVOY_LOG(error, "generic proxy upstream: id {} already registered for waiting responses",
+                stream_id);
+      downstream_conn_.close(Network::ConnectionCloseType::FlushWrite);
+      return;
+    }
+
+    encoder_decoder_->appendUpstreamRequest(stream_id, pending_request);
+    pending_request->onUpstreamSuccess();
+  } else {
+    ASSERT(encoder_decoder_ == nullptr);
+
+    if (pending_requests_.contains(stream_id)) {
+      ENVOY_LOG(error, "generic proxy upstream: id {} already registered for waiting upstream",
+                stream_id);
+      downstream_conn_.close(Network::ConnectionCloseType::FlushWrite);
+      return;
+    }
+
+    pending_requests_[stream_id] = pending_request;
+
+    // Try to initialize the upstream connection after there is at least one pending request.
+    // If the upstream connection is already initialized, this is a no-op.
+    tryInitialize();
+  }
+}
+
+void BoundGenericUpstream::removeUpstreamRequest(uint64_t stream_id) {
+  pending_requests_.erase(stream_id);
+  if (encoder_decoder_ != nullptr) {
+    encoder_decoder_->removeUpstreamRequest(stream_id);
+  }
+}
+
+void BoundGenericUpstream::cleanUp(bool close_connection) {
+  // Shared upstream manager never release the connection back to the pool
+  // because the connection is bound to the downstream connection and is shared by
+  // multiple requests.
+  if (close_connection) {
+    // Only actually do the cleanup when we want to close the connection.
+    BoundGenericUpstreamBase::cleanUp(true);
+  }
+}
+
+void BoundGenericUpstream::onEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::Connected ||
+      event == Network::ConnectionEvent::ConnectedZeroRtt) {
+    return;
+  }
+
+  if (encoder_decoder_ != nullptr) {
+    encoder_decoder_->onConnectionClose(event);
+  }
+
+  // If the downstream connection is not closed, close it.
+  downstream_conn_.close(Network::ConnectionCloseType::FlushWrite);
+}
+
+void BoundGenericUpstream::onUpstreamSuccess() {
+  // This should be called only once and all pending requests should be notified. After this is
+  // called, the upstream connection is ready and new upstream requests should be notified directly.
+
+  ASSERT(!upstream_conn_ready_.has_value());
+  // encoder_decoder_ should be initialized after the upstream connection is ready and before the
+  // onUpstreamSuccess() is called.
+  ASSERT(encoder_decoder_ != nullptr);
+  upstream_conn_ready_ = true;
+
+  while (!pending_requests_.empty()) {
+    auto it = pending_requests_.begin();
+    auto cb = it->second;
+
+    // Insert it to the waiting response list and remove it from the waiting upstream list.
+    encoder_decoder_->appendUpstreamRequest(it->first, cb);
+    pending_requests_.erase(it);
+
+    // Notify the upstream request that the upstream connection is ready and request could be sent.
+    cb->onUpstreamSuccess();
+  }
+}
+
+void BoundGenericUpstream::onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
+                                             absl::string_view transport_reason) {
+  // This should be called only once and all pending requests should be notified.
+  // Then the downstream connection will be closed.
+
+  ASSERT(!upstream_conn_ready_.has_value());
+  upstream_conn_ready_ = false;
+
+  while (!pending_requests_.empty()) {
+    auto it = pending_requests_.begin();
+    auto cb = it->second;
+
+    // Remove it from the waiting upstream list.
+    pending_requests_.erase(it);
+
+    // Now, notify the upstream request that the upstream connection is failed.
+    cb->onUpstreamFailure(reason, transport_reason);
+  }
+
+  // If the downstream connection is not closed, close it.
+  downstream_conn_.close(Network::ConnectionCloseType::FlushWrite);
+}
+
+void OwnedGenericUpstream::appendUpstreamRequest(uint64_t,
+                                                 UpstreamRequestCallbacks* pending_request) {
+  ASSERT(upstream_request_ == nullptr);
+  upstream_request_ = pending_request;
+  tryInitialize();
+}
+
+void OwnedGenericUpstream::removeUpstreamRequest(uint64_t) {
+  ASSERT(upstream_request_ != nullptr);
+  upstream_request_ = nullptr;
+  if (encoder_decoder_ != nullptr) {
+    encoder_decoder_->removeUpstreamRequest({});
+  }
+}
+
+void OwnedGenericUpstream::onEvent(Network::ConnectionEvent event) {
+  if (event == Network::ConnectionEvent::Connected ||
+      event == Network::ConnectionEvent::ConnectedZeroRtt) {
+    return;
+  }
+  if (encoder_decoder_ != nullptr) {
+    encoder_decoder_->onConnectionClose(event);
+  }
+}
+
+void OwnedGenericUpstream::onUpstreamSuccess() {
+  ASSERT(upstream_request_ != nullptr);
+  auto upstream_request = upstream_request_;
+  upstream_request_ = nullptr;
+
+  encoder_decoder_->appendUpstreamRequest({}, upstream_request);
+  upstream_request->onUpstreamSuccess();
+}
+
+void OwnedGenericUpstream::onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
+                                             absl::string_view transport_failure_reason) {
+  ASSERT(upstream_request_ != nullptr);
+  auto upstream_request = upstream_request_;
+  upstream_request_ = nullptr;
+
+  upstream_request->onUpstreamFailure(reason, transport_failure_reason);
+}
+
+GenericUpstreamSharedPtr ProdGenericUpstreamFactory::createGenericUpstream(
+    Upstream::ThreadLocalCluster& cluster, Upstream::LoadBalancerContext* context,
+    Network::Connection& downstream_conn, const CodecFactory& codec_factory, bool bound) const {
+
+  if (bound) {
+    auto* bound_upstream =
+        downstream_conn.streamInfo().filterState()->getDataMutable<BoundGenericUpstream>(
+            RouterFilterName);
+    if (bound_upstream == nullptr) {
+      // The upstream connection is not bound yet and create a new bound upstream connection.
+      auto pool_data = cluster.tcpConnPool(Upstream::ResourcePriority::Default, context);
+      if (!pool_data.has_value()) {
+        return nullptr;
+      }
+      auto new_bound_upstream = std::make_shared<BoundGenericUpstream>(
+          std::move(pool_data.value()), codec_factory, downstream_conn);
+      bound_upstream = new_bound_upstream.get();
+      downstream_conn.streamInfo().filterState()->setData(
+          RouterFilterName, std::move(new_bound_upstream),
+          StreamInfo::FilterState::StateType::Mutable,
+          StreamInfo::FilterState::LifeSpan::Connection);
+    }
+    return bound_upstream->shared_from_this();
+  } else {
+    // Upstream connection binding is disabled and create a new upstream connection.
+    auto pool_data = cluster.tcpConnPool(Upstream::ResourcePriority::Default, context);
+    if (!pool_data.has_value()) {
+      return nullptr;
+    }
+    return std::make_shared<OwnedGenericUpstream>(std::move(pool_data.value()), codec_factory);
+  }
+}
+
+} // namespace Router
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/router/upstream.cc
+++ b/contrib/generic_proxy/filters/network/source/router/upstream.cc
@@ -165,10 +165,10 @@ void BoundGenericUpstream::onDownstreamConnectionEvent(Network::ConnectionEvent 
 void BoundGenericUpstream::appendUpstreamRequest(uint64_t stream_id,
                                                  UpstreamRequestCallbacks* pending_request) {
 
-  if (upstream_conn_ready_.has_value()) {
+  if (upstream_conn_ok_.has_value()) {
     // Upstream connection is already ready. If the upstream connection is failed then
     // all pending requests will be reset and no new upstream request will be created.
-    if (!upstream_conn_ready_.value()) {
+    if (!upstream_conn_ok_.value()) {
       return;
     }
 
@@ -236,11 +236,11 @@ void BoundGenericUpstream::onUpstreamSuccess() {
   // This should be called only once and all pending requests should be notified. After this is
   // called, the upstream connection is ready and new upstream requests should be notified directly.
 
-  ASSERT(!upstream_conn_ready_.has_value());
+  ASSERT(!upstream_conn_ok_.has_value());
   // encoder_decoder_ should be initialized after the upstream connection is ready and before the
   // onUpstreamSuccess() is called.
   ASSERT(encoder_decoder_ != nullptr);
-  upstream_conn_ready_ = true;
+  upstream_conn_ok_ = true;
 
   while (!pending_requests_.empty()) {
     auto it = pending_requests_.begin();
@@ -260,8 +260,8 @@ void BoundGenericUpstream::onUpstreamFailure(ConnectionPool::PoolFailureReason r
   // This should be called only once and all pending requests should be notified.
   // Then the downstream connection will be closed.
 
-  ASSERT(!upstream_conn_ready_.has_value());
-  upstream_conn_ready_ = false;
+  ASSERT(!upstream_conn_ok_.has_value());
+  upstream_conn_ok_ = false;
 
   while (!pending_requests_.empty()) {
     auto it = pending_requests_.begin();

--- a/contrib/generic_proxy/filters/network/source/router/upstream.h
+++ b/contrib/generic_proxy/filters/network/source/router/upstream.h
@@ -1,0 +1,407 @@
+#pragma once
+
+#include <cstdint>
+
+#include "envoy/network/connection.h"
+
+#include "source/common/buffer/buffer_impl.h"
+
+#include "contrib/generic_proxy/filters/network/source/interface/codec.h"
+#include "quiche/common/quiche_linked_hash_map.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+namespace Router {
+
+constexpr absl::string_view RouterFilterName = "envoy.filters.generic.router";
+constexpr absl::string_view RouterFilterEncoderDecoderName = "envoy.filters.generic.router.codec";
+
+class UpstreamRequestCallbacks : public Envoy::Event::DeferredDeletable {
+public:
+  // Following methods may remove itself from the upstream clean up the upstream
+  // if necessary.
+
+  virtual void onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
+                                 absl::string_view transport_failure_reason) PURE;
+  virtual void onUpstreamSuccess() PURE;
+
+  virtual void onConnectionClose(Network::ConnectionEvent event) PURE;
+  virtual void onDecodingSuccess(ResponseHeaderFramePtr header_frame,
+                                 absl::optional<StartTime> start_time = {}) PURE;
+  virtual void onDecodingSuccess(ResponseCommonFramePtr common_frame) PURE;
+  virtual void onDecodingFailure(absl::string_view reason) PURE;
+};
+
+class GenericUpstream {
+public:
+  virtual ~GenericUpstream() = default;
+
+  // Insert a pending request that is waiting response into the upstream when the upstream
+  // request is started.
+  virtual void appendUpstreamRequest(uint64_t stream_id,
+                                     UpstreamRequestCallbacks* pending_request) PURE;
+
+  // Remove a pending request that is waiting response from the upstream when the upstream
+  // request is reset or completed.
+  virtual void removeUpstreamRequest(uint64_t stream_id) PURE;
+
+  // Return the upstream host description.
+  virtual Upstream::HostDescriptionConstSharedPtr upstreamHost() const PURE;
+
+  // Client codec to encode the upstream request and decode the upstream response. This is
+  // called when the upstream connection is ready.
+  virtual ClientCodec& clientCodec() PURE;
+
+  // Return the upstream connection. This could be called after the upstream connection is ready.
+  virtual OptRef<Network::Connection> upstreamConnection() PURE;
+
+  // Clean up the upstream. If close_connection is true, the connection will be closed.
+  // Any implementation should ensure that it is safe to call cleanUp() multiple times and
+  // ensure it works correctly.
+  virtual void cleanUp(bool close_connection) PURE;
+};
+
+using GenericUpstreamSharedPtr = std::shared_ptr<GenericUpstream>;
+
+class GenericUpstreamFactory {
+public:
+  virtual ~GenericUpstreamFactory() = default;
+
+  virtual GenericUpstreamSharedPtr createGenericUpstream(Upstream::ThreadLocalCluster& cluster,
+                                                         Upstream::LoadBalancerContext* context,
+                                                         Network::Connection& downstream_conn,
+                                                         const CodecFactory& codec_factory,
+                                                         bool bound) const PURE;
+};
+
+template <class RequestManager>
+class EncoderDecoder : public ClientCodecCallbacks, public StreamInfo::FilterState::Object {
+public:
+  EncoderDecoder(Network::Connection& connection, Upstream::HostDescriptionConstSharedPtr host,
+                 ClientCodecPtr client_codec)
+      : connection_(connection), host_(std::move(host)), client_codec_(std::move(client_codec)) {
+    client_codec_->setCodecCallbacks(*this);
+  }
+
+  ClientCodec& clientCodec() { return *client_codec_; }
+
+  // Insert a pending request that is waiting response into the encoder/decoder.
+  void appendUpstreamRequest(uint64_t stream_id, UpstreamRequestCallbacks* pending_request) {
+    request_manager_.appendUpstreamRequest(stream_id, pending_request);
+  }
+
+  // Remove a pending request that is waiting response from the encoder/decoder.
+  void removeUpstreamRequest(uint64_t stream_id) {
+    request_manager_.removeUpstreamRequest(stream_id);
+  }
+
+  // Called when the upstream connection is closed. All pending requests should
+  // be failed.
+  void onConnectionClose(Network::ConnectionEvent event) {
+    request_manager_.onConnectionClose(event);
+  }
+
+  size_t requestsSize() const { return request_manager_.size(); }
+  bool containsRequest(uint64_t stream_id) const { return request_manager_.contains(stream_id); }
+
+  // ClientCodecCallbacks
+  void onDecodingSuccess(ResponseHeaderFramePtr header_frame,
+                         absl::optional<StartTime> start_time = {}) override {
+    request_manager_.onDecodingSuccess(std::move(header_frame), std::move(start_time));
+  }
+  void onDecodingSuccess(ResponseCommonFramePtr common_frame) override {
+    request_manager_.onDecodingSuccess(std::move(common_frame));
+  }
+  void onDecodingFailure(absl::string_view reason) override {
+    request_manager_.onDecodingFailure(reason);
+  }
+  void writeToConnection(Buffer::Instance& buffer) override {
+    if (connection_.state() == Network::Connection::State::Open) {
+      connection_.write(buffer, false);
+    }
+  }
+  OptRef<Network::Connection> connection() override {
+    return connection_.state() == Network::Connection::State::Open
+               ? OptRef<Network::Connection>{connection_}
+               : OptRef<Network::Connection>{};
+  }
+  OptRef<const Upstream::ClusterInfo> upstreamCluster() const override { return host_->cluster(); }
+
+private:
+  Network::Connection& connection_;
+  Upstream::HostDescriptionConstSharedPtr host_;
+  ClientCodecPtr client_codec_;
+  RequestManager request_manager_{};
+};
+
+class SharedRequestManager : Logger::Loggable<Logger::Id::upstream> {
+public:
+  void appendUpstreamRequest(uint64_t stream_id, UpstreamRequestCallbacks* pending_request);
+  void removeUpstreamRequest(uint64_t stream_id);
+  void onConnectionClose(Network::ConnectionEvent event);
+
+  void onDecodingSuccess(ResponseHeaderFramePtr header_frame, absl::optional<StartTime> start_time);
+  void onDecodingSuccess(ResponseCommonFramePtr common_frame);
+  void onDecodingFailure(absl::string_view reason);
+
+  size_t size() const { return pending_requests_.size(); }
+  bool contains(uint64_t stream_id) const { return pending_requests_.contains(stream_id); }
+
+  absl::flat_hash_map<uint64_t, UpstreamRequestCallbacks*> pending_requests_;
+};
+
+class UniqueRequestManager : Logger::Loggable<Logger::Id::upstream> {
+public:
+  void appendUpstreamRequest(uint64_t stream_id, UpstreamRequestCallbacks* pending_request);
+  void removeUpstreamRequest(uint64_t stream_id);
+  void onConnectionClose(Network::ConnectionEvent event);
+
+  // ClientCodecCallbacks
+  void onDecodingSuccess(ResponseHeaderFramePtr header_frame,
+                         absl::optional<StartTime> start_time = {});
+  void onDecodingSuccess(ResponseCommonFramePtr common_frame);
+  void onDecodingFailure(absl::string_view reason);
+
+  size_t size() const { return pending_request_ != nullptr ? 1 : 0; }
+  // Stream id is not used in the unique request manager.
+  bool contains(uint64_t) const { return pending_request_ != nullptr; }
+
+  UpstreamRequestCallbacks* pending_request_{};
+};
+
+using SharedEncoderDecoder = EncoderDecoder<SharedRequestManager>;
+using UniqueEncoderDecoder = EncoderDecoder<UniqueRequestManager>;
+using SharedEncoderDecoderSharedPtr = std::shared_ptr<SharedEncoderDecoder>;
+using UniqueEncoderDecoderSharedPtr = std::shared_ptr<UniqueEncoderDecoder>;
+
+template <class EncoderDecoderType>
+class UpstreamBase : public GenericUpstream,
+                     public Tcp::ConnectionPool::Callbacks,
+                     public Tcp::ConnectionPool::UpstreamCallbacks,
+                     public Logger::Loggable<Logger::Id::upstream> {
+public:
+  UpstreamBase(Upstream::TcpPoolData pool_data, const CodecFactory& codec_factory)
+      : tcp_pool_data_(std::move(pool_data)), codec_factory_(codec_factory) {}
+  ~UpstreamBase() override {
+    if (tcp_pool_handle_ != nullptr) {
+      tcp_pool_handle_->cancel(Tcp::ConnectionPool::CancelPolicy::Default);
+    }
+  }
+
+  // Tcp::ConnectionPool::Callbacks
+  void onPoolFailure(ConnectionPool::PoolFailureReason reason, absl::string_view transport_reason,
+                     Upstream::HostDescriptionConstSharedPtr host) override {
+    ENVOY_LOG(debug, "generic proxy upstream manager: on upstream connection failure (host: {})",
+              host != nullptr ? host->address()->asStringView() : absl::string_view{});
+    tcp_pool_handle_ = nullptr;
+
+    onUpstreamFailure(reason, transport_reason);
+  }
+  void onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
+                   Upstream::HostDescriptionConstSharedPtr host) override {
+    ASSERT(host != nullptr);
+    ENVOY_LOG(debug, "generic proxy upstream manager: on upstream connection ready (host: {})",
+              host->address()->asStringView());
+    tcp_pool_handle_ = nullptr;
+
+    owned_conn_data_ = std::move(conn_data);
+    encoder_decoder_ = getOrCreateEncoderDecoder(owned_conn_data_->connection());
+    owned_conn_data_->addUpstreamCallbacks(*this);
+
+    onUpstreamSuccess();
+  }
+
+  // Tcp::ConnectionPool::UpstreamCallbacks
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+  void onUpstreamData(Buffer::Instance& data, bool end_stream) override {
+    if (data.length() == 0) {
+      return;
+    }
+    ASSERT(encoder_decoder_ != nullptr);
+    encoder_decoder_->clientCodec().decode(data, end_stream);
+  }
+
+  // Upstream
+  ClientCodec& clientCodec() override {
+    ASSERT(encoder_decoder_ != nullptr);
+    return encoder_decoder_->clientCodec();
+  }
+  void cleanUp(bool close_connection) override {
+    ENVOY_LOG(debug, "generic proxy upstream manager: clean up upstream (close: {})",
+              close_connection);
+
+    if (tcp_pool_handle_ != nullptr) {
+      ENVOY_LOG(debug, "generic proxy upstream manager: cancel pending connection");
+      ASSERT(owned_conn_data_ == nullptr);
+
+      // Clear the data first.
+      auto local_tcp_pool_handle = tcp_pool_handle_;
+      tcp_pool_handle_ = nullptr;
+      local_tcp_pool_handle->cancel(Tcp::ConnectionPool::CancelPolicy::Default);
+    }
+
+    if (owned_conn_data_ != nullptr) {
+      if (!close_connection) {
+        return;
+      }
+
+      ENVOY_LOG(debug, "generic proxy upstream request: close upstream connection");
+      ASSERT(tcp_pool_handle_ == nullptr);
+
+      // Clear the data first to avoid re-entering this function in the close callback.
+      auto local_conn_data = std::move(owned_conn_data_);
+      owned_conn_data_.reset();
+      local_conn_data->connection().close(Network::ConnectionCloseType::FlushWrite);
+    }
+  }
+  OptRef<Network::Connection> upstreamConnection() override {
+    if (owned_conn_data_ == nullptr) {
+      return {};
+    }
+    return owned_conn_data_->connection();
+  }
+  Upstream::HostDescriptionConstSharedPtr upstreamHost() const override {
+    return tcp_pool_data_.host();
+  }
+
+  virtual void onUpstreamSuccess() PURE;
+  virtual void onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
+                                 absl::string_view transport_failure_reason) PURE;
+
+protected:
+  void tryInitialize() {
+    if (!initialized_) {
+      initialized_ = true;
+      tcp_pool_handle_ = tcp_pool_data_.newConnection(*this);
+    }
+  }
+  EncoderDecoderType* getOrCreateEncoderDecoder(Network::Connection& connection) {
+    EncoderDecoderType* encoder_decoder =
+        connection.streamInfo().filterState()->getDataMutable<EncoderDecoderType>(
+            RouterFilterEncoderDecoderName);
+    if (encoder_decoder == nullptr) {
+      auto data = std::make_unique<EncoderDecoderType>(connection, tcp_pool_data_.host(),
+                                                       codec_factory_.createClientCodec());
+      encoder_decoder = data.get();
+      connection.streamInfo().filterState()->setData(RouterFilterEncoderDecoderName,
+                                                     std::move(data),
+                                                     StreamInfo::FilterState::StateType::Mutable,
+                                                     StreamInfo::FilterState::LifeSpan::Connection);
+    }
+    return encoder_decoder;
+  }
+
+  Upstream::TcpPoolData tcp_pool_data_;
+  Tcp::ConnectionPool::Cancellable* tcp_pool_handle_{};
+  Tcp::ConnectionPool::ConnectionDataPtr owned_conn_data_;
+  const CodecFactory& codec_factory_;
+  EncoderDecoderType* encoder_decoder_{};
+
+  // Whether the upstream connection is created. This will be set to true when
+  // the initialize() is called.
+  bool initialized_{};
+};
+
+struct EventWatcher : public Network::ConnectionCallbacks {
+  using EventWatcherFn = std::function<void(Network::ConnectionEvent)>;
+  EventWatcher(EventWatcherFn fn) : fn_(std::move(fn)) {}
+  // Network::ConnectionCallbacks
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+  void onEvent(Network::ConnectionEvent downstream_event) override { fn_(downstream_event); }
+  EventWatcherFn fn_;
+};
+
+using BoundGenericUpstreamBase = UpstreamBase<SharedEncoderDecoder>;
+class BoundGenericUpstream : public BoundGenericUpstreamBase,
+                             public StreamInfo::FilterState::Object,
+                             public std::enable_shared_from_this<BoundGenericUpstream> {
+public:
+  BoundGenericUpstream(Envoy::Upstream::TcpPoolData tcp_pool_data,
+                       const CodecFactory& codec_factory,
+                       Network::Connection& downstream_connection);
+
+  // Tcp::ConnectionPool::UpstreamCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+
+  // UpstreamBase
+  void onUpstreamSuccess() override;
+  void onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
+                         absl::string_view transport_failure_reason) override;
+
+  // Upstream
+  void appendUpstreamRequest(uint64_t stream_id,
+                             UpstreamRequestCallbacks* pending_request) override;
+  void removeUpstreamRequest(uint64_t stream_id) override;
+  void cleanUp(bool close_connection) override;
+
+  size_t waitingUpstreamRequestsSize() const { return pending_requests_.size(); }
+  size_t waitingResponseRequestsSize() const {
+    return encoder_decoder_ ? encoder_decoder_->requestsSize() : 0;
+  }
+
+private:
+  void onDownstreamConnectionEvent(Network::ConnectionEvent event);
+
+  Network::Connection& downstream_conn_;
+  EventWatcher connection_event_watcher_;
+  absl::optional<bool> upstream_conn_ready_;
+
+  // This ensure the requests that are waiting upstream connectin will be list in the order in
+  // which the requests were received. By this way, the protocols that require the requests and
+  // responses be handled in pipeline could works properly.
+  // Note we need not do that for the requests that are waiting responses. Because we assume that
+  // the clients of these protocols will send requests in order. Then when the connection is ready,
+  // generic proxy will send requests to server in order. Finally, the upstream server of these
+  // protocols will send respnoses in order. We also assume that the L7 filter chain of these
+  // protocols will not change the processing order.
+  using LinkedHashMap = quiche::QuicheLinkedHashMap<uint64_t, UpstreamRequestCallbacks*>;
+  LinkedHashMap pending_requests_;
+};
+
+using OwnedGenericUpstreamBase = UpstreamBase<UniqueEncoderDecoder>;
+class OwnedGenericUpstream : public OwnedGenericUpstreamBase {
+public:
+  using UpstreamBase::UpstreamBase;
+
+  // Tcp::ConnectionPool::UpstreamCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+
+  // UpstreamBase
+  void onUpstreamSuccess() override;
+  void onUpstreamFailure(ConnectionPool::PoolFailureReason reason,
+                         absl::string_view transport_failure_reason) override;
+
+  // Upstream
+  void appendUpstreamRequest(uint64_t stream_id,
+                             UpstreamRequestCallbacks* pending_request) override;
+  void removeUpstreamRequest(uint64_t stream_id) override;
+
+  size_t waitingUpstreamRequestsSize() const { return upstream_request_ ? 1 : 0; }
+  size_t waitingResponseRequestsSize() const {
+    return encoder_decoder_ ? encoder_decoder_->requestsSize() : 0;
+  }
+
+private:
+  UpstreamRequestCallbacks* upstream_request_{};
+};
+
+class ProdGenericUpstreamFactory : public GenericUpstreamFactory {
+public:
+  GenericUpstreamSharedPtr createGenericUpstream(Upstream::ThreadLocalCluster& cluster,
+                                                 Upstream::LoadBalancerContext* context,
+                                                 Network::Connection& downstream_conn,
+                                                 const CodecFactory& codec_factory,
+                                                 bool bound) const override;
+};
+
+using DefaultGenericUpstreamFactory = ConstSingleton<ProdGenericUpstreamFactory>;
+
+} // namespace Router
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/router/upstream.h
+++ b/contrib/generic_proxy/filters/network/source/router/upstream.h
@@ -348,7 +348,7 @@ private:
 
   Network::Connection& downstream_conn_;
   EventWatcher connection_event_watcher_;
-  absl::optional<bool> upstream_conn_ready_;
+  absl::optional<bool> upstream_conn_ok_;
 
   // This ensure the requests that are waiting upstream connectin will be list in the order in
   // which the requests were received. By this way, the protocols that require the requests and
@@ -358,8 +358,8 @@ private:
   // generic proxy will send requests to server in order. Finally, the upstream server of these
   // protocols will send respnoses in order. We also assume that the L7 filter chain of these
   // protocols will not change the processing order.
-  using LinkedHashMap = quiche::QuicheLinkedHashMap<uint64_t, UpstreamRequestCallbacks*>;
-  LinkedHashMap pending_requests_;
+  using LinkedAbslHashMap = quiche::QuicheLinkedHashMap<uint64_t, UpstreamRequestCallbacks*>;
+  LinkedAbslHashMap pending_requests_;
 };
 
 using OwnedGenericUpstreamBase = UpstreamBase<UniqueEncoderDecoder>;

--- a/contrib/generic_proxy/filters/network/test/router/BUILD
+++ b/contrib/generic_proxy/filters/network/test/router/BUILD
@@ -27,6 +27,24 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "upstream_test",
+    srcs = [
+        "upstream_test.cc",
+    ],
+    deps = [
+        "//contrib/generic_proxy/filters/network/source/router:router_lib",
+        "//contrib/generic_proxy/filters/network/test:fake_codec_lib",
+        "//contrib/generic_proxy/filters/network/test/mocks:codec_mocks",
+        "//contrib/generic_proxy/filters/network/test/mocks:filter_mocks",
+        "//contrib/generic_proxy/filters/network/test/mocks:route_mocks",
+        "//source/common/buffer:buffer_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "config_test",
     srcs = [
         "config_test.cc",

--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -36,7 +36,8 @@ public:
     ON_CALL(*this, removeUpstreamRequest(_)).WillByDefault(Invoke([this](uint64_t stream_id) {
       requests_.erase(stream_id);
     }));
-    ON_CALL(*this, upstreamConnection()).WillByDefault(ReturnRef(mock_upstream_connection_));
+    ON_CALL(*this, upstreamConnection())
+        .WillByDefault(Return(makeOptRef<Network::Connection>(mock_upstream_connection_)));
     ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_description_));
     ON_CALL(*this, clientCodec()).WillByDefault(ReturnRef(mock_client_codec_));
   }

--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -11,9 +11,9 @@
 #include "contrib/generic_proxy/filters/network/test/mocks/codec.h"
 #include "contrib/generic_proxy/filters/network/test/mocks/filter.h"
 #include "contrib/generic_proxy/filters/network/test/mocks/route.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::ByMove;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -25,21 +25,46 @@ namespace GenericProxy {
 namespace Router {
 namespace {
 
-#define ONLY_RUN_TEST_WITH_PARAM(param)                                                            \
-  if (GetParam() != param) {                                                                       \
-    return;                                                                                        \
+class MockGenericUpstream : public GenericUpstream {
+public:
+  MockGenericUpstream() {
+    ON_CALL(*this, appendUpstreamRequest(_, _))
+        .WillByDefault(
+            Invoke([this](uint64_t stream_id, UpstreamRequestCallbacks* pending_request) {
+              requests_[stream_id] = pending_request;
+            }));
+    ON_CALL(*this, removeUpstreamRequest(_)).WillByDefault(Invoke([this](uint64_t stream_id) {
+      requests_.erase(stream_id);
+    }));
+    ON_CALL(*this, upstreamConnection()).WillByDefault(ReturnRef(mock_upstream_connection_));
+    ON_CALL(*this, upstreamHost()).WillByDefault(Return(host_description_));
+    ON_CALL(*this, clientCodec()).WillByDefault(ReturnRef(mock_client_codec_));
   }
 
-struct TestParameters {
-  bool operator!=(const TestParameters& other) const {
-    return with_tracing != other.with_tracing || bind_upstream != other.bind_upstream;
-  }
+  MOCK_METHOD(void, appendUpstreamRequest,
+              (uint64_t stream_id, UpstreamRequestCallbacks* pending_request));
+  MOCK_METHOD(void, removeUpstreamRequest, (uint64_t stream_id));
+  MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, upstreamHost, (), (const));
+  MOCK_METHOD(ClientCodec&, clientCodec, ());
+  MOCK_METHOD(Network::Connection&, upstreamConnection, ());
+  MOCK_METHOD(void, cleanUp, (bool close_connection));
 
-  bool with_tracing{};
-  bool bind_upstream{};
+  std::shared_ptr<Upstream::MockHostDescription> host_description_ =
+      std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  NiceMock<Network::MockClientConnection> mock_upstream_connection_;
+  absl::flat_hash_map<uint32_t, UpstreamRequestCallbacks*> requests_;
+  NiceMock<MockClientCodec> mock_client_codec_{};
 };
 
-class RouterFilterTest : public testing::TestWithParam<TestParameters> {
+class MockGenericUpstreamFactory : public GenericUpstreamFactory {
+public:
+  MOCK_METHOD(GenericUpstreamSharedPtr, createGenericUpstream,
+              (Upstream::ThreadLocalCluster&, Upstream::LoadBalancerContext*, Network::Connection&,
+               const CodecFactory&, bool),
+              (const));
+};
+
+class RouterFilterTest : public testing::Test {
 public:
   RouterFilterTest() {
     // Common mock calls.
@@ -54,20 +79,18 @@ public:
     factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
         {cluster_name_});
 
-    auto parameter = GetParam();
-
     mock_downstream_connection_.stream_info_.filter_state_ =
         std::make_shared<StreamInfo::FilterStateImpl>(
             StreamInfo::FilterState::LifeSpan::Connection);
-
-    envoy::extensions::filters::network::generic_proxy::router::v3::Router router_config;
-    router_config.set_bind_upstream_connection(parameter.bind_upstream);
-    config_ = std::make_shared<Router::RouterConfig>(router_config);
-    with_tracing_ = parameter.with_tracing;
   }
 
-  void setup(FrameFlags frame_flags = FrameFlags{}) {
-    filter_ = std::make_shared<Router::RouterFilter>(config_, factory_context_);
+  void setup(FrameFlags frame_flags = FrameFlags{}, bool bound_upstream_connection = false) {
+    envoy::extensions::filters::network::generic_proxy::router::v3::Router router_config;
+    router_config.set_bind_upstream_connection(bound_upstream_connection);
+    config_ = std::make_shared<Router::RouterConfig>(router_config);
+
+    filter_ =
+        std::make_shared<Router::RouterFilter>(config_, factory_context_, &mock_upstream_factory_);
     filter_->setDecoderFilterCallbacks(mock_filter_callback_);
 
     request_ = std::make_unique<FakeStreamCodecFactory::FakeRequest>();
@@ -85,202 +108,86 @@ public:
         ->getDataMutable<BoundGenericUpstream>("envoy.filters.generic.router");
   }
 
-  void expectCreateConnection() {
-    creating_connection_++;
-    // New connection and response decoder will be created for this upstream request.
-    auto client_codec = std::make_unique<NiceMock<MockClientCodec>>();
-    mock_client_codec_ = client_codec.get();
-    EXPECT_CALL(mock_codec_factory_, createClientCodec())
-        .WillOnce(Return(ByMove(std::move(client_codec))));
-    EXPECT_CALL(*mock_client_codec_, setCodecCallbacks(_))
-        .WillOnce(Invoke([this](ClientCodecCallbacks& cb) { client_cb_ = &cb; }));
+  // void expectCreateConnection() {
+  //   creating_connection_++;
+  //   // New connection and response decoder will be created for this upstream request.
+  //   auto client_codec = std::make_unique<NiceMock<MockClientCodec>>();
+  //   mock_client_codec_ = client_codec.get();
+  //   EXPECT_CALL(mock_codec_factory_, createClientCodec())
+  //       .WillOnce(Return(ByMove(std::move(client_codec))));
+  //   EXPECT_CALL(*mock_client_codec_, setCodecCallbacks(_))
+  //       .WillOnce(Invoke([this](ClientCodecCallbacks& cb) { client_cb_ = &cb; }));
 
-    EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
-                    .tcp_conn_pool_,
-                newConnection(_));
-  }
+  //   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
+  //                   .tcp_conn_pool_,
+  //               newConnection(_));
+  // }
 
-  void expectCancelConnect() {
-    if (creating_connection_ > 0) {
-      creating_connection_--;
+  // void expectCancelConnect() {
+  //   if (creating_connection_ > 0) {
+  //     creating_connection_--;
 
-      // Only cancel the connection if it is owned by the upstream request. If the connection is
-      // bound to the downstream connection, then this won't be called.
-      if (!config_->bindUpstreamConnection()) {
-        EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
-                        .tcp_conn_pool_.handles_.back(),
-                    cancel(_));
-      }
-    }
-  }
+  //     // Only cancel the connection if it is owned by the upstream request. If the connection is
+  //     // bound to the downstream connection, then this won't be called.
+  //     if (!config_->bindUpstreamConnection()) {
+  //       EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
+  //                       .tcp_conn_pool_.handles_.back(),
+  //                   cancel(_));
+  //     }
+  //   }
+  // }
 
-  void expectUpstreamConnectionClose() {
-    EXPECT_CALL(mock_upstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
-  }
+  // void expectUpstreamConnectionClose() {
+  //   EXPECT_CALL(mock_upstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
+  // }
 
-  void notifyPoolFailure(Tcp::ConnectionPool::PoolFailureReason reason) {
-    if (creating_connection_ > 0) {
-      creating_connection_--;
-
-      if (config_->bindUpstreamConnection()) {
-        EXPECT_TRUE(!boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
-        EXPECT_TRUE(boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
-        EXPECT_CALL(mock_downstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
-      }
-
-      factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.tcp_conn_pool_
-          .poolFailure(reason);
-
-      if (config_->bindUpstreamConnection()) {
-        EXPECT_TRUE(boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
-        EXPECT_TRUE(boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
-      }
-    }
-  }
-
-  void notifyPoolReady(bool encoding_success = true) {
-    if (creating_connection_ > 0) {
-      creating_connection_--;
-
-      if (config_->bindUpstreamConnection()) {
-        EXPECT_TRUE(!boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
-        EXPECT_TRUE(boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
-      }
-
-      if (!encoding_success) {
-        EXPECT_CALL(mock_upstream_connection_, write(_, _)).Times(0);
-      } else {
-        EXPECT_CALL(mock_upstream_connection_, write(_, _)).Times(testing::AtLeast(1));
-      }
-
-      factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.tcp_conn_pool_
-          .poolReady(mock_upstream_connection_);
-
-      if (config_->bindUpstreamConnection()) {
-        EXPECT_TRUE(boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
-      }
-    }
-  }
-
-  void notifyConnectionClose(Network::ConnectionEvent event) {
+  void notifyUpstreamFailure(Tcp::ConnectionPool::PoolFailureReason reason) {
     ASSERT(!filter_->upstreamRequestsForTest().empty());
-    auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-    if (config_->bindUpstreamConnection()) {
-      EXPECT_TRUE(boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
-      EXPECT_TRUE(!boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
-      EXPECT_CALL(mock_downstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
-    }
-
-    upstream_request->generic_upstream_->onEvent(event);
-
-    if (config_->bindUpstreamConnection()) {
-      EXPECT_TRUE(boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
-      EXPECT_TRUE(boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
-    }
+    mock_generic_upstream_->requests_.begin()->second->onUpstreamFailure(reason, "");
   }
+
+  void notifyUpstreamSuccess() {
+    ASSERT(!filter_->upstreamRequestsForTest().empty());
+    mock_generic_upstream_->requests_.begin()->second->onUpstreamSuccess();
+  }
+
+  // void notifyConnectionClose(Network::ConnectionEvent event) {
+  //   ASSERT(!filter_->upstreamRequestsForTest().empty());
+  //   auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
+
+  //   if (config_->bindUpstreamConnection()) {
+  //     EXPECT_TRUE(boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
+  //     EXPECT_TRUE(!boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
+  //     EXPECT_CALL(mock_downstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
+  //   }
+
+  //   upstream_request->generic_upstream_->onEvent(event);
+
+  //   if (config_->bindUpstreamConnection()) {
+  //     EXPECT_TRUE(boundUpstreamConnection()->waitingUpstreamRequestsForTest().empty());
+  //     EXPECT_TRUE(boundUpstreamConnection()->waitingResponseRequestsForTest().empty());
+  //   }
+  // }
 
   void notifyDecodingSuccess(ResponseHeaderFramePtr&& response,
                              absl::optional<StartTime> start_time = {}) {
     ASSERT(!filter_->upstreamRequestsForTest().empty());
-
-    auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-    auto stream_frame = std::make_shared<ResponseHeaderFramePtr>(std::move(response));
-
-    EXPECT_CALL(*mock_client_codec_, decode(BufferStringEqual("test_1"), _))
-        .WillOnce(Invoke(
-            [this, resp = std::move(stream_frame), start_time](Buffer::Instance& buffer, bool) {
-              buffer.drain(buffer.length());
-
-              const bool end_stream = (*resp)->frameFlags().endStream();
-              int pending_request_size = 0;
-              if (config_->bindUpstreamConnection()) {
-                pending_request_size =
-                    boundUpstreamConnection()->waitingResponseRequestsForTest().size();
-              }
-
-              client_cb_->onDecodingSuccess(std::move(*resp), start_time);
-
-              if (config_->bindUpstreamConnection()) {
-                EXPECT_EQ(pending_request_size - (end_stream ? 1 : 0),
-                          boundUpstreamConnection()->waitingResponseRequestsForTest().size());
-              }
-            }));
-
-    Buffer::OwnedImpl test_buffer;
-    test_buffer.add("test_1");
-
-    upstream_request->generic_upstream_->onUpstreamData(test_buffer, false);
+    mock_generic_upstream_->requests_.begin()->second->onDecodingSuccess(std::move(response),
+                                                                         start_time);
   }
+
   void notifyDecodingSuccess(ResponseCommonFramePtr&& response) {
     ASSERT(!filter_->upstreamRequestsForTest().empty());
-
-    auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-    auto stream_frame = std::make_shared<ResponseCommonFramePtr>(std::move(response));
-
-    EXPECT_CALL(*mock_client_codec_, decode(BufferStringEqual("test_1"), _))
-        .WillOnce(Invoke([this, resp = std::move(stream_frame)](Buffer::Instance& buffer, bool) {
-          buffer.drain(buffer.length());
-
-          const bool end_stream = (*resp)->frameFlags().endStream();
-          int pending_request_size = 0;
-          if (config_->bindUpstreamConnection()) {
-            pending_request_size =
-                boundUpstreamConnection()->waitingResponseRequestsForTest().size();
-          }
-
-          client_cb_->onDecodingSuccess(std::move(*resp));
-
-          if (config_->bindUpstreamConnection()) {
-            EXPECT_EQ(pending_request_size - (end_stream ? 1 : 0),
-                      boundUpstreamConnection()->waitingResponseRequestsForTest().size());
-          }
-        }));
-
-    Buffer::OwnedImpl test_buffer;
-    test_buffer.add("test_1");
-
-    upstream_request->generic_upstream_->onUpstreamData(test_buffer, false);
+    mock_generic_upstream_->requests_.begin()->second->onDecodingSuccess(std::move(response));
   }
 
   void notifyDecodingFailure(absl::string_view reason) {
     ASSERT(!filter_->upstreamRequestsForTest().empty());
-
-    auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-    if (config_->bindUpstreamConnection()) {
-      // If upstream connection binding is enabled, the downstream connection will be closed
-      // when the upstream connection is closed and will clean up all active streams and
-      // L7 filter chains.
-      EXPECT_CALL(mock_downstream_connection_, close(Network::ConnectionCloseType::FlushWrite))
-          .WillOnce(Invoke([this](Network::ConnectionCloseType) { filter_->onDestroy(); }));
-    }
-
-    EXPECT_CALL(mock_upstream_connection_, close(Network::ConnectionCloseType::FlushWrite))
-        .WillOnce(Invoke([upstream_request](Network::ConnectionCloseType) {
-          // Mock clean up closing.
-          upstream_request->generic_upstream_->onEvent(Network::ConnectionEvent::LocalClose);
-        }));
-
-    EXPECT_CALL(*mock_client_codec_, decode(BufferStringEqual("test_1"), _))
-        .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) {
-          buffer.drain(buffer.length());
-          client_cb_->onDecodingFailure(reason);
-        }));
-
-    Buffer::OwnedImpl test_buffer;
-    test_buffer.add("test_1");
-
-    upstream_request->generic_upstream_->onUpstreamData(test_buffer, false);
+    mock_generic_upstream_->requests_.begin()->second->onDecodingFailure(reason);
   }
 
-  void expectNewUpstreamRequest() {
-    if (boundUpstreamConnection() == nullptr) {
-      // Upstream binding is disabled or not set up yet, try to create a new connection.
-      expectCreateConnection();
-    }
-
-    if (with_tracing_) {
+  void expectNewUpstreamRequest(bool with_tracing = false) {
+    if (with_tracing) {
       EXPECT_CALL(mock_filter_callback_, tracingConfig())
           .WillOnce(Return(OptRef<const Tracing::Config>{tracing_config_}));
       EXPECT_CALL(tracing_config_, spawnUpstreamSpan()).WillOnce(Return(true));
@@ -293,13 +200,35 @@ public:
       EXPECT_CALL(mock_filter_callback_, tracingConfig())
           .WillOnce(Return(OptRef<const Tracing::Config>{}));
     }
+
+    EXPECT_CALL(mock_upstream_factory_, createGenericUpstream(_, _, _, _, _))
+        .WillOnce(Return(mock_generic_upstream_));
+    EXPECT_CALL(*mock_generic_upstream_, appendUpstreamRequest(_, _));
+  }
+
+  void expectInjectContextToUpstreamRequest() { EXPECT_CALL(*child_span_, injectContext(_, _)); }
+  void expectFinalizeUpstreamSpanAny() {
+    EXPECT_CALL(*child_span_, setTag(_, _)).Times(testing::AnyNumber());
+    EXPECT_CALL(*child_span_, finishSpan());
+  }
+  void expectFinalizeUpstreamSpanWithError() {
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamAddress, _));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().PeerAddress, _));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Error, "true"));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, _));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
+    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
+    EXPECT_CALL(*child_span_,
+                setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
+    EXPECT_CALL(*child_span_, finishSpan());
   }
 
   /**
    * Kick off a new upstream request.
    */
-  void kickOffNewUpstreamRequest() {
-    expectNewUpstreamRequest();
+  void kickOffNewUpstreamRequest(bool with_tracing = false) {
+    expectNewUpstreamRequest(with_tracing);
     EXPECT_EQ(filter_->onStreamDecoded(*request_), FilterStatus::StopIteration);
     EXPECT_EQ(1, filter_->upstreamRequestsForTest().size());
   }
@@ -351,14 +280,14 @@ public:
   const std::string cluster_name_ = "cluster_0";
 
   NiceMock<MockDecoderFilterCallback> mock_filter_callback_;
+  NiceMock<MockCodecFactory> mock_codec_factory_;
   NiceMock<StreamInfo::MockStreamInfo> mock_stream_info_;
 
   NiceMock<Network::MockServerConnection> mock_downstream_connection_;
-  NiceMock<Network::MockClientConnection> mock_upstream_connection_;
 
-  NiceMock<MockCodecFactory> mock_codec_factory_;
-
-  NiceMock<MockClientCodec>* mock_client_codec_{};
+  NiceMock<MockGenericUpstreamFactory> mock_upstream_factory_;
+  std::shared_ptr<MockGenericUpstream> mock_generic_upstream_ =
+      std::make_shared<NiceMock<MockGenericUpstream>>();
 
   ClientCodecCallbacks* client_cb_{};
 
@@ -378,25 +307,7 @@ public:
   uint32_t creating_connection_{};
 };
 
-std::vector<TestParameters> getTestParameters() {
-  std::vector<TestParameters> ret;
-
-  ret.push_back({false, false});
-  ret.push_back({true, true});
-
-  return ret;
-}
-
-std::string testParameterToString(const testing::TestParamInfo<TestParameters>& params) {
-  return fmt::format("with_tracing_{}_bind_upstream_{}",
-                     params.param.with_tracing ? "true" : "false",
-                     params.param.bind_upstream ? "true" : "false");
-}
-
-INSTANTIATE_TEST_SUITE_P(GenericRoute, RouterFilterTest, testing::ValuesIn(getTestParameters()),
-                         testParameterToString);
-
-TEST_P(RouterFilterTest, OnStreamDecodedAndNoRouteEntry) {
+TEST_F(RouterFilterTest, OnStreamDecodedAndNoRouteEntry) {
   setup();
 
   EXPECT_CALL(mock_filter_callback_, routeEntry()).WillOnce(Return(nullptr));
@@ -412,7 +323,7 @@ TEST_P(RouterFilterTest, OnStreamDecodedAndNoRouteEntry) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, NoUpstreamCluster) {
+TEST_F(RouterFilterTest, NoUpstreamCluster) {
   setup();
 
   EXPECT_CALL(mock_filter_callback_, routeEntry()).WillOnce(Return(&mock_route_entry_));
@@ -433,7 +344,7 @@ TEST_P(RouterFilterTest, NoUpstreamCluster) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamClusterMaintainMode) {
+TEST_F(RouterFilterTest, UpstreamClusterMaintainMode) {
   setup();
 
   EXPECT_CALL(mock_filter_callback_, routeEntry()).WillOnce(Return(&mock_route_entry_));
@@ -462,7 +373,7 @@ TEST_P(RouterFilterTest, UpstreamClusterMaintainMode) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamClusterNoHealthyUpstream) {
+TEST_F(RouterFilterTest, UpstreamClusterNoHealthyUpstream) {
   setup();
 
   EXPECT_CALL(mock_filter_callback_, routeEntry()).WillOnce(Return(&mock_route_entry_));
@@ -474,10 +385,9 @@ TEST_P(RouterFilterTest, UpstreamClusterNoHealthyUpstream) {
   factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
       {cluster_name});
 
-  // No conn pool.
-  EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
-              tcpConnPool(_, _))
-      .WillOnce(Return(absl::nullopt));
+  // No valid upstream.
+  EXPECT_CALL(mock_upstream_factory_, createGenericUpstream(_, _, _, _, _))
+      .WillOnce(Return(nullptr));
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
@@ -492,9 +402,12 @@ TEST_P(RouterFilterTest, UpstreamClusterNoHealthyUpstream) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, KickOffNormalUpstreamRequest) {
+TEST_F(RouterFilterTest, KickOffNormalUpstreamRequest) {
   setup();
   kickOffNewUpstreamRequest();
+
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
   cleanUp();
 
@@ -502,7 +415,7 @@ TEST_P(RouterFilterTest, KickOffNormalUpstreamRequest) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, KickOffNormalUpstreamRequestAndTimeout) {
+TEST_F(RouterFilterTest, KickOffNormalUpstreamRequestAndTimeout) {
   setup();
 
   mock_route_entry_.timeout_ = std::chrono::milliseconds(1000);
@@ -516,6 +429,9 @@ TEST_P(RouterFilterTest, KickOffNormalUpstreamRequestAndTimeout) {
         EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
         EXPECT_EQ(status.message(), "timeout");
       }));
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
   response_timeout_->invokeCallback();
 
   cleanUp();
@@ -524,31 +440,18 @@ TEST_P(RouterFilterTest, KickOffNormalUpstreamRequestAndTimeout) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestResetBeforePoolCallback) {
+TEST_F(RouterFilterTest, UpstreamRequestResetBeforePoolCallback) {
   setup();
-  kickOffNewUpstreamRequest();
-
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().PeerAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Error, "true"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "local_reset"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
-    EXPECT_CALL(*child_span_,
-                setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
-
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
-
-  expectCancelConnect();
+  kickOffNewUpstreamRequest(true);
+  expectFinalizeUpstreamSpanWithError();
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([this](Status status, absl::string_view, ResponseUpdateFunction) {
         EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
         EXPECT_EQ(status.message(), "local_reset");
       }));
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
   filter_->upstreamRequestsForTest().begin()->get()->resetStream(StreamResetReason::LocalReset, {});
   EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
@@ -557,127 +460,124 @@ TEST_P(RouterFilterTest, UpstreamRequestResetBeforePoolCallback) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolFailureConnctionOverflow) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionOverflow) {
   setup();
-  kickOffNewUpstreamRequest();
-
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().PeerAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Error, "true"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "overflow"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
-    EXPECT_CALL(*child_span_,
-                setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  kickOffNewUpstreamRequest(true);
+  expectFinalizeUpstreamSpanWithError();
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
         EXPECT_EQ(status.message(), "overflow");
       }));
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
-  notifyPoolFailure(ConnectionPool::PoolFailureReason::Overflow);
+  notifyUpstreamFailure(ConnectionPool::PoolFailureReason::Overflow);
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeout) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeout) {
   setup();
-  kickOffNewUpstreamRequest();
-
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().PeerAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Error, "true"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "connection_failure"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
-    EXPECT_CALL(*child_span_,
-                setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  kickOffNewUpstreamRequest(true);
+  expectFinalizeUpstreamSpanWithError();
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
         EXPECT_EQ(status.message(), "connection_failure");
       }));
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
-  notifyPoolFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  notifyUpstreamFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+
   EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeoutAndWithRetry) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeoutAndWithRetryNoBound) {
   setup();
   RetryPolicy retry_policy{2};
   EXPECT_CALL(mock_route_entry_, retryPolicy()).WillRepeatedly(ReturnRef(retry_policy));
 
-  kickOffNewUpstreamRequest();
+  kickOffNewUpstreamRequest(true);
+  expectFinalizeUpstreamSpanWithError();
 
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().PeerAddress, _));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Error, "true"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ErrorReason, "connection_failure"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().Component, "proxy"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().ResponseFlags, "-"));
-    EXPECT_CALL(*child_span_, setTag(Tracing::Tags::get().UpstreamCluster, "fake_cluster"));
-    EXPECT_CALL(*child_span_,
-                setTag(Tracing::Tags::get().UpstreamClusterName, "observability_name"));
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  // Retry, expect new upstream request to be kicked off.
+  expectNewUpstreamRequest();
 
-  const bool bound_upstream_connection = GetParam().bind_upstream;
-  if (bound_upstream_connection) {
-    // No try if upstream connection is bound to downstream connection.
-    EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
-        .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
-          EXPECT_EQ(status.message(), "connection_failure");
-        }));
-  } else {
-    // Retry, expect new upstream request to be kicked off.
-    expectNewUpstreamRequest();
-  }
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
-  notifyPoolFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+  notifyUpstreamFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
 
-  if (bound_upstream_connection) {
-    // No retry.
-    EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
-  } else {
-    // Retry.
-    EXPECT_EQ(1, filter_->upstreamRequestsForTest().size());
+  // Retry.
+  EXPECT_EQ(1, filter_->upstreamRequestsForTest().size());
 
-    EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
-        .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
-          EXPECT_EQ(status.message(), "connection_failure");
-        }));
+  EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
+      .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
+        EXPECT_EQ(status.message(), "connection_failure");
+      }));
 
-    notifyPoolFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
-    EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
-  }
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
+  notifyUpstreamFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+
+  EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
 
   cleanUp();
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndExpectNoResponse) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeoutAndWithRetryWithBound) {
+  setup({}, true);
+  RetryPolicy retry_policy{2};
+  EXPECT_CALL(mock_route_entry_, retryPolicy()).WillRepeatedly(ReturnRef(retry_policy));
+
+  kickOffNewUpstreamRequest(true);
+  expectFinalizeUpstreamSpanWithError();
+
+  // No try if upstream connection is bound to downstream connection.
+  EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
+      .WillOnce(Invoke([](Status status, absl::string_view, ResponseUpdateFunction) {
+        EXPECT_EQ(status.message(), "connection_failure");
+      }));
+
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
+  notifyUpstreamFailure(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+
+  // No retry.
+  EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
+
+  cleanUp();
+  // Mock downstream closing.
+  mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndExpectNoResponse) {
   setup(FrameFlags(StreamFlags(0, true, false, false), true));
-  kickOffNewUpstreamRequest();
+  kickOffNewUpstreamRequest(true);
 
   EXPECT_CALL(mock_filter_callback_, completeDirectly()).WillOnce(Invoke([this]() -> void {
     EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
   }));
 
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(*mock_generic_upstream_, upstreamConnection());
+  EXPECT_CALL(mock_generic_upstream_->mock_upstream_connection_, write(_, _))
+      .WillOnce(Invoke(
+          [](Buffer::Instance& buffer, bool) -> void { EXPECT_EQ(buffer.toString(), "hello"); }));
+
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(false));
+
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -685,27 +585,22 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndExpectNoResponse) {
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  if (with_tracing_) {
-    // Request complete directly.
-    EXPECT_CALL(*child_span_, injectContext(_, _));
-    EXPECT_CALL(*child_span_, setTag(_, _)).Times(testing::AnyNumber());
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  expectInjectContextToUpstreamRequest();
+  expectFinalizeUpstreamSpanAny();
 
-  notifyPoolReady();
+  notifyUpstreamSuccess();
+
   EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButConnectionErrorBeforeResponse) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyButConnectionErrorBeforeResponse) {
   setup();
   kickOffNewUpstreamRequest();
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -713,9 +608,7 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButConnectionErrorBeforeRespons
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  notifyPoolReady();
-
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
+  notifyUpstreamSuccess();
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([this](Status status, absl::string_view, ResponseUpdateFunction) {
@@ -723,20 +616,22 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButConnectionErrorBeforeRespons
         EXPECT_EQ(status.message(), "local_reset");
       }));
 
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
   // Mock connection close event.
-  notifyConnectionClose(Network::ConnectionEvent::LocalClose);
+  mock_generic_upstream_->requests_.begin()->second->onConnectionClose(
+      Network::ConnectionEvent::LocalClose);
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButConnectionTerminationBeforeResponse) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyButConnectionTerminationBeforeResponse) {
   setup();
   kickOffNewUpstreamRequest();
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -744,9 +639,7 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButConnectionTerminationBeforeR
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  notifyPoolReady();
-
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
+  notifyUpstreamSuccess();
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([this](Status status, absl::string_view, ResponseUpdateFunction) {
@@ -754,20 +647,22 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButConnectionTerminationBeforeR
         EXPECT_EQ(status.message(), "connection_termination");
       }));
 
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
   // Mock connection close event.
-  notifyConnectionClose(Network::ConnectionEvent::RemoteClose);
+  mock_generic_upstream_->requests_.begin()->second->onConnectionClose(
+      Network::ConnectionEvent::RemoteClose);
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButStreamDestroyBeforeResponse) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyButStreamDestroyBeforeResponse) {
   setup();
   kickOffNewUpstreamRequest();
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -775,11 +670,10 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButStreamDestroyBeforeResponse)
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  notifyPoolReady();
+  notifyUpstreamSuccess();
 
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
-
-  expectUpstreamConnectionClose();
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
   filter_->onDestroy();
   // Do nothing for the second call.
@@ -789,33 +683,31 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyButStreamDestroyBeforeResponse)
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponse) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponse) {
   setup();
-  kickOffNewUpstreamRequest();
+  kickOffNewUpstreamRequest(true);
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
+  EXPECT_CALL(*mock_generic_upstream_, upstreamConnection());
+  EXPECT_CALL(mock_generic_upstream_->mock_upstream_connection_, write(_, _))
+      .WillOnce(Invoke([](Buffer::Instance& buffer, bool) -> void {
+        EXPECT_EQ(buffer.toString(), "helloxxxxxx");
+      }));
 
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
-        buffer.add("hello");
+        buffer.add("helloxxxxxx");
         // Expect response.
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  if (with_tracing_) {
-    // Inject tracing context.
-    EXPECT_CALL(*child_span_, injectContext(_, _));
-  }
+  expectInjectContextToUpstreamRequest();
 
-  notifyPoolReady();
+  notifyUpstreamSuccess();
 
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
-
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(_, _)).Times(testing::AnyNumber());
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  expectFinalizeUpstreamSpanAny();
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(false));
 
   EXPECT_CALL(mock_filter_callback_, onResponseStart(_)).WillOnce(Invoke([this](ResponsePtr) {
     // When the response is sent to callback, the upstream request should be removed.
@@ -823,19 +715,17 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponse) {
   }));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  notifyDecodingSuccess(std::move(response));
+  notifyDecodingSuccess(std::move(response), {});
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithStartTime) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithStartTime) {
   setup();
-  kickOffNewUpstreamRequest();
+  kickOffNewUpstreamRequest(true);
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -843,19 +733,13 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithStartTime) {
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  if (with_tracing_) {
-    // Inject tracing context.
-    EXPECT_CALL(*child_span_, injectContext(_, _));
-  }
+  expectInjectContextToUpstreamRequest();
 
-  notifyPoolReady();
+  notifyUpstreamSuccess();
 
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
-
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(_, _)).Times(testing::AnyNumber());
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  expectFinalizeUpstreamSpanAny();
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(false));
 
   EXPECT_CALL(mock_filter_callback_, onResponseStart(_)).WillOnce(Invoke([this](ResponsePtr) {
     // When the response is sent to callback, the upstream request should be removed.
@@ -879,37 +763,28 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithStartTime) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseAndTimeout) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseAndTimeout) {
   setup();
 
   mock_route_entry_.timeout_ = std::chrono::milliseconds(1000);
   expectResponseTimerCreate();
 
-  kickOffNewUpstreamRequest();
+  kickOffNewUpstreamRequest(true);
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
         // Expect response.
         callback.onEncodingSuccess(buffer, true);
       }));
+  expectInjectContextToUpstreamRequest();
 
-  if (with_tracing_) {
-    // Inject tracing context.
-    EXPECT_CALL(*child_span_, injectContext(_, _));
-  }
+  notifyUpstreamSuccess();
 
-  notifyPoolReady();
-
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
-
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(_, _)).Times(testing::AnyNumber());
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  expectFinalizeUpstreamSpanAny();
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(false));
 
   EXPECT_CALL(mock_filter_callback_, onResponseStart(_)).WillOnce(Invoke([this](ResponsePtr) {
     // When the response is sent to callback, the upstream request should be removed.
@@ -923,66 +798,10 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseAndTimeout) {
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseAndMultipleRequest) {
-  for (size_t i = 0; i < 5; i++) {
-    setup(FrameFlags(StreamFlags(i)));
-
-    // Expect immediate encoding.
-    if (GetParam().bind_upstream && i > 0) {
-      EXPECT_CALL(*mock_client_codec_, encode(_, _))
-          .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
-            Buffer::OwnedImpl buffer;
-            buffer.add("hello");
-            // Expect response.
-            callback.onEncodingSuccess(buffer, true);
-          }));
-    }
-
-    kickOffNewUpstreamRequest();
-
-    // Expect encoding after pool ready.
-    if (!GetParam().bind_upstream || i == 0) {
-      EXPECT_CALL(*mock_client_codec_, encode(_, _))
-          .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
-            Buffer::OwnedImpl buffer;
-            buffer.add("hello");
-            // Expect response.
-            callback.onEncodingSuccess(buffer, true);
-          }));
-    }
-
-    auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-    notifyPoolReady();
-
-    EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
-
-    EXPECT_CALL(mock_filter_callback_, onResponseStart(_)).WillOnce(Invoke([this](ResponsePtr) {
-      // When the response is sent to callback, the upstream request should be removed.
-      EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
-    }));
-
-    auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-    response->stream_frame_flags_ = FrameFlags(StreamFlags(i));
-    notifyDecodingSuccess(std::move(response));
-
-    cleanUp();
-  }
-  // Mock downstream closing.
-  mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
-}
-
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) {
   // There are multiple frames in the request.
   setup(FrameFlags(StreamFlags(0, false, false, true), /*end_stream*/ false));
-  kickOffNewUpstreamRequest();
-
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  if (with_tracing_) {
-    // Inject tracing context.
-    EXPECT_CALL(*child_span_, injectContext(_, _));
-  }
+  kickOffNewUpstreamRequest(true);
 
   auto frame_1 = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
   frame_1->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, false, true), false);
@@ -990,7 +809,7 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) 
   // This only store the frame and does nothing else because the pool is not ready yet.
   filter_->onRequestCommonFrame(std::move(frame_1));
 
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .Times(2)
       .WillRepeatedly(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
@@ -998,12 +817,12 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) 
         // Expect response.
         callback.onEncodingSuccess(buffer, false);
       }));
+  expectInjectContextToUpstreamRequest();
 
   // This will trigger two frames to be sent.
-  notifyPoolReady();
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
+  notifyUpstreamSuccess();
 
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -1017,10 +836,9 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) 
   // frames are already sent.
   filter_->onRequestCommonFrame(std::move(frame_2));
 
-  if (with_tracing_) {
-    EXPECT_CALL(*child_span_, setTag(_, _)).Times(testing::AnyNumber());
-    EXPECT_CALL(*child_span_, finishSpan());
-  }
+  expectFinalizeUpstreamSpanAny();
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(false));
 
   EXPECT_CALL(mock_filter_callback_, onResponseStart(_));
   EXPECT_CALL(mock_filter_callback_, onResponseFrame(_))
@@ -1036,6 +854,7 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) 
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
   response->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, false, false), false);
+
   notifyDecodingSuccess(std::move(response));
 
   auto response_frame_1 = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
@@ -1050,13 +869,11 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) 
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithDrainCloseSetInResponse) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithDrainCloseSetInResponse) {
   setup();
   kickOffNewUpstreamRequest();
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -1064,21 +881,15 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithDrainCloseSetInR
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  if (with_tracing_) {
-    // Inject tracing context.
-    EXPECT_CALL(*child_span_, injectContext(_, _));
-  }
+  notifyUpstreamSuccess();
 
-  notifyPoolReady();
-
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
 
   EXPECT_CALL(mock_filter_callback_, onResponseStart(_)).WillOnce(Invoke([this](ResponsePtr) {
     // When the response is sent to callback, the upstream request should be removed.
     EXPECT_EQ(0, filter_->upstreamRequestsForTest().size());
   }));
-
-  EXPECT_CALL(mock_upstream_connection_, close(Network::ConnectionCloseType::FlushWrite));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
   response->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, true, false), true);
@@ -1088,13 +899,11 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithDrainCloseSetInR
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseDecodingFailure) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseDecodingFailure) {
   setup();
   kickOffNewUpstreamRequest();
 
-  auto upstream_request = filter_->upstreamRequestsForTest().begin()->get();
-
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         Buffer::OwnedImpl buffer;
         buffer.add("hello");
@@ -1102,9 +911,7 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseDecodingFailure) {
         callback.onEncodingSuccess(buffer, true);
       }));
 
-  notifyPoolReady();
-
-  EXPECT_NE(nullptr, upstream_request->generic_upstream_->connection().ptr());
+  notifyUpstreamSuccess();
 
   EXPECT_CALL(mock_filter_callback_, sendLocalReply(_, _, _))
       .WillOnce(Invoke([this](Status status, absl::string_view data, ResponseUpdateFunction) {
@@ -1113,17 +920,20 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndResponseDecodingFailure) {
         EXPECT_EQ(data, "decoding-failure");
       }));
 
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
   notifyDecodingFailure("decoding-failure");
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndRequestEncodingFailure) {
+TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndRequestEncodingFailure) {
   setup();
   kickOffNewUpstreamRequest();
 
-  EXPECT_CALL(*mock_client_codec_, encode(_, _))
+  EXPECT_CALL(mock_generic_upstream_->mock_client_codec_, encode(_, _))
       .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) -> void {
         callback.onEncodingFailure("encoding-failure");
       }));
@@ -1135,26 +945,29 @@ TEST_P(RouterFilterTest, UpstreamRequestPoolReadyAndRequestEncodingFailure) {
         EXPECT_EQ(data, "encoding-failure");
       }));
 
-  notifyPoolReady(false);
+  EXPECT_CALL(*mock_generic_upstream_, removeUpstreamRequest(_));
+  EXPECT_CALL(*mock_generic_upstream_, cleanUp(true));
+
+  notifyUpstreamSuccess();
 
   // Mock downstream closing.
   mock_downstream_connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-TEST_P(RouterFilterTest, LoadBalancerContextDownstreamConnection) {
+TEST_F(RouterFilterTest, LoadBalancerContextDownstreamConnection) {
   setup();
   EXPECT_CALL(mock_filter_callback_, connection());
   filter_->downstreamConnection();
 }
 
-TEST_P(RouterFilterTest, LoadBalancerContextNoMetadataMatchCriteria) {
+TEST_F(RouterFilterTest, LoadBalancerContextNoMetadataMatchCriteria) {
   setup();
 
   // No metadata match criteria by default.
   EXPECT_EQ(nullptr, filter_->metadataMatchCriteria());
 }
 
-TEST_P(RouterFilterTest, LoadBalancerContextMetadataMatchCriteria) {
+TEST_F(RouterFilterTest, LoadBalancerContextMetadataMatchCriteria) {
   setup();
   verifyMetadataMatchCriteria();
 }

--- a/contrib/generic_proxy/filters/network/test/router/upstream_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/upstream_test.cc
@@ -1,0 +1,848 @@
+#include <memory>
+
+#include "source/common/tracing/common_values.h"
+
+#include "test/mocks/server/factory_context.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/utility.h"
+
+#include "contrib/generic_proxy/filters/network/source/router/router.h"
+#include "contrib/generic_proxy/filters/network/test/fake_codec.h"
+#include "contrib/generic_proxy/filters/network/test/mocks/codec.h"
+#include "contrib/generic_proxy/filters/network/test/mocks/filter.h"
+#include "contrib/generic_proxy/filters/network/test/mocks/route.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+using testing::Return;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+namespace Router {
+namespace {
+
+class MockUpstreamRequestCallbacks : public UpstreamRequestCallbacks {
+public:
+  MockUpstreamRequestCallbacks() {
+    ON_CALL(*this, onUpstreamFailure(_, _)).WillByDefault(testing::Invoke([&](auto, auto) {
+      if (upstream_ != nullptr) {
+        upstream_->removeUpstreamRequest(1);
+        upstream_->cleanUp(true);
+      }
+    }));
+    ON_CALL(*this, onConnectionClose(_)).WillByDefault(testing::Invoke([&](auto) {
+      if (upstream_ != nullptr) {
+        upstream_->removeUpstreamRequest(1);
+        upstream_->cleanUp(true);
+      }
+    }));
+    ON_CALL(*this, onDecodingSuccess(_, _))
+        .WillByDefault(testing::Invoke([&](ResponseHeaderFramePtr frame, auto) {
+          if (upstream_ != nullptr) {
+            if (frame->frameFlags().endStream()) {
+              upstream_->removeUpstreamRequest(frame->frameFlags().streamFlags().streamId());
+              upstream_->cleanUp(false);
+            }
+          }
+        }));
+    ON_CALL(*this, onDecodingSuccess(_))
+        .WillByDefault(testing::Invoke([&](ResponseCommonFramePtr frame) {
+          if (upstream_ != nullptr) {
+            if (frame->frameFlags().endStream()) {
+              upstream_->removeUpstreamRequest(frame->frameFlags().streamFlags().streamId());
+              upstream_->cleanUp(false);
+            }
+          }
+        }));
+    ON_CALL(*this, onDecodingFailure(_)).WillByDefault(testing::Invoke([&](auto) {
+      if (upstream_ != nullptr) {
+        upstream_->removeUpstreamRequest(1);
+        upstream_->cleanUp(true);
+      }
+    }));
+  }
+
+  MOCK_METHOD(void, onUpstreamFailure,
+              (ConnectionPool::PoolFailureReason reason,
+               absl::string_view transport_failure_reason));
+  MOCK_METHOD(void, onUpstreamSuccess, ());
+
+  MOCK_METHOD(void, onConnectionClose, (Network::ConnectionEvent event));
+  MOCK_METHOD(void, onDecodingSuccess,
+              (ResponseHeaderFramePtr response_header_frame, absl::optional<StartTime> start_time));
+  MOCK_METHOD(void, onDecodingSuccess, (ResponseCommonFramePtr response_common_frame));
+  MOCK_METHOD(void, onDecodingFailure, (absl::string_view reason));
+
+  GenericUpstream* upstream_{};
+};
+
+class UpstreamTest : public testing::Test {
+public:
+  UpstreamTest() {
+    mock_downstream_connection_1_.stream_info_.filter_state_ =
+        std::make_shared<StreamInfo::FilterStateImpl>(
+            StreamInfo::FilterState::LifeSpan::Connection);
+    mock_downstream_connection_2_.stream_info_.filter_state_ =
+        std::make_shared<StreamInfo::FilterStateImpl>(
+            StreamInfo::FilterState::LifeSpan::Connection);
+
+    // This should be called only once for one case.
+    ON_CALL(mock_codec_factory_, createClientCodec())
+        .WillByDefault(Return(ByMove(std::move(mock_client_codec_))));
+
+    ON_CALL(*mock_client_codec_raw_, setCodecCallbacks(_))
+        .WillByDefault(testing::Invoke(
+            [&](ClientCodecCallbacks& callbacks) { cocec_callbacks_ = &callbacks; }));
+  }
+
+  std::shared_ptr<BoundGenericUpstream> createBoundGenericUpstream(size_t connection_id = 1) {
+    if (connection_id == 1) {
+      auto result = DefaultGenericUpstreamFactory::get().createGenericUpstream(
+          thread_local_cluster_, nullptr, mock_downstream_connection_1_, mock_codec_factory_, true);
+      return std::dynamic_pointer_cast<BoundGenericUpstream>(result);
+    } else {
+      auto result = DefaultGenericUpstreamFactory::get().createGenericUpstream(
+          thread_local_cluster_, nullptr, mock_downstream_connection_2_, mock_codec_factory_, true);
+      return std::dynamic_pointer_cast<BoundGenericUpstream>(result);
+    }
+  }
+  std::shared_ptr<OwnedGenericUpstream> createOwnedGenericUpstream() {
+    auto result = DefaultGenericUpstreamFactory::get().createGenericUpstream(
+        thread_local_cluster_, nullptr, mock_downstream_connection_1_, mock_codec_factory_, false);
+    return std::dynamic_pointer_cast<OwnedGenericUpstream>(result);
+  }
+
+  NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster_;
+  NiceMock<MockCodecFactory> mock_codec_factory_;
+  std::unique_ptr<NiceMock<MockClientCodec>> mock_client_codec_{
+      std::make_unique<NiceMock<MockClientCodec>>()};
+  NiceMock<MockClientCodec>* mock_client_codec_raw_{mock_client_codec_.get()};
+  ClientCodecCallbacks* cocec_callbacks_{};
+
+  NiceMock<Network::MockClientConnection> mock_upstream_connection_;
+
+  NiceMock<Network::MockServerConnection> mock_downstream_connection_1_;
+  NiceMock<Network::MockServerConnection> mock_downstream_connection_2_;
+};
+
+TEST_F(UpstreamTest, BoundGenericUpstreamWillBeReusedForSameConnection) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream1 = createBoundGenericUpstream(1);
+  auto generic_upstream2 = createBoundGenericUpstream(1);
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream3 = createBoundGenericUpstream(2);
+
+  EXPECT_EQ(generic_upstream1, generic_upstream2);
+  EXPECT_NE(generic_upstream1, generic_upstream3);
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamWillNotBeReused) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto owned_upstream1 = createOwnedGenericUpstream();
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto owned_upstream2 = createOwnedGenericUpstream();
+
+  EXPECT_NE(owned_upstream1, owned_upstream2);
+}
+
+TEST_F(UpstreamTest, NoHealthyUpstream) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _)).WillOnce(Return(absl::nullopt));
+  auto generic_upstream = createBoundGenericUpstream();
+  EXPECT_EQ(nullptr, generic_upstream);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _)).WillOnce(Return(absl::nullopt));
+  auto owned_upstream = createOwnedGenericUpstream();
+  EXPECT_EQ(nullptr, owned_upstream);
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamInitializeAndPoolReady) {
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_3;
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(3, &mock_upstream_request_callbacks_3);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  // Mock pool ready.
+  // Ensure the following calls are in order.
+  testing::InSequence sequence;
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onUpstreamSuccess());
+  EXPECT_CALL(mock_upstream_request_callbacks_3, onUpstreamSuccess());
+  EXPECT_CALL(mock_upstream_request_callbacks_2, onUpstreamSuccess());
+
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  // Simple test for the following functions.
+  generic_upstream->onAboveWriteBufferHighWatermark();
+  generic_upstream->onBelowWriteBufferLowWatermark();
+  generic_upstream->upstreamHost();
+  generic_upstream->clientCodec();
+  generic_upstream->upstreamConnection();
+}
+
+class DownstreamEventHelper : public Network::ConnectionCallbacks {
+public:
+  void onEvent(Network::ConnectionEvent event) override {
+    if (event == Network::ConnectionEvent::LocalClose ||
+        event == Network::ConnectionEvent::RemoteClose) {
+      if (generic_upstream_ != nullptr) {
+        for (auto stream_id : stream_ids_) {
+          generic_upstream_->removeUpstreamRequest(stream_id);
+          generic_upstream_->cleanUp(true);
+        }
+      }
+    }
+  }
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+  void setUpstreamAndStreams(GenericUpstream* generic_upstream,
+                             const std::vector<uint64_t>& stream_ids) {
+    stream_ids_ = stream_ids;
+    generic_upstream_ = generic_upstream;
+  }
+
+private:
+  GenericUpstream* generic_upstream_{};
+  std::vector<uint64_t> stream_ids_;
+};
+
+TEST_F(UpstreamTest, BoundGenericUpstreamRepeatedRequestsThatAreWaitingUpstream) {
+  // This is used to mock the downstream connection close. All pending request will be
+  // reset.
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {1, 1});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  EXPECT_EQ(1, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.handles_.begin(), cancel(_));
+
+  // First, the downstream connection will be closed.
+  // Second, the downstream closing event will result in all pending requests reset.
+  // Third, the reset and the downstream closing event will result in the pending upstream
+  // connecting be cancelled.
+
+  EXPECT_CALL(mock_downstream_connection_1_, close(_));
+
+  // Same stream id with first request.
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamRepeatedRequestsThatAreWaitingResponse) {
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {1, 2, 2});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_3;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(2, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onUpstreamSuccess());
+  EXPECT_CALL(mock_upstream_request_callbacks_2, onUpstreamSuccess());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  // First, the downstream connection will be closed.
+  // Second, the downstream closing event will result in all pending requests reset.
+  // Third, the first request reset will result in the upstream connection be closed.
+  // Fourth, the upstream closing event will result in the downstream connection be closed again.
+  testing::InSequence sequence;
+  EXPECT_CALL(mock_downstream_connection_1_, close(_));
+  EXPECT_CALL(mock_upstream_connection_, close(_));
+  EXPECT_CALL(mock_upstream_request_callbacks_2, onConnectionClose(_));
+  EXPECT_CALL(mock_downstream_connection_1_, close(_));
+
+  // Same stream id with first request.
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_3);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamOnPoolFailure) {
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_3;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+  generic_upstream->appendUpstreamRequest(3, &mock_upstream_request_callbacks_3);
+
+  EXPECT_EQ(3, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  testing::InSequence sequence;
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onUpstreamFailure(_, _));
+  EXPECT_CALL(mock_upstream_request_callbacks_2, onUpstreamFailure(_, _));
+  EXPECT_CALL(mock_upstream_request_callbacks_3, onUpstreamFailure(_, _));
+
+  EXPECT_CALL(mock_downstream_connection_1_, close(_));
+
+  thread_local_cluster_.tcp_conn_pool_.poolFailure(ConnectionPool::PoolFailureReason::Timeout);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamDecodingSuccess) {
+
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(2, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+
+  auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2));
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_2, onDecodingSuccess(_, _));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_2), {});
+
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingSuccess(_, _));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_1), {});
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamDecodingSuccessWithMultipleFrames) {
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(2, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+
+  auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2), false);
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingSuccess(_, _));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_1), {});
+
+        EXPECT_CALL(mock_upstream_request_callbacks_2, onDecodingSuccess(_, _));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_2), {});
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
+  request_1_frame->stream_frame_flags_ = FrameFlags(StreamFlags(1), true);
+
+  auto request_2_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
+  request_2_frame->stream_frame_flags_ = FrameFlags(StreamFlags(2), true);
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_connection_, close(_)).Times(0);
+        EXPECT_CALL(mock_upstream_request_callbacks_2, onDecodingSuccess(_));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_2_frame));
+
+        EXPECT_CALL(mock_upstream_connection_, close(_)).Times(0);
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingSuccess(_));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_1_frame));
+      }));
+
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamDecodingFailureAndNoUpstreamConnectionClose) {
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(2, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+
+  auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2));
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingFailure(_))
+            .WillOnce(testing::Invoke([&](absl::string_view) {
+              // Overriden the default behavior to avoid closing the upstream connection.
+            }));
+        EXPECT_CALL(mock_upstream_request_callbacks_2, onDecodingFailure(_));
+
+        cocec_callbacks_->onDecodingFailure("test");
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamDecodingFailure) {
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(2, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+
+  auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2));
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingFailure(_));
+        EXPECT_CALL(mock_upstream_connection_, close(_));
+        EXPECT_CALL(mock_upstream_request_callbacks_2, onConnectionClose(_));
+        EXPECT_CALL(mock_downstream_connection_1_, close(_));
+
+        cocec_callbacks_->onDecodingFailure("test");
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, BoundGenericUpstreamUpstreamConnectionClose) {
+  DownstreamEventHelper downstream_event_helper;
+  mock_downstream_connection_1_.addConnectionCallbacks(downstream_event_helper);
+
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+  downstream_event_helper.setUpstreamAndStreams(generic_upstream.get(), {});
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_2;
+  // Only set one to ensure that even the the upstream request callbacks do not
+  // clean up the upstream, the upstream will do it itself.
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+  generic_upstream->appendUpstreamRequest(2, &mock_upstream_request_callbacks_2);
+
+  EXPECT_EQ(2, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onConnectionClose(_));
+  EXPECT_CALL(mock_upstream_request_callbacks_2, onConnectionClose(_));
+  EXPECT_CALL(mock_downstream_connection_1_, close(_));
+
+  mock_upstream_connection_.close(Network::ConnectionCloseType::NoFlush);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamInitializeAndPoolReady) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createOwnedGenericUpstream();
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+
+  // Mock pool ready.
+  // Ensure the following calls are in order.
+  testing::InSequence sequence;
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onUpstreamSuccess());
+
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  // Simple test for the following functions.
+  generic_upstream->onAboveWriteBufferHighWatermark();
+  generic_upstream->onBelowWriteBufferLowWatermark();
+  generic_upstream->upstreamHost();
+  generic_upstream->clientCodec();
+  generic_upstream->upstreamConnection();
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamOnPoolFailure) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createOwnedGenericUpstream();
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+
+  EXPECT_EQ(1, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  testing::InSequence sequence;
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onUpstreamFailure(_, _));
+
+  thread_local_cluster_.tcp_conn_pool_.poolFailure(ConnectionPool::PoolFailureReason::Timeout);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamDecodingSuccess) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createOwnedGenericUpstream();
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+
+  EXPECT_EQ(1, generic_upstream->waitingUpstreamRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingSuccess(_, _));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_1), {});
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamDecodingSuccessWithMultipleFrames) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+
+  EXPECT_EQ(1, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingSuccess(_, _));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_1), {});
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
+
+  auto request_1_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
+  request_1_frame->stream_frame_flags_ = FrameFlags(StreamFlags(1), true);
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_connection_, close(_)).Times(0);
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingSuccess(_));
+        cocec_callbacks_->onDecodingSuccess(std::move(request_1_frame));
+      }));
+
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamDecodingFailure) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+
+  EXPECT_EQ(1, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
+      .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
+        EXPECT_CALL(mock_upstream_request_callbacks_1, onDecodingFailure(_));
+        EXPECT_CALL(mock_upstream_connection_, close(_));
+
+        cocec_callbacks_->onDecodingFailure("test");
+      }));
+
+  Buffer::OwnedImpl fake_buffer;
+  fake_buffer.add("fake data");
+  generic_upstream->onUpstreamData(fake_buffer, false);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+TEST_F(UpstreamTest, OwnedGenericUpstreamUpstreamConnectionClose) {
+  EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _));
+  auto generic_upstream = createBoundGenericUpstream();
+
+  NiceMock<MockUpstreamRequestCallbacks> mock_upstream_request_callbacks_1;
+  mock_upstream_request_callbacks_1.upstream_ = generic_upstream.get();
+
+  EXPECT_CALL(thread_local_cluster_.tcp_conn_pool_, newConnection(_));
+
+  generic_upstream->appendUpstreamRequest(1, &mock_upstream_request_callbacks_1);
+
+  EXPECT_EQ(1, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(*thread_local_cluster_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(testing::Invoke([&](Tcp::ConnectionPool::UpstreamCallbacks& cb) {
+        mock_upstream_connection_.addConnectionCallbacks(cb);
+      }));
+  thread_local_cluster_.tcp_conn_pool_.poolReady(mock_upstream_connection_);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
+
+  EXPECT_CALL(mock_upstream_request_callbacks_1, onConnectionClose(_));
+
+  mock_upstream_connection_.close(Network::ConnectionCloseType::NoFlush);
+
+  EXPECT_EQ(0, generic_upstream->waitingUpstreamRequestsSize());
+  EXPECT_EQ(0, generic_upstream->waitingResponseRequestsSize());
+}
+
+} // namespace
+} // namespace Router
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: generic proxy: split the upstream to different module to simply test and mock
Additional Description:

1. Splited current upstream to `DecoderEncoder` and `GenericUpstream`. This make all these modules depend others by interfaces. This make it's possible to do flexible mock.
2. Now the client `DecoderEncoder` has same lifetime with the client connection (upstream connection).

Risk Level: low. Contrib only change.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.