### PR TITLE
CI: bumping bes timeout, making aync

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,8 @@ build:docs-ci --action_env=DOCS_RST_CHECK=1 --host_action_env=DOCS_RST_CHECK=1
 build --incompatible_config_setting_private_default_visibility
 build --incompatible_enforce_config_setting_visibility
 
+test --bes_upload_mode=nowait_for_upload_complete
+test --bes_timeout=30
 test --test_verbose_timeout_warnings
 
 # Allow tags to influence execution requirements

--- a/.bazelrc
+++ b/.bazelrc
@@ -55,7 +55,7 @@ build --incompatible_config_setting_private_default_visibility
 build --incompatible_enforce_config_setting_visibility
 
 test --bes_upload_mode=nowait_for_upload_complete
-test --bes_timeout=30
+test --bes_timeout=30s
 test --test_verbose_timeout_warnings
 
 # Allow tags to influence execution requirements


### PR DESCRIPTION
I'm hoping making it async will make bes failure upload a non-fail for CI

see https://bazel.build/reference/command-line-reference#flag--bes_upload_mode


