### PR TITLE
aws: relocate async credential provider stats initialization

### DIFF
--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -254,7 +254,7 @@ TEST_F(CredentialsFileCredentialsProviderTest, IncompleteProfile) {
   setUpTest(CREDENTIALS_FILE_CONTENTS, "profile2");
 
   const auto credentials = provider_.getCredentials();
-  EXPECT_EQ("profile2_access_key", credentials.accessKeyId().value());
+  EXPECT_FALSE(credentials.accessKeyId().has_value());
   EXPECT_FALSE(credentials.secretAccessKey().has_value());
   EXPECT_FALSE(credentials.sessionToken().has_value());
 }
@@ -281,7 +281,7 @@ TEST_F(CredentialsFileCredentialsProviderTest, EmptySecret) {
   setUpTest(CREDENTIALS_FILE_CONTENTS, "profile3");
 
   const auto credentials = provider_.getCredentials();
-  EXPECT_EQ("profile3_access_key", credentials.accessKeyId().value());
+  EXPECT_FALSE(credentials.accessKeyId().has_value());
   EXPECT_FALSE(credentials.secretAccessKey().has_value());
   EXPECT_FALSE(credentials.sessionToken().has_value());
 }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: aws: relocate async credential provider stats initialization

Additional Description: Fixes reported crash in dev due to statistics initialization being performed too late in the init cycle. Patch moves this initialization to the start of this init handler and removes extraneous checks for stats initialization.
Patch also makes a minor change to behaviour when credentials cannot be retrieved from the profile as the debug logs are misleading.

Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
