### PR TITLE
router: fix dynamic weight crash

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -53,6 +53,7 @@
 #include "source/extensions/path/match/uri_template/uri_template_match.h"
 #include "source/extensions/path/rewrite/uri_template/uri_template_rewrite.h"
 
+#include "absl/container/inlined_vector.h"
 #include "absl/strings/match.h"
 
 namespace Envoy {
@@ -671,9 +672,9 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
       return;
     }
 
-    weighted_clusters_config_ =
-        std::make_unique<WeightedClustersConfig>(std::move(weighted_clusters), total_weight,
-                                                 route.route().weighted_clusters().header_name());
+    weighted_clusters_config_ = std::make_unique<WeightedClustersConfig>(
+        std::move(weighted_clusters), total_weight, route.route().weighted_clusters().header_name(),
+        route.route().weighted_clusters().runtime_key_prefix());
 
   } else if (route.route().cluster_specifier_case() ==
              envoy::config::route::v3::RouteAction::ClusterSpecifierCase::
@@ -1347,12 +1348,15 @@ RouteConstSharedPtr RouteEntryImplBase::clusterEntry(const Http::RequestHeaderMa
       return cluster_specifier_plugin_->route(shared_from_this(), headers);
     }
   }
-  return pickWeightedCluster(headers, random_value, true);
+  return pickWeightedCluster(headers, random_value);
 }
 
+// Selects a cluster depending on weight parameters from configuration or from headers.
+// This function takes into account the weights set through configuration or through
+// runtime parameters.
+// Returns selected cluster, or nullptr if weighted configuration is invalid.
 RouteConstSharedPtr RouteEntryImplBase::pickWeightedCluster(const Http::HeaderMap& headers,
-                                                            const uint64_t random_value,
-                                                            const bool ignore_overflow) const {
+                                                            const uint64_t random_value) const {
   absl::optional<uint64_t> random_value_from_header;
   // Retrieve the random value from the header if corresponding header name is specified.
   // weighted_clusters_config_ is known not to be nullptr here. If it were, pickWeightedCluster
@@ -1380,23 +1384,55 @@ RouteConstSharedPtr RouteEntryImplBase::pickWeightedCluster(const Http::HeaderMa
     }
   }
 
+  auto runtime_key_prefix_configured =
+      (weighted_clusters_config_->runtime_key_prefix_.length() ? true : false);
+  uint32_t total_cluster_weight = weighted_clusters_config_->total_cluster_weight_;
+  absl::InlinedVector<uint32_t, 4> cluster_weights;
+
+  // if runtime config is used, we need to recompute total_weight
+  if (runtime_key_prefix_configured) {
+    // Temporary storage to hold consistent cluster weights. Since cluster weight
+    // can be changed with runtime keys, we need a way to gather all the weight
+    // and aggregate the total without a change in between.
+    // The InlinedVector will be able to handle at least 4 cluster weights
+    // without allocation. For cases when more clusters are needed, it is
+    // reserved to ensure at most a single allocation.
+    cluster_weights.reserve(weighted_clusters_config_->weighted_clusters_.size());
+
+    total_cluster_weight = 0;
+    for (const WeightedClusterEntrySharedPtr& cluster :
+         weighted_clusters_config_->weighted_clusters_) {
+      auto cluster_weight = cluster->clusterWeight();
+      cluster_weights.push_back(cluster_weight);
+      if (cluster_weight > std::numeric_limits<uint32_t>::max() - total_cluster_weight) {
+        IS_ENVOY_BUG("Sum of weight cannot overflow 2^32");
+        return nullptr;
+      }
+      total_cluster_weight += cluster_weight;
+    }
+  }
+
+  if (total_cluster_weight == 0) {
+    IS_ENVOY_BUG("Sum of weight cannot be zero");
+    return nullptr;
+  }
   const uint64_t selected_value =
       (random_value_from_header.has_value() ? random_value_from_header.value() : random_value) %
-      weighted_clusters_config_->total_cluster_weight_;
+      total_cluster_weight;
   uint64_t begin = 0;
   uint64_t end = 0;
