### PR TITLE
quic: fix test flake in UsesPreferredAddressDNAT

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -2070,6 +2070,9 @@ TEST_P(QuicHttpIntegrationSPATest, UsesPreferredAddressDNAT) {
         listener_filter->mutable_filter_disabled()->set_any_match(true);
       });
 
+  // Do socket swap before initialization to avoid races.
+  SocketInterfaceSwap socket_swap(Network::Socket::Type::Datagram);
+
   initialize();
   if (!Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.quic_send_server_preferred_address_to_all_clients")) {
@@ -2080,7 +2083,6 @@ TEST_P(QuicHttpIntegrationSPATest, UsesPreferredAddressDNAT) {
   auto listener_port = lookupPort("http");
 
   // Setup DNAT for 0.0.0.0:12345-->127.0.0.2:listener_port
-  SocketInterfaceSwap socket_swap(Network::Socket::Type::Datagram);
   socket_swap.write_matcher_->setDnat(
       Network::Utility::parseInternetAddress("1.2.3.4", 12345),
       Network::Utility::parseInternetAddress("127.0.0.2", listener_port));


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
Fixes #34640
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
