### PR TITLE
Make envoy user part of the tty group instead of chown stderr/stdout

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -19,7 +19,7 @@ EXPOSE 10000
 CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
 # Ensure the envoy user is able to write to container logs owned by root:tty
 RUN mkdir -p /etc/envoy \
-    && useradd --system --create-home --groups tty --shell /usr/sbin/nologin
+    && useradd --system --no-create-home -d /nonexistent --groups tty --shell /usr/sbin/nologin envoy
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # NB: Adding this here means that following steps, for example updating the system packages, are run
 #   when the version file changes. This should mean that a release version will always update.

--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -17,8 +17,9 @@ FROM ${BUILD_OS}:${BUILD_TAG} AS envoy-base
 ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 10000
 CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
+# Ensure the envoy user is able to write to container logs owned by root:tty
 RUN mkdir -p /etc/envoy \
-    && adduser --group --system envoy
+    && useradd --system --create-home --groups tty --shell /usr/sbin/nologin
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # NB: Adding this here means that following steps, for example updating the system packages, are run
 #   when the version file changes. This should mean that a release version will always update.

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -25,7 +25,7 @@ if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
         groupmod -g "$ENVOY_GID" envoy
     fi
     # Ensure the envoy user is able to write to container logs
-    chown envoy:envoy /dev/stdout /dev/stderr
+    usermod -a -G tty envoy
     exec su-exec envoy "${@}"
 else
     exec "${@}"

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -24,8 +24,6 @@ if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
     if [ -n "$ENVOY_GID" ]; then
         groupmod -g "$ENVOY_GID" envoy
     fi
-    # Ensure the envoy user is able to write to container logs
-    usermod -a -G tty envoy
     exec su-exec envoy "${@}"
 else
     exec "${@}"


### PR DESCRIPTION
Commit Message: Make envoy user part of the tty group instead of chown stderr/stdout
Additional Description: This PR addresses and issue with running Envoy on Openshift, where, with the built-in images, we the the following error:
```
kubectl logs -f envoy-secure-secureingress-7c4cc7f497-czjfn
chown: changing ownership of '/dev/stdout': Permission denied
chown: changing ownership of '/dev/stderr': Permission denied
```
This is was tested on Openshift Rosa:
```
kubectl version
Client Version: v1.29.0
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.28.8+8974577
```
This was inspired by https://github.com/moby/moby/issues/31243#issuecomment-406879017

Risk Level: Low
Testing: Deployed this branch in the mentioned Openshift Cluster.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: The issue showed up on Openshift, but the fix should be universal.
