### PR TITLE
http2: removes `envoy_reloadable_features_http2_validate_authority_with_quiche`

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -225,13 +225,7 @@ bool HeaderUtility::headerNameContainsUnderscore(const absl::string_view header_
 }
 
 bool HeaderUtility::authorityIsValid(const absl::string_view header_value) {
-  if (Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.http2_validate_authority_with_quiche")) {
-    return http2::adapter::HeaderValidator::IsValidAuthority(header_value);
-  } else {
-    return nghttp2_check_authority(reinterpret_cast<const uint8_t*>(header_value.data()),
-                                   header_value.size()) != 0;
-  }
+  return http2::adapter::HeaderValidator::IsValidAuthority(header_value);
 }
 
 bool HeaderUtility::isSpecial1xx(const ResponseHeaderMap& response_headers) {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -57,7 +57,6 @@ RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year.
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 RUNTIME_GUARD(envoy_reloadable_features_http2_use_visitor_for_data);
-RUNTIME_GUARD(envoy_reloadable_features_http2_validate_authority_with_quiche);
 RUNTIME_GUARD(envoy_reloadable_features_http_filter_avoid_reentrant_local_reply);
 // Delay deprecation and decommission until UHV is enabled.
 RUNTIME_GUARD(envoy_reloadable_features_http_reject_path_with_fragment);


### PR DESCRIPTION
Removes the false path of feature `envoy_reloadable_features_http2_validate_authority_with_quiche`.

Fixes https://github.com/envoyproxy/envoy/issues/30419

Commit Message:
Additional Description:
Risk Level:
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
