### PR TITLE
runtime: remove refresh rtt runtime flag

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -82,6 +82,9 @@ minor_behavior_changes:
 - area: filters
   change: |
     Set ``WWW-Authenticate`` header for 401 responses from the Basic Auth filter.
+- area: http
+  change: |
+    Removed runtime guard ``envoy.reloadable_features.refresh_rtt_after_request`` and legacy code path.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -638,8 +638,6 @@ private:
   uint32_t requests_during_dispatch_count_{0};
   const uint32_t max_requests_during_dispatch_{UINT32_MAX};
   Event::SchedulableCallbackPtr deferred_request_processing_callback_;
-
-  const bool refresh_rtt_after_request_{};
 };
 
 } // namespace Http

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -131,8 +131,6 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_runtime_initialized);
 // TODO(mattklein123): Also unit test this if this sticks and this becomes the default for Apple &
 // Android.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_always_use_v6);
-// TODO(wbpcode) complete remove this feature is no one use it.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_refresh_rtt_after_request);
 // TODO(vikaschoudhary16) flip this to true only after all the
 // TcpProxy::Filter::HttpStreamDecoderFilterCallbacks are implemented or commented as unnecessary
 FALSE_RUNTIME_GUARD(envoy_restart_features_upstream_http_filters_with_tcp_proxy);

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -3570,44 +3570,6 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterBidiData) {
   EXPECT_EQ("world", response_body);
 }
 
-TEST_F(HttpConnectionManagerImplTest, RoundTripTimeHasValue) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.refresh_rtt_after_request", "true"}});
-
-  setup(false, "");
-
-  // Set up the codec.
-  Buffer::OwnedImpl fake_input("input");
-  conn_manager_->createCodec(fake_input);
-
-  startRequest(true);
-
-  EXPECT_CALL(filter_callbacks_.connection_, lastRoundTripTime())
-      .WillOnce(Return(absl::optional<std::chrono::milliseconds>(300)));
-  EXPECT_CALL(filter_callbacks_.connection_, connectionInfoSetter());
-
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
-}
-
-TEST_F(HttpConnectionManagerImplTest, RoundTripTimeHasNoValue) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.refresh_rtt_after_request", "true"}});
-
-  setup(false, "");
-
-  // Set up the codec.
-  Buffer::OwnedImpl fake_input("input");
-  conn_manager_->createCodec(fake_input);
-
-  startRequest(true);
-
-  EXPECT_CALL(filter_callbacks_.connection_, lastRoundTripTime())
-      .WillOnce(Return(absl::optional<std::chrono::milliseconds>()));
-  EXPECT_CALL(filter_callbacks_.connection_, connectionInfoSetter()).Times(0);
-
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
-}
-
 TEST_F(HttpConnectionManagerImplTest, RequestTimeoutDisabledByDefault) {
   setup(false, "");
 

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -224,51 +224,6 @@ TEST_P(FilterIntegrationTest, MissingHeadersLocalReplyDownstreamBytesCount) {
   }
 }
 
-TEST_P(FilterIntegrationTest, RoundTripTimeForDownstreamConnection) {
-  config_helper_.addRuntimeOverride("envoy.reloadable_features.refresh_rtt_after_request", "true");
-
-  config_helper_.prependFilter(R"EOF(
-  name: stream-info-to-headers-filter
-  )EOF");
-  initialize();
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-
-  // Send first request.
-  {
-    // Send a headers only request.
-    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
-    waitForNextUpstreamRequest();
-
-    // Make sure that the body was injected to the request.
-    EXPECT_TRUE(upstream_request_->complete());
-
-    // Send a headers only response.
-    upstream_request_->encodeHeaders(default_response_headers_, true);
-    ASSERT_TRUE(response->waitForEndStream());
-
-    // Make sure that round trip time was populated
-    EXPECT_FALSE(response->headers().get(Http::LowerCaseString("round_trip_time")).empty());
-  }
-
-  // Send second request.
-  {
-    // Send a headers only request.
-    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
-    waitForNextUpstreamRequest();
-
-    // Make sure that the body was injected to the request.
-    EXPECT_TRUE(upstream_request_->complete());
-
-    // Send a headers only response.
-    upstream_request_->encodeHeaders(default_response_headers_, true);
-    ASSERT_TRUE(response->waitForEndStream());
-
-    // Make sure that round trip time was populated
-    EXPECT_FALSE(response->headers().get(Http::LowerCaseString("round_trip_time")).empty());
-  }
-}
-
 TEST_P(FilterIntegrationTest, MissingHeadersLocalReplyUpstreamBytesCount) {
   useAccessLog("%UPSTREAM_WIRE_BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% "
                "%UPSTREAM_HEADER_BYTES_SENT% %UPSTREAM_HEADER_BYTES_RECEIVED%");


### PR DESCRIPTION
Commit Message: runtime: remove refresh rtt runtime flag
Additional Description:

Long time go and seems no one complain this default false runtime flag. We will remove it now. Now this is no way to force envoy to refresh rtt for every request. But the rtt could be refreshed cyclically by the tcp_stats extension.

cc @ggreenway cc @botengyao cc @soulxu cc @alyssawilk 

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
