### PR TITLE
oauth filter: preserve existing auth header

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -74,7 +74,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 16]
+// [#next-free-field: 17]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -110,6 +110,12 @@ message OAuth2Config {
 
   // Forward the OAuth token as a Bearer to upstream web service.
   bool forward_bearer_token = 7;
+
+  // If set to true, preserve the existing authorization header.
+  // By default Envoy strips the existing authorization header before forwarding upstream.
+  // Can not be set to true if forward_bearer_token is already set to true.
+  // Default value is false.
+  bool preserve_authorization_header = 16;
 
   // Any request that matches any of the provided matchers will be passed through without OAuth validation.
   repeated config.route.v3.HeaderMatcher pass_through_matcher = 8;

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -64,6 +64,13 @@ Http::FilterFactoryCb OAuth2Config::createFilterFactoryFromProtoTyped(
     throw EnvoyException("invalid HMAC secret configuration");
   }
 
+  if (proto_config.preserve_authorization_header() && proto_config.forward_bearer_token()) {
+    throw EnvoyException(
+        "invalid combination of forward_bearer_token and preserve_authorization_header "
+        "configuration. If forward_bearer_token is set to true, then "
+        "preserve_authorization_header must be false");
+  }
+
   auto secret_reader = std::make_shared<SDSSecretReader>(
       std::move(secret_provider_token_secret), std::move(secret_provider_hmac_secret),
       context.serverFactoryContext().threadLocal(), context.serverFactoryContext().api());

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -119,6 +119,7 @@ public:
   const std::string& clusterName() const { return oauth_token_endpoint_.cluster(); }
   const std::string& clientId() const { return client_id_; }
   bool forwardBearerToken() const { return forward_bearer_token_; }
+  bool preserveAuthorizationHeader() const { return preserve_authorization_header_; }
   const std::vector<Http::HeaderUtility::HeaderData>& passThroughMatchers() const {
     return pass_through_header_matchers_;
   }
@@ -164,6 +165,7 @@ private:
   const std::string encoded_auth_scopes_;
   const std::string encoded_resource_query_params_;
   const bool forward_bearer_token_ : 1;
+  const bool preserve_authorization_header_ : 1;
   const std::vector<Http::HeaderUtility::HeaderData> pass_through_header_matchers_;
   const std::vector<Http::HeaderUtility::HeaderData> deny_redirect_header_matchers_;
   const CookieNames cookie_names_;

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -201,6 +201,64 @@ config:
       EnvoyException, "value does not match regex pattern");
 }
 
+TEST(ConfigTest, WrongCombinationOfPreserveAuthorizationAndForwardBearer) {
+  const std::string yaml = R"EOF(
+config:
+  forward_bearer_token: true
+  preserve_authorization_header: true
+  token_endpoint:
+    cluster: foo
+    uri: oauth.com/token
+    timeout: 3s
+  credentials:
+    client_id: "secret"
+    token_secret:
+      name: token
+    hmac_secret:
+      name: hmac
+    cookie_names:
+      bearer_token: BearerToken
+      oauth_hmac: OauthHMAC
+      oauth_expires: OauthExpires
+      id_token: IdToken
+      refresh_token: RefreshToken
+  authorization_endpoint: https://oauth.com/oauth/authorize/
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_path_matcher:
+    path:
+      exact: /callback
+  signout_path:
+    path:
+      exact: /signout
+  auth_scopes:
+  - user
+  - openid
+  - email
+  resources:
+  - oauth2-resource
+  - http://example.com
+  - https://example.com
+    )EOF";
+
+  OAuth2Config factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
+
+  // This returns non-nullptr for token_secret and hmac_secret.
+  auto& secret_manager =
+      context.server_factory_context_.cluster_manager_.cluster_manager_factory_.secretManager();
+  ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
+      .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
+          envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+
+  EXPECT_THROW_WITH_REGEX(
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
+      EnvoyException,
+      "invalid combination of forward_bearer_token and preserve_authorization_header");
+}
+
 } // namespace Oauth2
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
Allows to preserve the existing authorization header in oauth2 filter

Commit Message: oauth filter: preserve existing auth header: 
Risk Level: Low - small optional feature
Testing: unit test
Release Notes: Added oauth2 filter config preserve_authorization_header, which allows to preserve the existing authorization header in oauth2 filter
Fixes: #34236
