### PR TITLE
tests-refactor: pass unique_ptr pointer and not by ref

### DIFF
--- a/test/extensions/filters/http/on_demand/odcds_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/odcds_integration_test.cc
@@ -320,10 +320,11 @@ TEST_P(OdCdsIntegrationTest, OnDemandClusterDiscoveryWorksWithClusterHeader) {
   odcds_stream_->startGrpcStream();
 
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_.get());
+  EXPECT_TRUE(
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
   waitForNextUpstreamRequest(new_cluster_upstream_idx_);
   // Send response headers, and end_stream if there is no response body.
@@ -362,10 +363,11 @@ TEST_P(OdCdsIntegrationTest, OnDemandClusterDiscoveryRemembersDiscoveredCluster)
   odcds_stream_->startGrpcStream();
 
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_.get());
+  EXPECT_TRUE(
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
   waitForNextUpstreamRequest(new_cluster_upstream_idx_);
   // Send response headers, and end_stream if there is no response body.
@@ -409,7 +411,7 @@ TEST_P(OdCdsIntegrationTest, OnDemandClusterDiscoveryTimesOut) {
   odcds_stream_->startGrpcStream();
 
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   // not sending a response to trigger the timeout
 
   ASSERT_TRUE(response->waitForEndStream());
@@ -443,10 +445,11 @@ TEST_P(OdCdsIntegrationTest, OnDemandClusterDiscoveryForNonexistentCluster) {
   odcds_stream_->startGrpcStream();
 
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-      Config::TypeUrl::get().Cluster, {}, {"new_cluster"}, "1", odcds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+      Config::TypeUrl::get().Cluster, {}, {"new_cluster"}, "1", odcds_stream_.get());
+  EXPECT_TRUE(
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
   ASSERT_TRUE(response->waitForEndStream());
   verifyResponse(std::move(response), "503", {}, {});
@@ -869,11 +872,11 @@ key:
     odcds_stream_->startGrpcStream();
 
     EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                             odcds_stream_));
+                                             odcds_stream_.get()));
     sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-        Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_);
+        Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_.get());
     EXPECT_TRUE(
-        compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+        compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
     waitForNextUpstreamRequest(new_cluster_upstream_idx_);
     // Send response headers, and end_stream if there is no response body.

--- a/test/extensions/filters/http/on_demand/on_demand_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/on_demand_integration_test.cc
@@ -362,9 +362,9 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsVirtualHostAddUpdateRemove) {
 
   // A spontaneous VHDS DiscoveryResponse adds two virtual hosts
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
-      Config::TypeUrl::get().VirtualHost, buildVirtualHost1(), {}, "2", vhds_stream_);
+      Config::TypeUrl::get().VirtualHost, buildVirtualHost1(), {}, "2", vhds_stream_.get());
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
 
   testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/one", "vhost.first");
   cleanupUpstreamAndDownstream();
@@ -376,9 +376,9 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsVirtualHostAddUpdateRemove) {
   // A spontaneous VHDS DiscoveryResponse removes newly added virtual hosts
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
       Config::TypeUrl::get().VirtualHost, {}, {"my_route/vhost_1", "my_route/vhost_2"}, "3",
-      vhds_stream_);
+      vhds_stream_.get());
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
 
   // an upstream request to an (now) unknown domain
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
@@ -390,9 +390,9 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsVirtualHostAddUpdateRemove) {
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.first")}, {},
-                                           vhds_stream_));
+                                           vhds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
-      Config::TypeUrl::get().VirtualHost, {buildVirtualHost2()}, {}, "4", vhds_stream_,
+      Config::TypeUrl::get().VirtualHost, {buildVirtualHost2()}, {}, "4", vhds_stream_.get(),
       {"my_route/vhost.first"});
 
   waitForNextUpstreamRequest(1);
@@ -422,9 +422,9 @@ TEST_P(OnDemandVhdsIntegrationTest, RdsWithVirtualHostsVhdsVirtualHostAddUpdateR
 
   // A spontaneous VHDS DiscoveryResponse adds two virtual hosts
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
-      Config::TypeUrl::get().VirtualHost, buildVirtualHost1(), {}, "2", vhds_stream_);
+      Config::TypeUrl::get().VirtualHost, buildVirtualHost1(), {}, "2", vhds_stream_.get());
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
 
   // verify that rds-based virtual host can be resolved
   testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/rdsone", "vhost.rds.first");
