### PR TITLE
mobile: Remove associates in Kotlin build rules

### DIFF
--- a/mobile/bazel/kotlin_test.bzl
+++ b/mobile/bazel/kotlin_test.bzl
@@ -3,7 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_local_test")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 load("//bazel:kotlin_lib.bzl", "native_lib_name")
 
-def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], repository = "", exec_properties = {}, associates = []):
+def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], repository = "", exec_properties = {}):
     # This is to work around the issue where we have specific implementation functionality which
     # we want to avoid consumers to use but we want to unit test
     dep_srcs = []
@@ -28,7 +28,6 @@ def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], reposito
         data = data,
         jvm_flags = jvm_flags,
         exec_properties = exec_properties,
-        associates = associates,
     )
 
 # A simple macro to define the JVM flags that are common for envoy_mobile_jni_kt_test and
@@ -48,7 +47,7 @@ def jvm_flags(lib_name):
 
 # A basic macro to make it easier to declare and run kotlin tests which depend on a JNI lib
 # This will create the native .so binary (for linux) and a .jnilib (for macOS) look up
-def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps = [], repository = "", exec_properties = {}, associates = []):
+def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps = [], repository = "", exec_properties = {}):
     _internal_kt_test(
         name,
         srcs,
@@ -57,7 +56,6 @@ def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps
         jvm_flags = jvm_flags(native_lib_name),
         repository = repository,
         exec_properties = exec_properties,
-        associates = associates,
     )
 
 # A basic macro to make it easier to declare and run kotlin tests
@@ -76,11 +74,11 @@ def envoy_mobile_jni_kt_test(name, srcs, native_lib_name, native_deps = [], deps
 #         "ExampleTest.kt",
 #     ],
 # )
-def envoy_mobile_kt_test(name, srcs, deps = [], repository = "", exec_properties = {}, associates = []):
-    _internal_kt_test(name, srcs, deps, repository = repository, exec_properties = exec_properties, associates = associates)
+def envoy_mobile_kt_test(name, srcs, deps = [], repository = "", exec_properties = {}):
+    _internal_kt_test(name, srcs, deps, repository = repository, exec_properties = exec_properties)
 
 # A basic macro to run android based (robolectric) tests with native dependencies
-def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_deps = [], repository = "", exec_properties = {}, associates = []):
+def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_deps = [], repository = "", exec_properties = {}):
     android_library(
         name = name + "_test_lib",
         custom_package = "io.envoyproxy.envoymobile.test",
@@ -118,5 +116,4 @@ def envoy_mobile_android_test(name, srcs, native_lib_name, deps = [], native_dep
         test_class = "io.envoyproxy.envoymobile.bazel.EnvoyMobileTestSuite",
         jvm_flags = jvm_flags(native_lib_name),
         exec_properties = exec_properties,
-        associates = associates,
     )

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineImpl.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineImpl.kt
@@ -6,9 +6,9 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStatus
 
 /** An implementation of {@link Engine}. */
 class EngineImpl(
-  internal val envoyEngine: EnvoyEngine,
-  internal val envoyConfiguration: EnvoyConfiguration,
-  internal val logLevel: LogLevel
+  val envoyEngine: EnvoyEngine,
+  val envoyConfiguration: EnvoyConfiguration,
+  val logLevel: LogLevel
 ) : Engine {
 
   private val streamClient: StreamClient

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.Executor
  *
  * `StreamCallbacks` are bridged through to `EnvoyHTTPCallbacks` to communicate with the engine.
  */
-internal class StreamCallbacks {
+class StreamCallbacks {
   var onHeaders:
     ((headers: ResponseHeaders, endStream: Boolean, streamIntel: StreamIntel) -> Unit)? =
     null
@@ -29,7 +29,7 @@ internal class StreamCallbacks {
  * Class responsible for bridging between the platform-level `StreamCallbacks` and the engine's
  * `EnvoyHTTPCallbacks`.
  */
-internal class EnvoyHTTPCallbacksAdapter(
+class EnvoyHTTPCallbacksAdapter(
   private val executor: Executor?,
   private val callbacks: StreamCallbacks
 ) : EnvoyHTTPCallbacks {

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
@@ -156,7 +156,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
    * @param executor Executor on which to receive callback events.
    * @return A new set of engine callbacks.
    */
-  internal fun createCallbacks(executor: Executor?): EnvoyHTTPCallbacksAdapter {
+  protected fun createCallbacks(executor: Executor?): EnvoyHTTPCallbacksAdapter {
     return EnvoyHTTPCallbacksAdapter(executor, callbacks)
   }
 }

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -51,7 +51,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidNetworkMonitorTest.java",
     ],
-    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -64,6 +63,7 @@ envoy_mobile_android_test(
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//test/kotlin/io/envoyproxy/envoymobile/mocks:mocks_lib",
     ],
 )
@@ -73,7 +73,6 @@ envoy_mobile_android_test(
     srcs = [
         "ByteBuffersTest.java",
     ],
-    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -85,5 +84,6 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],
 )

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -10,9 +10,6 @@ envoy_mobile_android_test(
     srcs = [
         "EngineBuilderTest.kt",
     ],
-    associates = [
-        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-    ],
     exec_properties = {
         # TODO(lfpino): Remove this once the JVM paths are allow-listed in the sandbox.
         "sandboxAllowed": "False",
@@ -28,6 +25,7 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],
 )
 
@@ -46,8 +44,8 @@ envoy_mobile_kt_test(
     srcs = [
         "GRPCStreamTest.kt",
     ],
-    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
     deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//test/kotlin/io/envoyproxy/envoymobile/mocks:mocks_lib",
     ],
 )

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/BUILD
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/BUILD
@@ -14,6 +14,8 @@ envoy_mobile_kt_library(
         "MockStreamClient.kt",
         "MockStreamPrototype.kt",
     ],
-    associates = ["//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
 )


### PR DESCRIPTION
`associates` is not supported in Google's internal build rules. This PR also refactors the code to avoid needing `associates`.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
