### PR TITLE
Router filter security posture label update

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -56,7 +56,9 @@ steps:
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)
-
+  run: |
+    echo "jobs #:"
+    echo $(RbeJobs)
   displayName: "Run CI script ${{ parameters.ciTarget }}"
 
 - bash: |

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -56,7 +56,7 @@ steps:
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)
-  run: |
+  bash: |
     echo "jobs #:"
     echo $(RbeJobs)
   displayName: "Run CI script ${{ parameters.ciTarget }}"

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -56,7 +56,7 @@ steps:
     ${{ if eq(parameters.rbe, false) }}:
       BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: $(LocalBuildCache)
-  bash: |
+- bash: |
     echo "jobs #:"
     echo $(RbeJobs)
   displayName: "Run CI script ${{ parameters.ciTarget }}"

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -37,7 +37,9 @@ stages:
         key: "format | ./WORKSPACE | **/*.bzl"
         path: $(Build.StagingDirectory)/repository_cache
       continueOnError: true
-
+    - bash: |
+        echo "RbeJobs="
+        echo $(RbeJobs)
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format'
       workingDirectory: $(Build.SourcesDirectory)
       env:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -21,6 +21,7 @@ jobs:
      id: build
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      env:
+       TEST_NON_CFL: abc
        CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
        CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -2,6 +2,7 @@ name: CIFuzzTest
 on:
   pull_request_target:
     branches:
+      - main
       - cifuzz-workflow
     paths:
       - '**.c'

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -20,10 +20,10 @@ jobs:
    - name: Testing secret access
      run: |
        echo "token is"
-       echo t1 ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
+       echo ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
-     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      env:
        CFL_EXTRA_BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
@@ -33,7 +33,7 @@ jobs:
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cifuzz-rbe-integration
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -20,7 +20,9 @@ jobs:
    - name: Testing secret access
      env:
        CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
-     run: echo "token is $CFL_EXTRA_BAZEL_TOKEN"
+     run: |
+       echo "token is"
+       echo ${{secrets.GCP_RBE_TOKEN}} | sed 's/./& /g'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,0 +1,41 @@
+name: CIFuzz
+on:
+  pull_request:
+    branches:
+      - master
+      - 'releases/**'
+      - CIFuzz-Integration
+    paths:
+      - '**.c'
+      - '**.cc'
+      - '**.cpp'
+      - '**.cxx'
+      - '**.h'
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   strategy:
+     fail-fast: false
+     matrix:
+       sanitizer: [address, undefined, memory]
+   steps:
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'envoy'
+       language: c++
+       sanitizer: ${{ matrix.sanitizer }}
+   - name: Run Fuzzers (${{ matrix.sanitizer }})
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'envoy'
+       language: c++
+       fuzz-seconds: 600
+       sanitizer: ${{ matrix.sanitizer }}
+   - name: Upload Crash
+     uses: actions/upload-artifact@v1
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: ${{ matrix.sanitizer }}-artifacts
+       path: ./out/artifacts

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,8 +1,8 @@
 name: CIFuzz
 on:
-  pull_request:
+  pull_request_target:
     branches:
-      - main
+      - cifuzz-workflow
     paths:
       - '**.c'
       - '**.cc'
@@ -11,7 +11,6 @@ on:
 jobs:
  Fuzzing:
    runs-on: ubuntu-latest
-   environment: test
    strategy:
      fail-fast: false
      matrix:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -20,11 +20,11 @@ jobs:
    steps:
    - name: Testing secret access
      env:
-       CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
+       CFL_EXTRA_BAZEL_TOKEN: ${{ secrets.GCP_RBE_TOKEN }}
      run: |
        echo "token is"
-       echo ${{secrets.GCP_GITHUB_CI_KEY}} | sed -e 's/^\(.\{5\}\).*/\1/'
-       echo ${{secrets.GCP_RBE_TOKEN}} | sed -e 's/^\(.\{5\}\).*/\1/'
+       echo ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
+       echo ${{ secrets.GCP_RBE_TOKEN }} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration
@@ -33,7 +33,7 @@ jobs:
        CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
        CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
