### PR TITLE
ext_proc: observability mode part 4: Implement the deferred closure timeout. 

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -257,7 +257,6 @@ message ExternalProcessor {
   RouteCacheAction route_cache_action = 18
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
 
-  // [#not-implemented-hide:]
   // Specifies the deferred closure timeout for gRPC stream that connects to external processor. Currently, the deferred stream closure
   // is only used in :ref:`observability_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
   // In observability mode, gRPC streams may be held open to the external processor longer than the lifetime of the regular client to

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -146,15 +146,17 @@ private:
 };
 
 class ThreadLocalStreamManager;
-// TODO(tyxia) Make it configurable.
-inline constexpr uint32_t DEFAULT_CLOSE_TIMEOUT_MS = 1000;
+// Default value is 5000 milliseconds (5 seconds)
+inline constexpr uint32_t DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS = 5000;
 
 // Deferred deletable stream wrapper.
 struct DeferredDeletableStream : public Logger::Loggable<Logger::Id::ext_proc> {
   explicit DeferredDeletableStream(ExternalProcessorStreamPtr stream,
                                    ThreadLocalStreamManager& stream_manager,
-                                   const ExtProcFilterStats& stat)
-      : stream_(std::move(stream)), parent(stream_manager), stats(stat) {}
+                                   const ExtProcFilterStats& stat,
+                                   const std::chrono::milliseconds& timeout)
+      : stream_(std::move(stream)), parent(stream_manager), stats(stat),
+        deferred_close_timeout(timeout) {}
 
   void deferredClose(Envoy::Event::Dispatcher& dispatcher, uint64_t stream_id);
 
@@ -163,6 +165,7 @@ struct DeferredDeletableStream : public Logger::Loggable<Logger::Id::ext_proc> {
   ThreadLocalStreamManager& parent;
   ExtProcFilterStats stats;
   Event::TimerPtr derferred_close_timer;
+  const std::chrono::milliseconds deferred_close_timeout;
 };
 
 using DeferredDeletableStreamPtr = std::unique_ptr<DeferredDeletableStream>;
@@ -172,9 +175,9 @@ public:
   // Store the ExternalProcessorStreamPtr (as a wrapper object) in the map and return the raw
   // pointer of ExternalProcessorStream.
   ExternalProcessorStream* store(uint64_t stream_id, ExternalProcessorStreamPtr stream,
-                                 const ExtProcFilterStats& stat) {
+                                 const ExtProcFilterStats& stat, const std::chrono::milliseconds& timeout) {
     stream_manager_[stream_id] =
-        std::make_unique<DeferredDeletableStream>(std::move(stream), *this, stat);
+        std::make_unique<DeferredDeletableStream>(std::move(stream), *this, stat, timeout);
     return stream_manager_[stream_id]->stream_.get();
   }
 
@@ -207,6 +210,7 @@ public:
 
   bool observabilityMode() const { return observability_mode_; }
 
+  const std::chrono::milliseconds& deferredCloseTimeout() const { return deferred_close_timeout_; }
   const std::chrono::milliseconds& messageTimeout() const { return message_timeout_; }
 
   uint32_t maxMessageTimeout() const { return max_message_timeout_ms_; }
@@ -270,6 +274,7 @@ private:
   const bool observability_mode_;
   envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor::RouteCacheAction
       route_cache_action_;
+  const std::chrono::milliseconds deferred_close_timeout_;
   const std::chrono::milliseconds message_timeout_;
   const uint32_t max_message_timeout_ms_;
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -175,7 +175,8 @@ public:
   // Store the ExternalProcessorStreamPtr (as a wrapper object) in the map and return the raw
   // pointer of ExternalProcessorStream.
   ExternalProcessorStream* store(uint64_t stream_id, ExternalProcessorStreamPtr stream,
-                                 const ExtProcFilterStats& stat, const std::chrono::milliseconds& timeout) {
+                                 const ExtProcFilterStats& stat,
+                                 const std::chrono::milliseconds& timeout) {
     stream_manager_[stream_id] =
         std::make_unique<DeferredDeletableStream>(std::move(stream), *this, stat, timeout);
     return stream_manager_[stream_id]->stream_.get();

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -4253,7 +4253,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithTrailer) {
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequest) {
   proto_config_.set_observability_mode(true);
   uint32_t deferred_close_timeout_ms = 1000;
-  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms/1000);
+  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms / 1000);
 
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
   proto_config_.mutable_processing_mode()->set_request_trailer_mode(ProcessingMode::SEND);
