### PR TITLE
examples: wasm-cc: replace auto_config protocol option

### DIFF
--- a/examples/wasm-cc/envoy.yaml
+++ b/examples/wasm-cc/envoy.yaml
@@ -103,7 +103,7 @@ static_resources:
         upstream_http_protocol_options:
           auto_sni: false
           auto_san_validation: false
-        auto_config:
+        explicit_http_config:
           http2_protocol_options: {}
         http_filters:
         - name: envoy.filters.http.wasm


### PR DESCRIPTION
Commit Message: Auto-config allows switching on protocols based on ALPN and that is not supported by the cluster's transport socket in the wasm-cc example.

Fixes: `error initializing config '  /etc/envoy.yaml': ALPN configured for cluster web_service_with_wasm_filter which has a non-ALPN transport socket: name: "web_service_with_wasm_filter"`

Additional Description: N/A
Risk Level: Low
Testing: Manual testing, I have verified that with this fix both containers from wasm-cc example successfully start and are functional for the purposes of the example.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

