### PR TITLE
Upgrade boringssl version

### DIFF
--- a/bazel/boringssl_static.patch
+++ b/bazel/boringssl_static.patch
@@ -1,20 +1,20 @@
-diff --git a/BUILD b/BUILD
-index 206786442..c0b3de699 100644
---- a/BUILD
-+++ b/BUILD
-@@ -140,6 +140,7 @@ cc_library(
-         "@platforms//os:windows": ["-defaultlib:advapi32.lib"],
+diff --git a/BUILD.bazel b/BUILD.bazel
+index d3b66ee5f..b0791b0df 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -63,6 +63,7 @@ bssl_cc_library(
+         ],
          "//conditions:default": ["-pthread"],
      }),
 +    linkstatic = True,
      visibility = ["//visibility:public"],
  )
  
-@@ -149,6 +150,7 @@ cc_library(
+@@ -72,6 +73,7 @@ bssl_cc_library(
      hdrs = ssl_headers,
-     copts = boringssl_copts_cxx,
-     includes = ["src/include"],
+     copts = ["-DBORINGSSL_IMPLEMENTATION"],
+     internal_hdrs = ssl_internal_headers,
 +    linkstatic = True,
      visibility = ["//visibility:public"],
-     deps = [
-         ":crypto",
+     deps = [":crypto_internal"],
+ )

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -116,17 +116,16 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Minimal OpenSSL fork",
         project_url = "https://github.com/google/boringssl",
         # To update BoringSSL, which tracks Chromium releases:
-        # 1. Open https://omahaproxy.appspot.com/ and note <current_version> of linux/beta release.
-        # 2. Open https://chromium.googlesource.com/chromium/src/+/refs/tags/<current_version>/DEPS and note <boringssl_revision>.
-        # 3. Find a commit in BoringSSL's "master-with-bazel" branch that merges <boringssl_revision>.
+        # 1. Open https://chromiumdash.appspot.com/releases?platform=Linux and find the latest Stable release.
+        # 2. In the info for that release, open the "Branch Base Commit" link, then open DEPS, and use the <boringssl_revision>.
         #
-        # chromium-118.0.5993.54 (linux/beta)
-        version = "45cf810dbdbd767f09f8cb0b0fcccd342c39041f",
-        sha256 = "f1f421738e9ba39dd88daf8cf3096ddba9c53e2b6b41b32fff5a3ff82f4cd162",
+        # chromium-126.0.6478.55 (linux/stable)
+        version = "2db0eb3f96a5756298dcd7f9319e56a98585bd10",
+        sha256 = "cd240bf27450f75cd5f41c512a06297c00646cdbac9f87b604e9312771db15a6",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2023-08-28",
+        release_date = "2024-04-29",
         cpe = "cpe:2.3:a:google:boringssl:*",
         license = "Mixed",
         license_url = "https://github.com/google/boringssl/blob/{version}/LICENSE",


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Also updated the instructions to stop using a tool that no longer exists.

Note that it is no longer neccessary to use the `master-with-bazel` branch, as the main branch has bazel support.
Additional Description:
Risk Level: low
Testing: existing tests
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
