### PR TITLE
mobile: using lite protos on all linux builds

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -30,6 +30,7 @@ build --use_top_level_targets_for_symlinks
 build --experimental_repository_downloader_retries=2
 build --define=google_grpc=disabled
 build --define=envoy_yaml=disabled
+build --define=envoy_full_protos=disabled
 
 # We don't have a ton of Swift in Envoy Mobile, so always build with WMO
 # This also helps work around a bug in rules_swift: https://github.com/bazelbuild/rules_swift/issues/949
@@ -64,6 +65,7 @@ build:mobile-dbg-common --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 # https://github.com/envoyproxy/envoy/tree/master/bazel#enabling-optional-features
 build:ios --define=manual_stamp=manual_stamp
 build:ios --test_timeout=390,750,1500,5700
+build:ios --define=envoy_full_protos=enabled
 
 # Default flags for builds targeting Android
 build:android --define=logger=android
@@ -175,7 +177,6 @@ build:mobile-remote-ci-linux-clang --config=mobile-remote-ci-linux
 build:mobile-remote-ci-linux-asan --config=mobile-clang-asan
 build:mobile-remote-ci-linux-asan --config=mobile-remote-ci-linux-clang
 build:mobile-remote-ci-linux-asan --config=remote-ci
-build:mobile-remote-ci-linux-asan --define=envoy_full_protos=disabled
 build:mobile-remote-ci-linux-asan --build_tests_only
 test:mobile-remote-ci-linux-asan --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 
@@ -185,7 +186,6 @@ test:mobile-remote-ci-linux-asan --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 build:mobile-remote-ci-linux-tsan --config=clang-tsan
 build:mobile-remote-ci-linux-tsan --config=mobile-remote-ci-linux-clang
 build:mobile-remote-ci-linux-tsan --config=remote-ci
-build:mobile-remote-ci-linux-tsan --define=envoy_full_protos=disabled
 build:mobile-remote-ci-linux-tsan --build_tests_only
 test:mobile-remote-ci-linux-tsan --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 
@@ -200,7 +200,6 @@ build:mobile-ci-linux-coverage --action_env=BAZEL_LLVM_COV=/opt/llvm/bin/llvm-co
 build:mobile-ci-linux-coverage --test_env=BAZEL_LLVM_COV=/opt/llm/bin/llvm-cov
 build:mobile-ci-linux-coverage --action_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
 build:mobile-ci-linux-coverage --test_env=BAZEL_USE_LLVM_NATIVE_COVERAGE=1
-build:mobile-ci-linux-coverage --define=envoy_full_protos=disabled
 build:mobile-ci-linux-coverage --build_tests_only
 
 #############################################################################
@@ -229,6 +228,7 @@ build:mobile-remote-ci-macos --xcode_version_config=//ci:xcode_config
 build:mobile-remote-ci-macos --remote_download_toplevel
 build:mobile-remote-ci-macos --config=ci
 build:mobile-remote-ci-macos --config=remote
+build:mobile-remote-ci-macos --define=envoy_full_protos=disabled
 
 build:mobile-remote-ci --config=mobile-remote-ci-linux-clang
 build:mobile-remote-ci --config=remote-ci
@@ -240,7 +240,6 @@ test:mobile-remote-ci-android --config=mobile-remote-ci
 test:mobile-remote-ci-android --config=mobile-test-android
 
 build:mobile-remote-ci-cc --config=mobile-remote-ci
-build:mobile-remote-ci-cc --define=envoy_full_protos=disabled
 test:mobile-remote-ci-cc --action_env=LD_LIBRARY_PATH
 
 build:mobile-remote-ci-cc-no-exceptions --config=mobile-remote-ci-cc
@@ -249,7 +248,6 @@ build:mobile-remote-ci-cc-no-exceptions --copt=-fno-exceptions
 
 build:mobile-remote-ci-cc-full-protos-enabled --config=mobile-remote-ci-cc
 test:mobile-remote-ci-cc-full-protos-enabled --config=mobile-remote-ci-cc
-test:mobile-remote-ci-cc-full-protos-enabled --define=envoy_full_protos=enabled
 
 build:mobile-remote-ci-macos-kotlin --config=mobile-remote-ci-macos
 build:mobile-remote-ci-macos-kotlin --fat_apk_cpu=x86_64
@@ -260,7 +258,6 @@ build:mobile-remote-ci-macos-swift --config=mobile-test-ios
 build:mobile-remote-ci-macos-swift --@envoy//bazel:http3=False
 
 build:mobile-remote-ci-core --config=mobile-remote-ci
-build:mobile-remote-ci-core --define=envoy_full_protos=disabled
 test:mobile-remote-ci-core --action_env=LD_LIBRARY_PATH
 
 build:mobile-remote-ci-macos-ios --config=mobile-remote-ci-macos

--- a/mobile/examples/kotlin/hello_world/MainActivity.kt
+++ b/mobile/examples/kotlin/hello_world/MainActivity.kt
@@ -8,6 +8,8 @@ import android.util.Log
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.Element
 import io.envoyproxy.envoymobile.Engine
