### PR TITLE
upstream: Add dynamic `LbPolicyData` to `Host`.

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -300,6 +300,25 @@ public:
    * Set true to disable active health check for the host.
    */
   virtual void setDisableActiveHealthCheck(bool disable_active_health_check) PURE;
+
+  /**
+   * Base interface for attaching LbPolicy-specific data to individual hosts.
+   */
+  class HostLbPolicyData {
+  public:
+    virtual ~HostLbPolicyData() = default;
+  };
+  using HostLbPolicyDataPtr = std::shared_ptr<HostLbPolicyData>;
+
+  /* Takes ownership of lb_policy_data and attaches it to the host.
+   * Must be called before the host is used across threads.
+   */
+  virtual void setLbPolicyData(HostLbPolicyDataPtr lb_policy_data) PURE;
+
+  /*
+   * @return a reference to the LbPolicyData attached to the host.
+   */
+  virtual const HostLbPolicyDataPtr& lbPolicyData() const PURE;
 };
 
 using HostConstSharedPtr = std::shared_ptr<const Host>;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -411,6 +411,11 @@ public:
     return std::make_unique<HostHandleImpl>(shared_from_this());
   }
 
+  void setLbPolicyData(HostLbPolicyDataPtr lb_policy_data) override {
+    lb_policy_data_ = std::move(lb_policy_data);
+  }
+  const HostLbPolicyDataPtr& lbPolicyData() const override { return lb_policy_data_; }
+
 protected:
   static CreateConnectionData
   createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& cluster,
@@ -434,6 +439,7 @@ private:
   // flag access? May be we could refactor HealthFlag to contain all these statuses and flags in the
   // future.
   std::atomic<Host::HealthStatus> eds_health_status_{};
+  HostLbPolicyDataPtr lb_policy_data_;
 
   struct HostHandleImpl : HostHandle {
     HostHandleImpl(const std::shared_ptr<const HostImplBase>& parent) : parent_(parent) {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1574,6 +1574,23 @@ TEST_F(HostImplTest, Weight) {
   EXPECT_EQ(std::numeric_limits<uint32_t>::max(), host->weight());
 }
 
+TEST_F(HostImplTest, HostLbPolicyData) {
+  MockClusterMockPrioritySet cluster;
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  EXPECT_TRUE(host->lbPolicyData() == nullptr);
+
+  class TestLbPolicyData : public Host::HostLbPolicyData {
+  public:
+    int foo = 42;
+  };
+
+  host->setLbPolicyData(std::make_shared<TestLbPolicyData>());
+  EXPECT_TRUE(host->lbPolicyData() != nullptr);
+  auto* test_policy_data = dynamic_cast<TestLbPolicyData*>(host->lbPolicyData().get());
+  EXPECT_TRUE(test_policy_data != nullptr);
+  EXPECT_EQ(test_policy_data->foo, 42);
+}
+
 TEST_F(HostImplTest, HostnameCanaryAndLocality) {
   MockClusterMockPrioritySet cluster;
   envoy::config::core::v3::Metadata metadata;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -207,6 +207,8 @@ public:
   MOCK_METHOD(void, priority, (uint32_t));
   MOCK_METHOD(bool, warmed, (), (const));
   MOCK_METHOD(absl::optional<MonotonicTime>, lastHcPassTime, (), (const));
+  MOCK_METHOD(void, setLbPolicyData, (HostLbPolicyDataPtr lb_policy_data));
+  MOCK_METHOD(const HostLbPolicyDataPtr&, lbPolicyData, (), (const));
 
   bool disable_active_health_check_ = false;
 };


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: 
Add dynamic `LbPolicyData` to `Host`.

- Define base `HostLbPolicyData` interface that LB policy can implement in order to attach policy-specific dynamic data to the `Host`. Once attached the lbPolicyData is owned by the host.
- Add `Host::setLbPolicyData()` and `Host::lbPolicyData` methods to set and get it.
- In particular this will be used to implement `ClientSideWeightedRoundRobin` LB policy that needs to calculate host weight on the client side based on the ORCA load report received from the upstream.

Risk Level: Low
Testing: Unit test in `upstream_impl_test`
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: Cross-platform
Fixes #34529 
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
