### PR TITLE
generic proxy: enhance match input data to support more attributes

### DIFF
--- a/contrib/generic_proxy/filters/network/source/BUILD
+++ b/contrib/generic_proxy/filters/network/source/BUILD
@@ -92,11 +92,23 @@ envoy_cc_library(
         "match.h",
     ],
     deps = [
+        ":match_input_lib",
         "//contrib/generic_proxy/filters/network/source/interface:stream_interface",
         "//source/common/matcher:matcher_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3:pkg_cc_proto",
     ],
     alwayslink = 1,
+)
+
+envoy_cc_library(
+    name = "match_input_lib",
+    hdrs = [
+        "match_input.h",
+    ],
+    deps = [
+        "//contrib/generic_proxy/filters/network/source/interface:stream_interface",
+        "//envoy/stream_info:stream_info_interface",
+    ],
 )
 
 envoy_cc_library(

--- a/contrib/generic_proxy/filters/network/source/access_log.cc
+++ b/contrib/generic_proxy/filters/network/source/access_log.cc
@@ -7,64 +7,46 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
 
-class StringValueFormatterProvider : public FormatterProvider {
-public:
-  using ValueExtractor = std::function<absl::optional<std::string>(const FormatterContext&,
-                                                                   const StreamInfo::StreamInfo&)>;
-
-  StringValueFormatterProvider(ValueExtractor f, absl::optional<size_t> max_length = absl::nullopt)
-      : value_extractor_(f), max_length_(max_length) {}
-
-  // FormatterProvider
-  absl::optional<std::string>
-  formatWithContext(const FormatterContext& context,
-                    const StreamInfo::StreamInfo& stream_info) const override {
-    auto optional_str = value_extractor_(context, stream_info);
-    if (!optional_str) {
-      return absl::nullopt;
-    }
-    if (max_length_.has_value()) {
-      if (optional_str->length() > max_length_.value()) {
-        optional_str->resize(max_length_.value());
-      }
-    }
-    return optional_str;
+absl::optional<std::string>
+StringValueFormatterProvider::formatWithContext(const FormatterContext& context,
+                                                const StreamInfo::StreamInfo& stream_info) const {
+  auto optional_str = value_extractor_(context, stream_info);
+  if (!optional_str) {
+    return absl::nullopt;
   }
-  ProtobufWkt::Value
-  formatValueWithContext(const FormatterContext& context,
-                         const StreamInfo::StreamInfo& stream_info) const override {
-    return ValueUtil::optionalStringValue(formatWithContext(context, stream_info));
+  if (max_length_.has_value()) {
+    if (optional_str->length() > max_length_.value()) {
+      optional_str->resize(max_length_.value());
+    }
+  }
+  return optional_str;
+}
+ProtobufWkt::Value StringValueFormatterProvider::formatValueWithContext(
+    const FormatterContext& context, const StreamInfo::StreamInfo& stream_info) const {
+  return ValueUtil::optionalStringValue(formatWithContext(context, stream_info));
+}
+
+absl::optional<std::string>
+GenericStatusCodeFormatterProvider::formatWithContext(const FormatterContext& context,
+                                                      const StreamInfo::StreamInfo&) const {
+  if (context.response_ == nullptr) {
+    return absl::nullopt;
   }
 
-private:
-  ValueExtractor value_extractor_;
-  absl::optional<size_t> max_length_;
-};
+  const int code = context.response_->status().code();
+  return std::to_string(code);
+}
 
-class GenericStatusCodeFormatterProvider : public FormatterProvider {
-public:
-  GenericStatusCodeFormatterProvider() = default;
-
-  // FormatterProvider
-  absl::optional<std::string> formatWithContext(const FormatterContext& context,
-                                                const StreamInfo::StreamInfo&) const override {
-    if (context.response_ == nullptr) {
-      return absl::nullopt;
-    }
-
-    const int code = context.response_->status().code();
-    return std::to_string(code);
+ProtobufWkt::Value
+GenericStatusCodeFormatterProvider::formatValueWithContext(const FormatterContext& context,
+                                                           const StreamInfo::StreamInfo&) const {
+  if (context.response_ == nullptr) {
+    return ValueUtil::nullValue();
   }
-  ProtobufWkt::Value formatValueWithContext(const FormatterContext& context,
-                                            const StreamInfo::StreamInfo&) const override {
-    if (context.response_ == nullptr) {
-      return ValueUtil::nullValue();
-    }
 
-    const int code = context.response_->status().code();
-    return ValueUtil::numberValue(code);
-  }
-};
+  const int code = context.response_->status().code();
+  return ValueUtil::numberValue(code);
+}
 
 class SimpleCommandParser : public CommandParser {
 public:

--- a/contrib/generic_proxy/filters/network/source/access_log.h
+++ b/contrib/generic_proxy/filters/network/source/access_log.h
@@ -35,6 +35,38 @@ using AccessLogInstanceFactory = AccessLog::AccessLogInstanceFactoryBase<Formatt
 using FileAccessLog = FileAccessLogBase<FormatterContext>;
 using FileAccessLogFactory = FileAccessLogFactoryBase<FormatterContext>;
 
+class StringValueFormatterProvider : public FormatterProvider {
+public:
+  using ValueExtractor = std::function<absl::optional<std::string>(const FormatterContext&,
+                                                                   const StreamInfo::StreamInfo&)>;
+
+  StringValueFormatterProvider(ValueExtractor f, absl::optional<size_t> max_length = absl::nullopt)
+      : value_extractor_(f), max_length_(max_length) {}
+
+  // FormatterProvider
+  absl::optional<std::string>
+  formatWithContext(const FormatterContext& context,
+                    const StreamInfo::StreamInfo& stream_info) const override;
+  ProtobufWkt::Value
+  formatValueWithContext(const FormatterContext& context,
+                         const StreamInfo::StreamInfo& stream_info) const override;
+
+private:
+  ValueExtractor value_extractor_;
+  absl::optional<size_t> max_length_;
+};
+
+class GenericStatusCodeFormatterProvider : public FormatterProvider {
+public:
+  GenericStatusCodeFormatterProvider() = default;
+
+  // FormatterProvider
+  absl::optional<std::string> formatWithContext(const FormatterContext& context,
+                                                const StreamInfo::StreamInfo&) const override;
+  ProtobufWkt::Value formatValueWithContext(const FormatterContext& context,
+                                            const StreamInfo::StreamInfo&) const override;
+};
+
 } // namespace GenericProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/contrib/generic_proxy/filters/network/source/interface/BUILD
+++ b/contrib/generic_proxy/filters/network/source/interface/BUILD
@@ -65,6 +65,7 @@ envoy_cc_library(
     ],
     deps = [
         ":stream_interface",
+        "//contrib/generic_proxy/filters/network/source:match_input_lib",
         "//envoy/config:typed_metadata_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/network:connection_interface",
@@ -97,6 +98,7 @@ envoy_cc_library(
         ":filter_interface",
         ":route_interface",
         "//contrib/generic_proxy/filters/network/source:access_log_lib",
+        "//contrib/generic_proxy/filters/network/source:match_input_lib",
         "//envoy/tracing:trace_config_interface",
         "//envoy/tracing:tracer_interface",
     ],

--- a/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
+++ b/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
@@ -8,6 +8,7 @@
 #include "contrib/generic_proxy/filters/network/source/interface/filter.h"
 #include "contrib/generic_proxy/filters/network/source/interface/route.h"
 #include "contrib/generic_proxy/filters/network/source/stats.h"
+#include "contrib/generic_proxy/filters/network/source/match_input.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -24,7 +25,7 @@ public:
    * @param request request.
    * @return RouteEntryConstSharedPtr route entry.
    */
-  virtual RouteEntryConstSharedPtr routeEntry(const Request& request) const PURE;
+  virtual RouteEntryConstSharedPtr routeEntry(const MatchInput& request) const PURE;
 
   /**
    * Get codec factory for  decoding/encoding of request/response.

--- a/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
+++ b/contrib/generic_proxy/filters/network/source/interface/proxy_config.h
@@ -7,8 +7,8 @@
 #include "contrib/generic_proxy/filters/network/source/interface/codec.h"
 #include "contrib/generic_proxy/filters/network/source/interface/filter.h"
 #include "contrib/generic_proxy/filters/network/source/interface/route.h"
-#include "contrib/generic_proxy/filters/network/source/stats.h"
 #include "contrib/generic_proxy/filters/network/source/match_input.h"
+#include "contrib/generic_proxy/filters/network/source/stats.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/contrib/generic_proxy/filters/network/source/interface/route.h
+++ b/contrib/generic_proxy/filters/network/source/interface/route.h
@@ -8,6 +8,7 @@
 #include "envoy/router/router.h"
 
 #include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+#include "contrib/generic_proxy/filters/network/source/match_input.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -87,7 +88,7 @@ using RouteEntryConstSharedPtr = std::shared_ptr<const RouteEntry>;
 
 class RouteMatcher : public Rds::Config {
 public:
-  virtual RouteEntryConstSharedPtr routeEntry(const Request& request) const PURE;
+  virtual RouteEntryConstSharedPtr routeEntry(const MatchInput& request) const PURE;
 };
 using RouteMatcherPtr = std::unique_ptr<RouteMatcher>;
 

--- a/contrib/generic_proxy/filters/network/source/interface/stream.h
+++ b/contrib/generic_proxy/filters/network/source/interface/stream.h
@@ -175,9 +175,6 @@ public:
    * @param key The metadata key of string view type.
    */
   virtual void erase(absl::string_view /*key*/) {}
-
-  // Used for matcher.
-  static constexpr absl::string_view name() { return "generic_proxy"; }
 };
 
 // Alias for backward compatibility.

--- a/contrib/generic_proxy/filters/network/source/match.cc
+++ b/contrib/generic_proxy/filters/network/source/match.cc
@@ -5,17 +5,17 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace GenericProxy {
 
-REGISTER_FACTORY(ServiceMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+REGISTER_FACTORY(ServiceMatchDataInputFactory, Matcher::DataInputFactory<MatchInput>);
 
-REGISTER_FACTORY(HostMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+REGISTER_FACTORY(HostMatchDataInputFactory, Matcher::DataInputFactory<MatchInput>);
 
-REGISTER_FACTORY(PathMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+REGISTER_FACTORY(PathMatchDataInputFactory, Matcher::DataInputFactory<MatchInput>);
 
-REGISTER_FACTORY(MethodMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+REGISTER_FACTORY(MethodMatchDataInputFactory, Matcher::DataInputFactory<MatchInput>);
 
-REGISTER_FACTORY(PropertyMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+REGISTER_FACTORY(PropertyMatchDataInputFactory, Matcher::DataInputFactory<MatchInput>);
 
-REGISTER_FACTORY(RequestMatchDataInputFactory, Matcher::DataInputFactory<Request>);
+REGISTER_FACTORY(RequestMatchDataInputFactory, Matcher::DataInputFactory<MatchInput>);
 
 using StringMatcherImpl = Matchers::StringMatcherImpl<StringMatcherProto>;
 
@@ -50,10 +50,10 @@ bool RequestMatchInputMatcher::match(const Matcher::MatchingDataType& input) {
     return false;
   }
 
-  return match(typed_data->request());
+  return match(typed_data->data().requestHeader());
 }
 
-bool RequestMatchInputMatcher::match(const Request& request) {
+bool RequestMatchInputMatcher::match(const RequestHeaderFrame& request) {
   // TODO(wbpcode): may add more debug log for request match?
   if (host_ != nullptr) {
     if (!host_->match(request.host())) {

--- a/contrib/generic_proxy/filters/network/source/match_input.h
+++ b/contrib/generic_proxy/filters/network/source/match_input.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+#include "envoy/stream_info/stream_info.h"
+#include <cstdint>
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace GenericProxy {
+
+/**
+ * MatchAction is an enum class that represents the expected action of a matcher.
+ */
+enum class MatchAction : uint8_t {
+  Unknown = 0,
+  RouteAction,
+};
+
+/**
+ * MatchInput is a class that provides the input data for the matchers. It contains the
+ * request header frame and the stream info that are used to match the request.
+ */
+class MatchInput {
+public:
+  MatchInput(const RequestHeaderFrame& request, const StreamInfo::StreamInfo& stream_info,
+             MatchAction expect_action = MatchAction::Unknown)
+      : request_header_(request), stream_info_(stream_info), expect_action_(expect_action) {}
+
+  /**
+   * @return const RequestHeaderFrame& the request header frame that provides the request
+   * attributes.
+   */
+  const RequestHeaderFrame& requestHeader() const { return request_header_; }
+
+  /**
+   * @return const StreamInfo::StreamInfo& the stream info that provides the downstream
+   * stream info and attributes that not available in the request header.
+   */
+  const StreamInfo::StreamInfo& streamInfo() const { return stream_info_; }
+
+  /**
+   * @return MatchAction the expected action of the matcher. This allows the embedded matcher
+   * to know what action is matched for. This make it is possible to do debug logging or
+   * other custom logic based on the expected action.
+   */
+  MatchAction expectAction() const { return expect_action_; }
+
+  // Used for matcher.
+  static constexpr absl::string_view name() { return "generic_proxy_request_input"; }
+
+private:
+  const RequestHeaderFrame& request_header_;
+  const StreamInfo::StreamInfo& stream_info_;
+  const MatchAction expect_action_{};
+};
+
+} // namespace GenericProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/generic_proxy/filters/network/source/match_input.h
+++ b/contrib/generic_proxy/filters/network/source/match_input.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "contrib/generic_proxy/filters/network/source/interface/stream.h"
-#include "envoy/stream_info/stream_info.h"
 #include <cstdint>
+
+#include "envoy/stream_info/stream_info.h"
+
+#include "contrib/generic_proxy/filters/network/source/interface/stream.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -205,7 +205,8 @@ void ActiveStream::continueDecoding() {
   }
 
   if (cached_route_entry_ == nullptr) {
-    cached_route_entry_ = parent_.config_->routeEntry(*request_stream_);
+    const MatchInput match_input(*request_stream_, stream_info_, MatchAction::RouteAction);
+    cached_route_entry_ = parent_.config_->routeEntry(match_input);
     if (cached_route_entry_ != nullptr) {
       auto* cluster =
           parent_.cluster_manager_.getThreadLocalCluster(cached_route_entry_->clusterName());

--- a/contrib/generic_proxy/filters/network/source/proxy.h
+++ b/contrib/generic_proxy/filters/network/source/proxy.h
@@ -76,7 +76,7 @@ public:
         time_source_(context.serverFactoryContext().timeSource()) {}
 
   // FilterConfig
-  RouteEntryConstSharedPtr routeEntry(const Request& request) const override {
+  RouteEntryConstSharedPtr routeEntry(const MatchInput& request) const override {
     auto config = std::static_pointer_cast<const RouteMatcher>(route_config_provider_->config());
     return config->routeEntry(request);
   }

--- a/contrib/generic_proxy/filters/network/source/route.cc
+++ b/contrib/generic_proxy/filters/network/source/route.cc
@@ -77,7 +77,7 @@ VirtualHostImpl::VirtualHostImpl(const ProtoVirtualHost& virtual_host_config,
   RouteActionValidationVisitor validation_visitor;
   RouteActionContext action_context{context};
 
-  Matcher::MatchTreeFactory<Request, RouteActionContext> factory(action_context, context,
+  Matcher::MatchTreeFactory<MatchInput, RouteActionContext> factory(action_context, context,
                                                                  validation_visitor);
 
   matcher_ = factory.create(virtual_host_config.routes())();
@@ -88,8 +88,8 @@ VirtualHostImpl::VirtualHostImpl(const ProtoVirtualHost& virtual_host_config,
   }
 }
 
-RouteEntryConstSharedPtr VirtualHostImpl::routeEntry(const Request& request) const {
-  auto match = Matcher::evaluateMatch<Request>(*matcher_, request);
+RouteEntryConstSharedPtr VirtualHostImpl::routeEntry(const MatchInput& request) const {
+  auto match = Matcher::evaluateMatch<MatchInput>(*matcher_, request);
 
   if (match.result_) {
     auto action = match.result_();
@@ -191,8 +191,8 @@ const VirtualHostImpl* RouteMatcherImpl::findWildcardVirtualHost(
   return nullptr;
 }
 
-const VirtualHostImpl* RouteMatcherImpl::findVirtualHost(const Request& request) const {
-  absl::string_view host = request.host();
+const VirtualHostImpl* RouteMatcherImpl::findVirtualHost(const MatchInput& request) const {
+  absl::string_view host = request.requestHeader().host();
 
   // Fast path the case where we only have a default virtual host or host property is provided.
   if (host.empty() || (virtual_hosts_.empty() && wildcard_virtual_host_suffixes_.empty() &&
@@ -225,7 +225,7 @@ const VirtualHostImpl* RouteMatcherImpl::findVirtualHost(const Request& request)
   return default_virtual_host_.get();
 }
 
-RouteEntryConstSharedPtr RouteMatcherImpl::routeEntry(const Request& request) const {
+RouteEntryConstSharedPtr RouteMatcherImpl::routeEntry(const MatchInput& request) const {
   const auto* virtual_host = findVirtualHost(request);
   if (virtual_host != nullptr) {
     return virtual_host->routeEntry(request);

--- a/contrib/generic_proxy/filters/network/source/route.cc
+++ b/contrib/generic_proxy/filters/network/source/route.cc
@@ -78,7 +78,7 @@ VirtualHostImpl::VirtualHostImpl(const ProtoVirtualHost& virtual_host_config,
   RouteActionContext action_context{context};
 
   Matcher::MatchTreeFactory<MatchInput, RouteActionContext> factory(action_context, context,
-                                                                 validation_visitor);
+                                                                    validation_visitor);
 
   matcher_ = factory.create(virtual_host_config.routes())();
 

--- a/contrib/generic_proxy/filters/network/source/route.h
+++ b/contrib/generic_proxy/filters/network/source/route.h
@@ -19,6 +19,7 @@
 #include "contrib/envoy/extensions/filters/network/generic_proxy/v3/route.pb.validate.h"
 #include "contrib/generic_proxy/filters/network/source/interface/route.h"
 #include "contrib/generic_proxy/filters/network/source/interface/stream.h"
+#include "contrib/generic_proxy/filters/network/source/match_input.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -87,9 +88,9 @@ private:
   RouteEntryConstSharedPtr route_;
 };
 
-class RouteActionValidationVisitor : public Matcher::MatchTreeValidationVisitor<Request> {
+class RouteActionValidationVisitor : public Matcher::MatchTreeValidationVisitor<MatchInput> {
 public:
-  absl::Status performDataInputValidation(const Matcher::DataInputFactory<Request>&,
+  absl::Status performDataInputValidation(const Matcher::DataInputFactory<MatchInput>&,
                                           absl::string_view) override {
     return absl::OkStatus();
   }
@@ -110,7 +111,7 @@ public:
 class NullRouteMatcherImpl : public RouteMatcher {
 public:
   // RouteMatcher
-  RouteEntryConstSharedPtr routeEntry(const Request&) const override { return nullptr; }
+  RouteEntryConstSharedPtr routeEntry(const MatchInput&) const override { return nullptr; }
 };
 
 class VirtualHostImpl : Logger::Loggable<Envoy::Logger::Id::filter> {
@@ -119,12 +120,12 @@ public:
                   Envoy::Server::Configuration::ServerFactoryContext& context,
                   bool validate_clusters_default = false);
 
-  RouteEntryConstSharedPtr routeEntry(const Request& request) const;
+  RouteEntryConstSharedPtr routeEntry(const MatchInput& request) const;
   absl::string_view name() const { return name_; }
 
 private:
   std::string name_;
-  Matcher::MatchTreeSharedPtr<Request> matcher_;
+  Matcher::MatchTreeSharedPtr<MatchInput> matcher_;
 };
 using VirtualHostSharedPtr = std::shared_ptr<VirtualHostImpl>;
 
@@ -134,7 +135,7 @@ public:
                    Envoy::Server::Configuration::ServerFactoryContext& context,
                    bool validate_clusters_default = false);
 
-  RouteEntryConstSharedPtr routeEntry(const Request& request) const override;
+  RouteEntryConstSharedPtr routeEntry(const MatchInput& request) const override;
 
   absl::string_view name() const { return name_; }
 
@@ -146,7 +147,7 @@ private:
                                                  const WildcardVirtualHosts& wildcard_virtual_hosts,
                                                  SubstringFunction substring_function) const;
 
-  const VirtualHostImpl* findVirtualHost(const Request& request) const;
+  const VirtualHostImpl* findVirtualHost(const MatchInput& request) const;
 
   std::string name_;
 

--- a/contrib/generic_proxy/filters/network/test/match_test.cc
+++ b/contrib/generic_proxy/filters/network/test/match_test.cc
@@ -22,12 +22,14 @@ TEST(ServiceMatchDataInputTest, ServiceMatchDataInputTest) {
       factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
 
   FakeStreamCodecFactory::FakeRequest request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  MatchInput match_input(request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_EQ("", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("", absl::get<std::string>(input->get(match_input).data_));
 
   request.host_ = "fake_host_as_service";
 
-  EXPECT_EQ("fake_host_as_service", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("fake_host_as_service", absl::get<std::string>(input->get(match_input).data_));
 }
 
 TEST(HostMatchDataInputTest, HostMatchDataInputTest) {
@@ -38,12 +40,14 @@ TEST(HostMatchDataInputTest, HostMatchDataInputTest) {
       factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
 
   FakeStreamCodecFactory::FakeRequest request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  MatchInput match_input(request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_EQ("", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("", absl::get<std::string>(input->get(match_input).data_));
 
   request.host_ = "fake_host_as_service";
 
-  EXPECT_EQ("fake_host_as_service", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("fake_host_as_service", absl::get<std::string>(input->get(match_input).data_));
 }
 
 TEST(PathMatchDataInputTest, PathMatchDataInputTest) {
@@ -54,12 +58,14 @@ TEST(PathMatchDataInputTest, PathMatchDataInputTest) {
       factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
 
   FakeStreamCodecFactory::FakeRequest request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  MatchInput match_input(request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_EQ("", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("", absl::get<std::string>(input->get(match_input).data_));
 
   request.path_ = "fake_path";
 
-  EXPECT_EQ("fake_path", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("fake_path", absl::get<std::string>(input->get(match_input).data_));
 }
 
 TEST(MethodMatchDataInputTest, MethodMatchDataInputTest) {
@@ -70,12 +76,14 @@ TEST(MethodMatchDataInputTest, MethodMatchDataInputTest) {
       factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
 
   FakeStreamCodecFactory::FakeRequest request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  MatchInput match_input(request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_EQ("", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("", absl::get<std::string>(input->get(match_input).data_));
 
   request.method_ = "fake_method";
 
-  EXPECT_EQ("fake_method", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("fake_method", absl::get<std::string>(input->get(match_input).data_));
 }
 
 TEST(PropertyMatchDataInputTest, PropertyMatchDataInputTest) {
@@ -91,12 +99,14 @@ TEST(PropertyMatchDataInputTest, PropertyMatchDataInputTest) {
       factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
 
   FakeStreamCodecFactory::FakeRequest request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  MatchInput match_input(request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_TRUE(absl::holds_alternative<absl::monostate>(input->get(request).data_));
+  EXPECT_TRUE(absl::holds_alternative<absl::monostate>(input->get(match_input).data_));
 
   request.data_["key_0"] = "value_0";
 
-  EXPECT_EQ("value_0", absl::get<std::string>(input->get(request).data_));
+  EXPECT_EQ("value_0", absl::get<std::string>(input->get(match_input).data_));
 }
 
 TEST(RequestMatchDataInputTest, RequestMatchDataInputTest) {
@@ -107,12 +117,15 @@ TEST(RequestMatchDataInputTest, RequestMatchDataInputTest) {
       factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
 
   FakeStreamCodecFactory::FakeRequest request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  MatchInput match_input(request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_EQ(
-      &request,
-      &dynamic_cast<const RequestMatchData*>(
-           absl::get<std::shared_ptr<Matcher::CustomMatchData>>(input->get(request).data_).get())
-           ->request());
+  EXPECT_EQ(&request,
+            &dynamic_cast<const RequestMatchData*>(
+                 absl::get<std::shared_ptr<Matcher::CustomMatchData>>(input->get(match_input).data_)
+                     .get())
+                 ->data()
+                 .requestHeader());
 }
 
 TEST(RequestMatchInputMatcherTest, RequestMatchInputMatcherTest) {
@@ -134,7 +147,10 @@ TEST(RequestMatchInputMatcherTest, RequestMatchInputMatcherTest) {
 
   {
     FakeStreamCodecFactory::FakeRequest request;
-    Matcher::MatchingDataType input = std::make_shared<RequestMatchData>(request);
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    MatchInput match_input(request, stream_info, MatchAction::RouteAction);
+
+    Matcher::MatchingDataType input = std::make_shared<RequestMatchData>(match_input);
     EXPECT_TRUE(matcher->match(input));
   }
 }

--- a/contrib/generic_proxy/filters/network/test/mocks/route.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/route.h
@@ -34,7 +34,7 @@ class MockRouteMatcher : public RouteMatcher {
 public:
   MockRouteMatcher();
 
-  MOCK_METHOD(RouteEntryConstSharedPtr, routeEntry, (const Request& request), (const));
+  MOCK_METHOD(RouteEntryConstSharedPtr, routeEntry, (const MatchInput& request), (const));
 
   std::shared_ptr<const testing::NiceMock<MockRouteEntry>> route_entry_{
       std::make_shared<testing::NiceMock<MockRouteEntry>>()};

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -142,8 +142,10 @@ TEST_F(FilterConfigTest, RouteEntry) {
   EXPECT_CALL(*route_matcher_, routeEntry(_)).WillOnce(Return(mock_route_entry_));
 
   FakeStreamCodecFactory::FakeRequest fake_request;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  const MatchInput match_input(fake_request, stream_info, MatchAction::RouteAction);
 
-  EXPECT_EQ(filter_config_->routeEntry(fake_request).get(), mock_route_entry_.get());
+  EXPECT_EQ(filter_config_->routeEntry(match_input).get(), mock_route_entry_.get());
 }
 
 /**

--- a/contrib/generic_proxy/filters/network/test/route_test.cc
+++ b/contrib/generic_proxy/filters/network/test/route_test.cc
@@ -541,18 +541,22 @@ TEST_F(RouteMatcherImplTest, RouteMatch) {
 
   // Exact host searching.
   {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
     FakeStreamCodecFactory::FakeRequest fake_request_0;
     fake_request_0.host_ = "service_0";
     fake_request_0.method_ = "method_0";
     fake_request_0.data_.insert({"key_0", "value_0"});
+    const MatchInput match_input_0(fake_request_0, stream_info, MatchAction::RouteAction);
 
     FakeStreamCodecFactory::FakeRequest fake_request_1;
     fake_request_1.host_ = "service_0";
     fake_request_1.method_ = "method_0";
     fake_request_1.data_.insert({"key_1", "value_1"});
+    const MatchInput match_input_1(fake_request_1, stream_info, MatchAction::RouteAction);
 
-    auto route_entry_0 = route_matcher_->routeEntry(fake_request_0);
-    auto route_entry_1 = route_matcher_->routeEntry(fake_request_1);
+    auto route_entry_0 = route_matcher_->routeEntry(match_input_0);
+    auto route_entry_1 = route_matcher_->routeEntry(match_input_1);
 
     EXPECT_EQ(route_entry_0.get(), route_entry_1.get());
     EXPECT_NE(route_entry_0.get(), nullptr);
@@ -562,18 +566,22 @@ TEST_F(RouteMatcherImplTest, RouteMatch) {
 
   // Prefix host searching.
   {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
     FakeStreamCodecFactory::FakeRequest fake_request_0;
     fake_request_0.host_ = "prefix_service_0";
     fake_request_0.method_ = "method_0";
     fake_request_0.data_.insert({"key_0", "value_0"});
+    const MatchInput match_input_0(fake_request_0, stream_info, MatchAction::RouteAction);
 
     FakeStreamCodecFactory::FakeRequest fake_request_1;
     fake_request_1.host_ = "prefix_service_0";
     fake_request_1.method_ = "method_0";
     fake_request_1.data_.insert({"key_1", "value_1"});
+    const MatchInput match_input_1(fake_request_1, stream_info, MatchAction::RouteAction);
 
-    auto route_entry_0 = route_matcher_->routeEntry(fake_request_0);
-    auto route_entry_1 = route_matcher_->routeEntry(fake_request_1);
+    auto route_entry_0 = route_matcher_->routeEntry(match_input_0);
+    auto route_entry_1 = route_matcher_->routeEntry(match_input_1);
 
     EXPECT_EQ(route_entry_0.get(), route_entry_1.get());
     EXPECT_NE(route_entry_0.get(), nullptr);
@@ -583,18 +591,22 @@ TEST_F(RouteMatcherImplTest, RouteMatch) {
 
   // Suffix host searching.
   {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
     FakeStreamCodecFactory::FakeRequest fake_request_0;
     fake_request_0.host_ = "service_0_suffix";
     fake_request_0.method_ = "method_0";
     fake_request_0.data_.insert({"key_0", "value_0"});
+    const MatchInput match_input_0(fake_request_0, stream_info, MatchAction::RouteAction);
 
     FakeStreamCodecFactory::FakeRequest fake_request_1;
     fake_request_1.host_ = "service_0_suffix";
     fake_request_1.method_ = "method_0";
     fake_request_1.data_.insert({"key_1", "value_1"});
+    const MatchInput match_input_1(fake_request_1, stream_info, MatchAction::RouteAction);
 
-    auto route_entry_0 = route_matcher_->routeEntry(fake_request_0);
-    auto route_entry_1 = route_matcher_->routeEntry(fake_request_1);
+    auto route_entry_0 = route_matcher_->routeEntry(match_input_0);
+    auto route_entry_1 = route_matcher_->routeEntry(match_input_1);
 
     EXPECT_EQ(route_entry_0.get(), route_entry_1.get());
     EXPECT_NE(route_entry_0.get(), nullptr);
@@ -604,18 +616,22 @@ TEST_F(RouteMatcherImplTest, RouteMatch) {
 
   // Catch all host.
   {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
     FakeStreamCodecFactory::FakeRequest fake_request_0;
     fake_request_0.host_ = "any_service";
     fake_request_0.method_ = "method_0";
     fake_request_0.data_.insert({"catch_all", "catch_all"});
+    const MatchInput match_input_0(fake_request_0, stream_info, MatchAction::RouteAction);
 
     FakeStreamCodecFactory::FakeRequest fake_request_1;
     fake_request_1.host_ = "any_service";
     fake_request_1.method_ = "method_0";
     fake_request_1.data_.insert({"catch_all", "catch_all"});
+    const MatchInput match_input_1(fake_request_1, stream_info, MatchAction::RouteAction);
 
-    auto route_entry_0 = route_matcher_->routeEntry(fake_request_0);
-    auto route_entry_1 = route_matcher_->routeEntry(fake_request_1);
+    auto route_entry_0 = route_matcher_->routeEntry(match_input_0);
+    auto route_entry_1 = route_matcher_->routeEntry(match_input_1);
 
     EXPECT_EQ(route_entry_0.get(), route_entry_1.get());
     EXPECT_NE(route_entry_0.get(), nullptr);
@@ -629,6 +645,7 @@ TEST_F(RouteMatcherImplTest, RouteMatch) {
  */
 TEST_F(RouteMatcherImplTest, RouteNotMatch) {
   initialize(RouteConfigurationYaml);
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   // Test the service not match.
   {
@@ -636,8 +653,9 @@ TEST_F(RouteMatcherImplTest, RouteNotMatch) {
     fake_request.host_ = "prefix_service_1";
     fake_request.method_ = "method_0";
     fake_request.data_.insert({"key_0", "value_0"});
+    const MatchInput match_input(fake_request, stream_info, MatchAction::RouteAction);
 
-    EXPECT_EQ(nullptr, route_matcher_->routeEntry(fake_request));
+    EXPECT_EQ(nullptr, route_matcher_->routeEntry(match_input));
   }
 
   // Test the method not match.
@@ -646,8 +664,9 @@ TEST_F(RouteMatcherImplTest, RouteNotMatch) {
     fake_request.host_ = "service_0";
     fake_request.method_ = "method_x";
     fake_request.data_.insert({"key_0", "value_0"});
+    const MatchInput match_input(fake_request, stream_info, MatchAction::RouteAction);
 
-    EXPECT_EQ(nullptr, route_matcher_->routeEntry(fake_request));
+    EXPECT_EQ(nullptr, route_matcher_->routeEntry(match_input));
   }
 
   // Test the headers not match.
@@ -655,7 +674,9 @@ TEST_F(RouteMatcherImplTest, RouteNotMatch) {
     FakeStreamCodecFactory::FakeRequest fake_request;
     fake_request.host_ = "service_0";
     fake_request.method_ = "method_0";
-    EXPECT_EQ(nullptr, route_matcher_->routeEntry(fake_request));
+    const MatchInput match_input(fake_request, stream_info, MatchAction::RouteAction);
+
+    EXPECT_EQ(nullptr, route_matcher_->routeEntry(match_input));
   }
 }
 
@@ -722,6 +743,7 @@ virtual_hosts:
 
 TEST_F(RouteMatcherImplTest, NoHostMatch) {
   initialize(RouteConfigurationYamlWithoutDefaultHost);
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   // Test the host not match.
   {
@@ -729,8 +751,9 @@ TEST_F(RouteMatcherImplTest, NoHostMatch) {
     fake_request.host_ = "any_service";
     fake_request.method_ = "method_0";
     fake_request.data_.insert({"key_0", "value_0"});
+    const MatchInput match_input(fake_request, stream_info, MatchAction::RouteAction);
 
-    EXPECT_EQ(nullptr, route_matcher_->routeEntry(fake_request));
+    EXPECT_EQ(nullptr, route_matcher_->routeEntry(match_input));
   }
 }
 


### PR DESCRIPTION
Commit Message: generic proxy: enhance match input data to support more attributes
Additional Description:

Extended the match input of generic proxy to use both request and stream info. This provide more possible flexible matching.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.