### PR TITLE
proto_utility: remove printing the proto message before throwing

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -208,7 +208,7 @@ void ProtoExceptionUtil::throwMissingFieldException(const std::string& field_nam
 void ProtoExceptionUtil::throwProtoValidationException(const std::string& validation_error,
                                                        const Protobuf::Message& message) {
   std::string error = fmt::format("Proto constraint validation failed ({}): {}", validation_error,
-                                  message.DebugString());
+                                  message.GetTypeName());
   throwEnvoyExceptionOrPanic(error);
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -269,6 +269,15 @@ TEST_F(ProtobufUtilityTest, DowncastAndValidateUnknownFieldsNested) {
                            {1}));
 }
 
+// Proto validation exception thrown should not print the debug string of the message.
+TEST_F(ProtobufUtilityTest, ValidationExceptionThrown) {
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  EXPECT_THROW_WITH_MESSAGE(
+      ProtoExceptionUtil::throwProtoValidationException("validation error", bootstrap),
+      EnvoyException,
+      "Proto constraint validation failed (validation error): envoy.config.bootstrap.v3.Bootstrap");
+}
+
 // Validated exception thrown when observed nested unknown field with any.
 TEST_F(ProtobufUtilityTest, ValidateUnknownFieldsNestedAny) {
   // Constructs a nested message with unknown field

--- a/test/extensions/string_matcher/lua/lua_test.cc
+++ b/test/extensions/string_matcher/lua/lua_test.cc
@@ -91,9 +91,9 @@ TEST(LuaStringMatcher, NoCode) {
 
   LuaStringMatcherFactory factory;
   ::envoy::extensions::string_matcher::lua::v3::Lua empty_config;
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createStringMatcher(empty_config, context), EnvoyException,
-      "Proto constraint validation failed (LuaValidationError.SourceCode: value is required): ");
+  EXPECT_THROW_WITH_MESSAGE(factory.createStringMatcher(empty_config, context), EnvoyException,
+                            "Proto constraint validation failed (LuaValidationError.SourceCode: "
+                            "value is required): envoy.extensions.string_matcher.lua.v3.Lua");
 
   empty_config.mutable_source_code()->set_inline_string("");
   EXPECT_THROW_WITH_MESSAGE(factory.createStringMatcher(empty_config, context), EnvoyException,


### PR DESCRIPTION
The `proto2::Message::DebugString` call may crash on certain invalid proto messages and won't throw proto validation exception.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: proto_utility: remove printing the proto message before throwing
Additional Description: The `proto2::Message::DebugString` call may crash on certain invalid proto messages and won't throw proto validation exception.
Risk Level: Low
Testing: Manual testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
