### PR TITLE
Golang filter: make asan clean

### DIFF
--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -12,7 +12,6 @@ ENVOY_FILTER_EXAMPLE_SRCDIR="${BUILD_DIR}/envoy-filter-example"
 ENVOY_FILTER_EXAMPLE_TESTS=(
     "//:echo2_integration_test"
     "//http-filter-example:http_filter_integration_test"
-    "//contrib/golang/filters/http/test/..."
     "//:envoy_binary_test")
 
 if [[ ! -d "${ENVOY_FILTER_EXAMPLE_SRCDIR}/.git" ]]; then

--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -12,6 +12,7 @@ ENVOY_FILTER_EXAMPLE_SRCDIR="${BUILD_DIR}/envoy-filter-example"
 ENVOY_FILTER_EXAMPLE_TESTS=(
     "//:echo2_integration_test"
     "//http-filter-example:http_filter_integration_test"
+    "//contrib/golang/filters/http/test/..."
     "//:envoy_binary_test")
 
 if [[ ! -d "${ENVOY_FILTER_EXAMPLE_SRCDIR}/.git" ]]; then

--- a/contrib/golang/common/dso/dso.cc
+++ b/contrib/golang/common/dso/dso.cc
@@ -63,6 +63,8 @@ HttpFilterDsoImpl::HttpFilterDsoImpl(const std::string dso_name) : HttpFilterDso
       envoy_go_filter_on_http_destroy_, handler_, dso_name, "envoyGoFilterOnHttpDestroy");
   loaded_ &= dlsymInternal<decltype(envoy_go_filter_go_request_sema_dec_)>(
       envoy_go_filter_go_request_sema_dec_, handler_, dso_name, "envoyGoRequestSemaDec");
