### PR TITLE
grpc: Refactor the gRPC integration test 

### DIFF
--- a/test/common/grpc/grpc_client_integration.h
+++ b/test/common/grpc/grpc_client_integration.h
@@ -46,6 +46,18 @@ public:
   }
 };
 
+class EnvoyGrpcClientIntegrationParamTest
+    : public BaseGrpcClientIntegrationParamTest,
+      public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  static std::string
+  protocolTestParamsToString(const ::testing::TestParamInfo<Network::Address::IpVersion>& p) {
+    return fmt::format("{}_{}", TestUtility::ipVersionToString(p.param), "EnvoyGrpc");
+  }
+  Network::Address::IpVersion ipVersion() const override { return GetParam(); }
+  ClientType clientType() const override { return ClientType::EnvoyGrpc; }
+};
+
 class GrpcClientIntegrationParamTest
     : public BaseGrpcClientIntegrationParamTest,
       public testing::TestWithParam<std::tuple<Network::Address::IpVersion, ClientType>> {

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -42,7 +42,6 @@ TEST_P(EnvoyGrpcFlowControlTest, BasicStreamWithFlowControl) {
   RequestArgs request_args;
   request_args.request = &request_msg;
   stream->sendRequest(request_args);
-  ;
   stream->sendServerInitialMetadata(empty_metadata_);
   stream->sendReply();
   stream->sendServerTrailers(Status::WellKnownGrpcStatus::Ok, "", empty_metadata_);

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -14,6 +14,41 @@ namespace Envoy {
 namespace Grpc {
 namespace {
 
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, EnvoyGrpcFlowControlTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         EnvoyGrpcClientIntegrationParamTest::protocolTestParamsToString);
+
+TEST_P(EnvoyGrpcFlowControlTest, BasicStreamWithFlowControl) {
+  GrpcClientIntegrationTestBase::initialize(0);
+  auto stream = createStream(empty_metadata_);
+
+  testing::StrictMock<Http::MockStreamDecoderFilterCallbacks> watermark_callbacks;
+
+  // TODO(tyxia) Uncomment this section in https://github.com/envoyproxy/envoy/pull/34769
+  // Registering a new watermark callback should note that the high watermark
+  // has already been hit.
+  // stream->grpc_stream_->setWatermarkCallbacks(watermark_callbacks);
+
+  // EXPECT_CALL(watermark_callbacks,
+  //             onDecoderFilterAboveWriteBufferHighWatermark());
+  // EXPECT_CALL(watermark_callbacks,
+  //             onDecoderFilterBelowWriteBufferLowWatermark());
+
+  // Create the send request.
+  std::string large_request = std::string(64 * 1024, 'a');
+  helloworld::HelloRequest request_msg;
+  request_msg.set_name(large_request);
+
+  RequestArgs request_args;
+  request_args.request = &request_msg;
+  stream->sendRequest(request_args);
+  ;
+  stream->sendServerInitialMetadata(empty_metadata_);
+  stream->sendReply();
+  stream->sendServerTrailers(Status::WellKnownGrpcStatus::Ok, "", empty_metadata_);
+  dispatcher_helper_.runDispatcher();
+}
+
 // Parameterize the loopback test server socket address and gRPC client type.
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, GrpcClientIntegrationTest,
                          GRPC_CLIENT_INTEGRATION_PARAMS,

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -271,6 +271,7 @@ public:
 
 using HelloworldRequestPtr = std::unique_ptr<HelloworldRequest>;
 
+// Integration test base that can be used with time system varaints.
 template <class TimeSystemVariant> class GrpcClientIntegrationTestBase {
 public:
   GrpcClientIntegrationTestBase()

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -271,7 +271,7 @@ public:
 
 using HelloworldRequestPtr = std::unique_ptr<HelloworldRequest>;
 
-// Integration test base that can be used with time system varaints.
+// Integration test base that can be used with time system variants.
 template <class TimeSystemVariant> class GrpcClientIntegrationTestBase {
 public:
   GrpcClientIntegrationTestBase()

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -271,20 +271,23 @@ public:
 
 using HelloworldRequestPtr = std::unique_ptr<HelloworldRequest>;
 
-class GrpcClientIntegrationTest : public GrpcClientIntegrationParamTest {
+template <class TimeSystemVariant> class GrpcClientIntegrationTestBase {
 public:
-  GrpcClientIntegrationTest()
+  GrpcClientIntegrationTestBase()
       : method_descriptor_(helloworld::Greeter::descriptor()->FindMethodByName("SayHello")),
-        api_(Api::createApiForTest(stats_store_, test_time_.timeSystem())),
+        api_(Api::createApiForTest(stats_store_, time_system_)),
         dispatcher_(api_->allocateDispatcher("test_thread")),
         http_context_(stats_store_.symbolTable()), router_context_(stats_store_.symbolTable()) {}
+
+  virtual Network::Address::IpVersion getIpVersion() const PURE;
+  virtual ClientType getClientType() const PURE;
 
   virtual void initialize(uint32_t envoy_grpc_max_recv_msg_length = 0) {
     if (fake_upstream_ == nullptr) {
       fake_upstream_config_.upstream_protocol_ = Http::CodecType::HTTP2;
-      fake_upstream_ = std::make_unique<FakeUpstream>(0, ipVersion(), fake_upstream_config_);
+      fake_upstream_ = std::make_unique<FakeUpstream>(0, getIpVersion(), fake_upstream_config_);
     }
-    switch (clientType()) {
+    switch (getClientType()) {
     case ClientType::EnvoyGrpc:
       grpc_client_ = createAsyncClientImpl(envoy_grpc_max_recv_msg_length);
       break;
@@ -302,7 +305,7 @@ public:
     timeout_timer_->enableTimer(std::chrono::milliseconds(10000));
   }
 
-  void TearDown() override {
+  virtual ~GrpcClientIntegrationTestBase() {
     if (fake_connection_) {
       AssertionResult result = fake_connection_->close();
       RELEASE_ASSERT(result, result.message());
@@ -487,8 +490,8 @@ public:
     return stream;
   }
 
-  DangerousDeprecatedTestTime test_time_;
-  FakeUpstreamConfig fake_upstream_config_{test_time_.timeSystem()};
+  Event::DelegatingTestTimeSystem<TimeSystemVariant> time_system_;
+  FakeUpstreamConfig fake_upstream_config_{time_system_};
   std::unique_ptr<FakeUpstream> fake_upstream_;
   FakeHttpConnectionPtr fake_connection_;
   std::vector<FakeStreamPtr> fake_streams_;
@@ -531,6 +534,31 @@ public:
   Network::ClientConnectionPtr client_connection_;
 };
 
+class GrpcClientIntegrationTest : public GrpcClientIntegrationParamTest,
+                                  // The integration test uses `TestRealTimeSystem`
+                                  public GrpcClientIntegrationTestBase<Event::TestRealTimeSystem> {
+public:
+  virtual Network::Address::IpVersion getIpVersion() const override {
+    return GrpcClientIntegrationParamTest::ipVersion();
+  }
+  virtual ClientType getClientType() const override {
+    return GrpcClientIntegrationParamTest::clientType();
+  };
+};
+
+class EnvoyGrpcFlowControlTest
+    : public EnvoyGrpcClientIntegrationParamTest,
+      // The integration test uses `SimulatedTimeSystemHelper`
+      public GrpcClientIntegrationTestBase<Event::SimulatedTimeSystemHelper> {
+public:
+  virtual Network::Address::IpVersion getIpVersion() const override {
+    return EnvoyGrpcClientIntegrationParamTest::ipVersion();
+  }
+  virtual ClientType getClientType() const override {
+    return EnvoyGrpcClientIntegrationParamTest::clientType();
+  };
+};
+
 // SSL connection credential validation tests.
 class GrpcSslClientIntegrationTest : public GrpcClientIntegrationTest {
 public:
@@ -542,7 +570,13 @@ public:
   void TearDown() override {
     // Reset some state in the superclass before we destruct context_manager_ in our destructor, it
     // doesn't like dangling contexts at destruction.
-    GrpcClientIntegrationTest::TearDown();
+    if (fake_connection_) {
+      AssertionResult result = fake_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = fake_connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      fake_connection_.reset();
+    }
     fake_upstream_.reset();
     async_client_transport_socket_.reset();
     client_connection_.reset();
@@ -576,7 +610,7 @@ public:
             std::move(cfg), context_manager_, *stats_store_.rootScope());
     async_client_transport_socket_ =
         mock_host_description_->socket_factory_->createTransportSocket(nullptr, nullptr);
-    FakeUpstreamConfig config(test_time_.timeSystem());
+    FakeUpstreamConfig config(time_system_);
     config.upstream_protocol_ = Http::CodecType::HTTP2;
     fake_upstream_ =
         std::make_unique<FakeUpstream>(createUpstreamSslContext(), 0, ipVersion(), config);

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -535,8 +535,8 @@ public:
   Network::ClientConnectionPtr client_connection_;
 };
 
+// The integration test for Envoy gRPC and Google gRPC. It uses `TestRealTimeSystem`.
 class GrpcClientIntegrationTest : public GrpcClientIntegrationParamTest,
-                                  // The integration test uses `TestRealTimeSystem`
                                   public GrpcClientIntegrationTestBase<Event::TestRealTimeSystem> {
 public:
   virtual Network::Address::IpVersion getIpVersion() const override {
@@ -547,9 +547,9 @@ public:
   };
 };
 
+// The integration test for Envoy gRPC flow control. It uses `SimulatedTime`.
 class EnvoyGrpcFlowControlTest
     : public EnvoyGrpcClientIntegrationParamTest,
-      // The integration test uses `SimulatedTimeSystemHelper`
       public GrpcClientIntegrationTestBase<Event::SimulatedTimeSystemHelper> {
 public:
   virtual Network::Address::IpVersion getIpVersion() const override {


### PR DESCRIPTION
Refactor the test:
- `GrpcClientIntegrationTestBase`: It can be used by different test time variants ; it also can be used by both Envoy-gRPC and google-gRPC OR just either of these two alone
- `EnvoyGrpcFlowControlTest` is an example to use `GrpcClientIntegrationTestBase`:  (1) For envoy-gRPC only with `EnvoyGrpcClientIntegrationParamTest` 
  (2) use simulate test system instead of `testRealTime`

Risk: Low No change to existing tests functionality, `EnvoyGrpcFlowControlTest` in this PR serves as use example and it will be completed/used in a different PR