### PR TITLE
Removes unused createStaticConfigProvider

### DIFF
--- a/envoy/config/config_provider_manager.h
+++ b/envoy/config/config_provider_manager.h
@@ -59,23 +59,6 @@ public:
                           const OptionalArg& optarg) PURE;
 
   /**
-   * Returns a ConfigProvider associated with a statically specified configuration.
-   * @param config_proto supplies the configuration proto.
-   * @param factory_context is the context to use for the provider.
-   * @param optarg supplies an optional argument with data specific to the concrete class.
-   * @return ConfigProviderPtr a newly allocated static config provider.
-   */
-  virtual ConfigProviderPtr
-  createStaticConfigProvider(const Protobuf::Message& config_proto,
-                             Server::Configuration::ServerFactoryContext& factory_context,
-                             const OptionalArg& optarg) {
-    UNREFERENCED_PARAMETER(config_proto);
-    UNREFERENCED_PARAMETER(factory_context);
-    UNREFERENCED_PARAMETER(optarg);
-    return nullptr;
-  }
-
-  /**
    * Returns a ConfigProvider associated with a statically specified configuration. This is intended
    * to be used when a set of configuration protos is required to build the full configuration.
    * @param config_protos supplies a vector of configuration protos.
@@ -86,12 +69,7 @@ public:
   virtual ConfigProviderPtr
   createStaticConfigProvider(ProtobufTypes::ConstMessagePtrVector&& config_protos,
                              Server::Configuration::ServerFactoryContext& factory_context,
-                             const OptionalArg& optarg) {
-    UNREFERENCED_PARAMETER(config_protos);
-    UNREFERENCED_PARAMETER(factory_context);
-    UNREFERENCED_PARAMETER(optarg);
-    return nullptr;
-  }
+                             const OptionalArg& optarg) PURE;
 };
 
 } // namespace Config

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -284,12 +284,6 @@ public:
                           Server::Configuration::ServerFactoryContext& factory_context,
                           Init::Manager& init_manager, const std::string& stat_prefix,
                           const Envoy::Config::ConfigProviderManager::OptionalArg& optarg) override;
-  Envoy::Config::ConfigProviderPtr
-  createStaticConfigProvider(const Protobuf::Message&, Server::Configuration::ServerFactoryContext&,
-                             const Envoy::Config::ConfigProviderManager::OptionalArg&) override {
-    PANIC("SRDS supports delta updates and requires the use of the createStaticConfigProvider() "
-          "overload that accepts a config proto set as an argument.");
-  }
   Envoy::Config::ConfigProviderPtr createStaticConfigProvider(
       std::vector<std::unique_ptr<const Protobuf::Message>>&& config_protos,
       Server::Configuration::ServerFactoryContext& factory_context,

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -195,19 +195,11 @@ public:
 
   // Envoy::Config::ConfigProviderManager
   ConfigProviderPtr
-  createStaticConfigProvider(const Protobuf::Message& config_proto,
+  createStaticConfigProvider(std::vector<std::unique_ptr<const Protobuf::Message>>&& configs,
                              Server::Configuration::ServerFactoryContext& factory_context,
-                             const Envoy::Config::ConfigProviderManager::OptionalArg&) override {
-    return std::make_unique<StaticDummyConfigProvider>(
-        dynamic_cast<const test::common::config::DummyConfig&>(config_proto), factory_context,
-        *this);
-  }
-  ConfigProviderPtr
-  createStaticConfigProvider(std::vector<std::unique_ptr<const Protobuf::Message>>&&,
-                             Server::Configuration::ServerFactoryContext&,
                              const OptionalArg&) override {
-    ASSERT(false, "this provider does not expect multiple config protos");
-    return nullptr;
+    auto config = dynamic_cast<const test::common::config::DummyConfig&>(*configs[0]);
+    return std::make_unique<StaticDummyConfigProvider>(config, factory_context, *this);
   }
 };
 
@@ -248,6 +240,13 @@ protected:
 test::common::config::DummyConfig parseDummyConfigFromYaml(const std::string& yaml) {
   test::common::config::DummyConfig config;
   TestUtility::loadFromYaml(yaml, config);
+  return config;
+}
+
+std::unique_ptr<test::common::config::DummyConfig>
+parseDummyConfigPtrFromYaml(const std::string& yaml) {
+  auto config = std::make_unique<test::common::config::DummyConfig>();
+  TestUtility::loadFromYaml(yaml, *config);
   return config;
 }
 
@@ -431,12 +430,12 @@ dynamic_dummy_configs:
   EXPECT_EQ(expected_config_dump.DebugString(), dummy_config_dump.DebugString());
 
   // Static config dump only.
-  std::string config_yaml = "a: a static dummy config";
   timeSystem().setSystemTime(std::chrono::milliseconds(1234567891234));
 
+  ProtobufTypes::ConstMessagePtrVector configs;
+  configs.push_back(parseDummyConfigPtrFromYaml("a: a static dummy config"));
   ConfigProviderPtr static_config = provider_manager_->createStaticConfigProvider(
-      parseDummyConfigFromYaml(config_yaml), server_factory_context_,
-      ConfigProviderManager::NullOptionalArg());
+      std::move(configs), server_factory_context_, ConfigProviderManager::NullOptionalArg());
   message_ptr = server_factory_context_.admin_.config_tracker_.config_tracker_callbacks_["dummy"](
       Matchers::UniversalStringMatcher());
   const auto& dummy_config_dump2 =
@@ -481,9 +480,10 @@ dynamic_dummy_configs:
                             expected_config_dump);
   EXPECT_EQ(expected_config_dump.DebugString(), dummy_config_dump3.DebugString());
 
+  ProtobufTypes::ConstMessagePtrVector configs2;
+  configs2.push_back(parseDummyConfigPtrFromYaml("a: another static dummy config"));
   ConfigProviderPtr static_config2 = provider_manager_->createStaticConfigProvider(
-      parseDummyConfigFromYaml("a: another static dummy config"), server_factory_context_,
-      ConfigProviderManager::NullOptionalArg());
+      std::move(configs2), server_factory_context_, ConfigProviderManager::NullOptionalArg());
   message_ptr = server_factory_context_.admin_.config_tracker_.config_tracker_callbacks_["dummy"](
       Matchers::UniversalStringMatcher());
   const auto& dummy_config_dump4 =
@@ -665,6 +665,12 @@ public:
 
     return std::make_unique<DeltaDummyDynamicConfigProvider>(std::move(subscription));
   }
+
+  ConfigProviderPtr createStaticConfigProvider(ProtobufTypes::ConstMessagePtrVector&&,
+                                               Server::Configuration::ServerFactoryContext&,
+                                               const OptionalArg&) override {
+    return nullptr;
+  };
 };
 
 DeltaDummyConfigSubscription::DeltaDummyConfigSubscription(

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -198,6 +198,9 @@ public:
   createStaticConfigProvider(ProtobufTypes::ConstMessagePtrVector&& configs,
                              Server::Configuration::ServerFactoryContext& factory_context,
                              const OptionalArg&) override {
+    // Currently, the dummy config provider only supports a single static config. We can extend this
+    // to support multiple static configs if needed.
+    ASSERT(configs.size() == 1);
     auto config = dynamic_cast<const test::common::config::DummyConfig&>(*configs[0]);
     return std::make_unique<StaticDummyConfigProvider>(config, factory_context, *this);
   }

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -195,7 +195,7 @@ public:
 
   // Envoy::Config::ConfigProviderManager
   ConfigProviderPtr
-  createStaticConfigProvider(std::vector<std::unique_ptr<const Protobuf::Message>>&& configs,
+  createStaticConfigProvider(ProtobufTypes::ConstMessagePtrVector&& configs,
                              Server::Configuration::ServerFactoryContext& factory_context,
                              const OptionalArg&) override {
     auto config = dynamic_cast<const test::common::config::DummyConfig&>(*configs[0]);

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -1218,21 +1218,6 @@ dynamic_scoped_route_configs:
   EXPECT_THAT(expected_config_dump, ProtoEq(scoped_routes_config_dump7));
 }
 
-TEST_F(ScopedRdsTest, DeltaStaticConfigProviderOnly) {
-  // Use match all regex due to lack of distinctive matchable output for
-  // coverage test.
-  EXPECT_DEATH(config_provider_manager_->createStaticConfigProvider(
-                   parseScopedRouteConfigurationFromYaml(R"EOF(
-name: dynamic-foo
-route_configuration_name: static-foo-route-config
-key:
-  fragments: { string_key: "172.30.30.10" }
-)EOF"),
-                   server_factory_context_,
-                   Envoy::Config::ConfigProviderManager::NullOptionalArg()),
-               ".*");
-}
-
 // Tests whether scope key conflict with updated scopes is ignored.
 TEST_F(ScopedRdsTest, IgnoreConflictWithUpdatedScopeDelta) {
   setup();

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -158,10 +158,6 @@ public:
                Init::Manager& init_manager, const std::string& stat_prefix,
                const Envoy::Config::ConfigProviderManager::OptionalArg& optarg));
   MOCK_METHOD(ConfigProviderPtr, createStaticConfigProvider,
-              (const Protobuf::Message& config_proto,
-               Server::Configuration::ServerFactoryContext& factory_context,
-               const Envoy::Config::ConfigProviderManager::OptionalArg& optarg));
-  MOCK_METHOD(ConfigProviderPtr, createStaticConfigProvider,
               (std::vector<std::unique_ptr<const Protobuf::Message>> && config_protos,
                Server::Configuration::ServerFactoryContext& factory_context,
                const Envoy::Config::ConfigProviderManager::OptionalArg& optarg));


### PR DESCRIPTION
Commit Message: Removes unused createStaticConfigProvider
Additional Description:
Previously, a variant of createStaticConfigProvider taking `Protobuf::Message` 
as a first param was not used, and that was one reason for the low test coverage 
of envoy/config package. This removes it, and potentially allows the package 
to be removed from the coverage exception.

Risk Level: low
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

