### PR TITLE
http: adds support for formatter extensions in mutation

### DIFF
--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -4,6 +4,7 @@ package envoy.config.route.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/any.proto";
@@ -23,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
 // * HTTP :ref:`router filter <config_http_filters_router>`
 
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.RouteConfiguration";
 
@@ -155,6 +156,11 @@ message RouteConfiguration {
   // For instance, if the metadata is intended for the Router filter,
   // the filter name should be specified as ``envoy.filters.http.router``.
   core.v3.Metadata metadata = 17;
+
+  // Specifies a collection of Formatter plugins that can be called from request_headers_to_add and
+  // response_headers_to_add operations.
+  // [#extension-category: envoy.formatter]
+  repeated core.v3.TypedExtensionConfig formatters = 18;
 }
 
 message Vhds {

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -332,7 +332,8 @@ new_features:
     which, when set to true, will set the downstream request ``:scheme`` to match the upstream transport protocol.
 - area: http
   change: |
-    Added field :ref:`formatters <envoy_v3_api_field_config.route.v3.Route.formatters>` which enables the ability to use formatters extensiosn in header mutation.
+    Added field :ref:`formatters <envoy_v3_api_field_config.route.v3.Route.formatters>` which adds the ability
+    to use formatter extensions in header mutation.
 - area: redis
   change: |
     Added support for `inline commands <https://redis.io/docs/reference/protocol-spec/#inline-commands>`_.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -330,6 +330,9 @@ new_features:
   change: |
     Added field :ref:`match_upstream <envoy_v3_api_field_config.core.v3.SchemeHeaderTransformation.match_upstream>`,
     which, when set to true, will set the downstream request ``:scheme`` to match the upstream transport protocol.
+- area: http
+  change: |
+    Added field :ref:`formatters <envoy_v3_api_field_config.route.v3.Route.formatters>` which enables the ability to use formatters extensiosn in header mutation.
 - area: redis
   change: |
     Added support for `inline commands <https://redis.io/docs/reference/protocol-spec/#inline-commands>`_.

--- a/envoy/formatter/substitution_formatter.h
+++ b/envoy/formatter/substitution_formatter.h
@@ -36,7 +36,7 @@ public:
    */
   virtual CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message& config,
-                               Server::Configuration::GenericFactoryContext& context) PURE;
+                               Server::Configuration::ServerFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.formatter"; }
 };