@@ -440,9 +440,9 @@ TEST_P(OnDemandVhdsIntegrationTest, RdsWithVirtualHostsVhdsVirtualHostAddUpdateR
   // A spontaneous VHDS DiscoveryResponse removes virtual hosts added via vhds
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
       Config::TypeUrl::get().VirtualHost, {}, {"my_route/vhost_1", "my_route/vhost_2"}, "3",
-      vhds_stream_);
+      vhds_stream_.get());
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
 
   // verify rds-based virtual host is still present
   testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/rdsone", "vhost.rds.first");
@@ -458,9 +458,9 @@ TEST_P(OnDemandVhdsIntegrationTest, RdsWithVirtualHostsVhdsVirtualHostAddUpdateR
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.first")}, {},
-                                           vhds_stream_));
+                                           vhds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
-      Config::TypeUrl::get().VirtualHost, {buildVirtualHost2()}, {}, "4", vhds_stream_,
+      Config::TypeUrl::get().VirtualHost, {buildVirtualHost2()}, {}, "4", vhds_stream_.get(),
       {"my_route/vhost.first"});
 
   waitForNextUpstreamRequest(1);
@@ -498,7 +498,8 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsOnDemandUpdateWithResourceNameAsAlias) {
                                                  {"x-lyft-user-id", "123"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
-                                           {vhdsRequestResourceName("vhost_1")}, {}, vhds_stream_));
+                                           {vhdsRequestResourceName("vhost_1")}, {},
+                                           vhds_stream_.get()));
 
   envoy::service::discovery::v3::DeltaDiscoveryResponse vhds_update =
       createDeltaDiscoveryResponseWithResourceNameUsedAsAlias();
@@ -544,7 +545,7 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsOnDemandUpdateFailToResolveTheAlias) {
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.third")}, {},
-                                           vhds_stream_));
+                                           vhds_stream_.get()));
   // Send an empty response back (the management server isn't aware of vhost.third)
   notifyAboutAliasResolutionFailure("4", vhds_stream_, {"my_route/vhost.third"});
 
@@ -583,7 +584,7 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsOnDemandUpdateFailToResolveOneAliasOutOf
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.third")}, {},
-                                           vhds_stream_));
+                                           vhds_stream_.get()));
   // Send an empty response back (the management server isn't aware of vhost.third)
   sendDeltaDiscoveryResponseWithUnresolvedAliases({buildVirtualHost2()}, {}, "4", vhds_stream_,
                                                   {"my_route/vhost.first"},
@@ -615,7 +616,8 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsOnDemandUpdateHttpConnectionCloses) {
   Http::RequestEncoder& encoder = encoder_decoder.first;
   IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
-                                           {vhdsRequestResourceName("vhost_1")}, {}, vhds_stream_));
+                                           {vhdsRequestResourceName("vhost_1")}, {},
+                                           vhds_stream_.get()));
 
   envoy::service::discovery::v3::DeltaDiscoveryResponse vhds_update =
       createDeltaDiscoveryResponseWithResourceNameUsedAsAlias();
@@ -654,12 +656,12 @@ TEST_P(OnDemandVhdsIntegrationTest, MultipleUpdates) {
     IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
     EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                              {vhdsRequestResourceName("vhost.first")}, {},
-                                             vhds_stream_));
+                                             vhds_stream_.get()));
     sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
-        Config::TypeUrl::get().VirtualHost, {buildVirtualHost2()}, {}, "4", vhds_stream_,
+        Config::TypeUrl::get().VirtualHost, {buildVirtualHost2()}, {}, "4", vhds_stream_.get(),
         {"my_route/vhost.first"});
-    EXPECT_TRUE(
-        compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+    EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {},
+                                             vhds_stream_.get()));
 
     waitForNextUpstreamRequest(1);
     // Send response headers, and end_stream if there is no response body.
