### PR TITLE
xDS: update GCP auth filter config for compatibility with gRPC

### DIFF
--- a/api/envoy/extensions/filters/http/gcp_authn/v3/BUILD
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -23,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.gcp_authn]
 
 // Filter configuration.
+// [#next-free-field: 7]
 message GcpAuthnFilterConfig {
   // The HTTP URI to fetch tokens from GCE Metadata Server(https://cloud.google.com/compute/docs/metadata/overview).
   // The URL format is "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=[AUDIENCE]"
@@ -32,7 +33,8 @@ message GcpAuthnFilterConfig {
   // The cluster and timeout can be configured using the `cluster` and `timeout` fields instead.
   // For backward compatibility, the cluster and timeout configured in this field will be used
   // if the new `cluster` and `timeout` fields are not set.
-  config.core.v3.HttpUri http_uri = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+  config.core.v3.HttpUri http_uri = 1
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Retry policy for fetching tokens. This field is optional.
   // Not supported by all data planes.

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -5,6 +5,7 @@ package envoy.extensions.filters.http.gcp_authn.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/http_uri.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -30,9 +30,9 @@ message GcpAuthnFilterConfig {
   //
   // This field is deprecated because it does not match the API surface provided by the google auth libraries.
   // Control planes should not attempt to override the metadata server URI.
-  // The cluster and timeout can be configured using the `cluster` and `timeout` fields instead.
+  // The cluster and timeout can be configured using the ``cluster`` and ``timeout`` fields instead.
   // For backward compatibility, the cluster and timeout configured in this field will be used
-  // if the new `cluster` and `timeout` fields are not set.
+  // if the new ``cluster`` and ``timeout`` fields are not set.
   config.core.v3.HttpUri http_uri = 1
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -29,6 +29,8 @@ message GcpAuthnFilterConfig {
   // This field is deprecated because it does not match the API surface provided by the google auth libraries.
   // Control planes should not attempt to override the metadata server URI.
   // The cluster and timeout can be configured using the `cluster` and `timeout` fields instead.
+  // For backward compatibility, the cluster and timeout configured in this field will be used
+  // if the new `cluster` and `timeout` fields are not set.
   config.core.v3.HttpUri http_uri = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Retry policy for fetching tokens. This field is optional.

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/http_uri.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -24,9 +25,14 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message GcpAuthnFilterConfig {
   // The HTTP URI to fetch tokens from GCE Metadata Server(https://cloud.google.com/compute/docs/metadata/overview).
   // The URL format is "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=[AUDIENCE]"
-  config.core.v3.HttpUri http_uri = 1 [(validate.rules).message = {required: true}];
+  //
+  // This field is deprecated because it does not match the API surface provided by the google auth libraries.
+  // Control planes should not attempt to override the metadata server URI.
+  // The cluster and timeout can be configured using the `cluster` and `timeout` fields instead.
+  config.core.v3.HttpUri http_uri = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Retry policy for fetching tokens. This field is optional.
+  // Not supported by all data planes.
   config.core.v3.RetryPolicy retry_policy = 2;
 
   // Token cache configuration. This field is optional.
@@ -34,7 +40,22 @@ message GcpAuthnFilterConfig {
 
   // Request header location to extract the token. By default (i.e. if this field is not specified), the token
   // is extracted to the Authorization HTTP header, in the format "Authorization: Bearer <token>".
-  TokenHeader token_header = 4;
+  //
+  // This field is deprecated because it does not match the API surface provided by the google auth libraries.
+  // Control planes should not attempt to override the token header.
+  TokenHeader token_header = 4 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+  // Cluster to send traffic to the GCE metadata server. Not supported
+  // by all data planes; a data plane may instead have its own mechanism
+  // for contacting the metadata server.
+  string cluster = 5 [(validate.rules).string = {min_len: 1}];
+
+  // Timeout for fetching the tokens from the GCE metadata server.
+  // Not supported by all data planes.
+  google.protobuf.Duration timeout = 6 [(validate.rules).duration = {
+    lt {seconds: 4294967296}
+    gte {}
+  }];
 }
 
 // Audience is the URL of the receiving service that performs token authentication.

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -51,7 +51,7 @@ message GcpAuthnFilterConfig {
   // Cluster to send traffic to the GCE metadata server. Not supported
   // by all data planes; a data plane may instead have its own mechanism
   // for contacting the metadata server.
-  string cluster = 5 [(validate.rules).string = {min_len: 1}];
+  string cluster = 5;
 
   // Timeout for fetching the tokens from the GCE metadata server.
   // Not supported by all data planes.

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -43,10 +43,8 @@ message GcpAuthnFilterConfig {
 
   // Request header location to extract the token. By default (i.e. if this field is not specified), the token
   // is extracted to the Authorization HTTP header, in the format "Authorization: Bearer <token>".
-  //
-  // This field is deprecated because it does not match the API surface provided by the google auth libraries.
-  // Control planes should not attempt to override the token header.
-  TokenHeader token_header = 4 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+  // Not supported by all data planes.
+  TokenHeader token_header = 4;
 
   // Cluster to send traffic to the GCE metadata server. Not supported
   // by all data planes; a data plane may instead have its own mechanism


### PR DESCRIPTION
Commit Message: xDS: update GCP auth filter config for compatibility with gRPC
Additional Description: gRPC is implementing support for this filter.  However, most gRPC implementations will delegate to the existing google auth libraries for the actual token functionality, and those libraries do not allow configuring many of the parameters present in this configuration.  This PR updates the config accordingly.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @tyxia 