--- a/envoy/formatter/substitution_formatter_base.h
+++ b/envoy/formatter/substitution_formatter_base.h
@@ -102,7 +102,7 @@ public:
    */
   virtual CommandParserBasePtr<FormatterContext>
   createCommandParserFromProto(const Protobuf::Message& config,
-                               Server::Configuration::GenericFactoryContext& context) PURE;
+                               Server::Configuration::ServerFactoryContext& context) PURE;
 
   std::string category() const override {
     return fmt::format("envoy.{}.formatters", FormatterContext::category());

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -31,7 +31,7 @@ public:
   template <class FormatterContext = HttpFormatterContext>
   static std::vector<CommandParserBasePtr<FormatterContext>>
   parseFormatters(const FormattersConfig& formatters,
-                  Server::Configuration::GenericFactoryContext& context) {
+                  Server::Configuration::ServerFactoryContext& context) {
     std::vector<CommandParserBasePtr<FormatterContext>> commands;
     for (const auto& formatter : formatters) {
       auto* factory =
@@ -58,7 +58,7 @@ public:
   template <class FormatterContext = HttpFormatterContext>
   static FormatterBasePtr<FormatterContext>
   fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config,
-                  Server::Configuration::GenericFactoryContext& context) {
+                  Server::Configuration::ServerFactoryContext& context) {
     // Instantiate formatter extensions.
     auto commands = parseFormatters<FormatterContext>(config.formatters(), context);
     switch (config.format_case()) {
@@ -72,9 +72,9 @@ public:
           commands);
     case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormatSource:
       return std::make_unique<FormatterBaseImpl<FormatterContext>>(
-          THROW_OR_RETURN_VALUE(Config::DataSource::read(config.text_format_source(), true,
-                                                         context.serverFactoryContext().api()),
-                                std::string),
+          THROW_OR_RETURN_VALUE(
+              Config::DataSource::read(config.text_format_source(), true, context.api()),
+              std::string),
           config.omit_empty_values(), commands);
     case envoy::config::core::v3::SubstitutionFormatString::FormatCase::FORMAT_NOT_SET:
       PANIC_DUE_TO_PROTO_UNSET;

--- a/source/common/http/header_mutation.cc
+++ b/source/common/http/header_mutation.cc
@@ -16,7 +16,7 @@ using HeaderValueOption = envoy::config::core::v3::HeaderValueOption;
 class AppendMutation : public HeaderEvaluator, public Envoy::Router::HeadersToAddEntry {
 public:
   AppendMutation(const HeaderValueOption& header_value_option, absl::Status& creation_status)
-      : HeadersToAddEntry(header_value_option, creation_status),
+      : HeadersToAddEntry(header_value_option, creation_status, absl::nullopt),
         header_name_(header_value_option.header().key()) {}
 
   void evaluateHeaders(Http::HeaderMap& headers, const Formatter::HttpFormatterContext& context,

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -24,7 +24,8 @@ public:
 
   BodyFormatter(const envoy::config::core::v3::SubstitutionFormatString& config,
                 Server::Configuration::GenericFactoryContext& context)
-      : formatter_(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, context)),
+      : formatter_(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+            config, context.serverFactoryContext())),
         content_type_(
             !config.content_type().empty() ? config.content_type()
             : config.format_case() ==

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -62,6 +62,7 @@ envoy_cc_library(
         "//source/common/config:metadata_lib",
         "//source/common/config:utility_lib",
         "//source/common/config:well_known_names",
+        "//source/common/formatter:substitution_format_string_lib",
         "//source/common/http:hash_policy_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -122,21 +122,7 @@ absl::StatusOr<HeaderParserPtr> HeaderParser::configure(
 absl::StatusOr<HeaderParserPtr>
 HeaderParser::configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
                         const Protobuf::RepeatedPtrField<std::string>& headers_to_remove) {
-  auto parser_or_error = configure(headers_to_add);
-  RETURN_IF_STATUS_NOT_OK(parser_or_error);
-  HeaderParserPtr header_parser = std::move(parser_or_error.value());
-
-  for (const auto& header : headers_to_remove) {
-    // We reject :-prefix (e.g. :path) removal here. This is dangerous, since other aspects of
-    // request finalization assume their existence and they are needed for well-formedness in most
-    // cases.
-    if (!Http::HeaderUtility::isRemovableHeader(header)) {
-      return absl::InvalidArgumentError(":-prefixed or host headers may not be removed");
-    }
-    header_parser->headers_to_remove_.emplace_back(header);
-  }
-
-  return header_parser;
+  return configure(headers_to_add, headers_to_remove, absl::nullopt);
 }
 
 absl::StatusOr<HeaderParserPtr>

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -708,7 +708,7 @@ TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
   substitution_format_config.mutable_text_format_source()->set_inline_string(
       config_message.tunneling_config().hostname());
   hostname_fmt_ = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-      substitution_format_config, context);
+      substitution_format_config, context.serverFactoryContext());
 }
 
 std::string TunnelingConfigHelperImpl::host(const StreamInfo::StreamInfo& stream_info) const {

--- a/source/extensions/access_loggers/common/stream_access_log_common_impl.h
+++ b/source/extensions/access_loggers/common/stream_access_log_common_impl.h
@@ -18,8 +18,8 @@ createStreamAccessLogInstance(const Protobuf::Message& config, AccessLog::Filter
       MessageUtil::downcastAndValidate<const T&>(config, context.messageValidationVisitor());
   Formatter::FormatterPtr formatter;
   if (fal_config.access_log_format_case() == T::AccessLogFormatCase::kLogFormat) {
-    formatter =
-        Formatter::SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format(), context);
+    formatter = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+        fal_config.log_format(), context.serverFactoryContext());
   } else if (fal_config.access_log_format_case() ==
              T::AccessLogFormatCase::ACCESS_LOG_FORMAT_NOT_SET) {
     formatter = Formatter::HttpSubstitutionFormatUtils::defaultSubstitutionFormatter();

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -28,6 +28,8 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       config, context.messageValidationVisitor());
   Formatter::FormatterPtr formatter;
 
+  auto& server_factory_context = context.serverFactoryContext();
+
   switch (fal_config.access_log_format_case()) {
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kFormat:
     if (fal_config.format().empty()) {
@@ -35,7 +37,8 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
     } else {
       envoy::config::core::v3::SubstitutionFormatString sff_config;
       sff_config.mutable_text_format_source()->set_inline_string(fal_config.format());
-      formatter = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(sff_config, context);
+      formatter = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(sff_config,
+                                                                            server_factory_context);
     }
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kJsonFormat:
@@ -46,12 +49,13 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       kTypedJsonFormat: {
     envoy::config::core::v3::SubstitutionFormatString sff_config;
     *sff_config.mutable_json_format() = fal_config.typed_json_format();
-    formatter = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(sff_config, context);
+    formatter = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(sff_config,
+                                                                          server_factory_context);
     break;
   }
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kLogFormat:
-    formatter =
-        Formatter::SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format(), context);
+    formatter = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format(),
+                                                                          server_factory_context);
     break;
   case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
       ACCESS_LOG_FORMAT_NOT_SET:

