### PR TITLE
use exact match for illegal path check

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -339,6 +339,8 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
+  // It will allow the canonical path such as /sysroot/ which is not the
+  // default reserved directories (/dev, /sys, /proc)
   if (absl::StartsWith(canonical_path.return_value_, "/dev/") ||
       absl::StartsWith(canonical_path.return_value_, "/sys/") ||
       absl::StartsWith(canonical_path.return_value_, "/proc/") ||

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -339,8 +339,7 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (canonical_path.return_value_ == "/dev" ||
-      canonical_path.return_value_ == "/sys" ||
+  if (canonical_path.return_value_ == "/dev" || canonical_path.return_value_ == "/sys" ||
       canonical_path.return_value_ == "/proc") {
     return true;
   }

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -339,9 +339,9 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (absl::StartsWith(canonical_path.return_value_, "/dev") ||
-      absl::StartsWith(canonical_path.return_value_, "/sys") ||
-      absl::StartsWith(canonical_path.return_value_, "/proc")) {
+  if (canonical_path.return_value_ == "/dev" ||
+      canonical_path.return_value_ == "/sys" ||
+      canonical_path.return_value_ == "/proc") {
     return true;
   }
   return false;

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -339,7 +339,10 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (canonical_path.return_value_ == "/dev" || canonical_path.return_value_ == "/sys" ||
+  if (absl::StartsWith(canonical_path.return_value_, "/dev/") ||
+      absl::StartsWith(canonical_path.return_value_, "/sys/") ||
+      absl::StartsWith(canonical_path.return_value_, "/proc/") ||
+      canonical_path.return_value_ == "/dev" || canonical_path.return_value_ == "/sys" ||
       canonical_path.return_value_ == "/proc") {
     return true;
   }

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -235,6 +235,8 @@ TEST_F(FileSystemImplTest, IllegalPath) {
   EXPECT_TRUE(file_system_.illegalPath("/sys"));
   EXPECT_TRUE(file_system_.illegalPath("/sys/"));
   EXPECT_TRUE(file_system_.illegalPath("/_some_non_existent_file"));
+  EXPECT_FALSE(file_system_.illegalPath("/sysroot"));
+  EXPECT_FALSE(file_system_.illegalPath("/sysroot/"));
 #endif
 }
 

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -235,8 +235,6 @@ TEST_F(FileSystemImplTest, IllegalPath) {
   EXPECT_TRUE(file_system_.illegalPath("/sys"));
   EXPECT_TRUE(file_system_.illegalPath("/sys/"));
   EXPECT_TRUE(file_system_.illegalPath("/_some_non_existent_file"));
-  EXPECT_FALSE(file_system_.illegalPath("/sysroot"));
-  EXPECT_FALSE(file_system_.illegalPath("/sysroot/"));
 #endif
 }
 

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1349,6 +1349,7 @@ sys
 syscall
 syscalls
 sysctl
+sysroot
 sz
 tchar
 tchars


### PR DESCRIPTION
In our environment, the file system directory is as follows:
```
Tue Jun 04 22:28:35][#48# ]$df -h
Filesystem                 Size  Used Avail Use% Mounted on
tmpfs                       77G  104K   77G   1% /dev/shm
tmpfs                       31G  9.8M   31G   1% /run
tmpfs                      5.0M     0  5.0M   0% /run/lock
tmpfs                      4.0M     0  4.0M   0% /sys/fs/cgroup
/dev/mapper/atomicos-root  150G  144G  5.8G  97% /sysroot
/dev/vda2                  483M   84M  400M  18% /boot
/dev/vdc                   1.2T   87G  1.1T   8% /sysroot/home/centos/external
```
We have a directory named /sysroot. If the envoy config file is the that directory, envoy can not start up.
```
[2024-06-04 22:28:35.581][3382724][critical][main] [source/server/server.cc:131] error initializing configuration 'configs/envoy.yaml': Invalid path: configs/envoy.yaml
[2024-06-04 22:28:35.581][3382724][info][main] [source/server/server.cc:972] exiting
Invalid path: configs/envoy.yaml
```
In my mind, envoy should only check the default system directory such as /dev /sys /proc as illegal path.
So it is better to use exact match instead of startwith match.