### PR TITLE
xds-failover: add unified gRPC mux support

### DIFF
--- a/source/extensions/config_subscription/grpc/xds_mux/BUILD
+++ b/source/extensions/config_subscription/grpc/xds_mux/BUILD
@@ -70,6 +70,7 @@ envoy_cc_extension(
         "//source/common/memory:utils_lib",
         "//source/extensions/config_subscription/grpc:eds_resources_cache_lib",
         "//source/extensions/config_subscription/grpc:grpc_mux_context_lib",
+        "//source/extensions/config_subscription/grpc:grpc_mux_failover_lib",
         "//source/extensions/config_subscription/grpc:grpc_stream_lib",
         "//source/extensions/config_subscription/grpc:pausable_ack_queue_lib",
         "//source/extensions/config_subscription/grpc:watch_map_lib",


### PR DESCRIPTION
Commit Message: xds-failover: add unified gRPC mux support
Additional Description:
This PR introduces xDS-Failover support for unified gRPC mux implementations.
This is similar to #34437, and another part of #34417.

Risk Level: medium if the runtime flag is set to true and unified-gRPC-mux is used.
Testing: Updated the test cases (parameterized).
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