@@ -682,14 +684,14 @@ TEST_P(OnDemandVhdsIntegrationTest, MultipleUpdates) {
     IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
     EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                              {vhdsRequestResourceName("vhost.second")}, {},
-                                             vhds_stream_));
+                                             vhds_stream_.get()));
     sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
         Config::TypeUrl::get().VirtualHost,
         {TestUtility::parseYaml<envoy::config::route::v3::VirtualHost>(
             virtualHostYaml("my_route/vhost_2", "vhost.second"))},
-        {}, "4", vhds_stream_, {"my_route/vhost.second"});
-    EXPECT_TRUE(
-        compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+        {}, "4", vhds_stream_.get(), {"my_route/vhost.second"});
+    EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {},
+                                             vhds_stream_.get()));
 
     waitForNextUpstreamRequest(1);
     // Send response headers, and end_stream if there is no response body.
@@ -709,9 +711,9 @@ TEST_P(OnDemandVhdsIntegrationTest, MultipleUpdates) {
              fmt::format(VhostTemplateAfterUpdate, "my_route/vhost_1", "vhost.first")),
          TestUtility::parseYaml<envoy::config::route::v3::VirtualHost>(
              fmt::format(VhostTemplateAfterUpdate, "my_route/vhost_2", "vhost.second"))},
-        {}, "5", vhds_stream_);
-    EXPECT_TRUE(
-        compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+        {}, "5", vhds_stream_.get());
+    EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {},
+                                             vhds_stream_.get()));
 
     // verify that both virtual hosts have been updated
     testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/after_update", "vhost.first");
@@ -742,18 +744,19 @@ TEST_P(OnDemandVhdsIntegrationTest, AttemptAddingDuplicateDomainNames) {
            virtualHostYaml("my_route/vhost_1", "vhost.duplicate")),
        TestUtility::parseYaml<envoy::config::route::v3::VirtualHost>(
            virtualHostYaml("my_route/vhost_2", "vhost.duplicate"))},
-      {}, "2", vhds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_,
-                                           13, "Only unique values for domains are permitted"));
+      {}, "2", vhds_stream_.get());
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {},
+                                           vhds_stream_.get(), 13,
+                                           "Only unique values for domains are permitted"));
 
   // Another update, this time valid, should result in no errors
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
       Config::TypeUrl::get().VirtualHost,
       {TestUtility::parseYaml<envoy::config::route::v3::VirtualHost>(
           virtualHostYaml("my_route/vhost_3", "vhost.third"))},
-      {}, "2", vhds_stream_);
+      {}, "2", vhds_stream_.get());
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
 
   cleanupUpstreamAndDownstream();
 }

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -274,7 +274,7 @@ TEST_P(AdsIntegrationTest, DeltaSdsRemovals) {
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(cds_type_url, {cluster}, {}, "1");
 
   // The cluster needs this secret, so it's going to request it.
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(sds_type_url, {"validation_context"}, {}, {}));
+  EXPECT_TRUE(compareDeltaDiscoveryRequest(sds_type_url, {"validation_context"}, {}));
 
   // Cluster should start off warming as the secret is being requested.
   test_server_->waitForGaugeEq("cluster.cluster_0.warming_state", 1);

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -611,15 +611,17 @@ AssertionResult BaseIntegrationTest::compareDiscoveryRequest(
     const std::vector<std::string>& expected_resource_names,
     const std::vector<std::string>& expected_resource_names_added,
     const std::vector<std::string>& expected_resource_names_removed, bool expect_node,
-    const Protobuf::int32 expected_error_code, const std::string& expected_error_substring) {
+    const Protobuf::int32 expected_error_code, const std::string& expected_error_substring,
+    FakeStream* stream) {
   if (sotw_or_delta_ == Grpc::SotwOrDelta::Sotw ||
       sotw_or_delta_ == Grpc::SotwOrDelta::UnifiedSotw) {
     return compareSotwDiscoveryRequest(expected_type_url, expected_version, expected_resource_names,
-                                       expect_node, expected_error_code, expected_error_substring);
+                                       expect_node, expected_error_code, expected_error_substring,
+                                       stream);
   } else {
     return compareDeltaDiscoveryRequest(expected_type_url, expected_resource_names_added,
-                                        expected_resource_names_removed, expected_error_code,
-                                        expected_error_substring, expect_node);
+                                        expected_resource_names_removed, stream,
+                                        expected_error_code, expected_error_substring, expect_node);
   }
 }
 
