### PR TITLE
mobile: Rename setRuntimeGuard to addRuntimeGuard

### DIFF
--- a/mobile/docs/root/api/starting_envoy.rst
+++ b/mobile/docs/root/api/starting_envoy.rst
@@ -490,7 +490,7 @@ A maximum of 100 entries will be stored.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-``setRuntimeGuard``
+``addRuntimeGuard``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Adds a runtime guard key value pair to envoy configuration.  The guard is of the short form "feature"
@@ -500,10 +500,10 @@ Note that Envoy will fail to start up in debug mode if an unknown guard is speci
 **Example**::
 
   // Kotlin
-  builder.setRuntimeGuard("feature", true)
+  builder.addRuntimeGuard("feature", true)
 
   // Swift
-  builder.setRuntimeGuard("feature", true)
+  builder.addRuntimeGuard("feature", true)
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``setXds``

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -410,7 +410,7 @@ EngineBuilder& EngineBuilder::addPlatformFilter(const std::string& name) {
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setRuntimeGuard(std::string guard, bool value) {
+EngineBuilder& EngineBuilder::addRuntimeGuard(std::string guard, bool value) {
   runtime_guards_.emplace_back(std::move(guard), value);
   return *this;
 }

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -188,8 +188,10 @@ public:
   EngineBuilder& addNativeFilter(std::string name, std::string typed_config);
 
   EngineBuilder& addPlatformFilter(const std::string& name);
-
-  EngineBuilder& setRuntimeGuard(std::string guard, bool value);
+  // Adds a runtime guard for the `envoy.reloadable_features.<guard>`.
+  // For example if the runtime guard is `envoy.reloadable_features.use_foo`, the guard name is
+  // `use_foo`.
+  EngineBuilder& addRuntimeGuard(std::string guard, bool value);
 
   // These functions don't affect the Bootstrap configuration but instead perform registrations.
   EngineBuilder& addKeyValueStore(std::string name, KeyValueStoreSharedPtr key_value_store);

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -158,16 +158,14 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
   }
 
   /**
-   * Sets the boolean value for the reloadable runtime feature flag value. For example, to set the
+   * Adds the boolean value for the reloadable runtime feature flag value. For example, to set the
    * Envoy runtime flag `envoy.reloadable_features.http_allow_partial_urls_in_referer` to true,
-   * call `setRuntimeGuard("http_allow_partial_urls_in_referer", true)`.
-   *
-   * TODO(abeyad): Change the name to setRuntimeFeature here and in the C++ APIs.
+   * call `addRuntimeGuard("http_allow_partial_urls_in_referer", true)`.
    *
    * @param feature The reloadable runtime feature flag name.
    * @param value The Boolean value to set the runtime feature flag to.
    */
-  public NativeCronvoyEngineBuilderImpl setRuntimeGuard(String feature, boolean value) {
+  public NativeCronvoyEngineBuilderImpl addRuntimeGuard(String feature, boolean value) {
     mRuntimeGuards.put(feature, value);
     return this;
   }

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -1205,7 +1205,7 @@ void configureBuilder(Envoy::JNI::JniHelper& jni_helper, jlong connect_timeout_s
 
   auto guards = javaObjectArrayToStringPairVector(jni_helper, runtime_guards);
   for (std::pair<std::string, std::string>& entry : guards) {
-    builder.setRuntimeGuard(entry.first, entry.second == "true");
+    builder.addRuntimeGuard(entry.first, entry.second == "true");
   }
 
   auto filters = javaObjectArrayToStringPairVector(jni_helper, filter_chain);

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -631,13 +631,14 @@ open class EngineBuilder() {
   }
 
   /**
-   * Set a runtime guard with the provided value.
+   * Adds a runtime guard for the `envoy.reloadable_features.<guard>`. For example if the runtime
+   * guard is `envoy.reloadable_features.use_foo`, the guard name is `use_foo`.
    *
    * @param name the name of the runtime guard, e.g. test_feature_false.
    * @param value the value for the runtime guard.
    * @return This builder.
    */
-  fun setRuntimeGuard(name: String, value: Boolean): EngineBuilder {
+  fun addRuntimeGuard(name: String, value: Boolean): EngineBuilder {
     this.runtimeGuards.put(name, value)
     return this
   }

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -208,7 +208,7 @@
 
   for (NSString *key in self.runtimeGuards) {
     BOOL value = [[self.runtimeGuards objectForKey:key] isEqualToString:@"true"];
-    builder.setRuntimeGuard([key toCXXString], value);
+    builder.addRuntimeGuard([key toCXXString], value);
   }
 
   builder.addConnectTimeoutSeconds(self.connectTimeoutSeconds);

--- a/mobile/library/swift/EngineBuilder.swift
+++ b/mobile/library/swift/EngineBuilder.swift
@@ -553,14 +553,16 @@ open class EngineBuilder: NSObject {
     return self
   }
 
-  /// Set a runtime guard with the provided value.
+  // Adds a runtime guard for the `envoy.reloadable_features.<guard>`.
+  // For example if the runtime guard is `envoy.reloadable_features.use_foo`, the guard name is
+  // `use_foo`.
   ///
   /// - parameter name:  the name of the runtime guard, e.g. test_feature_false.
   /// - parameter value: the value for the runtime guard.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func setRuntimeGuard(_ name: String, _ value: Bool) -> Self {
+  public func addRuntimeGuard(_ name: String, _ value: Bool) -> Self {
     self.runtimeGuards[name] = value
     return self
   }

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -83,7 +83,7 @@ TEST(TestConfig, ConfigIsApplied) {
       .addH2ConnectionKeepaliveTimeoutSeconds(333)
       .setAppVersion("1.2.3")
       .setAppId("1234-1234-1234")
-      .setRuntimeGuard("test_feature_false", true)
+      .addRuntimeGuard("test_feature_false", true)
       .enableDnsCache(true, /* save_interval_seconds */ 101)
       .addDnsPreresolveHostnames({"lyft.com", "google.com"})
       .setForceAlwaysUsev6(true)
@@ -129,8 +129,8 @@ TEST(TestConfig, ConfigIsApplied) {
 
 TEST(TestConfig, MultiFlag) {
   EngineBuilder engine_builder;
-  engine_builder.setRuntimeGuard("test_feature_false", true)
-      .setRuntimeGuard("test_feature_true", false);
+  engine_builder.addRuntimeGuard("test_feature_false", true)
+      .addRuntimeGuard("test_feature_true", false);
 
   std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
   const std::string bootstrap_str = bootstrap->ShortDebugString();
@@ -409,7 +409,7 @@ TEST(TestConfig, XdsConfig) {
 
 TEST(TestConfig, MoveConstructor) {
   EngineBuilder engine_builder;
-  engine_builder.setRuntimeGuard("test_feature_false", true).enableGzipDecompression(false);
+  engine_builder.addRuntimeGuard("test_feature_false", true).enableGzipDecompression(false);
 
   std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
   std::string bootstrap_str = bootstrap->ShortDebugString();

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -674,7 +674,7 @@ TEST_P(ClientIntegrationTest, InvalidDomainFakeResolver) {
 }
 
 TEST_P(ClientIntegrationTest, InvalidDomainReresolveWithNoAddresses) {
-  builder_.setRuntimeGuard("reresolve_null_addresses", true);
+  builder_.addRuntimeGuard("reresolve_null_addresses", true);
   Network::OverrideAddrInfoDnsResolverFactory factory;
   Registry::InjectFactory<Network::DnsResolverFactory> inject_factory(factory);
   Registry::InjectFactory<Network::DnsResolverFactory>::forceAllowDuplicates();
@@ -1333,8 +1333,8 @@ TEST_P(ClientIntegrationTest, DirectResponse) {
 }
 
 TEST_P(ClientIntegrationTest, TestRuntimeSet) {
-  builder_.setRuntimeGuard("test_feature_true", false);
-  builder_.setRuntimeGuard("test_feature_false", true);
+  builder_.addRuntimeGuard("test_feature_true", false);
+  builder_.addRuntimeGuard("test_feature_false", true);
   initialize();
 
   // Verify that the Runtime config values are from the RTDS response.

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -217,8 +217,8 @@ class EngineBuilderTest {
   fun `specifying runtime guards work`() {
     engineBuilder = EngineBuilder()
     engineBuilder
-      .setRuntimeGuard("test_feature_false", true)
-      .setRuntimeGuard("test_feature_true", false)
+      .addRuntimeGuard("test_feature_false", true)
+      .addRuntimeGuard("test_feature_true", false)
     val engine = engineBuilder.build() as EngineImpl
     assertThat(engine.envoyConfiguration.runtimeGuards["test_feature_false"]).isEqualTo("true")
     assertThat(engine.envoyConfiguration.runtimeGuards["test_feature_true"]).isEqualTo("false")

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -13,10 +13,10 @@ final class EngineBuilderTests: XCTestCase {
     MockEnvoyEngine.onRunWithConfig = nil
   }
 
-  func testSetRuntimeGuard() {
+  func testAddRuntimeGuard() {
     let bootstrapDebugDescription = EngineBuilder()
-      .setRuntimeGuard("test_feature_false", true)
-      .setRuntimeGuard("test_feature_true", false)
+      .addRuntimeGuard("test_feature_false", true)
+      .addRuntimeGuard("test_feature_true", false)
       .bootstrapDebugDescription()
     XCTAssertTrue(
       bootstrapDebugDescription.contains(#""test_feature_false" value { bool_value: true }"#)

--- a/mobile/test/swift/integration/KeyValueStoreTest.swift
+++ b/mobile/test/swift/integration/KeyValueStoreTest.swift
@@ -52,7 +52,7 @@ final class KeyValueStoreTests: XCTestCase {
         // swiftlint:disable:next line_length
         typedConfig: "[\(kvStoreType)]{ kv_store_name: 'envoy.key_value.platform_test', test_key: 'foo', test_value: 'bar'}"
       )
-      .setRuntimeGuard("test_feature_false", true)
+      .addRuntimeGuard("test_feature_false", true)
       .build()
 
     let client = engine.streamClient()


### PR DESCRIPTION
Calling it `addRuntimeGuard` makes more sense since we can add multiple runtime guards. This PR also adds comments related to what the guard name is.

Risk Level: low (refactoring)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
