### PR TITLE
fuzz: header_parser_fuzz handle StatusOr error gracefully

### DIFF
--- a/test/common/router/header_parser_corpus/append_and_append_action
+++ b/test/common/router/header_parser_corpus/append_and_append_action
@@ -1,0 +1,20 @@
+headers_to_add {
+  header {
+    key: " "
+    value: "%UPSTREAM_METADATA([\"\313\253\313\256\313\256*\313\210])%"
+  }
+  append {
+    value: true
+  }
+  keep_empty_value: true
+}
+headers_to_add {
+  header {
+    key: " "
+    value: "%UPSTREAM_METADATA([\"\313\253\313\256\313\256*\313\210])%"
+  }
+  append {
+    value: true
+  }
+  append_action: OVERWRITE_IF_EXISTS_OR_ADD
+}


### PR DESCRIPTION
Commit Message: header_parser_fuzz handle StatusOr error gracefully
Additional Description:
Following #34388 this PR does graceful handling of a parser error.

Risk Level: low - tests only.
Testing: Added corpus entry.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Fixes fuzz issue [69360](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69360).