+  loaded_ &= dlsymInternal<decltype(envoy_go_filter_cleanup_)>(envoy_go_filter_cleanup_, handler_,
+                                                               dso_name, "envoyGoFilterCleanUp");
 }
 
 GoUint64 HttpFilterDsoImpl::envoyGoFilterNewHttpPluginConfig(httpConfig* p0) {
@@ -106,6 +108,11 @@ void HttpFilterDsoImpl::envoyGoFilterOnHttpDestroy(httpRequest* p0, int p1) {
 void HttpFilterDsoImpl::envoyGoRequestSemaDec(httpRequest* p0) {
   ASSERT(envoy_go_filter_go_request_sema_dec_ != nullptr);
   envoy_go_filter_go_request_sema_dec_(p0);
+}
+
+void HttpFilterDsoImpl::cleanup() {
+  ASSERT(envoy_go_filter_cleanup_ != nullptr);
+  envoy_go_filter_cleanup_();
 }
 
 ClusterSpecifierDsoImpl::ClusterSpecifierDsoImpl(const std::string dso_name)

--- a/contrib/golang/common/dso/dso.h
+++ b/contrib/golang/common/dso/dso.h
@@ -17,8 +17,12 @@ class Dso {
 public:
   Dso() = default;
   Dso(const std::string dso_name);
-  ~Dso();
+  virtual ~Dso();
   bool loaded() { return loaded_; }
+  /*
+   * Clean up resources that are referenced on the Golang side.
+   */
+  virtual void cleanup(){};
 
 protected:
   const std::string dso_name_;
@@ -29,7 +33,7 @@ protected:
 class HttpFilterDso : public Dso {
 public:
   HttpFilterDso(const std::string dso_name) : Dso(dso_name){};
-  virtual ~HttpFilterDso() = default;
+  ~HttpFilterDso() override = default;
 
   virtual GoUint64 envoyGoFilterNewHttpPluginConfig(httpConfig* p0) PURE;
   virtual GoUint64 envoyGoFilterMergeHttpPluginConfig(GoUint64 p0, GoUint64 p1, GoUint64 p2,
@@ -60,6 +64,7 @@ public:
   void envoyGoFilterOnHttpLog(httpRequest* p0, int p1) override;
   void envoyGoFilterOnHttpDestroy(httpRequest* p0, int p1) override;
   void envoyGoRequestSemaDec(httpRequest* p0) override;
+  void cleanup() override;
 
 private:
   GoUint64 (*envoy_go_filter_new_http_plugin_config_)(httpConfig* p0) = {nullptr};
@@ -73,12 +78,13 @@ private:
   void (*envoy_go_filter_on_http_log_)(httpRequest* p0, GoUint64 p1) = {nullptr};
   void (*envoy_go_filter_on_http_destroy_)(httpRequest* p0, GoUint64 p1) = {nullptr};
   void (*envoy_go_filter_go_request_sema_dec_)(httpRequest* p0) = {nullptr};
+  void (*envoy_go_filter_cleanup_)() = {nullptr};
 };
 
 class ClusterSpecifierDso : public Dso {
 public:
   ClusterSpecifierDso(const std::string dso_name) : Dso(dso_name){};
-  virtual ~ClusterSpecifierDso() = default;
+  ~ClusterSpecifierDso() override = default;
 
   virtual GoInt64 envoyGoOnClusterSpecify(GoUint64 plugin_ptr, GoUint64 header_ptr,
                                           GoUint64 plugin_id, GoUint64 buffer_ptr,
@@ -110,7 +116,7 @@ class NetworkFilterDso : public Dso {
 public:
   NetworkFilterDso() = default;
   NetworkFilterDso(const std::string dso_name) : Dso(dso_name){};
-  virtual ~NetworkFilterDso() = default;
+  ~NetworkFilterDso() override = default;
 
   virtual GoUint64 envoyGoFilterOnNetworkFilterConfig(GoUint64 library_id_ptr,
                                                       GoUint64 library_id_len, GoUint64 config_ptr,
@@ -263,6 +269,22 @@ public:
       return it->second;
     }
     return nullptr;
+  };
+
+  /**
+   * Clear all dso to make asan happy in testing.
+   */
+  static void cleanUpForTest() {
+    DsoStoreType& dsoStore = getDsoStore();
+    absl::WriterMutexLock lock(&dsoStore.mutex_);
+    for (auto it = dsoStore.id_to_dso_.begin(); it != dsoStore.id_to_dso_.end(); it++) {
+      auto dso = it->second;
+      if (dso != nullptr) {
+        dso->cleanup();
+      }
+    }
+    dsoStore.id_to_dso_.clear();
+    dsoStore.plugin_name_to_dso_.clear();
   };
 
 private:

--- a/contrib/golang/common/dso/dso.h
+++ b/contrib/golang/common/dso/dso.h
@@ -272,7 +272,7 @@ public:
   };
 
   /**
-   * Clear all dso to make asan happy in testing.
+   * Clean up all golang runtime to make asan happy in testing.
    */
   static void cleanUpForTest() {
     DsoStoreType& dsoStore = getDsoStore();

--- a/contrib/golang/common/dso/libgolang.h
+++ b/contrib/golang/common/dso/libgolang.h
@@ -130,6 +130,10 @@ extern void envoyGoFilterOnHttpDestroy(httpRequest* r, GoUint64 reason);
 // github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http.envoyGoRequestSemaDec
 extern void envoyGoRequestSemaDec(httpRequest* r);
 
+// go:linkname envoyGoFilterCleanUp
+// github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http.envoyGoFilterCleanUp
+extern void envoyGoFilterCleanUp();
+
 // go:linkname envoyGoOnClusterSpecify
 // github.com/envoyproxy/envoy/contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier.envoyGoOnClusterSpecify
 extern GoInt64 envoyGoOnClusterSpecify(GoUint64 plugin_ptr, GoUint64 header_ptr, GoUint64 plugin_id,

--- a/contrib/golang/common/dso/test/mocks.h
+++ b/contrib/golang/common/dso/test/mocks.h
@@ -24,6 +24,7 @@ public:
   MOCK_METHOD(void, envoyGoFilterOnHttpLog, (httpRequest * p0, int p1));
   MOCK_METHOD(void, envoyGoFilterOnHttpDestroy, (httpRequest * p0, int p1));
   MOCK_METHOD(void, envoyGoRequestSemaDec, (httpRequest * p0));
+  MOCK_METHOD(void, envoyGoFilterCleanUp, ());
 };
 
 class MockNetworkFilterDsoImpl : public NetworkFilterDso {

--- a/contrib/golang/common/dso/test/test_data/simple.go
+++ b/contrib/golang/common/dso/test/test_data/simple.go
@@ -119,5 +119,9 @@ func envoyGoFilterOnSemaDec(wrapper unsafe.Pointer) {
 func envoyGoRequestSemaDec(r *C.httpRequest) {
 }
 
+//export envoyGoFilterCleanUp
+func envoyGoFilterCleanUp() {
+}
+
 func main() {
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/BUILD
+++ b/contrib/golang/filters/http/source/go/pkg/http/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "http",
     srcs = [
         "api.h",
+        "asan.go",
         "capi_impl.go",
         "config.go",
         "filter.go",

--- a/contrib/golang/filters/http/source/go/pkg/http/asan.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/asan.go
@@ -25,7 +25,7 @@ func forceGCFinalizer() {
 		})
 	}
 
-	api.LogDebugf("golang filter enforcing GC")
+	api.LogWarn("golang filter enforcing GC")
 	// enforce a GC cycle.
 	runtime.GC()
 

--- a/contrib/golang/filters/http/source/go/pkg/http/asan.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/asan.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+)
+
+var (
+	asanTestEnabled = false
+)
+
+// forceGCFinalizer enforce GC and wait GC finalizer finished.
+// Just for testing, to make asan happy.
+func forceGCFinalizer() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	{
+		// create a fake httpRequest to trigger GC finalizer.
+		fake := &httpRequest{}
+		runtime.SetFinalizer(fake, func(*httpRequest) {
+			wg.Done()
+		})
+	}
+
+	api.LogDebugf("golang filter enforcing GC")
+	// enforce a GC cycle.
+	runtime.GC()
+
+	// wait GC finalizers finished.
+	wg.Wait()
+}

--- a/contrib/golang/filters/http/source/go/pkg/http/config.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/config.go
@@ -111,6 +111,9 @@ func envoyGoFilterDestroyHttpPluginConfig(id uint64, needDelay int) {
 		// there is no race for non-merged config.
 		configCache.Delete(id)
 	}
+	if asanTestEnabled {
+		forceGCFinalizer()
+	}
 }
 
 //export envoyGoFilterMergeHttpPluginConfig

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -316,3 +316,11 @@ func envoyGoRequestSemaDec(r *C.httpRequest) {
 	defer req.recoverPanic()
 	req.resumeWaitCallback()
 }
+
+// This is unsafe, just for asan testing.
+//
+//export envoyGoFilterCleanUp
+func envoyGoFilterCleanUp() {
+	asanTestEnabled = true
+	forceGCFinalizer()
+}

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -76,6 +76,7 @@ public:
     if (filter_ != nullptr) {
       filter_->onDestroy();
     }
+    Dso::DsoManager<Dso::HttpFilterDsoImpl>::cleanUpForTest();
   }
 
   void setup(const std::string& lib_id, const std::string& lib_path,
@@ -179,6 +180,8 @@ TEST_F(GolangHttpFilterTest, SetHeaderAtWrongStage) {
   auto req = new HttpRequestInternal(*filter_);
 
   EXPECT_EQ(CAPINotInGo, filter_->setHeader(req->decodingState(), "foo", "bar", HeaderSet));
+
+  delete req;
 }
 
 // invalid config for routeconfig filter

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -664,7 +664,11 @@ typed_config:
     cleanup();
   }
 
-  void cleanup() { cleanupUpstreamAndDownstream(); }
+  void cleanup() {
+    cleanupUpstreamAndDownstream();
+
+    Dso::DsoManager<Dso::HttpFilterDsoImpl>::cleanUpForTest();
+  }
 
   void testDynamicMetadata(std::string path) {
     initializeBasicFilter(BASIC, "*", true);

--- a/contrib/golang/filters/http/test/websocket_integration_test.cc
+++ b/contrib/golang/filters/http/test/websocket_integration_test.cc
@@ -13,11 +13,17 @@
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_cat.h"
+#include "contrib/golang/filters/http/source/golang_filter.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
 
-INSTANTIATE_TEST_SUITE_P(Protocols, WebsocketIntegrationTest,
+class GolangWebsocketIntegrationTest : public WebsocketIntegrationTest {
+public:
+  void cleanup() { Dso::DsoManager<Dso::HttpFilterDsoImpl>::cleanUpForTest(); }
+};
+
+INSTANTIATE_TEST_SUITE_P(Protocols, GolangWebsocketIntegrationTest,
                          testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                          HttpProtocolIntegrationTest::protocolTestParamsToString);
 
@@ -51,7 +57,7 @@ typed_config:
   return absl::StrFormat(yaml_fmt, name, genSoPath(name), name);
 }
 
-TEST_P(WebsocketIntegrationTest, WebsocketGolangFilterChain) {
+TEST_P(GolangWebsocketIntegrationTest, WebsocketGolangFilterChain) {
   if (downstreamProtocol() != Http::CodecType::HTTP1 ||
       upstreamProtocol() != Http::CodecType::HTTP1) {
     return;
@@ -108,6 +114,8 @@ TEST_P(WebsocketIntegrationTest, WebsocketGolangFilterChain) {
   ASSERT_TRUE(absl::StrContains(tcp_client->data(), "Bye_bar foo"));
   tcp_client->close();
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect());
+
+  cleanup();
 }
 
 } // namespace Envoy


### PR DESCRIPTION
add a new API(only for testing) to clean up resources that are referenced on the Golang side, to make asan happy.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
