### PR TITLE
fine_grain_logger: make sure fine-grain-logger map registration in macros

### DIFF
--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -197,8 +197,6 @@ FineGrainLogContext& getFineGrainLogContext();
   do {                                                                                             \
     static std::atomic<spdlog::logger*> flogger{0};                                                \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
-    bool n = local_flogger == nullptr;                                                             \
-    std::cout << "boteng fine logger nultptr? " << n << std::endl;                                 \
     if (!local_flogger) {                                                                          \
       ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
       local_flogger = flogger.load(std::memory_order_relaxed);                                     \

--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -124,6 +124,14 @@ public:
    */
   static bool safeFileNameMatch(absl::string_view pattern, absl::string_view str);
 
+  /**
+   * Remove a fine grain log entry for testing only.
+   */
+  void removeFineGrainLogEntry(absl::string_view key) ABSL_LOCKS_EXCLUDED(fine_grain_log_lock_) {
+    absl::WriterMutexLock wl(&fine_grain_log_lock_);
+    fine_grain_log_map_->erase(key);
+  }
+
 private:
   /**
    * Initializes sink for the initialization of loggers, needed only in benchmark test.
@@ -189,6 +197,8 @@ FineGrainLogContext& getFineGrainLogContext();
   do {                                                                                             \
     static std::atomic<spdlog::logger*> flogger{0};                                                \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
+    bool n = local_flogger == nullptr;                                                             \
+    std::cout << "boteng fine logger nultptr? " << n << std::endl;                                 \
     if (!local_flogger) {                                                                          \
       ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
       local_flogger = flogger.load(std::memory_order_relaxed);                                     \

--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -127,7 +127,8 @@ public:
   /**
    * Remove a fine grain log entry for testing only.
    */
-  void removeFineGrainLogEntry(absl::string_view key) ABSL_LOCKS_EXCLUDED(fine_grain_log_lock_) {
+  void removeFineGrainLogEntryForTest(absl::string_view key)
+      ABSL_LOCKS_EXCLUDED(fine_grain_log_lock_) {
     absl::WriterMutexLock wl(&fine_grain_log_lock_);
     fine_grain_log_map_->erase(key);
   }

--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -188,19 +188,28 @@ private:
 FineGrainLogContext& getFineGrainLogContext();
 
 /**
- * Macro for fine-grain logger.
+ * Macro to get a fine-grain logger.
  * Uses a global map to store logger and take use of thread-safe spdlog::logger.
  * The local pointer is used to avoid another load() when logging. Here we use
  * spdlog::logger* as atomic<shared_ptr> is a C++20 feature.
  */
-#define FINE_GRAIN_LOG(LEVEL, ...)                                                                 \
-  do {                                                                                             \
-    static std::atomic<spdlog::logger*> flogger{0};                                                \
+#define FINE_GRAIN_LOGGER()                                                                        \
+  ([]() -> spdlog::logger* {                                                                       \
+    static std::atomic<spdlog::logger*> flogger{nullptr};                                          \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
     if (!local_flogger) {                                                                          \
-      ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
+      Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                      \
       local_flogger = flogger.load(std::memory_order_relaxed);                                     \
     }                                                                                              \
+    return local_flogger;                                                                          \
+  }())
+
+/**
+ * Macro for fine-grain logger to log.
+ */
+#define FINE_GRAIN_LOG(LEVEL, ...)                                                                 \
+  do {                                                                                             \
+    spdlog::logger* local_flogger = FINE_GRAIN_LOGGER();                                           \
     if (ENVOY_LOG_COMP_LEVEL(*local_flogger, LEVEL)) {                                             \
       local_flogger->log(spdlog::source_loc{__FILE__, __LINE__, __func__},                         \
                          ENVOY_SPDLOG_LEVEL(LEVEL), __VA_ARGS__);                                  \

--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -198,7 +198,7 @@ FineGrainLogContext& getFineGrainLogContext();
     static std::atomic<spdlog::logger*> flogger{nullptr};                                          \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
     if (!local_flogger) {                                                                          \
-      Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                      \
+      ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
       local_flogger = flogger.load(std::memory_order_relaxed);                                     \
     }                                                                                              \
     return local_flogger;                                                                          \

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -503,9 +503,26 @@ public:
 
 #define ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL) (ENVOY_SPDLOG_LEVEL(LEVEL) >= (LOGGER).level())
 
-// Compare levels before invoking logger. This is an optimization to avoid
-// executing expressions computing log contents when they would be suppressed.
-// The same filtering will also occur in spdlog::logger.
+/**
+ * Compare levels and use the fine grain logger if fine grain logging is enabled.
+ */
+#define ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(LOGGER, LEVEL)                                          \
+  (Envoy::Logger::Context::useFineGrainLogger() ? ([&]() -> bool {                                 \
+    static std::atomic<spdlog::logger*> flogger{0};                                                \
+    spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
+    if (!local_flogger) {                                                                          \
+      ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
+      local_flogger = flogger.load(std::memory_order_relaxed);                                     \
+    }                                                                                              \
+    return ENVOY_SPDLOG_LEVEL(LEVEL) >= (*local_flogger).level();                                  \
+  })()                                                                                             \
+                                                : (ENVOY_SPDLOG_LEVEL(LEVEL) >= (LOGGER).level()))
+
+/**
+ * Compare levels before invoking logger. This is an optimization to avoid
+ * executing expressions computing log contents when they would be suppressed.
+ * The same filtering will also occur in spdlog::logger.
+ */
 #define ENVOY_LOG_COMP_AND_LOG(LOGGER, LEVEL, ...)                                                 \
   do {                                                                                             \
     if (Envoy::Logger::should_log && ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                        \
@@ -580,7 +597,7 @@ public:
 
 #define ENVOY_CONN_LOG_TO_LOGGER(LOGGER, LEVEL, FORMAT, CONNECTION, ...)                           \
   do {                                                                                             \
-    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
+    if (ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(LOGGER, LEVEL)) {                                       \
       std::map<std::string, std::string> log_tags;                                                 \
       log_tags.emplace("ConnectionId", std::to_string((CONNECTION).id()));                         \
       ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, "{}" FORMAT,                                              \
@@ -590,7 +607,7 @@ public:
 
 #define ENVOY_STREAM_LOG_TO_LOGGER(LOGGER, LEVEL, FORMAT, STREAM, ...)                             \
   do {                                                                                             \
-    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
+    if (ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(LOGGER, LEVEL)) {                                       \
       std::map<std::string, std::string> log_tags;                                                 \
       log_tags.emplace("ConnectionId",                                                             \
                        (STREAM).connection() ? std::to_string((STREAM).connection()->id()) : "0"); \
@@ -646,7 +663,7 @@ public:
 #define ENVOY_LOG_EVENT_TO_LOGGER(LOGGER, LEVEL, EVENT_NAME, ...)                                  \
   do {                                                                                             \
     ENVOY_LOG_TO_LOGGER(LOGGER, LEVEL, ##__VA_ARGS__);                                             \
-    if (ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL)) {                                                     \
+    if (ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(LOGGER, LEVEL)) {                                       \
       ::Envoy::Logger::Registry::getSink()->logWithStableName(EVENT_NAME, #LEVEL, (LOGGER).name(), \
                                                               fmt::format(__VA_ARGS__));           \
     }                                                                                              \
@@ -654,7 +671,7 @@ public:
 
 #define ENVOY_CONN_LOG_EVENT(LEVEL, EVENT_NAME, FORMAT, CONNECTION, ...)                           \
   do {                                                                                             \
-    if (ENVOY_LOG_COMP_LEVEL(ENVOY_LOGGER(), LEVEL)) {                                             \
+    if (ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(ENVOY_LOGGER(), LEVEL)) {                               \
       std::map<std::string, std::string> log_tags;                                                 \
       log_tags.emplace("ConnectionId", std::to_string((CONNECTION).id()));                         \
       ENVOY_LOG_TO_LOGGER(ENVOY_LOGGER(), LEVEL, "{}" FORMAT,                                      \

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -507,16 +507,9 @@ public:
  * Compare levels and use the fine grain logger if fine grain logging is enabled.
  */
 #define ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF(LOGGER, LEVEL)                                          \
-  (Envoy::Logger::Context::useFineGrainLogger() ? ([&]() -> bool {                                 \
-    static std::atomic<spdlog::logger*> flogger{0};                                                \
-    spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
-    if (!local_flogger) {                                                                          \
-      ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, flogger);                    \
-      local_flogger = flogger.load(std::memory_order_relaxed);                                     \
-    }                                                                                              \
-    return ENVOY_SPDLOG_LEVEL(LEVEL) >= (*local_flogger).level();                                  \
-  })()                                                                                             \
-                                                : (ENVOY_SPDLOG_LEVEL(LEVEL) >= (LOGGER).level()))
+  (Envoy::Logger::Context::useFineGrainLogger()                                                    \
+       ? (ENVOY_SPDLOG_LEVEL(LEVEL) >= (*FINE_GRAIN_LOGGER()).level())                             \
+       : (ENVOY_SPDLOG_LEVEL(LEVEL) >= (LOGGER).level()))
 
 /**
  * Compare levels before invoking logger. This is an optimization to avoid

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -43,6 +43,14 @@ public:
                             "fake message {}", "val");
   }
 
+  void logConnTraceMessage() { ENVOY_CONN_LOG(trace, "fake trace message", connection_); }
+
+  void logStreamTraceMessage() { ENVOY_STREAM_LOG(trace, "fake trace message", stream_); }
+
+  void logEventTraceMessage() {
+    ENVOY_CONN_LOG_EVENT(trace, "fake_event", "fake message", connection_);
+  }
+
   void logMessageEscapeSequences() { ENVOY_LOG_MISC(info, "line 1 \n line 2 \t tab \\r test"); }
 
 private:
@@ -50,6 +58,57 @@ private:
   NiceMock<Network::MockConnection> connection_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> stream_;
 };
+
+TEST(Logger, StreamFineGrainLoggerRegistration) {
+  Envoy::Thread::MutexBasicLockable lock;
+  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
+                                  lock, false};
+  Logger::Context::enableFineGrainLogger();
+  TestFilterLog filter;
+  getFineGrainLogContext().removeFineGrainLogEntry(__FILE__);
+
+  // Make sure fine-grain logger is initialized even the log level is trace.
+  filter.logStreamTraceMessage();
+  filter.logStreamTraceMessage();
+  filter.logStreamTraceMessage();
+  SpdLoggerSharedPtr p = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
+  ASSERT_NE(p, nullptr);
+  EXPECT_EQ(p->level(), spdlog::level::warn);
+}
+
+TEST(Logger, EventFineGrainLoggerRegistration) {
+  Envoy::Thread::MutexBasicLockable lock;
+  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
+                                  lock, false};
+  Logger::Context::enableFineGrainLogger();
+  TestFilterLog filter;
+  getFineGrainLogContext().removeFineGrainLogEntry(__FILE__);
+
+  // Make sure fine-grain logger is initialized even the log level is trace.
+  filter.logEventTraceMessage();
+  filter.logEventTraceMessage();
+  filter.logEventTraceMessage();
+  SpdLoggerSharedPtr p = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
+  ASSERT_NE(p, nullptr);
+  EXPECT_EQ(p->level(), spdlog::level::warn);
+}
+
+TEST(Logger, ConnFineGrainLoggerRegistration) {
+  Envoy::Thread::MutexBasicLockable lock;
+  Logger::Context logging_context{spdlog::level::warn, Logger::Context::getFineGrainLogFormat(),
+                                  lock, false};
+  Logger::Context::enableFineGrainLogger();
+  TestFilterLog filter;
+  getFineGrainLogContext().removeFineGrainLogEntry(__FILE__);
+
+  // Make sure fine-grain logger is initialized even the log level is trace.
+  filter.logConnTraceMessage();
+  filter.logConnTraceMessage();
+  filter.logConnTraceMessage();
+  SpdLoggerSharedPtr p = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
+  ASSERT_NE(p, nullptr);
+  EXPECT_EQ(p->level(), spdlog::level::warn);
+}
 
 TEST(Logger, All) {
   // This test exists just to ensure all macros compile and run with the expected arguments provided

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -65,7 +65,7 @@ TEST(Logger, StreamFineGrainLoggerRegistration) {
                                   lock, false};
   Logger::Context::enableFineGrainLogger();
   TestFilterLog filter;
-  getFineGrainLogContext().removeFineGrainLogEntry(__FILE__);
+  getFineGrainLogContext().removeFineGrainLogEntryForTest(__FILE__);
 
   // Make sure fine-grain logger is initialized even the log level is trace.
   filter.logStreamTraceMessage();
@@ -82,7 +82,7 @@ TEST(Logger, EventFineGrainLoggerRegistration) {
                                   lock, false};
   Logger::Context::enableFineGrainLogger();
   TestFilterLog filter;
-  getFineGrainLogContext().removeFineGrainLogEntry(__FILE__);
+  getFineGrainLogContext().removeFineGrainLogEntryForTest(__FILE__);
 
   // Make sure fine-grain logger is initialized even the log level is trace.
   filter.logEventTraceMessage();
@@ -99,7 +99,7 @@ TEST(Logger, ConnFineGrainLoggerRegistration) {
                                   lock, false};
   Logger::Context::enableFineGrainLogger();
   TestFilterLog filter;
-  getFineGrainLogContext().removeFineGrainLogEntry(__FILE__);
+  getFineGrainLogContext().removeFineGrainLogEntryForTest(__FILE__);
 
   // Make sure fine-grain logger is initialized even the log level is trace.
   filter.logConnTraceMessage();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

The `ENVOY_LOG_COMP_LEVEL` will lead to non-active fine-grain loggers are not managed by the fine-grain logger map when log level is lower than default, since `ENVOY_LOG_TO_LOGGER` is the only way to call `FINE_GRAIN_LOG` to initialize a fg-logger.

This PR creates a new `FINE_GRAIN_LOGGER()` and that can be used for getting fine-grain logger. 
Also creates a new `ENVOY_LOG_COMP_LEVEL_FINE_GRAIN_IF()` to consider fine-grain logger when doing comparison. 

Note, not all marcos are migrated.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
