### PR TITLE
coverage: add datadog test and bring back `extensions/tracers` threshhold

### DIFF
--- a/test/extensions/tracers/datadog/agent_http_client_test.cc
+++ b/test/extensions/tracers/datadog/agent_http_client_test.cc
@@ -352,6 +352,43 @@ TEST_F(DatadogAgentHttpClientTest, OnErrorStreamReset) {
   callbacks_->onFailure(request_, Http::AsyncClient::FailureReason::Reset);
 }
 
+TEST_F(DatadogAgentHttpClientTest, OnErrorExceedResponseBufferLimit) {
+  // When `onFailure` is invoked on the `Http::AsyncClient::Callbacks` with
+  // `FailureReason::ExceedResponseBufferLimit`, the associated `on_error` callback is invoked
+  // with a corresponding `datadog::tracing::Error`.
+
+  EXPECT_CALL(cluster_manager_.instance_.thread_local_cluster_.async_client_, send_(_, _, _))
+      .WillOnce(
+          Invoke([this](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& callbacks_arg,
+                        const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            callbacks_ = &callbacks_arg;
+            return &request_;
+          }));
+
+  // `callbacks_->onFailure(...)` will cause `on_error_` to be called.
+  // `on_response_` will not be called.
+  EXPECT_CALL(on_error_, Call(_)).WillOnce(Invoke([](datadog::tracing::Error error) {
+    EXPECT_EQ(error.code, datadog::tracing::Error::ENVOY_HTTP_CLIENT_FAILURE);
+  }));
+  EXPECT_CALL(on_response_, Call(_, _, _)).Times(0);
+
+  // The request will not be canceled; neither explicitly nor in
+  // `~AgentHTTPClient`, because it will have been fulfilled.
+  EXPECT_CALL(request_, cancel()).Times(0);
+
+  const auto ignore = [](auto&&...) {};
+  datadog::tracing::Expected<void> result =
+      client_.post(url_, ignore, "{}", on_response_.AsStdFunction(), on_error_.AsStdFunction(),
+                   time_.monotonicTime() + std::chrono::seconds(1));
+  EXPECT_TRUE(result) << result.error();
+
+  Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
+  msg->body().add("{}");
+
+  callbacks_->onFailure(request_, Http::AsyncClient::FailureReason::ExceedResponseBufferLimit);
+}
+
 TEST_F(DatadogAgentHttpClientTest, OnErrorOther) {
   // When `onFailure` is invoked on the `Http::AsyncClient::Callbacks` with any
   // value other than `FailureReason::Reset`, the associated `on_error` callback
@@ -638,6 +675,10 @@ TEST_F(DatadogAgentHttpClientTest, SkipReportIfCollectorClusterHasBeenRemoved) {
     EXPECT_EQ(0U, stats_.reports_sent_.value());
     EXPECT_EQ(1U, stats_.reports_dropped_.value());
     EXPECT_EQ(1U, stats_.reports_failed_.value());
+  }
+
+  {
+
   }
 }
 

--- a/test/extensions/tracers/datadog/agent_http_client_test.cc
+++ b/test/extensions/tracers/datadog/agent_http_client_test.cc
@@ -676,10 +676,6 @@ TEST_F(DatadogAgentHttpClientTest, SkipReportIfCollectorClusterHasBeenRemoved) {
     EXPECT_EQ(1U, stats_.reports_dropped_.value());
     EXPECT_EQ(1U, stats_.reports_failed_.value());
   }
-
-  {
-
-  }
 }
 
 } // namespace

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -44,7 +44,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/rate_limit_descriptors/expr:95.0"
 "source/extensions/stat_sinks/graphite_statsd:82.8" # Death tests don't report LCOV
 "source/extensions/stat_sinks/statsd:85.2" # Death tests don't report LCOV
-"source/extensions/tracers:96.4"
+"source/extensions/tracers:96.5"
 "source/extensions/tracers/common:74.8"
 "source/extensions/tracers/common/ot:72.9"
 "source/extensions/tracers/opencensus:93.9"


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->


Basically revert this change #34553 with more tests

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
