### PR TITLE
build: removes unnecessary //test:__subpackages__ visibility

### DIFF
--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -157,9 +157,6 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
-    extra_visibility = [
-        "//source/server/admin:__subpackages__",
-    ],
     deps = [
         ":header_validator_factory",
         "//envoy/http:header_validator_factory_interface",

--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -157,11 +157,10 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
-    visibility = [
+    extra_visibility = [
         "//source/exe:__subpackages__",
         "//source/extensions/filters/network/http_connection_manager:__subpackages__",
         "//source/server/admin:__subpackages__",
-        "//test:__subpackages__",
     ],
     deps = [
         ":header_validator_factory",

--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -157,6 +157,9 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    extra_visibility = [
+        "//source/server/admin:__subpackages__",
+    ],
     deps = [
         ":header_validator_factory",
         "//envoy/http:header_validator_factory_interface",

--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -158,8 +158,6 @@ envoy_cc_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     extra_visibility = [
-        "//source/exe:__subpackages__",
-        "//source/extensions/filters/network/http_connection_manager:__subpackages__",
         "//source/server/admin:__subpackages__",
     ],
     deps = [

--- a/source/extensions/quic/connection_debug_visitor/BUILD
+++ b/source/extensions/quic/connection_debug_visitor/BUILD
@@ -22,7 +22,6 @@ envoy_cc_library(
     tags = ["nofips"],
     visibility = [
         "//source/common/quic:__subpackages__",
-        "//test:__subpackages__",
     ],
     deps = [
         "//envoy/registry",

--- a/source/extensions/quic/connection_id_generator/BUILD
+++ b/source/extensions/quic/connection_id_generator/BUILD
@@ -20,9 +20,6 @@ envoy_cc_library(
     srcs = ["envoy_deterministic_connection_id_generator.cc"],
     hdrs = ["envoy_deterministic_connection_id_generator.h"],
     tags = ["nofips"],
-    visibility = [
-        "//test:__subpackages__",
-    ],
     deps = [
         "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
         "//source/common/quic:envoy_quic_utils_lib",
@@ -48,7 +45,6 @@ envoy_cc_extension(
     name = "envoy_deterministic_connection_id_generator_config",
     extra_visibility = [
         "//source/common/quic:__subpackages__",
-        "//test:__subpackages__",
     ],
     tags = ["nofips"],
     deps = select(

--- a/source/extensions/quic/server_preferred_address/BUILD
+++ b/source/extensions/quic/server_preferred_address/BUILD
@@ -75,9 +75,6 @@ envoy_cc_library(
 
 envoy_cc_extension(
     name = "datasource_server_preferred_address_config_factory_config",
-    extra_visibility = [
-        "//test:__subpackages__",
-    ],
     tags = ["nofips"],
     deps = select(
         {

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -90,7 +90,6 @@ envoy_cc_library(
         "//source/common/router:scoped_config_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/access_loggers/common:file_access_log_lib",
-        "//source/extensions/http/header_validators/envoy_default:config",
         "//source/extensions/request_id/uuid:config",
         "//source/server:null_overload_manager_lib",
     ] + envoy_select_admin_html([

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -90,6 +90,7 @@ envoy_cc_library(
         "//source/common/router:scoped_config_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/access_loggers/common:file_access_log_lib",
+        "//source/extensions/http/header_validators/envoy_default:config",
         "//source/extensions/request_id/uuid:config",
         "//source/server:null_overload_manager_lib",
     ] + envoy_select_admin_html([


### PR DESCRIPTION
Commit Message: build: removes unnecessary `//test:__subpackages__` visibility
Additional Description:
This removes the unnecessary visibility in some extension targets.
ref #35026 

Risk Level: none
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
