### PR TITLE
Fix //test/common/websocket:codec_test on big endian

### DIFF
--- a/source/common/websocket/codec.cc
+++ b/source/common/websocket/codec.cc
@@ -128,7 +128,11 @@ uint8_t Decoder::doDecodeExtendedLength(absl::Span<const uint8_t>& data) {
   num_remaining_extended_length_bytes_ -= bytes_to_decode;
 
   if (num_remaining_extended_length_bytes_ == 0) {
+#if ABSL_IS_BIG_ENDIAN
+    length_ = state_ == State::FrameHeaderExtendedLength16Bit ? htole16(le64toh(length_)) : length_;
+#else
     length_ = state_ == State::FrameHeaderExtendedLength16Bit ? htobe16(length_) : htobe64(length_);
+#endif
     if (num_remaining_masking_key_bytes_ > 0) {
       state_ = State::FrameHeaderMaskingKey;
     } else {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: As length is set using memcpy and further processed as per LE format, the test fails on s390x(big endian). Little endian platforms are not affected by this change.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
