### PR TITLE
mobile: Bump Android min SDK to 26 and target SDK to 30

### DIFF
--- a/mobile/bazel/android_artifacts.bzl
+++ b/mobile/bazel/android_artifacts.bzl
@@ -308,7 +308,7 @@ def _manifest(package_name):
     package="{}" >
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 </manifest>
 """.format(package_name)

--- a/mobile/bazel/test_manifest.xml
+++ b/mobile/bazel/test_manifest.xml
@@ -1,12 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.test">
-
     <uses-permission android:name="android.permission.INTERNET"/>
-    <!-- This permission is needed in order to allow the application
-     to initiate DNS resolution via c-ares. -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 </manifest>

--- a/mobile/examples/java/hello_world/AndroidManifest.xml
+++ b/mobile/examples/java/hello_world/AndroidManifest.xml
@@ -8,8 +8,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
     <application
             android:label="Hello Envoy Java">

--- a/mobile/examples/kotlin/hello_world/AndroidManifest.xml
+++ b/mobile/examples/kotlin/hello_world/AndroidManifest.xml
@@ -6,8 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
     <application
             android:label="Hello Envoy">

--- a/mobile/examples/kotlin/shared/AndroidManifest.xml
+++ b/mobile/examples/kotlin/shared/AndroidManifest.xml
@@ -4,6 +4,6 @@
           android:versionName="0.1">
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 </manifest>

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.engine">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
 </manifest>

--- a/mobile/library/java/io/envoyproxy/envoymobile/utilities/UtilitiesManifest.xml
+++ b/mobile/library/java/io/envoyproxy/envoymobile/utilities/UtilitiesManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.utilities">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/ChromiumNetManifest.xml
+++ b/mobile/library/java/org/chromium/net/ChromiumNetManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.chromium.net">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27" />
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30" />
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/impl/CronvoyManifest.xml
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.cronvoy">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27" />
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30" />
 
 </manifest>

--- a/mobile/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
+++ b/mobile/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.urlconnection">
   <uses-sdk
-      android:minSdkVersion="21"
-      android:targetSdkVersion="29" />
+      android:minSdkVersion="26"
+      android:targetSdkVersion="30" />
 </manifest>

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
 </manifest>

--- a/mobile/test/kotlin/apps/baseline/AndroidManifest.xml
+++ b/mobile/test/kotlin/apps/baseline/AndroidManifest.xml
@@ -6,8 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
     <application
             android:label="Hello Envoy Baseline Test">

--- a/mobile/test/kotlin/apps/experimental/AndroidManifest.xml
+++ b/mobile/test/kotlin/apps/experimental/AndroidManifest.xml
@@ -6,8 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="27"/>
+            android:minSdkVersion="26"
+            android:targetSdkVersion="30"/>
 
     <application
             android:label="Hello Envoy Experimental Test">


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
