### PR TITLE
address: removing the throwing variant of parseInternetAddress

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -714,7 +714,7 @@ TEST_P(ClientIntegrationTest, ReresolveAndDrain) {
     return; // This test relies on ipv4 loopback.
   }
 
-  auto next_address = Network::Utility::parseInternetAddress(
+  auto next_address = Network::Utility::parseInternetAddressNoThrow(
       "127.0.0.3", fake_upstreams_[0]->localAddress()->ip()->port());
   // This will hopefully be miniminally flaky because of low use of 127.0.0.3
   // but may need to be disabled.

--- a/mobile/test/common/network/src_addr_socket_option_impl_test.cc
+++ b/mobile/test/common/network/src_addr_socket_option_impl_test.cc
@@ -30,28 +30,28 @@ protected:
 };
 
 TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionPreBindSetsAddress) {
-  const auto address = Network::Utility::parseInternetAddress("127.0.0.2");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("127.0.0.2");
   auto option = makeOptionByAddress(address);
   EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
   EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionPreBindSetsAddressSecond) {
-  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   auto option = makeOptionByAddress(address);
   EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
   EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionNotPrebindDoesNotSetAddress) {
-  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   auto option = makeOptionByAddress(address);
   EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_LISTENING));
   EXPECT_NE(*socket_.connection_info_provider_->localAddress(), *address);
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionSafeWithNullAddress) {
-  const auto address = Network::Utility::parseInternetAddress("4.3.2.1");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("4.3.2.1");
   socket_.connection_info_provider_->setLocalAddress(address);
   auto option = std::make_unique<SrcAddrSocketOptionImpl>(nullptr);
   EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
@@ -59,7 +59,7 @@ TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionSafeWithNullAddress) {
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestIpv4HashKey) {
-  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -69,7 +69,7 @@ TEST_F(SrcAddrSocketOptionImplTest, TestIpv4HashKey) {
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestIpv4HashKeyOther) {
-  const auto address = Network::Utility::parseInternetAddress("255.254.253.0");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("255.254.253.0");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -79,7 +79,8 @@ TEST_F(SrcAddrSocketOptionImplTest, TestIpv4HashKeyOther) {
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestIpv6HashKey) {
-  const auto address = Network::Utility::parseInternetAddress("102:304:506:708:90a:b0c:d0e:f00");
+  const auto address =
+      Network::Utility::parseInternetAddressNoThrow("102:304:506:708:90a:b0c:d0e:f00");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -89,7 +90,8 @@ TEST_F(SrcAddrSocketOptionImplTest, TestIpv6HashKey) {
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestIpv6HashKeyOther) {
-  const auto address = Network::Utility::parseInternetAddress("F02:304:519:708:90a:b0e:FFFF:0000");
+  const auto address =
+      Network::Utility::parseInternetAddressNoThrow("F02:304:519:708:90a:b0e:FFFF:0000");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -99,7 +101,7 @@ TEST_F(SrcAddrSocketOptionImplTest, TestIpv6HashKeyOther) {
 }
 
 TEST_F(SrcAddrSocketOptionImplTest, TestOptionDetailsNotSupported) {
-  const auto address = Network::Utility::parseInternetAddress("255.254.253.0");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("255.254.253.0");
   auto option = makeOptionByAddress(address);
 
   auto details =

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -28,7 +28,7 @@ namespace FilterChain {
 // when no IP matcher is configured.
 Network::Address::InstanceConstSharedPtr fakeAddress() {
   CONSTRUCT_ON_FIRST_USE(Network::Address::InstanceConstSharedPtr,
-                         Network::Utility::parseInternetAddress("255.255.255.255"));
+                         Network::Utility::parseInternetAddressNoThrow("255.255.255.255"));
 }
 
 struct FilterChainNameAction

--- a/source/common/network/resolver_impl.cc
+++ b/source/common/network/resolver_impl.cc
@@ -25,9 +25,15 @@ public:
     switch (socket_address.port_specifier_case()) {
     case envoy::config::core::v3::SocketAddress::PortSpecifierCase::kPortValue:
     // Default to port 0 if no port value is specified.
-    case envoy::config::core::v3::SocketAddress::PortSpecifierCase::PORT_SPECIFIER_NOT_SET:
-      return Network::Utility::parseInternetAddress(
+    case envoy::config::core::v3::SocketAddress::PortSpecifierCase::PORT_SPECIFIER_NOT_SET: {
+      auto addr = Network::Utility::parseInternetAddressNoThrow(
           socket_address.address(), socket_address.port_value(), !socket_address.ipv4_compat());
+      if (!addr) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("malformed IP address: ", socket_address.address()));
+      }
+      return addr;
+    }
     case envoy::config::core::v3::SocketAddress::PortSpecifierCase::kNamedPort:
       break;
     }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -160,16 +160,6 @@ Address::InstanceConstSharedPtr Utility::parseInternetAddressNoThrow(const std::
   return nullptr;
 }
 
-Address::InstanceConstSharedPtr Utility::parseInternetAddress(const std::string& ip_address,
-                                                              uint16_t port, bool v6only) {
-  const Address::InstanceConstSharedPtr address =
-      parseInternetAddressNoThrow(ip_address, port, v6only);
-  if (address == nullptr) {
-    throwEnvoyExceptionOrPanic(absl::StrCat("malformed IP address: ", ip_address));
-  }
-  return address;
-}
-
 Address::InstanceConstSharedPtr
 Utility::parseInternetAddressAndPortNoThrow(const std::string& ip_address, bool v6only) {
   if (ip_address.empty()) {
@@ -446,12 +436,12 @@ absl::uint128 Utility::flipOrder(const absl::uint128& input) {
 }
 
 Address::InstanceConstSharedPtr
-Utility::protobufAddressToAddress(const envoy::config::core::v3::Address& proto_address) {
+Utility::protobufAddressToAddressNoThrow(const envoy::config::core::v3::Address& proto_address) {
   switch (proto_address.address_case()) {
   case envoy::config::core::v3::Address::AddressCase::kSocketAddress:
-    return Utility::parseInternetAddress(proto_address.socket_address().address(),
-                                         proto_address.socket_address().port_value(),
-                                         !proto_address.socket_address().ipv4_compat());
+    return Utility::parseInternetAddressNoThrow(proto_address.socket_address().address(),
+                                                proto_address.socket_address().port_value(),
+                                                !proto_address.socket_address().ipv4_compat());
   case envoy::config::core::v3::Address::AddressCase::kPipe:
     return std::make_shared<Address::PipeInstance>(proto_address.pipe().path(),
                                                    proto_address.pipe().mode());

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -241,18 +241,6 @@ public:
                                                             uint32_t port);
 
   /**
-   * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address must
-   * not include a port number. Throws EnvoyException if unable to parse the address.
-   * @param ip_address string to be parsed as an internet address.
-   * @param port optional port to include in Instance created from ip_address, 0 by default.
-   * @param v6only disable IPv4-IPv6 mapping for IPv6 addresses?
-   * @return pointer to the Instance.
-   * @throw EnvoyException in case of a malformed IP address.
-   */
-  static Address::InstanceConstSharedPtr
-  parseInternetAddress(const std::string& ip_address, uint16_t port = 0, bool v6only = true);
-
-  /**
    * Retrieve the original destination address from an accepted socket.
    * The address (IP and port) may be not local and the port may differ from
    * the listener port if the packets were redirected using iptables
@@ -275,8 +263,12 @@ public:
    */
   static absl::uint128 Ip6htonl(const absl::uint128& address);
 
+  /**
+   * @param proto_address supplies the proto address to convert
+   * @return the InstanceConstSharedPtr for the address, or null if proto_address is invalid.
+   */
   static Address::InstanceConstSharedPtr
-  protobufAddressToAddress(const envoy::config::core::v3::Address& proto_address);
+  protobufAddressToAddressNoThrow(const envoy::config::core::v3::Address& proto_address);
 
   /**
    * Copies the address instance into the protobuf representation of an address.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1793,7 +1793,7 @@ ClusterImplBase::resolveProtoAddress(const envoy::config::core::v3::Address& add
   absl::Status resolve_status;
   TRY_ASSERT_MAIN_THREAD {
     auto address_or_error = Network::Address::resolveProtoAddress(address);
-    if (address_or_error.value()) {
+    if (address_or_error.status().ok()) {
       return address_or_error.value();
     }
     resolve_status = address_or_error.status();

--- a/source/extensions/filters/udp/dns_filter/dns_filter.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.cc
@@ -55,7 +55,10 @@ DnsFilterEnvoyConfig::DnsFilterEnvoyConfig(
       // Creating the IP address will throw an exception if the address string is malformed
       for (auto index = 0; index < address_list.size(); index++) {
         const auto address_iter = std::next(address_list.begin(), (i++ % address_list.size()));
-        auto ipaddr = Network::Utility::parseInternetAddress(*address_iter, 0 /* port */);
+        auto ipaddr = Network::Utility::parseInternetAddressNoThrow(*address_iter, 0 /* port */);
+        if (!ipaddr) {
+          throw EnvoyException(absl::StrCat("malformed IP address: ", *address_iter));
+        }
         addrs.push_back(std::move(ipaddr));
       }
 

--- a/source/extensions/quic/server_preferred_address/fixed_server_preferred_address_config.cc
+++ b/source/extensions/quic/server_preferred_address/fixed_server_preferred_address_config.cc
@@ -34,7 +34,11 @@ quic::QuicSocketAddress parseSocketAddress(const envoy::config::core::v3::Socket
   // existing helpers.
   envoy::config::core::v3::Address outer;
   *outer.mutable_socket_address() = addr;
-  auto envoy_addr = Network::Utility::protobufAddressToAddress(outer);
+  auto envoy_addr = Network::Utility::protobufAddressToAddressNoThrow(outer);
+  if (!envoy_addr) {
+    ProtoExceptionUtil::throwProtoValidationException(absl::StrCat("Invalid address ", outer),
+                                                      message);
+  }
   ASSERT(envoy_addr != nullptr,
          "Network::Utility::protobufAddressToAddress throws on failure so this can't be nullptr");
   if (envoy_addr->ip() == nullptr || envoy_addr->ip()->version() != version) {

--- a/source/extensions/tracers/xray/daemon_broker.cc
+++ b/source/extensions/tracers/xray/daemon_broker.cc
@@ -32,7 +32,7 @@ DaemonBrokerImpl::DaemonBrokerImpl(const std::string& daemon_endpoint)
           Network::Utility::parseInternetAddressAndPortNoThrow(daemon_endpoint, false /*v6only*/)),
       io_handle_(Network::ioHandleForAddr(Network::Socket::Type::Datagram, address_, {})) {
   if (address_ == nullptr) {
-    throwEnvoyExceptionOrPanic(absl::StrCat("malformed IP address: ", daemon_endpoint));
+    throw EnvoyException(absl::StrCat("malformed IP address: ", daemon_endpoint));
   }
 }
 

--- a/test/common/common/dns_utils_test.cc
+++ b/test/common/common/dns_utils_test.cc
@@ -20,11 +20,11 @@ TEST(DnsUtils, MultipleGenerateTest) {
 
 TEST(DnsUtils, ListChanged) {
   Network::Address::InstanceConstSharedPtr address1 =
-      Network::Utility::parseInternetAddress("10.0.0.1");
+      Network::Utility::parseInternetAddressNoThrow("10.0.0.1");
   Network::Address::InstanceConstSharedPtr address1_dup =
-      Network::Utility::parseInternetAddress("10.0.0.1");
+      Network::Utility::parseInternetAddressNoThrow("10.0.0.1");
   Network::Address::InstanceConstSharedPtr address2 =
-      Network::Utility::parseInternetAddress("10.0.0.2");
+      Network::Utility::parseInternetAddressNoThrow("10.0.0.2");
 
   std::vector<Network::Address::InstanceConstSharedPtr> addresses1 = {address1, address2};
   std::vector<Network::Address::InstanceConstSharedPtr> addresses2 = {address1_dup, address2};

--- a/test/common/listener_manager/filter_chain_benchmark_test.cc
+++ b/test/common/listener_manager/filter_chain_benchmark_test.cc
@@ -56,16 +56,16 @@ public:
           std::make_shared<Network::Address::PipeInstance>(destination_address));
     } else {
       res->connection_info_provider_->setLocalAddress(
-          Network::Utility::parseInternetAddress(destination_address, destination_port));
+          Network::Utility::parseInternetAddressNoThrow(destination_address, destination_port));
     }
     if (absl::StartsWith(source_address, "/")) {
       res->connection_info_provider_->setRemoteAddress(
           std::make_shared<Network::Address::PipeInstance>(source_address));
     } else {
       res->connection_info_provider_->setRemoteAddress(
-          Network::Utility::parseInternetAddress(source_address, source_port));
+          Network::Utility::parseInternetAddressNoThrow(source_address, source_port));
       res->connection_info_provider_->setDirectRemoteAddressForTest(
-          Network::Utility::parseInternetAddress(source_address, source_port));
+          Network::Utility::parseInternetAddressNoThrow(source_address, source_port));
     }
     res->server_name_ = server_name;
     res->ja3_hash_ = ja3_hash;

--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -82,7 +82,7 @@ public:
       local_address_ = std::make_shared<Network::Address::PipeInstance>(destination_address);
     } else {
       local_address_ =
-          Network::Utility::parseInternetAddress(destination_address, destination_port);
+          Network::Utility::parseInternetAddressNoThrow(destination_address, destination_port);
     }
     mock_socket->connection_info_provider_->setLocalAddress(local_address_);
 
@@ -96,7 +96,7 @@ public:
     if (absl::StartsWith(source_address, "/")) {
       remote_address_ = std::make_shared<Network::Address::PipeInstance>(source_address);
     } else {
-      remote_address_ = Network::Utility::parseInternetAddress(source_address, source_port);
+      remote_address_ = Network::Utility::parseInternetAddressNoThrow(source_address, source_port);
     }
     mock_socket->connection_info_provider_->setRemoteAddress(remote_address_);
     NiceMock<StreamInfo::MockStreamInfo> stream_info;

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -6519,7 +6519,8 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, AddressResolver) {
   NiceMock<Network::MockAddressResolver> mock_resolver;
   EXPECT_CALL(mock_resolver, resolve(_))
       .Times(2)
-      .WillRepeatedly(Return(Network::Utility::parseInternetAddress("127.0.0.1", 1111, false)));
+      .WillRepeatedly(
+          Return(Network::Utility::parseInternetAddressNoThrow("127.0.0.1", 1111, false)));
   Registry::InjectFactory<Network::Address::Resolver> register_resolver(mock_resolver);
 
   EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -228,7 +228,7 @@ protected:
       local_address_ = std::make_shared<Network::Address::PipeInstance>(destination_address);
     } else {
       local_address_ =
-          Network::Utility::parseInternetAddress(destination_address, destination_port);
+          Network::Utility::parseInternetAddressNoThrow(destination_address, destination_port);
     }
     socket_->connection_info_provider_->setLocalAddress(local_address_);
 
@@ -242,7 +242,7 @@ protected:
     if (absl::StartsWith(source_address, "/")) {
       remote_address_ = std::make_shared<Network::Address::PipeInstance>(source_address);
     } else {
-      remote_address_ = Network::Utility::parseInternetAddress(source_address, source_port);
+      remote_address_ = Network::Utility::parseInternetAddressNoThrow(source_address, source_port);
     }
     socket_->connection_info_provider_->setRemoteAddress(remote_address_);
 
@@ -254,7 +254,7 @@ protected:
           std::make_shared<Network::Address::PipeInstance>(direct_source_address);
     } else {
       direct_remote_address_ =
-          Network::Utility::parseInternetAddress(direct_source_address, source_port);
+          Network::Utility::parseInternetAddressNoThrow(direct_source_address, source_port);
     }
     socket_->connection_info_provider_->setDirectRemoteAddressForTest(direct_remote_address_);
 

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -100,7 +100,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
 
   if (!v6only) {
     ASSERT_EQ(IpVersion::v6, addr_port->ip()->version());
-    auto v4_addr_port = Network::Utility::parseInternetAddress(
+    auto v4_addr_port = Network::Utility::parseInternetAddressNoThrow(
         Network::Test::getLoopbackAddressUrlString(Network::Address::IpVersion::v4),
         addr_port->ip()->port(), true);
     ASSERT_NE(v4_addr_port, nullptr);
@@ -157,7 +157,7 @@ TEST(Ipv4InstanceTest, SocketAddress) {
   EXPECT_EQ("1.2.3.4", address.ip()->addressAsString());
   EXPECT_EQ(6502U, address.ip()->port());
   EXPECT_EQ(IpVersion::v4, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("1.2.3.4"), address));
+  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddressNoThrow("1.2.3.4"), address));
   EXPECT_EQ(nullptr, address.ip()->ipv6());
   EXPECT_TRUE(address.ip()->isUnicastAddress());
   EXPECT_EQ(nullptr, address.pipe());
@@ -172,7 +172,7 @@ TEST(Ipv4InstanceTest, AddressOnly) {
   EXPECT_EQ("3.4.5.6", address.ip()->addressAsString());
   EXPECT_EQ(0U, address.ip()->port());
   EXPECT_EQ(IpVersion::v4, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("3.4.5.6"), address));
+  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddressNoThrow("3.4.5.6"), address));
   EXPECT_TRUE(address.ip()->isUnicastAddress());
 }
 
