### PR TITLE
generic proxy: filter chain support for local reply and refactored the stream flags

### DIFF
--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -137,10 +137,16 @@ public:
       }
 
       auto message = std::make_unique<DecoderMessageType>(metadata_);
-      message->stream_frame_flags_ = {{static_cast<uint64_t>(metadata_->requestId()),
-                                       !metadata_->context().isTwoWay(), false,
-                                       metadata_->context().heartbeat()},
-                                      true};
+
+      uint32_t frame_flags = FrameFlags::FLAG_END_STREAM; // Dubbo message only has one frame.
+      if (!metadata_->context().isTwoWay()) {
+        frame_flags |= FrameFlags::FLAG_ONE_WAY;
+      }
+      if (metadata_->context().heartbeat()) {
+        frame_flags |= FrameFlags::FLAG_HEARTBEAT;
+      }
+
+      message->stream_frame_flags_ = {static_cast<uint64_t>(metadata_->requestId()), frame_flags};
       metadata_.reset();
       callback_->onDecodingSuccess(std::move(message));
 

--- a/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/dubbo/config.h
@@ -28,6 +28,16 @@ public:
     ASSERT(inner_metadata_ != nullptr);
     ASSERT(inner_metadata_->hasContext());
     ASSERT(inner_metadata_->hasRequest());
+
+    uint32_t frame_flags = FrameFlags::FLAG_END_STREAM; // Dubbo message only has one frame.
+    if (!inner_metadata_->context().isTwoWay()) {
+      frame_flags |= FrameFlags::FLAG_ONE_WAY;
+    }
+    if (inner_metadata_->context().heartbeat()) {
+      frame_flags |= FrameFlags::FLAG_HEARTBEAT;
+    }
+
+    stream_frame_flags_ = {static_cast<uint64_t>(inner_metadata_->requestId()), frame_flags};
   }
 
   // Request
@@ -43,9 +53,10 @@ public:
   // StreamFrame
   FrameFlags frameFlags() const override { return stream_frame_flags_; }
 
-  FrameFlags stream_frame_flags_;
-
   Common::Dubbo::MessageMetadataSharedPtr inner_metadata_;
+
+private:
+  FrameFlags stream_frame_flags_;
 };
 
 class DubboResponse : public Response {
@@ -56,6 +67,16 @@ public:
     ASSERT(inner_metadata_->hasContext());
     ASSERT(inner_metadata_->hasResponse());
     refreshStatus();
+
+    uint32_t frame_flags = FrameFlags::FLAG_END_STREAM; // Dubbo message only has one frame.
+    if (!inner_metadata_->context().isTwoWay()) {
+      frame_flags |= FrameFlags::FLAG_ONE_WAY;
+    }
+    if (inner_metadata_->context().heartbeat()) {
+      frame_flags |= FrameFlags::FLAG_HEARTBEAT;
+    }
+
+    stream_frame_flags_ = {static_cast<uint64_t>(inner_metadata_->requestId()), frame_flags};
   }
 
   void refreshStatus();
@@ -67,10 +88,11 @@ public:
   // StreamFrame
   FrameFlags frameFlags() const override { return stream_frame_flags_; }
 
-  FrameFlags stream_frame_flags_;
-
   StreamStatus status_;
   Common::Dubbo::MessageMetadataSharedPtr inner_metadata_;
+
+private:
+  FrameFlags stream_frame_flags_;
 };
 
 class DubboCodecBase : public Logger::Loggable<Logger::Id::connection> {
@@ -136,18 +158,9 @@ public:
         return Common::Dubbo::DecodeStatus::Success;
       }
 
-      auto message = std::make_unique<DecoderMessageType>(metadata_);
-
-      uint32_t frame_flags = FrameFlags::FLAG_END_STREAM; // Dubbo message only has one frame.
-      if (!metadata_->context().isTwoWay()) {
-        frame_flags |= FrameFlags::FLAG_ONE_WAY;
-      }
-      if (metadata_->context().heartbeat()) {
-        frame_flags |= FrameFlags::FLAG_HEARTBEAT;
-      }
-
-      message->stream_frame_flags_ = {static_cast<uint64_t>(metadata_->requestId()), frame_flags};
+      auto message = std::make_unique<DecoderMessageType>(std::move(metadata_));
       metadata_.reset();
+
       callback_->onDecodingSuccess(std::move(message));
 
       return Common::Dubbo::DecodeStatus::Success;

--- a/contrib/generic_proxy/filters/network/source/codecs/http1/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/http1/config.h
@@ -60,7 +60,7 @@ public:
   HttpRequestFrame(Http::RequestHeaderMapPtr request, bool end_stream)
       : request_(std::move(request)) {
     ASSERT(request_ != nullptr);
-    frame_flags_ = {StreamFlags{}, end_stream};
+    frame_flags_ = {0, end_stream ? FrameFlags::FLAG_END_STREAM : FrameFlags::FLAG_EMPTY};
   }
 
   absl::string_view host() const override { return request_->getHostValue(); }
