### PR TITLE
Fix //test/common/common:bit_array_test on s390x

### DIFF
--- a/source/common/common/bit_array.h
+++ b/source/common/common/bit_array.h
@@ -129,13 +129,14 @@ private:
   }
 
   static inline void storeUnsignedWord(void* destination, uint64_t value) {
+    value = htole64(value);
     safeMemcpyUnsafeDst(destination, &value);
   }
 
   static inline uint64_t loadUnsignedWord(const void* source) {
     uint64_t destination;
     safeMemcpyUnsafeSrc(&destination, source);
-    return destination;
+    return le64toh(destination);
   }
 
   // Backing storage for the underlying array of bits.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: //test/common/common:bit_array_test fails on big endian(s390x) as safeMemcpyUnsafeDst doesn't return expected values.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
