### PR TITLE
aws: avoid duplicate headers

### DIFF
--- a/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_request_signing_filter.rst
@@ -46,6 +46,16 @@ length of time after which this URL becomes invalid, starting from the time the 
 The default expiration time is 5 seconds, with a maximum of 3600 seconds. It is recommended to keep this value as small as practicable,
 as the generated URL is replayable before this time expires.
 
+Header Modification
+-------------------
+
+Unless the  :ref:`query_string <envoy_v3_api_field_extensions.filters.http.aws_request_signing.v3.AwsRequestSigning.query_string>` signing method is used,
+the following HTTP header modifications will be made by this extension:
+- The HTTP ``authorization`` header will be replaced with the calculated SigV4/SigV4A Authorization value
+- The ``x-amz-security-token`` header will be removed, or replaced if a session token is present via credentials
+- The ``x-amz-date`` header will be replaced with the current date
+- The ``x-amz-region-set`` header will replaced if the ``AWS_SIGV4A`` signing algorithm is used
+
 Example configuration
 ---------------------
 

--- a/source/extensions/common/aws/sigv4a_signer_impl.cc
+++ b/source/extensions/common/aws/sigv4a_signer_impl.cc
@@ -51,7 +51,7 @@ std::string SigV4ASignerImpl::createStringToSign(const absl::string_view canonic
 
 void SigV4ASignerImpl::addRegionHeader(Http::RequestHeaderMap& headers,
                                        const absl::string_view override_region) const {
-  headers.addCopy(SigV4ASignatureHeaders::get().RegionSet,
+  headers.setCopy(SigV4ASignatureHeaders::get().RegionSet,
                   override_region.empty() ? getRegion() : override_region);
 }
 


### PR DESCRIPTION
Commit Message: aws: avoid duplicate headers
Additional Description: Fixes identified issue with headers being added, rather than replaced
Risk Level: Low
Testing: Unit
Docs Changes: Doc changes made to explain header modifications by this extension
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/35075
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
