### PR TITLE
[bp/1.28] Only download go sdk when not using host sdk

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -27,7 +27,8 @@ def envoy_dependency_imports(go_version = GO_VERSION, jq_version = JQ_VERSION, y
     rules_foreign_cc_dependencies()
     go_rules_dependencies()
     go_register_toolchains(go_version)
-    envoy_download_go_sdks(go_version)
+    if go_version != "host":
+        envoy_download_go_sdks(go_version)
     gazelle_dependencies(go_sdk = "go_sdk")
     apple_rules_dependencies()
     pip_dependencies()


### PR DESCRIPTION
Cherry-pick of https://github.com/envoyproxy/envoy/pull/32126