@@ -723,10 +725,13 @@ BaseIntegrationTest::createExplicitResourcesDeltaDiscoveryResponse(
 AssertionResult BaseIntegrationTest::compareDeltaDiscoveryRequest(
     const std::string& expected_type_url,
     const std::vector<std::string>& expected_resource_subscriptions,
-    const std::vector<std::string>& expected_resource_unsubscriptions, FakeStreamPtr& xds_stream,
+    const std::vector<std::string>& expected_resource_unsubscriptions, FakeStream* xds_stream,
     const Protobuf::int32 expected_error_code, const std::string& expected_error_substring,
     bool expect_node) {
   envoy::service::discovery::v3::DeltaDiscoveryRequest request;
+  if (xds_stream == nullptr) {
+    xds_stream = xds_stream_.get();
+  }
   VERIFY_ASSERTION(xds_stream->waitForGrpcMessage(*dispatcher_, request));
 
   // Verify all we care about node.

--- a/test/integration/leds_integration_test.cc
+++ b/test/integration/leds_integration_test.cc
@@ -99,7 +99,7 @@ protected:
       // Receive LEDS ack.
       EXPECT_TRUE(compareDeltaDiscoveryRequest(
           Config::TypeUrl::get().LbEndpoint, {}, {},
-          leds_upstream_info_.stream_by_resource_name_[localities_prefixes_[locality_idx]]));
+          leds_upstream_info_.stream_by_resource_name_[localities_prefixes_[locality_idx]].get()));
     }
   }
 
@@ -319,14 +319,14 @@ protected:
     // (ClusterLoadAssignment).
     EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment,
                                              {"cluster_0"}, {},
-                                             eds_upstream_info_.defaultStream()));
+                                             eds_upstream_info_.defaultStream().get()));
     sendDeltaDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
         Config::TypeUrl::get().ClusterLoadAssignment, {cluster_load_assignment_}, {}, "2",
-        eds_upstream_info_.defaultStream());
+        eds_upstream_info_.defaultStream().get());
 
     // Receive EDS ack.
     EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment, {}, {},
-                                             eds_upstream_info_.defaultStream()));
+                                             eds_upstream_info_.defaultStream().get()));
 
     EXPECT_EQ(1, test_server_->gauge("cluster_manager.warming_clusters")->value());
     EXPECT_EQ(2, test_server_->gauge("cluster_manager.active_clusters")->value());
@@ -798,7 +798,7 @@ TEST_P(LedsIntegrationTest, LedsSameAddressEndpoints) {
   // Await for update (LEDS Ack).
   EXPECT_TRUE(compareDeltaDiscoveryRequest(
       Config::TypeUrl::get().LbEndpoint, {}, {},
-      leds_upstream_info_.stream_by_resource_name_[localities_prefixes_[0]]));
+      leds_upstream_info_.stream_by_resource_name_[localities_prefixes_[0]].get()));
 
   // Verify that the update is successful.
   test_server_->waitForCounterEq("cluster.cluster_0.leds.update_success", 1);

