### PR TITLE
mobile: Replace rawEngine() with internalEngine()

### DIFF
--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -174,9 +174,9 @@ uint64_t BaseClientIntegrationTest::getCounterValue(const std::string& name) {
   uint64_t counter_value = 0UL;
   uint64_t* counter_value_ptr = &counter_value;
   absl::Notification counter_value_set;
-  auto engine = reinterpret_cast<Envoy::InternalEngine*>(rawEngine());
-  engine->dispatcher().post([&] {
-    Stats::CounterSharedPtr counter = TestUtility::findCounter(engine->getStatsStore(), name);
+  internalEngine()->dispatcher().post([&] {
+    Stats::CounterSharedPtr counter =
+        TestUtility::findCounter(internalEngine()->getStatsStore(), name);
     if (counter != nullptr) {
       *counter_value_ptr = counter->value();
     }
@@ -205,9 +205,8 @@ uint64_t BaseClientIntegrationTest::getGaugeValue(const std::string& name) {
   uint64_t gauge_value = 0UL;
   uint64_t* gauge_value_ptr = &gauge_value;
   absl::Notification gauge_value_set;
-  auto engine = reinterpret_cast<Envoy::InternalEngine*>(rawEngine());
-  engine->dispatcher().post([&] {
-    Stats::GaugeSharedPtr gauge = TestUtility::findGauge(engine->getStatsStore(), name);
+  internalEngine()->dispatcher().post([&] {
+    Stats::GaugeSharedPtr gauge = TestUtility::findGauge(internalEngine()->getStatsStore(), name);
     if (gauge != nullptr) {
       *gauge_value_ptr = gauge->value();
     }

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -46,9 +46,9 @@ public:
   void TearDown();
 
 protected:
-  envoy_engine_t rawEngine() {
+  InternalEngine* internalEngine() {
     absl::MutexLock l(&engine_lock_);
-    return reinterpret_cast<envoy_engine_t>(engine_->engine_);
+    return engine_->engine_;
   }
   void initialize() override;
   Platform::StreamSharedPtr createNewStream(EnvoyStreamCallbacks&& stream_callbacks);


### PR DESCRIPTION
Converting the `InternalEngine` into `envoy_engine_t` and then converting it back to `InternalEngine` is unnecessary.

Risk Level: low (tests only)
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a