### PR TITLE
Redact sensitive fields before outputting the configuration when it failed to start

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -84,7 +84,7 @@ minor_behavior_changes:
     Set ``WWW-Authenticate`` header for 401 responses from the Basic Auth filter.
 - area: log
   change: |
-    Redact sensitive fields before outputting the configuration when Envoy failed to start.
+    Redact sensitive fields before outputting the configuration when Envoy failed to start. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.redact_bootstrap_before_outputting`` to false.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -82,6 +82,9 @@ minor_behavior_changes:
 - area: filters
   change: |
     Set ``WWW-Authenticate`` header for 401 responses from the Basic Auth filter.
+- area: log
+  change: |
+    Redact sensitive fields before outputting the configuration when Envoy failed to start.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -409,8 +409,10 @@ void InstanceBase::initialize(Network::Address::InstanceConstSharedPtr local_add
   MULTI_CATCH(
       const EnvoyException& e,
       {
+        envoy::config::bootstrap::v3::Bootstrap redacted_bootstrap = options_.configProto();
+        MessageUtil::redact(redacted_bootstrap);
         ENVOY_LOG(critical, "error initializing config '{} {} {}': {}",
-                  MessageUtil::redact(options_.configProto()).DebugString(), options_.configYaml(),
+                  redacted_bootstrap.DebugString(), options_.configYaml(),
                   options_.configPath(), e.what());
         terminate();
         throw;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -410,7 +410,7 @@ void InstanceBase::initialize(Network::Address::InstanceConstSharedPtr local_add
       const EnvoyException& e,
       {
         ENVOY_LOG(critical, "error initializing config '{} {} {}': {}",
-                  options_.configProto().DebugString(), options_.configYaml(),
+                  MessageUtil::redact(options_.configProto()).DebugString(), options_.configYaml(),
                   options_.configPath(), e.what());
         terminate();
         throw;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
When Envoy failed to parse the config, Envoy print the config to the log file. Some sensitive fields, such as private_key should be redacted before the output.

Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