@@ -80,7 +80,15 @@ public:
     const bool drain_close = Envoy::StringUtil::caseFindToken(
         response_->getConnectionValue(), ",", Http::Headers::get().ConnectionValues.Close);
 
-    frame_flags_ = {StreamFlags{0, false, drain_close, false}, end_stream};
+    uint32_t flags = 0;
+    if (end_stream) {
+      flags |= FrameFlags::FLAG_END_STREAM;
+    }
+    if (drain_close) {
+      flags |= FrameFlags::FLAG_DRAIN_CLOSE;
+    }
+
+    frame_flags_ = {0, flags};
   }
 
   StreamStatus status() const override {
@@ -101,7 +109,7 @@ public:
 class HttpRawBodyFrame : public CommonFrame {
 public:
   HttpRawBodyFrame(Envoy::Buffer::Instance& buffer, bool end_stream)
-      : frame_flags_({StreamFlags{}, end_stream}) {
+      : frame_flags_(0, end_stream ? FrameFlags::FLAG_END_STREAM : FrameFlags::FLAG_EMPTY) {
     buffer_.move(buffer);
   }
   FrameFlags frameFlags() const override { return frame_flags_; }

--- a/contrib/generic_proxy/filters/network/source/codecs/kafka/config.h
+++ b/contrib/generic_proxy/filters/network/source/codecs/kafka/config.h
@@ -28,8 +28,7 @@ public:
     if (request_ == nullptr) {
       return FrameFlags{};
     }
-    return FrameFlags{
-        StreamFlags{static_cast<uint64_t>(request_->request_header_.correlation_id_)}};
+    return FrameFlags{static_cast<uint64_t>(request_->request_header_.correlation_id_)};
   }
 
   absl::string_view protocol() const override { return "kafka"; }
@@ -46,7 +45,7 @@ public:
     if (response_ == nullptr) {
       return FrameFlags{};
     }
-    return FrameFlags{StreamFlags{static_cast<uint64_t>(response_->metadata_.correlation_id_)}};
+    return FrameFlags{static_cast<uint64_t>(response_->metadata_.correlation_id_)};
   }
 
   absl::string_view protocol() const override { return "kafka"; }

--- a/contrib/generic_proxy/filters/network/source/router/router.h
+++ b/contrib/generic_proxy/filters/network/source/router/router.h
@@ -48,7 +48,7 @@ class UpstreamRequest : public UpstreamRequestCallbacks,
                         public EncodingContext,
                         Logger::Loggable<Envoy::Logger::Id::filter> {
 public:
-  UpstreamRequest(RouterFilter& parent, StreamFlags stream_flags,
+  UpstreamRequest(RouterFilter& parent, FrameFlags header_frame_flags,
                   GenericUpstreamSharedPtr generic_upstream);
 
   void startStream();

--- a/contrib/generic_proxy/filters/network/test/codecs/http1/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/http1/config_test.cc
@@ -132,14 +132,14 @@ TEST(Http1MessageFrameTest, Http1MessageFrameTest) {
     HttpResponseFrame frame(std::move(headers), true);
 
     EXPECT_EQ(true, frame.frameFlags().endStream());
-    EXPECT_EQ(false, frame.frameFlags().streamFlags().drainClose());
+    EXPECT_EQ(false, frame.frameFlags().drainClose());
 
     auto headers2 = Http::ResponseHeaderMapImpl::create();
     headers2->setConnection("close");
     HttpResponseFrame frame2(std::move(headers2), false);
 
     EXPECT_EQ(false, frame2.frameFlags().endStream());
-    EXPECT_EQ(true, frame2.frameFlags().streamFlags().drainClose());
+    EXPECT_EQ(true, frame2.frameFlags().drainClose());
   }
 
   // Request FrameType.

--- a/contrib/generic_proxy/filters/network/test/fake_codec.h
+++ b/contrib/generic_proxy/filters/network/test/fake_codec.h
@@ -115,8 +115,15 @@ public:
         data.erase("one_way");
       }
 
-      auto frame_flags =
-          FrameFlags(StreamFlags(stream_id.value_or(0), one_way_stream, false, false), end_stream);
+      uint32_t flags = 0;
+      if (end_stream) {
+        flags |= FrameFlags::FLAG_END_STREAM;
+      }
+      if (one_way_stream) {
+        flags |= FrameFlags::FLAG_ONE_WAY;
+      }
+
+      FrameFlags frame_flags(stream_id.value_or(0), flags);
 
       const auto it = data.find("message_type");
 
@@ -208,8 +215,7 @@ public:
 
       buffer += fmt::format("stream_id:{};", response.frameFlags().streamId());
       buffer += fmt::format("end_stream:{};", response.frameFlags().endStream());
-      buffer +=
-          fmt::format("close_connection:{};", response.frameFlags().streamFlags().drainClose());
+      buffer += fmt::format("close_connection:{};", response.frameFlags().drainClose());
 
       ENVOY_LOG(debug, "FakeServerCodec::encode: {}", buffer);
 
@@ -274,8 +280,15 @@ public:
         data.erase("close_connection");
       }
 
-      auto frame_flags = FrameFlags(
-          StreamFlags(stream_id.value_or(0), false, close_connection, false), end_stream);
+      uint32_t flags = 0;
+      if (end_stream) {
+        flags |= FrameFlags::FLAG_END_STREAM;
+      }
+      if (close_connection) {
+        flags |= FrameFlags::FLAG_DRAIN_CLOSE;
+      }
+
+      FrameFlags frame_flags(stream_id.value_or(0), flags);
 
       const auto it = data.find("message_type");
 
@@ -371,7 +384,7 @@ public:
 
       buffer += fmt::format("stream_id:{};", request.frameFlags().streamId());
       buffer += fmt::format("end_stream:{};", request.frameFlags().endStream());
-      buffer += fmt::format("one_way:{};", request.frameFlags().streamFlags().oneWayStream());
+      buffer += fmt::format("one_way:{};", request.frameFlags().oneWayStream());
 
       ENVOY_LOG(debug, "FakeClientCodec::encode: {}", buffer);
 

--- a/contrib/generic_proxy/filters/network/test/integration_test.cc
+++ b/contrib/generic_proxy/filters/network/test/integration_test.cc
@@ -425,235 +425,235 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, IntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-// TEST_P(IntegrationTest, InitializeInstance) {
-//   FakeStreamCodecFactoryConfig codec_factory_config;
-//   Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+TEST_P(IntegrationTest, InitializeInstance) {
+  FakeStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
 
-//   initialize(defaultConfig(), std::make_unique<FakeStreamCodecFactory>());
-// }
+  initialize(defaultConfig(), std::make_unique<FakeStreamCodecFactory>());
+}
 
