### PR TITLE
Fix for SSL Client Auth filter closing connection without reason

### DIFF
--- a/contrib/client_ssl_auth/filters/network/source/client_ssl_auth.cc
+++ b/contrib/client_ssl_auth/filters/network/source/client_ssl_auth.cc
@@ -130,7 +130,8 @@ void ClientSslAuthFilter::onEvent(Network::ConnectionEvent event) {
         StreamInfo::CoreResponseFlag::UpstreamProtocolError);
     read_callbacks_->connection().streamInfo().setResponseCodeDetails(AuthDigestNoMatch);
     config_->stats().auth_digest_no_match_.inc();
-    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush,
+                                        "auth_digest_no_match");
     return;
   }
 

--- a/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
+++ b/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
@@ -167,7 +167,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
               setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError));
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
               setResponseCodeDetails("auth_digest_no_match"));
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush, _));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);

--- a/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
+++ b/contrib/client_ssl_auth/filters/network/test/client_ssl_auth_test.cc
@@ -167,7 +167,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
               setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamProtocolError));
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_,
               setResponseCodeDetails("auth_digest_no_match"));
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush, _));
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::NoFlush, "auth_digest_no_match"));
   EXPECT_EQ(Network::FilterStatus::StopIteration, instance_->onNewConnection());
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::Connected);
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);


### PR DESCRIPTION
Commit Message: Fix for SSL Client Auth filter closing connection without reason

Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A
Fixes #34997
