### PR TITLE
Fix //test/common/network:multi_connection_base_impl_test on big endian

### DIFF
--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -297,7 +297,8 @@ TEST_F(MultiConnectionBaseImplTest, HashKey) {
   startConnect();
 
   std::vector<uint8_t> hash_key = {'A', 'B', 'C'};
-  uint8_t* id_array = reinterpret_cast<uint8_t*>(&id);
+  uint8_t id_array[sizeof(id)];
+  absl::little_endian::Store64(id_array, id);
   impl_->hashKey(hash_key);
   EXPECT_EQ(3 + sizeof(id), hash_key.size());
   EXPECT_EQ('A', hash_key[0]);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: The Hashkey subtest fais when comparing the specific elements in id_array and hash_key vector. Byte-swapping the id_array resolves the issue. Little endian platforms are not affected by this change.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