-// TEST_P(IntegrationTest, RequestRouteNotFound) {
-//   FakeStreamCodecFactoryConfig codec_factory_config;
-//   Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+TEST_P(IntegrationTest, RequestRouteNotFound) {
+  FakeStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
 
-//   initialize(defaultConfig(), std::make_unique<FakeStreamCodecFactory>());
-//   EXPECT_TRUE(makeClientConnectionForTest());
+  initialize(defaultConfig(), std::make_unique<FakeStreamCodecFactory>());
+  EXPECT_TRUE(makeClientConnectionForTest());
 
-//   FakeStreamCodecFactory::FakeRequest request;
-//   request.host_ = "service_name_0";
-//   request.method_ = "hello";
-//   request.path_ = "/path_or_anything";
-//   request.protocol_ = "fake_fake_fake";
-//   request.data_ = {{"version", "v2"}};
+  FakeStreamCodecFactory::FakeRequest request;
+  request.host_ = "service_name_0";
+  request.method_ = "hello";
+  request.path_ = "/path_or_anything";
+  request.protocol_ = "fake_fake_fake";
+  request.data_ = {{"version", "v2"}};
 
-//   sendRequestForTest(request);
+  sendRequestForTest(request);
 
-//   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
-//                  "unexpected timeout");
+  RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
+                 "unexpected timeout");
 
-//   EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(),
-//             static_cast<uint32_t>(absl::StatusCode::kNotFound));
+  EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
+  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(),
+            static_cast<uint32_t>(absl::StatusCode::kNotFound));
 
-//   cleanup();
-// }
+  cleanup();
+}
 
-// TEST_P(IntegrationTest, RequestAndResponse) {
-//   FakeStreamCodecFactoryConfig codec_factory_config;
-//   Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+TEST_P(IntegrationTest, RequestAndResponse) {
+  FakeStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
 
-//   initialize(defaultConfig(), std::make_unique<FakeStreamCodecFactory>());
+  initialize(defaultConfig(), std::make_unique<FakeStreamCodecFactory>());
 
-//   EXPECT_TRUE(makeClientConnectionForTest());
+  EXPECT_TRUE(makeClientConnectionForTest());
 
-//   FakeStreamCodecFactory::FakeRequest request;
-//   request.host_ = "service_name_0";
-//   request.method_ = "hello";
-//   request.path_ = "/path_or_anything";
-//   request.protocol_ = "fake_fake_fake";
-//   request.data_ = {{"version", "v1"}};
+  FakeStreamCodecFactory::FakeRequest request;
+  request.host_ = "service_name_0";
+  request.method_ = "hello";
+  request.path_ = "/path_or_anything";
+  request.protocol_ = "fake_fake_fake";
+  request.data_ = {{"version", "v1"}};
 