@@ -4276,6 +4276,8 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequest) {
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
   proto_config_.set_observability_mode(true);
+  uint32_t deferred_close_timeout_ms = 1000;
+  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms / 1000);
 
   proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SKIP);
   proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
@@ -4293,7 +4295,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(1000));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(deferred_close_timeout_ms));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithLogging) {
@@ -4384,7 +4386,6 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersUpstreamObservabilityMode) {
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
-
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(100, true);

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -44,7 +44,7 @@ using envoy::service::ext_proc::v3::ImmediateResponse;
 using envoy::service::ext_proc::v3::ProcessingRequest;
 using envoy::service::ext_proc::v3::ProcessingResponse;
 using envoy::service::ext_proc::v3::TrailersResponse;
-using Extensions::HttpFilters::ExternalProcessing::DEFAULT_CLOSE_TIMEOUT_MS;
+using Extensions::HttpFilters::ExternalProcessing::DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS;
 using Extensions::HttpFilters::ExternalProcessing::HasNoHeader;
 using Extensions::HttpFilters::ExternalProcessing::HeaderProtosEqual;
 using Extensions::HttpFilters::ExternalProcessing::makeHeaderValue;
@@ -4154,7 +4154,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithHeader) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithBody) {
@@ -4197,7 +4197,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithBody) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithWrongBodyMode) {
@@ -4215,7 +4215,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithWrongBodyMode) {
   handleUpstreamRequest();
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithTrailer) {
@@ -4247,11 +4247,13 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithTrailer) {
   verifyDownstreamResponse(*response, 200);
   EXPECT_THAT(*(response->trailers()), HasNoHeader("x-modified-trailers"));
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequest) {
   proto_config_.set_observability_mode(true);
+  uint32_t deferred_close_timeout_ms = 1000;
+  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms/1000);
 
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
   proto_config_.mutable_processing_mode()->set_request_trailer_mode(ProcessingMode::SEND);
@@ -4269,7 +4271,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequest) {
   handleUpstreamRequest();
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(deferred_close_timeout_ms));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
@@ -4291,7 +4293,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(1000));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithLogging) {
@@ -4383,8 +4385,6 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersUpstreamObservabilityMode) {
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
-  // EXPECT_THAT(upstream_request_->headers(), HasNoHeader("x-remove-this"));
-  // EXPECT_THAT(upstream_request_->headers(), HasNoHeader("x-new-header", "new"));
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(100, true);
@@ -4483,7 +4483,7 @@ TEST_P(ExtProcIntegrationTest, InvalidServerOnResponseInObservabilityMode) {
   handleUpstreamRequest();
   EXPECT_FALSE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, processor_connection_,
                                                          std::chrono::milliseconds(25000)));
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstream) {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -4104,7 +4104,7 @@ TEST_F(HttpFilterTest, HeaderProcessingInObservabilityMode) {
   // Deferred close timer is expected to be enabled by `DeferredDeletableStream`'s deferredClose(),
   // which is triggered by filter onDestroy() function below.
   EXPECT_CALL(*deferred_close_timer_,
-              enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS), _));
+              enableTimer(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS), _));
   filter_->onDestroy();
   deferred_close_timer_->invokeCallback();
 
@@ -4192,7 +4192,7 @@ TEST_F(HttpFilterTest, StreamingBodiesInObservabilityMode) {
   // Deferred close timer is expected to be enabled by `DeferredDeletableStream`'s deferredClose(),
   // which is triggered by filter onDestroy() function.
   EXPECT_CALL(*deferred_close_timer_,
-              enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS), _));
+              enableTimer(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS), _));
   filter_->onDestroy();
   deferred_close_timer_->invokeCallback();
 
@@ -4240,7 +4240,7 @@ TEST_F(HttpFilterTest, StreamingAllDataInObservabilityMode) {
   // Deferred close timer is expected to be enabled by `DeferredDeletableStream`'s deferredClose(),
   // which is triggered by filter onDestroy() function.
   EXPECT_CALL(*deferred_close_timer_,
-              enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS), _));
+              enableTimer(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS), _));
   filter_->onDestroy();
   deferred_close_timer_->invokeCallback();
 


### PR DESCRIPTION
Implements the derferred closure timeout, the API was implemented in https://github.com/envoyproxy/envoy/pull/34971