### PR TITLE
Fix fake_upstream for tsan

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -111,7 +111,7 @@ void FakeStream::encodeHeaders(const Http::HeaderMap& headers, bool end_stream) 
     }
   }
 
-  postToConnectionThread([this, headers_copy, end_stream]() -> void {
+  postToConnectionThread([this, headers_copy = std::move(headers_copy), end_stream]() -> void {
     {
       absl::MutexLock lock(&lock_);
       if (!parent_.connected() || saw_reset_) {


### PR DESCRIPTION
Commit Message: Fix fake_upstream for tsan
Additional Description: Based on the traces in #34644 my understanding is that the lambda given to `postToConnectionThread` reads from the header object sometimes before and sometimes after the main thread 'deletes' the shared_ptr. I think this is actually tsan being incorrect, because either way the race goes, the shared_ptr is always deleted after the read, but it also is unnecessary to have the race because the main thread doesn't use the object after posting it, so posting it by move should resolve the problem.
I wasn't able to test this fix myself because some part of the test command in standard vscode dev container was unhappy and just failed the test at startup every time with or without this change, saying `FATAL: ThreadSanitizer: unexpected memory mapping 0x74ee2ec72000-0x74ee2f100000`. Even if this doesn't fix it it's still an improvement.
Risk Level: None
Testing: Yes it is
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #34644
