### PR TITLE
[cache-filter] addEncodedData is streaming

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -465,7 +465,7 @@ void CacheFilter::onBody(Buffer::InstancePtr&& body) {
 
   filter_state_ == FilterState::DecodeServingFromCache
       ? decoder_callbacks_->encodeData(*body, end_stream)
-      : encoder_callbacks_->addEncodedData(*body, !response_has_trailers_);
+      : encoder_callbacks_->addEncodedData(*body, true);
 
   if (!remaining_ranges_.empty()) {
     getBody();


### PR DESCRIPTION
Commit Message: [cache-filter] addEncodedData is streaming
Additional Description: It's possible that this change is incorrect, but I can't justify how it was, and the justification for this parameter being always true is is "the filter is streaming content, not buffering, and that doesn't change depending on whether there are trailers or not". I think probably the previous way was a misunderstanding that this argument is equivalent to `end_stream`, which I believe it is not. (One effect this argument can have is, if false, it can cause a response to fully abort if the buffer is over the watermark limit, which I believe is an argument in favor of this change.)
Risk Level: Might make a WIP filter misbehave if I'm wrong. Might be the filter already misbehaves if I'm right, so net-neutral.
Testing: All existing tests still pass.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
