### PR TITLE
Fix mongo_proxy:codec_impl_test and mongo_proxy:bson_impl_test on big endian

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -23,7 +23,11 @@ int32_t BufferHelper::peekInt32(Buffer::Instance& data) {
 
   int32_t val;
   val = data.peekLEInt<uint32_t>();
-  return le32toh(val);
+  #ifdef ABSL_IS_BIG_ENDIAN
+    return val;
+  #else
+    return le32toh(val);
+  #endif
 }
 
 uint8_t BufferHelper::removeByte(Buffer::Instance& data) {
@@ -88,7 +92,11 @@ int64_t BufferHelper::removeInt64(Buffer::Instance& data) {
 
   int64_t val;
   val = data.drainLEInt<uint64_t>();
-  return le64toh(val);
+  #ifdef ABSL_IS_BIG_ENDIAN
+    return val;
+  #else
+    return le64toh(val);
+  #endif
 }
 
 std::string BufferHelper::removeString(Buffer::Instance& data) {

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -23,11 +23,11 @@ int32_t BufferHelper::peekInt32(Buffer::Instance& data) {
 
   int32_t val;
   val = data.peekLEInt<uint32_t>();
-  #ifdef ABSL_IS_BIG_ENDIAN
-    return val;
-  #else
-    return le32toh(val);
-  #endif
+#ifdef ABSL_IS_BIG_ENDIAN
+  return val;
+#else
+  return le32toh(val);
+#endif
 }
 
 uint8_t BufferHelper::removeByte(Buffer::Instance& data) {
@@ -92,11 +92,11 @@ int64_t BufferHelper::removeInt64(Buffer::Instance& data) {
 
   int64_t val;
   val = data.drainLEInt<uint64_t>();
-  #ifdef ABSL_IS_BIG_ENDIAN
-    return val;
-  #else
-    return le64toh(val);
-  #endif
+#ifdef ABSL_IS_BIG_ENDIAN
+  return val;
+#else
+  return le64toh(val);
+#endif
 }
 
 std::string BufferHelper::removeString(Buffer::Instance& data) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fix //test/extensions/filters/network/mongo_proxy:codec_impl_test and //test/extensions/filters/network/mongo_proxy:bson_impl_test and tests on big endian systems.

Additional Description: `//test/extensions/filters/network/mongo_proxy:codec_impl_test` and `//test/extensions/filters/network/mongo_proxy:bson_impl_test`
 fails because applying `le32toh` or `le64toh` on big-endian systems incorrectly converts values that are already in the correct format, leading to data corruption.
 
Signed-off-by: Sankalp [Sankalp@ibm.com](mailto:Sankalp@ibm.com)

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