@@ -185,7 +185,7 @@ TEST(Ipv4InstanceTest, AddressAndPort) {
   EXPECT_FALSE(address.ip()->isAnyAddress());
   EXPECT_EQ(80U, address.ip()->port());
   EXPECT_EQ(IpVersion::v4, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("127.0.0.1"), address));
+  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddressNoThrow("127.0.0.1"), address));
   EXPECT_TRUE(address.ip()->isUnicastAddress());
 }
 
@@ -198,7 +198,7 @@ TEST(Ipv4InstanceTest, PortOnly) {
   EXPECT_TRUE(address.ip()->isAnyAddress());
   EXPECT_EQ(443U, address.ip()->port());
   EXPECT_EQ(IpVersion::v4, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("0.0.0.0"), address));
+  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddressNoThrow("0.0.0.0"), address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
@@ -211,7 +211,7 @@ TEST(Ipv4InstanceTest, Multicast) {
   EXPECT_FALSE(address.ip()->isAnyAddress());
   EXPECT_EQ(0U, address.ip()->port());
   EXPECT_EQ(IpVersion::v4, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("230.0.0.1"), address));
+  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddressNoThrow("230.0.0.1"), address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
@@ -223,7 +223,8 @@ TEST(Ipv4InstanceTest, Broadcast) {
   EXPECT_EQ("255.255.255.255", address.ip()->addressAsString());
   EXPECT_EQ(0U, address.ip()->port());
   EXPECT_EQ(IpVersion::v4, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("255.255.255.255"), address));
