### PR TITLE
ext_proc: add prefix to immediate response details

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1097,7 +1097,7 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
   sent_immediate_response_ = true;
   ENVOY_LOG(debug, "Sending local reply with status code {}", status_code);
   const std::string prefix =
-      fmt::format("immediate_response_from_ext_proc[{}]", encoder_callbacks_->filterConfigName());
+      fmt::format(ImmediateResponsePrefix, encoder_callbacks_->filterConfigName());
   const std::string response_details =
       StringUtil::replaceAllEmptySpace(absl::StrCat(prefix, ":", response.details()));
   encoder_callbacks_->sendLocalReply(static_cast<Http::Code>(status_code), response.body(),

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1096,11 +1096,8 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
 
   sent_immediate_response_ = true;
   ENVOY_LOG(debug, "Sending local reply with status code {}", status_code);
-  // const auto details = StringUtil::replaceAllEmptySpace(response.details());
   const std::string prefix =
       fmt::format("immediate_response_from_ext_proc[{}]", encoder_callbacks_->filterConfigName());
-  // const std::string response_details = absl::StrCat(prefix, ":", response.details());
-
   const std::string response_details =
       StringUtil::replaceAllEmptySpace(absl::StrCat(prefix, ":", response.details()));
   encoder_callbacks_->sendLocalReply(static_cast<Http::Code>(status_code), response.body(),

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1096,9 +1096,15 @@ void Filter::sendImmediateResponse(const ImmediateResponse& response) {
 
   sent_immediate_response_ = true;
   ENVOY_LOG(debug, "Sending local reply with status code {}", status_code);
-  const auto details = StringUtil::replaceAllEmptySpace(response.details());
+  // const auto details = StringUtil::replaceAllEmptySpace(response.details());
+  const std::string prefix =
+      fmt::format("immediate_response_from_ext_proc[{}]", encoder_callbacks_->filterConfigName());
+  // const std::string response_details = absl::StrCat(prefix, ":", response.details());
+
+  const std::string response_details =
+      StringUtil::replaceAllEmptySpace(absl::StrCat(prefix, ":", response.details()));
   encoder_callbacks_->sendLocalReply(static_cast<Http::Code>(status_code), response.body(),
-                                     mutate_headers, grpc_status, details);
+                                     mutate_headers, grpc_status, response_details);
 }
 
 void Filter::mergePerRouteConfig() {

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -52,6 +52,7 @@ namespace ExternalProcessing {
 struct ExtProcFilterStats {
   ALL_EXT_PROC_FILTER_STATS(GENERATE_COUNTER_STRUCT)
 };
+constexpr absl::string_view ImmediateResponsePrefix = "direct_response_from_ext_proc[{}]";
 
 class ExtProcLoggingInfo : public Envoy::StreamInfo::FilterState::Object {
 public:

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -52,7 +52,8 @@ namespace ExternalProcessing {
 struct ExtProcFilterStats {
   ALL_EXT_PROC_FILTER_STATS(GENERATE_COUNTER_STRUCT)
 };
-constexpr absl::string_view ImmediateResponsePrefix = "direct_response_from_ext_proc[{}]";
+
+inline constexpr absl::string_view ImmediateResponsePrefix = "direct_response_from_ext_proc[{}]";
 
 class ExtProcLoggingInfo : public Envoy::StreamInfo::FilterState::Object {
 public:

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -83,7 +83,6 @@ using namespace std::chrono_literals;
 
 static const uint32_t BufferSize = 100000;
 constexpr absl::string_view FilterConfigName = "scooby.dooby.doo";
-constexpr absl::string_view ImmediateResponsePrefix = "immediate_response_from_ext_proc[{}]";
 const std::string badRequestResponseDetails() {
   CONSTRUCT_ON_FIRST_USE(std::string,
                          absl::StrCat(fmt::format(ImmediateResponsePrefix, FilterConfigName), ":",


### PR DESCRIPTION
Add common prefix to response details so that consumer (e.g., logging customer) can perform post-processing based on prefix (e.g., lookup  etc)

Example response details: 

Before: `Got_a_bad_request`
Now: `direct_response_from_ext_proc[ext_proc_filter_name]:Got_a_bad_request`

