### PR TITLE
data source: clean up unnecessary method and correct the behavior of max_size

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -574,7 +574,6 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
       case_sensitive_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.match(), case_sensitive, true)) {
 
   if (route.has_direct_response() && route.direct_response().has_body()) {
-
     auto provider_or_error = Envoy::Config::DataSource::DataSourceProvider::create(
         route.direct_response().body(), factory_context.mainThreadDispatcher(),
         factory_context.threadLocal(), factory_context.api(), true,

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -108,24 +108,6 @@ ConfigUtility::parseDirectResponseCode(const envoy::config::route::v3::Route& ro
   return {};
 }
 
-absl::StatusOr<std::string>
-ConfigUtility::parseDirectResponseBody(const envoy::config::route::v3::Route& route, Api::Api& api,
-                                       uint32_t max_body_size_bytes) {
-  if (!route.has_direct_response() || !route.direct_response().has_body()) {
-    return EMPTY_STRING;
-  }
-  const auto& body = route.direct_response().body();
-
-  auto body_or_error = Envoy::Config::DataSource::read(body, true, api, max_body_size_bytes);
-  RETURN_IF_STATUS_NOT_OK(body_or_error);
-  const std::string& string_body = body_or_error.value();
-  if (string_body.length() > max_body_size_bytes) {
-    return absl::InvalidArgumentError(fmt::format("response body size is {} bytes; maximum is {}",
-                                                  string_body.length(), max_body_size_bytes));
-  }
-  return string_body;
-}
-
 Http::Code ConfigUtility::parseClusterNotFoundResponseCode(
     const envoy::config::route::v3::RouteAction::ClusterNotFoundResponseCode& code) {
   switch (code) {

--- a/source/common/router/config_utility.h
+++ b/source/common/router/config_utility.h
@@ -85,20 +85,6 @@ public:
   parseDirectResponseCode(const envoy::config::route::v3::Route& route);
 
   /**
-   * Returns the content of the response body to send with direct responses from a route or an
-   * error.
-   * @param route supplies the Route configuration.
-   * @param api reference to the Api object
-   * @param max_body_size_bytes supplies the maximum response body size in bytes.
-   * @return absl::optional<std::string> the response body provided inline in the route's
-   *         direct_response if specified, or the contents of the file named in the
-   *         route's direct_response if specified, or an empty string otherwise.
-   */
-  static absl::StatusOr<std::string>
-  parseDirectResponseBody(const envoy::config::route::v3::Route& route, Api::Api& api,
-                          uint32_t max_body_size_bytes);
-
-  /**
    * Returns the HTTP Status Code enum parsed from proto.
    * @param code supplies the ClusterNotFoundResponseCode enum.
    * @return Returns the Http::Code version of the ClusterNotFoundResponseCode enum.

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -176,7 +176,7 @@ TEST(DataSourceProviderTest, NonFileDataSourceTest) {
   NiceMock<ThreadLocal::MockInstance> tls;
 
   auto provider_or_error =
-      DataSource::DataSourceProvider::create(config, *dispatcher, tls, *api, false, 15);
+      DataSource::DataSourceProvider::create(config, *dispatcher, tls, *api, false, 0);
   EXPECT_EQ(provider_or_error.value()->data(), "Hello, world!");
 }
 

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -156,6 +156,50 @@ TEST(DataSourceTest, EmptyEnvironmentVariableTest) {
 #endif
 }
 
+TEST(DataSourceTest, NotExistFileTest) {
+  envoy::config::core::v3::DataSource config;
+  TestEnvironment::createPath(TestEnvironment::temporaryPath("envoy_test"));
+  const std::string filename = TestEnvironment::temporaryPath("envoy_test/not_exist_file");
+
+  const std::string yaml = fmt::format(R"EOF(
+    filename: "{}"
+  )EOF",
+                                       filename);
+  TestUtility::loadFromYamlAndValidate(yaml, config);
+
+  EXPECT_EQ(envoy::config::core::v3::DataSource::SpecifierCase::kFilename, config.specifier_case());
+  EXPECT_EQ(config.filename(), filename);
+  Api::ApiPtr api = Api::createApiForTest();
+  EXPECT_EQ(DataSource::read(config, false, *api, 555).status().message(),
+            fmt::format("file {} does not exist", filename));
+}
+
+TEST(DataSourceTest, EmptyFileTest) {
+  envoy::config::core::v3::DataSource config;
+  TestEnvironment::createPath(TestEnvironment::temporaryPath("envoy_test"));
+  const std::string filename = TestEnvironment::temporaryPath("envoy_test/empty_file");
+  {
+    std::ofstream file(filename);
+    file.close();
+  }
+
+  const std::string yaml = fmt::format(R"EOF(
+    filename: "{}"
+  )EOF",
+                                       filename);
+  TestUtility::loadFromYamlAndValidate(yaml, config);
+  EXPECT_EQ(envoy::config::core::v3::DataSource::SpecifierCase::kFilename, config.specifier_case());
+  EXPECT_EQ(config.filename(), filename);
+
+  Api::ApiPtr api = Api::createApiForTest();
+
+  EXPECT_EQ(DataSource::read(config, false, *api, 555).status().message(),
+            fmt::format("file {} is empty", filename));
+
+  const auto file_data = DataSource::read(config, true, *api, 555).value();
+  EXPECT_TRUE(file_data.empty());
+}
+
 TEST(DataSourceProviderTest, NonFileDataSourceTest) {
   envoy::config::core::v3::DataSource config;
   TestEnvironment::createPath(TestEnvironment::temporaryPath("envoy_test"));


### PR DESCRIPTION
Commit Message: data source: clean up unnecessary method and correct the behavior of max_size
Additional Description:

We introduced dynamic file support at #32789. But there is error about the max_size (because my incorrect insistence when doing review.)

This PR fixed it and cleaned up unnecessary legacy method.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.