### PR TITLE
[balsa] Add runtime guard for rejecting CR in chunk extension.

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -62,6 +62,9 @@ minor_behavior_changes:
 - area: http
   change: |
     Fixed host header changes for shadow requests to properly handle ipv6 addresses.
+  change: |
+    Reject messages with chunked transfer encoding with chunk extension containing CR not followed by LF. This can be temporarily reverted
+    by setting runtime guard ``envoy.reloadable_features.http1_balsa_disallow_lone_cr_in_chunk_extension`` to ``false``.
 - area: tracers
   change: |
     Set status code for OpenTelemetry tracers (previously unset).

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -62,9 +62,6 @@ minor_behavior_changes:
 - area: http
   change: |
     Fixed host header changes for shadow requests to properly handle ipv6 addresses.
-  change: |
-    Reject messages with chunked transfer encoding with chunk extension containing CR not followed by LF. This can be temporarily reverted
-    by setting runtime guard ``envoy.reloadable_features.http1_balsa_disallow_lone_cr_in_chunk_extension`` to ``false``.
 - area: tracers
   change: |
     Set status code for OpenTelemetry tracers (previously unset).
@@ -146,6 +143,10 @@ minor_behavior_changes:
     config. Previously, the config only removes JWT if set in headers. With this addition, the config can also be
     used to remove JWT set in query parameters. This behavior can be reverted by setting the runtime guard
     ``envoy.reloadable_features.jwt_authn_remove_jwt_from_query_params`` to false.
+- area: http
+  change: |
+    Reject messages with chunked transfer encoding with chunk extension containing CR not followed by LF. This can be temporarily reverted
+    by setting runtime guard ``envoy.reloadable_features.http1_balsa_disallow_lone_cr_in_chunk_extension`` to ``false``.
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -6,6 +6,7 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/http/headers.h"
+#include "source/common/runtime/runtime_features.h"
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
@@ -160,7 +161,8 @@ BalsaParser::BalsaParser(MessageType type, ParserCallbacks* connection, size_t m
   http_validation_policy.validate_transfer_encoding = false;
   http_validation_policy.require_content_length_if_body_required = false;
   http_validation_policy.disallow_invalid_header_characters_in_response = true;
-  http_validation_policy.disallow_lone_cr_in_chunk_extension = true;
+  http_validation_policy.disallow_lone_cr_in_chunk_extension = Runtime::runtimeFeatureEnabled(
+      "envoy.reloadable_features.http1_balsa_disallow_lone_cr_in_chunk_extension");
   framer_.set_http_validation_policy(http_validation_policy);
 
   framer_.set_balsa_headers(&headers_);

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -50,6 +50,7 @@ RUNTIME_GUARD(envoy_reloadable_features_grpc_http1_reverse_bridge_change_http_st
 RUNTIME_GUARD(envoy_reloadable_features_grpc_http1_reverse_bridge_handle_empty_response);
 RUNTIME_GUARD(envoy_reloadable_features_grpc_side_stream_flow_control);
 RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_delay_reset);
+RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_disallow_lone_cr_in_chunk_extension);
 RUNTIME_GUARD(envoy_reloadable_features_http1_connection_close_header_in_redirect);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year.
 RUNTIME_GUARD(envoy_reloadable_features_http1_use_balsa_parser);

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1179,6 +1179,7 @@ refcount
 referencee
 referer
 refetch
+reframed
 refvec
 regex
 regexes


### PR DESCRIPTION
Commit Message: [balsa] Add runtime guard for rejecting CR in chunk extension.
Additional Description: #34906 landed without runtime guard protection. This PR retroactively adds a default-true feature flag.
Risk Level: low
Testing: //test/common/http/http1:codec_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a