+  EXPECT_TRUE(
+      addressesEqual(Network::Utility::parseInternetAddressNoThrow("255.255.255.255"), address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
@@ -247,7 +248,8 @@ TEST(Ipv6InstanceTest, SocketAddress) {
   EXPECT_FALSE(address.ip()->isAnyAddress());
   EXPECT_EQ(32000U, address.ip()->port());
   EXPECT_EQ(IpVersion::v6, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("1:0023::0Ef"), address));
+  EXPECT_TRUE(
+      addressesEqual(Network::Utility::parseInternetAddressNoThrow("1:0023::0Ef"), address));
   EXPECT_EQ(nullptr, address.ip()->ipv4());
   EXPECT_TRUE(address.ip()->isUnicastAddress());
   EXPECT_EQ(nullptr, address.pipe());
@@ -263,7 +265,7 @@ TEST(Ipv6InstanceTest, AddressOnly) {
   EXPECT_EQ(0U, address.ip()->port());
   EXPECT_EQ(IpVersion::v6, address.ip()->version());
   EXPECT_TRUE(addressesEqual(
-      Network::Utility::parseInternetAddress("2001:db8:85a3::8a2e:0370:7334"), address));
+      Network::Utility::parseInternetAddressNoThrow("2001:db8:85a3::8a2e:0370:7334"), address));
   EXPECT_TRUE(address.ip()->isUnicastAddress());
 }
 
@@ -275,7 +277,8 @@ TEST(Ipv6InstanceTest, AddressAndPort) {
   EXPECT_EQ("::1", address.ip()->addressAsString());
   EXPECT_EQ(80U, address.ip()->port());
   EXPECT_EQ(IpVersion::v6, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("0:0:0:0:0:0:0:1"), address));
+  EXPECT_TRUE(
+      addressesEqual(Network::Utility::parseInternetAddressNoThrow("0:0:0:0:0:0:0:1"), address));
   EXPECT_TRUE(address.ip()->isUnicastAddress());
 }
 
