### PR TITLE
ext_proc: Fix status code in the test

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1023,7 +1023,11 @@ TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingSucceeded) {
 }
 
 TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingFailed) {
+  // Allows route mutation.
   proto_config_.mutable_mutation_rules()->mutable_allow_all_routing()->set_value(true);
+  // Skip the header processing on response path.
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+
   initializeConfig();
   // Set up the route config.
   std::string vhost_domain = "new_host";
@@ -1060,9 +1064,9 @@ TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingFailed) {
         return true;
       });
 
-  // The routing to upstream is expected to fail and 500 is returned to downstream client, since no
+  // The routing to upstream is expected to fail and 404 is returned to downstream client, since no
   // route is found for mismatched vhost.
-  verifyDownstreamResponse(*response, 500);
+  verifyDownstreamResponse(*response, 404);
 }
 
 TEST_P(ExtProcIntegrationTest, GetAndSetPathHeader) {

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1023,7 +1023,6 @@ TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingSucceeded) {
 }
 
 TEST_P(ExtProcIntegrationTest, SetHostHeaderRoutingFailed) {
-  // Allows route mutation.
   proto_config_.mutable_mutation_rules()->mutable_allow_all_routing()->set_value(true);
   // Skip the header processing on response path.
   proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);


### PR DESCRIPTION
500 is returned because the onMessageTimeout is invoked by mistake, which is because test is missing skip_header_processing_on_response (or ext_proc test server should handle request)

404 should be returned from upstream sever in this case, as downstream client request failed to reach the server due to route mismatch.