### PR TITLE
mobile: Remove sandboxNetwork=standard

### DIFF
--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -14,10 +14,6 @@ envoy_mobile_package()
 envoy_cc_test(
     name = "client_integration_test",
     srcs = ["client_integration_test.cc"],
-    exec_properties = {
-        # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     linkopts = select({
         "@envoy//bazel:apple": [
             # For the TestProxyResolutionApi test.
@@ -52,10 +48,6 @@ envoy_cc_test(
     data = [
         "@envoy//test/config/integration/certs",
     ],
-    exec_properties = {
-        # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     external_deps = [
         "abseil_strings",
     ],
@@ -79,10 +71,6 @@ envoy_cc_test(
     data = [
         "@envoy//test/config/integration/certs",
     ],
-    exec_properties = {
-        # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     external_deps = [
         "abseil_strings",
     ],
@@ -105,10 +93,6 @@ envoy_cc_test(
     data = [
         "@envoy//test/config/integration/certs",
     ],
-    exec_properties = {
-        # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     repository = "@envoy",
     deps = [
         ":xds_integration_test_lib",

--- a/mobile/test/java/integration/BUILD
+++ b/mobile/test/java/integration/BUILD
@@ -10,10 +10,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEngineStartUpTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -33,10 +29,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEngineFlowTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -57,10 +49,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEngineExplicitFlowTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -81,10 +69,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEngineSocketTagTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/BUILD
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/BUILD
@@ -74,10 +74,6 @@ envoy_mobile_android_test(
     srcs = [
         "QuicTestServerTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/java/org/chromium/net/BUILD
+++ b/mobile/test/java/org/chromium/net/BUILD
@@ -17,10 +17,6 @@ envoy_mobile_android_test(
         "UploadDataProvidersTest.java",
         "UrlResponseInfoTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -47,10 +43,6 @@ envoy_mobile_android_test(
     srcs = [
         "CronetUrlRequestContextTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -76,10 +68,6 @@ envoy_mobile_android_test(
     srcs = [
         "CronetUrlRequestTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -105,10 +93,6 @@ envoy_mobile_android_test(
     srcs = [
         "BidirectionalStreamTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/java/org/chromium/net/impl/BUILD
+++ b/mobile/test/java/org/chromium/net/impl/BUILD
@@ -16,10 +16,6 @@ envoy_mobile_android_test(
         "ErrorsTest.java",
         "UrlRequestCallbackTester.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/java/org/chromium/net/testing/BUILD
+++ b/mobile/test/java/org/chromium/net/testing/BUILD
@@ -84,10 +84,6 @@ envoy_mobile_android_test(
     srcs = [
         "Http2TestServerTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({
@@ -108,10 +104,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEnvoyExplicitH2FlowTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/java/org/chromium/net/urlconnection/BUILD
+++ b/mobile/test/java/org/chromium/net/urlconnection/BUILD
@@ -17,10 +17,6 @@ envoy_mobile_android_test(
         "MessageLoopTest.java",
         "TestUtil.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
     native_deps = [
         "//test/jni:libenvoy_jni_with_test_extensions.so",
     ] + select({

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -332,8 +332,6 @@ envoy_mobile_android_test(
         "FilterThrowingExceptionTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [

--- a/mobile/test/kotlin/integration/proxying/BUILD
+++ b/mobile/test/kotlin/integration/proxying/BUILD
@@ -11,8 +11,6 @@ envoy_mobile_android_test(
         "ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [
@@ -38,8 +36,6 @@ envoy_mobile_android_test(
         "ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [
@@ -65,8 +61,6 @@ envoy_mobile_android_test(
         "ProxyInfoIntentPerformHTTPSRequestUsingAsyncProxyTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [
@@ -92,8 +86,6 @@ envoy_mobile_android_test(
         "ProxyInfoIntentPerformHTTPSRequestBadHostnameTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [
@@ -119,8 +111,6 @@ envoy_mobile_android_test(
         "ProxyPollPerformHTTPRequestUsingProxyTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [
@@ -146,8 +136,6 @@ envoy_mobile_android_test(
         "ProxyPollPerformHTTPRequestWithoutUsingPACProxyTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
         "dockerNetwork": "standard",
     },
     native_deps = [


### PR DESCRIPTION
`sandboxNetwork=standard` is no longer needed.

Risk Level: low  (tests only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
