### PR TITLE
mobile: Increase the engine running timeout to 30 seconds

### DIFF
--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -12,7 +12,7 @@
 
 namespace Envoy {
 namespace {
-constexpr absl::Duration ENGINE_RUNNING_TIMEOUT = absl::Seconds(3);
+constexpr absl::Duration ENGINE_RUNNING_TIMEOUT = absl::Seconds(30);
 } // namespace
 
 static std::atomic<envoy_stream_t> current_stream_handle_{0};


### PR DESCRIPTION
Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile