### PR TITLE
Fix zipkin_test on big-endian systems

### DIFF
--- a/test/extensions/tracers/zipkin/span_buffer_test.cc
+++ b/test/extensions/tracers/zipkin/span_buffer_test.cc
@@ -327,7 +327,11 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
   EXPECT_EQ(withDefaultTimestampAndDuration("{"
                                             R"("spans":[{)"
                                             R"("traceId":"AAAAAAAAAAE=",)"
+#ifdef ABSL_IS_BIG_ENDIAN
+                                            R"("id":"AAAAAAAAAAE=",)"
+#else
                                             R"("id":"AQAAAAAAAAA=",)"
+#endif
                                             R"("kind":"CLIENT",)"
                                             R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
@@ -346,7 +350,11 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                 "{"
                 R"("spans":[{)"
                 R"("traceId":"AAAAAAAAAAE=",)"
+#ifdef ABSL_IS_BIG_ENDIAN
+                R"("id":"AAAAAAAAAAE=",)"
+#else
                 R"("id":"AQAAAAAAAAA=",)"
+#endif
                 R"("kind":"CLIENT",)"
                 R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                 R"("duration":"DEFAULT_TEST_DURATION",)"
@@ -365,7 +373,11 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
   EXPECT_EQ(withDefaultTimestampAndDuration("{"
                                             R"("spans":[{)"
                                             R"("traceId":"AAAAAAAAAAE=",)"
+#ifdef ABSL_IS_BIG_ENDIAN
+                                            R"("id":"AAAAAAAAAAE=",)"
+#else
                                             R"("id":"AQAAAAAAAAA=",)"
+#endif
                                             R"("kind":"CLIENT",)"
                                             R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
@@ -377,7 +389,11 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("response_size":"DEFAULT_TEST_DURATION"}},)"
                                             R"({)"
                                             R"("traceId":"AAAAAAAAAAE=",)"
+#ifdef ABSL_IS_BIG_ENDIAN
+                                            R"("id":"AAAAAAAAAAE=",)"
+#else
                                             R"("id":"AQAAAAAAAAA=",)"
+#endif
                                             R"("kind":"SERVER",)"
                                             R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
@@ -396,7 +412,11 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
   EXPECT_EQ(withDefaultTimestampAndDuration("{"
                                             R"("spans":[{)"
                                             R"("traceId":"AAAAAAAAAAE=",)"
+#ifdef ABSL_IS_BIG_ENDIAN
+                                            R"("id":"AAAAAAAAAAE=",)"
+#else
                                             R"("id":"AQAAAAAAAAA=",)"
+#endif
                                             R"("kind":"CLIENT",)"
                                             R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
@@ -408,7 +428,11 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("response_size":"DEFAULT_TEST_DURATION"}},)"
                                             R"({)"
                                             R"("traceId":"AAAAAAAAAAE=",)"
+#ifdef ABSL_IS_BIG_ENDIAN
+                                            R"("id":"AAAAAAAAAAE=",)"
+#else
                                             R"("id":"AQAAAAAAAAA=",)"
+#endif
                                             R"("kind":"SERVER",)"
                                             R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix //test/extensions/tracers/zipkin:zipkin_test on big-endian systems.

Additional Description: The subtest "ZipkinSpanBufferTest.SerializeSpan" was failing due to discrepancies in the id field of the expected JSON string and the serialized JSON representation. The expected id was `AQAAAAAAAAA=` but we were getting `AAAAAAAAAAE=` on s390x. This was only occurring when serializing the buffer with HTTP_PROTO whereas HTTP_JSON was working fine. On checking more into the serialized MessageToJsonString, I found that the hexadecimal representation of id was `id: "\000\000\000\000\000\000\000\001"`  which is `id:"AAAAAAAAAAE="` on s390x and that on Intel was ` id: "\001\000\000\000\000\000\000\000"` which is  `id:"AQAAAAAAAAA="` . Further found that this is occurring due to endianness, and the value of id on both Intel and s390x is same in respective endianness and because the expected content is hard coded in little-endian format, it was failing on big-endian system.

Signed-off-by: Pandurang Khandeparker <PANDURANG.KHANDEPARKER@ibm.com>

Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