-//   sendRequestForTest(request);
+  sendRequestForTest(request);
 
-//   waitForUpstreamConnectionForTest();
-//   const std::function<bool(const std::string&)> data_validator =
-//       [](const std::string& data) -> bool { return data.find("v1") != std::string::npos; };
-//   waitForUpstreamRequestForTest(data_validator);
+  waitForUpstreamConnectionForTest();
+  const std::function<bool(const std::string&)> data_validator =
+      [](const std::string& data) -> bool { return data.find("v1") != std::string::npos; };
+  waitForUpstreamRequestForTest(data_validator);
 
-//   FakeStreamCodecFactory::FakeResponse response;
-//   response.protocol_ = "fake_fake_fake";
-//   response.status_ = StreamStatus();
-//   response.data_["zzzz"] = "xxxx";
+  FakeStreamCodecFactory::FakeResponse response;
+  response.protocol_ = "fake_fake_fake";
+  response.status_ = StreamStatus();
+  response.data_["zzzz"] = "xxxx";
 
-//   sendResponseForTest(response);
+  sendResponseForTest(response);
 
-//   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
-//                  "unexpected timeout");
+  RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
+                 "unexpected timeout");
 
-//   EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(), 0);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->get("zzzz"), "xxxx");
+  EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
+  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->get("zzzz"), "xxxx");
 
-//   cleanup();
-// }
+  cleanup();
+}
 
-// TEST_P(IntegrationTest, RequestTimeout) {
-//   FakeStreamCodecFactoryConfig codec_factory_config;
-//   Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+TEST_P(IntegrationTest, RequestTimeout) {
+  FakeStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
 
-//   initialize(timeoutConfig(), std::make_unique<FakeStreamCodecFactory>());
+  initialize(timeoutConfig(), std::make_unique<FakeStreamCodecFactory>());
 
-//   EXPECT_TRUE(makeClientConnectionForTest());
+  EXPECT_TRUE(makeClientConnectionForTest());
 
-//   FakeStreamCodecFactory::FakeRequest request;
-//   request.host_ = "service_name_0";
-//   request.method_ = "hello";
-//   request.path_ = "/path_or_anything";
-//   request.protocol_ = "fake_fake_fake";
-//   request.data_ = {{"version", "v1"}};
+  FakeStreamCodecFactory::FakeRequest request;
+  request.host_ = "service_name_0";
+  request.method_ = "hello";
+  request.path_ = "/path_or_anything";
+  request.protocol_ = "fake_fake_fake";
+  request.data_ = {{"version", "v1"}};
 
-//   sendRequestForTest(request);
+  sendRequestForTest(request);
 
-//   waitForUpstreamConnectionForTest();
-//   const std::function<bool(const std::string&)> data_validator =
-//       [](const std::string& data) -> bool { return data.find("v1") != std::string::npos; };
-//   waitForUpstreamRequestForTest(data_validator);
+  waitForUpstreamConnectionForTest();
+  const std::function<bool(const std::string&)> data_validator =
+      [](const std::string& data) -> bool { return data.find("v1") != std::string::npos; };
+  waitForUpstreamRequestForTest(data_validator);
 
-//   // No response is sent, so the downstream should timeout.
+  // No response is sent, so the downstream should timeout.
 
-//   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
-//                  "unexpected timeout");
+  RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
+                 "unexpected timeout");
 
-//   EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(), 4);
+  EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
+  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(), 4);
 
-//   cleanup();
-// }
+  cleanup();
+}
 
-// TEST_P(IntegrationTest, MultipleRequestsWithSameStreamId) {
-//   FakeStreamCodecFactoryConfig codec_factory_config;
-//   Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+TEST_P(IntegrationTest, MultipleRequestsWithSameStreamId) {
+  FakeStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
 
-//   auto codec_factory = std::make_unique<FakeStreamCodecFactory>();
+  auto codec_factory = std::make_unique<FakeStreamCodecFactory>();
 
-//   initialize(defaultConfig(true), std::move(codec_factory));
+  initialize(defaultConfig(true), std::move(codec_factory));
 
-//   EXPECT_TRUE(makeClientConnectionForTest());
+  EXPECT_TRUE(makeClientConnectionForTest());
 
