### PR TITLE
conn_pool: TCP pool failure if H3 pool is still connecting in connectivity grid

### DIFF
--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -133,6 +133,11 @@ void ConnectivityGrid::WrapperCallbacks::onConnectionAttemptFailed(
 
   // If there is another connection attempt in flight then let that proceed.
   if (!connection_attempts_.empty()) {
+    if (!grid_.isPoolHttp3(attempt->pool())) {
+      // TCP pool failed before HTTP/3 pool.
+      prev_tcp_pool_failure_reason_ = reason;
+      prev_tcp_pool_transport_failure_reason_ = transport_failure_reason;
+    }
     return;
   }
 
@@ -154,6 +159,15 @@ void ConnectivityGrid::WrapperCallbacks::signalFailureAndDeleteSelf(
   deleteThis();
   if (callbacks != nullptr) {
     ENVOY_LOG(trace, "Passing pool failure up to caller.");
+    std::string failure_str;
+    if (prev_tcp_pool_failure_reason_.has_value()) {
+      // TCP pool failed early on, log its error details as well.
+      failure_str = fmt::format("{} (with earlier TCP attempt failure reason {}, {})",
+                                transport_failure_reason,
+                                static_cast<int>(prev_tcp_pool_failure_reason_.value()),
+                                prev_tcp_pool_transport_failure_reason_);
+      transport_failure_reason = failure_str;
+    }
     callbacks->onPoolFailure(reason, transport_failure_reason, host);
   }
 }

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -172,6 +172,8 @@ public:
     bool tcp_attempt_succeeded_{};
     // Latch the passed-in stream options.
     const Instance::StreamOptions stream_options_{};
+    absl::optional<ConnectionPool::PoolFailureReason> prev_tcp_pool_failure_reason_;
+    std::string prev_tcp_pool_transport_failure_reason_;
   };
   using WrapperCallbacksPtr = std::unique_ptr<WrapperCallbacks>;
 

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -47,14 +47,17 @@ struct ConnPoolCallbacks : public Http::ConnectionPool::Callbacks {
     pool_ready_.ready();
   }
 
-  void onPoolFailure(ConnectionPool::PoolFailureReason reason, absl::string_view,
+  void onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                     absl::string_view transport_failure_reason,
                      Upstream::HostDescriptionConstSharedPtr host) override {
     host_ = host;
     reason_ = reason;
+    transport_failure_reason_ = transport_failure_reason;
     pool_failure_.ready();
   }
 
   ConnectionPool::PoolFailureReason reason_;
+  std::string transport_failure_reason_;
   testing::NiceMock<ReadyWatcher> pool_failure_;
   testing::NiceMock<ReadyWatcher> pool_ready_;
   Http::RequestEncoder* outer_encoder_{};


### PR DESCRIPTION
Commit Message: make ConnectivityGrid to retain TCP pool failure reason enum and transport failure reason string if there is any H3 pool still connecting. This is unexpected case, though we observed it in production. The retained TCP failure details will be appended to the transport_failure_reason which gets propagated via onPoolFailure() callback and reported in stream intel in E-M to assist debugging.

Risk Level: low, logging only
Testing: new unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
