### PR TITLE
Make envoy user part of the tty group instead of chown stderr/stdout …

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -17,8 +17,9 @@ FROM ${BUILD_OS}:${BUILD_TAG} AS envoy-base
 ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 10000
 CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
+# Ensure the envoy user is able to write to container logs owned by root:tty
 RUN mkdir -p /etc/envoy \
-    && adduser --group --system envoy
+    && useradd --system --no-create-home -d /nonexistent --groups tty --shell /usr/sbin/nologin envoy
 ENTRYPOINT ["/docker-entrypoint.sh"]
 # NB: Adding this here means that following steps, for example updating the system packages, are run
 #   when the version file changes. This should mean that a release version will always update.

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -24,8 +24,6 @@ if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
     if [ -n "$ENVOY_GID" ]; then
         groupmod -g "$ENVOY_GID" envoy
     fi
-    # Ensure the envoy user is able to write to container logs
-    chown envoy:envoy /dev/stdout /dev/stderr
     exec su-exec envoy "${@}"
 else
     exec "${@}"


### PR DESCRIPTION
Commit Message: Make envoy user part of the tty group instead of chown stderr/stdout
Additional Description: Back porting https://github.com/envoyproxy/envoy/pull/34830 to v1.30