### PR TITLE
Add remove_match field to HeaderMutation

### DIFF
--- a/api/envoy/config/common/mutation_rules/v3/mutation_rules.proto
+++ b/api/envoy/config/common/mutation_rules/v3/mutation_rules.proto
@@ -4,6 +4,7 @@ package envoy.config.common.mutation_rules.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/type/matcher/v3/regex.proto";
+import "envoy/type/matcher/v3/string.proto";
 
 import "google/protobuf/wrappers.proto";
 
@@ -96,6 +97,9 @@ message HeaderMutation {
     // Remove the specified header if it exists.
     string remove = 1
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
+
+    // Remove the header if it matches.
+    type.matcher.v3.StringMatcher remove_match = 3;
 
     // Append new header by the specified HeaderValueOption.
     core.v3.HeaderValueOption append = 2;

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -277,6 +277,10 @@ new_features:
   change: |
     Added field :ref:`match_upstream <envoy_v3_api_field_config.core.v3.SchemeHeaderTransformation.match_upstream>`,
     which, when set to true, will set the downstream request ``:scheme`` to match the upstream transport protocol.
+- area: http
+  change: |
+    Added field :ref:`remove_match <envoy_v3_api_field_config.common.mutation_rules.v3.HeaderMutation.remove_match>`,
+    which removes a header based on a :ref:`string match <envoy_v3_api_msg_type.matcher.v3.StringMatcher>`.
 - area: redis
   change: |
     Added support for `inline commands <https://redis.io/docs/reference/protocol-spec/#inline-commands>`_.

--- a/source/common/http/header_mutation.h
+++ b/source/common/http/header_mutation.h
@@ -15,14 +15,17 @@ using ProtoHeaderValueOption = envoy::config::core::v3::HeaderValueOption;
 class HeaderMutations : public HeaderEvaluator {
 public:
   static absl::StatusOr<std::unique_ptr<HeaderMutations>>
-  create(const ProtoHeaderMutatons& header_mutations);
+  create(const ProtoHeaderMutatons& header_mutations,
+         Server::Configuration::ServerFactoryContext& factory_context);
 
   // Http::HeaderEvaluator
   void evaluateHeaders(Http::HeaderMap& headers, const Formatter::HttpFormatterContext& context,
                        const StreamInfo::StreamInfo& stream_info) const override;
 
 private:
-  HeaderMutations(const ProtoHeaderMutatons& header_mutations, absl::Status& creation_status);
+  HeaderMutations(const ProtoHeaderMutatons& header_mutations,
+                  Server::Configuration::ServerFactoryContext& context,
+                  absl::Status& creation_status);
 
   std::vector<std::unique_ptr<HeaderEvaluator>> header_mutations_;
 };

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -12,8 +12,8 @@ namespace HeaderMutation {
 absl::StatusOr<Http::FilterFactoryCb>
 HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
     const ProtoConfig& config, const std::string&, DualInfo,
-    Server::Configuration::ServerFactoryContext&) {
-  auto filter_config = std::make_shared<HeaderMutationConfig>(config);
+    Server::Configuration::ServerFactoryContext& factory_context) {
+  auto filter_config = std::make_shared<HeaderMutationConfig>(config, factory_context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<HeaderMutation>(filter_config));
   };
@@ -21,9 +21,10 @@ HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
 
 Router::RouteSpecificFilterConfigConstSharedPtr
 HeaderMutationFactoryConfig::createRouteSpecificFilterConfigTyped(
-    const PerRouteProtoConfig& proto_config, Server::Configuration::ServerFactoryContext&,
+    const PerRouteProtoConfig& proto_config,
+    Server::Configuration::ServerFactoryContext& factory_context,
     ProtobufMessage::ValidationVisitor&) {
-  return std::make_shared<PerRouteHeaderMutation>(proto_config);
+  return std::make_shared<PerRouteHeaderMutation>(proto_config, factory_context);
 }
 
 using UpstreamHeaderMutationFactoryConfig = HeaderMutationFactoryConfig;

--- a/source/extensions/filters/http/header_mutation/header_mutation.cc
+++ b/source/extensions/filters/http/header_mutation/header_mutation.cc
@@ -24,11 +24,13 @@ void Mutations::mutateResponseHeaders(Http::HeaderMap& headers,
   response_mutations_->evaluateHeaders(headers, ctx, stream_info);
 }
 
-PerRouteHeaderMutation::PerRouteHeaderMutation(const PerRouteProtoConfig& config)
-    : mutations_(config.mutations()) {}
+PerRouteHeaderMutation::PerRouteHeaderMutation(const PerRouteProtoConfig& config,
+                                               Server::Configuration::ServerFactoryContext& context)
+    : mutations_(config.mutations(), context) {}
 
-HeaderMutationConfig::HeaderMutationConfig(const ProtoConfig& config)
-    : mutations_(config.mutations()),
+HeaderMutationConfig::HeaderMutationConfig(const ProtoConfig& config,
+                                           Server::Configuration::ServerFactoryContext& context)
+    : mutations_(config.mutations(), context),
       most_specific_header_mutations_wins_(config.most_specific_header_mutations_wins()) {}
 
 Http::FilterHeadersStatus HeaderMutation::decodeHeaders(Http::RequestHeaderMap& headers, bool) {

--- a/source/extensions/filters/http/header_mutation/header_mutation.h
+++ b/source/extensions/filters/http/header_mutation/header_mutation.h
@@ -27,11 +27,12 @@ class Mutations {
 public:
   using HeaderMutations = Http::HeaderMutations;
 
-  Mutations(const MutationsProto& config)
-      : request_mutations_(THROW_OR_RETURN_VALUE(
-            HeaderMutations::create(config.request_mutations()), std::unique_ptr<HeaderMutations>)),
+  Mutations(const MutationsProto& config, Server::Configuration::ServerFactoryContext& context)
+      : request_mutations_(
+            THROW_OR_RETURN_VALUE(HeaderMutations::create(config.request_mutations(), context),
+                                  std::unique_ptr<HeaderMutations>)),
         response_mutations_(
-            THROW_OR_RETURN_VALUE(HeaderMutations::create(config.response_mutations()),
+            THROW_OR_RETURN_VALUE(HeaderMutations::create(config.response_mutations(), context),
                                   std::unique_ptr<HeaderMutations>)) {}
 
   void mutateRequestHeaders(Http::HeaderMap& headers, const Formatter::HttpFormatterContext& ctx,
@@ -46,7 +47,8 @@ private:
 
 class PerRouteHeaderMutation : public Router::RouteSpecificFilterConfig {
 public:
-  PerRouteHeaderMutation(const PerRouteProtoConfig& config);
+  PerRouteHeaderMutation(const PerRouteProtoConfig& config,
+                         Server::Configuration::ServerFactoryContext& context);
 
   const Mutations& mutations() const { return mutations_; }
 
@@ -57,7 +59,8 @@ using PerRouteHeaderMutationSharedPtr = std::shared_ptr<PerRouteHeaderMutation>;
 
 class HeaderMutationConfig {
 public:
-  HeaderMutationConfig(const ProtoConfig& config);
+  HeaderMutationConfig(const ProtoConfig& config,
+                       Server::Configuration::ServerFactoryContext& context);
 
   const Mutations& mutations() const { return mutations_; }
 

--- a/source/extensions/http/early_header_mutation/header_mutation/config.cc
+++ b/source/extensions/http/early_header_mutation/header_mutation/config.cc
@@ -17,7 +17,7 @@ Factory::createExtension(const Protobuf::Message& message,
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::http::early_header_mutation::header_mutation::v3::HeaderMutation&>(
       *mptr, context.messageValidationVisitor());
-  return std::make_unique<HeaderMutation>(proto_config);
+  return std::make_unique<HeaderMutation>(proto_config, context.serverFactoryContext());
 }
 
 REGISTER_FACTORY(Factory, Envoy::Http::EarlyHeaderMutationFactory);

--- a/source/extensions/http/early_header_mutation/header_mutation/header_mutation.cc
+++ b/source/extensions/http/early_header_mutation/header_mutation/header_mutation.cc
@@ -10,9 +10,11 @@ namespace Http {
 namespace EarlyHeaderMutation {
 namespace HeaderMutation {
 
-HeaderMutation::HeaderMutation(const ProtoHeaderMutation& mutations)
-    : mutations_(THROW_OR_RETURN_VALUE(Envoy::Http::HeaderMutations::create(mutations.mutations()),
-                                       std::unique_ptr<Envoy::Http::HeaderMutations>)) {}
+HeaderMutation::HeaderMutation(const ProtoHeaderMutation& mutations,
+                               Server::Configuration::ServerFactoryContext& context)
+    : mutations_(THROW_OR_RETURN_VALUE(
+          Envoy::Http::HeaderMutations::create(mutations.mutations(), context),
+          std::unique_ptr<Envoy::Http::HeaderMutations>)) {}
 
 bool HeaderMutation::mutate(Envoy::Http::RequestHeaderMap& headers,
                             const StreamInfo::StreamInfo& stream_info) const {

--- a/source/extensions/http/early_header_mutation/header_mutation/header_mutation.h
+++ b/source/extensions/http/early_header_mutation/header_mutation/header_mutation.h
@@ -19,7 +19,8 @@ using ProtoHeaderMutation =
 
 class HeaderMutation : public Envoy::Http::EarlyHeaderMutation {
 public:
-  HeaderMutation(const ProtoHeaderMutation& mutations);
+  HeaderMutation(const ProtoHeaderMutation& mutations,
+                 Server::Configuration::ServerFactoryContext& context);
 
   bool mutate(Envoy::Http::RequestHeaderMap& headers,
               const StreamInfo::StreamInfo& stream_info) const override;

--- a/test/extensions/filters/http/header_mutation/BUILD
+++ b/test/extensions/filters/http/header_mutation/BUILD
@@ -19,9 +19,11 @@ envoy_extension_cc_test(
     extension_names = ["envoy.filters.http.header_mutation"],
     deps = [
         "//source/extensions/filters/http/header_mutation:config",
+        "//source/extensions/string_matcher/lua:config",
         "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
     ],

--- a/test/extensions/http/early_header_mutation/header_mutation/BUILD
+++ b/test/extensions/http/early_header_mutation/header_mutation/BUILD
@@ -19,6 +19,8 @@ envoy_extension_cc_test(
     extension_names = ["envoy.http.early_header_mutation.header_mutation"],
     deps = [
         "//source/extensions/http/early_header_mutation/header_mutation:header_mutation_lib",
+        "//source/extensions/string_matcher/lua:config",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
     ],

--- a/test/extensions/http/early_header_mutation/header_mutation/header_mutation_test.cc
+++ b/test/extensions/http/early_header_mutation/header_mutation/header_mutation_test.cc
@@ -1,6 +1,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/extensions/http/early_header_mutation/header_mutation/header_mutation.h"
 
+#include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
 
@@ -40,12 +41,28 @@ TEST(HeaderMutationTest, TestAll) {
         key: "flag-header-4"
         value: "flag-header-4-value"
       append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+  - remove_match:
+      exact: "flag-header-5"
+  - remove_match:
+      safe_regex:
+        regex: "flag-[a-z]+-6"
+  - remove_match:
+      custom:
+        name: envoy.string_matcher.lua
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.string_matcher.lua.v3.Lua
+          source_code:
+            inline_string: |
+              function envoy_match(str)
+                  return str == "flag-header-7"
+              end
   )EOF";
 
   ProtoHeaderMutation proto_mutation;
   TestUtility::loadFromYaml(config, proto_mutation);
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
 
-  HeaderMutation mutation(proto_mutation);
+  HeaderMutation mutation(proto_mutation, factory_context);
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
 
   Envoy::Http::TestRequestHeaderMapImpl headers = {
@@ -54,6 +71,9 @@ TEST(HeaderMutationTest, TestAll) {
       {"flag-header-2", "flag-header-2-value-old"},
       {"flag-header-3", "flag-header-3-value-old"},
       {"flag-header-4", "flag-header-4-value-old"},
+      {"flag-header-5", "flag-header-value"},
+      {"flag-header-6", "flag-header-value"},
+      {"flag-header-7", "flag-header-value"},
       {":method", "GET"},
   };
 
@@ -69,6 +89,12 @@ TEST(HeaderMutationTest, TestAll) {
   // 'flag-header-4' is overwritten.
   EXPECT_EQ(1, headers.get(Envoy::Http::LowerCaseString("flag-header-4")).size());
   EXPECT_EQ("flag-header-4-value", headers.get_("flag-header-4"));
+  // 'flag-header-5' is removed.
+  EXPECT_FALSE(headers.has(Envoy::Http::LowerCaseString("flag-header-5")));
+  // 'flag-header-6' is removed by regex match.
+  EXPECT_FALSE(headers.has(Envoy::Http::LowerCaseString("flag-header-6")));
+  // 'flag-header-7' is removed by lua match.
+  EXPECT_FALSE(headers.has(Envoy::Http::LowerCaseString("flag-header-7")));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: add remove_match field to HeaderMutation
Additional Description: Allow removing headers based on a StringMatcher
Risk Level: low
Testing: unit testing
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #34642
