### PR TITLE
aws: sts and webidentity fix for sigv4a edge case

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -18,10 +18,14 @@ secret access key (the session token is optional).
    ``Expiration``). To enable this credentials provider set ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to ``true``
    so that it can use http async client to fetch the credentials. This provider is not compatible with :ref:`Grpc Credentials AWS AwsIamConfig
    <envoy_v3_api_file_envoy/config/grpc_credential/v3/aws_iam.proto>` plugin which can only support deprecated libcurl credentials fetcher
-   , see https://github.com/envoyproxy/envoy/pull/30626. To fetch the credentials a static cluster is required with the name
-   ``sts_token_service_internal`` pointing towards regional AWS Security Token Service. The static internal cluster will still be added even
-   if initially ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` is not set so that subsequently if the reloadable feature
-   is set to ``true`` the cluster config is available to fetch the credentials.
+   , see https://github.com/envoyproxy/envoy/pull/30626. To fetch the credentials a static cluster is created with the name
+   ``sts_token_service_internal-<region>`` pointing towards regional AWS Security Token Service.
+
+   Note: If ``signing_algorithm: AWS_SIGV4A`` is set, the logic for STS cluster host generation is as follows:
+   - If the ``region`` is configured (either through profile, environment or inline) as a SigV4A region set
+   - And if the first region in the region set contains a wildcard
+   - Then STS cluster host is set to ``sts.amazonaws.com`` (or ``sts-fips.us-east-1.amazonaws.com`` if compiled with FIPS support
+   - Else STS cluster host is set to ``sts.<first region in region set>.amazonaws.com``
 
 4. Either EC2 instance metadata, ECS task metadata or EKS Pod Identity.
    For EC2 instance metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and ``Token`` are used, and credentials are cached for 1 hour.

--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -18,7 +18,7 @@ secret access key (the session token is optional).
    ``Expiration``). To enable this credentials provider set ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to ``true``
    so that it can use http async client to fetch the credentials. This provider is not compatible with :ref:`Grpc Credentials AWS AwsIamConfig
    <envoy_v3_api_file_envoy/config/grpc_credential/v3/aws_iam.proto>` plugin which can only support deprecated libcurl credentials
-   fetcher (see https://github.com/envoyproxy/envoy/pull/30626) . To fetch the credentials a static cluster is created with the name
+   fetcher (see `issue #30626 <https://github.com/envoyproxy/envoy/pull/30626>`_). To fetch the credentials a static cluster is created with the name
    ``sts_token_service_internal-<region>`` pointing towards regional AWS Security Token Service.
 
    Note: If ``signing_algorithm: AWS_SIGV4A`` is set, the logic for STS cluster host generation is as follows:

