### PR TITLE
tracer(datadog): improve remote configuration usability

### DIFF
--- a/api/envoy/config/trace/v3/datadog.proto
+++ b/api/envoy/config/trace/v3/datadog.proto
@@ -18,13 +18,13 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Datadog tracer]
 
-// Remote Configuration
+// Configuration for the Remote Configuration feature.
 message DatadogRemoteConfig {
-  // Allows to configure and change the tracer behaviour from Datadog's UI.
-  // Default value is `false`, which disable the feature.
+  // Allows to configure and change the tracer behaviour from Datadog's user interface.
+  // Default value is ``false``, which disable the feature.
   // [#comment: This feature can drastically increase the number of connections to the Datadog Agent.
-  // This is the consequence of each tracer regularly polling for configuration updates, and the number
-  // of tracer is the product of the number of listeners and worker threads.]
+  // Each tracer regularly polls for configuration updates, and the number of tracers is the product
+  // of the number of listeners and worker threads.]
   bool enabled = 1;
 
   // Frequency at which new configuration updates are queried.

--- a/api/envoy/config/trace/v3/datadog.proto
+++ b/api/envoy/config/trace/v3/datadog.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration for the Remote Configuration feature.
 message DatadogRemoteConfig {
   // Frequency at which new configuration updates are queried.
-  // [#comment: If no value is provided, the default value is delegated to the Datadog tracing library.]
+  // If no value is provided, the default value is delegated to the Datadog tracing library.
   google.protobuf.Duration polling_interval = 1;
 }
 
@@ -43,8 +43,8 @@ message DatadogConfig {
 
   // Enables and configures remote configuration.
   // Remote Configuration allows to configure the tracer from Datadog's user interface.
-  // [#comment: This feature can drastically increase the number of connections to the Datadog Agent.
+  // This feature can drastically increase the number of connections to the Datadog Agent.
   // Each tracer regularly polls for configuration updates, and the number of tracers is the product
-  // of the number of listeners and worker threads.]
+  // of the number of listeners and worker threads.
   DatadogRemoteConfig remote_config = 4;
 }

--- a/api/envoy/config/trace/v3/datadog.proto
+++ b/api/envoy/config/trace/v3/datadog.proto
@@ -20,15 +20,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the Remote Configuration feature.
 message DatadogRemoteConfig {
-  // Allows to configure and change the tracer behaviour from Datadog's user interface.
-  // Default value is ``false``, which disable the feature.
-  // [#comment: This feature can drastically increase the number of connections to the Datadog Agent.
-  // Each tracer regularly polls for configuration updates, and the number of tracers is the product
-  // of the number of listeners and worker threads.]
-  bool enabled = 1;
-
   // Frequency at which new configuration updates are queried.
-  google.protobuf.Duration polling_interval = 2;
+  // [#comment: If no value is provided, the default value is delegated to the Datadog tracing library.]
+  google.protobuf.Duration polling_interval = 1;
 }
 
 // Configuration for the Datadog tracer.
@@ -47,6 +41,10 @@ message DatadogConfig {
   // that require a specific hostname. Defaults to :ref:`collector_cluster <envoy_v3_api_field_config.trace.v3.DatadogConfig.collector_cluster>` above.
   string collector_hostname = 3;
 
-  // Remote Configuration.
+  // Enables and configures remote configuration.
+  // Remote Configuration allows to configure the tracer from Datadog's user interface.
+  // [#comment: This feature can drastically increase the number of connections to the Datadog Agent.
+  // Each tracer regularly polls for configuration updates, and the number of tracers is the product
+  // of the number of listeners and worker threads.]
   DatadogRemoteConfig remote_config = 4;
 }

--- a/api/envoy/config/trace/v3/datadog.proto
+++ b/api/envoy/config/trace/v3/datadog.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.trace.v3;
 
+import "google/protobuf/duration.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -15,6 +17,19 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.trace
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Datadog tracer]
+
+// Remote Configuration
+message DatadogRemoteConfig {
+  // Allows to configure and change the tracer behaviour from Datadog's UI.
+  // Default value is `false`, which disable the feature.
+  // [#comment: This feature can drastically increase the number of connections to the Datadog Agent.
+  // This is the consequence of each tracer regularly polling for configuration updates, and the number
+  // of tracer is the product of the number of listeners and worker threads.]
+  bool enabled = 1;
+
+  // Frequency at which new configuration updates are queried.
+  google.protobuf.Duration polling_interval = 2;
+}
 
 // Configuration for the Datadog tracer.
 // [#extension: envoy.tracers.datadog]
