### PR TITLE
admin_fine_logger: replace log level int with nice string

### DIFF
--- a/source/common/common/fine_grain_logger.cc
+++ b/source/common/common/fine_grain_logger.cc
@@ -85,8 +85,9 @@ std::string FineGrainLogContext::listFineGrainLoggers() ABSL_LOCKS_EXCLUDED(fine
   absl::ReaderMutexLock l(&fine_grain_log_lock_);
   std::string info =
       absl::StrJoin(*fine_grain_log_map_, "\n", [](std::string* out, const auto& log_pair) {
+        auto level_str_view = spdlog::level::to_string_view(log_pair.second->level());
         absl::StrAppend(out, "  ", log_pair.first, ": ",
-                        fmt::to_string(spdlog::level::to_string_view(log_pair.second->level())));
+                        absl::string_view(level_str_view.data(), level_str_view.size()));
       });
   return info;
 }

--- a/source/common/common/fine_grain_logger.cc
+++ b/source/common/common/fine_grain_logger.cc
@@ -85,7 +85,8 @@ std::string FineGrainLogContext::listFineGrainLoggers() ABSL_LOCKS_EXCLUDED(fine
   absl::ReaderMutexLock l(&fine_grain_log_lock_);
   std::string info =
       absl::StrJoin(*fine_grain_log_map_, "\n", [](std::string* out, const auto& log_pair) {
-        absl::StrAppend(out, "  ", log_pair.first, ": ", log_pair.second->level());
+        absl::StrAppend(out, "  ", log_pair.first, ": ",
+                        fmt::to_string(spdlog::level::to_string_view(log_pair.second->level())));
       });
   return info;
 }

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -381,11 +381,28 @@ TEST(FineGrainLog, Iteration) {
   FINE_GRAIN_LOG(info, "Info: iteration test begins.");
   getFineGrainLogContext().setAllFineGrainLoggers(spdlog::level::info);
   std::string output = getFineGrainLogContext().listFineGrainLoggers();
-  EXPECT_THAT(output, HasSubstr("  " __FILE__ ": 2"));
+  EXPECT_THAT(output, HasSubstr("  " __FILE__ ": info"));
   getFineGrainLogContext().setFineGrainLogger(__FILE__, spdlog::level::err);
 
   FINE_GRAIN_LOG(warn, "Warning: now level is warning, format changed (Date removed).");
   FINE_GRAIN_LOG(warn, getFineGrainLogContext().listFineGrainLoggers());
+}
+
+TEST(FineGrainLog, ListIteration) {
+  FINE_GRAIN_LOG(info, "Info: iteration test begins.");
+  const absl::flat_hash_map<spdlog::level::level_enum, std::string> log_level_strings = {
+      {spdlog::level::trace, "trace"}, {spdlog::level::debug, "debug"},
+      {spdlog::level::info, "info"},   {spdlog::level::warn, "warn"},
+      {spdlog::level::err, "error"},   {spdlog::level::critical, "critical"},
+      {spdlog::level::off, "off"},
+  };
+
+  std::string output;
+  for (const auto& [level, level_str] : log_level_strings) {
+    getFineGrainLogContext().setAllFineGrainLoggers(level);
+    output = getFineGrainLogContext().listFineGrainLoggers();
+    EXPECT_THAT(output, HasSubstr("  " __FILE__ ": " + level_str));
+  }
 }
 
 TEST(FineGrainLog, Context) {

--- a/test/server/admin/logs_handler_test.cc
+++ b/test/server/admin/logs_handler_test.cc
@@ -71,6 +71,18 @@ TEST_P(AdminInstanceTest, LogLevelSetting) {
   EXPECT_EQ(Http::Code::OK, postCallback("/logging?level=warning&paths=", header_map, response));
 }
 
+TEST_P(AdminInstanceTest, LogLevelDisplay) {
+  Http::TestResponseHeaderMapImpl header_map;
+  Buffer::OwnedImpl response;
+
+  Logger::Context::enableFineGrainLogger();
+  FINE_GRAIN_LOG(info, "Build the logger for this file.");
+  EXPECT_EQ(Http::Code::OK, postCallback("/logging?level=warning", header_map, response));
+  postCallback("/logging", header_map, response);
+  FINE_GRAIN_LOG(error, response.toString());
+  EXPECT_THAT(response.toString(), HasSubstr("  " __FILE__ ": warning"));
+}
+
 TEST_P(AdminInstanceTest, LogLevelFineGrainGlobSupport) {
   Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Before:
```
active loggers:
  source/server/admin/logs_handler.cc: 3
  source/common/common/logger.cc: 3
```

After:
```
active loggers:
  source/server/admin/logs_handler.cc: warn
  source/common/common/logger.cc: warn
```

admin test:

<img width="724" alt="Screenshot 2024-06-20 at 8 58 37 AM" src="https://github.com/envoyproxy/envoy/assets/50897472/e8864b60-7424-4f7a-b6b7-fe2bf8c6a2d2">



Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
