### PR TITLE
mobile: Move all C++ tests into cc-tests

### DIFF
--- a/.github/workflows/mobile-cc_tests.yml
+++ b/.github/workflows/mobile-cc_tests.yml
@@ -44,7 +44,7 @@ jobs:
       args: >-
         test
         --config=mobile-remote-ci-cc
-        //test/cc/...
+        //test/cc/... //test/common/...
       request: ${{ needs.load.outputs.request }}
       target: cc-tests
       timeout-minutes: 120

--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -56,17 +56,6 @@ jobs:
             build
             --config=mobile-remote-ci-cc-no-exceptions
             //test/performance:test_binary_size //library/cc/...
-        - name: Running C++ test
-          target: cc-test
-          args: >-
-            test
-            --config=mobile-remote-ci-cc-test
-          entrypoint: |
-            #!/bin/bash -e
-            export PATH=/opt/llvm/bin:$PATH
-            cd /source/mobile
-            EXTRA_ARGS=$(bazel query //test/cc/... + //test/common/... except //test/common/integration:client_integration_test)
-            exec "$@" $EXTRA_ARGS
 
   build:
     permissions:

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -253,6 +253,10 @@ build:mobile-remote-ci-cc-no-exceptions --config=mobile-remote-ci-cc
 build:mobile-remote-ci-cc-no-exceptions --define envoy_exceptions=disabled
 build:mobile-remote-ci-cc-no-exceptions --copt=-fno-exceptions
 
+build:mobile-remote-ci-cc-test --config=mobile-remote-ci-cc
+test:mobile-remote-ci-cc-test --test_output=all
+test:mobile-remote-ci-cc-test --config=mobile-remote-ci-cc
+
 build:mobile-remote-ci-macos-kotlin --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-kotlin --fat_apk_cpu=x86_64
 

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -253,10 +253,6 @@ build:mobile-remote-ci-cc-no-exceptions --config=mobile-remote-ci-cc
 build:mobile-remote-ci-cc-no-exceptions --define envoy_exceptions=disabled
 build:mobile-remote-ci-cc-no-exceptions --copt=-fno-exceptions
 
-build:mobile-remote-ci-cc-test --config=mobile-remote-ci-cc
-test:mobile-remote-ci-cc-test --test_output=all
-test:mobile-remote-ci-cc-test --config=mobile-remote-ci-cc
-
 build:mobile-remote-ci-macos-kotlin --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-kotlin --fat_apk_cpu=x86_64
 


### PR DESCRIPTION
The `compile-time-options` should be reserved for running the build different compilation options, such as enabling xDS, full protos, etc and not for running `//test/common` tests.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
