### PR TITLE
aws: recreate cluster during cds deletion

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_credentials.rst
@@ -1,7 +1,7 @@
 Credentials
 -----------
 
-The filter uses a few different credentials providers to obtain an AWS access key ID, AWS secret access key, and AWS session token.
+The filter uses a number of different credentials providers to obtain an AWS access key ID, AWS secret access key, and AWS session token.
 It moves through the credentials providers in the order described below, stopping when one of them returns an access key ID and a
 secret access key (the session token is optional).
 
@@ -45,3 +45,21 @@ secret access key (the session token is optional).
    from ECS task metadata. If these clusters are not provided in the bootstrap configuration then either of these will be added by default.
    The static internal cluster will still be added even if initially ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` is
    not set so that subsequently if the reloadable feature is set to ``true`` the cluster config is available to fetch the credentials.
+
+Statistics
+----------
+
+When using the ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` reloadable feature, the following
+statistics are output under the ``aws.metadata_credentials_provider`` namespace:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :escape: '
+  :widths: 1, 1, 2
+
+  <provider_cluster>.credential_refreshes_performed, Counter, Total credential refreshes performed by this cluster
+  <provider_cluster>.credential_refreshes_failed, Counter, Total credential refreshes failed by this cluster. For example', this would be incremented if a WebIdentity token was expired
+  <provider_cluster>.credential_refreshes_succeeded, Counter, Total successful credential refreshes for this cluster. Successful refresh would indicate credentials are available for signing
+  <provider_cluster>.metadata_refresh_state, Gauge, 0 means the cluster is in initial refresh state', ie no successful credential refreshes have been performed. In 0 state the cluster will attempt credential refresh up to a maximum of once every 30 seconds. 1 means the cluster is in normal credential expiration based refresh state
+  <provider_cluster>.clusters_removed_by_cds, Counter, Number of metadata clusters removed during CDS refresh
+  <provider_cluster>.clusters_readded_after_cds, Counter, Number of metadata clusters replaced when CDS deletion occurs

--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -119,16 +119,3 @@ comes from the owning HTTP connection manager.
   payload_signing_added, Counter, Total requests for which the payload was buffered signing succeeded
   payload_signing_failed, Counter, Total requests for which the payload was buffered but signing failed
 
-In addition, when using the ``envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`` reloadable feature, the following
-statistics are output under the ``aws.metadata_credentials_provider`` namespace:
-
-.. csv-table::
-  :header: Name, Type, Description
-  :escape: '
-  :widths: 1, 1, 2
-
-  <provider_cluster>.credential_refreshes_performed, Counter, Total credential refreshes performed by this cluster
-  <provider_cluster>.credential_refreshes_failed, Counter, Total credential refreshes failed by this cluster. For example', this would be incremented if a WebIdentity token was expired
-  <provider_cluster>.credential_refreshes_succeeded, Counter, Total successful credential refreshes for this cluster. Successful refresh would indicate credentials are available for signing
-  <provider_cluster>.metadata_refresh_state, Gauge, 0 means the cluster is in initial refresh state', ie no successful credential refreshes have been performed. In 0 state the cluster will attempt credential refresh up to a maximum of once every 30 seconds. 1 means the cluster is in normal credential expiration based refresh state
-

--- a/source/extensions/common/aws/credentials_provider_impl.h
+++ b/source/extensions/common/aws/credentials_provider_impl.h
@@ -114,6 +114,8 @@ public:
   COUNTER(credential_refreshes_performed)                                                          \
   COUNTER(credential_refreshes_failed)                                                             \
   COUNTER(credential_refreshes_succeeded)                                                          \
