### PR TITLE
generic proxy: change the encoding interface to sync mode

### DIFF
--- a/contrib/generic_proxy/filters/network/source/codecs/http1/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/http1/config.cc
@@ -434,12 +434,12 @@ Http::Http1::CallbackResult Http1ServerCodec::onMessageCompleteImpl() {
   return Http::Http1::CallbackResult::Success;
 }
 
-void Http1ServerCodec::encode(const StreamFrame& frame, EncodingCallbacks& callbacks) {
+EncodingResult Http1ServerCodec::encode(const StreamFrame& frame, EncodingContext&) {
   const bool response_end_stream = frame.frameFlags().endStream();
 
   if (auto* headers = dynamic_cast<const HttpResponseFrame*>(&frame); headers != nullptr) {
-    ENVOY_LOG(debug, "encoding response headers (end_stream={}):\n{}", response_end_stream,
-              *headers->response_);
+    ENVOY_LOG(debug, "Generic proxy HTTP1 codec: encoding response headers (end_stream={}):\n{}",
+              response_end_stream, *headers->response_);
 
     active_request_->response_chunk_encoding_ =
         Utility::isChunked(*headers->response_, response_end_stream);
@@ -449,8 +449,7 @@ void Http1ServerCodec::encode(const StreamFrame& frame, EncodingCallbacks& callb
     if (!status.ok()) {
       ENVOY_LOG(error, "Generic proxy HTTP1 codec: failed to encode response headers: {}",
                 status.message());
-      callbacks_->connection()->close(Network::ConnectionCloseType::FlushWrite);
-      return;
+      return status;
     }
 
     // Encode the optional buffer if it exists. This is used for local response or for the
@@ -462,27 +461,31 @@ void Http1ServerCodec::encode(const StreamFrame& frame, EncodingCallbacks& callb
     }
 
   } else if (auto* body = dynamic_cast<const HttpRawBodyFrame*>(&frame); body != nullptr) {
-    ENVOY_LOG(debug, "encoding response body (end_stream={} size={})", response_end_stream,
-              body->buffer().length());
+    ENVOY_LOG(debug, "Generic proxy HTTP1 codec: encoding response body (end_stream={} size={})",
+              response_end_stream, body->buffer().length());
     Utility::encodeBody(encoding_buffer_, body->buffer(), active_request_->response_chunk_encoding_,
                         response_end_stream);
   }
 
-  callbacks.onEncodingSuccess(encoding_buffer_, response_end_stream);
+  const uint64_t encoded_size = encoding_buffer_.length();
+
+  // Send the encoded data to the connection and reset the buffer for the next frame.
+  callbacks_->writeToConnection(encoding_buffer_);
+  ASSERT(encoding_buffer_.length() == 0);
 
   if (response_end_stream) {
     if (active_request_->request_complete_) {
       active_request_.reset();
-      return;
+      return encoded_size;
     }
     ENVOY_LOG(debug, "Generic proxy HTTP1 server codec: response complete before request complete");
-    if (callbacks_->connection().has_value()) {
-      callbacks_->connection()->close(Network::ConnectionCloseType::FlushWrite);
-    }
+    return absl::InvalidArgumentError("response complete before request complete");
   }
+
+  return encoded_size;
 }
 
-void Http1ClientCodec::encode(const StreamFrame& frame, EncodingCallbacks& callbacks) {
+EncodingResult Http1ClientCodec::encode(const StreamFrame& frame, EncodingContext&) {
   const bool request_end_stream = frame.frameFlags().endStream();
 
   if (auto* headers = dynamic_cast<const HttpRequestFrame*>(&frame); headers != nullptr) {
@@ -501,8 +504,7 @@ void Http1ClientCodec::encode(const StreamFrame& frame, EncodingCallbacks& callb
     if (!status.ok()) {
       ENVOY_LOG(error, "Generic proxy HTTP1 codec: failed to encode request headers: {}",
                 status.message());
-      callbacks_->connection()->close(Network::ConnectionCloseType::FlushWrite);
-      return;
+      return status;
     }
 
     // Encode the optional buffer if it exists. This is used for local response or for the
@@ -524,7 +526,13 @@ void Http1ClientCodec::encode(const StreamFrame& frame, EncodingCallbacks& callb
     expect_response_->request_complete_ = true;
   }
 
-  callbacks.onEncodingSuccess(encoding_buffer_, request_end_stream);
+  const uint64_t encoded_size = encoding_buffer_.length();
+
+  // Send the encoded data to the connection and reset the buffer for the next frame.
+  callbacks_->writeToConnection(encoding_buffer_);
+  ASSERT(encoding_buffer_.length() == 0);
+
+  return encoded_size;
 }
 
 Http::Http1::CallbackResult Http1ClientCodec::onMessageBeginImpl() {

--- a/contrib/generic_proxy/filters/network/source/codecs/http1/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/http1/config.h
@@ -291,7 +291,7 @@ public:
       callbacks_->onDecodingFailure();
     }
   }
-  void encode(const StreamFrame& frame, EncodingCallbacks& callbacks) override;
+  EncodingResult encode(const StreamFrame& frame, EncodingContext& ctx) override;
   ResponsePtr respond(absl::Status status, absl::string_view data, const Request&) override {
     auto response = Http::ResponseHeaderMapImpl::create();
     response->setStatus(std::to_string(Utility::statusToHttpStatus(status.code())));
@@ -352,7 +352,7 @@ public:
       callbacks_->onDecodingFailure();
     }
   }
-  void encode(const StreamFrame& frame, EncodingCallbacks& callbacks) override;
+  EncodingResult encode(const StreamFrame& frame, EncodingContext& ctx) override;
 
   void onDecodingSuccess(RequestHeaderFramePtr, absl::optional<StartTime>) override {}
   void onDecodingSuccess(ResponseHeaderFramePtr response_header_frame,

--- a/contrib/generic_proxy/filters/network/source/codecs/kafka/config.cc
+++ b/contrib/generic_proxy/filters/network/source/codecs/kafka/config.cc
@@ -22,23 +22,28 @@ void KafkaServerCodec::decode(Envoy::Buffer::Instance& buffer, bool) {
   request_buffer_.drain(request_buffer_.length());
 }
 
-void KafkaServerCodec::encode(const GenericProxy::StreamFrame& frame,
-                              GenericProxy::EncodingCallbacks& callbacks) {
+GenericProxy::EncodingResult KafkaServerCodec::encode(const GenericProxy::StreamFrame& frame,
+                                                      GenericProxy::EncodingContext&) {
   auto* typed_response = dynamic_cast<const KafkaResponseFrame*>(&frame);
   if (typed_response == nullptr) {
     ENVOY_LOG(error, "Kafka codec: invalid response frame type and cannot encode");
-    return;
+    return absl::InvalidArgumentError("Invalid response frame type");
   }
   if (typed_response->response_ != nullptr) {
     response_encoder_.encode(*typed_response->response_);
   } else {
-    ENVOY_LOG(error, "Kafka codec: invalid empty response frame type and close connection");
-    request_callbacks_->callbacks_.connection()->close(Network::ConnectionCloseType::FlushWrite);
-    return;
+    ENVOY_LOG(error, "Kafka codec: invalid empty response frame");
+    return absl::InvalidArgumentError("Invalid empty response frame");
   }
-  callbacks.onEncodingSuccess(response_buffer_, true);
+
+  const uint64_t encoded_size = response_buffer_.length();
+
+  // Write the encoded data to the connection and clean the buffer for the next encoding.
+  request_callbacks_->callbacks_.writeToConnection(response_buffer_);
   // All data should be consumed by the generic proxy and send to the network.
   ASSERT(response_buffer_.length() == 0);
+
+  return encoded_size;
 }
 GenericProxy::ResponsePtr KafkaServerCodec::respond(absl::Status, absl::string_view,
                                                     const GenericProxy::Request&) {
@@ -60,20 +65,26 @@ void KafkaClientCodec::decode(Envoy::Buffer::Instance& buffer, bool) {
   response_buffer_.drain(response_buffer_.length());
 }
 
-void KafkaClientCodec::encode(const GenericProxy::StreamFrame& frame,
-                              GenericProxy::EncodingCallbacks& callbacks) {
+GenericProxy::EncodingResult KafkaClientCodec::encode(const GenericProxy::StreamFrame& frame,
+                                                      GenericProxy::EncodingContext&) {
   auto* typed_request = dynamic_cast<const KafkaRequestFrame*>(&frame);
   if (typed_request == nullptr) {
     ENVOY_LOG(error, "Kafka codec: invalid request frame type and cannot encode");
-    return;
+    return absl::InvalidArgumentError("Invalid request frame type");
   }
   response_decoder_->expectResponse(typed_request->request_->request_header_.correlation_id_,
                                     typed_request->request_->request_header_.api_key_,
                                     typed_request->request_->request_header_.api_version_);
   request_encoder_.encode(*typed_request->request_);
-  callbacks.onEncodingSuccess(request_buffer_, true);
+
+  const uint64_t encoded_size = request_buffer_.length();
+
+  // Write the encoded data to the connection and clean the buffer for the next encoding.
+  response_callbacks_->callbacks_.writeToConnection(request_buffer_);
   // All data should be consumed by the generic proxy and send to the network.
   ASSERT(request_buffer_.length() == 0);
+
+  return encoded_size;
 }
 
 CodecFactoryPtr

--- a/contrib/generic_proxy/filters/network/source/codecs/kafka/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/kafka/config.h
@@ -91,7 +91,6 @@ public:
     callbacks_.onDecodingFailure();
   }
 
-private:
   GenericProxy::ClientCodecCallbacks& callbacks_;
 };
 
@@ -102,8 +101,8 @@ public:
 
   void setCodecCallbacks(GenericProxy::ServerCodecCallbacks& callbacks) override;
   void decode(Envoy::Buffer::Instance& buffer, bool end_stream) override;
-  void encode(const GenericProxy::StreamFrame& frame,
-              GenericProxy::EncodingCallbacks& callbacks) override;
+  GenericProxy::EncodingResult encode(const GenericProxy::StreamFrame& frame,
+                                      GenericProxy::EncodingContext& ctx) override;
   GenericProxy::ResponsePtr respond(absl::Status, absl::string_view,
                                     const GenericProxy::Request&) override;
 
@@ -123,8 +122,8 @@ public:
 
   void setCodecCallbacks(GenericProxy::ClientCodecCallbacks& callbacks) override;
   void decode(Envoy::Buffer::Instance& buffer, bool end_stream) override;
-  void encode(const GenericProxy::StreamFrame& frame,
-              GenericProxy::EncodingCallbacks& callbacks) override;
+  GenericProxy::EncodingResult encode(const GenericProxy::StreamFrame& frame,
+                                      GenericProxy::EncodingContext& ctx) override;
 
   Envoy::Buffer::OwnedImpl request_buffer_;
   Envoy::Buffer::OwnedImpl response_buffer_;

--- a/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
+++ b/contrib/generic_proxy/filters/network/source/interface/codec_callbacks.h
@@ -149,25 +149,11 @@ public:
 };
 
 /**
- * Callback of request/response frame.
+ * Context of stream that will be used to encode request/response frame.
  */
-class EncodingCallbacks {
+class EncodingContext {
 public:
-  virtual ~EncodingCallbacks() = default;
-
-  /**
-   * If encoding success then this method will be called to write the data to upstream
-   * or downstream connection and notify the generic proxy if the encoding is completed.
-   * @param buffer encoding result buffer.
-   * @param end_stream if last frame is encoded.
-   */
-  virtual void onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) PURE;
-
-  /**
-   * If encoding failure then this method will be called.
-   * @param reason the reason of encoding failure.
-   */
-  virtual void onEncodingFailure(absl::string_view reason = {}) PURE;
+  virtual ~EncodingContext() = default;
 
   /**
    * The route that the request is matched to. This is optional when encoding the response
@@ -178,6 +164,8 @@ public:
    */
   virtual OptRef<const RouteEntry> routeEntry() const PURE;
 };
+
+using EncodingResult = absl::StatusOr<uint64_t>;
 
 } // namespace GenericProxy
 } // namespace NetworkFilters

--- a/contrib/generic_proxy/filters/network/source/interface/filter.h
+++ b/contrib/generic_proxy/filters/network/source/interface/filter.h
@@ -104,13 +104,13 @@ public:
    * Called when the upstream response frame is received. This should only be called once.
    * @param frame supplies the upstream response frame.
    */
-  virtual void onResponseStart(ResponseHeaderFramePtr frame) PURE;
+  virtual void onResponseHeaderFrame(ResponseHeaderFramePtr frame) PURE;
 
   /**
    * Called when the upstream response frame is received.
    * @param frame supplies the upstream frame.
    */
-  virtual void onResponseFrame(ResponseCommonFramePtr frame) PURE;
+  virtual void onResponseCommonFrame(ResponseCommonFramePtr frame) PURE;
 
   /**
    * Register a request frames handler to used to handle the request frames (except the special

--- a/contrib/generic_proxy/filters/network/source/interface/stream.h
+++ b/contrib/generic_proxy/filters/network/source/interface/stream.h
@@ -132,9 +132,21 @@ public:
   virtual FrameFlags frameFlags() const { return {}; }
 };
 
+/**
+ * Common frame that used to represent any data or structure of L7 protocols. No specific
+ * interface is provided for the common frame.
+ */
 class CommonFrame : public StreamFrame {};
 using CommonFramePtr = std::unique_ptr<CommonFrame>;
 
+/**
+ * Header frame of generic request or response. This provide some basic interfaces that are
+ * used to get/set attributes of the request or response.
+ * NOTE: Header frame should always be the first frame of the request or response. And there
+ * has no requirement that the header frame could only contain the 'header' of L7 protocols.
+ * For example, for short HTTP request, the header frame could contain the whole request
+ * header map, body, and even trailer.
+ */
 class HeaderFrame : public StreamFrame {
 public:
   using IterateCallback = std::function<bool(absl::string_view key, absl::string_view val)>;
@@ -186,10 +198,6 @@ using StreamBase = HeaderFrame;
 /**
  * Interface of generic request. This is derived from StreamFrame that contains the request
  * specific information. First frame of the request MUST be a RequestHeaderFrame.
- *
- * NOTE: using interface that provided by the TraceContext as the interface of generic request
- * here to simplify the tracing integration. This is not a good design. This should be changed
- * in the future.
  */
 class RequestHeaderFrame : public HeaderFrame {
 public:

--- a/contrib/generic_proxy/filters/network/source/proxy.cc
+++ b/contrib/generic_proxy/filters/network/source/proxy.cc
@@ -128,15 +128,13 @@ void ActiveStream::resetStream(DownstreamStreamResetReason reason) {
   completeRequest();
 }
 
-void ActiveStream::sendResponseStartToDownstream() {
+void ActiveStream::sendHeaderFrameToDownstream() {
   ASSERT(response_stream_ != nullptr);
   response_filter_chain_complete_ = true;
-  // The first frame of response is sent.
-  stream_info_.downstreamTiming().onFirstDownstreamTxByteSent(parent_.time_source_);
-  parent_.sendFrameToDownstream(*response_stream_, *this);
+  sendFrameToDownstream(*response_stream_, true);
 }
 
-void ActiveStream::sendResponseFrameToDownstream() {
+void ActiveStream::sendCommonFrameToDownstream() {
   if (!response_filter_chain_complete_) {
     // Wait for the response header frame to be sent first. It may be blocked by
     // the filter chain.
@@ -149,8 +147,39 @@ void ActiveStream::sendResponseFrameToDownstream() {
     response_stream_frames_.pop_front();
 
     // Send the frame to downstream.
-    parent_.sendFrameToDownstream(*frame, *this);
+    if (!sendFrameToDownstream(*frame, false)) {
+      break;
+    }
   }
+}
+
+bool ActiveStream::sendFrameToDownstream(const StreamFrame& frame, bool header_frame) {
+  const bool end_stream = frame.frameFlags().endStream();
+
+  const auto result = parent_.server_codec_->encode(frame, *this);
+  if (!result.ok()) {
+    ENVOY_LOG(error, "Generic proxy: response encoding failure: {}", result.status().message());
+    resetStream(DownstreamStreamResetReason::ProtocolError);
+    return false;
+  }
+
+  ENVOY_LOG(debug, "Generic proxy: send {} bytes to client, complete: {}", result.value(),
+            end_stream);
+
+  if (header_frame) {
+    stream_info_.downstreamTiming().onFirstDownstreamTxByteSent(parent_.time_source_);
+  }
+
+  // If the request is fully sent, record the last downstream tx byte sent time and clean
+  // up the stream.
+  if (end_stream) {
+    stream_info_.downstreamTiming().onLastDownstreamTxByteSent(parent_.time_source_);
+
+    ASSERT(response_stream_end_);
+    ASSERT(response_stream_frames_.empty());
+    completeRequest();
+  }
+  return true;
 }
 
 void ActiveStream::sendRequestFrameToUpstream() {
@@ -196,7 +225,7 @@ void ActiveStream::sendLocalReply(Status status, absl::string_view data,
   // Set the response code to the stream info.
   stream_info_.setResponseCode(response_stream_->status().code());
 
-  sendResponseStartToDownstream();
+  sendHeaderFrameToDownstream();
 }
 
 void ActiveStream::continueDecoding() {
@@ -250,7 +279,7 @@ void ActiveStream::onRequestFrame(RequestCommonFramePtr request_common_frame) {
   sendRequestFrameToUpstream();
 }
 
-void ActiveStream::onResponseStart(ResponsePtr response) {
+void ActiveStream::onResponseHeaderFrame(ResponsePtr response) {
   ASSERT(response_stream_ == nullptr);
   response_stream_ = std::move(response);
   ASSERT(response_stream_ != nullptr);
@@ -264,11 +293,11 @@ void ActiveStream::onResponseStart(ResponsePtr response) {
   continueEncoding();
 }
 
-void ActiveStream::onResponseFrame(ResponseCommonFramePtr response_common_frame) {
+void ActiveStream::onResponseCommonFrame(ResponseCommonFramePtr response_common_frame) {
   response_stream_end_ = response_common_frame->frameFlags().endStream();
   response_stream_frames_.emplace_back(std::move(response_common_frame));
   // Try to send the frame to downstream immediately.
-  sendResponseFrameToDownstream();
+  sendCommonFrameToDownstream();
 }
 
 void ActiveStream::completeDirectly() {
@@ -297,33 +326,9 @@ void ActiveStream::continueEncoding() {
 
   if (next_encoder_filter_index_ == encoder_filters_.size()) {
     ENVOY_LOG(debug, "Complete encoder filters");
-    sendResponseStartToDownstream();
-    sendResponseFrameToDownstream();
+    sendHeaderFrameToDownstream();
+    sendCommonFrameToDownstream();
   }
-}
-
-void ActiveStream::onEncodingSuccess(Buffer::Instance& buffer, bool end_stream) {
-  ASSERT(parent_.downstreamConnection().state() == Network::Connection::State::Open);
-  parent_.downstreamConnection().write(buffer, false);
-
-  if (!end_stream) {
-    return;
-  }
-
-  // The response is fully sent.
-  stream_info_.downstreamTiming().onLastDownstreamTxByteSent(parent_.time_source_);
-
-  ENVOY_LOG(debug, "Generic proxy: downstream response complete");
-
-  ASSERT(response_stream_end_);
-  ASSERT(response_stream_frames_.empty());
-
-  completeRequest();
-}
-
-void ActiveStream::onEncodingFailure(absl::string_view reason) {
-  ENVOY_LOG(error, "Generic proxy: response encoding failure: {}", reason);
-  resetStream(DownstreamStreamResetReason::ProtocolError);
 }
 
 void ActiveStream::initializeFilterChain(FilterChainFactory& factory) {
@@ -437,10 +442,6 @@ OptRef<Network::Connection> Filter::connection() {
     return {};
   }
   return {downstreamConnection()};
-}
-
-void Filter::sendFrameToDownstream(StreamFrame& frame, EncodingCallbacks& callbacks) {
-  server_codec_->encode(frame, callbacks);
 }
 
 void Filter::registerFrameHandler(uint64_t stream_id, ActiveStream* raw_stream) {

--- a/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/dubbo/config_test.cc
@@ -243,15 +243,15 @@ TEST(DubboServerCodecTest, DubboServerCodecTest) {
   // Encode response.
   {
 
-    MockEncodingCallbacks encoding_callbacks;
+    MockEncodingContext encoding_context;
     DubboRequest request(createDubboRequst(false));
     DubboResponse response(
         createDubboResponse(request, ResponseStatus::Ok, RpcResponseType::ResponseWithValue));
 
     EXPECT_CALL(*raw_serializer, serializeRpcResponse(_, _));
-    EXPECT_CALL(encoding_callbacks, onEncodingSuccess(_, _));
+    EXPECT_CALL(callbacks, writeToConnection(_));
 
-    server_codec.encode(response, encoding_callbacks);
+    EXPECT_TRUE(server_codec.encode(response, encoding_context).ok());
   }
 
   {
@@ -368,26 +368,26 @@ TEST(DubboClientCodecTest, DubboClientCodecTest) {
 
   // Encode normal request.
   {
-    MockEncodingCallbacks encoding_callbacks;
+    MockEncodingContext encoding_context;
 
     DubboRequest request(createDubboRequst(false));
 
     EXPECT_CALL(*raw_serializer, serializeRpcRequest(_, _));
-    EXPECT_CALL(encoding_callbacks, onEncodingSuccess(_, _));
+    EXPECT_CALL(callbacks, writeToConnection(_));
 
-    client_codec.encode(request, encoding_callbacks);
+    EXPECT_TRUE(client_codec.encode(request, encoding_context).ok());
   }
 
   // Encode one-way request.
   {
-    MockEncodingCallbacks encoding_callbacks;
+    MockEncodingContext encoding_context;
 
     DubboRequest request(createDubboRequst(true));
 
     EXPECT_CALL(*raw_serializer, serializeRpcRequest(_, _));
-    EXPECT_CALL(encoding_callbacks, onEncodingSuccess(_, _));
+    EXPECT_CALL(callbacks, writeToConnection(_));
 
-    client_codec.encode(request, encoding_callbacks);
+    EXPECT_TRUE(client_codec.encode(request, encoding_context).ok());
   }
 }
 

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -178,7 +178,7 @@ public:
       }
     }
 
-    void encode(const StreamFrame& response, EncodingCallbacks& callback) override {
+    EncodingResult encode(const StreamFrame& response, EncodingContext&) override {
       std::string buffer;
       buffer.reserve(512);
       buffer += "FAKE-RSP|";
@@ -212,7 +212,11 @@ public:
       encoding_buffer_.writeBEInt<uint32_t>(buffer.size());
       encoding_buffer_.add(buffer);
 
-      callback.onEncodingSuccess(encoding_buffer_, response.frameFlags().endStream());
+      const uint64_t encoded_size = encoding_buffer_.length();
+
+      callback_->writeToConnection(encoding_buffer_);
+
+      return encoded_size;
     }
 
     ResponsePtr respond(Status status, absl::string_view, const Request&) override {
@@ -332,7 +336,7 @@ public:
       }
     }
 
-    void encode(const StreamFrame& request, EncodingCallbacks& callback) override {
+    EncodingResult encode(const StreamFrame& request, EncodingContext&) override {
       std::string buffer;
       buffer.reserve(512);
       buffer += "FAKE-REQ|";
@@ -366,7 +370,11 @@ public:
       encoding_buffer_.writeBEInt<uint32_t>(buffer.size());
       encoding_buffer_.add(buffer);
 
-      callback.onEncodingSuccess(encoding_buffer_, request.frameFlags().endStream());
+      const uint64_t encoded_size = encoding_buffer_.length();
+
+      callback_->writeToConnection(encoding_buffer_);
+
+      return encoded_size;
     }
 
     absl::optional<uint32_t> message_size_;

--- a/contrib/generic_proxy/filters/network/test/mocks/filter.h
+++ b/contrib/generic_proxy/filters/network/test/mocks/filter.h
@@ -108,8 +108,8 @@ public:
 
   MOCK_METHOD(void, sendLocalReply, (Status, absl::string_view, ResponseUpdateFunction));
   MOCK_METHOD(void, continueDecoding, ());
-  MOCK_METHOD(void, onResponseStart, (ResponseHeaderFramePtr));
-  MOCK_METHOD(void, onResponseFrame, (ResponseCommonFramePtr));
+  MOCK_METHOD(void, onResponseHeaderFrame, (ResponseHeaderFramePtr));
+  MOCK_METHOD(void, onResponseCommonFrame, (ResponseCommonFramePtr));
   MOCK_METHOD(void, setRequestFramesHandler, (RequestFramesHandler&));
   MOCK_METHOD(void, completeDirectly, ());
 };

--- a/contrib/generic_proxy/filters/network/test/proxy_test.cc
+++ b/contrib/generic_proxy/filters/network/test/proxy_test.cc
@@ -188,19 +188,19 @@ public:
         .WillOnce(Return(ByMove(std::move(server_codec))));
 
     EXPECT_CALL(*server_codec_, setCodecCallbacks(_))
-        .WillOnce(
-            Invoke([this](ServerCodecCallbacks& callback) { decoder_callback_ = &callback; }));
+        .WillOnce(Invoke(
+            [this](ServerCodecCallbacks& callback) { server_codec_callbacks_ = &callback; }));
 
     filter_ = std::make_shared<Filter>(filter_config_, factory_context_);
 
-    EXPECT_EQ(filter_.get(), decoder_callback_);
+    EXPECT_EQ(filter_.get(), server_codec_callbacks_);
 
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
 
   std::shared_ptr<Filter> filter_;
 
-  ServerCodecCallbacks* decoder_callback_{};
+  ServerCodecCallbacks* server_codec_callbacks_{};
 
   NiceMock<MockServerCodec>* server_codec_{};
 
@@ -230,7 +230,7 @@ TEST_F(FilterTest, OnDecodingFailureWithoutActiveStreams) {
   filter_->onData(fake_empty_buffer, false);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(_));
-  decoder_callback_->onDecodingFailure();
+  server_codec_callbacks_->onDecodingFailure();
 
   EXPECT_EQ(filter_config_->stats().downstream_rq_decoding_error_.value(), 1);
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 0);
@@ -256,7 +256,7 @@ TEST_F(FilterTest, OnDecodingSuccessWithNormalRequest) {
   // Three mock factories was added.
   EXPECT_CALL(*mock_stream_filter, onStreamDecoded(_)).Times(3);
 
-  decoder_callback_->onDecodingSuccess(std::move(request));
+  server_codec_callbacks_->onDecodingSuccess(std::move(request));
 
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 1);
   EXPECT_EQ(filter_config_->stats().downstream_rq_active_.value(), 1);
@@ -279,32 +279,6 @@ TEST_F(FilterTest, OnConnectionClosedEvent) {
 
   // Return directly.
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(fake_empty_buffer, false));
-}
-
-TEST_F(FilterTest, SendReplyDownstream) {
-  initializeFilter();
-
-  NiceMock<MockEncodingCallbacks> encoder_callback;
-
-  auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-
-  Buffer::OwnedImpl response_buffer;
-
-  EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
-
-  EXPECT_CALL(encoder_callback, onEncodingSuccess(_, _))
-      .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) {
-        filter_callbacks_.connection_.write(buffer, false);
-      }));
-
-  EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) {
-        Buffer::OwnedImpl buffer;
-        buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
-      }));
-
-  filter_->sendFrameToDownstream(*response, encoder_callback);
 }
 
 TEST_F(FilterTest, GetConnection) {
@@ -404,7 +378,7 @@ TEST_F(FilterTest, OnDecodingFailureWithActiveStreams) {
   filter_->onData(fake_empty_buffer, false);
 
   EXPECT_CALL(filter_callbacks_.connection_, close(_));
-  decoder_callback_->onDecodingFailure();
+  server_codec_callbacks_->onDecodingFailure();
 
   EXPECT_EQ(0, filter_->activeStreamsForTest().size());
 
@@ -434,8 +408,10 @@ TEST_F(FilterTest, OnEncodingFailureWithActiveStreams) {
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 2);
   EXPECT_EQ(filter_config_->stats().downstream_rq_active_.value(), 2);
 
-  // One of stream encoding failed.
-  filter_->activeStreamsForTest().begin()->get()->onEncodingFailure();
+  EXPECT_CALL(*server_codec_, encode(_, _))
+      .WillOnce(Return(EncodingResult{absl::InvalidArgumentError("encoding-error")}));
+  auto response_0 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
+  filter_->activeStreamsForTest().begin()->get()->onResponseHeaderFrame(std::move(response_0));
 
   EXPECT_EQ(1, filter_->activeStreamsForTest().size());
 
@@ -672,8 +648,8 @@ TEST_F(FilterTest, ActiveStreamFiltersContinueEncoding) {
   EXPECT_EQ(0, active_stream->nextEncoderFilterIndexForTest());
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  // `continueEncoding` will be called in the `onResponseStart`.
-  active_stream->onResponseStart(std::move(response));
+  // `continueEncoding` will be called in the `onResponseHeaderFrame`.
+  active_stream->onResponseHeaderFrame(std::move(response));
 
   // Encoding will be stopped when `onStreamEncoded` of `mock_stream_filter_1` is called.
   EXPECT_EQ(2, active_stream->nextEncoderFilterIndexForTest());
@@ -681,10 +657,14 @@ TEST_F(FilterTest, ActiveStreamFiltersContinueEncoding) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
 
   EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) {
+      .WillOnce(Invoke([&](const StreamFrame&, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   active_stream->encoderFiltersForTest()[1]->continueEncoding();
@@ -727,12 +707,16 @@ TEST_F(FilterTest, ActiveStreamSendLocalReply) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
 
   EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame& response, EncodingCallbacks& callback) {
+      .WillOnce(Invoke([&](const StreamFrame& response, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         EXPECT_EQ(dynamic_cast<const Response*>(&response)->status().code(),
                   static_cast<uint32_t>(StatusCode::kUnknown));
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   active_stream->sendLocalReply(
@@ -815,10 +799,14 @@ TEST_F(FilterTest, NewStreamAndReplyNormally) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
 
   EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) {
+      .WillOnce(Invoke([&](const StreamFrame&, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   EXPECT_CALL(*factory_context_.server_factory_context_.access_log_manager_.file_,
@@ -832,7 +820,7 @@ TEST_F(FilterTest, NewStreamAndReplyNormally) {
   response->status_ = {0, true};
   response->data_["response-key"] = "response-value";
 
-  active_stream->onResponseStart(std::move(response));
+  active_stream->onResponseHeaderFrame(std::move(response));
 
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 1);
   EXPECT_EQ(filter_config_->stats().downstream_rq_active_.value(), 0);
@@ -902,10 +890,14 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithMultipleFrames) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false)).Times(2);
   EXPECT_CALL(*server_codec_, encode(_, _))
       .Times(2)
-      .WillRepeatedly(Invoke([&](const StreamFrame& frame, EncodingCallbacks& callback) {
+      .WillRepeatedly(Invoke([&](const StreamFrame&, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, frame.frameFlags().endStream());
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
@@ -913,12 +905,12 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithMultipleFrames) {
   response->stream_frame_flags_ = FrameFlags(StreamFlags(), false);
   response->status_ = {123, false}; // Response non-OK.
 
-  active_stream->onResponseStart(std::move(response));
+  active_stream->onResponseHeaderFrame(std::move(response));
 
   auto response_frame_1 = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
   response_frame_1->stream_frame_flags_ = FrameFlags(StreamFlags(), true);
 
-  active_stream->onResponseFrame(std::move(response_frame_1));
+  active_stream->onResponseCommonFrame(std::move(response_frame_1));
 
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 1);
   EXPECT_EQ(filter_config_->stats().downstream_rq_active_.value(), 0);
@@ -948,10 +940,14 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithDrainClose) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
 
   EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) {
+      .WillOnce(Invoke([&](const StreamFrame&, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(true));
@@ -961,7 +957,7 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithDrainClose) {
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
   response->status_ = {234, false}; // Response non-OK.
   active_stream->streamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError);
-  active_stream->onResponseStart(std::move(response));
+  active_stream->onResponseHeaderFrame(std::move(response));
 
   EXPECT_EQ(filter_config_->stats().downstream_rq_total_.value(), 1);
   EXPECT_EQ(filter_config_->stats().downstream_rq_active_.value(), 0);
@@ -990,10 +986,14 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithStreamDrainClose) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
 
   EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) {
+      .WillOnce(Invoke([&](const StreamFrame&, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   // The drain close of factory_context_.drain_manager_ is false, but the drain close of
@@ -1004,7 +1004,7 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithStreamDrainClose) {
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
   response->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, true, false), true);
-  active_stream->onResponseStart(std::move(response));
+  active_stream->onResponseHeaderFrame(std::move(response));
 }
 
 TEST_F(FilterTest, NewStreamAndReplyNormallyWithTracing) {
@@ -1035,17 +1035,21 @@ TEST_F(FilterTest, NewStreamAndReplyNormallyWithTracing) {
   EXPECT_CALL(filter_callbacks_.connection_, write(BufferStringEqual("test"), false));
 
   EXPECT_CALL(*server_codec_, encode(_, _))
-      .WillOnce(Invoke([&](const StreamFrame&, EncodingCallbacks& callback) {
+      .WillOnce(Invoke([&](const StreamFrame&, EncodingContext&) {
         Buffer::OwnedImpl buffer;
         buffer.add("test");
-        callback.onEncodingSuccess(buffer, true);
+
+        server_codec_callbacks_->writeToConnection(buffer);
+        buffer.drain(buffer.length());
+
+        return EncodingResult{4};
       }));
 
   EXPECT_CALL(factory_context_.drain_manager_, drainClose()).WillOnce(Return(false));
   EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  active_stream->onResponseStart(std::move(response));
+  active_stream->onResponseHeaderFrame(std::move(response));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: generic proxy: change the encode interface to sync mode
Additional Description:

In the initial design of generic codec, full async interface is used for both encoding and decoding. it make that offloading encoding and decoding to other hardware is possible. But, after the practice in the production env, we found the offloading just an illusion.
The async decoding is just well. But the async encoding bring nothing except complexity. This PR removed the async encoding and make it to use sync interface.

Risk Level: low.
Testing: unit, integration
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