--- a/source/extensions/access_loggers/fluentd/config.cc
+++ b/source/extensions/access_loggers/fluentd/config.cc
@@ -60,8 +60,8 @@ FluentdAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config
   // payload.
   // TODO(ohadvano): Improve the formatting operation by creating a dedicated formatter that
   //                 will directly serialize the record to msgpack payload.
-  auto commands =
-      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context);
+  auto commands = Formatter::SubstitutionFormatStringUtils::parseFormatters(
+      proto_config.formatters(), context.serverFactoryContext());
   Formatter::FormatterPtr json_formatter =
       Formatter::SubstitutionFormatStringUtils::createJsonFormatter(proto_config.record(), true,
                                                                     false, false, commands);

--- a/source/extensions/access_loggers/open_telemetry/config.cc
+++ b/source/extensions/access_loggers/open_telemetry/config.cc
@@ -41,8 +41,8 @@ AccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&>(
       config, context.messageValidationVisitor());
 
-  auto commands =
-      Formatter::SubstitutionFormatStringUtils::parseFormatters(proto_config.formatters(), context);
+  auto commands = Formatter::SubstitutionFormatStringUtils::parseFormatters(
+      proto_config.formatters(), context.serverFactoryContext());
 
   return std::make_shared<AccessLog>(
       std::move(filter), proto_config, context.serverFactoryContext().threadLocal(),

--- a/source/extensions/filters/common/set_filter_state/filter_config.cc
+++ b/source/extensions/filters/common/set_filter_state/filter_config.cc
@@ -51,7 +51,7 @@ Config::parse(const Protobuf::RepeatedPtrField<FilterStateValueProto>& proto_val
     }
     value.skip_if_empty_ = proto_value.skip_if_empty();
     value.value_ = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-        proto_value.format_string(), context);
+        proto_value.format_string(), context.serverFactoryContext());
     values.push_back(std::move(value));
   }
   return values;

--- a/source/extensions/filters/udp/udp_proxy/config.cc
+++ b/source/extensions/filters/udp/udp_proxy/config.cc
@@ -58,7 +58,7 @@ TunnelingConfigImpl::TunnelingConfigImpl(const TunnelingConfig& config,
   proxy_substitution_format_config.mutable_text_format_source()->set_inline_string(
       config.proxy_host());
   proxy_host_formatter_ = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-      proxy_substitution_format_config, context);