+  COUNTER(clusters_removed_by_cds)                                                                 \
+  COUNTER(clusters_readded_after_cds)                                                              \
   GAUGE(metadata_refresh_state, Accumulate)
 
 struct MetadataCredentialsProviderStats {
@@ -139,6 +141,9 @@ public:
 
   // Get the Metadata credentials cache duration.
   static std::chrono::seconds getCacheDuration();
+
+private:
+  void createCluster(bool new_timer);
 
 protected:
   struct LoadClusterEntryHandleImpl
@@ -236,6 +241,8 @@ protected:
   Stats::ScopeSharedPtr scope_ = nullptr;
   // Pointer to our stats structure
   std::shared_ptr<MetadataCredentialsProviderStats> stats_;
+  // Atomic flag for cluster recreate
+  std::atomic<bool> is_creating_ = false;
 };
 
 /**

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
@@ -500,6 +500,73 @@ TEST_F(InitializeFilterTest, TestWithTwoClustersRouteLevelAndStandardInstancePro
                                  "service_internal-ap-southeast-2.credential_refreshes_performed",
                                  1, std::chrono::seconds(10));
 }
+
+class CdsInteractionTest : public testing::Test, public HttpIntegrationTest {
+public:
+  CdsInteractionTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4) {}
+
+  void addStandardFilter(bool downstream = true) {
+    config_helper_.prependFilter(AWS_REQUEST_SIGNING_CONFIG_SIGV4, downstream);
+  }
+};
+
+TEST_F(CdsInteractionTest, ClusterRemovalRecreatesCluster) {
+
+  // Web Identity Credentials only
+
+  TestEnvironment::setEnvVar("AWS_EC2_METADATA_DISABLED", "true", 1);
+  TestEnvironment::setEnvVar("AWS_WEB_IDENTITY_TOKEN_FILE", "/path/to/web_token", 1);
+  TestEnvironment::setEnvVar("AWS_ROLE_ARN", "aws:iam::123456789012:role/arn", 1);
+  TestEnvironment::setEnvVar("AWS_ROLE_SESSION_NAME", "role-session-name", 1);
+  config_helper_.addRuntimeOverride(
+      "envoy.reloadable_features.use_http_client_to_fetch_aws_credentials", "true");
+
+  CdsHelper cds_helper_;
+
+  // Add CDS cluster using cds helper
+  config_helper_.addConfigModifier(
+      [&cds_helper_](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
+            envoy::config::core::v3::ApiVersion::V3);
+        bootstrap.mutable_dynamic_resources()
+            ->mutable_cds_config()
+            ->mutable_path_config_source()
+            ->set_path(cds_helper_.cdsPath());
+        bootstrap.mutable_static_resources()->clear_clusters();
+      });
+
+  // Don't validate clusters so we can use the CDS cluster as a route target
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.mutable_route_config()->mutable_validate_clusters()->set_value(false); });
+
+  addStandardFilter();
+
+  // Use CDS helper to add initial CDS cluster
+  envoy::config::cluster::v3::Cluster cluster_;
+  cluster_.mutable_connect_timeout()->CopyFrom(
+      Protobuf::util::TimeUtil::MillisecondsToDuration(100));
+  cluster_.set_name("cluster_0");
+  cluster_.set_lb_policy(envoy::config::cluster::v3::Cluster::ROUND_ROBIN);
+
+  cds_helper_.setCds({cluster_});
+
+  initialize();
+  test_server_->waitForCounterGe("cluster_manager.cluster_added", 2);
+
+  cluster_.set_name("testing");
+  cds_helper_.setCds({cluster_});
+
+  // Should delete our sts cluster and cluster_0
+  test_server_->waitForCounterGe("aws.metadata_credentials_provider.sts_token_"
+                                 "service_internal-ap-southeast-2.clusters_removed_by_cds",
+                                 1, std::chrono::seconds(5));
+  test_server_->waitForCounterGe("aws.metadata_credentials_provider.sts_token_"
+                                 "service_internal-ap-southeast-2.clusters_readded_after_cds",
+                                 1, std::chrono::seconds(5));
+}
+
 } // namespace
 } // namespace Aws
 } // namespace Common

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
@@ -504,18 +504,60 @@ TEST_F(InitializeFilterTest, TestWithTwoClustersRouteLevelAndStandardInstancePro
 class CdsInteractionTest : public testing::Test, public HttpIntegrationTest {
 public:
   CdsInteractionTest()
-      : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4) {}
+      : HttpIntegrationTest(Http::CodecType::HTTP1, Network::Address::IpVersion::v4),
+        dns_cluster_factory_(logical_dns_cluster_factory_),
+        registered_dns_factory_(dns_resolver_factory_) {}
 
   void addStandardFilter(bool downstream = true) {
     config_helper_.prependFilter(AWS_REQUEST_SIGNING_CONFIG_SIGV4, downstream);
   }
+
+  void expectResolve(Network::DnsLookupFamily, const std::string& expected_address) {
+    EXPECT_CALL(*dns_resolver_, resolve(expected_address, _, _))
+        .WillRepeatedly(Invoke([&](const std::string&, Network::DnsLookupFamily,
+                                   Network::DnsResolver::ResolveCb cb) -> Network::ActiveDnsQuery* {
+          cb(Network::DnsResolver::ResolutionStatus::Success, "",
+             TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
+
+          return nullptr;
+        }));
+  }
+
+  void dnsSetup() {
+    ON_CALL(dns_resolver_factory_, createDnsResolver(_, _, _)).WillByDefault(Return(dns_resolver_));
+    expectResolve(Network::DnsLookupFamily::V4Only, "sts.ap-southeast-2.amazonaws.com");
+  }
+
+  NiceMock<MockLogicalDnsClusterFactory> logical_dns_cluster_factory_;
+  Registry::InjectFactory<Envoy::Upstream::LogicalDnsClusterFactory> dns_cluster_factory_;
+  NiceMock<Network::MockDnsResolverFactory> dns_resolver_factory_;
+  Registry::InjectFactory<Network::DnsResolverFactory> registered_dns_factory_;
+
+  Network::DnsResolver::ResolveCb dns_callback_;
+  Network::MockActiveDnsQuery active_dns_query_;
+  std::shared_ptr<NiceMock<Network::MockDnsResolver>> dns_resolver_{
+      new NiceMock<Network::MockDnsResolver>};
+  NiceMock<Event::MockDispatcher> dispatcher_;
+
+  void SetUp() override {
+    TestEnvironment::unsetEnvVar("AWS_ACCESS_KEY_ID");
+    TestEnvironment::unsetEnvVar("AWS_SECRET_ACCESS_KEY");
+    TestEnvironment::unsetEnvVar("AWS_SESSION_TOKEN");
+    TestEnvironment::unsetEnvVar("AWS_WEB_IDENTITY_TOKEN_FILE");
+    TestEnvironment::unsetEnvVar("AWS_ROLE_ARN");
+    TestEnvironment::unsetEnvVar("AWS_ROLE_SESSION_NAME");
+    TestEnvironment::unsetEnvVar("AWS_CONTAINER_CREDENTIALS_FULL_URI");
+    TestEnvironment::unsetEnvVar("AWS_CONTAINER_AUTHORIZATION_TOKEN");
+  }
 };
 
-TEST_F(CdsInteractionTest, ClusterRemovalRecreatesCluster) {
+TEST_F(CdsInteractionTest, ClusterRemovalRecreatesSTSCluster) {
   Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
 
-  // Web Identity Credentials only
+  // STS cluster requires dns mocking
+  dnsSetup();
 
+  // Web Identity Credentials only
   TestEnvironment::setEnvVar("AWS_EC2_METADATA_DISABLED", "true", 1);
   TestEnvironment::setEnvVar("AWS_WEB_IDENTITY_TOKEN_FILE", "/path/to/web_token", 1);
   TestEnvironment::setEnvVar("AWS_ROLE_ARN", "aws:iam::123456789012:role/arn", 1);
@@ -562,10 +604,61 @@ TEST_F(CdsInteractionTest, ClusterRemovalRecreatesCluster) {
   // Should delete our sts cluster and cluster_0
   test_server_->waitForCounterGe("aws.metadata_credentials_provider.sts_token_"
                                  "service_internal-ap-southeast-2.clusters_removed_by_cds",
-                                 1, std::chrono::seconds(5));
+                                 1);
   test_server_->waitForCounterGe("aws.metadata_credentials_provider.sts_token_"
                                  "service_internal-ap-southeast-2.clusters_readded_after_cds",
-                                 1, std::chrono::seconds(5));
+                                 1);
+}
+
+TEST_F(CdsInteractionTest, ClusterRemovalRecreatesIMDSCluster) {
+  // Instance Metadata Service only
+  TestEnvironment::setEnvVar("AWS_EC2_METADATA_DISABLED", "false", 1);
+  config_helper_.addRuntimeOverride(
+      "envoy.reloadable_features.use_http_client_to_fetch_aws_credentials", "true");
+
+  CdsHelper cds_helper_;
+
+  // Add CDS cluster using cds helper
+  config_helper_.addConfigModifier(
+      [&cds_helper_](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_resource_api_version(
+            envoy::config::core::v3::ApiVersion::V3);
+        bootstrap.mutable_dynamic_resources()
+            ->mutable_cds_config()
+            ->mutable_path_config_source()
+            ->set_path(cds_helper_.cdsPath());
+        bootstrap.mutable_static_resources()->clear_clusters();
+      });
+
+  // Don't validate clusters so we can use the CDS cluster as a route target
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.mutable_route_config()->mutable_validate_clusters()->set_value(false); });
+
+  addStandardFilter();
+
+  // Use CDS helper to add initial CDS cluster
+  envoy::config::cluster::v3::Cluster cluster_;
+  cluster_.mutable_connect_timeout()->CopyFrom(
+      Protobuf::util::TimeUtil::MillisecondsToDuration(100));
+  cluster_.set_name("cluster_0");
+  cluster_.set_lb_policy(envoy::config::cluster::v3::Cluster::ROUND_ROBIN);
+
+  cds_helper_.setCds({cluster_});
+
+  initialize();
+  test_server_->waitForCounterGe("cluster_manager.cluster_added", 2);
+
+  cluster_.set_name("testing");
+  cds_helper_.setCds({cluster_});
+
+  // Should delete our sts cluster and cluster_0
+  test_server_->waitForCounterGe("aws.metadata_credentials_provider.ec2_instance_metadata_server_"
+                                 "internal.clusters_removed_by_cds",
+                                 1);
+  test_server_->waitForCounterGe("aws.metadata_credentials_provider.ec2_instance_metadata_server_"
+                                 "internal.clusters_readded_after_cds",
+                                 1);
 }
 
 } // namespace

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
@@ -270,7 +270,6 @@ public:
         [&yaml_config](
             envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                 cfg) {
-          ENVOY_LOG_MISC(debug, "{}", yaml_config);
           envoy::extensions::filters::http::aws_request_signing::v3::AwsRequestSigningPerRoute
               per_route_config;
           TestUtility::loadFromYaml(yaml_config, per_route_config);
@@ -552,7 +551,6 @@ public:
 };
 
 TEST_F(CdsInteractionTest, ClusterRemovalRecreatesSTSCluster) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
 
   // STS cluster requires dns mocking
   dnsSetup();

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
@@ -512,6 +512,7 @@ public:
 };
 
 TEST_F(CdsInteractionTest, ClusterRemovalRecreatesCluster) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
 
   // Web Identity Credentials only
 


### PR DESCRIPTION
Commit Message: aws: recreate cluster during cds deletion
Additional Description: Adds handler for onClusterRemoval to handle CDS refresh case identified in https://github.com/envoyproxy/envoy/issues/35022
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] 35022
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
