### PR TITLE
golang fitler: use Router::StringAccessor instead of GoStringFilterState.

### DIFF
--- a/contrib/golang/filters/http/source/BUILD
+++ b/contrib/golang/filters/http/source/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/http/http1:codec_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/router:string_accessor_lib",
         "//source/extensions/filters/common/expr:cel_state_lib",
         "//source/extensions/filters/common/expr:evaluator_lib",
         "@com_google_cel_cpp//eval/public:activation",

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -370,15 +370,6 @@ struct httpConfigInternal : httpConfig {
   std::weak_ptr<FilterConfig> weakFilterConfig() { return config_; }
 };
 
-class GoStringFilterState : public StreamInfo::FilterState::Object {
-public:
-  GoStringFilterState(absl::string_view value) : value_(value) {}
-  const std::string& value() const { return value_; }
-
-private:
-  const std::string value_;
-};
-
 } // namespace Golang
 } // namespace HttpFilters
 } // namespace Extensions

--- a/contrib/golang/filters/network/source/BUILD
+++ b/contrib/golang/filters/network/source/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
         ":cgo",
         ":upstream",
         "//contrib/golang/common/dso:dso_lib",
+        "//source/common/router:string_accessor_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/golang/v3alpha:pkg_cc_proto",
     ],
 )

--- a/contrib/golang/filters/network/source/golang.h
+++ b/contrib/golang/filters/network/source/golang.h
@@ -117,15 +117,6 @@ public:
   std::string str_value_;
 };
 
-class GoStringFilterState : public StreamInfo::FilterState::Object {
-public:
-  GoStringFilterState(absl::string_view value) : value_(value) {}
-  const std::string& value() const { return value_; }
-
-private:
-  const std::string value_;
-};
-
 } // namespace Golang
 } // namespace NetworkFilters
 } // namespace Extensions


### PR DESCRIPTION
fix #34183 

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