+      proxy_substitution_format_config, context.serverFactoryContext());
 
   if (config.has_proxy_port()) {
     uint32_t port = config.proxy_port().value();
@@ -73,7 +73,7 @@ TunnelingConfigImpl::TunnelingConfigImpl(const TunnelingConfig& config,
   target_substitution_format_config.mutable_text_format_source()->set_inline_string(
       config.target_host());
   target_host_formatter_ = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
-      target_substitution_format_config, context);
+      target_substitution_format_config, context.serverFactoryContext());
 }
 
 UdpProxyFilterConfigImpl::UdpProxyFilterConfigImpl(

--- a/source/extensions/formatter/cel/config.cc
+++ b/source/extensions/formatter/cel/config.cc
@@ -9,9 +9,9 @@ namespace Extensions {
 namespace Formatter {
 
 ::Envoy::Formatter::CommandParserPtr CELFormatterFactory::createCommandParserFromProto(
-    const Protobuf::Message&, Server::Configuration::GenericFactoryContext& context) {
+    const Protobuf::Message&, Server::Configuration::ServerFactoryContext& context) {
 #if defined(USE_CEL_PARSER)
-  return std::make_unique<CELFormatterCommandParser>(context.serverFactoryContext());
+  return std::make_unique<CELFormatterCommandParser>(context);
 #else
   UNREFERENCED_PARAMETER(context);
   throw EnvoyException("CEL is not available for use in this environment.");

--- a/source/extensions/formatter/cel/config.h
+++ b/source/extensions/formatter/cel/config.h
@@ -11,7 +11,7 @@ class CELFormatterFactory : public ::Envoy::Formatter::CommandParserFactory {
 public:
   ::Envoy::Formatter::CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message&,
-                               Server::Configuration::GenericFactoryContext&) override;
+                               Server::Configuration::ServerFactoryContext&) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override;
 };

--- a/source/extensions/formatter/metadata/config.cc
+++ b/source/extensions/formatter/metadata/config.cc
@@ -9,7 +9,7 @@ namespace Extensions {
 namespace Formatter {
 
 ::Envoy::Formatter::CommandParserPtr MetadataFormatterFactory::createCommandParserFromProto(
-    const Protobuf::Message&, Server::Configuration::GenericFactoryContext&) {
+    const Protobuf::Message&, Server::Configuration::ServerFactoryContext&) {
   return std::make_unique<MetadataFormatterCommandParser>();
 }
 

--- a/source/extensions/formatter/metadata/config.h
+++ b/source/extensions/formatter/metadata/config.h
@@ -10,7 +10,7 @@ class MetadataFormatterFactory : public ::Envoy::Formatter::CommandParserFactory
 public:
   ::Envoy::Formatter::CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message&,
-                               Server::Configuration::GenericFactoryContext&) override;
+                               Server::Configuration::ServerFactoryContext&) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override;
 };

--- a/source/extensions/formatter/req_without_query/config.cc
+++ b/source/extensions/formatter/req_without_query/config.cc
@@ -8,8 +8,9 @@ namespace Envoy {
 namespace Extensions {
 namespace Formatter {
 
-::Envoy::Formatter::CommandParserPtr ReqWithoutQueryFactory::createCommandParserFromProto(
-    const Protobuf::Message&, Server::Configuration::GenericFactoryContext&) {
+::Envoy::Formatter::CommandParserPtr
+ReqWithoutQueryFactory::createCommandParserFromProto(const Protobuf::Message&,
+                                                     Server::Configuration::ServerFactoryContext&) {
   return std::make_unique<ReqWithoutQueryCommandParser>();
 }
 

--- a/source/extensions/formatter/req_without_query/config.h
+++ b/source/extensions/formatter/req_without_query/config.h
@@ -10,7 +10,7 @@ class ReqWithoutQueryFactory : public ::Envoy::Formatter::CommandParserFactory {
 public:
   ::Envoy::Formatter::CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message&,
-                               Server::Configuration::GenericFactoryContext&) override;
+                               Server::Configuration::ServerFactoryContext&) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override;
 };

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -39,8 +39,8 @@ LocalResponsePolicy::LocalResponsePolicy(
   // by this PR and will be fixed in the future.
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
   if (config.has_body_format()) {
-    formatter_ = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config.body_format(),
-                                                                           generic_context);
+    formatter_ = Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+        config.body_format(), generic_context.serverFactoryContext());
   }
 }
 

--- a/source/extensions/matching/actions/format_string/config.cc
+++ b/source/extensions/matching/actions/format_string/config.cc
@@ -33,7 +33,7 @@ ActionFactory::createActionFactoryCb(const Protobuf::Message& proto_config,
 
   Server::GenericFactoryContextImpl generic_context(context, validator);
   Formatter::FormatterConstSharedPtr formatter =
-      Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, generic_context);
+      Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, context);
   return [formatter]() { return std::make_unique<ActionImpl>(formatter); };
 }
 

