### PR TITLE
utility_trie_speed_test: remove char for uniform_int_distribution undifined behavior

### DIFF
--- a/test/common/common/utility_trie_speed_test.cc
+++ b/test/common/common/utility_trie_speed_test.cc
@@ -48,7 +48,7 @@ template <class TableType> static void typedBmTrieLookups(benchmark::State& stat
   std::mt19937 prng(1); // PRNG with a fixed seed, for repeatability
   int num_keys = state.range(0);
   int key_length = state.range(1);
-  std::uniform_int_distribution<> char_distribution('a', 'z');
+  std::uniform_int_distribution<short> char_distribution('a', 'z');
   std::uniform_int_distribution<size_t> key_length_distribution(key_length == 0 ? 8 : key_length,
                                                                 key_length == 0 ? 128 : key_length);
   auto make_key = [&](size_t len) {

--- a/test/common/common/utility_trie_speed_test.cc
+++ b/test/common/common/utility_trie_speed_test.cc
@@ -48,13 +48,13 @@ template <class TableType> static void typedBmTrieLookups(benchmark::State& stat
   std::mt19937 prng(1); // PRNG with a fixed seed, for repeatability
   int num_keys = state.range(0);
   int key_length = state.range(1);
-  std::uniform_int_distribution<char> char_distribution('a', 'z');
+  std::uniform_int_distribution<> char_distribution('a', 'z');
   std::uniform_int_distribution<size_t> key_length_distribution(key_length == 0 ? 8 : key_length,
                                                                 key_length == 0 ? 128 : key_length);
   auto make_key = [&](size_t len) {
     std::string ret;
     for (size_t i = 0; i < len; i++) {
-      ret.push_back(char_distribution(prng));
+      ret.push_back(static_cast<char>(char_distribution(prng)));
     }
     return ret;
   };


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

template< class IntType = int > class uniform_int_distribution

[IntType](https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution) | - | The result type generated by the generator. The effect is undefined if this is not one of short, int, long, long long, unsigned short, unsigned int, unsigned long, or unsigned long long.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