+  auto cluster_weight = cluster_weights.begin();
 
   // Find the right cluster to route to based on the interval in which
   // the selected value falls. The intervals are determined as
   // [0, cluster1_weight), [cluster1_weight, cluster1_weight+cluster2_weight),..
   for (const WeightedClusterEntrySharedPtr& cluster :
        weighted_clusters_config_->weighted_clusters_) {
-    end = begin + cluster->clusterWeight();
-    if (!ignore_overflow) {
-      // end > total_cluster_weight: This case can only occur with Runtimes,
-      // when the user specifies invalid weights such that
-      // sum(weights) > total_cluster_weight.
-      ASSERT(end <= weighted_clusters_config_->total_cluster_weight_);
+
+    if (runtime_key_prefix_configured) {
+      end = begin + *cluster_weight++;
+    } else {
+      end = begin + cluster->clusterWeight();
     }
 
     if (selected_value >= begin && selected_value < end) {
@@ -1415,7 +1451,8 @@ RouteConstSharedPtr RouteEntryImplBase::pickWeightedCluster(const Http::HeaderMa
     begin = end;
   }
 
-  PANIC("unexpected");
+  IS_ENVOY_BUG("unexpected");
+  return nullptr;
 }
 
 absl::Status RouteEntryImplBase::validateClusters(

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1089,13 +1089,16 @@ public:
   struct WeightedClustersConfig {
     WeightedClustersConfig(const std::vector<WeightedClusterEntrySharedPtr>&& weighted_clusters,
                            uint64_t total_cluster_weight,
-                           const std::string& random_value_header_name)
+                           const std::string& random_value_header_name,
+                           const std::string& runtime_key_prefix)
         : weighted_clusters_(std::move(weighted_clusters)),
           total_cluster_weight_(total_cluster_weight),
-          random_value_header_name_(random_value_header_name) {}
+          random_value_header_name_(random_value_header_name),
+          runtime_key_prefix_(runtime_key_prefix) {}
     const std::vector<WeightedClusterEntrySharedPtr> weighted_clusters_;
     const uint64_t total_cluster_weight_;
     const std::string random_value_header_name_;
+    const std::string runtime_key_prefix_;
   };
 
 protected:
@@ -1207,8 +1210,8 @@ private:
                               const Http::HeaderMap& headers,
                               const RouteEntryAndRoute* route_selector_override) const;
 
-  RouteConstSharedPtr pickWeightedCluster(const Http::HeaderMap& headers, uint64_t random_value,
-                                          bool ignore_overflow) const;
+  RouteConstSharedPtr pickWeightedCluster(const Http::HeaderMap& headers,
+                                          uint64_t random_value) const;
 
   // Default timeout is 15s if nothing is specified in the route config.
   static const uint64_t DEFAULT_ROUTE_TIMEOUT_MS = 15000;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6305,19 +6305,58 @@ virtual_hosts:
   {
     Http::TestRequestHeaderMapImpl headers = genHeaders("www3.lyft.com", "/foo", "GET");
     EXPECT_CALL(runtime.snapshot_, featureEnabled("www3", 100, _)).WillRepeatedly(Return(true));
+    // new total weight will be 140
     EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster1", 30))
         .WillRepeatedly(Return(10));
-
-    // We return an invalid value here, one that is greater than 100
-    // Expect any random value > 10 to always land in cluster2.
     EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster2", 30))
         .WillRepeatedly(Return(120));
     EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster3", 40))
         .WillRepeatedly(Return(10));
 
-    EXPECT_EQ("cluster1", config.route(headers, 1005)->routeEntry()->clusterName());
+    // 1005 % total_weight == 25
+    EXPECT_EQ("cluster2", config.route(headers, 1005)->routeEntry()->clusterName());
     EXPECT_EQ("cluster2", config.route(headers, 82)->routeEntry()->clusterName());
     EXPECT_EQ("cluster2", config.route(headers, 92)->routeEntry()->clusterName());
+  }
+
+  // Weighted Cluster with runtime values under total weight
+  // Makes sure new total weight is taken into account
+  // if total_weight is not recomputed, it will raise "unexpected" error
+  {
+    Http::TestRequestHeaderMapImpl headers = genHeaders("www3.lyft.com", "/foo", "GET");
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("www3", 100, _)).WillRepeatedly(Return(true));
+    // new total weight will be 6
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster1", 30))
+        .WillRepeatedly(Return(1));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster2", 30))
+        .WillRepeatedly(Return(2));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster3", 40))
+        .WillRepeatedly(Return(3));
+
+    // 1005 % total_weight == 3
+    EXPECT_EQ("cluster3", config.route(headers, 1005)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster3", config.route(headers, 82)->routeEntry()->clusterName());
+    EXPECT_EQ("cluster2", config.route(headers, 92)->routeEntry()->clusterName());
+  }
+
+  // Total weight is set to zero
+  {
+    Http::TestRequestHeaderMapImpl headers = genHeaders("www3.lyft.com", "/foo", "GET");
+    EXPECT_CALL(runtime.snapshot_, featureEnabled("www3", 100, _)).WillRepeatedly(Return(true));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster1", 30))
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster2", 30))
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(runtime.snapshot_, getInteger("www3_weights.cluster3", 40))
+        .WillRepeatedly(Return(0));
+
+#if defined(NDEBUG)
+    // sum of weight returns nullptr
+    EXPECT_EQ(nullptr, config.route(headers, 42));
+#else
+    // in debug mode, it aborts
+    EXPECT_DEATH(config.route(headers, 42), "Sum of weight cannot be zero");
+#endif
   }
 
   // Weighted Cluster with runtime values, total weight = 10000


### PR DESCRIPTION
Commit Message:

fix up crash while updating weighted clusters, when the total weight is changing through runtime keys.

Additional Description:

```
[assert] [source/common/router/config_impl.cc:1366] panic: unexpected
[backtrace] [./source/server/backtrace.h:127] Caught Aborted, suspect faulting address 0xfffe00000001
[backtrace] [./source/server/backtrace.h:111] Backtrace (use tools/stack_decode.py to get line numbers):
[backtrace] [./source/server/backtrace.h:112] Envoy version: 16a0cedaba5335a8003c5077a07a49fafd3eea97/1.30.1/Clean/RELEASE/BoringSSL
[backtrace] [./source/server/backtrace.h:114] Address mapping: 560c90beb000-560c93592000 /usr/local/bin/envoy
[backtrace] [./source/server/backtrace.h:121] #0: [0x7f7cc0a1f520]
ActiveStream 0x55d99505500, stream_id_: 7019320575973121232&filter_manager_:
  FilterManager 0x55d995055b0, state_.has_1xx_headers_: 0
  filter_manager_callbacks_.requestHeaders():
  &streamInfo():
    StreamInfoImpl 0x55d995056f0, protocol_: 1, response_code_: null, response_code_details_: null, attempt_count_: null, health_check_request_: 0, getRouteName():     upstream_info_:     null
    OverridableRemoteConnectionInfoSetterStreamInfo 0x55d995056f0, remoteAddress(): 10.128.7.99:18710, directRemoteAddress(): 10.128.7.99:18710, localAddress(): 10.128.38.140:6032
Http1::ConnectionImpl 0x55daa38f810, dispatching_: 1, dispatching_slice_already_drained_: 0, reset_stream_called_: 0, handling_upgrade_: 0, deferred_end_stream_headers_: 0, processing_trailers_: 0, buffered_body_.length(): 0, header_parsing_state_: Field, current_header_field_: , current_header_value_:
active_request_:
, request_url_: null, response_encoder_.local_end_stream_: 0
absl::get<RequestHeaderMapPtr>(headers_or_trailers_): null
ConnectionImpl 0x55da6d047d0, connecting_: 0, bind_error_: 0, state(): Open, read_buffer_limit_: 131072
socket_:
  ListenSocketImpl 0x55db7be3ef0, transport_protocol_: raw_buffer
  connection_info_provider_:
    ConnectionInfoSetterImpl 0x55da4b54b18, remote_address_: 10.128.7.99:18710, direct_remote_address_: 10.128.7.99:18710, local_address_: 10.128.38.140:6032, server_name_:
[backtrace] [./source/server/backtrace.h:127] Caught Segmentation fault, suspect faulting address 0x0
[backtrace] [./source/server/backtrace.h:111] Backtrace (use tools/stack_decode.py to get line numbers):
[backtrace] [./source/server/backtrace.h:112] Envoy version: 16a0cedaba5335a8003c5077a07a49fafd3eea97/1.30.1/Clean/RELEASE/BoringSSL
[backtrace] [./source/server/backtrace.h:114] Address mapping: 560c90beb000-560c93592000 /usr/local/bin/envoy
[backtrace] [./source/server/backtrace.h:121] #0: [0x7f7cc0a1f520]
Our FatalActions triggered a fatal signal.
```

Risk Level: Low

Testing:

We update the tests to reflect the changes which are now taking care of runtime values.

tests:
- deploy a config with 2 weighted cluster weight 1/100
```
  "routing.cluster_weight.fooA": {
   "final_value": "1",
   "layer_values": [
    "1",
    "",
    "",
    ""
   ]
  },
  "routing.cluster_weight.fooB": {
   "final_value": "100",
   "layer_values": [
    "100",
    "",
    "",
    ""
   ]
  }
```
- deploy the new binary
- update the weight to 100/100
```
  "routing.cluster_weight.fooA": {
   "final_value": "100",
   "layer_values": [
    "100",
    "",
    "",
    ""
   ]
  },
  "routing.cluster_weight.fooB": {
   "final_value": "100",
   "layer_values": [
    "100",
    "",
    "",
    ""
   ]
  }
```
- there should be no crash

some notes/open questions:

- There is a similar function in utility:
https://github.com/envoyproxy/envoy/blob/570869520b69fcee00e3b834c40053d55907facb/source/common/common/utility.h#L505
We could refactor it to make use of it everywhere, but it is a much larger change. I believe this could be followed in another PR.

- should we get rid of `total cluster weight` parameter entirely? maybe for another PR as well? https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-weightedcluster-total-weight

this PR also fixes issue #22873
