### PR TITLE
proxy_protocol_filter: Add field `stat_prefix` to the filter configuration

### DIFF
--- a/api/envoy/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto
+++ b/api/envoy/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto
@@ -85,4 +85,10 @@ message ProxyProtocol {
   //   and an incoming request matches the V2 signature, the filter will allow the request through without any modification.
   //   The filter treats this request as if it did not have any PROXY protocol information.
   repeated config.core.v3.ProxyProtocolConfig.Version disallowed_versions = 4;
+
+  // The human readable prefix to use when emitting statistics for the filter.
+  // If not configured, statistics will be emitted without the prefix segment.
+  // See the :ref:`filter's statistics documentation <config_listener_filters_proxy_protocol>` for
+  // more information.
+  string stat_prefix = 5;
 }

--- a/api/envoy/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto
+++ b/api/envoy/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.proto
@@ -18,6 +18,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // PROXY protocol listener filter.
 // [#extension: envoy.filters.listener.proxy_protocol]
 
+// [#next-free-field: 6]
 message ProxyProtocol {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.listener.proxy_protocol.v2.ProxyProtocol";

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -187,7 +187,7 @@ new_features:
 - area: proxy_protocol
   change: |
     Added field :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.stat_prefix>`
-    to the proxy protocol listener filter configuration, allowing for differentiating statistics when multiple proxy 
+    to the proxy protocol listener filter configuration, allowing for differentiating statistics when multiple proxy
     protocol listener filters are configured.
 - area: aws_lambda
   change: |

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -184,6 +184,11 @@ new_features:
 - area: redis
   change: |
     Added support for `inline commands <https://redis.io/docs/reference/protocol-spec/#inline-commands>`_.
+- area: proxy_protocol
+  change: |
+    Added field :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.stat_prefix>`
+    to the proxy protocol listener filter configuration, allowing for differentiating statistics when multiple proxy 
+    protocol listener filters are configured.
 - area: aws_lambda
   change: |
     The ``aws_lambda`` filter now supports the

--- a/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
+++ b/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
@@ -33,8 +33,8 @@ If there is a protocol error or an unsupported address family
 Statistics
 ----------
 
-This filter emits the following general statistics, rooted at *downstream_proxy_proto*
-
+This filter emits the following general statistics, rooted at *downstream_proxy_proto.<stat_prefix>*
+<stat_prefix>
 .. csv-table::
   :header: Name, Type, Description
   :widths: 4, 1, 8
@@ -42,7 +42,7 @@ This filter emits the following general statistics, rooted at *downstream_proxy_
   not_found_disallowed, Counter, "Total number of connections that don't contain the PROXY protocol header and are rejected."
   not_found_allowed, Counter, "Total number of connections that don't contain the PROXY protocol header, but are allowed due to :ref:`allow_requests_without_proxy_protocol <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.allow_requests_without_proxy_protocol>`."
 
-The filter also emits the statistics rooted at *downstream_proxy_proto.versions.<version>*
+The filter also emits the statistics rooted at *downstream_proxy_proto.<stat_prefix>.versions.<version>*
 for each matched PROXY protocol version. Proxy protocol versions include ``v1`` and ``v2``.
 
 .. csv-table::
@@ -53,7 +53,7 @@ for each matched PROXY protocol version. Proxy protocol versions include ``v1`` 
   disallowed, Counter, "Total number of ``found`` connections that are rejected due to :ref:`disallowed_versions <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.disallowed_versions>`."
   error, Counter, "Total number of connections where the PROXY protocol header was malformed (and the connection was rejected)."
 
-The filter also emits the following legacy statistics, rooted at its own scope:
+The filter also emits the following legacy statistics, rooted at its own scope and **not** including the *stat_prefix*:
 
 .. csv-table::
   :header: Name, Type, Description

--- a/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
+++ b/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
@@ -34,7 +34,7 @@ Statistics
 ----------
 
 This filter emits the following general statistics, rooted at *downstream_proxy_proto.<stat_prefix>*
-<stat_prefix>
+
 .. csv-table::
   :header: Name, Type, Description
   :widths: 4, 1, 8

--- a/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
+++ b/docs/root/configuration/listeners/listener_filters/proxy_protocol.rst
@@ -33,7 +33,7 @@ If there is a protocol error or an unsupported address family
 Statistics
 ----------
 
-This filter emits the following general statistics, rooted at *downstream_proxy_proto.<stat_prefix>*
+This filter emits the following general statistics, rooted at *proxy_proto.[<stat_prefix>.]*
 
 .. csv-table::
   :header: Name, Type, Description
@@ -42,7 +42,7 @@ This filter emits the following general statistics, rooted at *downstream_proxy_
   not_found_disallowed, Counter, "Total number of connections that don't contain the PROXY protocol header and are rejected."
   not_found_allowed, Counter, "Total number of connections that don't contain the PROXY protocol header, but are allowed due to :ref:`allow_requests_without_proxy_protocol <envoy_v3_api_field_extensions.filters.listener.proxy_protocol.v3.ProxyProtocol.allow_requests_without_proxy_protocol>`."
 
-The filter also emits the statistics rooted at *downstream_proxy_proto.<stat_prefix>.versions.<version>*
+The filter also emits the statistics rooted at *proxy_proto.[<stat_prefix>.]versions.<version>*
 for each matched PROXY protocol version. Proxy protocol versions include ``v1`` and ``v2``.
 
 .. csv-table::

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -27,7 +27,8 @@ std::string expandRegex(const std::string& regex) {
               // alphanumerics, underscores, and dashes.
               {"<ROUTE_CONFIG_NAME>", R"([\w-\./]+)"},
               // Match a prefix that is either a listener plus name or cluster plus name
-              {"<LISTENER_OR_CLUSTER_WITH_NAME>", R"((?:listener|cluster)\..*?)"}});
+              {"<LISTENER_OR_CLUSTER_WITH_NAME>", R"((?:listener|cluster)\..*?)"},
+              {"<PROXY_PROTOCOL_VERSION>", R"(\d+)"}});
 }
 
 const Regex::CompiledGoogleReMatcher& validTagValueRegex() {
@@ -218,8 +219,15 @@ TagNameValues::TagNameValues() {
   // http.<stat_prefix>.rbac.(<rules_stat_prefix>.)* but excluding policy
   addRe2(RBAC_HTTP_PREFIX, R"(^http\.<TAG_VALUE>\.rbac\.((<TAG_VALUE>)\.).*?)", "", "policy");
 
-  // proxy_proto.(versions.v<version_number>.)**
-  addRe2(PROXY_PROTOCOL_VERSION, R"(^proxy_proto\.(versions\.v(\d)\.)\w+)", "proxy_proto.versions");
+  // proxy_proto.(<stat_prefix>.)**
+  addRe2(PROXY_PROTOCOL_PREFIX, R"(^proxy_proto\.((<TAG_VALUE>)\.).+$)", "", "versions");
+
+  // proxy_proto.([<optional stat_prefix>.]versions.v(<version_number>).)(found|disallowed|error)
+  //
+  // Strips out:  [<optional stat_prefix>.]versions.v(<version_number>).
+  // Leaving: proxy_proto.(found|disallowed|error)
+  addRe2(PROXY_PROTOCOL_VERSION,
+         R"(^proxy_proto\.((?:<TAG_VALUE>\.)?versions\.v(<PROXY_PROTOCOL_VERSION>)\.)\w+$)");
 }
 
 void TagNameValues::addRe2(const std::string& name, const std::string& regex,

--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -28,7 +28,7 @@ std::string expandRegex(const std::string& regex) {
               {"<ROUTE_CONFIG_NAME>", R"([\w-\./]+)"},
               // Match a prefix that is either a listener plus name or cluster plus name
               {"<LISTENER_OR_CLUSTER_WITH_NAME>", R"((?:listener|cluster)\..*?)"},
-              {"<PROXY_PROTOCOL_VERSION>", R"(\d+)"}});
+              {"<PROXY_PROTOCOL_VERSION>", R"(\d)"}});
 }
 
 const Regex::CompiledGoogleReMatcher& validTagValueRegex() {

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -165,6 +165,8 @@ public:
   const std::string REDIS_PREFIX = "envoy.redis_prefix";
   // Proxy Protocol version for a connection (Proxy Protocol listener filter).
   const std::string PROXY_PROTOCOL_VERSION = "envoy.proxy_protocol_version";
+  // Stats prefix for the proxy protocol listener filter.
+  const std::string PROXY_PROTOCOL_PREFIX = "envoy.proxy_protocol_prefix";
 
   // Mapping from the names above to their respective regex strings.
   const std::vector<std::pair<std::string, std::string>> name_regex_pairs_;

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
@@ -96,7 +96,7 @@ struct ProxyProtocolStats {
    * For backwards compatibility, the legacy stats are rooted under their own scope.
    * The general and versioned stats are correctly rooted at this filter's own scope.
    */
-  static ProxyProtocolStats create(Stats::Scope& scope);
+  static ProxyProtocolStats create(Stats::Scope& scope, absl::string_view stat_prefix);
 };
 
 /**

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -485,12 +485,23 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
                          "http.rbac.policy.shadow_denied",
                          {rbac_http_hcm_prefix, rbac_http_prefix, rbac_policy_name});
 
+  // Proxy Protocol stat prefix
+  Tag proxy_protocol_prefix;
+  proxy_protocol_prefix.name_ = tag_names.PROXY_PROTOCOL_PREFIX;
+  proxy_protocol_prefix.value_ = "test_stat_prefix";
+  regex_tester.testRegex("proxy_proto.not_found_disallowed", "proxy_proto.not_found_disallowed",
+                         {});
+  regex_tester.testRegex("proxy_proto.test_stat_prefix.not_found_disallowed",
+                         "proxy_proto.not_found_disallowed", {proxy_protocol_prefix});
+
   // Proxy Protocol version prefix
   Tag proxy_protocol_version;
   proxy_protocol_version.name_ = tag_names.PROXY_PROTOCOL_VERSION;
   proxy_protocol_version.value_ = "2";
   regex_tester.testRegex("proxy_proto.versions.v2.error", "proxy_proto.error",
                          {proxy_protocol_version});
+  regex_tester.testRegex("proxy_proto.test_stat_prefix.versions.v2.error", "proxy_proto.error",
+                         {proxy_protocol_prefix, proxy_protocol_version});
 }
 
 TEST(TagExtractorTest, ExtAuthzTagExtractors) {


### PR DESCRIPTION
Commit Message:
proxy_protocol_filter: Add field `stat_prefix` to the filter configuration

Additional Description:
This field allows for differentiating statistics when multiple proxy protocol listener filters are configured.

This PR is a follow-up from previous conversation: https://github.com/envoyproxy/envoy/pull/32861#discussion_r1539832395

Risk Level: Low
- All client-facing behavior changes are guarded by new filter config field.

Testing:
- Stats unit tests
- Proxy protocol listener filter integration tests

Docs Changes:
Done

Release Notes:
Done

Platform Specific Features:
None
