### PR TITLE
uri_template: Allow uri_template variables in literal expression

### DIFF
--- a/test/extensions/path/match/uri_template/config_test.cc
+++ b/test/extensions/path/match/uri_template/config_test.cc
@@ -70,8 +70,8 @@ TEST(ConfigTest, InvalidConfigSetup) {
 }
 
 // Followup on issue https://github.com/envoyproxy/envoy/issues/34507 -
-// providing more details on errors.
-TEST(ConfigTest, InvalidConfigSetupMoreInfo) {
+// providing more details on errors - this is now allowed
+TEST(ConfigTest, ValidConfigSetupPathTemplate) {
   const std::string yaml_string = R"EOF(
       name: envoy.path.match.uri_template.uri_template_matcher
       typed_config:
@@ -96,10 +96,40 @@ TEST(ConfigTest, InvalidConfigSetupMoreInfo) {
   absl::StatusOr<Router::PathMatcherSharedPtr> config_or_error =
       factory->createPathMatcher(*message);
 
+  EXPECT_TRUE(config_or_error.ok());
+}
+
+// Followup on issue https://github.com/envoyproxy/envoy/issues/34507 -
+// providing more details on errors.
+TEST(ConfigTest, InvalidConfigSetupMoreInfo) {
+  const std::string yaml_string = R"EOF(
+      name: envoy.path.match.uri_template.uri_template_matcher
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+        path_template: "/api/MyFunction[123]"
+)EOF";
+
+  envoy::config::core::v3::TypedExtensionConfig config;
+  TestUtility::loadFromYaml(yaml_string, config);
+
+  const auto& factory =
+      &Envoy::Config::Utility::getAndCheckFactory<Router::PathMatcherFactory>(config);
+
+  EXPECT_NE(nullptr, factory);
+  EXPECT_EQ(factory->name(), "envoy.path.match.uri_template.uri_template_matcher");
+
+  auto message = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
+
+  EXPECT_NE(nullptr, message);
+
+  absl::StatusOr<Router::PathMatcherSharedPtr> config_or_error =
+      factory->createPathMatcher(*message);
+
   EXPECT_FALSE(config_or_error.ok());
   EXPECT_EQ(config_or_error.status().message(),
-            "path_match_policy.path_template /api/MyFunction('{id}') is invalid: Invalid literal: "
-            "\"MyFunction('{id}')\"");
+            "path_match_policy.path_template /api/MyFunction[123] is invalid: Invalid literal: "
+            "\"MyFunction[123]\"");
 }
 
 TEST(ConfigTest, TestConfigSetup) {

--- a/test/extensions/path/match/uri_template/library_test.cc
+++ b/test/extensions/path/match/uri_template/library_test.cc
@@ -73,6 +73,21 @@ TEST(MatchTest, MatchDoubleEquals) {
   EXPECT_TRUE(matcher->match("/bar/en==/us"));
 }
 
+TEST(MatchTest, MatchPathParamInLiteral) {
+  const std::string yaml_string = R"EOF(
+      name: envoy.path.match.uri_template.uri_template_matcher
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.path.match.uri_template.v3.UriTemplateMatchConfig
+        path_template: "/bar/Foo('{lang}')"
+)EOF";
+
+  Router::PathMatcherSharedPtr matcher = createMatcherFromYaml(yaml_string);
+  EXPECT_EQ(matcher->uriTemplate(), "/bar/Foo('{lang}')");
+  EXPECT_EQ(matcher->name(), "envoy.path.match.uri_template.uri_template_matcher");
+
+  EXPECT_TRUE(matcher->match("/bar/Foo('en')"));
+}
+
 } // namespace Match
 } // namespace UriTemplate
 } // namespace Extensions


### PR DESCRIPTION
Commit Message: Allow uri_template variables in literal expression
Additional Description:
UriTemplateMatch now allows for variables to be defined in a literal. Before this change, all variables had to be clamped by path separators (/).

This is not according [RFC6570](https://www.rfc-editor.org/rfc/rfc6570.html).

Even though the spec is not implemented by Envoy (`*`, `**` are not a glob in the file system sense), it is good to have more feature parity with URI Templates.

The change is to treat path separators as literals. The restriction can then be easily lifted to allow variables inside literals.

2 checks have been rewritten, double slashes are not allowed, `/abc//d` and `/abc/{var=/d}`, and that a PathGlob can only exist between two path separators.
Risk Level: Low
Testing: Tests added and adjusted where necessary
Docs Changes: 
Release Notes:
Optional Fixes #Issue: #34507
