### PR TITLE
http: fix cookie attributes

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -195,6 +195,10 @@ bug_fixes:
   change: |
     Fixed missing :ref:`additional addresses <envoy_v3_api_msg_config.endpoint.v3.Endpoint.AdditionalAddress>`
     for :ref:`LbEndpoint <envoy_v3_api_field_config.endpoint.v3.LbEndpoint.endpoint>` in config dump.
+- area: http
+  change: |
+    Fixed a bug where additional :ref:`cookie attributes <envoy_v3_api_msg_config.route.v3.RouteAction.HashPolicy.cookie>`
+    are not sent properly to clients.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`


### PR DESCRIPTION
Commit Message: fix cookie attributes
Additional Description: store cookie attributes in normal vector instead of reference wrapper to retain the actual values. Without this, they are getting garbled.
Risk Level: Low
Testing: Added
Docs Changes: N/A
Release Notes: Updated
Fixes https://github.com/envoyproxy/envoy/issues/34818