--- a/test/common/formatter/command_extension.cc
+++ b/test/common/formatter/command_extension.cc
@@ -27,7 +27,7 @@ FormatterProviderPtr TestCommandParser::parse(const std::string& command, const 
 
 CommandParserPtr
 TestCommandFactory::createCommandParserFromProto(const Protobuf::Message& message,
-                                                 Server::Configuration::GenericFactoryContext&) {
+                                                 Server::Configuration::ServerFactoryContext&) {
   // Cast the config message to the actual type to test that it was constructed properly.
   [[maybe_unused]] const auto& config =
       *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::StringValue>(&message);
@@ -64,7 +64,7 @@ FormatterProviderPtr AdditionalCommandParser::parse(const std::string& command, 
 }
 
 CommandParserPtr AdditionalCommandFactory::createCommandParserFromProto(
-    const Protobuf::Message& message, Server::Configuration::GenericFactoryContext&) {
+    const Protobuf::Message& message, Server::Configuration::ServerFactoryContext&) {
   // Cast the config message to the actual type to test that it was constructed properly.
   [[maybe_unused]] const auto& config =
       *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::UInt32Value>(&message);
@@ -83,7 +83,7 @@ std::string AdditionalCommandFactory::name() const { return "envoy.formatter.Add
 
 CommandParserPtr
 FailCommandFactory::createCommandParserFromProto(const Protobuf::Message& message,
-                                                 Server::Configuration::GenericFactoryContext&) {
+                                                 Server::Configuration::ServerFactoryContext&) {
   // Cast the config message to the actual type to test that it was constructed properly.
   [[maybe_unused]] const auto& config =
       *Envoy::Protobuf::DynamicCastToGenerated<const ProtobufWkt::UInt64Value>(&message);

--- a/test/common/formatter/command_extension.h
+++ b/test/common/formatter/command_extension.h
@@ -32,7 +32,7 @@ class TestCommandFactory : public CommandParserFactory {
 public:
   CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message&,
-                               Server::Configuration::GenericFactoryContext&) override;
+                               Server::Configuration::ServerFactoryContext&) override;
   std::set<std::string> configTypes() override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override;
@@ -60,7 +60,7 @@ class AdditionalCommandFactory : public CommandParserFactory {
 public:
   CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message&,
-                               Server::Configuration::GenericFactoryContext&) override;
+                               Server::Configuration::ServerFactoryContext&) override;
   std::set<std::string> configTypes() override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override;
@@ -70,7 +70,7 @@ class FailCommandFactory : public CommandParserFactory {
 public:
   CommandParserPtr
   createCommandParserFromProto(const Protobuf::Message&,
-                               Server::Configuration::GenericFactoryContext&) override;
+                               Server::Configuration::ServerFactoryContext&) override;
   std::set<std::string> configTypes() override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override;

--- a/test/common/formatter/substitution_format_string_test.cc
+++ b/test/common/formatter/substitution_format_string_test.cc
@@ -47,7 +47,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigText) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter = SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter =
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext());
   EXPECT_EQ("plain text, path=/bar/foo, code=200",
             formatter->formatWithContext(formatter_context_, stream_info_));
 }
@@ -63,7 +64,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJson) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter = SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter =
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext());
   const auto out_json = formatter->formatWithContext(formatter_context_, stream_info_);
 
   const std::string expected = R"EOF({
@@ -86,10 +88,11 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestInvalidConfigs) {
   };
   for (const auto& yaml : invalid_configs) {
     TestUtility::loadFromYaml(yaml, config_);
-    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-                              EnvoyException,
-                              "Only string values, nested structs, list values and number values "
-                              "are supported in structured access log format.");
+    EXPECT_THROW_WITH_MESSAGE(
+        SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext()),
+        EnvoyException,
+        "Only string values, nested structs, list values and number values "
+        "are supported in structured access log format.");
   }
 }
 
@@ -107,7 +110,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigFormatterExtension)
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter = SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter =
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext());
   EXPECT_EQ("plain text TestFormatter",
             formatter->formatWithContext(formatter_context_, stream_info_));
 }
