### PR TITLE
mobile: Perform clean up in JNI_OnUnload

### DIFF
--- a/mobile/library/jni/jni_helper.h
+++ b/mobile/library/jni/jni_helper.h
@@ -144,6 +144,9 @@ public:
   /** Initializes the `JavaVM`. This function is typically called inside `JNI_OnLoad`. */
   static void initialize(JavaVM* java_vm);
 
+  /** Performs a clean up. This function is typically called inside `JNI_OnUnload`. */
+  static void finalize();
+
   /**
    * Adds the `jclass` object into a cache. This function is typically called inside `JNI_OnLoad`.
    *

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -19,7 +19,7 @@ using Envoy::Platform::EngineBuilder;
 
 // NOLINT(namespace-envoy)
 
-extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
   Envoy::JNI::JniHelper::addClassToCache("java/lang/Object");
   Envoy::JNI::JniHelper::addClassToCache("java/lang/Integer");
@@ -37,6 +37,10 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
   Envoy::JNI::JniHelper::addClassToCache(
       "io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");
   return Envoy::JNI::JniHelper::getVersion();
+}
+
+extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM*, void* /* reserved */) {
+  Envoy::JNI::JniHelper::finalize();
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/mobile/test/jni/jni_helper_test.cc
+++ b/mobile/test/jni/jni_helper_test.cc
@@ -16,20 +16,16 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   return Envoy::JNI::JniHelper::getVersion();
 }
 
+extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM*, void* /* reserved */) {
+  Envoy::JNI::JniHelper::finalize();
+}
+
 extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getFieldId(
     JNIEnv* env, jclass, jclass clazz, jstring name, jstring signature) {
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::JNI::StringUtfUniquePtr name_ptr = jni_helper.getStringUtfChars(name, nullptr);
   Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
   jni_helper.getFieldId(clazz, name_ptr.get(), sig_ptr.get());
-}
-
-extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticFieldId(
-    JNIEnv* env, jclass, jclass clazz, jstring name, jstring signature) {
-  Envoy::JNI::JniHelper jni_helper(env);
-  Envoy::JNI::StringUtfUniquePtr name_ptr = jni_helper.getStringUtfChars(name, nullptr);
-  Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
-  jni_helper.getStaticFieldId(clazz, name_ptr.get(), sig_ptr.get());
 }
 
 #define DEFINE_JNI_GET_FIELD(JAVA_TYPE, JNI_TYPE)                                                  \

--- a/mobile/test/jni/jni_helper_test.cc
+++ b/mobile/test/jni/jni_helper_test.cc
@@ -28,6 +28,14 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTe
   jni_helper.getFieldId(clazz, name_ptr.get(), sig_ptr.get());
 }
 
+extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticFieldId(
+    JNIEnv* env, jclass, jclass clazz, jstring name, jstring signature) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  Envoy::JNI::StringUtfUniquePtr name_ptr = jni_helper.getStringUtfChars(name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
+  jni_helper.getStaticFieldId(clazz, name_ptr.get(), sig_ptr.get());
+}
+
 #define DEFINE_JNI_GET_FIELD(JAVA_TYPE, JNI_TYPE)                                                  \
   extern "C" JNIEXPORT JNI_TYPE JNICALL                                                            \
       Java_io_envoyproxy_envoymobile_jni_JniHelperTest_get##JAVA_TYPE##Field(                      \

--- a/mobile/test/jni/jni_utility_test.cc
+++ b/mobile/test/jni/jni_utility_test.cc
@@ -30,6 +30,10 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   return Envoy::JNI::JniHelper::getVersion();
 }
 
+extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM*, void* /* reserved */) {
+  Envoy::JNI::JniHelper::finalize();
+}
+
 extern "C" JNIEXPORT jbyteArray JNICALL
 Java_io_envoyproxy_envoymobile_jni_JniUtilityTest_protoJavaByteArrayConversion(JNIEnv* env, jclass,
                                                                                jbyteArray source) {


### PR DESCRIPTION
This PR does a clean by deleting the JNI caches as well as deleting the `jclass` global references in `JNI_OnUnload`.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
