### PR TITLE
mobile: Pass EnvoyError by const ref

### DIFF
--- a/mobile/examples/cc/fetch_client/fetch_client.cc
+++ b/mobile/examples/cc/fetch_client/fetch_client.cc
@@ -79,10 +79,10 @@ void Fetch::sendRequest(absl::string_view url_string) {
               << final_intel.stream_end_ms - final_intel.stream_start_ms << "ms\n";
     request_finished.Notify();
   };
-  stream_callbacks.on_error_ = [&request_finished](EnvoyError error, envoy_stream_intel,
+  stream_callbacks.on_error_ = [&request_finished](const EnvoyError& error, envoy_stream_intel,
                                                    envoy_final_stream_intel final_intel) {
     std::cerr << "Request failed after " << final_intel.stream_end_ms - final_intel.stream_start_ms
-              << "ms with error message: " << error.message << "\n";
+              << "ms with error message: " << error.message_ << "\n";
     request_finished.Notify();
   };
   stream_callbacks.on_cancel_ = [&request_finished](envoy_stream_intel,

--- a/mobile/library/common/bridge/utility.cc
+++ b/mobile/library/common/bridge/utility.cc
@@ -32,10 +32,10 @@ envoy_map makeEnvoyMap(std::initializer_list<std::pair<std::string, std::string>
 
 envoy_error toBridgeError(const EnvoyError& error) {
   envoy_error error_bridge{};
-  error_bridge.message = copyToBridgeData(error.message);
-  error_bridge.error_code = error.error_code;
-  if (error.attempt_count.has_value()) {
-    error_bridge.attempt_count = *error.attempt_count;
+  error_bridge.message = copyToBridgeData(error.message_);
+  error_bridge.error_code = error.error_code_;
+  if (error.attempt_count_.has_value()) {
+    error_bridge.attempt_count = *error.attempt_count_;
   }
   return error_bridge;
 }

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -38,9 +38,9 @@ struct EnvoyEventTracker {
 
 /** The Envoy error passed into `EnvoyStreamCallbacks::on_error_` callback. */
 struct EnvoyError {
-  envoy_error_code_t error_code;
-  std::string message;
-  absl::optional<int> attempt_count = absl::nullopt;
+  envoy_error_code_t error_code_;
+  std::string message_;
+  absl::optional<int> attempt_count_ = absl::nullopt;
 };
 
 /** The callbacks for the stream. */
@@ -106,8 +106,8 @@ struct EnvoyStreamCallbacks {
    * - stream_intel: contains internal stream metrics.
    * - final_stream_intel: contains final internal stream metrics.
    */
-  absl::AnyInvocable<void(EnvoyError, envoy_stream_intel, envoy_final_stream_intel)> on_error_ =
-      [](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {};
+  absl::AnyInvocable<void(const EnvoyError&, envoy_stream_intel, envoy_final_stream_intel)>
+      on_error_ = [](const EnvoyError&, envoy_stream_intel, envoy_final_stream_intel) {};
 
   /**
    * The callback for when the stream is cancelled.

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -433,23 +433,23 @@ void Client::DirectStreamCallbacks::latchError() {
 
   OptRef<RequestDecoder> request_decoder = direct_stream_.requestDecoder();
   if (!request_decoder) {
-    error_->message = "";
+    error_->message_ = "";
     return;
   }
   const auto& info = request_decoder->streamInfo();
 
   std::vector<std::string> error_msg_details;
   if (info.responseCode().has_value()) {
-    error_->error_code = Bridge::Utility::errorCodeFromLocalStatus(
+    error_->error_code_ = Bridge::Utility::errorCodeFromLocalStatus(
         static_cast<Http::Code>(info.responseCode().value()));
     error_msg_details.push_back(absl::StrCat("RESPONSE_CODE: ", info.responseCode().value()));
   } else if (StreamInfo::isStreamIdleTimeout(info)) {
-    error_->error_code = ENVOY_REQUEST_TIMEOUT;
+    error_->error_code_ = ENVOY_REQUEST_TIMEOUT;
   } else {
-    error_->error_code = ENVOY_STREAM_RESET;
+    error_->error_code_ = ENVOY_STREAM_RESET;
   }
 
-  error_msg_details.push_back(absl::StrCat("ERROR_CODE: ", error_->error_code));
+  error_msg_details.push_back(absl::StrCat("ERROR_CODE: ", error_->error_code_));
   std::vector<std::string> response_flags(info.responseFlags().size());
   std::transform(info.responseFlags().begin(), info.responseFlags().end(), response_flags.begin(),
                  [](StreamInfo::ResponseFlag flag) { return std::to_string(flag.value()); });
@@ -465,8 +465,8 @@ void Client::DirectStreamCallbacks::latchError() {
   // ERROR_CODE is of the envoy_error_code_t enum type, and gets mapped from RESPONSE_CODE.
   // RESPONSE_FLAGS comes from StreamInfo::responseFlags().
   // DETAILS is the contents of StreamInfo::responseCodeDetails().
-  error_->message = absl::StrJoin(std::move(error_msg_details), "|");
-  error_->attempt_count = info.attemptCount().value_or(0);
+  error_->message_ = absl::StrJoin(std::move(error_msg_details), "|");
+  error_->attempt_count_ = info.attemptCount().value_or(0);
 }
 
 Client::DirectStream::DirectStream(envoy_stream_t stream_handle, Client& http_client)

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -841,7 +841,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
     jni_helper.getEnv()->DeleteGlobalRef(java_stream_callbacks_global_ref);
   };
   stream_callbacks.on_error_ = [java_stream_callbacks_global_ref](
-                                   Envoy::EnvoyError error, envoy_stream_intel stream_intel,
+                                   const Envoy::EnvoyError& error, envoy_stream_intel stream_intel,
                                    envoy_final_stream_intel final_stream_intel) {
     Envoy::JNI::JniHelper jni_helper(Envoy::JNI::JniHelper::getThreadLocalEnv());
     auto java_stream_intel = Envoy::JNI::cppStreamIntelToJavaStreamIntel(jni_helper, stream_intel);
@@ -852,10 +852,10 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
         java_stream_callbacks_class.get(), "onError",
         "(ILjava/lang/String;ILio/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel;"
         "Lio/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel;)V");
-    auto java_error_message = Envoy::JNI::cppStringToJavaString(jni_helper, error.message);
+    auto java_error_message = Envoy::JNI::cppStringToJavaString(jni_helper, error.message_);
     jni_helper.callVoidMethod(java_stream_callbacks_global_ref, java_on_error_method_id,
-                              static_cast<jint>(error.error_code), java_error_message.get(),
-                              error.attempt_count.value_or(-1), java_stream_intel.get(),
+                              static_cast<jint>(error.error_code_), java_error_message.get(),
+                              error.attempt_count_.value_or(-1), java_stream_intel.get(),
                               java_final_stream_intel.get());
     // on_error_ is a terminal callback, delete the java_stream_callbacks_global_ref.
     jni_helper.getEnv()->DeleteGlobalRef(java_stream_callbacks_global_ref);

--- a/mobile/library/objective-c/EnvoyHTTPStreamImpl.mm
+++ b/mobile/library/objective-c/EnvoyHTTPStreamImpl.mm
@@ -183,7 +183,8 @@ static void ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
                                            envoy_final_stream_intel final_stream_intel) {
     ios_on_complete(stream_intel, final_stream_intel, context);
   };
-  streamCallbacks.on_error_ = [context](Envoy::EnvoyError error, envoy_stream_intel stream_intel,
+  streamCallbacks.on_error_ = [context](const Envoy::EnvoyError &error,
+                                        envoy_stream_intel stream_intel,
                                         envoy_final_stream_intel final_stream_intel) {
     envoy_error bridge_error = Envoy::Bridge::Utility::toBridgeError(error);
     ios_on_error(bridge_error, stream_intel, final_stream_intel, context);

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -41,9 +41,8 @@ TEST(EngineTest, SetLogger) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
@@ -89,9 +88,8 @@ TEST(EngineTest, SetEngineCallbacks) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
@@ -160,9 +158,8 @@ TEST(EngineTest, DontWaitForOnEngineRunning) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -33,9 +33,8 @@ void sendRequest() {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/receive_data_test.cc
+++ b/mobile/test/cc/integration/receive_data_test.cc
@@ -40,9 +40,8 @@ TEST(ReceiveDataTest, Success) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/receive_headers_test.cc
+++ b/mobile/test/cc/integration/receive_headers_test.cc
@@ -36,9 +36,8 @@ TEST(ReceiveHeadersTest, Success) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/receive_trailers_test.cc
+++ b/mobile/test/cc/integration/receive_trailers_test.cc
@@ -36,9 +36,8 @@ TEST(ReceiveTrailersTest, Success) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/send_data_test.cc
+++ b/mobile/test/cc/integration/send_data_test.cc
@@ -47,9 +47,8 @@ TEST(SendDataTest, Success) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -47,9 +47,8 @@ TEST(SendHeadersTest, Success) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/cc/integration/send_trailers_test.cc
+++ b/mobile/test/cc/integration/send_trailers_test.cc
@@ -49,9 +49,8 @@ TEST(SendTrailersTest, Success) {
   stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };
-  stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-    stream_complete.Notify();
-  };
+  stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
+                                   envoy_final_stream_intel) { stream_complete.Notify(); };
   stream_callbacks.on_cancel_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
     stream_complete.Notify();
   };

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -122,7 +122,7 @@ protected:
     stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) -> void {
       callbacks_called.on_complete_calls_++;
     };
-    stream_callbacks.on_error_ = [&](EnvoyError, envoy_stream_intel,
+    stream_callbacks.on_error_ = [&](const EnvoyError&, envoy_stream_intel,
                                      envoy_final_stream_intel) -> void {
       callbacks_called.on_error_calls_++;
     };
@@ -474,13 +474,13 @@ TEST_P(ClientTest, EnvoyLocalError) {
   // Override the on_error default with some custom checks.
   StreamCallbacksCalled callbacks_called;
   auto stream_callbacks = createDefaultStreamCallbacks(callbacks_called);
-  stream_callbacks.on_error_ = [&](EnvoyError error, envoy_stream_intel,
+  stream_callbacks.on_error_ = [&](const EnvoyError& error, envoy_stream_intel,
                                    envoy_final_stream_intel) -> void {
-    EXPECT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
+    EXPECT_EQ(error.error_code_, ENVOY_CONNECTION_FAILURE);
     EXPECT_THAT(
-        error.message,
+        error.message_,
         Eq("RESPONSE_CODE: 503|ERROR_CODE: 2|RESPONSE_FLAGS: 4,26|DETAILS: failed miserably"));
-    EXPECT_EQ(error.attempt_count, 123);
+    EXPECT_EQ(error.attempt_count_, 123);
     callbacks_called.on_error_calls_++;
   };
 
@@ -553,11 +553,11 @@ TEST_P(ClientTest, RemoteResetAfterStreamStart) {
   callbacks_called.end_stream_with_headers_ = false;
 
   auto stream_callbacks = createDefaultStreamCallbacks(callbacks_called);
-  stream_callbacks.on_error_ = [&](EnvoyError error, envoy_stream_intel,
+  stream_callbacks.on_error_ = [&](const EnvoyError& error, envoy_stream_intel,
                                    envoy_final_stream_intel) -> void {
-    EXPECT_EQ(error.error_code, ENVOY_STREAM_RESET);
-    EXPECT_THAT(error.message, ContainsRegex("ERROR_CODE: 1"));
-    EXPECT_EQ(error.attempt_count, 0);
+    EXPECT_EQ(error.error_code_, ENVOY_STREAM_RESET);
+    EXPECT_THAT(error.message_, ContainsRegex("ERROR_CODE: 1"));
+    EXPECT_EQ(error.attempt_count_, 0);
     callbacks_called.on_error_calls_++;
   };
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -471,9 +471,8 @@ void ClientIntegrationTest::explicitFlowControlWithCancels(const uint32_t body_s
       // Allow reading up to 100 bytes.
       streams[i]->readData(100);
     };
-    stream_callbacks.on_error_ = [](EnvoyError, envoy_stream_intel, envoy_final_stream_intel) {
-      RELEASE_ASSERT(0, "unexpected");
-    };
+    stream_callbacks.on_error_ = [](const EnvoyError&, envoy_stream_intel,
+                                    envoy_final_stream_intel) { RELEASE_ASSERT(0, "unexpected"); };
 
     auto stream = createNewStream(std::move(stream_callbacks));
     stream->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),


### PR DESCRIPTION
This PR updates the `on_error_` callback to pass `EnvoyError` by const ref instead of value. This PR also appends `_` in the struct field members of `EnvoyError` to conform with Envoy naming convention.

Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
 