### PR TITLE
mobile: Don't double post proxy resolution to the dispatcher

### DIFF
--- a/mobile/library/common/extensions/filters/http/network_configuration/BUILD
+++ b/mobile/library/common/extensions/filters/http/network_configuration/BUILD
@@ -31,6 +31,7 @@ envoy_cc_extension(
         "//library/common/types:c_types_lib",
         "@envoy//envoy/http:codes_interface",
         "@envoy//envoy/http:filter_interface",
+        "@envoy//source/common/common:thread_lib",
         "@envoy//source/common/grpc:common_lib",
         "@envoy//source/common/grpc:status_lib",
         "@envoy//source/common/http:codes_lib",

--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/server/filter_config.h"
 
+#include "source/common/common/thread.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
 #include "source/common/network/filter_state_proxy_info.h"
@@ -97,6 +98,7 @@ NetworkConfigurationFilter::decodeHeaders(Http::RequestHeaderMap& request_header
 Http::FilterHeadersStatus
 NetworkConfigurationFilter::resolveProxy(Http::RequestHeaderMap& request_headers,
                                          Network::ProxyResolverApi* proxy_resolver) {
+  ASSERT(Thread::MainThread::isMainOrTestThread());
   ASSERT(proxy_resolver != nullptr, "proxy_resolver must not be null.");
 
   const std::string target_url = Http::Utility::buildOriginalUri(request_headers, absl::nullopt);
@@ -105,8 +107,9 @@ NetworkConfigurationFilter::resolveProxy(Http::RequestHeaderMap& request_headers
   Network::ProxyResolutionResult proxy_resolution_result = proxy_resolver->resolver->resolveProxy(
       target_url, proxy_settings_,
       [&weak_self](const std::vector<Network::ProxySettings>& proxies) {
+        ASSERT(Thread::MainThread::isMainOrTestThread());
         // This is the callback invoked from the Apple APIs resolving the PAC file URL, which
-        // happens on a separate Apple run loop thread. We keep a weak_ptr to this filter instance
+        // gets invoked on the Envoy thread. We keep a weak_ptr to this filter instance
         // so that, if the stream is canceled and the filter chain is torn down in the meantime,
         // we will fail to aquire the weak_ptr lock and won't execute any callbacks on the resolved
         // proxies.

--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -111,8 +111,9 @@ NetworkConfigurationFilter::resolveProxy(Http::RequestHeaderMap& request_headers
         // we will fail to aquire the weak_ptr lock and won't execute any callbacks on the resolved
         // proxies.
         if (auto filter_ptr = weak_self.lock()) {
-          // This call does not need to be posted on the dispatcher, because
-          // onProxyResolutionComplete posts continuing with decoding to the dispatcher already.
+          // This call does not need to be posted on the dispatcher, because all work happens on
+          // the same thread (Envoy Mobile has one thread) and onProxyResolutionComplete posts
+          // the continueDecoding call to the dispatcher already.
           filter_ptr->onProxyResolutionComplete(Network::ProxySettings::create(proxies));
         }
       });

--- a/mobile/library/common/network/apple_pac_proxy_resolver.cc
+++ b/mobile/library/common/network/apple_pac_proxy_resolver.cc
@@ -102,7 +102,7 @@ void ApplePacProxyResolver::resolveProxies(
   CFRunLoopSourceRef run_loop_source = createPacUrlResolverSource(
       cf_proxy_autoconfiguration_file_url, cf_target_url, context.release());
 
-  CFRunLoopAddSource(CFRunLoopGetMain(), run_loop_source, kCFRunLoopDefaultMode);
+  CFRunLoopAddSource(CFRunLoopGetCurrent(), run_loop_source, kCFRunLoopDefaultMode);
 
   CFRelease(cf_target_url);
   CFRelease(cf_proxy_autoconfiguration_file_url);


### PR DESCRIPTION
`onProxyResolutionCallback()` already posts the `continueDecoding()` call to the dispatcher,
so once a `shared_ptr` has been obtained from the `weak_ptr`, directly invoke `onProxyResolutionCallback()`.