@@ -306,7 +309,7 @@ TEST(Ipv6InstanceTest, PortOnly) {
   EXPECT_TRUE(address.ip()->isAnyAddress());
   EXPECT_EQ(443U, address.ip()->port());
   EXPECT_EQ(IpVersion::v6, address.ip()->version());
-  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddress("::0000"), address));
+  EXPECT_TRUE(addressesEqual(Network::Utility::parseInternetAddressNoThrow("::0000"), address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
@@ -320,7 +323,8 @@ TEST(Ipv6InstanceTest, Multicast) {
   EXPECT_EQ(0U, address.ip()->port());
   EXPECT_EQ(IpVersion::v6, address.ip()->version());
   EXPECT_TRUE(addressesEqual(
-      Network::Utility::parseInternetAddress("FF00:0000:0000:0000:0000:0000:0000:0000"), address));
+      Network::Utility::parseInternetAddressNoThrow("FF00:0000:0000:0000:0000:0000:0000:0000"),
+      address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 
@@ -332,7 +336,8 @@ TEST(Ipv6InstanceTest, Broadcast) {
   EXPECT_EQ(0U, address.ip()->port());
   EXPECT_EQ(IpVersion::v6, address.ip()->version());
   EXPECT_TRUE(addressesEqual(
-      Network::Utility::parseInternetAddress("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"), address));
+      Network::Utility::parseInternetAddressNoThrow("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"),
+      address));
   EXPECT_FALSE(address.ip()->isUnicastAddress());
 }
 

--- a/test/common/network/cidr_range_test.cc
+++ b/test/common/network/cidr_range_test.cc
@@ -69,7 +69,7 @@ TEST(TruncateIpAddressAndLength, Various) {
       {{"ffff::ffff", 999}, {"ffff::ffff", 128}},
   };
   for (const auto& kv : test_cases) {
-    InstanceConstSharedPtr inPtr = Utility::parseInternetAddress(kv.first.first);
+    InstanceConstSharedPtr inPtr = Utility::parseInternetAddressNoThrow(kv.first.first);
     EXPECT_NE(inPtr, nullptr) << kv.first.first;
     int length_io = kv.first.second;
     InstanceConstSharedPtr outPtr = CidrRange::truncateIpAddressAndLength(inPtr, &length_io);
@@ -202,7 +202,7 @@ TEST(CidrRangeTest, OperatorIsEqual) {
 TEST(CidrRangeTest, InvalidCidrRange) { EXPECT_FALSE(CidrRange::create("foo").status().ok()); }
 
 TEST(Ipv4CidrRangeTest, InstanceConstSharedPtrAndLengthCtor) {
-  InstanceConstSharedPtr ptr = Utility::parseInternetAddress("1.2.3.5");
+  InstanceConstSharedPtr ptr = Utility::parseInternetAddressNoThrow("1.2.3.5");
   CidrRange rng(*CidrRange::create(ptr, 31)); // Copy ctor.
   EXPECT_EQ(rng.length(), 31);
   EXPECT_EQ(rng.ip()->version(), IpVersion::v4);
@@ -267,7 +267,7 @@ TEST(Ipv4CidrRangeTest, BigRange) {
 }
 
 TEST(Ipv6CidrRange, InstanceConstSharedPtrAndLengthCtor) {
-  InstanceConstSharedPtr ptr = Utility::parseInternetAddress("abcd::0345");
+  InstanceConstSharedPtr ptr = Utility::parseInternetAddressNoThrow("abcd::0345");
   CidrRange rng(*CidrRange::create(ptr, 127)); // Copy ctor.
   EXPECT_EQ(rng.length(), 127);
   EXPECT_EQ(rng.ip()->version(), IpVersion::v6);

--- a/test/common/network/lc_trie_speed_test.cc
+++ b/test/common/network/lc_trie_speed_test.cc
@@ -12,7 +12,7 @@ struct AddressInputs {
         "192.0.2.225",   "198.51.100.55", "198.51.100.105", "192.0.2.150",   "203.0.113.162",
         "203.0.113.110", "203.0.113.99",  "198.51.100.23",  "198.51.100.24", "203.0.113.12"};
     for (const auto& address : test_addresses) {
-      addresses_.push_back(Envoy::Network::Utility::parseInternetAddress(address));
+      addresses_.push_back(Envoy::Network::Utility::parseInternetAddressNoThrow(address));
     }
   }
 

--- a/test/common/network/lc_trie_test.cc
+++ b/test/common/network/lc_trie_test.cc
@@ -40,7 +40,8 @@ public:
     for (const auto& kv : test_output) {
       std::vector<std::string> expected(kv.second);
       std::sort(expected.begin(), expected.end());
-      std::vector<std::string> actual(trie_->getData(Utility::parseInternetAddress(kv.first)));
+      std::vector<std::string> actual(
+          trie_->getData(Utility::parseInternetAddressNoThrow(kv.first)));
       std::sort(actual.begin(), actual.end());
       EXPECT_EQ(expected, actual);
     }

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -207,7 +207,8 @@ TEST_P(ListenSocketImplTestTcp, SetLocalAddress) {
     address_str = "1::2";
   }
 
-  Address::InstanceConstSharedPtr address = Network::Utility::parseInternetAddress(address_str);
+  Address::InstanceConstSharedPtr address =
+      Network::Utility::parseInternetAddressNoThrow(address_str);
 
   TestListenSocket socket(Utility::getIpv4AnyAddress());
 

--- a/test/common/network/utility_fuzz_test.cc
+++ b/test/common/network/utility_fuzz_test.cc
@@ -12,31 +12,27 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   const std::string string_buffer(reinterpret_cast<const char*>(buf), len);
 
   try {
-    Network::Utility::parseInternetAddress(string_buffer);
+    Network::Utility::parseInternetAddressNoThrow(string_buffer);
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
   }
 
   Network::Utility::parseInternetAddressAndPortNoThrow(string_buffer);
 
-  try {
+  {
     envoy::config::core::v3::Address proto_address;
     proto_address.mutable_pipe()->set_path(string_buffer);
-    Network::Utility::protobufAddressToAddress(proto_address);
-  } catch (const EnvoyException& e) {
-    ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
+    Network::Utility::protobufAddressToAddressNoThrow(proto_address);
   }
 
-  try {
+  {
     FuzzedDataProvider provider(buf, len);
     envoy::config::core::v3::Address proto_address;
     const auto port_value = provider.ConsumeIntegral<uint16_t>();
     const std::string address_value = provider.ConsumeRemainingBytesAsString();
     proto_address.mutable_socket_address()->set_address(address_value);
     proto_address.mutable_socket_address()->set_port_value(port_value);
-    Network::Utility::protobufAddressToAddress(proto_address);
-  } catch (const EnvoyException& e) {
-    ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
+    Network::Utility::protobufAddressToAddressNoThrow(proto_address);
   }
 
   try {

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -98,7 +98,7 @@ public:
   void makeTestHost(const std::string& host, const std::string& address) {
     EXPECT_TRUE(host_map_.find(host) == host_map_.end());
     host_map_[host] = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-    host_map_[host]->address_ = Network::Utility::parseInternetAddress(address);
+    host_map_[host]->address_ = Network::Utility::parseInternetAddressNoThrow(address);
 
     // Allow touch() to still be strict.
     EXPECT_CALL(*host_map_[host], address()).Times(AtLeast(0));
@@ -109,7 +109,7 @@ public:
 
   void updateTestHostAddress(const std::string& host, const std::string& address) {
     EXPECT_FALSE(host_map_.find(host) == host_map_.end());
-    host_map_[host]->address_ = Network::Utility::parseInternetAddress(address);
+    host_map_[host]->address_ = Network::Utility::parseInternetAddressNoThrow(address);
   }
 
   void refreshLb() { lb_ = lb_factory_->create(lb_params_); }

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -481,13 +481,13 @@ TEST(Context, ConnectionAttributes) {
   PeerWrapper destination(arena, info, true);
 
   Network::Address::InstanceConstSharedPtr local =
-      Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   Network::Address::InstanceConstSharedPtr remote =
-      Network::Utility::parseInternetAddress("10.20.30.40", 456, false);
+      Network::Utility::parseInternetAddressNoThrow("10.20.30.40", 456, false);
   Network::Address::InstanceConstSharedPtr upstream_address =
-      Network::Utility::parseInternetAddress("10.1.2.3", 679, false);
+      Network::Utility::parseInternetAddressNoThrow("10.1.2.3", 679, false);
   Network::Address::InstanceConstSharedPtr upstream_local_address =
-      Network::Utility::parseInternetAddress("10.1.2.3", 1000, false);
+      Network::Utility::parseInternetAddressNoThrow("10.1.2.3", 1000, false);
   const std::string sni_name = "kittens.com";
   info.downstream_connection_info_provider_->setLocalAddress(local);
   info.downstream_connection_info_provider_->setRemoteAddress(remote);

--- a/test/extensions/filters/common/original_src/original_src_socket_option_test.cc
+++ b/test/extensions/filters/common/original_src/original_src_socket_option_test.cc
@@ -31,21 +31,21 @@ protected:
 };
 
 TEST_F(OriginalSrcSocketOptionTest, TestSetOptionPreBindSetsAddress) {
-  const auto address = Network::Utility::parseInternetAddress("127.0.0.2");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("127.0.0.2");
   auto option = makeOptionByAddress(address);
   EXPECT_EQ(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND), true);
   EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestSetOptionPreBindSetsAddressSecond) {
-  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   auto option = makeOptionByAddress(address);
   EXPECT_EQ(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND), true);
   EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestSetOptionNotPrebindDoesNotSetAddress) {
-  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   auto option = makeOptionByAddress(address);
   EXPECT_EQ(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_LISTENING),
             true);
@@ -53,7 +53,7 @@ TEST_F(OriginalSrcSocketOptionTest, TestSetOptionNotPrebindDoesNotSetAddress) {
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestIpv4HashKey) {
-  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -63,7 +63,7 @@ TEST_F(OriginalSrcSocketOptionTest, TestIpv4HashKey) {
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestIpv4HashKeyOther) {
-  const auto address = Network::Utility::parseInternetAddress("255.254.253.0");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("255.254.253.0");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -73,7 +73,8 @@ TEST_F(OriginalSrcSocketOptionTest, TestIpv4HashKeyOther) {
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestIpv6HashKey) {
-  const auto address = Network::Utility::parseInternetAddress("102:304:506:708:90a:b0c:d0e:f00");
+  const auto address =
+      Network::Utility::parseInternetAddressNoThrow("102:304:506:708:90a:b0c:d0e:f00");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -83,7 +84,8 @@ TEST_F(OriginalSrcSocketOptionTest, TestIpv6HashKey) {
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestIpv6HashKeyOther) {
-  const auto address = Network::Utility::parseInternetAddress("F02:304:519:708:90a:b0e:FFFF:0000");
+  const auto address =
+      Network::Utility::parseInternetAddressNoThrow("F02:304:519:708:90a:b0e:FFFF:0000");
   auto option = makeOptionByAddress(address);
   option->hashKey(key_);
 
@@ -93,7 +95,7 @@ TEST_F(OriginalSrcSocketOptionTest, TestIpv6HashKeyOther) {
 }
 
 TEST_F(OriginalSrcSocketOptionTest, TestOptionDetailsNotSupported) {
-  const auto address = Network::Utility::parseInternetAddress("255.254.253.0");
+  const auto address = Network::Utility::parseInternetAddressNoThrow("255.254.253.0");
   auto option = makeOptionByAddress(address);
 
   auto details =

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -215,11 +215,11 @@ TEST(RoleBasedAccessControlEngineImpl, AllowedAllowlist) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, true, LogResult::Undecided, info, conn, headers);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, false, LogResult::Undecided, info, conn, headers);
 }
@@ -240,11 +240,11 @@ TEST(RoleBasedAccessControlEngineImpl, DeniedDenylist) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, false, LogResult::Undecided, info, conn, headers);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, true, LogResult::Undecided, info, conn, headers);
 }
@@ -470,7 +470,7 @@ TEST(RoleBasedAccessControlEngineImpl, ConjunctiveCondition) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, false, LogResult::Undecided, info, conn, headers);
 }
@@ -523,7 +523,7 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, AllowedAllowlist) {
   EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
 
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   EXPECT_CALL(stream_info, downstreamAddressProvider())
@@ -531,7 +531,7 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, AllowedAllowlist) {
 
   checkMatcherEngine(engine, true, LogResult::Undecided, stream_info, conn, headers);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkMatcherEngine(engine, false, LogResult::Undecided, stream_info, conn, headers);
 }
@@ -570,13 +570,13 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, DeniedDenylist) {
   NiceMock<StreamInfo::MockStreamInfo> info;
 
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   EXPECT_CALL(info, downstreamAddressProvider())
       .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
   checkMatcherEngine(engine, false, LogResult::Undecided, info, conn, headers);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkMatcherEngine(engine, true, LogResult::Undecided, info, conn, headers);
 }
@@ -612,11 +612,11 @@ TEST(RoleBasedAccessControlEngineImpl, LogIfMatched) {
   onMetadata(info);
 
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, true, RBAC::LogResult::Yes, info, conn, headers);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkEngine(engine, true, RBAC::LogResult::No, info, conn, headers);
 }
