### PR TITLE
update security label for router filter

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -526,7 +526,7 @@ envoy.filters.http.rbac:
 envoy.filters.http.router:
   categories:
   - envoy.filters.http
-  security_posture: robust_to_untrusted_downstream
+  security_posture: robust_to_untrusted_downstream_and_upstream
   status: stable
   type_urls:
   - envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION

Commit Message: Updating security posture of http router filter from robust_to_downstream to robust_to_downstream_and_upstream.

Additional Description: It seems Router filter is mislabeled as robust_to_downstream when it should be robust_to_downstream_and_upstream as it doesn't process responses and has been one of the last filters used for L7 load balancing in a typical edge deployment. AFAICT, it also matches guidelines for robustness mentioned here https://github.com/envoyproxy/envoy/blob/main/EXTENSION_POLICY.md#extension-stability-and-security-posture

Risk Level:Low
Testing: NA
Docs Changes: Y
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
