### PR TITLE
aws: Fix for s3 double encoding

### DIFF
--- a/test/extensions/common/aws/utility_test.cc
+++ b/test/extensions/common/aws/utility_test.cc
@@ -320,6 +320,38 @@ TEST(UtilityTest, EncodeS3PathSegment) {
   EXPECT_EQ("/test/%5E%21%40%3D/-_~.", encoded_path);
 }
 
+// We assume that by the time our path has reached encodePathSegment, it has already been uriEncoded
+// These tests validate that we do not doubly encode these
+TEST(UtilityTest, CheckDoubleEncodingS3) {
+  const absl::string_view path = "/test%20file";
+  const auto encoded_path = Utility::encodePathSegment(path, "s3");
+  EXPECT_EQ("/test%20file", encoded_path);
+}
+
+TEST(UtilityTest, CheckDoubleEncodingS3withSpace) {
+  const absl::string_view path = "/test file";
+  const auto encoded_path = Utility::encodePathSegment(path, "s3");
+  EXPECT_EQ("/test%20file", encoded_path);
+}
+
+TEST(UtilityTest, CheckDoubleEncodingS3Outposts) {
+  const absl::string_view path = "/test%20file";
+  const auto encoded_path = Utility::encodePathSegment(path, "s3-outposts");
+  EXPECT_EQ("/test%20file", encoded_path);
+}
+
+TEST(UtilityTest, CheckDoubleEncodingS3Folder) {
+  const absl::string_view path = "/test%20folder/test%20file";
+  const auto encoded_path = Utility::encodePathSegment(path, "s3");
+  EXPECT_EQ("/test%20folder/test%20file", encoded_path);
+}
+
+TEST(UtilityTest, CheckDoubleEncodingS3FolderPercentFile) {
+  const absl::string_view path = "/test%20folder/%25";
+  const auto encoded_path = Utility::encodePathSegment(path, "s3");
+  EXPECT_EQ("/test%20folder/%25", encoded_path);
+}
+
 TEST(UtilityTest, CanonicalizeQueryString) {
   const absl::string_view query = "a=1&b=2";
   const auto canonical_query = Utility::canonicalizeQueryString(query);


### PR DESCRIPTION
Commit Message: aws: Fix for s3 double encoding 
Additional Description:

Bugfix for issue https://github.com/envoyproxy/envoy/issues/35023 . Includes additional unit tests and support for s3-outposts which also has the same workaround in the SDK for double encoding.

Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] 35023
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
