### PR TITLE
[grpc-transcoder] Add option to pack unknown parameters into HttpBody extension

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -18,7 +18,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // gRPC-JSON transcoder :ref:`configuration overview <config_http_filters_grpc_json_transcoder>`.
 // [#extension: envoy.filters.http.grpc_json_transcoder]
 
-// [#next-free-field: 17]
+// [#next-free-field: 18]
 // GrpcJsonTranscoder filter configuration.
 // The filter itself can be used per route / per virtual host or on the general level. The most
 // specific one is being used for a given route. If the list of services is empty - filter
@@ -288,4 +288,17 @@ message GrpcJsonTranscoder {
   //
   // If unset, the current stream buffer size is used.
   google.protobuf.UInt32Value max_response_body_size = 16 [(validate.rules).uint32 = {gt: 0}];
+
+  // If true, query parameters that cannot be mapped to a corresponding
+  // protobuf field are captured in an HttpBody extension of UnknownVariableBindings.
+  // This overrides ``ignore_unknown_query_parameters`` and ``reject_unknown_query_parameters``.
+  bool capture_unknown_query_parameters = 17;
+}
+
+// ``UnknownVariableBindings`` is added as an extension field in ``HttpBody`` if
+// ``GrpcJsonTranscoder::capture_unknown_query_parameters`` is true and unknown query
+// parameters were present in the request.
+message UnknownVariableBindings {
+  // A map from unrecognized query parameter keys, to the values associated with those keys.
+  map<string, string> bindings = 1;
 }