@@ -31,4 +46,7 @@ message DatadogConfig {
   // Optional hostname to use when sending spans to the collector_cluster. Useful for collectors
   // that require a specific hostname. Defaults to :ref:`collector_cluster <envoy_v3_api_field_config.trace.v3.DatadogConfig.collector_cluster>` above.
   string collector_hostname = 3;
+
+  // Remote Configuration.
+  DatadogRemoteConfig remote_config = 4;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -46,6 +46,10 @@ behavior_changes:
   change: |
     Move ``Continue``, ``SendLocalReply`` and ``RecoverPanic` from ``FilterCallbackHandler`` to ``DecoderFilterCallbacks`` and
     ``EncoderFilterCallbacks``, to support full-duplex processing.
+- area: tracing
+  change: |
+    Datadog: Disabled remote configuration by default.
+    To enable this feature, use the :ref:`remote_config <envoy_v3_api_field_config.trace.v3.DatadogConfig.remote_config` field.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -49,7 +49,7 @@ behavior_changes:
 - area: tracing
   change: |
     Datadog: Disabled remote configuration by default.
-    To enable this feature, use the :ref:`remote_config <envoy_v3_api_field_config.trace.v3.DatadogConfig.remote_config` field.
+    To enable this feature, use the :ref:`remote_config <envoy_v3_api_field_config.trace.v3.DatadogConfig.remote_config>` field.
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*

--- a/source/extensions/tracers/datadog/config.cc
+++ b/source/extensions/tracers/datadog/config.cc
@@ -30,12 +30,16 @@ DatadogTracerFactory::makeConfig(const envoy::config::trace::v3::DatadogConfig& 
     config.service = proto_config.service_name();
   }
 
-  const auto& proto_remote_config = proto_config.remote_config();
-  config.agent.remote_configuration_enabled = proto_remote_config.enabled();
+  if (proto_config.has_remote_config()) {
+    const auto& proto_remote_config = proto_config.remote_config();
+    config.agent.remote_configuration_enabled = true;
 
-  if (proto_remote_config.has_polling_interval()) {
-    config.agent.remote_configuration_poll_interval_seconds =
-        proto_remote_config.polling_interval().seconds();
+    if (proto_remote_config.has_polling_interval()) {
+      config.agent.remote_configuration_poll_interval_seconds =
+          proto_remote_config.polling_interval().seconds();
+    }
+  } else {
+    config.agent.remote_configuration_enabled = false;
   }
 
   config.integration_name = "envoy";

--- a/source/extensions/tracers/datadog/config.cc
+++ b/source/extensions/tracers/datadog/config.cc
@@ -30,6 +30,14 @@ DatadogTracerFactory::makeConfig(const envoy::config::trace::v3::DatadogConfig& 
     config.service = proto_config.service_name();
   }
 
+  const auto& proto_remote_config = proto_config.remote_config();
+  config.agent.remote_configuration_enabled = proto_remote_config.enabled();
+
+  if (proto_remote_config.has_polling_interval()) {
+    config.agent.remote_configuration_poll_interval_seconds =
+        proto_remote_config.polling_interval().seconds();
+  }
+
   config.integration_name = "envoy";
   config.integration_version = Envoy::VersionInfo::version();
 

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -94,6 +94,11 @@ public:
   Event::SimulatedTimeSystem time_;
 };
 
+TEST_F(DatadogConfigTest, DefaultConfiguration) {
+  envoy::config::trace::v3::DatadogConfig datadog_config;
+  EXPECT_EQ(datadog_config.remote_config().enabled(), false);
+}
+
 TEST_F(DatadogConfigTest, ConfigureTracer) {
   {
     envoy::config::trace::v3::DatadogConfig datadog_config;
@@ -110,8 +115,14 @@ TEST_F(DatadogConfigTest, ConfigureTracer) {
   }
 
   {
-    auto datadog_config =
-        makeConfig<envoy::config::trace::v3::DatadogConfig>("collector_cluster: fake_cluster");
+    const std::string yaml_conf = R"EOF(
+      collector_cluster: fake_cluster
+      remote_config:
+        enabled: true
+    )EOF";
+
+    auto datadog_config = makeConfig<envoy::config::trace::v3::DatadogConfig>(yaml_conf);
+
     cm_.initializeClusters({"fake_cluster"}, {});
 
     EXPECT_CALL(tls_.dispatcher_, createTimer_(testing::_)).Times(2);
@@ -155,6 +166,9 @@ TEST_F(DatadogConfigTest, ConfigureViaFactory) {
       "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
       collector_cluster: fake_cluster
       service_name: fake_file
+      remote_config:
+        enabled: true
+        polling_interval: "10s"
    )EOF");
 
   DatadogTracerFactory factory;
@@ -171,7 +185,7 @@ TEST_F(DatadogConfigTest, AllowCollectorClusterToBeAddedViaApi) {
   auto datadog_config =
       makeConfig<envoy::config::trace::v3::DatadogConfig>("collector_cluster: fake_cluster");
 
-  EXPECT_CALL(tls_.dispatcher_, createTimer_(testing::_)).Times(2);
+  EXPECT_CALL(tls_.dispatcher_, createTimer_(testing::_));
   Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cm_.thread_local_cluster_.async_client_, send_(_, _, _))
@@ -209,7 +223,7 @@ TEST_F(DatadogConfigTest, CollectorHostname) {
   )EOF");
   cm_.initializeClusters({"fake_cluster"}, {});
 
-  EXPECT_CALL(tls_.dispatcher_, createTimer_(testing::_)).Times(2);
+  EXPECT_CALL(tls_.dispatcher_, createTimer_(testing::_));
   Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cm_.thread_local_cluster_.async_client_, send_(_, _, _))

--- a/test/extensions/tracers/datadog/config_test.cc
+++ b/test/extensions/tracers/datadog/config_test.cc
@@ -96,7 +96,7 @@ public:
 
 TEST_F(DatadogConfigTest, DefaultConfiguration) {
   envoy::config::trace::v3::DatadogConfig datadog_config;
-  EXPECT_EQ(datadog_config.remote_config().enabled(), false);
+  EXPECT_EQ(datadog_config.has_remote_config(), false);
 }
 
 TEST_F(DatadogConfigTest, ConfigureTracer) {
@@ -117,8 +117,7 @@ TEST_F(DatadogConfigTest, ConfigureTracer) {
   {
     const std::string yaml_conf = R"EOF(
       collector_cluster: fake_cluster
-      remote_config:
-        enabled: true
+      remote_config: {}
     )EOF";
 
     auto datadog_config = makeConfig<envoy::config::trace::v3::DatadogConfig>(yaml_conf);
@@ -167,7 +166,6 @@ TEST_F(DatadogConfigTest, ConfigureViaFactory) {
       collector_cluster: fake_cluster
       service_name: fake_file
       remote_config:
-        enabled: true
         polling_interval: "10s"
    )EOF");
 


### PR DESCRIPTION
Commit Message: tracer(datadog): improve remote configuration usability
Additional Description: Remote Configuration has been introduced in https://github.com/envoyproxy/envoy/pull/33294.
It was enabled by default with the only way to configure the feature being an environment variable. This commit disables the feature by default and adds a new fields to enable and configure it from Envoy's configuration.

Here's a snippet for enabling remote configuration with a 10s polling interval:
```yaml
...
          tracing:
            provider:
              name: envoy.tracers.datadog
              typed_config:
                "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
                collector_cluster: datadog_agent
                service_name: envoy-demo
                remote_config:
                  enabled: true
                  polling_interval: "10s"
...
```

Changes:
  - Add configuration options for remote configuration.
  - Disable remote configuration by default.

Risk Level: Low.
Testing: unit test and manual testing.
Docs Changes: NA.
Release Notes: Updated.
Platform Specific Features: NA.