@@ -127,9 +131,9 @@ TEST_F(SubstitutionFormatStringUtilsTest,
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-                            EnvoyException,
-                            "Failed to create command parser: envoy.formatter.FailFormatter");
+  EXPECT_THROW_WITH_MESSAGE(
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext()),
+      EnvoyException, "Failed to create command parser: envoy.formatter.FailFormatter");
 }
 
 TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigFormatterExtensionUnknown) {
@@ -143,9 +147,9 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigFormatterExtensionU
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-                            EnvoyException,
-                            "Formatter not found: envoy.formatter.TestFormatterUnknown");
+  EXPECT_THROW_WITH_MESSAGE(
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext()),
+      EnvoyException, "Formatter not found: envoy.formatter.TestFormatterUnknown");
 }
 
 TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJsonWithExtension) {
@@ -166,7 +170,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJsonWithExtension) 
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter = SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter =
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext());
   const auto out_json = formatter->formatWithContext(formatter_context_, stream_info_);
 
   const std::string expected = R"EOF({
@@ -201,7 +206,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJsonWithMultipleExt
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter = SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter =
+      SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.serverFactoryContext());
   const auto out_json = formatter->formatWithContext(formatter_context_, stream_info_);
 
   const std::string expected = R"EOF({
@@ -225,9 +231,9 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestParseFormattersWithUnknownExtensio
   TestUtility::loadFromYaml(yaml, proto);
   *entry1 = proto;
 
-  EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatStringUtils::parseFormatters(config, context_),
-                            EnvoyException,
-                            "Formatter not found: envoy.formatter.TestFormatterUnknown");
+  EXPECT_THROW_WITH_MESSAGE(
+      SubstitutionFormatStringUtils::parseFormatters(config, context_.serverFactoryContext()),
+      EnvoyException, "Formatter not found: envoy.formatter.TestFormatterUnknown");
 }
 
 TEST_F(SubstitutionFormatStringUtilsTest, TestParseFormattersWithInvalidFormatter) {
@@ -246,9 +252,9 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestParseFormattersWithInvalidFormatte
   TestUtility::loadFromYaml(yaml, proto);
   *entry1 = proto;
 
-  EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatStringUtils::parseFormatters(config, context_),
-                            EnvoyException,
-                            "Failed to create command parser: envoy.formatter.FailFormatter");
+  EXPECT_THROW_WITH_MESSAGE(
+      SubstitutionFormatStringUtils::parseFormatters(config, context_.serverFactoryContext()),
+      EnvoyException, "Failed to create command parser: envoy.formatter.FailFormatter");
 }
 
 TEST_F(SubstitutionFormatStringUtilsTest, TestParseFormattersWithSingleExtension) {
@@ -267,7 +273,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestParseFormattersWithSingleExtension
   TestUtility::loadFromYaml(yaml, proto);
   *entry1 = proto;
 
-  auto commands = SubstitutionFormatStringUtils::parseFormatters(config, context_);
+  auto commands =
+      SubstitutionFormatStringUtils::parseFormatters(config, context_.serverFactoryContext());
   ASSERT_EQ(1, commands.size());
 
   absl::optional<size_t> max_length = {};
@@ -306,7 +313,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestParseFormattersWithMultipleExtensi
   TestUtility::loadFromYaml(additional_command_yaml, additional_command_proto);
   *entry2 = additional_command_proto;
 
-  auto commands = SubstitutionFormatStringUtils::parseFormatters(config, context_);
+  auto commands =
+      SubstitutionFormatStringUtils::parseFormatters(config, context_.serverFactoryContext());
   ASSERT_EQ(2, commands.size());
 
   absl::optional<size_t> max_length = {};

--- a/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/access_log_impl_test.cc
@@ -83,8 +83,8 @@ public:
           EXPECT_EQ(Common::GrpcAccessLoggerType::HTTP, logger_type);
           return logger_;
         });
-    auto commands =
-        Formatter::SubstitutionFormatStringUtils::parseFormatters(config_.formatters(), context_);
+    auto commands = Formatter::SubstitutionFormatStringUtils::parseFormatters(
+        config_.formatters(), context_.serverFactoryContext());
 
     return std::make_unique<AccessLog>(FilterPtr{filter_}, config_, tls_, logger_cache_, commands);
   }