-//   FakeStreamCodecFactory::FakeRequest request_1;
-//   request_1.host_ = "service_name_0";
-//   request_1.method_ = "hello";
-//   request_1.path_ = "/path_or_anything";
-//   request_1.protocol_ = "fake_fake_fake";
-//   request_1.data_ = {{"version", "v1"}};
-//   request_1.stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  FakeStreamCodecFactory::FakeRequest request_1;
+  request_1.host_ = "service_name_0";
+  request_1.method_ = "hello";
+  request_1.path_ = "/path_or_anything";
+  request_1.protocol_ = "fake_fake_fake";
+  request_1.data_ = {{"version", "v1"}};
+  request_1.stream_frame_flags_ = FrameFlags(1);
 
-//   sendRequestForTest(request_1);
+  sendRequestForTest(request_1);
 
-//   waitForUpstreamConnectionForTest();
-//   const std::function<bool(const std::string&)> data_validator =
-//       [](const std::string& data) -> bool { return data.find("v1") != std::string::npos; };
-//   waitForUpstreamRequestForTest(data_validator);
+  waitForUpstreamConnectionForTest();
+  const std::function<bool(const std::string&)> data_validator =
+      [](const std::string& data) -> bool { return data.find("v1") != std::string::npos; };
+  waitForUpstreamRequestForTest(data_validator);
 
-//   FakeStreamCodecFactory::FakeRequest request_2;
-//   request_2.host_ = "service_name_0";
-//   request_2.method_ = "hello";
-//   request_2.path_ = "/path_or_anything";
-//   request_2.protocol_ = "fake_fake_fake";
-//   request_2.data_ = {{"version", "v1"}};
-//   request_2.stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  FakeStreamCodecFactory::FakeRequest request_2;
+  request_2.host_ = "service_name_0";
+  request_2.method_ = "hello";
+  request_2.path_ = "/path_or_anything";
+  request_2.protocol_ = "fake_fake_fake";
+  request_2.data_ = {{"version", "v1"}};
+  request_2.stream_frame_flags_ = FrameFlags(1);
 
-//   // Send the second request with the same stream id and expect the connection to be closed.
-//   sendRequestForTest(request_2);
+  // Send the second request with the same stream id and expect the connection to be closed.
+  sendRequestForTest(request_2);
 
-//   // Wait for the connection to be closed.
-//   auto result = upstream_connection_->waitForDisconnect();
-//   RELEASE_ASSERT(result, result.message());
+  // Wait for the connection to be closed.
+  auto result = upstream_connection_->waitForDisconnect();
+  RELEASE_ASSERT(result, result.message());
 
-//   cleanup();
-// }
+  cleanup();
+}
 
