### PR TITLE
ci: remove zstd docker-compose 'version' as obsolete

### DIFF
--- a/examples/zstd/docker-compose.yaml
+++ b/examples/zstd/docker-compose.yaml
@@ -1,5 +1,5 @@
-version: "3.7"
 services:
+
   envoy-stats:
     build:
       context: .


### PR DESCRIPTION
Commit Message: ci: remove zstd docker-compose 'version' as obsolete
Additional Description: from CI logs:
```time="2024-07-01T21:16:14Z" level=warning msg="/home/runner/work/envoy/envoy/examples/zstd/docker-compose.yaml: `version` is obsolete"```
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