@@ -656,14 +656,14 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, LogIfMatched) {
   onMetadata(info);
 
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   EXPECT_CALL(info, downstreamAddressProvider())
       .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
   EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(info));
   checkMatcherEngine(engine, true, RBAC::LogResult::Yes, info, conn, headers);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
   checkMatcherEngine(engine, true, RBAC::LogResult::No, info, conn, headers);
 }

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -56,14 +56,14 @@ TEST(AndMatcher, Permission_Set) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   checkMatcher(
       RBAC::AndMatcher(set, ProtobufMessage::getStrictValidationVisitor(), factory_context), true,
       conn, headers, info);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 8080, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 8080, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   checkMatcher(
@@ -88,12 +88,12 @@ TEST(AndMatcher, Principal_Set) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setDirectRemoteAddressForTest(addr);
 
   checkMatcher(RBAC::AndMatcher(set, factory_context), true, conn, headers, info);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.4.6", 123, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.4.6", 123, false);
   info.downstream_connection_info_provider_->setDirectRemoteAddressForTest(addr);
 
   checkMatcher(RBAC::AndMatcher(set, factory_context), false, conn, headers, info);
@@ -109,7 +109,7 @@ TEST(OrMatcher, Permission_Set) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   checkMatcher(RBAC::OrMatcher(set, ProtobufMessage::getStrictValidationVisitor(), factory_context),
@@ -141,7 +141,7 @@ TEST(OrMatcher, Principal_Set) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.4.6", 456, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.4.6", 456, false);
   info.downstream_connection_info_provider_->setDirectRemoteAddressForTest(addr);
 
   checkMatcher(RBAC::OrMatcher(set, factory_context), false, conn, headers, info);
@@ -198,13 +198,13 @@ TEST(IPMatcher, IPMatcher) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr connection_remote =
-      Envoy::Network::Utility::parseInternetAddress("12.13.14.15", 789, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("12.13.14.15", 789, false);
   Envoy::Network::Address::InstanceConstSharedPtr direct_local =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   Envoy::Network::Address::InstanceConstSharedPtr direct_remote =
-      Envoy::Network::Utility::parseInternetAddress("4.5.6.7", 456, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("4.5.6.7", 456, false);
   Envoy::Network::Address::InstanceConstSharedPtr downstream_remote =
-      Envoy::Network::Utility::parseInternetAddress("8.9.10.11", 456, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("8.9.10.11", 456, false);
   conn.stream_info_.downstream_connection_info_provider_->setRemoteAddress(connection_remote);
   info.downstream_connection_info_provider_->setLocalAddress(direct_local);
   info.downstream_connection_info_provider_->setDirectRemoteAddressForTest(direct_remote);
@@ -255,7 +255,7 @@ TEST(PortMatcher, PortMatcher) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 123, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   checkMatcher(PortMatcher(123), true, conn, headers, info);
@@ -268,7 +268,7 @@ TEST(PortRangeMatcher, PortRangeMatcher) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   // IP address with port 456 is in range [123, 789) and [456, 789), but not in range [123, 456) or
@@ -454,7 +454,7 @@ TEST(PolicyMatcher, PolicyMatcher) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   auto ssl = std::make_shared<Ssl::MockConnectionInfo>();
   Envoy::Network::Address::InstanceConstSharedPtr addr =
-      Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+      Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 456, false);
 
   const std::vector<std::string> uri_sans{"bar", "baz"};
   const std::vector<std::string> dns_sans;
@@ -473,7 +473,7 @@ TEST(PolicyMatcher, PolicyMatcher) {
 
   checkMatcher(matcher, false, conn, headers, info);
 
-  addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 789, false);
+  addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 789, false);
   info.downstream_connection_info_provider_->setLocalAddress(addr);
 
   checkMatcher(matcher, false, conn, headers, info);

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -853,7 +853,7 @@ TEST_P(ProxyFilterIntegrationTest, StreamPersistAcrossShortTtlResFail) {
   EXPECT_EQ("503", response2->headers().getStatusValue());
 }
 const BaseIntegrationTest::InstanceConstSharedPtrFn alternateLoopbackFunction() {
-  return [](int) { return Network::Utility::parseInternetAddress("127.0.0.2", 0); };
+  return [](int) { return Network::Utility::parseInternetAddressNoThrow("127.0.0.2", 0); };
 }
 
 // Make sure that even with a resolution success we won't drain the connection.

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -555,7 +555,7 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, AddResolvedHostFilterStateMetadata
 
   // Setup test host
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 80);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 80);
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_, getThreadLocalCluster(_));
@@ -595,7 +595,7 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
 
   // Pre-populate the filter state with an address.
   auto& filter_state = callbacks_.streamInfo().filterState();