-// TEST_P(IntegrationTest, MultipleRequests) {
-//   FakeStreamCodecFactoryConfig codec_factory_config;
-//   Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
+TEST_P(IntegrationTest, MultipleRequests) {
+  FakeStreamCodecFactoryConfig codec_factory_config;
+  Registry::InjectFactory<CodecFactoryConfig> registration(codec_factory_config);
 
-//   auto codec_factory = std::make_unique<FakeStreamCodecFactory>();
+  auto codec_factory = std::make_unique<FakeStreamCodecFactory>();
 
-//   initialize(defaultConfig(true), std::move(codec_factory));
+  initialize(defaultConfig(true), std::move(codec_factory));
 
-//   EXPECT_TRUE(makeClientConnectionForTest());
+  EXPECT_TRUE(makeClientConnectionForTest());
 
-//   FakeStreamCodecFactory::FakeRequest request_1;
-//   request_1.host_ = "service_name_0";
-//   request_1.method_ = "hello";
-//   request_1.path_ = "/path_or_anything";
-//   request_1.protocol_ = "fake_fake_fake";
-//   request_1.data_ = {{"version", "v1"}, {"frame", "1_header"}};
-//   request_1.stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  FakeStreamCodecFactory::FakeRequest request_1;
+  request_1.host_ = "service_name_0";
+  request_1.method_ = "hello";
+  request_1.path_ = "/path_or_anything";
+  request_1.protocol_ = "fake_fake_fake";
+  request_1.data_ = {{"version", "v1"}, {"frame", "1_header"}};
+  request_1.stream_frame_flags_ = FrameFlags(1);
 
-//   sendRequestForTest(request_1);
+  sendRequestForTest(request_1);
 
-//   waitForUpstreamConnectionForTest();
+  waitForUpstreamConnectionForTest();
 
-//   const std::function<bool(const std::string&)> data_validator_1 =
-//       [](const std::string& data) -> bool {
-//     return data.find("frame:1_header") != std::string::npos;
-//   };
-//   waitForUpstreamRequestForTest(data_validator_1);
+  const std::function<bool(const std::string&)> data_validator_1 =
+      [](const std::string& data) -> bool {
+    return data.find("frame:1_header") != std::string::npos;
+  };
+  waitForUpstreamRequestForTest(data_validator_1);
 
-//   FakeStreamCodecFactory::FakeRequest request_2;
-//   request_2.host_ = "service_name_0";
-//   request_2.method_ = "hello";
-//   request_2.path_ = "/path_or_anything";
-//   request_2.protocol_ = "fake_fake_fake";
-//   request_2.data_ = {{"version", "v1"}, {"frame", "2_header"}};
-//   request_2.stream_frame_flags_ = FrameFlags(StreamFlags(2));
+  FakeStreamCodecFactory::FakeRequest request_2;
+  request_2.host_ = "service_name_0";
+  request_2.method_ = "hello";
+  request_2.path_ = "/path_or_anything";
+  request_2.protocol_ = "fake_fake_fake";
+  request_2.data_ = {{"version", "v1"}, {"frame", "2_header"}};
+  request_2.stream_frame_flags_ = FrameFlags(2);
 
-//   // Reset request encoder callback.
-//   test_encoding_context_ = std::make_shared<TestEncodingContext>();
+  // Reset request encoder callback.
+  test_encoding_context_ = std::make_shared<TestEncodingContext>();
 
-//   // Send the second request with the different stream id and expect the connection to be alive.
-//   sendRequestForTest(request_2);
-//   const std::function<bool(const std::string&)> data_validator_2 =
-//       [](const std::string& data) -> bool {
-//     return data.find("frame:2_header") != std::string::npos;
-//   };
-//   waitForUpstreamRequestForTest(data_validator_2);
+  // Send the second request with the different stream id and expect the connection to be alive.
+  sendRequestForTest(request_2);
+  const std::function<bool(const std::string&)> data_validator_2 =
+      [](const std::string& data) -> bool {
+    return data.find("frame:2_header") != std::string::npos;
+  };
+  waitForUpstreamRequestForTest(data_validator_2);
 
-//   FakeStreamCodecFactory::FakeResponse response_2;
-//   response_2.protocol_ = "fake_fake_fake";
-//   response_2.status_ = StreamStatus();
-//   response_2.data_["zzzz"] = "xxxx";
-//   response_2.stream_frame_flags_ = FrameFlags(StreamFlags(2));
+  FakeStreamCodecFactory::FakeResponse response_2;
+  response_2.protocol_ = "fake_fake_fake";
+  response_2.status_ = StreamStatus();
+  response_2.data_["zzzz"] = "xxxx";
+  response_2.stream_frame_flags_ = FrameFlags(2);
 
-//   sendResponseForTest(response_2);
+  sendResponseForTest(response_2);
 
-//   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 2),
-//                  "unexpected timeout");
+  RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 2),
+                 "unexpected timeout");
 
-//   EXPECT_NE(client_codec_callabcks_->responses_[2].response_, nullptr);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->status().code(), 0);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->get("zzzz"), "xxxx");
-//   EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->frameFlags().streamId(), 2);
+  EXPECT_NE(client_codec_callabcks_->responses_[2].response_, nullptr);
+  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->get("zzzz"), "xxxx");
+  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->frameFlags().streamId(), 2);
 
-//   FakeStreamCodecFactory::FakeResponse response_1;
-//   response_1.protocol_ = "fake_fake_fake";
-//   response_1.status_ = StreamStatus();
-//   response_1.data_["zzzz"] = "yyyy";
-//   response_1.stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  FakeStreamCodecFactory::FakeResponse response_1;
+  response_1.protocol_ = "fake_fake_fake";
+  response_1.status_ = StreamStatus();
+  response_1.data_["zzzz"] = "yyyy";
+  response_1.stream_frame_flags_ = FrameFlags(1);
 
-//   sendResponseForTest(response_1);
+  sendResponseForTest(response_1);
 
-//   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 1),
-//                  "unexpected timeout");
+  RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 1),
+                 "unexpected timeout");
 
-//   EXPECT_NE(client_codec_callabcks_->responses_[1].response_, nullptr);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->status().code(), 0);
-//   EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->get("zzzz"), "yyyy");
-//   EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->frameFlags().streamId(), 1);
+  EXPECT_NE(client_codec_callabcks_->responses_[1].response_, nullptr);
+  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->get("zzzz"), "yyyy");
+  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->frameFlags().streamId(), 1);
 
-//   cleanup();
-// }
+  cleanup();
+}
 
 TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   FakeStreamCodecFactoryConfig codec_factory_config;
@@ -671,15 +671,15 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   request_1.path_ = "/path_or_anything";
   request_1.protocol_ = "fake_fake_fake";
   request_1.data_ = {{"version", "v1"}, {"frame", "1_header"}};
-  request_1.stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+  request_1.stream_frame_flags_ = FrameFlags(1, FrameFlags::FLAG_EMPTY);
 
   FakeStreamCodecFactory::FakeCommonFrame request_1_frame_1;
   request_1_frame_1.data_ = {{"frame", "1_frame_1"}};
