### PR TITLE
fluentd_access_logger: check cluster existance

### DIFF
--- a/source/extensions/access_loggers/fluentd/fluentd_access_log_impl.cc
+++ b/source/extensions/access_loggers/fluentd/fluentd_access_log_impl.cc
@@ -167,6 +167,10 @@ FluentdAccessLoggerCacheImpl::getOrCreateLogger(const FluentdAccessLogConfigShar
   }
 
   auto* cluster = cluster_manager_.getThreadLocalCluster(config->cluster());
+  if (!cluster) {
+    return nullptr;
+  }
+
   auto client =
       cluster->tcpAsyncClient(nullptr, std::make_shared<const Tcp::AsyncTcpClientOptions>(false));
 


### PR DESCRIPTION
Additional Description: If a cluster does not exist at the time of logger creation, Envoy would crash. When running in validation mode, the cluster manager returns ``nullptr`` by design, which causes the process to crash. Fixes #35098
Risk Level: low
Testing: unit tests
Docs Changes: none
Release Notes: none
Platform Specific Features: none