-  const auto pre_address = Network::Utility::parseInternetAddress("1.2.3.3", 80);
+  const auto pre_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.3", 80);
   auto address_obj = std::make_unique<StreamInfo::UpstreamAddress>();
   address_obj->address_ = pre_address;
   filter_state->setData(StreamInfo::UpstreamAddress::key(), std::move(address_obj),
@@ -606,7 +606,7 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
 
   // Setup test host
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 80);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 80);
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_, getThreadLocalCluster(_));

--- a/test/extensions/filters/http/geoip/geoip_filter_test.cc
+++ b/test/extensions/filters/http/geoip/geoip_filter_test.cc
@@ -89,7 +89,7 @@ TEST_F(GeoipFilterTest, NoXffSuccessfulLookup) {
   Http::TestRequestHeaderMapImpl request_headers;
   expectStats();
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
   EXPECT_CALL(*dummy_driver_, lookup(_, _))
@@ -124,7 +124,7 @@ TEST_F(GeoipFilterTest, UseXffSuccessfulLookup) {
   request_headers.addCopy("x-forwarded-for", "10.0.0.1,10.0.0.2");
   expectStats();
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
   EXPECT_CALL(*dummy_driver_, lookup(_, _))
@@ -159,7 +159,7 @@ TEST_F(GeoipFilterTest, GeoHeadersOverridenForIncomingRequest) {
                                                     {"x-geo-city", "dummy_city"}};
   expectStats();
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
   EXPECT_CALL(*dummy_driver_, lookup(_, _))
@@ -200,7 +200,7 @@ TEST_F(GeoipFilterTest, AllHeadersPropagatedCorrectly) {
                                                          {"x-geo-anon-proxy", "true"}};
   expectStats();
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
   EXPECT_CALL(*dummy_driver_, lookup(_, _))
@@ -248,7 +248,7 @@ TEST_F(GeoipFilterTest, GeoHeaderNotAppendedOnEmptyLookup) {
   Http::TestRequestHeaderMapImpl request_headers;
   expectStats();
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
   EXPECT_CALL(*dummy_driver_, lookup(_, _))
@@ -278,7 +278,7 @@ TEST_F(GeoipFilterTest, NoCrashIfFilterDestroyedBeforeCallbackCalled) {
   initializeFilter(external_request_yaml);
   Http::TestRequestHeaderMapImpl request_headers;
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
   EXPECT_CALL(*dummy_driver_, lookup(_, _))

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -64,7 +64,7 @@ TEST_F(IpTaggingFilterTest, InternalRequest) {
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.5");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.5");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -100,7 +100,7 @@ ip_tags:
   EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit"));
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -138,7 +138,7 @@ ip_tags:
   EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit"));
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.5");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.5");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -146,7 +146,7 @@ ip_tags:
   EXPECT_EQ("internal_request", request_headers.get_(Http::Headers::get().EnvoyIpTags));
 
   request_headers = Http::TestRequestHeaderMapImpl{};
-  remote_address = Network::Utility::parseInternetAddress("1.2.3.4");
+  remote_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -159,7 +159,7 @@ TEST_F(IpTaggingFilterTest, NoHits) {
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("10.2.3.5");
+      Network::Utility::parseInternetAddressNoThrow("10.2.3.5");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -180,7 +180,7 @@ TEST_F(IpTaggingFilterTest, AppendEntry) {
                                                  {"x-envoy-ip-tags", "test"}};
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.5");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.5");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -209,7 +209,7 @@ ip_tags:
                                                  {"x-envoy-ip-tags", "test"}};
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.4");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -241,7 +241,7 @@ ip_tags:
   Http::TestRequestHeaderMapImpl request_headers;
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("2001:abcd:ef01:2345::1");
+      Network::Utility::parseInternetAddressNoThrow("2001:abcd:ef01:2345::1");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 
@@ -271,7 +271,7 @@ TEST_F(IpTaggingFilterTest, ClearRouteCache) {
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
 
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.3.5");
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.5");
   filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
       remote_address);
 

--- a/test/extensions/filters/http/original_src/original_src_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_test.cc
@@ -132,7 +132,7 @@ TEST_F(OriginalSrcHttpTest, DecodeHeadersIpv4AddressBleachesPort) {
   filter->decodeHeaders(headers_, false);
 
   NiceMock<Network::MockConnectionSocket> socket;
-  const auto expected_address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto expected_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
 
   for (const auto& option : *options) {
     option->setOption(socket, envoy::config::core::v3::SocketOption::STATE_PREBIND);
@@ -209,7 +209,7 @@ TEST_F(OriginalSrcHttpTest, TrailersAndDataEndStreamDoNothing) {
   EXPECT_CALL(callbacks, addUpstreamSocketOptions(_));
   EXPECT_CALL(callbacks, streamInfo());
   callbacks.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
-      Network::Utility::parseInternetAddress("1.2.3.4"));
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4"));
   filter->decodeHeaders(headers_, true);
 
   // No new expectations => no side effects from calling these.
@@ -226,7 +226,7 @@ TEST_F(OriginalSrcHttpTest, TrailersAndDataNotEndStreamDoNothing) {
   EXPECT_CALL(callbacks, addUpstreamSocketOptions(_));
   EXPECT_CALL(callbacks, streamInfo());
   callbacks.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
-      Network::Utility::parseInternetAddress("1.2.3.4"));
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4"));
   filter->decodeHeaders(headers_, false);
 
   // No new expectations => no side effects from calling these.

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -260,7 +260,7 @@ on_no_match:
   RoleBasedAccessControlFilterTest() = default;
 
   void setDestinationAddressAndPortNoThrow(std::string server_addr, uint16_t port) {
-    address_ = Envoy::Network::Utility::parseInternetAddress(server_addr, port, false);
+    address_ = Envoy::Network::Utility::parseInternetAddressNoThrow(server_addr, port, false);
     req_info_.downstream_connection_info_provider_->setLocalAddress(address_);
 
     ON_CALL(connection_.stream_info_, downstreamAddressProvider())

--- a/test/extensions/filters/listener/original_dst/original_dst_test.cc
+++ b/test/extensions/filters/listener/original_dst/original_dst_test.cc
@@ -82,8 +82,8 @@ TEST_F(OriginalDstTest, InternalDynamicMetadataFailure) {
 
 TEST_F(OriginalDstTest, InternalFilterState) {
   expectInternalAddress();
-  const auto local = Network::Utility::parseInternetAddress("10.20.30.40", 456, false);
-  const auto remote = Network::Utility::parseInternetAddress("127.0.0.1", 8000, false);
+  const auto local = Network::Utility::parseInternetAddressNoThrow("10.20.30.40", 456, false);
+  const auto remote = Network::Utility::parseInternetAddressNoThrow("127.0.0.1", 8000, false);
   cb_.filter_state_.setData("envoy.filters.listener.original_dst.local_ip",
                             std::make_shared<Network::AddressObject>(local),
                             StreamInfo::FilterState::StateType::Mutable,

--- a/test/extensions/filters/listener/original_src/original_src_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_test.cc
@@ -112,7 +112,7 @@ TEST_F(OriginalSrcTest, OnNewConnectionIpv4AddressBleachesPort) {
   filter->onAccept(callbacks_);
 
   NiceMock<Network::MockConnectionSocket> socket;
-  const auto expected_address = Network::Utility::parseInternetAddress("1.2.3.4");
+  const auto expected_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
 
   // not ideal -- we're assuming that the original_src option is first, but it's a fair assumption
   // for now.

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -177,7 +177,7 @@ on_no_match:
   }
 
   void setDestinationPort(uint16_t port) {
-    address_ = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", port, false);
+    address_ = Envoy::Network::Utility::parseInternetAddressNoThrow("1.2.3.4", port, false);
 
     stream_info_.downstream_connection_info_provider_->setLocalAddress(address_);
     ON_CALL(callbacks_.connection_.stream_info_, downstreamAddressProvider())

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -1252,7 +1252,7 @@ TEST_F(RedisConnPoolImplTest, MovedRedirectionSuccessWithDNSEntryCached) {
 
   // DNS entry is cached.
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 6379);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 6379);
   EXPECT_CALL(*dns_cache, loadDnsCacheEntry_(Eq("foo:6379"), 6379, false, _))
       .WillOnce(Invoke([&](absl::string_view, uint16_t, bool,
                            Extensions::Common::DynamicForwardProxy::DnsCache::
@@ -1360,7 +1360,7 @@ TEST_F(RedisConnPoolImplTest, MovedRedirectionSuccessWithDNSEntryViaCallback) {
   EXPECT_CALL(*handle, onDestroy());
 
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 6379);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 6379);
   EXPECT_CALL(*host_info, address()).Times(2);
 
   EXPECT_CALL(*this, create_(_)).WillOnce(DoAll(SaveArg<0>(&host1), Return(client2)));

--- a/test/extensions/filters/udp/dns_filter/dns_filter_utils_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_utils_test.cc
@@ -88,12 +88,12 @@ TEST_F(DnsFilterUtilsTest, GetAddressRecordTypeTest) {
   auto addr_type = getAddressRecordType(pipe);
   EXPECT_EQ(addr_type, absl::nullopt);
 
-  const auto ipv6addr = Network::Utility::parseInternetAddress("fec0:1::1", 0);
+  const auto ipv6addr = Network::Utility::parseInternetAddressNoThrow("fec0:1::1", 0);
   addr_type = getAddressRecordType(ipv6addr);
   EXPECT_TRUE(addr_type.has_value());
   EXPECT_EQ(addr_type.value(), DNS_RECORD_TYPE_AAAA);
 
-  const auto ipv4addr = Network::Utility::parseInternetAddress("127.0.0.1", 0);
+  const auto ipv4addr = Network::Utility::parseInternetAddressNoThrow("127.0.0.1", 0);
   addr_type = getAddressRecordType(ipv4addr);
   EXPECT_TRUE(addr_type.has_value());
   EXPECT_EQ(addr_type.value(), DNS_RECORD_TYPE_A);

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -211,7 +211,7 @@ TEST_F(DynamicProxyFilterTest,
   EXPECT_CALL(callbacks_, continueFilterChain());
 
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 50);
   EXPECT_CALL(*host_info, address());
   filter_->onLoadDnsCacheComplete(host_info);
 
@@ -243,7 +243,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithDefaultBufferConfig) {
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_)).Times(2);
 
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 50);
   EXPECT_CALL(*host_info, address());
   filter_->onLoadDnsCacheComplete(host_info);
 
@@ -277,7 +277,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferSizeOverflow) {
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_));
 
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 50);
   EXPECT_CALL(*host_info, address());
   filter_->onLoadDnsCacheComplete(host_info);
 
@@ -311,7 +311,7 @@ TEST_F(DynamicProxyFilterTest, LoadingCacheEntryWithBufferBytesOverflow) {
   EXPECT_CALL(callbacks_, injectDatagramToFilterChain(_));
 
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
-  host_info->address_ = Network::Utility::parseInternetAddress("1.2.3.4", 50);
+  host_info->address_ = Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 50);
   EXPECT_CALL(*host_info, address());
   filter_->onLoadDnsCacheComplete(host_info);
 

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -79,7 +79,7 @@ TEST_F(GeoipProviderTest, ValidConfigCityAndIspDbsSuccessfulLookup) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("78.26.243.166");
+      Network::Utility::parseInternetAddressNoThrow("78.26.243.166");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -108,7 +108,7 @@ TEST_F(GeoipProviderTest, ValidConfigCityLookupError) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("2345:0425:2CA1:0:0:0567:5673:23b5");
+      Network::Utility::parseInternetAddressNoThrow("2345:0425:2CA1:0:0:0567:5673:23b5");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -130,7 +130,7 @@ TEST_F(GeoipProviderTest, ValidConfigAnonVpnSuccessfulLookup) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("1.2.0.0");
+      Network::Utility::parseInternetAddressNoThrow("1.2.0.0");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -154,7 +154,7 @@ TEST_F(GeoipProviderTest, ValidConfigAnonHostingSuccessfulLookup) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("71.160.223.45");
+      Network::Utility::parseInternetAddressNoThrow("71.160.223.45");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -178,7 +178,7 @@ TEST_F(GeoipProviderTest, ValidConfigAnonTorNodeSuccessfulLookup) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("65.4.3.2");
+      Network::Utility::parseInternetAddressNoThrow("65.4.3.2");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -202,7 +202,7 @@ TEST_F(GeoipProviderTest, ValidConfigAnonProxySuccessfulLookup) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("abcd:1000::1");
+      Network::Utility::parseInternetAddressNoThrow("abcd:1000::1");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -225,7 +225,7 @@ TEST_F(GeoipProviderTest, ValidConfigEmptyLookupResult) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("10.10.10.10");
+      Network::Utility::parseInternetAddressNoThrow("10.10.10.10");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -246,7 +246,7 @@ TEST_F(GeoipProviderTest, ValidConfigCityMultipleLookups) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address1 =
-      Network::Utility::parseInternetAddress("78.26.243.166");
+      Network::Utility::parseInternetAddressNoThrow("78.26.243.166");
   Geolocation::LookupRequest lookup_rq1{std::move(remote_address1)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();
@@ -255,7 +255,7 @@ TEST_F(GeoipProviderTest, ValidConfigCityMultipleLookups) {
   EXPECT_EQ(3, captured_lookup_response_.size());
   // Another lookup request.
   Network::Address::InstanceConstSharedPtr remote_address2 =
-      Network::Utility::parseInternetAddress("63.25.243.11");
+      Network::Utility::parseInternetAddressNoThrow("63.25.243.11");
   Geolocation::LookupRequest lookup_rq2{std::move(remote_address2)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb2;
   auto lookup_cb_std2 = lookup_cb2.AsStdFunction();
@@ -277,7 +277,7 @@ TEST_F(GeoipProviderDeathTest, GeoDbNotSetForConfiguredHeader) {
   )EOF";
   initializeProvider(config_yaml);
   Network::Address::InstanceConstSharedPtr remote_address =
-      Network::Utility::parseInternetAddress("78.26.243.166");
+      Network::Utility::parseInternetAddressNoThrow("78.26.243.166");
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
   testing::MockFunction<void(Geolocation::LookupResult &&)> lookup_cb;
   auto lookup_cb_std = lookup_cb.AsStdFunction();

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -478,7 +478,7 @@ TEST_F(DnsImplConstructor, SupportsCustomResolvers) {
 
 TEST_F(DnsImplConstructor, SupportsCustomResolversAsFallback) {
   char addr4str[INET_ADDRSTRLEN];
-  auto addr4 = Network::Utility::parseInternetAddress("1.2.3.4");
+  auto addr4 = Network::Utility::parseInternetAddressNoThrow("1.2.3.4");
 
   // First, create a resolver with no fallback. Check to see if cares default is
   // the only nameserver.

--- a/test/extensions/quic/server_preferred_address/fixed_server_preferred_address_test.cc
+++ b/test/extensions/quic/server_preferred_address/fixed_server_preferred_address_test.cc
@@ -23,7 +23,7 @@ TEST_F(FixedServerPreferredAddressConfigTest, Validation) {
     cfg.mutable_ipv4_config()->mutable_address()->set_address("not an address");
     cfg.mutable_ipv4_config()->mutable_address()->set_port_value(1);
     EXPECT_THROW_WITH_REGEX(factory_.createServerPreferredAddressConfig(cfg, visitor_, {}),
-                            EnvoyException, ".*malformed IP address: not an address.*");
+                            EnvoyException, ".*Invalid address socket_address.*");
   }
   {
     // Bad address.

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -514,7 +514,7 @@ TEST_F(HystrixSinkTest, HystrixEventStreamHandler) {
   NiceMock<Server::MockAdminStream> admin_stream_mock;
   NiceMock<Network::MockConnection> connection_mock;
 
-  auto addr_instance_ = Envoy::Network::Utility::parseInternetAddress("2.3.4.5", 123, false);
+  auto addr_instance_ = Envoy::Network::Utility::parseInternetAddressNoThrow("2.3.4.5", 123, false);
 
   Http::MockHttp1StreamEncoderOptions stream_encoder_options;
   ON_CALL(admin_stream_mock, getDecoderFilterCallbacks()).WillByDefault(ReturnRef(callbacks_));

--- a/test/extensions/tracers/zipkin/span_buffer_test.cc
+++ b/test/extensions/tracers/zipkin/span_buffer_test.cc
@@ -34,10 +34,10 @@ enum class IpType { V4, V6 };
 
 Endpoint createEndpoint(const IpType ip_type) {
   Endpoint endpoint;
-  endpoint.setAddress(ip_type == IpType::V6
-                          ? Envoy::Network::Utility::parseInternetAddress(
-                                "2001:db8:85a3::8a2e:370:4444", 7334, true)
-                          : Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 8080, false));
+  endpoint.setAddress(ip_type == IpType::V6 ? Envoy::Network::Utility::parseInternetAddressNoThrow(
+                                                  "2001:db8:85a3::8a2e:370:4444", 7334, true)
+                                            : Envoy::Network::Utility::parseInternetAddressNoThrow(
+                                                  "1.2.3.4", 8080, false));
   endpoint.setServiceName("service1");
   return endpoint;
 }

--- a/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
@@ -25,7 +25,7 @@ TEST(ZipkinCoreTypesEndpointTest, defaultConstructor) {
                               ep.toStruct(replacements)));
 
   Network::Address::InstanceConstSharedPtr addr =
-      Network::Utility::parseInternetAddress("127.0.0.1");
+      Network::Utility::parseInternetAddressNoThrow("127.0.0.1");
   ep.setAddress(addr);
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtility::jsonToStruct(R"({"ipv4":"127.0.0.1","port":0,"serviceName":""})"),

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -91,8 +91,8 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
 const BaseIntegrationTest::InstanceConstSharedPtrFn
 BaseIntegrationTest::defaultAddressFunction(Network::Address::IpVersion version) {
   return [version](int) {
-    return Network::Utility::parseInternetAddress(Network::Test::getLoopbackAddressString(version),
-                                                  0);
+    return Network::Utility::parseInternetAddressNoThrow(
+        Network::Test::getLoopbackAddressString(version), 0);
   };
 }
 

--- a/test/integration/clusters/custom_static_cluster.cc
+++ b/test/integration/clusters/custom_static_cluster.cc
@@ -23,7 +23,7 @@ void CustomStaticCluster::startPreInit() {
 
 Upstream::HostSharedPtr CustomStaticCluster::makeHost() {
   Network::Address::InstanceConstSharedPtr address =
-      Network::Utility::parseInternetAddress(address_, port_, true);
+      Network::Utility::parseInternetAddressNoThrow(address_, port_, true);
   return Upstream::HostSharedPtr{new Upstream::HostImpl(
       info(), "", address,
       std::make_shared<const envoy::config::core::v3::Metadata>(info()->metadata()), 1,

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -616,8 +616,8 @@ makeTcpListenSocket(const Network::Address::InstanceConstSharedPtr& address) {
 
 static Network::Address::InstanceConstSharedPtr makeAddress(uint32_t port,
                                                             Network::Address::IpVersion version) {
-  return Network::Utility::parseInternetAddress(Network::Test::getLoopbackAddressString(version),
-                                                port);
+  return Network::Utility::parseInternetAddressNoThrow(
+      Network::Test::getLoopbackAddressString(version), port);
 }
 
 static Network::SocketPtr

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -323,7 +323,7 @@ HttpIntegrationTest::HttpIntegrationTest(Http::CodecType downstream_protocol,
     : HttpIntegrationTest::HttpIntegrationTest(
           downstream_protocol,
           [version](int) {
-            return Network::Utility::parseInternetAddress(
+            return Network::Utility::parseInternetAddressNoThrow(
                 Network::Test::getLoopbackAddressString(version), 0);
           },
           version, config) {}

--- a/test/integration/integration_test.h
+++ b/test/integration/integration_test.h
@@ -31,7 +31,7 @@ public:
       : HttpIntegrationTest(
             Http::CodecType::HTTP1,
             [](int) {
-              return Network::Utility::parseInternetAddress(
+              return Network::Utility::parseInternetAddressNoThrow(
                   Network::Test::getLoopbackAddressString(std::get<0>(GetParam())), 0);
             },
             std::get<0>(GetParam())),

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -2082,8 +2082,8 @@ TEST_P(QuicHttpIntegrationSPATest, UsesPreferredAddressDNAT) {
   // Setup DNAT for 0.0.0.0:12345-->127.0.0.2:listener_port
   SocketInterfaceSwap socket_swap(Network::Socket::Type::Datagram);
   socket_swap.write_matcher_->setDnat(
-      Network::Utility::parseInternetAddress("1.2.3.4", 12345),
-      Network::Utility::parseInternetAddress("127.0.0.2", listener_port));
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.4", 12345),
+      Network::Utility::parseInternetAddressNoThrow("127.0.0.2", listener_port));
 
   codec_client_ = makeHttpConnection(makeClientConnection(listener_port));
   EnvoyQuicClientSession* quic_session =

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -328,7 +328,8 @@ std::list<Network::DnsResponse>
 TestUtility::makeDnsResponse(const std::list<std::string>& addresses, std::chrono::seconds ttl) {
   std::list<Network::DnsResponse> ret;
   for (const auto& address : addresses) {
-    ret.emplace_back(Network::DnsResponse(Network::Utility::parseInternetAddress(address), ttl));
+    ret.emplace_back(
+        Network::DnsResponse(Network::Utility::parseInternetAddressNoThrow(address), ttl));
   }
   return ret;
 }

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -105,7 +105,6 @@ paths:
     - source/common/network/listen_socket_impl.cc
     - source/common/network/io_socket_handle_base_impl.cc
     - source/common/network/address_impl.cc
-    - source/common/network/utility.cc
     - source/common/formatter/http_specific_formatter.cc
     - source/common/formatter/stream_info_formatter.h
     - source/common/formatter/stream_info_formatter.cc


### PR DESCRIPTION
Risk Level: low
Testing: updated tests
Docs Changes: n/a
Release Notes: n/a
https://github.com/envoyproxy/envoy-mobile/issues/176
