### PR TITLE
mobile: Fix Mobile/Compile time options CI

### DIFF
--- a/.github/workflows/mobile-compile_time_options.yml
+++ b/.github/workflows/mobile-compile_time_options.yml
@@ -79,7 +79,6 @@ jobs:
     needs:
     - load
     - cc
-    - build
     uses: ./.github/workflows/_finish.yml
     with:
       needs: ${{ toJSON(needs) }}


### PR DESCRIPTION
The error:

```
Invalid workflow file: .github/workflows/mobile-compile_time_options.yml#L82
The workflow is not valid. .github/workflows/mobile-compile_time_options.yml (Line: 82, Col: 7): Job 'request' depends on unknown job 'build'.
```

A follow-up of https://github.com/envoyproxy/envoy/pull/35019

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a