-  request_1_frame_1.stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+  request_1_frame_1.stream_frame_flags_ = FrameFlags(1, FrameFlags::FLAG_EMPTY);
 
   FakeStreamCodecFactory::FakeCommonFrame request_1_frame_2;
   request_1_frame_2.data_ = {{"frame", "1_frame_2"}};
-  request_1_frame_2.stream_frame_flags_ = FrameFlags(StreamFlags(1), true);
+  request_1_frame_2.stream_frame_flags_ = FrameFlags(1);
 
   FakeStreamCodecFactory::FakeRequest request_2;
   request_2.host_ = "service_name_0";
@@ -687,15 +687,15 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   request_2.path_ = "/path_or_anything";
   request_2.protocol_ = "fake_fake_fake";
   request_2.data_ = {{"version", "v1"}, {"frame", "2_header"}};
-  request_2.stream_frame_flags_ = FrameFlags(StreamFlags(2), false);
+  request_2.stream_frame_flags_ = FrameFlags(2, FrameFlags::FLAG_EMPTY);
 
   FakeStreamCodecFactory::FakeCommonFrame request_2_frame_1;
   request_2_frame_1.data_ = {{"frame", "2_frame_1"}};
-  request_2_frame_1.stream_frame_flags_ = FrameFlags(StreamFlags(2), false);
+  request_2_frame_1.stream_frame_flags_ = FrameFlags(2, FrameFlags::FLAG_EMPTY);
 
   FakeStreamCodecFactory::FakeCommonFrame request_2_frame_2;
   request_2_frame_2.data_ = {{"frame", "2_frame_2"}};
-  request_2_frame_2.stream_frame_flags_ = FrameFlags(StreamFlags(2), true);
+  request_2_frame_2.stream_frame_flags_ = FrameFlags(2);
 
   // We handle frame one by one to make sure the order is correct.
 
@@ -753,10 +753,10 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   response_2.protocol_ = "fake_fake_fake";
   response_2.status_ = StreamStatus();
   response_2.data_["zzzz"] = "xxxx";
-  response_2.stream_frame_flags_ = FrameFlags(StreamFlags(2), false);
+  response_2.stream_frame_flags_ = FrameFlags(2, FrameFlags::FLAG_EMPTY);
 
   FakeStreamCodecFactory::FakeCommonFrame response_2_frame_1;
-  response_2_frame_1.stream_frame_flags_ = FrameFlags(StreamFlags(2), true);
+  response_2_frame_1.stream_frame_flags_ = FrameFlags(2);
 
   sendResponseForTest(response_2);
   sendResponseForTest(response_2_frame_1);
@@ -773,10 +773,10 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   response_1.protocol_ = "fake_fake_fake";
   response_1.status_ = StreamStatus();
   response_1.data_["zzzz"] = "yyyy";
-  response_1.stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+  response_1.stream_frame_flags_ = FrameFlags(1, FrameFlags::FLAG_EMPTY);
 
   FakeStreamCodecFactory::FakeCommonFrame response_1_frame_1;
-  response_1_frame_1.stream_frame_flags_ = FrameFlags(StreamFlags(1), true);
+  response_1_frame_1.stream_frame_flags_ = FrameFlags(1);
 
   sendResponseForTest(response_1);
   sendResponseForTest(response_1_frame_1);

--- a/contrib/generic_proxy/filters/network/test/router/router_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/router_test.cc
@@ -516,7 +516,7 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolFailureConnctionTimeoutAndWithRetryW
 }
 
 TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndExpectNoResponse) {
-  setup(FrameFlags(StreamFlags(0, true, false, false), true));
+  setup(FrameFlags(0, FrameFlags::FLAG_END_STREAM | FrameFlags::FLAG_ONE_WAY));
   kickOffNewUpstreamRequest(true);
 
   EXPECT_CALL(mock_filter_callback_, completeDirectly()).WillOnce(Invoke([this]() -> void {
@@ -700,11 +700,11 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseAndTimeout) {
 
 TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) {
   // There are multiple frames in the request.
-  setup(FrameFlags(StreamFlags(0, false, false, true), /*end_stream*/ false));
+  setup(FrameFlags(0, FrameFlags::FLAG_EMPTY));
   kickOffNewUpstreamRequest(true);
 
   auto frame_1 = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
-  frame_1->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, false, true), false);
+  frame_1->stream_frame_flags_ = FrameFlags(0, FrameFlags::FLAG_EMPTY);
   EXPECT_EQ(CommonFilterStatus::StopIteration, filter_->decodeCommonFrame(*frame_1));
 
   // This only store the frame and does nothing else because the pool is not ready yet.
@@ -744,12 +744,12 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithMultipleFrames) 
       }));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  response->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, false, false), false);
