### PR TITLE
Fixed bazel configuration ambiguity for non HTTP3 builds

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -367,6 +367,48 @@ selects.config_setting_group(
     ],
 )
 
+bool_flag(
+    name = "always_true_flag",
+    build_setting_default = True,
+    visibility = ["//visibility:private"],
+)
+
+bool_flag(
+    name = "always_false_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:private"],
+)
+
+# Alias equal to "not(":disable_http3")" (if "not()" existed).
+alias(
+    name = "enable_http3_setting",
+    actual = select({
+        ":disable_http3": ":always_false_flag",
+        "//conditions:default": ":always_true_flag",
+    }),
+)
+
+config_setting(
+    name = "enable_http3",
+    flag_values = {":enable_http3_setting": "True"},
+)
+
+selects.config_setting_group(
+    name = "enable_http3_on_linux_ppc",
+    match_all = [
+        ":enable_http3",
+        ":linux_ppc",
+    ],
+)
+
+selects.config_setting_group(
+    name = "enable_http3_on_windows_x86_64",
+    match_all = [
+        ":enable_http3",
+        ":windows_x86_64",
+    ],
+)
+
 config_setting(
     name = "disable_admin_html",
     values = {"define": "admin_html=disabled"},

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -368,13 +368,13 @@ selects.config_setting_group(
 )
 
 bool_flag(
-    name = "always_true_flag",
+    name = "enabled",
     build_setting_default = True,
     visibility = ["//visibility:private"],
 )
 
 bool_flag(
-    name = "always_false_flag",
+    name = "disabled",
     build_setting_default = False,
     visibility = ["//visibility:private"],
 )
@@ -383,8 +383,8 @@ bool_flag(
 alias(
     name = "enable_http3_setting",
     actual = select({
-        ":disable_http3": ":always_false_flag",
-        "//conditions:default": ":always_true_flag",
+        ":disable_http3": ":disabled",
+        "//conditions:default": ":enabled",
     }),
 )
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -351,6 +351,22 @@ selects.config_setting_group(
     ],
 )
 
+selects.config_setting_group(
+    name = "disable_http3_on_linux_ppc",
+    match_all = [
+        ":disable_http3",
+        ":linux_ppc",
+    ],
+)
+
+selects.config_setting_group(
+    name = "disable_http3_on_windows_x86_64",
+    match_all = [
+        ":disable_http3",
+        ":windows_x86_64",
+    ],
+)
+
 config_setting(
     name = "disable_admin_html",
     values = {"define": "admin_html=disabled"},

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -45,8 +45,8 @@ envoy_cc_library(
         "//source/server:options_base",
         "//source/server:server_base_lib",
     ] + select({
-        "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
-        "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
+        "//bazel:enable_http3_on_windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
+        "//bazel:enable_http3_on_linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
         "//bazel:disable_http3_on_windows_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + WINDOWS_SKIP_TARGETS),
         "//bazel:disable_http3_on_linux_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + PPC_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -47,7 +47,8 @@ envoy_cc_library(
     ] + select({
         "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
-        "//bazel:disable_http3": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS),
+        "//bazel:disable_http3_on_windows_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + WINDOWS_SKIP_TARGETS),
+        "//bazel:disable_http3_on_linux_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + PPC_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),
 )

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -65,7 +65,8 @@ envoy_cc_test_library(
     ] + select({
         "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
-        "//bazel:disable_http3": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS),
+        "//bazel:disable_http3_on_windows_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + WINDOWS_SKIP_TARGETS),
+        "//bazel:disable_http3_on_linux_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + PPC_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),
 )

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -63,8 +63,8 @@ envoy_cc_test_library(
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
     ] + select({
-        "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
-        "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
+        "//bazel:enable_http3_on_windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
+        "//bazel:enable_http3_on_linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
         "//bazel:disable_http3_on_windows_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + WINDOWS_SKIP_TARGETS),
         "//bazel:disable_http3_on_linux_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + PPC_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),


### PR DESCRIPTION
To avoid ambiguity when building with `//bazel:http3=False` (on PPC and Windows) this commit adds 2 new `config_setting_group`s and updates the relevant `select()` statements.

Fixes #34482
