### PR TITLE
mobile ci: removing the iOS no-http3 build

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -69,38 +69,6 @@ jobs:
             --config=mobile-remote-ci-cc-full-protos-enabled
             //test/common/... //test/cc/...
 
-  build:
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/_run.yml
-    if: ${{ fromJSON(needs.load.outputs.request).run.mobile-compile-time-options }}
-    needs: load
-    with:
-      args: ${{ matrix.args }}
-      command: ./bazelw
-      container-command:
-      request: ${{ needs.load.outputs.request }}
-      runs-on: macos-12
-      source: ${{ matrix.source }}
-      steps-pre: ${{ matrix.steps-pre }}
-      target: ${{ matrix.target || matrix.name }}
-      trusted: ${{ fromJSON(needs.load.outputs.trusted) }}
-      timeout-minutes: 120
-      working-directory: mobile
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - name: swift-build
-          args: >-
-            build
-            --config=mobile-remote-ci-macos-swift
-            //library/swift:ios_framework
-          source: |
-            source ./ci/mac_ci_setup.sh
-            ./bazelw shutdown
-
   request:
     secrets:
       app-id: ${{ secrets.ENVOY_CI_APP_ID }}

--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -265,6 +265,7 @@ test:mobile-remote-ci-cc-full-protos-enabled --define=envoy_full_protos=enabled
 build:mobile-remote-ci-macos-kotlin --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-kotlin --fat_apk_cpu=x86_64
 
+# TODO(alyssar) remove in a follow-up PR
 build:mobile-remote-ci-macos-swift --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-swift --config=mobile-test-ios
 build:mobile-remote-ci-macos-swift --@envoy//bazel:http3=False


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