+  response->stream_frame_flags_ = FrameFlags(0, FrameFlags::FLAG_EMPTY);
 
   notifyDecodingSuccess(std::move(response));
 
   auto response_frame_1 = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
-  response_frame_1->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, false, false), false);
+  response_frame_1->stream_frame_flags_ = FrameFlags(0, FrameFlags::FLAG_EMPTY);
   notifyDecodingSuccess(std::move(response_frame_1));
 
   // End stream is set to true by default.
@@ -777,7 +777,8 @@ TEST_F(RouterFilterTest, UpstreamRequestPoolReadyAndResponseWithDrainCloseSetInR
   }));
 
   auto response = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  response->stream_frame_flags_ = FrameFlags(StreamFlags(0, false, true, false), true);
+  response->stream_frame_flags_ =
+      FrameFlags(0, FrameFlags::FLAG_END_STREAM | FrameFlags::FLAG_DRAIN_CLOSE);
   notifyDecodingSuccess(std::move(response));
 
   // Mock downstream closing.

--- a/contrib/generic_proxy/filters/network/test/router/upstream_test.cc
+++ b/contrib/generic_proxy/filters/network/test/router/upstream_test.cc
@@ -377,10 +377,10 @@ TEST_F(UpstreamTest, BoundGenericUpstreamDecodingSuccess) {
   EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  request_1->stream_frame_flags_ = FrameFlags(1);
 
   auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2));
+  request_2->stream_frame_flags_ = FrameFlags(2);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -431,10 +431,10 @@ TEST_F(UpstreamTest, BoundGenericUpstreamDecodingSuccessWithMultipleFrames) {
   EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+  request_1->stream_frame_flags_ = FrameFlags(1, FrameFlags::FLAG_EMPTY);
 
   auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2), false);
+  request_2->stream_frame_flags_ = FrameFlags(2, FrameFlags::FLAG_EMPTY);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -453,10 +453,10 @@ TEST_F(UpstreamTest, BoundGenericUpstreamDecodingSuccessWithMultipleFrames) {
   EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
-  request_1_frame->stream_frame_flags_ = FrameFlags(StreamFlags(1), true);
+  request_1_frame->stream_frame_flags_ = FrameFlags(1);
 
   auto request_2_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
-  request_2_frame->stream_frame_flags_ = FrameFlags(StreamFlags(2), true);
+  request_2_frame->stream_frame_flags_ = FrameFlags(2);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -504,10 +504,10 @@ TEST_F(UpstreamTest, BoundGenericUpstreamDecodingFailureAndNoUpstreamConnectionC
   EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  request_1->stream_frame_flags_ = FrameFlags(1);
 
   auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2));
+  request_2->stream_frame_flags_ = FrameFlags(2);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -557,10 +557,10 @@ TEST_F(UpstreamTest, BoundGenericUpstreamDecodingFailure) {
   EXPECT_EQ(2, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  request_1->stream_frame_flags_ = FrameFlags(1);
 
   auto request_2 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_2->stream_frame_flags_ = FrameFlags(StreamFlags(2));
+  request_2->stream_frame_flags_ = FrameFlags(2);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -733,7 +733,7 @@ TEST_F(UpstreamTest, OwnedGenericUpstreamDecodingSuccess) {
   EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1));
+  request_1->stream_frame_flags_ = FrameFlags(1);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -773,7 +773,7 @@ TEST_F(UpstreamTest, OwnedGenericUpstreamDecodingSuccessWithMultipleFrames) {
   EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1 = std::make_unique<FakeStreamCodecFactory::FakeResponse>();
-  request_1->stream_frame_flags_ = FrameFlags(StreamFlags(1), false);
+  request_1->stream_frame_flags_ = FrameFlags(1, FrameFlags::FLAG_EMPTY);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {
@@ -789,7 +789,7 @@ TEST_F(UpstreamTest, OwnedGenericUpstreamDecodingSuccessWithMultipleFrames) {
   EXPECT_EQ(1, generic_upstream->waitingResponseRequestsSize());
 
   auto request_1_frame = std::make_unique<FakeStreamCodecFactory::FakeCommonFrame>();
-  request_1_frame->stream_frame_flags_ = FrameFlags(StreamFlags(1), true);
+  request_1_frame->stream_frame_flags_ = FrameFlags(1);
 
   EXPECT_CALL(*mock_client_codec_raw_, decode(_, _))
       .WillOnce(testing::Invoke([&](Buffer::Instance&, bool) {


### PR DESCRIPTION
Commit Message: generic proxy: filter chain support for local reply and refactored the stream flags
Additional Description: 

1. filter chain support for the local reply.
2. refactored the stream flags.

Risk Level: low, contrib only.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.