### PR TITLE
formatter: removes unused getHostNameOrDefault

### DIFF
--- a/source/common/formatter/substitution_format_utility.cc
+++ b/source/common/formatter/substitution_format_utility.cc
@@ -69,14 +69,6 @@ const absl::optional<std::string> SubstitutionFormatUtils::getHostname() {
   return hostname;
 }
 
-const std::string SubstitutionFormatUtils::getHostnameOrDefault() {
-  absl::optional<std::string> hostname = getHostname();
-  if (hostname.has_value()) {
-    return hostname.value();
-  }
-  return DefaultUnspecifiedValueString;
-}
-
 const ProtobufWkt::Value& SubstitutionFormatUtils::unspecifiedValue() {
   return ValueUtil::nullValue();
 }

--- a/source/common/formatter/substitution_format_utility.h
+++ b/source/common/formatter/substitution_format_utility.h
@@ -40,7 +40,6 @@ public:
   static const std::string&
   protocolToStringOrDefault(const absl::optional<Http::Protocol>& protocol);
   static const absl::optional<std::string> getHostname();
-  static const std::string getHostnameOrDefault();
 
   /**
    * Unspecified value for protobuf.


### PR DESCRIPTION
Commit Message: formatter: removes unused getHostNameOrDefault
Additional Description:
Previously getHostNameOrDefault was used to resolve HOSTNAME substitution, but now it's implemented via `const absl::optional<std::string> getHostname()`, and getHostNameOrDefault hasn't been used since then.
As a result, this would increase the test coverage of substitution_format_utility.cc. 

Risk Level: lo
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
