### PR TITLE
ext_proc: observability mode part 4: add deferred closure timeout config

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -260,7 +260,7 @@ message ExternalProcessor {
   // [#not-implemented-hide:]
   // Specifies the deferred closure timeout for gRPC stream that connects to external processor. Currently, the deferred stream closure
   // is only used in :ref:`observability_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
-  // In observability mode, grpc streams may be held open to the external processor longer than the lifetime of the regular client to
+  // In observability mode, gRPC streams may be held open to the external processor longer than the lifetime of the regular client to
   // backend stream lifetime. In this case, Envoy will eventually timeout the external processor stream according to this time limit.
   // The default value is 5000 milliseconds (5 seconds) if not specified.
   google.protobuf.Duration deferred_close_timeout = 19;

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -98,7 +98,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <arch_overview_advanced_filter_state_sharing>` object in a namespace matching the filter
 // name.
 //
-// [#next-free-field: 19]
+// [#next-free-field: 20]
 message ExternalProcessor {
   // Describes the route cache action to be taken when an external processor response
   // is received in response to request headers.
@@ -256,6 +256,12 @@ message ExternalProcessor {
   // Only one of ``disable_clear_route_cache`` or ``route_cache_action`` can be set.
   RouteCacheAction route_cache_action = 18
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
+
+  // [#not-implemented-hide:]
+  // Specifies the deferred closure timeout for gRPC stream (that connects to external processor). Currently, derferred stream closure is
+  // only used in :ref:`clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
+  // The default grace period is 5000 milliseconds (5 seconds)if not specified.
+  google.protobuf.Duration deferred_close_timeout = 19;
 }
 
 // The MetadataOptions structure defines options for the sending and receiving of

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -258,8 +258,10 @@ message ExternalProcessor {
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
 
   // [#not-implemented-hide:]
-  // Specifies the deferred closure timeout for gRPC stream (that connects to external processor). Currently, deferred stream closure is
-  // only used in :ref:`clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
+  // Specifies the deferred closure timeout for gRPC stream that connects to external processor. Currently, the deferred stream closure
+  // is only used in :ref:`observability_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
+  // In observability mode, grpc streams may be held open to the external processor longer than the lifetime of the regular client to
+  // backend stream lifetime. In this case, Envoy will eventually timeout the external processor stream according to this time limit.
   // The default value is 5000 milliseconds (5 seconds) if not specified.
   google.protobuf.Duration deferred_close_timeout = 19;
 }

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -258,7 +258,7 @@ message ExternalProcessor {
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
 
   // [#not-implemented-hide:]
-  // Specifies the deferred closure timeout for gRPC stream (that connects to external processor). Currently, derferred stream closure is
+  // Specifies the deferred closure timeout for gRPC stream (that connects to external processor). Currently, deferred stream closure is
   // only used in :ref:`clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
   // The default value is 5000 milliseconds (5 seconds) if not specified.
   google.protobuf.Duration deferred_close_timeout = 19;

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -260,7 +260,7 @@ message ExternalProcessor {
   // [#not-implemented-hide:]
   // Specifies the deferred closure timeout for gRPC stream (that connects to external processor). Currently, derferred stream closure is
   // only used in :ref:`clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
-  // The default grace period is 5000 milliseconds (5 seconds)if not specified.
+  // The default value is 5000 milliseconds (5 seconds) if not specified.
   google.protobuf.Duration deferred_close_timeout = 19;
 }
 


### PR DESCRIPTION
The default timeout value is chosen same as [drain timeout](https://github.com/envoyproxy/envoy/blob/3feff04eeb2356cf16f799bc9fb812e5b765315f/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#L553) `<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`
