### PR TITLE
outlier_detection: add always_eject_one_host

### DIFF
--- a/api/envoy/config/cluster/v3/outlier_detection.proto
+++ b/api/envoy/config/cluster/v3/outlier_detection.proto
@@ -43,7 +43,7 @@ message OutlierDetection {
   google.protobuf.Duration base_ejection_time = 3 [(validate.rules).duration = {gt {}}];
 
   // The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% .
-  // Will eject at least one host regardless of the value if :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.may_always_eject_one>` is enabled
+  // Will eject at least one host regardless of the value if :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.may_always_eject_one>` is enabled.
   google.protobuf.UInt32Value max_ejection_percent = 4 [(validate.rules).uint32 = {lte: 100}];
 
   // The % chance that a host will be actually ejected when an outlier status
@@ -174,7 +174,7 @@ message OutlierDetection {
   // [#not-implemented-hide:]
   repeated core.v3.TypedExtensionConfig monitors = 24;
 
-  // If may_always_eject_one is enabled, :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>` is not considered for first ejection.
+  // If enabled, :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>` is not considered for first ejection.
   // Defaults to false.
   google.protobuf.BoolValue may_always_eject_one = 25;
 }

--- a/api/envoy/config/cluster/v3/outlier_detection.proto
+++ b/api/envoy/config/cluster/v3/outlier_detection.proto
@@ -43,7 +43,7 @@ message OutlierDetection {
   google.protobuf.Duration base_ejection_time = 3 [(validate.rules).duration = {gt {}}];
 
   // The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% .
-  // Will eject at least one host regardless of the value if :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.may_always_eject_one>` is enabled.
+  // Will eject at least one host regardless of the value if :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.always_eject_one_host>` is enabled.
   google.protobuf.UInt32Value max_ejection_percent = 4 [(validate.rules).uint32 = {lte: 100}];
 
   // The % chance that a host will be actually ejected when an outlier status
@@ -176,5 +176,5 @@ message OutlierDetection {
 
   // If enabled, at least one host is ejected regardless of the value of :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>`.
   // Defaults to false.
-  google.protobuf.BoolValue may_always_eject_one = 25;
+  google.protobuf.BoolValue always_eject_one_host = 25;
 }

--- a/api/envoy/config/cluster/v3/outlier_detection.proto
+++ b/api/envoy/config/cluster/v3/outlier_detection.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // See the :ref:`architecture overview <arch_overview_outlier_detection>` for
 // more information on outlier detection.
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message OutlierDetection {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.cluster.OutlierDetection";
@@ -42,8 +42,8 @@ message OutlierDetection {
   // Defaults to 30000ms or 30s.
   google.protobuf.Duration base_ejection_time = 3 [(validate.rules).duration = {gt {}}];
 
-  // The maximum % of an upstream cluster that can be ejected due to outlier
-  // detection. Defaults to 10% but will eject at least one host regardless of the value.
+  // The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% .
+  // Will eject at least one host regardless of the value if :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.may_always_eject_one>` is enabled
   google.protobuf.UInt32Value max_ejection_percent = 4 [(validate.rules).uint32 = {lte: 100}];
 
   // The % chance that a host will be actually ejected when an outlier status
@@ -173,4 +173,8 @@ message OutlierDetection {
   // Set of host's passive monitors.
   // [#not-implemented-hide:]
   repeated core.v3.TypedExtensionConfig monitors = 24;
+
+  // If may_always_eject_one is enabled, :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>` is not considered for first ejection.
+  // Defaults to false.
+  google.protobuf.BoolValue may_always_eject_one = 25;
 }

--- a/api/envoy/config/cluster/v3/outlier_detection.proto
+++ b/api/envoy/config/cluster/v3/outlier_detection.proto
@@ -174,7 +174,7 @@ message OutlierDetection {
   // [#not-implemented-hide:]
   repeated core.v3.TypedExtensionConfig monitors = 24;
 
-  // If enabled, :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>` is not considered for first ejection.
+  // If enabled, at least one host is ejected regardless of the value of :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>`.
   // Defaults to false.
   google.protobuf.BoolValue may_always_eject_one = 25;
 }

--- a/api/envoy/config/cluster/v3/outlier_detection.proto
+++ b/api/envoy/config/cluster/v3/outlier_detection.proto
@@ -43,7 +43,7 @@ message OutlierDetection {
   google.protobuf.Duration base_ejection_time = 3 [(validate.rules).duration = {gt {}}];
 
   // The maximum % of an upstream cluster that can be ejected due to outlier detection. Defaults to 10% .
-  // Will eject at least one host regardless of the value if :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.always_eject_one_host>` is enabled.
+  // Will eject at least one host regardless of the value if :ref:`always_eject_one_host<envoy_v3_api_field_config.cluster.v3.OutlierDetection.always_eject_one_host>` is enabled.
   google.protobuf.UInt32Value max_ejection_percent = 4 [(validate.rules).uint32 = {lte: 100}];
 
   // The % chance that a host will be actually ejected when an outlier status
@@ -174,7 +174,7 @@ message OutlierDetection {
   // [#not-implemented-hide:]
   repeated core.v3.TypedExtensionConfig monitors = 24;
 
-  // If enabled, at least one host is ejected regardless of the value of :ref:`base_ejection_time<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>`.
+  // If enabled, at least one host is ejected regardless of the value of :ref:`max_ejection_percent<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>`.
   // Defaults to false.
   google.protobuf.BoolValue always_eject_one_host = 25;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -240,6 +240,9 @@ removed_config_or_runtime:
 - area: jwt
   change: |
     Removed ``envoy.reloadable_features.token_passed_entirely`` runtime flag and legacy code paths.
+- area: outlier detection
+  change: |
+    Removed ``envoy.reloadable_features.check_mep_on_first_eject`` runtime flag and legacy code paths.
 - area: http
   change: |
     Removed ``envoy.reloadable_features.stop_decode_metadata_on_local_reply`` runtime flag and legacy code paths.
@@ -335,6 +338,10 @@ new_features:
     to listen to file changes and dynamically update the response when :ref:`watched_directory
     <envoy_v3_api_field_config.core.v3.datasource.watched_directory>`
     is configured in :ref:`DataSource <envoy_v3_api_msg_config.core.v3.datasource>`.
+- area: outlier detection
+  change: |
+    Added :ref:`always_eject_one_host<envoy_v3_api_field_config.cluster.v3.OutlierDetection.always_eject_one_host>`
+    to optionally override the :ref:`max_ejection_percent<envoy_v3_api_field_config.cluster.v3.OutlierDetection.max_ejection_percent>`.
 - area: listener
   change: |
     Added :ref:`bypass_overload_manager <envoy_v3_api_field_config.listener.v3.Listener.bypass_overload_manager>`

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -31,7 +31,6 @@
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_abort_filter_chain_on_stream_reset);
 RUNTIME_GUARD(envoy_reloadable_features_avoid_zombie_streams);
-RUNTIME_GUARD(envoy_reloadable_features_check_mep_on_first_eject);
 RUNTIME_GUARD(envoy_reloadable_features_check_switch_protocol_websocket_handshake);
 RUNTIME_GUARD(envoy_reloadable_features_conn_pool_delete_when_idle);
 RUNTIME_GUARD(envoy_reloadable_features_consistent_header_validation);

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -218,6 +218,8 @@ DetectorConfig::DetectorConfig(const envoy::config::cluster::v3::OutlierDetectio
           config, consecutive_gateway_failure, DEFAULT_CONSECUTIVE_GATEWAY_FAILURE))),
       max_ejection_percent_(static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, max_ejection_percent, DEFAULT_MAX_EJECTION_PERCENT))),
+      may_always_eject_one_(
+          static_cast<bool>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, may_always_eject_one, false))),
       success_rate_minimum_hosts_(static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, success_rate_minimum_hosts, DEFAULT_SUCCESS_RATE_MINIMUM_HOSTS))),
       success_rate_request_volume_(static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
@@ -480,7 +482,7 @@ void DetectorImpl::ejectHost(HostSharedPtr host,
   // Note this is not currently checked per-priority level, so it is possible
   // for outlier detection to eject all hosts at any given priority level.
   bool should_eject = (ejected_percent <= max_ejection_percent);
-  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.check_mep_on_first_eject")) {
+  if (config_.mayAlwaysEjectOne()) {
     should_eject = (ejections_active_helper_.value() == 0) || should_eject;
   }
   if (should_eject) {

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -482,7 +482,7 @@ void DetectorImpl::ejectHost(HostSharedPtr host,
   // Note this is not currently checked per-priority level, so it is possible
   // for outlier detection to eject all hosts at any given priority level.
   bool should_eject = (ejected_percent <= max_ejection_percent);
-  if (config_.mayAlwaysEjectOne()) {
+  if (config_.alwaysEjectOneHost()) {
     should_eject = (ejections_active_helper_.value() == 0) || should_eject;
   }
   if (should_eject) {

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -218,8 +218,8 @@ DetectorConfig::DetectorConfig(const envoy::config::cluster::v3::OutlierDetectio
           config, consecutive_gateway_failure, DEFAULT_CONSECUTIVE_GATEWAY_FAILURE))),
       max_ejection_percent_(static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, max_ejection_percent, DEFAULT_MAX_EJECTION_PERCENT))),
-      may_always_eject_one_(
-          static_cast<bool>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, may_always_eject_one, false))),
+      always_eject_one_host_(
+          static_cast<bool>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, always_eject_one_host, false))),
       success_rate_minimum_hosts_(static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, success_rate_minimum_hosts, DEFAULT_SUCCESS_RATE_MINIMUM_HOSTS))),
       success_rate_request_volume_(static_cast<uint64_t>(PROTOBUF_GET_WRAPPED_OR_DEFAULT(

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -290,6 +290,7 @@ public:
   uint64_t consecutive5xx() const { return consecutive_5xx_; }
   uint64_t consecutiveGatewayFailure() const { return consecutive_gateway_failure_; }
   uint64_t maxEjectionPercent() const { return max_ejection_percent_; }
+  bool mayAlwaysEjectOne() const { return may_always_eject_one_; }
   uint64_t successRateMinimumHosts() const { return success_rate_minimum_hosts_; }
   uint64_t successRateRequestVolume() const { return success_rate_request_volume_; }
   uint64_t successRateStdevFactor() const { return success_rate_stdev_factor_; }
@@ -323,6 +324,7 @@ private:
   const uint64_t consecutive_5xx_;
   const uint64_t consecutive_gateway_failure_;
   const uint64_t max_ejection_percent_;
+  const bool may_always_eject_one_;
   const uint64_t success_rate_minimum_hosts_;
   const uint64_t success_rate_request_volume_;
   const uint64_t success_rate_stdev_factor_;

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -290,7 +290,7 @@ public:
   uint64_t consecutive5xx() const { return consecutive_5xx_; }
   uint64_t consecutiveGatewayFailure() const { return consecutive_gateway_failure_; }
   uint64_t maxEjectionPercent() const { return max_ejection_percent_; }
-  bool mayAlwaysEjectOne() const { return may_always_eject_one_; }
+  bool mayAlwaysEjectOne() const { return always_eject_one_host_; }
   uint64_t successRateMinimumHosts() const { return success_rate_minimum_hosts_; }
   uint64_t successRateRequestVolume() const { return success_rate_request_volume_; }
   uint64_t successRateStdevFactor() const { return success_rate_stdev_factor_; }
@@ -324,7 +324,7 @@ private:
   const uint64_t consecutive_5xx_;
   const uint64_t consecutive_gateway_failure_;
   const uint64_t max_ejection_percent_;
-  const bool may_always_eject_one_;
+  const bool always_eject_one_host_;
   const uint64_t success_rate_minimum_hosts_;
   const uint64_t success_rate_request_volume_;
   const uint64_t success_rate_stdev_factor_;

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -290,7 +290,7 @@ public:
   uint64_t consecutive5xx() const { return consecutive_5xx_; }
   uint64_t consecutiveGatewayFailure() const { return consecutive_gateway_failure_; }
   uint64_t maxEjectionPercent() const { return max_ejection_percent_; }
-  bool mayAlwaysEjectOne() const { return always_eject_one_host_; }
+  bool alwaysEjectOneHost() const { return always_eject_one_host_; }
   uint64_t successRateMinimumHosts() const { return success_rate_minimum_hosts_; }
   uint64_t successRateRequestVolume() const { return success_rate_request_volume_; }
   uint64_t successRateStdevFactor() const { return success_rate_stdev_factor_; }

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1915,6 +1915,44 @@ max_ejection_time_jitter: 13s
   EXPECT_FALSE(hosts_[2]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
 }
 
+TEST_F(OutlierDetectorImplTest, MaxEjectionPercentageOverride) {
+  // Should eject one host even if mep doesn't allow it.
+  const std::string yaml = R"EOF(
+max_ejection_percent: 30
+may_always_eject_one: true
+max_ejection_time_jitter: 13s
+  )EOF";
+  envoy::config::cluster::v3::OutlierDetection outlier_detection_;
+  TestUtility::loadFromYaml(yaml, outlier_detection_);
+  EXPECT_CALL(cluster_.prioritySet(), addMemberUpdateCb(_));
+
+  // add 3 hosts.
+  addHosts({"tcp://127.0.0.2:80"});
+  addHosts({"tcp://127.0.0.3:80"});
+  addHosts({"tcp://127.0.0.4:80"});
+
+  EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000), _));
+  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(cluster_, outlier_detection_,
+                                                              dispatcher_, runtime_, time_system_,
+                                                              event_logger_, random_)
+                                             .value());
+
+  detector->addChangedStateCb([&](HostSharedPtr host) -> void { checker_.check(host); });
+
+  time_system_.setMonotonicTime(std::chrono::milliseconds(0));
+  // Expect only one ejection.
+  EXPECT_CALL(checker_, check(hosts_[0]));
+  EXPECT_CALL(*event_logger_, logEject(std::static_pointer_cast<const HostDescription>(hosts_[0]),
+                                       _, envoy::data::cluster::v3::CONSECUTIVE_5XX, true));
+
+  loadRq(hosts_[0], 5, 500);
+  loadRq(hosts_[1], 5, 500);
+  loadRq(hosts_[2], 5, 500);
+  EXPECT_TRUE(hosts_[0]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
+  EXPECT_FALSE(hosts_[1]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
+  EXPECT_FALSE(hosts_[2]->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK));
+}
+
 TEST_F(OutlierDetectorImplTest, MaxEjectionPercentageSingleHost) {
   // Single host should not be ejected with a max ejection percent <100% .
   const std::string yaml = R"EOF(

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1916,7 +1916,8 @@ max_ejection_time_jitter: 13s
 }
 
 TEST_F(OutlierDetectorImplTest, MaxEjectionPercentageOverride) {
-  // Should eject one host even if mep doesn't allow it.
+  // Should eject one host even if max_ejection_percent doesn't allow it.
+  // One host represents 33% which isn't allowed by max_ejection_percent, which is 30.
   const std::string yaml = R"EOF(
 max_ejection_percent: 30
 may_always_eject_one: true

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1920,7 +1920,7 @@ TEST_F(OutlierDetectorImplTest, MaxEjectionPercentageOverride) {
   // One host represents 33% which isn't allowed by max_ejection_percent, which is 30.
   const std::string yaml = R"EOF(
 max_ejection_percent: 30
-may_always_eject_one: true
+always_eject_one_host: true
 max_ejection_time_jitter: 13s
   )EOF";
   envoy::config::cluster::v3::OutlierDetection outlier_detection_;


### PR DESCRIPTION
Commit Message: Add a config option to allow ejecting one host regardless of max_ejection_percentage
Risk Level: low
Testing: added test
Docs Changes: updated proto comment
Release Notes: todo
Fixes #34666 