-       CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_GITHUB_CI_KEY}}
+       CFL_EXTRA_BAZEL_TOKEN: ${{ secrets.GCP_GITHUB_CI_KEY }}
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -23,8 +23,8 @@ jobs:
        CFL_EXTRA_BAZEL_TOKEN: ${{ secrets.GCP_RBE_TOKEN }}
      run: |
        echo "token is"
-       echo ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
-       echo ${{ secrets.GCP_RBE_TOKEN }} | sed -e 's/^\(.\{5\}\).*/\1/'
+       echo t1 ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
+       echo t2 ${{ secrets.GCP_RBE_TOKEN }} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -21,12 +21,14 @@ jobs:
        type: string
        default: "--flaky_test_attempts=2"
    steps:
-   - name: Build Fuzzers (${{ matrix.sanitizer }})
+   - name: Build Fuzzers test
      env:
        CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) ${{ parameters.bazelBuildExtraOptions }}"
        CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
      run: echo "$CFL_EXTRA_BAZEL_BUILD_OPTIONS"
+
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -16,8 +16,17 @@ jobs:
      fail-fast: false
      matrix:
        sanitizer: [address]
+   parameters:
+     - name: bazelBuildExtraOptions
+       type: string
+       default: "--flaky_test_attempts=2"
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
+     env:
+       CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) ${{ parameters.bazelBuildExtraOptions }}"
+       CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+       CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+     run: echo "$CFL_EXTRA_BAZEL_BUILD_OPTIONS"
      id: build
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -17,16 +17,13 @@ jobs:
      matrix:
        sanitizer: [address]
    steps:
-   - name: Build Fuzzers test
-     env:
-       CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) --flaky_test_attempts=2"
-       CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
-       CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
-     run: echo "$CFL_EXTRA_BAZEL_BUILD_OPTIONS"
-
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     env:
+       CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
+       CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+       CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -23,7 +23,7 @@ jobs:
        CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
      run: |
        echo "token is"
-       echo ${{secrets.GCP_RBE_TOKEN}} | sed 's/./& /g'
+       echo ${{secrets.GCP_GITHUB_CI_KEY}} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration
@@ -32,10 +32,8 @@ jobs:
        CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
        CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
-       CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
+       CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_GITHUB_CI_KEY}}
      with:
-       repository: krajshiva/oss-fuzz
-       ref: cifuzz-rbe-integration
        oss-fuzz-project-name: 'envoy'
        language: c++
        sanitizer: ${{ matrix.sanitizer }}

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -2,9 +2,7 @@ name: CIFuzz
 on:
   pull_request:
     branches:
-      - master
-      - 'releases/**'
-      - CIFuzz-Integration
+      - main
     paths:
       - '**.c'
       - '**.cc'

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -30,6 +30,8 @@ jobs:
        oss-fuzz-project-name: 'envoy'
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
+   - name: Testing secret access
+     run: echo "$CFL_EXTRA_BAZEL_TOKEN"
    - name: Run Fuzzers (${{ matrix.sanitizer }})
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cifuzz-rbe-integration
      with:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -40,8 +40,7 @@ jobs:
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@v3
-     ref: cifuzz-rbe-integration
+     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cifuzz-rbe-integration
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -16,14 +16,10 @@ jobs:
      fail-fast: false
      matrix:
        sanitizer: [address]
-   parameters:
-     - name: bazelBuildExtraOptions
-       type: string
-       default: "--flaky_test_attempts=2"
    steps:
    - name: Build Fuzzers test
      env:
-       CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) ${{ parameters.bazelBuildExtraOptions }}"
+       CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) --flaky_test_attempts=2"
        CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
      run: echo "$CFL_EXTRA_BAZEL_BUILD_OPTIONS"

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -2,7 +2,11 @@ name: CIFuzz
 on:
   pull_request:
     branches:
-      - main
+      - master
+      -   pull_request:
+    branches:
+      - master
+      - 'releases/**'
     paths:
       - '**.c'
       - '**.cc'
@@ -15,7 +19,7 @@ jobs:
    strategy:
      fail-fast: false
      matrix:
-       sanitizer: [address, undefined, memory]
+       sanitizer: [address]
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -25,6 +25,7 @@ jobs:
        CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
        CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+       CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -34,11 +34,14 @@ jobs:
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
        CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
      with:
