### PR TITLE
report human readable conn error msg

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -753,7 +753,7 @@ void ConnectionImpl::onWriteReady() {
         return;
       }
     } else {
-      setFailureReason(absl::StrCat("delayed connect error: ", error));
+      setFailureReason(absl::StrCat("delayed connect error: ", errorDetails(error)));
       ENVOY_CONN_LOG_EVENT(debug, "connection_error", "{}", *this, transportFailureReason());
       closeSocket(ConnectionEvent::RemoteClose);
       return;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: report human readable delayed connection error message
Additional Description: turns "delayed_connect_error:_111" into "delayed_connect_error:_ECONNREFUSED" (or similar)
Risk Level: low? I don't really know what I'm doing. I'm just copying the fix for #20313
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
