### PR TITLE
filter-network-redis: Add support for all Bloom 1.0.0 commands, and documentation

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -336,7 +336,7 @@ new_features:
     Added support for all Bloom 1.0.0 commands.
 - area: redis
   change: |
-    Added support for xack, xadd, xautoclaim, xclaim, xdel, xlen, xpending, xrange, xrevrange, xtrim.    
+    Added support for xack, xadd, xautoclaim, xclaim, xdel, xlen, xpending, xrange, xrevrange, xtrim.
 - area: hot_restart
   change: |
     Added new command-line flag :option:`--skip-hot-restart-parent-stats`.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -333,7 +333,10 @@ removed_config_or_runtime:
 new_features:
 - area: redis
   change: |
-    Added support for xack, xadd, xautoclaim, xclaim, xdel, xlen, xpending, xrange, xrevrange, xtrim.
+    Added support for all Bloom 1.0.0 commands.
+- area: redis
+  change: |
+    Added support for xack, xadd, xautoclaim, xclaim, xdel, xlen, xpending, xrange, xrevrange, xtrim.    
 - area: hot_restart
   change: |
     Added new command-line flag :option:`--skip-hot-restart-parent-stats`.

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -265,6 +265,16 @@ For details on each command's usage see the official
   XRANGE, Stream
   XREVRANGE, Stream
   XTRIM, Stream
+  BF.ADD, Bloom
+  BF.CARD, Bloom
+  BF.EXISTS, Bloom
+  BF.INFO, Bloom
+  BF.INSERT, Bloom
+  BF.LOADCHUNK, Bloom
+  BF.MADD, Bloom
+  BF.MEXISTS, Bloom
+  BF.RESERVE, Bloom
+  BF.SCANDUMP, Bloom
 
 Failure modes
 -------------

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -37,15 +37,10 @@ struct SupportedCommands {
         "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan", "zscore");
   }
 
-  BF.ADD, Bloom BF.CARD, Bloom BF.EXISTS, Bloom BF.INFO, Bloom BF.INSERT, Bloom BF.LOADCHUNK,
-      Bloom BF.MADD, Bloom BF.MEXISTS, Bloom BF.RESERVE, Bloom BF.SCANDUMP,
-      Bloom
-
-      /**
-       * @return commands which hash on the fourth argument
-       */
-      static const absl::flat_hash_set<std::string>&
-      evalCommands() {
+  /**
+   * @return commands which hash on the fourth argument
+   */
+  static const absl::flat_hash_set<std::string>& evalCommands() {
     CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha");
   }
 

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -20,26 +20,32 @@ struct SupportedCommands {
    */
   static const absl::flat_hash_set<std::string>& simpleCommands() {
     CONSTRUCT_ON_FIRST_USE(
-        absl::flat_hash_set<std::string>, "append", "bitcount", "bitfield", "bitpos", "decr",
-        "decrby", "dump", "expire", "expireat", "geoadd", "geodist", "geohash", "geopos",
-        "georadius_ro", "georadiusbymember_ro", "get", "getbit", "getdel", "getrange", "getset",
-        "hdel", "hexists", "hget", "hgetall", "hincrby", "hincrbyfloat", "hkeys", "hlen", "hmget",
-        "hmset", "hscan", "hset", "hsetnx", "hstrlen", "hvals", "incr", "incrby", "incrbyfloat",
-        "lindex", "linsert", "llen", "lmove", "lpop", "lpush", "lpushx", "lrange", "lrem", "lset",
-        "ltrim", "persist", "pexpire", "pexpireat", "pfadd", "pfcount", "psetex", "pttl", "restore",
-        "rpop", "rpush", "rpushx", "sadd", "scard", "set", "setbit", "setex", "setnx", "setrange",
-        "sismember", "smembers", "spop", "srandmember", "srem", "sscan", "strlen", "ttl", "type",
-        "watch", "xack", "xadd", "xautoclaim", "xclaim", "xdel", "xlen", "xpending", "xrange",
-        "xrevrange", "xtrim", "zadd", "zcard", "zcount", "zincrby", "zlexcount", "zpopmin",
-        "zpopmax", "zrange", "zrangebylex", "zrangebyscore", "zrank", "zrem", "zremrangebylex",
-        "zremrangebyrank", "zremrangebyscore", "zrevrange", "zrevrangebylex", "zrevrangebyscore",
-        "zrevrank", "zscan", "zscore");
+        absl::flat_hash_set<std::string>, "append", "bf.add", "bf.card", "bf.exists", "bf.info",
+        "bf.insert", "bf.loadchunk", "bf.madd", "bf.mexists", "bf.reserve", "bf.scandump",
+        "bitcount", "bitfield", "bitpos", "decr", "decrby", "dump", "expire", "expireat", "geoadd",
+        "geodist", "geohash", "geopos", "georadius_ro", "georadiusbymember_ro", "get", "getbit",
+        "getdel", "getrange", "getset", "hdel", "hexists", "hget", "hgetall", "hincrby",
+        "hincrbyfloat", "hkeys", "hlen", "hmget", "hmset", "hscan", "hset", "hsetnx", "hstrlen",
+        "hvals", "incr", "incrby", "incrbyfloat", "lindex", "linsert", "llen", "lmove", "lpop",
+        "lpush", "lpushx", "lrange", "lrem", "lset", "ltrim", "persist", "pexpire", "pexpireat",
+        "pfadd", "pfcount", "psetex", "pttl", "restore", "rpop", "rpush", "rpushx", "sadd", "scard",
+        "set", "setbit", "setex", "setnx", "setrange", "sismember", "smembers", "spop",
+        "srandmember", "srem", "sscan", "strlen", "ttl", "type", "watch", "xack", "xadd",
+        "xautoclaim", "xclaim", "xdel", "xlen", "xpending", "xrange", "xrevrange", "xtrim", "zadd",
+        "zcard", "zcount", "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange", "zrangebylex",
+        "zrangebyscore", "zrank", "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore",
+        "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan", "zscore");
   }
 
-  /**
-   * @return commands which hash on the fourth argument
-   */
-  static const absl::flat_hash_set<std::string>& evalCommands() {
+  BF.ADD, Bloom BF.CARD, Bloom BF.EXISTS, Bloom BF.INFO, Bloom BF.INSERT, Bloom BF.LOADCHUNK,
+      Bloom BF.MADD, Bloom BF.MEXISTS, Bloom BF.RESERVE, Bloom BF.SCANDUMP,
+      Bloom
+
+      /**
+       * @return commands which hash on the fourth argument
+       */
+      static const absl::flat_hash_set<std::string>&
+      evalCommands() {
     CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha");
   }
 


### PR DESCRIPTION
Commit Message:
Add support for all the Bloom 1.0.0 commands, they are all based on the first argument (the key)

Additional Description:
Similar to https://github.com/envoyproxy/envoy/pull/35105 but covers all the commands in the group.

Risk Level: Low

Testing: Covered by existing simple command tests

Docs Changes:
Added reference to new commands.

Release Notes:
Added reference to new commands.

Platform Specific Features: N/A