--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -88,7 +88,8 @@ message GrpcJsonTranscoder {
     // When set to true, the request will be rejected with a ``HTTP 400 Bad Request``.
     //
     // The fields
-    // :ref:`ignore_unknown_query_parameters <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.ignore_unknown_query_parameters>`
+    // :ref:`ignore_unknown_query_parameters <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.ignore_unknown_query_parameters>`,
+    // :ref:`capture_unknown_query_parameters <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.capture_unknown_query_parameters>`,
     // and
     // :ref:`ignored_query_parameters <envoy_v3_api_field_extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder.ignored_query_parameters>`
     // have priority over this strict validation behavior.
@@ -291,7 +292,6 @@ message GrpcJsonTranscoder {
 
   // If true, query parameters that cannot be mapped to a corresponding
   // protobuf field are captured in an HttpBody extension of UnknownQueryParams.
-  // This overrides ``ignore_unknown_query_parameters`` and ``reject_unknown_query_parameters``.
   bool capture_unknown_query_parameters = 17;
 }
 

--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -302,6 +302,7 @@ message UnknownQueryParams {
   message Values {
     repeated string values = 1;
   }
+
   // A map from unrecognized query parameter keys, to the values associated with those keys.
   map<string, Values> key = 1;
 }

--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -290,15 +290,18 @@ message GrpcJsonTranscoder {
   google.protobuf.UInt32Value max_response_body_size = 16 [(validate.rules).uint32 = {gt: 0}];
 
   // If true, query parameters that cannot be mapped to a corresponding
-  // protobuf field are captured in an HttpBody extension of UnknownVariableBindings.
+  // protobuf field are captured in an HttpBody extension of UnknownQueryParams.
   // This overrides ``ignore_unknown_query_parameters`` and ``reject_unknown_query_parameters``.
   bool capture_unknown_query_parameters = 17;
 }
 
-// ``UnknownVariableBindings`` is added as an extension field in ``HttpBody`` if
+// ``UnknownQueryParams`` is added as an extension field in ``HttpBody`` if
 // ``GrpcJsonTranscoder::capture_unknown_query_parameters`` is true and unknown query
 // parameters were present in the request.
-message UnknownVariableBindings {
+message UnknownQueryParams {
+  message Values {
+    repeated string values = 1;
+  }
   // A map from unrecognized query parameter keys, to the values associated with those keys.
-  map<string, string> bindings = 1;
+  map<string, Values> key = 1;
 }

--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
     deps = [
         "//source/common/grpc:codec_lib",
         "//source/common/protobuf",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -4,7 +4,7 @@
 
 #include "google/api/httpbody.pb.h"
 
-using envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings;
+using envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownQueryParams;
 using Envoy::Protobuf::io::CodedInputStream;
 using Envoy::Protobuf::io::CodedOutputStream;
 using Envoy::Protobuf::io::ZeroCopyInputStream;
@@ -64,8 +64,7 @@ bool HttpBodyUtils::parseMessageByFieldPath(
 
 void HttpBodyUtils::appendHttpBodyEnvelope(
     Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
-    std::string content_type, uint64_t content_length,
-    const UnknownVariableBindings& unknown_bindings) {
+    std::string content_type, uint64_t content_length, const UnknownQueryParams& unknown_params) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded for wire format.
 
@@ -79,8 +78,8 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
 
     ::google::api::HttpBody body;
     body.set_content_type(std::move(content_type));
-    if (!unknown_bindings.bindings().empty()) {
-      body.add_extensions()->PackFrom(unknown_bindings);
+    if (!unknown_params.key().empty()) {
+      body.add_extensions()->PackFrom(unknown_params);
     }
 
     uint64_t envelope_size = body.ByteSizeLong() +

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -1,7 +1,10 @@
 #include "source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h"
 
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
+
 #include "google/api/httpbody.pb.h"
 
+using envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings;
 using Envoy::Protobuf::io::CodedInputStream;
 using Envoy::Protobuf::io::CodedOutputStream;
 using Envoy::Protobuf::io::ZeroCopyInputStream;
@@ -60,8 +63,9 @@ bool HttpBodyUtils::parseMessageByFieldPath(
 }
 
 void HttpBodyUtils::appendHttpBodyEnvelope(
-    Buffer::Instance& output, const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
-    std::string content_type, uint64_t content_length) {
+    Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
+    std::string content_type, uint64_t content_length,
+    const UnknownVariableBindings& unknown_bindings) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded for wire format.
 
@@ -75,6 +79,9 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
 
     ::google::api::HttpBody body;
     body.set_content_type(std::move(content_type));
+    if (!unknown_bindings.bindings().empty()) {
+      body.add_extensions()->PackFrom(unknown_bindings);
+    }
 
     uint64_t envelope_size = body.ByteSizeLong() +
                              CodedOutputStream::VarintSize32(http_body_field_number) +

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/grpc/codec.h"
@@ -16,10 +17,11 @@ public:
   static bool parseMessageByFieldPath(Protobuf::io::ZeroCopyInputStream* stream,
                                       const std::vector<const ProtobufWkt::Field*>& field_path,
                                       Protobuf::Message* message);
-  static void
-  appendHttpBodyEnvelope(Buffer::Instance& output,
-                         const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
-                         std::string content_type, uint64_t content_length);
+  static void appendHttpBodyEnvelope(
+      Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
+      std::string content_type, uint64_t content_length,
+      const envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings&
+          unknown_bindings);
 };
 
 } // namespace GrpcJsonTranscoder

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
@@ -20,8 +20,8 @@ public:
   static void appendHttpBodyEnvelope(
       Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
       std::string content_type, uint64_t content_length,
-      const envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings&
-          unknown_bindings);
+      const envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownQueryParams&
+          unknown_params);
 };
 
 } // namespace GrpcJsonTranscoder

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -18,6 +18,7 @@
 #include "source/common/runtime/runtime_features.h"
 #include "source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h"
 
+#include "absl/strings/str_join.h"
 #include "google/api/annotations.pb.h"
 #include "google/api/http.pb.h"
 #include "google/api/httpbody.pb.h"
@@ -43,6 +44,7 @@ using google::grpc::transcoding::Transcoder;
 using TranscoderPtr = std::unique_ptr<Transcoder>;
 using google::grpc::transcoding::TranscoderInputStream;
 using TranscoderInputStreamPtr = std::unique_ptr<TranscoderInputStream>;