--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
@@ -916,7 +916,7 @@ TEST(SubstitutionFormatterTest, CELFormatterTest) {
     )EOF",
                               otel_config);
     auto commands = Formatter::SubstitutionFormatStringUtils::parseFormatters(
-        otel_config.formatters(), context);
+        otel_config.formatters(), context.serverFactoryContext());
 
     OpenTelemetryFormatter formatter(otel_config.resource_attributes(), commands);
 

--- a/test/extensions/formatter/cel/cel_test.cc
+++ b/test/extensions/formatter/cel/cel_test.cc
@@ -76,8 +76,8 @@ TEST_F(CELFormatterTest, TestRequestHeader) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("GET", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -92,8 +92,8 @@ TEST_F(CELFormatterTest, TestMissingRequestHeader) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("-", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -108,8 +108,8 @@ TEST_F(CELFormatterTest, TestWithoutMaxLength) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("/original/path?secret=parameter",
             formatter->formatWithContext(formatter_context_, stream_info_));
 }
@@ -125,8 +125,8 @@ TEST_F(CELFormatterTest, TestMaxLength) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("/original", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -141,8 +141,8 @@ TEST_F(CELFormatterTest, TestContains) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("true", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -157,9 +157,9 @@ TEST_F(CELFormatterTest, TestInvalidExpression) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  EXPECT_THROW_WITH_REGEX(
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-      EnvoyException, "Not able to parse filter expression: .*");
+  EXPECT_THROW_WITH_REGEX(Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                              config_, context_.serverFactoryContext()),
+                          EnvoyException, "Not able to parse filter expression: .*");
 }
 #endif
 

--- a/test/extensions/formatter/metadata/metadata_test.cc
+++ b/test/extensions/formatter/metadata/metadata_test.cc
@@ -37,7 +37,8 @@ public:
 )EOF",
                                          tag, type);
     TestUtility::loadFromYaml(yaml, config_);
-    return Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+    return Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+        config_, context_.serverFactoryContext());
   }
 
   Http::TestRequestHeaderMapImpl request_headers_;

--- a/test/extensions/formatter/req_without_query/req_without_query_test.cc
+++ b/test/extensions/formatter/req_without_query/req_without_query_test.cc
@@ -43,8 +43,8 @@ TEST_F(ReqWithoutQueryTest, TestStripQueryString) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("/request/path", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -60,8 +60,8 @@ TEST_F(ReqWithoutQueryTest, TestSelectMainHeader) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("/original/path", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -77,8 +77,8 @@ TEST_F(ReqWithoutQueryTest, TestSelectAlternativeHeader) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("/request/path", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -94,8 +94,8 @@ TEST_F(ReqWithoutQueryTest, TestTruncateHeader) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("/requ", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -111,8 +111,8 @@ TEST_F(ReqWithoutQueryTest, TestNonExistingHeader) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   EXPECT_EQ("-", formatter->formatWithContext(formatter_context_, stream_info_));
 }
 
@@ -138,8 +138,8 @@ TEST_F(ReqWithoutQueryTest, TestFormatJson) {
 })EOF";
 
   TestUtility::loadFromYaml(yaml, config_);
-  auto formatter =
-      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  auto formatter = Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+      config_, context_.serverFactoryContext());
   const std::string actual = formatter->formatWithContext(formatter_context_, stream_info_);
   EXPECT_TRUE(TestUtility::jsonStringEqual(actual, expected));
 }
@@ -156,7 +156,8 @@ TEST_F(ReqWithoutQueryTest, TestParserNotRecognizingCommand) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  EXPECT_THROW(Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
+  EXPECT_THROW(Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(
+                   config_, context_.serverFactoryContext()),
                EnvoyException);
 }
 


### PR DESCRIPTION
Commit Message: http: adds support for metadata formatter in mutation
Additional Description:
Previously, %METADATA% format is not supported in header additions. This adds the formatters field in the router configuration, and enables users to use the formatter extensions in header mutation values, notably `envoy.formatter.metadata` extension. 

Fixes https://github.com/envoyproxy/envoy/issues/34671

Risk Level: low
Testing: unit tests
Docs Changes: done
Release Notes: done
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
