### PR TITLE
mobile/ci: Set the default GPG key in the Mobile Release job (take 2)

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -114,24 +114,24 @@ jobs:
       run: |
         # https://github.com/keybase/keybase-issues/issues/2798
         export GPG_TTY=$(tty)
-        # Import gpg keys and warm the passphrase to avoid the gpg
-        # passphrase prompt when initating a deploy
-        # `--pinentry-mode=loopback` could be needed to ensure we
-        # suppress the gpg prompt
-        echo $GPG_KEY | base64 --decode > signing-key
         # The key ID C9ADE25A75333454 was obtained from a previous
         # run of the Mobile Release job. The key ID is consistent
         # between runs. Hard-coding the key ID is more straightforward
         # than using `list-secret-keys` to parse out the correct
         # key ID.
-        echo "default-key C9ADE25A75333454" >> ~/.gnupg/gpg.conf
-        gpg --passphrase $GPG_PASSPHRASE --batch --import signing-key
+        export GPG_DEFAULT_KEY=C9ADE25A75333454
+        # Import gpg keys and warm the passphrase to avoid the gpg
+        # passphrase prompt when initating a deploy
+        # `--pinentry-mode=loopback` could be needed to ensure we
+        # suppress the gpg prompt
+        echo $GPG_KEY | base64 --decode > signing-key
+        gpg --default-key $GPG_DEFAULT_KEY --passphrase $GPG_PASSPHRASE --batch --import signing-key
         shred signing-key
 
-        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}.aar
-        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}-pom.xml
-        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}-javadoc.jar
-        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}-sources.jar
+        gpg --default-key $GPG_DEFAULT_KEY --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}.aar
+        gpg --default-key $GPG_DEFAULT_KEY --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}-pom.xml
+        gpg --default-key $GPG_DEFAULT_KEY --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}-javadoc.jar
+        gpg --default-key $GPG_DEFAULT_KEY --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE -ab ${{ matrix.output }}-sources.jar
     - name: 'Release to sonatype repository'
       env:
         READWRITE_USER: ${{ secrets.EM_SONATYPE_USER }}


### PR DESCRIPTION
The changes in https://github.com/envoyproxy/envoy/pull/34390 resulted in an error:

```
/home/runner/.gnupg/gpg.conf: No such file or directory
```