### PR TITLE
Make TrieLookupTable destruction non-recursive

### DIFF
--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -780,7 +780,7 @@ public:
   ~TrieLookupTable() {
     // To avoid stack overflow on recursive destruction if the tree is very deep,
     // delete it iteratively (or, really, delete it using a stack on the heap).
-    std::stack<std::unique_ptr<TrieNode>> nodes_to_delete;
+    std::stack<std::unique_ptr<TrieNode>, std::vector<std::unique_ptr<TrieNode>>> nodes_to_delete;
     for (std::unique_ptr<TrieNode>& child : root_.children_) {
       if (child != nullptr) {
         nodes_to_delete.push(std::move(child));

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -663,8 +663,6 @@ template <class Value> class TrieLookupTable {
   // less than 20 bytes per node, for a total of 0.14KB.
   class TrieNode {
   public:
-    Value value_{};
-
     // Returns a pointer to the child branch at child_index, or nullptr if
     // there are no entries in the trie on that branch.
     const TrieNode* operator[](uint8_t child_index) const {
@@ -709,6 +707,7 @@ template <class Value> class TrieLookupTable {
       children_[child_index - min_child_] = std::move(node);
     }
 
+    Value value_{};
     uint8_t min_child_{0};
     std::vector<std::unique_ptr<TrieNode>> children_;
   };

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -779,19 +779,19 @@ public:
 
   ~TrieLookupTable() {
     // To avoid stack overflow on recursive destruction if the tree is very deep,
-    // flatten the branches first.
-    std::stack<std::unique_ptr<TrieNode>> flat_tree;
+    // delete it iteratively (or, really, delete it using a stack on the heap).
+    std::stack<std::unique_ptr<TrieNode>> nodes_to_delete;
     for (std::unique_ptr<TrieNode>& child : root_.children_) {
       if (child != nullptr) {
-        flat_tree.push(std::move(child));
+        nodes_to_delete.push(std::move(child));
       }
     }
-    while (!flat_tree.empty()) {
-      std::unique_ptr<TrieNode> node = std::move(flat_tree.top());
-      flat_tree.pop();
+    while (!nodes_to_delete.empty()) {
+      std::unique_ptr<TrieNode> node = std::move(nodes_to_delete.top());
+      nodes_to_delete.pop();
       for (std::unique_ptr<TrieNode>& child : node->children_) {
         if (child != nullptr) {
-          flat_tree.push(std::move(child));
+          nodes_to_delete.push(std::move(child));
         }
       }
     }

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -1118,6 +1118,15 @@ TEST(TrieLookupTable, LongestPrefix) {
   EXPECT_EQ(nullptr, trie.findLongestPrefix(" "));
 }
 
+TEST(TrieLookupTable, VeryDeepTrieDoesNotStackOverflowOnDestructor) {
+  TrieLookupTable<const char*> trie;
+  const char* cstr_a = "a";
+
+  std::string key_a(20960, 'a');
+  EXPECT_TRUE(trie.add(key_a, cstr_a));
+  EXPECT_EQ(cstr_a, trie.find(key_a));
+}
+
 TEST(InlineStorageTest, InlineString) {
   InlineStringPtr hello = InlineString::create("Hello, world!");
   EXPECT_EQ("Hello, world!", hello->toStringView());


### PR DESCRIPTION
Commit Message: Make TrieLookupTable destruction non-recursive
Additional Description: Apparently someone might feed a 20000-character long key into this trie, for example in a fuzz test, but never a 40000-character string because *that* would be ridiculous, so I have to do this or we'd have to revert back to the version that was worse in every other way, because that absolutely makes sense, and we definitely should not have someone who is in charge of the ridiculous test fix it.