@@ -57,13 +59,12 @@ class MainActivity : Activity() {
         .addPlatformFilter(::AsyncDemoFilter)
         .addNativeFilter(
           "envoy.filters.http.buffer",
-          String(
-            com.google.protobuf.Any.newBuilder()
-              .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
-              .setValue(com.google.protobuf.ByteString.empty())
-              .build()
-              .toByteArray()
-          )
+          Any.newBuilder()
+            .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+            .setValue(ByteString.empty())
+            .build()
+            .toByteArray()
+            .toString(Charsets.UTF_8)
         )
         .addStringAccessor("demo-accessor", { "PlatformString" })
         .setOnEngineRunning { Log.d(TAG, "Envoy async internal setup completed") }

--- a/mobile/examples/kotlin/hello_world/MainActivity.kt
+++ b/mobile/examples/kotlin/hello_world/MainActivity.kt
@@ -57,7 +57,13 @@ class MainActivity : Activity() {
         .addPlatformFilter(::AsyncDemoFilter)
         .addNativeFilter(
           "envoy.filters.http.buffer",
-          "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes: { value: 5242880 } }"
+          String(
+            com.google.protobuf.Any.newBuilder()
+              .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+              .setValue(com.google.protobuf.ByteString.empty())
+              .build()
+              .toByteArray()
+          )
         )
         .addStringAccessor("demo-accessor", { "PlatformString" })
         .setOnEngineRunning { Log.d(TAG, "Envoy async internal setup completed") }

--- a/mobile/library/common/engine_common.h
+++ b/mobile/library/common/engine_common.h
@@ -16,6 +16,10 @@
 
 namespace Envoy {
 
+// If Envoy is built with lite protos, this will register Envoy-Mobile specific
+// descriptors for reflection.
+void registerMobileProtoDescriptors();
+
 /**
  * This class is used instead of Envoy::MainCommon to customize logic for the Envoy Mobile setting.
  * It largely leverages Envoy::StrippedMainBase.

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -211,9 +211,14 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
    */
   @VisibleForTesting
   public CronvoyEngineBuilderImpl addUrlInterceptorsForTesting() {
-    nativeFilterChain.add(new EnvoyNativeFilterConfig(
-        "envoy.filters.http.test_read",
-        "[type.googleapis.com/envoymobile.test.integration.filters.http.test_read.TestRead] {}"));
+    com.google.protobuf.Any anyProto =
+        com.google.protobuf.Any.newBuilder()
+            .setTypeUrl(
+                "type.googleapis.com/envoymobile.test.integration.filters.http.test_read.TestRead")
+            .setValue(com.google.protobuf.ByteString.empty())
+            .build();
+    String config = new String(anyProto.toByteArray());
+    nativeFilterChain.add(new EnvoyNativeFilterConfig("envoy.filters.http.test_read", config));
     return this;
   }
 

--- a/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
+++ b/mobile/library/java/org/chromium/net/impl/NativeCronvoyEngineBuilderImpl.java
@@ -2,6 +2,7 @@ package org.chromium.net.impl;
 
 import static io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification.VERIFY_TRUST_CHAIN;
 
+import java.nio.charset.StandardCharsets;
 import android.content.Context;
 import androidx.annotation.VisibleForTesting;
 import com.google.protobuf.Struct;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.chromium.net.ExperimentalCronetEngine;
 import org.chromium.net.ICronetEngineBuilder;
+import com.google.protobuf.Any;
 
 /**
  * Implementation of {@link ICronetEngineBuilder} that builds native Cronvoy engine.
@@ -211,13 +213,13 @@ public class NativeCronvoyEngineBuilderImpl extends CronvoyEngineBuilderImpl {
    */
   @VisibleForTesting
   public CronvoyEngineBuilderImpl addUrlInterceptorsForTesting() {
-    com.google.protobuf.Any anyProto =
-        com.google.protobuf.Any.newBuilder()
+    Any anyProto =
+        Any.newBuilder()
             .setTypeUrl(
                 "type.googleapis.com/envoymobile.test.integration.filters.http.test_read.TestRead")
             .setValue(com.google.protobuf.ByteString.empty())
             .build();
-    String config = new String(anyProto.toByteArray());
+    String config = new String(anyProto.toByteArray(), StandardCharsets.UTF_8);
     nativeFilterChain.add(new EnvoyNativeFilterConfig("envoy.filters.http.test_read", config));
     return this;
   }

--- a/mobile/library/jni/jni_utility.cc
+++ b/mobile/library/jni/jni_utility.cc
@@ -305,8 +305,7 @@ MatcherData::Type StringToType(std::string type_as_string) {
   return MatcherData::EXACT;
 }
 
-void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
-                          Envoy::Protobuf::MessageLite* dest) {
+void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source, Protobuf::Message* dest) {
   ArrayElementsUniquePtr<jbyteArray, jbyte> bytes =
       jni_helper.getByteArrayElements(source, /* is_copy= */ nullptr);
   jsize size = jni_helper.getArrayLength(source);
@@ -315,7 +314,7 @@ void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
 }
 
 LocalRefUniquePtr<jbyteArray> protoToJavaByteArray(JniHelper& jni_helper,
-                                                   const Envoy::Protobuf::MessageLite& source) {
+                                                   const Envoy::Protobuf::Message& source) {
   size_t size = source.ByteSizeLong();
   LocalRefUniquePtr<jbyteArray> byte_array = jni_helper.newByteArray(size);
   auto bytes = jni_helper.getByteArrayElements(byte_array.get(), nullptr);

--- a/mobile/library/jni/jni_utility.h
+++ b/mobile/library/jni/jni_utility.h
@@ -93,12 +93,11 @@ void javaByteArrayToByteVector(JniHelper& jni_helper, jbyteArray array, std::vec
 void javaByteArrayToString(JniHelper& jni_helper, jbyteArray jbytes, std::string* out);
 
 /** Parses the proto from Java byte array and stores the output into `dest` proto. */
-void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source,
-                          Envoy::Protobuf::MessageLite* dest);
+void javaByteArrayToProto(JniHelper& jni_helper, jbyteArray source, Envoy::Protobuf::Message* dest);
 
 /** Converts from Proto to Java byte array. */
 LocalRefUniquePtr<jbyteArray> protoToJavaByteArray(JniHelper& jni_helper,
-                                                   const Envoy::Protobuf::MessageLite& source);
+                                                   const Envoy::Protobuf::Message& source);
 
 /** Converts from Java `String` to C++ `std::string`. */
 std::string javaStringToCppString(JniHelper& jni_helper, jstring java_string);

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -47,7 +47,7 @@ DfpClusterConfig getDfpClusterConfig(const Bootstrap& bootstrap) {
   return cluster_config;
 }
 
-bool repeatedPtrFieldEqual(
+bool socketAddressesEqual(
     const Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketAddress>& lhs,
     const Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketAddress>& rhs) {
   if (lhs.size() != rhs.size()) {
@@ -291,7 +291,7 @@ TEST(TestConfig, AddDnsPreresolveHostnames) {
   auto& host_addr2 = *expected_dns_preresolve_hostnames.Add();
   host_addr2.set_address("lyft.com");
   host_addr2.set_port_value(443);
-  EXPECT_TRUE(repeatedPtrFieldEqual(
+  EXPECT_TRUE(socketAddressesEqual(
       getDfpClusterConfig(*bootstrap).dns_cache_config().preresolve_hostnames(),
       expected_dns_preresolve_hostnames));
 
@@ -302,7 +302,7 @@ TEST(TestConfig, AddDnsPreresolveHostnames) {
   auto& host_addr3 = *expected_dns_preresolve_hostnames.Add();
   host_addr3.set_address("google.com");
   host_addr3.set_port_value(443);
-  EXPECT_TRUE(repeatedPtrFieldEqual(
+  EXPECT_TRUE(socketAddressesEqual(
       getDfpClusterConfig(*bootstrap).dns_cache_config().preresolve_hostnames(),
       expected_dns_preresolve_hostnames));
 }

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -47,15 +47,15 @@ DfpClusterConfig getDfpClusterConfig(const Bootstrap& bootstrap) {
   return cluster_config;
 }
 
-template <typename ProtoType>
-bool repeatedPtrFieldEqual(const Protobuf::RepeatedPtrField<ProtoType>& lhs,
-                           const Protobuf::RepeatedPtrField<ProtoType>& rhs) {
+bool repeatedPtrFieldEqual(
+    const Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketAddress>& lhs,
+    const Protobuf::RepeatedPtrField<envoy::config::core::v3::SocketAddress>& rhs) {
   if (lhs.size() != rhs.size()) {
     return false;
   }
 
   for (int i = 0; i < lhs.size(); ++i) {
-    if (!Protobuf::util::MessageDifferencer::Equals(lhs[i], rhs[i])) {
+    if ((lhs[i].address() != rhs[i].address()) || lhs[i].port_value() != rhs[i].port_value()) {
       return false;
     }
   }

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test_library(
     ],
     repository = "@envoy",
     deps = [
+        "//library/common:engine_common_lib",
         "@envoy//source/common/listener_manager:listener_manager_lib",
         "@envoy//source/exe:process_wide_lib",
         "@envoy//test/integration:autonomous_upstream_lib",

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -24,6 +24,7 @@
 #include "test/test_common/network_utility.h"
 
 #include "extension_registry.h"
+#include "library/common/engine_common.h"
 
 namespace Envoy {
 namespace {
@@ -173,7 +174,9 @@ void TestServer::start(TestServerType type) {
     Server::forceRegisterDefaultListenerManagerFactoryImpl();
     Extensions::TransportSockets::RawBuffer::forceRegisterDownstreamRawBufferSocketFactory();
     Server::forceRegisterConnectionHandlerFactoryImpl();
-
+#if !defined(ENVOY_ENABLE_FULL_PROTOS)
+    registerMobileProtoDescriptors();
+#endif
     test_server_ = IntegrationTestServer::create(
         "", Network::Address::IpVersion::v4, nullptr, nullptr, {}, time_system_, *api_, false,
         absl::nullopt, Server::FieldValidationConfig(), 1, std::chrono::seconds(1),
@@ -186,6 +189,9 @@ void TestServer::start(TestServerType type) {
     Server::forceRegisterDefaultListenerManagerFactoryImpl();
     Extensions::TransportSockets::RawBuffer::forceRegisterDownstreamRawBufferSocketFactory();
     Server::forceRegisterConnectionHandlerFactoryImpl();
+#if !defined(ENVOY_ENABLE_FULL_PROTOS)
+    registerMobileProtoDescriptors();
+#endif
     test_server_ = IntegrationTestServer::create(
         "", Network::Address::IpVersion::v4, nullptr, nullptr, {}, time_system_, *api_, false,
         absl::nullopt, Server::FieldValidationConfig(), 1, std::chrono::seconds(1),

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -99,7 +99,15 @@ class EnvoyConfigurationTest {
     appVersion: String = "v1.2.3",
     appId: String = "com.example.myapp",
     trustChainVerification: TrustChainVerification = TrustChainVerification.VERIFY_TRUST_CHAIN,
-    filterChain: MutableList<EnvoyNativeFilterConfig> = mutableListOf(EnvoyNativeFilterConfig("buffer_filter_1", "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes: { value: 5242880 } }"), EnvoyNativeFilterConfig("buffer_filter_2", "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes: { value: 5242880 } }")),
+    filterChain: MutableList<EnvoyNativeFilterConfig> = mutableListOf(EnvoyNativeFilterConfig("buffer_filter_1",
+        String(com.google.protobuf.Any.newBuilder()
+          .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+          .setValue(com.google.protobuf.ByteString.empty())
+        .build().toByteArray())), EnvoyNativeFilterConfig("buffer_filter_2",
+        String(com.google.protobuf.Any.newBuilder()
+          .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+          .setValue(com.google.protobuf.ByteString.empty())
+        .build().toByteArray()))),
     platformFilterFactories: MutableList<EnvoyHTTPFilterFactory> = mutableListOf(TestEnvoyHTTPFilterFactory("name1"), TestEnvoyHTTPFilterFactory("name2")),
     runtimeGuards: Map<String,Boolean> = emptyMap(),
     enablePlatformCertificatesValidation: Boolean = false,

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -15,6 +15,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.regex.Pattern
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 
 class TestFilter : EnvoyHTTPFilter {
 
@@ -100,14 +102,14 @@ class EnvoyConfigurationTest {
     appId: String = "com.example.myapp",
     trustChainVerification: TrustChainVerification = TrustChainVerification.VERIFY_TRUST_CHAIN,
     filterChain: MutableList<EnvoyNativeFilterConfig> = mutableListOf(EnvoyNativeFilterConfig("buffer_filter_1",
-        String(com.google.protobuf.Any.newBuilder()
+        Any.newBuilder()
           .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
-          .setValue(com.google.protobuf.ByteString.empty())
-        .build().toByteArray())), EnvoyNativeFilterConfig("buffer_filter_2",
-        String(com.google.protobuf.Any.newBuilder()
+          .setValue(ByteString.empty())
+        .build().toByteArray().toString(Charsets.UTF_8)), EnvoyNativeFilterConfig("buffer_filter_2",
+        Any.newBuilder()
           .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
-          .setValue(com.google.protobuf.ByteString.empty())
-        .build().toByteArray()))),
+          .setValue(ByteString.empty())
+        .build().toByteArray().toString(Charsets.UTF_8))),
     platformFilterFactories: MutableList<EnvoyHTTPFilterFactory> = mutableListOf(TestEnvoyHTTPFilterFactory("name1"), TestEnvoyHTTPFilterFactory("name2")),
     runtimeGuards: Map<String,Boolean> = emptyMap(),
     enablePlatformCertificatesValidation: Boolean = false,

--- a/mobile/test/kotlin/apps/baseline/MainActivity.kt
+++ b/mobile/test/kotlin/apps/baseline/MainActivity.kt
@@ -8,6 +8,8 @@ import android.util.Log
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.Element
 import io.envoyproxy.envoymobile.Engine
@@ -46,13 +48,12 @@ class MainActivity : Activity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
     val config =
-      String(
-        com.google.protobuf.Any.newBuilder()
-          .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
-          .setValue(com.google.protobuf.ByteString.empty())
-          .build()
-          .toByteArray()
-      )
+      Any.newBuilder()
+        .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+        .setValue(ByteString.empty())
+        .build()
+        .toByteArray()
+        .toString(Charsets.UTF_8)
 
     engine =
       AndroidEngineBuilder(application)

--- a/mobile/test/kotlin/apps/baseline/MainActivity.kt
+++ b/mobile/test/kotlin/apps/baseline/MainActivity.kt
@@ -45,16 +45,21 @@ class MainActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
+    val config =
+      String(
+        com.google.protobuf.Any.newBuilder()
+          .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+          .setValue(com.google.protobuf.ByteString.empty())
+          .build()
+          .toByteArray()
+      )
 
     engine =
       AndroidEngineBuilder(application)
         .setLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> Log.d(TAG, msg) }
         .addPlatformFilter(::DemoFilter)
-        .addNativeFilter(
-          "envoy.filters.http.buffer",
-          "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes: { value: 5242880 } }"
-        )
+        .addNativeFilter("envoy.filters.http.buffer", config)
         .addStringAccessor("demo-accessor", { "PlatformString" })
         .setOnEngineRunning { Log.d(TAG, "Envoy async internal setup completed") }
         .setEventTracker({

--- a/mobile/test/kotlin/apps/experimental/MainActivity.kt
+++ b/mobile/test/kotlin/apps/experimental/MainActivity.kt
@@ -68,7 +68,13 @@ class MainActivity : Activity() {
         // .enablePlatformCertificatesValidation(true)
         .addNativeFilter(
           "envoy.filters.http.buffer",
-          "[type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer] { max_request_bytes: { value: 5242880 } }"
+          String(
+            com.google.protobuf.Any.newBuilder()
+              .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+              .setValue(com.google.protobuf.ByteString.empty())
+              .build()
+              .toByteArray()
+          )
         )
         .addStringAccessor("demo-accessor", { "PlatformString" })
         .setOnEngineRunning { Log.d(TAG, "Envoy async internal setup completed") }

--- a/mobile/test/kotlin/apps/experimental/MainActivity.kt
+++ b/mobile/test/kotlin/apps/experimental/MainActivity.kt
@@ -9,6 +9,8 @@ import android.util.Log
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.Element
 import io.envoyproxy.envoymobile.Engine
@@ -68,13 +70,12 @@ class MainActivity : Activity() {
         // .enablePlatformCertificatesValidation(true)
         .addNativeFilter(
           "envoy.filters.http.buffer",
-          String(
-            com.google.protobuf.Any.newBuilder()
-              .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
-              .setValue(com.google.protobuf.ByteString.empty())
-              .build()
-              .toByteArray()
-          )
+          Any.newBuilder()
+            .setTypeUrl("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer")
+            .setValue(ByteString.empty())
+            .build()
+            .toByteArray()
+            .toString(Charsets.UTF_8)
         )
         .addStringAccessor("demo-accessor", { "PlatformString" })
         .setOnEngineRunning { Log.d(TAG, "Envoy async internal setup completed") }

--- a/mobile/test/kotlin/integration/BUILD
+++ b/mobile/test/kotlin/integration/BUILD
@@ -62,6 +62,7 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/common/http/filters/test_kv_store:filter_java_proto",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -83,6 +84,7 @@ envoy_mobile_android_test(
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/common/http/filters/test_event_tracker:filter_java_proto",
     ],
 )
 
@@ -103,6 +105,7 @@ envoy_mobile_android_test(
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/common/http/filters/test_logger:filter_java_proto",
     ],
 )
 
@@ -241,6 +244,7 @@ envoy_mobile_android_test(
     }),
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
+        "//library/common/extensions/filters/http/local_error:filter_java_proto",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
@@ -262,6 +266,7 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/common/http/filters/assertion:filter_java_proto",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -282,6 +287,7 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/common/http/filters/assertion:filter_java_proto",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )
@@ -302,6 +308,7 @@ envoy_mobile_android_test(
     native_lib_name = "envoy_jni_with_test_extensions",
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//test/common/http/filters/assertion:filter_java_proto",
         "//test/java/io/envoyproxy/envoymobile/engine/testing:http_test_server_factory_lib",
     ],
 )

--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -23,10 +23,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-private const val FILTER_NAME = "cancel_validation_filter"
-private const val LOCAL_ERROR_FILTER_CONFIG =
-  "[type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError] {}"
-
 @RunWith(RobolectricTestRunner::class)
 class CancelGRPCStreamTest {
 
@@ -72,15 +68,24 @@ class CancelGRPCStreamTest {
 
   @Test
   fun `cancel grpc stream calls onCancel callback`() {
+
+    var any_proto =
+      com.google.protobuf.Any.newBuilder()
+        .setTypeUrl(
+          "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+        )
+        .setValue(com.google.protobuf.ByteString.empty())
+        .build()
+
     val engine =
       EngineBuilder()
         .setLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> print(msg) }
         .addPlatformFilter(
-          name = FILTER_NAME,
+          name = "cancel_validation_filter",
           factory = { CancelValidationFilter(filterExpectation) }
         )
-        .addNativeFilter("envoy.filters.http.local_error", LOCAL_ERROR_FILTER_CONFIG)
+        .addNativeFilter("envoy.filters.http.local_error", String(any_proto.toByteArray()))
         .build()
 
     val client = GRPCClient(engine.streamClient())

--- a/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
+++ b/mobile/test/kotlin/integration/CancelGRPCStreamTest.kt
@@ -1,6 +1,8 @@
 package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -69,12 +71,12 @@ class CancelGRPCStreamTest {
   @Test
   fun `cancel grpc stream calls onCancel callback`() {
 
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl(
           "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
         )
-        .setValue(com.google.protobuf.ByteString.empty())
+        .setValue(ByteString.empty())
         .build()
 
     val engine =
@@ -85,7 +87,10 @@ class CancelGRPCStreamTest {
           name = "cancel_validation_filter",
           factory = { CancelValidationFilter(filterExpectation) }
         )
-        .addNativeFilter("envoy.filters.http.local_error", String(any_proto.toByteArray()))
+        .addNativeFilter(
+          "envoy.filters.http.local_error",
+          anyProto.toByteArray().toString(Charsets.UTF_8)
+        )
         .build()
 
     val client = GRPCClient(engine.streamClient())

--- a/mobile/test/kotlin/integration/KeyValueStoreTest.kt
+++ b/mobile/test/kotlin/integration/KeyValueStoreTest.kt
@@ -57,16 +57,27 @@ class KeyValueStoreTest {
         }
       }
 
+    val config_proto =
+      envoymobile.extensions.filters.http.test_kv_store.Filter.TestKeyValueStore.newBuilder()
+        .setKvStoreName("envoy.key_value.platform_test")
+        .setTestKey("$TEST_KEY")
+        .setTestValue("$TEST_VALUE")
+        .build()
+    var any_proto =
+      com.google.protobuf.Any.newBuilder()
+        .setTypeUrl(
+          "type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore"
+        )
+        .setValue(config_proto.toByteString())
+        .build()
+
     val engine =
       EngineBuilder()
         .setLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> print(msg) }
         .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .addKeyValueStore("envoy.key_value.platform_test", testKeyValueStore)
-        .addNativeFilter(
-          "envoy.filters.http.test_kv_store",
-          "[type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore] { kv_store_name: 'envoy.key_value.platform_test', test_key: '$TEST_KEY', test_value: '$TEST_VALUE'}"
-        )
+        .addNativeFilter("envoy.filters.http.test_kv_store", String(any_proto.toByteArray()))
         .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/KeyValueStoreTest.kt
+++ b/mobile/test/kotlin/integration/KeyValueStoreTest.kt
@@ -1,6 +1,8 @@
 package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Any
+import envoymobile.extensions.filters.http.test_kv_store.Filter.TestKeyValueStore
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.KeyValueStore
 import io.envoyproxy.envoymobile.LogLevel
@@ -57,18 +59,18 @@ class KeyValueStoreTest {
         }
       }
 
-    val config_proto =
-      envoymobile.extensions.filters.http.test_kv_store.Filter.TestKeyValueStore.newBuilder()
+    val configProto =
+      TestKeyValueStore.newBuilder()
         .setKvStoreName("envoy.key_value.platform_test")
-        .setTestKey("$TEST_KEY")
-        .setTestValue("$TEST_VALUE")
+        .setTestKey(TEST_KEY)
+        .setTestValue(TEST_VALUE)
         .build()
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl(
           "type.googleapis.com/envoymobile.extensions.filters.http.test_kv_store.TestKeyValueStore"
         )
-        .setValue(config_proto.toByteString())
+        .setValue(configProto.toByteString())
         .build()
 
     val engine =
@@ -77,7 +79,10 @@ class KeyValueStoreTest {
         .setLogger { _, msg -> print(msg) }
         .setTrustChainVerification(EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED)
         .addKeyValueStore("envoy.key_value.platform_test", testKeyValueStore)
-        .addNativeFilter("envoy.filters.http.test_kv_store", String(any_proto.toByteArray()))
+        .addNativeFilter(
+          "envoy.filters.http.test_kv_store",
+          anyProto.toByteArray().toString(Charsets.UTF_8)
+        )
         .build()
     val client = engine.streamClient()
 

--- a/mobile/test/kotlin/integration/ReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveErrorTest.kt
@@ -2,6 +2,8 @@ package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus
@@ -85,11 +87,8 @@ class ReceiveErrorTest {
         )
         .build()
 
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
-        .setTypeUrl(LOCAL_ERROR_FILTER_TYPE)
-        .setValue(com.google.protobuf.ByteString.empty())
-        .build()
+    var anyProto =
+      Any.newBuilder().setTypeUrl(LOCAL_ERROR_FILTER_TYPE).setValue(ByteString.empty()).build()
 
     val engine =
       EngineBuilder()
@@ -99,7 +98,10 @@ class ReceiveErrorTest {
           name = FILTER_NAME,
           factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }
         )
-        .addNativeFilter("envoy.filters.http.local_error", String(any_proto.toByteArray()))
+        .addNativeFilter(
+          "envoy.filters.http.local_error",
+          anyProto.toByteArray().toString(Charsets.UTF_8)
+        )
         .build()
 
     var errorCode: Int? = null

--- a/mobile/test/kotlin/integration/ReceiveErrorTest.kt
+++ b/mobile/test/kotlin/integration/ReceiveErrorTest.kt
@@ -85,6 +85,12 @@ class ReceiveErrorTest {
         )
         .build()
 
+    var any_proto =
+      com.google.protobuf.Any.newBuilder()
+        .setTypeUrl(LOCAL_ERROR_FILTER_TYPE)
+        .setValue(com.google.protobuf.ByteString.empty())
+        .build()
+
     val engine =
       EngineBuilder()
         .setLogLevel(LogLevel.DEBUG)
@@ -93,7 +99,7 @@ class ReceiveErrorTest {
           name = FILTER_NAME,
           factory = { ErrorValidationFilter(filterReceivedError, filterNotCancelled) }
         )
-        .addNativeFilter("envoy.filters.http.local_error", "[$LOCAL_ERROR_FILTER_TYPE]{}")
+        .addNativeFilter("envoy.filters.http.local_error", String(any_proto.toByteArray()))
         .build()
 
     var errorCode: Int? = null

--- a/mobile/test/kotlin/integration/SendDataTest.kt
+++ b/mobile/test/kotlin/integration/SendDataTest.kt
@@ -1,6 +1,11 @@
 package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Any
+import envoymobile.extensions.filters.http.assertion.Filter.Assertion
+import io.envoyproxy.envoy.config.common.matcher.v3.HttpGenericBodyMatch
+import io.envoyproxy.envoy.config.common.matcher.v3.HttpGenericBodyMatch.GenericTextMatch
+import io.envoyproxy.envoy.config.common.matcher.v3.MatchPredicate
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -46,27 +51,14 @@ class SendDataTest {
   fun `successful sending data`() {
     val expectation = CountDownLatch(1)
 
-    val string_match =
-      io.envoyproxy.envoy.config.common.matcher.v3.HttpGenericBodyMatch.GenericTextMatch
-        .newBuilder()
-        .setStringMatch("request body")
-        .build()
-    val match =
-      io.envoyproxy.envoy.config.common.matcher.v3.HttpGenericBodyMatch.newBuilder()
-        .addPatterns(string_match)
-        .build()
-    val match_config =
-      io.envoyproxy.envoy.config.common.matcher.v3.MatchPredicate.newBuilder()
-        .setHttpRequestGenericBodyMatch(match)
-        .build()
-    val config_proto =
-      envoymobile.extensions.filters.http.assertion.Filter.Assertion.newBuilder()
-        .setMatchConfig(match_config)
-        .build()
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    val stringMatch = GenericTextMatch.newBuilder().setStringMatch("request body").build()
+    val match = HttpGenericBodyMatch.newBuilder().addPatterns(stringMatch).build()
+    val matchConfig = MatchPredicate.newBuilder().setHttpRequestGenericBodyMatch(match).build()
+    val configProto = Assertion.newBuilder().setMatchConfig(matchConfig).build()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl("type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion")
-        .setValue(config_proto.toByteString())
+        .setValue(configProto.toByteString())
         .build()
 
     val engine =
@@ -74,7 +66,10 @@ class SendDataTest {
         .setLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> print(msg) }
         .setTrustChainVerification(TrustChainVerification.ACCEPT_UNTRUSTED)
-        .addNativeFilter("envoy.filters.http.assertion", String(any_proto.toByteArray()))
+        .addNativeFilter(
+          "envoy.filters.http.assertion",
+          anyProto.toByteArray().toString(Charsets.UTF_8)
+        )
         .build()
 
     val client = engine.streamClient()

--- a/mobile/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/mobile/test/kotlin/integration/SetEventTrackerTest.kt
@@ -1,6 +1,8 @@
 package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Any
+import envoymobile.extensions.filters.http.test_event_tracker.Filter.TestEventTracker
 import io.envoyproxy.envoymobile.EngineBuilder
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
@@ -23,16 +25,13 @@ class SetEventTrackerTest {
   @Test
   fun `set eventTracker`() {
     val countDownLatch = CountDownLatch(1)
-    val config_proto =
-      envoymobile.extensions.filters.http.test_event_tracker.Filter.TestEventTracker.newBuilder()
-        .putAttributes("foo", "bar")
-        .build()
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    val configProto = TestEventTracker.newBuilder().putAttributes("foo", "bar").build()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl(
           "type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker"
         )
-        .setValue(config_proto.toByteString())
+        .setValue(configProto.toByteString())
         .build()
     val engine =
       EngineBuilder()
@@ -45,7 +44,10 @@ class SetEventTrackerTest {
           }
           countDownLatch.countDown()
         }
-        .addNativeFilter("envoy.filters.http.test_event_tracker", String(any_proto.toByteArray()))
+        .addNativeFilter(
+          "envoy.filters.http.test_event_tracker",
+          anyProto.toByteArray().toString(Charsets.UTF_8)
+        )
         .build()
 
     val client = engine.streamClient()
@@ -69,20 +71,20 @@ class SetEventTrackerTest {
   @Test
   fun `engine should continue to run if no eventTracker is set and event is emitted`() {
     val countDownLatch = CountDownLatch(1)
-    val config_proto =
-      envoymobile.extensions.filters.http.test_event_tracker.Filter.TestEventTracker.newBuilder()
-        .putAttributes("foo", "bar")
-        .build()
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    val configProto = TestEventTracker.newBuilder().putAttributes("foo", "bar").build()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl(
           "type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker"
         )
-        .setValue(config_proto.toByteString())
+        .setValue(configProto.toByteString())
         .build()
     val engine =
       EngineBuilder()
-        .addNativeFilter("envoy.filters.http.test_event_tracker", String(any_proto.toByteArray()))
+        .addNativeFilter(
+          "envoy.filters.http.test_event_tracker",
+          anyProto.toByteArray().toString(Charsets.UTF_8)
+        )
         .build()
 
     val client = engine.streamClient()

--- a/mobile/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/mobile/test/kotlin/integration/SetEventTrackerTest.kt
@@ -23,6 +23,17 @@ class SetEventTrackerTest {
   @Test
   fun `set eventTracker`() {
     val countDownLatch = CountDownLatch(1)
+    val config_proto =
+      envoymobile.extensions.filters.http.test_event_tracker.Filter.TestEventTracker.newBuilder()
+        .putAttributes("foo", "bar")
+        .build()
+    var any_proto =
+      com.google.protobuf.Any.newBuilder()
+        .setTypeUrl(
+          "type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker"
+        )
+        .setValue(config_proto.toByteString())
+        .build()
     val engine =
       EngineBuilder()
         .setLogLevel(LogLevel.DEBUG)
@@ -34,10 +45,7 @@ class SetEventTrackerTest {
           }
           countDownLatch.countDown()
         }
-        .addNativeFilter(
-          "envoy.filters.http.test_event_tracker",
-          """[type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker] { attributes { key: "foo" value: "bar" } } }"""
-        )
+        .addNativeFilter("envoy.filters.http.test_event_tracker", String(any_proto.toByteArray()))
         .build()
 
     val client = engine.streamClient()
@@ -61,12 +69,20 @@ class SetEventTrackerTest {
   @Test
   fun `engine should continue to run if no eventTracker is set and event is emitted`() {
     val countDownLatch = CountDownLatch(1)
+    val config_proto =
+      envoymobile.extensions.filters.http.test_event_tracker.Filter.TestEventTracker.newBuilder()
+        .putAttributes("foo", "bar")
+        .build()
+    var any_proto =
+      com.google.protobuf.Any.newBuilder()
+        .setTypeUrl(
+          "type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker"
+        )
+        .setValue(config_proto.toByteString())
+        .build()
     val engine =
       EngineBuilder()
-        .addNativeFilter(
-          "envoy.filters.http.test_event_tracker",
-          """[type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker] { attributes { key: "foo" value: "bar" } } }"""
-        )
+        .addNativeFilter("envoy.filters.http.test_event_tracker", String(any_proto.toByteArray()))
         .build()
 
     val client = engine.streamClient()

--- a/mobile/test/kotlin/integration/SetLoggerTest.kt
+++ b/mobile/test/kotlin/integration/SetLoggerTest.kt
@@ -1,6 +1,8 @@
 package test.kotlin.integration
 
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
 import envoymobile.extensions.filters.http.test_logger.Filter.TestLogger
 import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.EngineBuilder
@@ -24,21 +26,19 @@ class SetLoggerTest {
   fun `set logger`() {
     val countDownLatch = CountDownLatch(1)
     val logEventLatch = CountDownLatch(1)
-    val config_proto =
-      envoymobile.extensions.filters.http.test_logger.Filter.TestLogger.newBuilder()
-        .getDefaultInstanceForType()
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    val configProto = TestLogger.newBuilder().getDefaultInstanceForType()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl(
           "type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger"
         )
-        .setValue(config_proto.toByteString())
+        .setValue(configProto.toByteString())
         .build()
     val engine =
       EngineBuilder()
         .setLogLevel(LogLevel.DEBUG)
         .setLogger { _, msg -> print(msg) }
-        .addNativeFilter("test_logger", String(any_proto.toByteArray()))
+        .addNativeFilter("test_logger", anyProto.toByteArray().toString(Charsets.UTF_8))
         .setLogger { _, msg ->
           if (msg.contains("starting main dispatch loop")) {
             countDownLatch.countDown()
@@ -66,12 +66,12 @@ class SetLoggerTest {
   fun `engine should continue to run if no logger is set`() {
     val countDownLatch = CountDownLatch(1)
     val logEventLatch = CountDownLatch(1)
-    var any_proto =
-      com.google.protobuf.Any.newBuilder()
+    var anyProto =
+      Any.newBuilder()
         .setTypeUrl(
           "type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger"
         )
-        .setValue(com.google.protobuf.ByteString.empty())
+        .setValue(ByteString.empty())
         .build()
 
     val engine =
@@ -82,7 +82,7 @@ class SetLoggerTest {
           }
         }
         .setLogLevel(LogLevel.DEBUG)
-        .addNativeFilter("test_logger", String(any_proto.toByteArray()))
+        .addNativeFilter("test_logger", anyProto.toByteArray().toString(Charsets.UTF_8))
         .setOnEngineRunning { countDownLatch.countDown() }
         .build()
 


### PR DESCRIPTION
This switches the kotlin and java builds and releases to using proto lite, and only supporting binary protos.

Risk Level: medium for E-M, no-op for Envoy
Testing: updated tests
Docs Changes: 
Release Notes: n/a