+using envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings;
 
 namespace Envoy {
 namespace Extensions {
@@ -229,6 +231,7 @@ JsonTranscoderConfig::JsonTranscoderConfig(
 
   match_incoming_request_route_ = proto_config.match_incoming_request_route();
   ignore_unknown_query_parameters_ = proto_config.ignore_unknown_query_parameters();
+  capture_unknown_query_parameters_ = proto_config.capture_unknown_query_parameters();
   request_validation_options_ = proto_config.request_validation_options();
   case_insensitive_enum_parsing_ = proto_config.case_insensitive_enum_parsing();
   if (proto_config.has_max_request_body_size()) {
@@ -327,7 +330,8 @@ bool JsonTranscoderConfig::convertGrpcStatus() const { return convert_grpc_statu
 absl::Status JsonTranscoderConfig::createTranscoder(
     const Http::RequestHeaderMap& headers, ZeroCopyInputStream& request_input,
     google::grpc::transcoding::TranscoderInputStream& response_input,
-    std::unique_ptr<Transcoder>& transcoder, MethodInfoSharedPtr& method_info) const {
+    std::unique_ptr<Transcoder>& transcoder, MethodInfoSharedPtr& method_info,
+    UnknownVariableBindings& unknown_bindings) const {
 
   ASSERT(!disabled_);
   const std::string method(headers.getMethodValue());
@@ -361,7 +365,11 @@ absl::Status JsonTranscoderConfig::createTranscoder(
     status = type_helper_->ResolveFieldPath(*request_info.message_type, binding.field_path,
                                             &resolved_binding.field_path);
     if (!status.ok()) {
-      if (ignore_unknown_query_parameters_) {
+      if (capture_unknown_query_parameters_) {
+        auto binding_key = absl::StrJoin(binding.field_path, ".");
+        (*unknown_bindings.mutable_bindings())[binding_key] = binding.value;
+        continue;
+      } else if (ignore_unknown_query_parameters_) {
         continue;
       }
       return status;
@@ -464,8 +472,9 @@ Http::FilterHeadersStatus JsonTranscoderFilter::decodeHeaders(Http::RequestHeade
     return Http::FilterHeadersStatus::Continue;
   }
 
-  const auto status =
-      per_route_config_->createTranscoder(headers, request_in_, response_in_, transcoder_, method_);
+  const auto status = per_route_config_->createTranscoder(headers, request_in_, response_in_,
+                                                          transcoder_, method_, unknown_bindings_);
+
   if (!status.ok()) {
     ENVOY_STREAM_LOG(debug, "Failed to transcode request headers: {}", *decoder_callbacks_,
                      status.message());
@@ -904,7 +913,8 @@ void JsonTranscoderFilter::maybeSendHttpBodyRequestMessage(Buffer::Instance* dat
   stats_->transcoder_request_buffer_bytes_.sub(initial_request_data_.length());
   message_payload.move(initial_request_data_);
   HttpBodyUtils::appendHttpBodyEnvelope(message_payload, method_->request_body_field_path,
-                                        std::move(content_type_), request_data_.length());
+                                        std::move(content_type_), request_data_.length(),
+                                        unknown_bindings_);
   content_type_.clear();
   stats_->transcoder_request_buffer_bytes_.sub(request_data_.length());
   message_payload.move(request_data_);

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -78,11 +78,13 @@ public:
    *         is not found, status with Code::NOT_FOUND is returned. If the method is found, but
    * fields cannot be resolved, status with Code::INVALID_ARGUMENT is returned.
    */
-  absl::Status createTranscoder(const Http::RequestHeaderMap& headers,
-                                Protobuf::io::ZeroCopyInputStream& request_input,
-                                google::grpc::transcoding::TranscoderInputStream& response_input,
-                                std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
-                                MethodInfoSharedPtr& method_info) const;
+  absl::Status createTranscoder(
+      const Http::RequestHeaderMap& headers, Protobuf::io::ZeroCopyInputStream& request_input,
+      google::grpc::transcoding::TranscoderInputStream& response_input,
+      std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
+      MethodInfoSharedPtr& method_info,
+      envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings&
+          unknown_bindings) const;
 
   /**
    * Converts an arbitrary protobuf message to JSON.
@@ -135,6 +137,7 @@ private:
 
   bool match_incoming_request_route_{false};
   bool ignore_unknown_query_parameters_{false};
+  bool capture_unknown_query_parameters_{false};
   bool convert_grpc_status_{false};
   bool case_insensitive_enum_parsing_{false};
 
@@ -217,6 +220,8 @@ private:
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   MethodInfoSharedPtr method_;
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings
+      unknown_bindings_;
   Http::ResponseHeaderMap* response_headers_{};
   Grpc::Decoder decoder_;
 

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -78,13 +78,14 @@ public:
    *         is not found, status with Code::NOT_FOUND is returned. If the method is found, but
    * fields cannot be resolved, status with Code::INVALID_ARGUMENT is returned.
    */
-  absl::Status createTranscoder(
-      const Http::RequestHeaderMap& headers, Protobuf::io::ZeroCopyInputStream& request_input,
-      google::grpc::transcoding::TranscoderInputStream& response_input,
-      std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
-      MethodInfoSharedPtr& method_info,
-      envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings&
-          unknown_bindings) const;
+  absl::Status
+  createTranscoder(const Http::RequestHeaderMap& headers,
+                   Protobuf::io::ZeroCopyInputStream& request_input,
+                   google::grpc::transcoding::TranscoderInputStream& response_input,
+                   std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
+                   MethodInfoSharedPtr& method_info,
+                   envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownQueryParams&
+                       unknown_params) const;
 
   /**
    * Converts an arbitrary protobuf message to JSON.
@@ -220,8 +221,7 @@ private:
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   MethodInfoSharedPtr method_;
-  envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings
-      unknown_bindings_;
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownQueryParams unknown_params_;
   Http::ResponseHeaderMap* response_headers_{};
   Grpc::Decoder decoder_;
 

--- a/test/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/test/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -39,6 +39,7 @@ envoy_extension_cc_test(
         "//source/common/buffer:zero_copy_input_stream_lib",
         "//source/extensions/filters/http/grpc_json_transcoder:http_body_utils_lib",
         "//test/proto:bookstore_proto_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/filters/http/grpc_json_transcoder/http_body_utils_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/http_body_utils_test.cc
@@ -6,8 +6,8 @@
 
 #include "test/proto/bookstore.pb.h"
 
-#include "google/api/httpbody.pb.h"
 #include "gmock/gmock.h"
+#include "google/api/httpbody.pb.h"
 #include "gtest/gtest.h"
 
 using testing::ElementsAre;

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -339,8 +339,8 @@ TEST_F(GrpcJsonTranscoderConfigTest, UnknownQueryParameterIsCaptured) {
   proto_config.set_capture_unknown_query_parameters(true);
   JsonTranscoderConfig config(proto_config, *api_);
 
-  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
-                                         {":path", "/shelves?foo=bar+dsa&eep=baz&foo=asd"}};
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "GET"}, {":path", "/shelves?foo=bar+dsa&eep=baz&foo=asd&foo.bar=baz"}};
 
   TranscoderInputStreamImpl request_in, response_in;
   TranscoderPtr transcoder;
@@ -353,8 +353,10 @@ TEST_F(GrpcJsonTranscoderConfigTest, UnknownQueryParameterIsCaptured) {
   EXPECT_TRUE(transcoder);
   ASSERT_TRUE(unknown_query_params.key().contains("foo"));
   ASSERT_TRUE(unknown_query_params.key().contains("eep"));
+  ASSERT_TRUE(unknown_query_params.key().contains("foo.bar"));
   EXPECT_THAT(unknown_query_params.key().at("foo").values(), ElementsAre("bar+dsa", "asd"));
   EXPECT_THAT(unknown_query_params.key().at("eep").values(), ElementsAre("baz"));
+  EXPECT_THAT(unknown_query_params.key().at("foo.bar").values(), ElementsAre("baz"));
 }
 
 TEST_F(GrpcJsonTranscoderConfigTest, IgnoredQueryParameter) {


### PR DESCRIPTION
Commit Message: [grpc-transcoder] Add option to pack unknown parameters into HttpBody extension
Additional Description: We've been using this behavior for years, with PR #15338 as a patch. Finally getting around to trying to upstream the behavior to make it available for others, and to make it so I don't have to keep repositioning the patch. Unlike #15338 I'm also adding a configuration option so that no behavior change will occur without a corresponding configuration change.
Risk Level: Very low, guarded by a new config field.
Testing: Added positive unit tests, added conditions to other tests for the negative case.
Docs Changes: Autogen
Fixes #14710
