### PR TITLE
mobile: Remove is_installed function for checking installed Homebrew package

### DIFF
--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -47,8 +47,9 @@ fi
 
 # This is to save some disk space.
 # https://mac.install.guide/homebrew/8
-# brew autoremove
+brew autoremove
 brew cleanup --prune=all
+brew cleanup --prune-prefix
 
 DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -47,7 +47,7 @@ fi
 
 # This is to save some disk space.
 # https://mac.install.guide/homebrew/8
-brew autoremove
+# brew autoremove
 # brew cleanup --prune=all
 # brew cleanup --prune-prefix
 # brew uninstall coreutils

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -29,7 +29,7 @@ function retry () {
 }
 
 function is_installed {
-    brew ls --versions "$1" >/dev/null
+    brew ls --versions "$1"
 }
 
 function install {
@@ -45,16 +45,16 @@ if ! retry brew update; then
   echo "Failed to update homebrew"
 fi
 
+# This is to save some disk space.
+# https://mac.install.guide/homebrew/8
+brew autoremove
+brew cleanup --prune=all
+
 DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"
 done
-
-# This is to save some disk space.
-# https://mac.install.guide/homebrew/8
-brew autoremove
-brew cleanup --prune=all
 
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
 sudo xcode-select --switch /Applications/Xcode_14.1.app

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -50,6 +50,8 @@ fi
 brew autoremove
 brew cleanup --prune=all
 brew cleanup --prune-prefix
+brew uninstall coreutils
+brew install coreutils
 
 DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -29,13 +29,14 @@ function retry () {
 }
 
 function is_installed {
+    echo "Checking brew package $1"
     brew ls --versions "$1"
 }
 
 function install {
-    echo "Installing $1"
+    echo "Installing brew package $1"
     if ! retry brew install --quiet "$1"; then
-        echo "Failed to install $1"
+        echo "Failed to install brew package $1"
         exit 1
     fi
 }
@@ -47,11 +48,11 @@ fi
 
 # This is to save some disk space.
 # https://mac.install.guide/homebrew/8
-# brew autoremove
-# brew cleanup --prune=all
-# brew cleanup --prune-prefix
-# brew uninstall coreutils
-# brew install coreutils
+brew autoremove
+brew cleanup --prune=all
+# Remove broken symlinks.
+brew cleanup --prune-prefix
+brew uninstall coreutils || brew install coreutils
 
 DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -48,10 +48,10 @@ fi
 # This is to save some disk space.
 # https://mac.install.guide/homebrew/8
 brew autoremove
-brew cleanup --prune=all
-brew cleanup --prune-prefix
-brew uninstall coreutils
-brew install coreutils
+# brew cleanup --prune=all
+# brew cleanup --prune-prefix
+# brew uninstall coreutils
+# brew install coreutils
 
 DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -28,11 +28,6 @@ function retry () {
     return "$returns"
 }
 
-function is_installed {
-    echo "Checking brew package $1"
-    brew ls --versions "$1"
-}
-
 function install {
     echo "Installing brew package $1"
     if ! retry brew install --quiet "$1"; then
@@ -52,12 +47,11 @@ brew autoremove
 brew cleanup --prune=all
 # Remove broken symlinks.
 brew cleanup --prune-prefix
-brew uninstall coreutils || brew install coreutils
 
 DEPS="automake cmake coreutils libtool ninja"
 for DEP in ${DEPS}
 do
-    is_installed "${DEP}" || install "${DEP}"
+    install "${DEP}"
 done
 
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode

--- a/mobile/ci/mac_ci_setup.sh
+++ b/mobile/ci/mac_ci_setup.sh
@@ -47,7 +47,7 @@ fi
 
 # This is to save some disk space.
 # https://mac.install.guide/homebrew/8
-brew autoremove
+# brew autoremove
 brew cleanup --prune=all
 
 DEPS="automake cmake coreutils libtool ninja"


### PR DESCRIPTION
This is to fix this CI failure: https://github.com/envoyproxy/envoy/actions/runs/9450017536/job/26029390577#step:8:1452

Prior to this PR, the script would check if a homebrew package had already been installed via `brew ls --versions <package>`, I suspect there is a change in behavior where `brew ls --versions <package>` no longer returns non-zero exit code causing the `install` function to not be executed, which means `coreutils` package would never be installed. The fix is to remove the `is_installed` function since reinstalling a homebrew package that already exists is fine.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