--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -27,6 +27,9 @@ secret access key (the session token is optional).
    - Then STS cluster host is set to ``sts.amazonaws.com`` (or ``sts-fips.us-east-1.amazonaws.com`` if compiled with FIPS support
    - Else STS cluster host is set to ``sts.<first region in region set>.amazonaws.com``
 
+  If you require the use of SigV4A signing and you are using an alternate partition, such as cn or GovCloud, you can ensure correct generation
+  of the STS endpoint by setting the first region in your SigV4A region set to the correct region (such as ``cn-northwest-1`` with no wildcard)
+
 4. Either EC2 instance metadata, ECS task metadata or EKS Pod Identity.
    For EC2 instance metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and ``Token`` are used, and credentials are cached for 1 hour.
    For ECS task metadata, the fields ``AccessKeyId``, ``SecretAccessKey``, and ``Token`` are used, and credentials are cached for 1 hour or

--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -17,8 +17,8 @@ secret access key (the session token is optional).
    ``SecretAccessKey``, and ``SessionToken`` are used, and credentials are cached for 1 hour or until they expire (according to the field
    ``Expiration``). To enable this credentials provider set ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` to ``true``
    so that it can use http async client to fetch the credentials. This provider is not compatible with :ref:`Grpc Credentials AWS AwsIamConfig
-   <envoy_v3_api_file_envoy/config/grpc_credential/v3/aws_iam.proto>` plugin which can only support deprecated libcurl credentials fetcher
-   , see https://github.com/envoyproxy/envoy/pull/30626. To fetch the credentials a static cluster is created with the name
+   <envoy_v3_api_file_envoy/config/grpc_credential/v3/aws_iam.proto>` plugin which can only support deprecated libcurl credentials
+   fetcher (see https://github.com/envoyproxy/envoy/pull/30626) . To fetch the credentials a static cluster is created with the name
    ``sts_token_service_internal-<region>`` pointing towards regional AWS Security Token Service.
 
    Note: If ``signing_algorithm: AWS_SIGV4A`` is set, the logic for STS cluster host generation is as follows:

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -238,7 +238,7 @@ std::string Utility::getSTSEndpoint(absl::string_view region) {
   // Handle the scenario where we are using SigV4A and a region set has been provided
   // SigV4A region sets are comma separated and may include wildcard
 
-  absl::string_view single_region;
+  std::string single_region;
 
   // If we contain a comma or asterisk it looks like a region set
   if (absl::StrContains(region, ",") || (absl::StrContains(region, "*"))) {

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -234,19 +234,45 @@ Utility::joinCanonicalHeaderNames(const std::map<std::string, std::string>& cano
 }
 
 std::string Utility::getSTSEndpoint(absl::string_view region) {
-  if (region == "cn-northwest-1" || region == "cn-north-1") {
-    return fmt::format("sts.{}.amazonaws.com.cn", region);
+
+  // Handle the scenario where we are using SigV4A and a region set has been provided
+  // SigV4A region sets are comma seperated and may include wildcard
+
+  absl::string_view single_region;
+
+  // If we contain a comma or asterisk it looks like a region set
+  if (absl::StrContains(region, ",") || (absl::StrContains(region, "*"))) {
+    // Use the first element from a region set if we have multiple regions specified
+    std::vector<std::string> region_v = absl::StrSplit(region, ',');
+    // If we still have a * in the first element, then send them to us-east-1 fips or global
+    // endpoint
+    if (absl::StrContains(region_v[0], '*')) {
+#ifdef ENVOY_SSL_FIPS
+      return "sts-fips.us-east-1.amazonaws.com";
+#else
+      return "sts.amazonaws.com";
+#endif
+    }
+    single_region = region_v[0];
+  } else {
+    // Otherwise it's a standard region, so use that
+    single_region = region;
   }
+
+  if (single_region == "cn-northwest-1" || single_region == "cn-north-1") {
+    return fmt::format("sts.{}.amazonaws.com.cn", single_region);
+  }
+
 #ifdef ENVOY_SSL_FIPS
   // Use AWS STS FIPS endpoints in FIPS mode https://docs.aws.amazon.com/general/latest/gr/sts.html.
   // Note: AWS GovCloud doesn't have separate fips endpoints.
   // TODO(suniltheta): Include `ca-central-1` when sts supports a dedicated FIPS endpoint.
-  if (region == "us-east-1" || region == "us-east-2" || region == "us-west-1" ||
-      region == "us-west-2") {
-    return fmt::format("sts-fips.{}.amazonaws.com", region);
+  if (single_region == "us-east-1" || single_region == "us-east-2" ||
+      single_region == "us-west-1" || single_region == "us-west-2") {
+    return fmt::format("sts-fips.{}.amazonaws.com", single_region);
   }
 #endif
-  return fmt::format("sts.{}.amazonaws.com", region);
+  return fmt::format("sts.{}.amazonaws.com", single_region);
 }
 
 static size_t curlCallback(char* ptr, size_t, size_t nmemb, void* data) {

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -240,7 +240,6 @@ Utility::joinCanonicalHeaderNames(const std::map<std::string, std::string>& cano
  * (or FIPS if compiled for FIPS support)
  */
 std::string Utility::getSTSEndpoint(absl::string_view region) {
-
   std::string single_region;
 
   // If we contain a comma or asterisk it looks like a region set.

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -236,7 +236,7 @@ Utility::joinCanonicalHeaderNames(const std::map<std::string, std::string>& cano
 std::string Utility::getSTSEndpoint(absl::string_view region) {
 
   // Handle the scenario where we are using SigV4A and a region set has been provided
-  // SigV4A region sets are comma seperated and may include wildcard
+  // SigV4A region sets are comma separated and may include wildcard
 
   absl::string_view single_region;
 

--- a/test/extensions/common/aws/utility_test.cc
+++ b/test/extensions/common/aws/utility_test.cc
@@ -488,6 +488,24 @@ TEST(UtilityTest, GetGovCloudSTSEndpoints) {
   EXPECT_EQ("sts.us-gov-west-1.amazonaws.com", Utility::getSTSEndpoint("us-gov-west-1"));
 }
 
+// Test edge case where a SigV4a region set is provided and also web identity provider is in use
+TEST(UtilityTest, CorrectlyConvertRegionSet) {
+#ifdef ENVOY_SSL_FIPS
+  EXPECT_EQ("sts-fips.us-east-1.amazonaws.com", Utility::getSTSEndpoint("*"));
+  EXPECT_EQ("sts-fips.us-east-1.amazonaws.com", Utility::getSTSEndpoint("*,ap-southeast-2"));
+  EXPECT_EQ("sts-fips.us-east-1.amazonaws.com",
+            Utility::getSTSEndpoint("ca-central-*,ap-southeast-2"));
+#else
+  EXPECT_EQ("sts.amazonaws.com", Utility::getSTSEndpoint("*"));
+  EXPECT_EQ("sts.amazonaws.com", Utility::getSTSEndpoint("*,ap-southeast-2"));
+  EXPECT_EQ("sts.amazonaws.com", Utility::getSTSEndpoint("ca-central-*,ap-southeast-2"));
+#endif
+  EXPECT_EQ("sts.ap-southeast-2.amazonaws.com",
+            Utility::getSTSEndpoint("ap-southeast-2,us-east-2"));
+  EXPECT_EQ("sts.ca-central-1.amazonaws.com",
+            Utility::getSTSEndpoint("ca-central-1,ap-southeast-2,eu-central-1"));
+}
+
 TEST(UtilityTest, JsonStringFound) {
   auto test_json = Json::Factory::loadFromStringNoThrow("{\"access_key_id\":\"testvalue\"}");
   EXPECT_TRUE(test_json.ok());


### PR DESCRIPTION
Commit Message: aws: sts and webidentity fix for sigv4a edge case
Additional Description: 

If webidentity provider and sigv4a are both in use, and a regionset is used for sigv4a, sts endpoint could be generated incorrectly. This amends utility.cc to handle this edge case.

If a regionset is provided (ie the region string contains a comma or a *) the following logic will occur:

- Split the regionset by comma
- If first region still contains a *, return global endpoint sts.amazonaws.com (or FIPS us-east-1 if in FIPS mode)
- Otherwise, use the first region

Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