+       repository: krajshiva/oss-fuzz
+       ref: cifuzz-rbe-integration
        oss-fuzz-project-name: 'envoy'
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cifuzz-rbe-integration
+     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@v3
+     ref: cifuzz-rbe-integration
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
  Fuzzing:
    runs-on: ubuntu-latest
+   environment: test
    strategy:
      fail-fast: false
      matrix:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -7,7 +7,6 @@ on:
       - '**.c'
       - '**.cc'
       - '**.cpp'
-      - '**.cxx'
       - '**.h'
 jobs:
  Fuzzing:
@@ -19,19 +18,14 @@ jobs:
        sanitizer: [address]
    steps:
    - name: Testing secret access
-     env:
-       CFL_EXTRA_BAZEL_TOKEN: ${{ secrets.GCP_RBE_TOKEN }}
      run: |
        echo "token is"
        echo t1 ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
-       echo t2 ${{ secrets.GCP_RBE_TOKEN }} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration
      env:
-       TEST_NON_CFL: abc
-       CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
-       CFL_EXTRA_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+       CFL_EXTRA_BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
        CFL_EXTRA_BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
        CFL_EXTRA_BAZEL_TOKEN: ${{ secrets.GCP_GITHUB_CI_KEY }}
      with:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -24,6 +24,7 @@ jobs:
      run: |
        echo "token is"
        echo ${{secrets.GCP_GITHUB_CI_KEY}} | sed -e 's/^\(.\{5\}\).*/\1/'
+       echo ${{secrets.GCP_RBE_TOKEN}} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -19,7 +19,7 @@ jobs:
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
-     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration
      env:
        TEST_NON_CFL: abc
        CFL_EXTRA_BAZEL_BUILD_OPTIONS: "--config=remote-ci --flaky_test_attempts=2"
@@ -30,7 +30,7 @@ jobs:
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cifuzz-rbe-integration
      with:
        oss-fuzz-project-name: 'envoy'
        language: c++

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,4 +1,4 @@
-name: CIFuzz
+name: CIFuzzTest
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - master
-      -   pull_request:
-    branches:
-      - master
       - 'releases/**'
     paths:
       - '**.c'

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -17,6 +17,10 @@ jobs:
      matrix:
        sanitizer: [address]
    steps:
+   - name: Testing secret access
+     env:
+       CFL_EXTRA_BAZEL_TOKEN: ${{secrets.GCP_RBE_TOKEN}}
+     run: echo "token is $CFL_EXTRA_BAZEL_TOKEN"
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/build_fuzzers@cifuzz-rbe-integration
@@ -30,8 +34,6 @@ jobs:
        oss-fuzz-project-name: 'envoy'
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
-   - name: Testing secret access
-     run: echo "$CFL_EXTRA_BAZEL_TOKEN"
    - name: Run Fuzzers (${{ matrix.sanitizer }})
      uses: krajshiva/oss-fuzz/infra/cifuzz/actions/run_fuzzers@cifuzz-rbe-integration
      with:

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -2,8 +2,7 @@ name: CIFuzz
 on:
   pull_request:
     branches:
-      - master
-      - 'releases/**'
+      - main
     paths:
       - '**.c'
       - '**.cc'

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -18,7 +18,7 @@ jobs:
    steps:
    - name: Testing secret access
      run: |
-       echo "token is"
+       echo "token is:"
        echo ${{ secrets.GCP_GITHUB_CI_KEY }} | sed -e 's/^\(.\{5\}\).*/\1/'
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -422,7 +422,7 @@ envoy.filters.http.rbac:
 envoy.filters.http.router:
   categories:
   - envoy.filters.http
-  security_posture: robust_to_untrusted_downstream
+  security_posture: robust_to_untrusted_downstream_and_upstream
   status: stable
   type_urls:
   - envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
Commit Message: Updating security posture of http router filter from robust_to_downstream to robust_to_downstream_and_upstream.

Additional Description: It seems Router filter is mislabeled as robust_to_downstream when it should be robust_to_downstream_and_upstream as it doesn't process responses and has been one of the last filters used for L7 load balancing in a typical edge deployment.  AFAICT, it also matches guidelines for robustness mentioned here https://github.com/envoyproxy/envoy/blob/main/EXTENSION_POLICY.md#extension-stability-and-security-posture
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