--- a/test/integration/tcp_proxy_odcds_integration_test.cc
+++ b/test/integration/tcp_proxy_odcds_integration_test.cc
@@ -142,13 +142,14 @@ TEST_P(TcpProxyOdcdsIntegrationTest, SingleTcpClient) {
   test_server_->waitForCounterEq("tcp.tcpproxy_stats.on_demand_cluster_attempt", 1);
   // Verify the on-demand CDS request and respond with the prepared `new_cluster`.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   // The on demand cluster request is received and the response is not sent. The tcp proxy must not
   ASSERT_TRUE(fake_upstreams_.back()->assertPendingConnectionsEmpty());
 
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_.get());
+  EXPECT_TRUE(
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
   // This upstream is listening on the endpoint of `new_cluster`. It starts to serve tcp_proxy.
   FakeRawConnectionPtr fake_upstream_connection;
@@ -186,10 +187,11 @@ TEST_P(TcpProxyOdcdsIntegrationTest, RepeatedRequest) {
 
   // Verify the on-demand CDS request and respond without providing the cluster.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+      Config::TypeUrl::get().Cluster, {new_cluster_}, {}, "1", odcds_stream_.get());
+  EXPECT_TRUE(
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
   test_server_->waitForCounterEq("tcp.tcpproxy_stats.on_demand_cluster_attempt",
                                  expected_upstream_connections);
@@ -244,7 +246,7 @@ TEST_P(TcpProxyOdcdsIntegrationTest, ShutdownConnectionOnTimeout) {
 
   // Verify the on-demand CDS request and respond without providing the cluster.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   EXPECT_EQ(1, test_server_->counter("tcp.tcpproxy_stats.on_demand_cluster_attempt")->value());
 
   tcp_client->waitForHalfClose();
@@ -267,10 +269,11 @@ TEST_P(TcpProxyOdcdsIntegrationTest, ShutdownConnectionOnClusterMissing) {
 
   // Verify the on-demand CDS request and respond the required cluster is missing.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
-      Config::TypeUrl::get().Cluster, {}, {"new_cluster"}, "1", odcds_stream_);
-  EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_));
+      Config::TypeUrl::get().Cluster, {}, {"new_cluster"}, "1", odcds_stream_.get());
+  EXPECT_TRUE(
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {}, {}, odcds_stream_.get()));
 
   EXPECT_EQ(1, test_server_->counter("tcp.tcpproxy_stats.on_demand_cluster_attempt")->value());
 
@@ -295,7 +298,7 @@ TEST_P(TcpProxyOdcdsIntegrationTest, ShutdownAllConnectionsOnClusterLookupTimeou
 
   // Verify the on-demand CDS request and respond without providing the cluster.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
 
   EXPECT_EQ(1, test_server_->counter("tcp.tcpproxy_stats.on_demand_cluster_attempt")->value());
 
@@ -326,7 +329,7 @@ TEST_P(TcpProxyOdcdsIntegrationTest, ShutdownTcpClientBeforeOdcdsResponse) {
 
   // Verify the on-demand CDS request and stall the response before tcp client close.
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {},
-                                           odcds_stream_));
+                                           odcds_stream_.get()));
   EXPECT_EQ(1, test_server_->counter("tcp.tcpproxy_stats.on_demand_cluster_attempt")->value());
   // Client disconnect when the tcp proxy is waiting for the on demand response.
   tcp_client->close();

--- a/test/integration/vhds.h
+++ b/test/integration/vhds.h
@@ -216,12 +216,12 @@ public:
     RELEASE_ASSERT(result, result.message());
     vhds_stream_->startGrpcStream();
 
-    EXPECT_TRUE(
-        compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+    EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {},
+                                             vhds_stream_.get()));
     sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
-        Config::TypeUrl::get().VirtualHost, {buildVirtualHost()}, {}, "1", vhds_stream_);
-    EXPECT_TRUE(
-        compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+        Config::TypeUrl::get().VirtualHost, {buildVirtualHost()}, {}, "1", vhds_stream_.get());
+    EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {},
+                                             vhds_stream_.get()));
 
     // Wait for our statically specified listener to become ready, and register its port in the
     // test framework's downstream listener port map.

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -119,14 +119,14 @@ TEST_P(VhdsInitializationTest, InitializeVhdsAfterRdsHasBeenInitialized) {
   vhds_stream_->startGrpcStream();
 
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
   sendDeltaDiscoveryResponse<envoy::config::route::v3::VirtualHost>(
       Config::TypeUrl::get().VirtualHost,
       {TestUtility::parseYaml<envoy::config::route::v3::VirtualHost>(
           fmt::format(VhostTemplate, "my_route/vhost_0", "vhost.first"))},
-      {}, "1", vhds_stream_);
+      {}, "1", vhds_stream_.get());
   EXPECT_TRUE(
-      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_));
+      compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost, {}, {}, vhds_stream_.get()));
 
   // Confirm vhost.first that was configured via VHDS is reachable
   testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/", "vhost.first");


### PR DESCRIPTION
Commit Message: tests-refactor: pass unique_ptr pointer and not by ref
Additional Description:
Passing a unique_ptr's pointer, instead of passing it by ref.
Part of #34417 that I took out of that PR to make it smaller.
Risk Level: low - tests only.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
