### PR TITLE
ext_authz fuzzers: fuzz request body

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.cc
@@ -26,6 +26,7 @@ ReusableFilterFactory::ReusableFilterFactory()
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_callbacks_.stream_info_, dynamicMetadata())
       .WillByDefault(testing::ReturnRef(metadata_));
+  ON_CALL(decoder_callbacks_, decodingBuffer()).WillByDefault(testing::Return(&decoding_buffer_));
 }
 
 std::unique_ptr<Filter>

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.cc
@@ -26,13 +26,16 @@ ReusableFilterFactory::ReusableFilterFactory()
       .WillByDefault(Return(OptRef<const Network::Connection>{connection_}));
   ON_CALL(decoder_callbacks_.stream_info_, dynamicMetadata())
       .WillByDefault(testing::ReturnRef(metadata_));
-  ON_CALL(decoder_callbacks_, decodingBuffer()).WillByDefault(testing::Return(&decoding_buffer_));
+  ON_CALL(decoder_callbacks_, decodingBuffer()).WillByDefault([this]() {
+    return decoding_buffer_.get();
+  });
 }
 
 std::unique_ptr<Filter>
 ReusableFilterFactory::newFilter(FilterConfigSharedPtr config,
                                  Filters::Common::ExtAuthz::ClientPtr&& client,
                                  const envoy::config::core::v3::Metadata& metadata) {
+  decoding_buffer_ = std::make_unique<Buffer::OwnedImpl>();
   metadata_ = metadata;
   std::unique_ptr<Filter> filter = std::make_unique<Filter>(std::move(config), std::move(client));
   filter->setDecoderFilterCallbacks(decoder_callbacks_);

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.h
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.h
@@ -3,6 +3,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/network/address.h"
 
+#include "source/common/buffer/buffer_impl.h"
 #include "source/extensions/filters/http/ext_authz/ext_authz.h"
 
 #include "test/extensions/filters/http/ext_authz/ext_authz_fuzz.pb.h"
@@ -31,6 +32,7 @@ private:
   // Do not use ON_CALL outside of constructor on these mocks. Each ON_CALL has a memory cost and
   // will cause OOMs if the fuzzer runs long enough.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  Buffer::OwnedImpl decoding_buffer_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   Network::Address::InstanceConstSharedPtr addr_;
   NiceMock<Envoy::Network::MockConnection> connection_;

--- a/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.h
+++ b/test/extensions/filters/http/ext_authz/ext_authz_fuzz_lib.h
@@ -32,7 +32,7 @@ private:
   // Do not use ON_CALL outside of constructor on these mocks. Each ON_CALL has a memory cost and
   // will cause OOMs if the fuzzer runs long enough.
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
-  Buffer::OwnedImpl decoding_buffer_;
+  std::unique_ptr<Buffer::OwnedImpl> decoding_buffer_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   Network::Address::InstanceConstSharedPtr addr_;
   NiceMock<Envoy::Network::MockConnection> connection_;


### PR DESCRIPTION
Commit Message: ext_authz fuzzers: fuzz request body
Additional Description: This PR allows the ext_authz fuzzers to access [this code block](https://github.com/envoyproxy/envoy/blob/main/source/extensions/filters/common/ext_authz/check_request_utils.cc#L182-L210) and start fuzzing the request body handling code.
Risk Level: none
Testing: test-only change
Docs Changes: none
Release Notes: none
Platform Specific Features: none