### PR TITLE
mobile: Add response flags in the error message

### DIFF
--- a/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -2057,23 +2057,23 @@ public class CronetUrlRequestTest {
   public void testErrorCodes() throws Exception {
     checkSpecificErrorCode(EnvoyMobileError.DNS_RESOLUTION_FAILED, NetError.ERR_NAME_NOT_RESOLVED,
                            NetworkException.ERROR_HOSTNAME_NOT_RESOLVED, "NAME_NOT_RESOLVED", false,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 26");
     checkSpecificErrorCode(EnvoyMobileError.UPSTREAM_CONNECTION_TERMINATION,
                            NetError.ERR_CONNECTION_CLOSED, NetworkException.ERROR_CONNECTION_CLOSED,
                            "CONNECTION_CLOSED", true,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 6");
     checkSpecificErrorCode(EnvoyMobileError.UPSTREAM_CONNECTION_FAILURE,
                            NetError.ERR_CONNECTION_REFUSED,
                            NetworkException.ERROR_CONNECTION_REFUSED, "CONNECTION_REFUSED", false,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 5");
     checkSpecificErrorCode(EnvoyMobileError.UPSTREAM_REMOTE_RESET, NetError.ERR_CONNECTION_RESET,
                            NetworkException.ERROR_CONNECTION_RESET, "CONNECTION_RESET", true,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 4");
     checkSpecificErrorCode(EnvoyMobileError.STREAM_IDLE_TIMEOUT, NetError.ERR_TIMED_OUT,
                            NetworkException.ERROR_TIMED_OUT, "TIMED_OUT", true,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 16");
     checkSpecificErrorCode(0x2000, NetError.ERR_OTHER, NetworkException.ERROR_OTHER, "OTHER", false,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 13");
   }
 
   /*
@@ -2095,10 +2095,10 @@ public class CronetUrlRequestTest {
     androidNetworkMonitor.onReceive(getContext(), intent);
 
     // send request and confirm errorcode
-    checkSpecificErrorCode(EnvoyMobileError.DNS_RESOLUTION_FAILED,
-                           NetError.ERR_INTERNET_DISCONNECTED,
-                           NetworkException.ERROR_INTERNET_DISCONNECTED, "INTERNET_DISCONNECTED",
-                           false, /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+    checkSpecificErrorCode(
+        EnvoyMobileError.DNS_RESOLUTION_FAILED, NetError.ERR_INTERNET_DISCONNECTED,
+        NetworkException.ERROR_INTERNET_DISCONNECTED, "INTERNET_DISCONNECTED", false,
+        /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 26");
 
     // bring back online since the AndroidNetworkMonitor class is a singleton
     connectivityManager.setActiveNetworkInfo(networkInfo);
@@ -2319,7 +2319,7 @@ public class CronetUrlRequestTest {
     checkSpecificErrorCode(EnvoyMobileError.UPSTREAM_CONNECTION_FAILURE,
                            NetError.ERR_CONNECTION_REFUSED,
                            NetworkException.ERROR_CONNECTION_REFUSED, "CONNECTION_REFUSED", false,
-                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0");
+                           /*error_details=*/"RESPONSE_CODE: 400|ERROR_CODE: 0|RESPONSE_FLAGS: 5");
   }
 
   @Test

--- a/mobile/test/java/org/chromium/net/impl/ErrorsTest.java
+++ b/mobile/test/java/org/chromium/net/impl/ErrorsTest.java
@@ -13,7 +13,6 @@ import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class ErrorsTest {
-
   @Test
   public void testMapEnvoyMobileErrorToNetErrorHttp3() throws Exception {
     // 8 corresponds to NoRouteFound in StreamInfo::CoreResponseFlag:
@@ -31,6 +30,16 @@ public class ErrorsTest {
     // https://github.com/envoyproxy/envoy/blob/410e9a77bd6b74abb3e1545b4fd077e734d0fce3/envoy/stream_info/stream_info.h#L39
     long responseFlags = 1L << 4;
     EnvoyFinalStreamIntel intel = constructStreamIntel(responseFlags, UpstreamHttpProtocol.HTTP2);
+    NetError error = mapEnvoyMobileErrorToNetError(intel);
+    assertEquals(NetError.ERR_CONNECTION_RESET, error);
+  }
+
+  @Test
+  public void testMapEnvoyMobileErrorToNetErrorFoundInMapOnHttp3() throws Exception {
+    // 4 corresponds to UpstreamRemoteReset in StreamInfo::CoreResponseFlag:
+    // https://github.com/envoyproxy/envoy/blob/410e9a77bd6b74abb3e1545b4fd077e734d0fce3/envoy/stream_info/stream_info.h#L39
+    long responseFlags = 1L << 4;
+    EnvoyFinalStreamIntel intel = constructStreamIntel(responseFlags, UpstreamHttpProtocol.HTTP3);
     NetError error = mapEnvoyMobileErrorToNetError(intel);
     assertEquals(NetError.ERR_CONNECTION_RESET, error);
   }


### PR DESCRIPTION
This PR adds response flags into the error message for more debugging info. This PR also updates the logic in Cronvoy to perform an error check based on the response flags first and then do the HTTP/3 protocol error check last.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
