### PR TITLE
Add the sample() convenience function in CEL expression builder

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -274,4 +274,7 @@ new_features:
     Added :ref:`external_auth_provider <envoy_v3_api_msg_extensions.filters.network.redis_proxy.v3.RedisProxy>` to support
     external authentication for redis proxy.
 
+- area: cel
+  change: |
+    Added the ``context`` attribute and the ``request.sample(p, i)`` and ``context.sample(p, i)`` convenience functions.
 deprecated:

--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -16,6 +16,7 @@ Attribute value types are limited to:
 * ``bytes`` for byte buffers
 * ``int`` for 64-bit signed integers
 * ``uint`` for 64-bit unsigned integers
+* ``double`` for 64-bit floating point numbers
 * ``bool`` for booleans
 * ``list`` for lists of values
 * ``map`` for associative arrays with string keys
@@ -61,6 +62,7 @@ processing, which makes them suitable for RBAC policies.
    request.id, string, Request ID corresponding to ``x-request-id`` header value
    request.protocol, string, "Request protocol ('"HTTP/1.0'", '"HTTP/1.1'", '"HTTP/2'", or '"HTTP/3'")"
    request.query, string, The query portion of the URL in the format of "name1=value1&name2=value2".
+   request.random_value, uint, A random integer sourced from the Request ID if possible else generated.
 
 Header values in ``request.headers`` associative array are comma-concatenated in case of multiple values.
 
@@ -73,6 +75,14 @@ Additional attributes are available once the request completes:
    request.duration, duration, Total duration of the request
    request.size, int, Size of the request body. Content length header is used if available.
    request.total_size, int, Total size of the request including the approximate uncompressed size of the headers
+
+The Request group also provides the following instance functions:
+
+.. csv-table::
+   :header: Function, Type, Description
+   :widths: 1, 1, 4
+
+   "request.sample(p, i)", "request.(double, int) -> bool", "Deterministically returns true with a probability of p based on i"
 
 Response attributes
 -------------------
@@ -151,6 +161,25 @@ The following attributes are available once the upstream connection is establish
    upstream.sha256_peer_certificate_digest, string, SHA256 digest of the peer certificate in the upstream TLS connection if present
    upstream.local_address, string, The local address of the upstream connection
    upstream.transport_failure_reason, string, The upstream transport failure reason e.g. certificate validation failed
+
+Context attributes
+-------------------------
+
+The following attributes are provided per expression for utility purposes:
+
+.. csv-table::
+   :header: Attribute, Type, Description
+   :widths: 1, 1, 4
+
+   context.random_value, uint, A random integer generated per expression invocation
+
+The Context group also provides the following instance functions:
+
+.. csv-table::
+   :header: Function, Type, Description
+   :widths: 1, 1, 4
+
+   "context.sample(p, i)", "context.(double, int) -> bool", "Deterministically returns true with a probability of p based on i"
 
 Metadata and filter state
 -------------------------

--- a/envoy/matcher/BUILD
+++ b/envoy/matcher/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "abseil_hash",
     ],
     deps = [
+        "//envoy/common:random_generator_interface",
         "//envoy/config:typed_config_interface",
         "//envoy/protobuf:message_validator_interface",
         "@com_github_cncf_xds//xds/type/matcher/v3:pkg_cc_proto",

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "envoy/common/pure.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/config/common/matcher/v3/matcher.pb.h"
 #include "envoy/config/core/v3/extension.pb.h"
 #include "envoy/config/typed_config.h"
@@ -285,7 +286,8 @@ public:
    */
   virtual DataInputFactoryCb<DataType>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                           Random::RandomGenerator& random) PURE;
 
   /**
    * The category of this factory depends on the DataType, so we require a name() function to exist

--- a/source/common/http/matching/inputs.h
+++ b/source/common/http/matching/inputs.h
@@ -55,7 +55,8 @@ public:
 
   Matcher::DataInputFactoryCb<HttpMatchingData>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) override {
+                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                           Random::RandomGenerator&) override {
     const auto& typed_config =
         MessageUtil::downcastAndValidate<const ProtoType&>(config, validation_visitor);
 
@@ -182,7 +183,8 @@ public:
 
   Matcher::DataInputFactoryCb<HttpMatchingData>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) override {
+                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                           Random::RandomGenerator&) override {
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::type::matcher::v3::HttpRequestQueryParamMatchInput&>(config,
                                                                           validation_visitor);

--- a/source/common/http/matching/status_code_input.h
+++ b/source/common/http/matching/status_code_input.h
@@ -76,7 +76,8 @@ public:
   std::string name() const override { return name_; }
 
   Matcher::DataInputFactoryCb<HttpMatchingData>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
 
     return [] { return std::make_unique<DataInputType>(); };
   };

--- a/source/common/network/matching/inputs.h
+++ b/source/common/network/matching/inputs.h
@@ -21,7 +21,8 @@ public:
   std::string name() const override { return "envoy.matching.inputs." + name_; }
 
   Matcher::DataInputFactoryCb<MatchingDataType>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<InputType>(); };
   };
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -324,8 +324,8 @@ RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(
         // dual registered as an extension descriptor and an HTTP matcher input
         // function, the descriptor extension takes priority.
         RateLimitDescriptorValidationVisitor validation_visitor;
-        Matcher::MatchInputFactory<Http::HttpMatchingData> input_factory(validator,
-                                                                         validation_visitor);
+        Matcher::MatchInputFactory<Http::HttpMatchingData> input_factory(
+            validator, validation_visitor, context.api().randomGenerator());
         Matcher::DataInputFactoryCb<Http::HttpMatchingData> data_input_cb =
             input_factory.createDataInput(action.extension());
         actions_.emplace_back(std::make_unique<MatchInputRateLimitDescriptor>(

--- a/source/common/ssl/matching/inputs.h
+++ b/source/common/ssl/matching/inputs.h
@@ -19,7 +19,8 @@ public:
   std::string name() const override { return "envoy.matching.inputs." + name_; }
 
   Matcher::DataInputFactoryCb<MatchingDataType>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<InputType>(); };
   };
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/access_loggers/filters/cel/cel.cc
+++ b/source/extensions/access_loggers/filters/cel/cel.cc
@@ -10,8 +10,8 @@ namespace Expr = Envoy::Extensions::Filters::Common::Expr;
 
 CELAccessLogExtensionFilter::CELAccessLogExtensionFilter(
     const ::Envoy::LocalInfo::LocalInfo& local_info, Expr::BuilderInstanceSharedPtr builder,
-    const google::api::expr::v1alpha1::Expr& input_expr)
-    : local_info_(local_info), builder_(builder), parsed_expr_(input_expr) {
+    const google::api::expr::v1alpha1::Expr& input_expr, Random::RandomGenerator& random)
+    : local_info_(local_info), builder_(builder), parsed_expr_(input_expr), random_(random) {
   compiled_expr_ = Expr::createExpression(builder_->builder(), parsed_expr_);
 }
 
@@ -20,7 +20,7 @@ bool CELAccessLogExtensionFilter::evaluate(const Formatter::HttpFormatterContext
   Protobuf::Arena arena;
   auto eval_status = Expr::evaluate(*compiled_expr_, arena, &local_info_, stream_info,
                                     &log_context.requestHeaders(), &log_context.responseHeaders(),
-                                    &log_context.responseTrailers());
+                                    &log_context.responseTrailers(), random_.random());
   if (!eval_status.has_value() || eval_status.value().IsError()) {
     return false;
   }

--- a/source/extensions/access_loggers/filters/cel/cel.h
+++ b/source/extensions/access_loggers/filters/cel/cel.h
@@ -21,7 +21,7 @@ class CELAccessLogExtensionFilter : public AccessLog::Filter {
 public:
   CELAccessLogExtensionFilter(const ::Envoy::LocalInfo::LocalInfo& local_info,
                               Extensions::Filters::Common::Expr::BuilderInstanceSharedPtr,
-                              const google::api::expr::v1alpha1::Expr&);
+                              const google::api::expr::v1alpha1::Expr&, Random::RandomGenerator&);
 
   bool evaluate(const Formatter::HttpFormatterContext& log_context,
                 const StreamInfo::StreamInfo& stream_info) const override;
@@ -31,6 +31,7 @@ private:
   Extensions::Filters::Common::Expr::BuilderInstanceSharedPtr builder_;
   const google::api::expr::v1alpha1::Expr parsed_expr_;
   Extensions::Filters::Common::Expr::ExpressionPtr compiled_expr_;
+  Random::RandomGenerator& random_;
 };
 
 } // namespace CEL

--- a/source/extensions/access_loggers/filters/cel/config.cc
+++ b/source/extensions/access_loggers/filters/cel/config.cc
@@ -35,7 +35,7 @@ Envoy::AccessLog::FilterPtr CELAccessLogExtensionFilterFactory::createFilter(
   return std::make_unique<CELAccessLogExtensionFilter>(
       context.serverFactoryContext().localInfo(),
       Extensions::Filters::Common::Expr::getBuilder(context.serverFactoryContext()),
-      parse_status.value().expr());
+      parse_status.value().expr(), context.serverFactoryContext().api().randomGenerator());
 #else
   throw EnvoyException("CEL is not available for use in this environment.");
 #endif

--- a/source/extensions/filters/common/expr/BUILD
+++ b/source/extensions/filters/common/expr/BUILD
@@ -16,12 +16,14 @@ envoy_cc_library(
     deps = [
         ":context_lib",
         "//envoy/singleton:manager_interface",
+        "//source/common/crypto:utility_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf",
         "@com_google_cel_cpp//eval/public:activation",
         "@com_google_cel_cpp//eval/public:builtin_func_registrar",
         "@com_google_cel_cpp//eval/public:cel_expr_builder_factory",
         "@com_google_cel_cpp//eval/public:cel_expression",
+        "@com_google_cel_cpp//eval/public:cel_function",
         "@com_google_cel_cpp//eval/public:cel_value",
     ],
 )
@@ -38,6 +40,8 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/singleton:const_singleton",
         "//source/common/stream_info:utility_lib",
+        "@com_google_cel_cpp//eval/public:cel_function",
+        "@com_google_cel_cpp//eval/public:cel_function_adapter",
         "@com_google_cel_cpp//eval/public:cel_value",
         "@com_google_cel_cpp//eval/public:cel_value_producer",
         "@com_google_cel_cpp//eval/public/containers:container_backed_list_impl",

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -3,6 +3,9 @@
 #include "envoy/common/exception.h"
 #include "envoy/singleton/manager.h"
 
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/crypto/utility.h"
+
 #include "eval/public/builtin_func_registrar.h"
 #include "eval/public/cel_expr_builder_factory.h"
 
@@ -15,8 +18,8 @@ namespace Expr {
 namespace {
 
 #define ACTIVATION_TOKENS(_f)                                                                      \
-  _f(Request) _f(Response) _f(Connection) _f(Upstream) _f(Source) _f(Destination) _f(Metadata)     \
-      _f(FilterState) _f(XDS) _f(UpstreamFilterState)
+  _f(Request) _f(Response) _f(Connection) _f(Context) _f(Upstream) _f(Source) _f(Destination)      \
+      _f(Metadata) _f(FilterState) _f(XDS) _f(UpstreamFilterState)
 
 #define _DECLARE(_t) _t,
 enum class ActivationToken { ACTIVATION_TOKENS(_DECLARE) };
@@ -49,13 +52,16 @@ absl::optional<CelValue> StreamActivation::FindValue(absl::string_view name,
   const StreamInfo::StreamInfo& info = *activation_info_;
   switch (token->second) {
   case ActivationToken::Request:
-    return CelValue::CreateMap(
-        Protobuf::Arena::Create<RequestWrapper>(arena, *arena, activation_request_headers_, info));
+    return CelValue::CreateMap(Protobuf::Arena::Create<RequestWrapper>(
+        arena, *arena, activation_request_headers_, info, random_value_));
   case ActivationToken::Response:
     return CelValue::CreateMap(Protobuf::Arena::Create<ResponseWrapper>(
         arena, *arena, activation_response_headers_, activation_response_trailers_, info));
   case ActivationToken::Connection:
     return CelValue::CreateMap(Protobuf::Arena::Create<ConnectionWrapper>(arena, *arena, info));
+  case ActivationToken::Context:
+    return CelValue::CreateMap(
+        Protobuf::Arena::Create<ContextWrapper>(arena, *arena, random_value_));
   case ActivationToken::Upstream:
     return CelValue::CreateMap(Protobuf::Arena::Create<UpstreamWrapper>(arena, *arena, info));
   case ActivationToken::Source:
@@ -91,9 +97,10 @@ ActivationPtr createActivation(const LocalInfo::LocalInfo* local_info,
                                const StreamInfo::StreamInfo& info,
                                const Http::RequestHeaderMap* request_headers,
                                const Http::ResponseHeaderMap* response_headers,
-                               const Http::ResponseTrailerMap* response_trailers) {
+                               const Http::ResponseTrailerMap* response_trailers,
+                               uint64_t random_value) {
   return std::make_unique<StreamActivation>(local_info, info, request_headers, response_headers,
-                                            response_trailers);
+                                            response_trailers, random_value);
 }
 
 BuilderPtr createBuilder(Protobuf::Arena* arena) {
@@ -107,12 +114,9 @@ BuilderPtr createBuilder(Protobuf::Arena* arena) {
   options.enable_string_conversion = false;
   options.enable_string_concat = false;
   options.enable_list_concat = false;
-
-  // Enable constant folding (performance optimization)
-  if (arena != nullptr) {
-    options.constant_folding = true;
-    options.constant_arena = arena;
-  }
+  options.constant_folding =
+      false; // disable constant folding to prevent random() function from being inlined
+  options.constant_arena = arena;
 
   auto builder = google::api::expr::runtime::CreateCelExpressionBuilder(options);
   auto register_status =
@@ -120,6 +124,16 @@ BuilderPtr createBuilder(Protobuf::Arena* arena) {
   if (!register_status.ok()) {
     throw CelException(
         absl::StrCat("failed to register built-in functions: ", register_status.message()));
+  }
+
+  // Register custom functions
+  auto sample_register_status =
+      CelFunctionAdapter<absl::StatusOr<bool>, const CelMap*, double, int64_t>::CreateAndRegister(
+          Sample,
+          /*receiver_style=*/true, &SampleExtensionFunction, builder->GetRegistry());
+  if (!sample_register_status.ok()) {
+    throw CelException(
+        absl::StrCat("failed to register sample function: ", sample_register_status.message()));
   }
   return builder;
 }
@@ -142,14 +156,13 @@ ExpressionPtr createExpression(Builder& builder, const google::api::expr::v1alph
   return std::move(cel_expression_status.value());
 }
 
-absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena& arena,
-                                  const LocalInfo::LocalInfo* local_info,
-                                  const StreamInfo::StreamInfo& info,
-                                  const Http::RequestHeaderMap* request_headers,
-                                  const Http::ResponseHeaderMap* response_headers,
-                                  const Http::ResponseTrailerMap* response_trailers) {
-  auto activation =
-      createActivation(local_info, info, request_headers, response_headers, response_trailers);
+absl::optional<CelValue>
+evaluate(const Expression& expr, Protobuf::Arena& arena, const LocalInfo::LocalInfo* local_info,
+         const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap* request_headers,
+         const Http::ResponseHeaderMap* response_headers,
+         const Http::ResponseTrailerMap* response_trailers, uint64_t random_value) {
+  auto activation = createActivation(local_info, info, request_headers, response_headers,
+                                     response_trailers, random_value);
   auto eval_status = expr.Evaluate(*activation, &arena);
   if (!eval_status.ok()) {
     return {};
@@ -159,9 +172,10 @@ absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena& arena
 }
 
 bool matches(const Expression& expr, const StreamInfo::StreamInfo& info,
-             const Http::RequestHeaderMap& headers) {
+             const Http::RequestHeaderMap& headers, uint64_t random_value) {
   Protobuf::Arena arena;
-  auto eval_status = Expr::evaluate(expr, arena, nullptr, info, &headers, nullptr, nullptr);
+  auto eval_status =
+      Expr::evaluate(expr, arena, nullptr, info, &headers, nullptr, nullptr, random_value);
   if (!eval_status.has_value()) {
     return false;
   }
@@ -194,6 +208,40 @@ std::string print(CelValue value) {
   default:
     return absl::StrCat(CelValue::TypeName(value.type()), " value");
   }
+}
+
+absl::StatusOr<bool> SampleExtensionFunction(Protobuf::Arena*, const CelMap* map,
+                                             double probability, int64_t idx) {
+  // search for random value
+  absl::optional<CelValue> entry = (*map)[CelValue::CreateStringView(RandomValue)];
+  if (!entry.has_value() || !entry.value().IsUint64()) {
+    return absl::InvalidArgumentError("map missing uint random value key");
+  }
+
+  // bounds check probability
+  if (probability <= 0) {
+    return false;
+  } else if (probability >= 1) {
+    return true;
+  }
+
+  // Generate deterministic random value by generating a sha of a random value
+  // concatenated with the index. Use consistent endianness to ensure consistency
+  // between evaluations across multiple envoy hops.
+  uint64_t seed = entry.value().Uint64OrDie();
+  Buffer::OwnedImpl buffer;
+  buffer.writeLEInt<uint64_t>(seed);
+  buffer.writeLEInt<int64_t>(idx);
+  std::vector<uint8_t> digest =
+      Envoy::Common::Crypto::UtilitySingleton::get().getSha256Digest(buffer);
+  RELEASE_ASSERT(digest.size() >= sizeof(uint64_t), "Missing enough bytes to construct uint64_t");
+  uint64_t* toCopy = reinterpret_cast<uint64_t*>(digest.data());
+  uint64_t randomUint = fromEndianness<ByteOrder::LittleEndian, uint64_t>(*toCopy);
+
+  // copied from Random::RandomGenerator. Negligibly biases high values due to floating point
+  // precision.
+  return randomUint < static_cast<uint64_t>(
+                          probability * static_cast<double>(std::numeric_limits<uint64_t>::max()));
 }
 
 } // namespace Expr

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -261,7 +261,7 @@ bool PolicyMatcher::matches(const Network::Connection& connection,
                             const StreamInfo::StreamInfo& info) const {
   return permissions_.matches(connection, headers, info) &&
          principals_.matches(connection, headers, info) &&
-         (expr_ == nullptr ? true : Expr::matches(*expr_, info, headers));
+         (expr_ == nullptr ? true : Expr::matches(*expr_, info, headers, random_.random()));
 }
 
 bool RequestedServerNameMatcher::matches(const Network::Connection& connection,

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -230,7 +230,8 @@ public:
                 ProtobufMessage::ValidationVisitor& validation_visitor,
                 Server::Configuration::CommonFactoryContext& context)
       : permissions_(policy.permissions(), validation_visitor, context),
-        principals_(policy.principals(), context), condition_(policy.condition()) {
+        principals_(policy.principals(), context), condition_(policy.condition()),
+        random_(context.api().randomGenerator()) {
     if (policy.has_condition()) {
       expr_ = Expr::createExpression(*builder, condition_);
     }
@@ -244,6 +245,7 @@ private:
   const OrMatcher principals_;
   const google::api::expr::v1alpha1::Expr condition_;
   Expr::ExpressionPtr expr_;
+  Random::RandomGenerator& random_;
 };
 
 class MetadataMatcher : public Matcher {

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -209,7 +209,8 @@ FilterConfig::FilterConfig(
       expression_manager_(builder, context.localInfo(), config.request_attributes(),
                           config.response_attributes()),
       immediate_mutation_checker_(context.regexEngine()),
-      thread_local_stream_manager_slot_(context.threadLocal().allocateSlot()) {
+      thread_local_stream_manager_slot_(context.threadLocal().allocateSlot()),
+      random_(context.api().randomGenerator()) {
   if (config.disable_clear_route_cache() &&
       (route_cache_action_ !=
        envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor::DEFAULT)) {
@@ -996,7 +997,8 @@ void Filter::addAttributes(ProcessorState& state, ProcessingRequest& req) {
   auto activation_ptr = Filters::Common::Expr::createActivation(
       &config_->expressionManager().localInfo(), state.callbacks()->streamInfo(),
       state.requestHeaders(), dynamic_cast<const Http::ResponseHeaderMap*>(state.responseHeaders()),
-      dynamic_cast<const Http::ResponseTrailerMap*>(state.responseTrailers()));
+      dynamic_cast<const Http::ResponseTrailerMap*>(state.responseTrailers()),
+      config_->random().random());
   auto attributes = state.evaluateAttributes(config_->expressionManager(), *activation_ptr);
 
   state.setSentAttributes(true);

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -265,6 +265,8 @@ public:
     return thread_local_stream_manager_slot_->getTyped<ThreadLocalStreamManager>();
   }
 
+  Random::RandomGenerator& random() const { return random_; }
+
 private:
   ExtProcFilterStats generateStats(const std::string& prefix,
                                    const std::string& filter_stats_prefix, Stats::Scope& scope) {
@@ -301,6 +303,8 @@ private:
 
   const ImmediateMutationChecker immediate_mutation_checker_;
   ThreadLocal::SlotPtr thread_local_stream_manager_slot_;
+
+  Random::RandomGenerator& random_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -53,7 +53,8 @@ public:
                        Grpc::GrpcServiceConfigWithHashKey config_with_hash_key)
       : config_(std::move(config)), config_with_hash_key_(config_with_hash_key),
         factory_context_(factory_context), quota_buckets_(quota_buckets), client_(client),
-        time_source_(factory_context.serverFactoryContext().mainThreadDispatcher().timeSource()) {
+        time_source_(factory_context.serverFactoryContext().mainThreadDispatcher().timeSource()),
+        random_(factory_context.serverFactoryContext().api().randomGenerator()) {
     createMatcher();
   }
 
@@ -113,6 +114,7 @@ private:
   BucketsCache& quota_buckets_;
   ThreadLocalClient& client_;
   TimeSource& time_source_;
+  Random::RandomGenerator& random_;
 };
 
 } // namespace RateLimitQuota

--- a/source/extensions/filters/http/rate_limit_quota/matcher.cc
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.cc
@@ -32,7 +32,8 @@ RateLimitOnMatchAction::generateBucketId(const Http::Matching::HttpMatchingDataI
       // Initialize the pointer to input factory on first use.
       if (input_factory_ptr == nullptr) {
         input_factory_ptr = std::make_unique<Matcher::MatchInputFactory<Http::HttpMatchingData>>(
-            factory_context.messageValidationVisitor(), visitor);
+            factory_context.messageValidationVisitor(), visitor,
+            factory_context.serverFactoryContext().api().randomGenerator());
       }
       // Create `DataInput` factory callback from the config.
       Matcher::DataInputFactoryCb<Http::HttpMatchingData> data_input_cb =

--- a/source/extensions/filters/network/generic_proxy/match.h
+++ b/source/extensions/filters/network/generic_proxy/match.h
@@ -53,7 +53,8 @@ public:
   }
 
   Matcher::DataInputFactoryCb<MatchInput>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<ServiceMatchDataInput>(); };
   }
 
@@ -77,7 +78,8 @@ public:
   }
 
   Matcher::DataInputFactoryCb<MatchInput>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<HostMatchDataInput>(); };
   }
 
@@ -101,7 +103,8 @@ public:
   }
 
   Matcher::DataInputFactoryCb<MatchInput>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<PathMatchDataInput>(); };
   }
 
@@ -125,7 +128,8 @@ public:
   }
 
   Matcher::DataInputFactoryCb<MatchInput>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<MethodMatchDataInput>(); };
   }
 
@@ -158,7 +162,8 @@ public:
 
   Matcher::DataInputFactoryCb<MatchInput>
   createDataInputFactoryCb(const Protobuf::Message& message,
-                           ProtobufMessage::ValidationVisitor& visitor) override {
+                           ProtobufMessage::ValidationVisitor& visitor,
+                           Random::RandomGenerator&) override {
     const auto& config =
         MessageUtil::downcastAndValidate<const PropertyDataInputProto&>(message, visitor);
     const std::string name = config.property_name();
@@ -202,7 +207,8 @@ public:
   }
 
   Matcher::DataInputFactoryCb<MatchInput>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<RequestMatchDataInput>(); };
   }
 

--- a/source/extensions/formatter/cel/cel.cc
+++ b/source/extensions/formatter/cel/cel.cc
@@ -18,9 +18,9 @@ namespace Expr = Filters::Common::Expr;
 CELFormatter::CELFormatter(const ::Envoy::LocalInfo::LocalInfo& local_info,
                            Expr::BuilderInstanceSharedPtr expr_builder,
                            const google::api::expr::v1alpha1::Expr& input_expr,
-                           absl::optional<size_t>& max_length)
+                           absl::optional<size_t>& max_length, Random::RandomGenerator& random)
     : local_info_(local_info), expr_builder_(expr_builder), parsed_expr_(input_expr),
-      max_length_(max_length) {
+      max_length_(max_length), random_(random) {
   compiled_expr_ = Expr::createExpression(expr_builder_->builder(), parsed_expr_);
 }
 
@@ -30,7 +30,7 @@ CELFormatter::formatWithContext(const Envoy::Formatter::HttpFormatterContext& co
   Protobuf::Arena arena;
   auto eval_status =
       Expr::evaluate(*compiled_expr_, arena, &local_info_, stream_info, &context.requestHeaders(),
-                     &context.responseHeaders(), &context.responseTrailers());
+                     &context.responseHeaders(), &context.responseTrailers(), random_.random());
   if (!eval_status.has_value() || eval_status.value().IsError()) {
     return absl::nullopt;
   }
@@ -64,7 +64,7 @@ CELFormatterCommandParser::parse(absl::string_view command, absl::string_view su
     }
 
     return std::make_unique<CELFormatter>(local_info_, expr_builder_, parse_status.value().expr(),
-                                          max_length);
+                                          max_length, random_);
   }
 
   return nullptr;

--- a/source/extensions/formatter/cel/cel.h
+++ b/source/extensions/formatter/cel/cel.h
@@ -16,7 +16,8 @@ class CELFormatter : public ::Envoy::Formatter::FormatterProvider {
 public:
   CELFormatter(const ::Envoy::LocalInfo::LocalInfo& local_info,
                Extensions::Filters::Common::Expr::BuilderInstanceSharedPtr,
-               const google::api::expr::v1alpha1::Expr&, absl::optional<size_t>&);
+               const google::api::expr::v1alpha1::Expr&, absl::optional<size_t>&,
+               Random::RandomGenerator&);
 
   absl::optional<std::string>
   formatWithContext(const Envoy::Formatter::HttpFormatterContext& context,
@@ -30,13 +31,15 @@ private:
   const google::api::expr::v1alpha1::Expr parsed_expr_;
   const absl::optional<size_t> max_length_;
   Extensions::Filters::Common::Expr::ExpressionPtr compiled_expr_;
+  Random::RandomGenerator& random_;
 };
 
 class CELFormatterCommandParser : public ::Envoy::Formatter::CommandParser {
 public:
   CELFormatterCommandParser(Server::Configuration::CommonFactoryContext& context)
       : local_info_(context.localInfo()),
-        expr_builder_(Extensions::Filters::Common::Expr::getBuilder(context)){};
+        expr_builder_(Extensions::Filters::Common::Expr::getBuilder(context)),
+        random_(context.api().randomGenerator()){};
   ::Envoy::Formatter::FormatterProviderPtr parse(absl::string_view command,
                                                  absl::string_view subcommand,
                                                  absl::optional<size_t> max_length) const override;
@@ -44,6 +47,7 @@ public:
 private:
   const ::Envoy::LocalInfo::LocalInfo& local_info_;
   Extensions::Filters::Common::Expr::BuilderInstanceSharedPtr expr_builder_;
+  Random::RandomGenerator& random_;
 };
 
 } // namespace Formatter

--- a/source/extensions/matching/http/metadata_input/meta_input.h
+++ b/source/extensions/matching/http/metadata_input/meta_input.h
@@ -55,7 +55,8 @@ public:
 
   Matcher::DataInputFactoryCb<MatchingDataType>
   createDataInputFactoryCb(const Protobuf::Message& message,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) override {
+                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                           Random::RandomGenerator&) override {
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::extensions::matching::common_inputs::network::v3::DynamicMetadataInput&>(
         message, validation_visitor);

--- a/source/extensions/matching/network/common/inputs.h
+++ b/source/extensions/matching/network/common/inputs.h
@@ -21,7 +21,8 @@ public:
   std::string name() const override { return "envoy.matching.inputs." + name_; }
 
   Matcher::DataInputFactoryCb<MatchingDataType>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&,
+                           Random::RandomGenerator&) override {
     return []() { return std::make_unique<InputType>(); };
   };
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -289,7 +290,8 @@ public:
 
   Matcher::DataInputFactoryCb<MatchingDataType>
   createDataInputFactoryCb(const Protobuf::Message& message,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) override {
+                           ProtobufMessage::ValidationVisitor& validation_visitor,
+                           Random::RandomGenerator&) override {
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::extensions::matching::common_inputs::network::v3::FilterStateInput&>(
         message, validation_visitor);

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -66,8 +66,9 @@ public:
   TestDataInputStringFactory(absl::string_view data)
       : TestDataInputStringFactory(
             {DataInputGetResult::DataAvailability::AllDataAvailable, std::string(data)}) {}
-  DataInputFactoryCb<TestData>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  DataInputFactoryCb<TestData> createDataInputFactoryCb(const Protobuf::Message&,
+                                                        ProtobufMessage::ValidationVisitor&,
+                                                        Random::RandomGenerator&) override {
     return [&]() { return std::make_unique<TestInput>(result_); };
   }
 
@@ -88,8 +89,9 @@ public:
   TestDataInputBoolFactory(absl::string_view data)
       : TestDataInputBoolFactory(
             {DataInputGetResult::DataAvailability::AllDataAvailable, std::string(data)}) {}
-  DataInputFactoryCb<TestData>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  DataInputFactoryCb<TestData> createDataInputFactoryCb(const Protobuf::Message&,
+                                                        ProtobufMessage::ValidationVisitor&,
+                                                        Random::RandomGenerator&) override {
     // Note, here is using `TestInput` same as `TestDataInputStringFactory`.
     return [&]() { return std::make_unique<TestInput>(result_); };
   }
@@ -110,8 +112,9 @@ public:
   TestDataInputFloatFactory(float)
       : TestDataInputFloatFactory(
             {DataInputGetResult::DataAvailability::AllDataAvailable, absl::monostate()}) {}
-  DataInputFactoryCb<TestData>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  DataInputFactoryCb<TestData> createDataInputFactoryCb(const Protobuf::Message&,
+                                                        ProtobufMessage::ValidationVisitor&,
+                                                        Random::RandomGenerator&) override {
     return [&]() { return std::make_unique<TestFloatInput>(result_); };
   }
 

--- a/test/extensions/filters/common/expr/BUILD
+++ b/test/extensions/filters/common/expr/BUILD
@@ -1,6 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_fuzz_test",
+    "envoy_cc_test_library",
     "envoy_package",
     "envoy_proto_library",
 )
@@ -36,12 +37,19 @@ envoy_extension_cc_test(
     ],
 )
 
+envoy_cc_test_library(
+    name = "evaluator_test_lib",
+    hdrs = ["evaluator_test.h"],
+    tags = ["skip_on_windows"],
+)
+
 envoy_extension_cc_test(
     name = "evaluator_test",
     srcs = ["evaluator_test.cc"],
     extension_names = ["envoy.filters.http.rbac"],
     tags = ["skip_on_windows"],
     deps = [
+        ":evaluator_test_lib",
         "//source/extensions/filters/common/expr:evaluator_lib",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
+++ b/test/extensions/filters/common/expr/evaluator_fuzz_test.cc
@@ -45,7 +45,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::common::expr::EvaluatorTest
     // Evaluate the CEL expression.
     Protobuf::Arena arena;
     Expr::evaluate(*expr, arena, nullptr, *stream_info, &request_headers, &response_headers,
-                   &response_trailers);
+                   &response_trailers, 42);
   } catch (const CelException& e) {
     ENVOY_LOG_MISC(debug, "CelException: {}", e.what());
   }

--- a/test/extensions/filters/common/expr/evaluator_test.h
+++ b/test/extensions/filters/common/expr/evaluator_test.h
@@ -1,0 +1,264 @@
+#pragma once
+
+namespace Envoy {
+namespace Extensions {
+namespace Filters {
+namespace Common {
+namespace Expr {
+
+// true
+inline constexpr char TrueCelString[] = R"pb(
+  expr: {
+    id: 1
+    const_expr: {
+      bool_value: true
+    }
+  }
+)pb";
+
+// false
+inline constexpr char FalseCelString[] = R"pb(
+  expr: {
+    id: 1
+    const_expr: {
+      bool_value: false
+    }
+  }
+)pb";
+
+// context.sample(0.5, 1)
+inline constexpr char SampleHalfCelString[] = R"pb(
+  expr: {
+    id: 2
+    call_expr: {
+      target: {
+        id: 1
+        ident_expr: {
+          name: "context"
+        }
+      }
+      function: "sample"
+      args: {
+        id: 3
+        const_expr: {
+          double_value: 0.5
+        }
+      }
+      args: {
+        id: 4
+        const_expr: {
+          int64_value: 1
+        }
+      }
+    }
+  }
+)pb";
+
+// context.sample(0.0, 1) || context.sample(0.0, 2) || context.sample(0.0, 3)
+inline constexpr char SampleNeverCelString[] = R"pb(
+  expr:  {
+    id:  14
+    call_expr:  {
+      function:  "_||_"
+      args:  {
+        id:  9
+        call_expr:  {
+          function:  "_||_"
+          args:  {
+            id:  2
+            call_expr:  {
+              target:  {
+                id:  1
+                ident_expr:  {
+                  name:  "context"
+                }
+              }
+              function:  "sample"
+              args:  {
+                id:  3
+                const_expr:  {
+                  double_value:  0
+                }
+              }
+              args:  {
+                id:  4
+                const_expr:  {
+                  int64_value:  1
+                }
+              }
+            }
+          }
+          args:  {
+            id:  6
+            call_expr:  {
+              target:  {
+                id:  5
+                ident_expr:  {
+                  name:  "context"
+                }
+              }
+              function:  "sample"
+              args:  {
+                id:  7
+                const_expr:  {
+                  double_value:  0
+                }
+              }
+              args:  {
+                id:  8
+                const_expr:  {
+                  int64_value:  2
+                }
+              }
+            }
+          }
+        }
+      }
+      args:  {
+        id:  11
+        call_expr:  {
+          target:  {
+            id:  10
+            ident_expr:  {
+              name:  "context"
+            }
+          }
+          function:  "sample"
+          args:  {
+            id:  12
+            const_expr:  {
+              double_value:  0
+            }
+          }
+          args:  {
+            id:  13
+            const_expr:  {
+              int64_value:  3
+            }
+          }
+        }
+      }
+    }
+  }
+)pb";
+
+// context.sample(1.0, 1) && context.sample(1.0, 2) && context.sample(1.0, 3)
+inline constexpr char SampleAlwaysCelString[] = R"pb(
+  expr:  {
+    id:  14
+    call_expr:  {
+      function:  "_&&_"
+      args:  {
+        id:  9
+        call_expr:  {
+          function:  "_&&_"
+          args:  {
+            id:  2
+            call_expr:  {
+              target:  {
+                id:  1
+                ident_expr:  {
+                  name:  "context"
+                }
+              }
+              function:  "sample"
+              args:  {
+                id:  3
+                const_expr:  {
+                  double_value:  1
+                }
+              }
+              args:  {
+                id:  4
+                const_expr:  {
+                  int64_value:  1
+                }
+              }
+            }
+          }
+          args:  {
+            id:  6
+            call_expr:  {
+              target:  {
+                id:  5
+                ident_expr:  {
+                  name:  "context"
+                }
+              }
+              function:  "sample"
+              args:  {
+                id:  7
+                const_expr:  {
+                  double_value:  1
+                }
+              }
+              args:  {
+                id:  8
+                const_expr:  {
+                  int64_value:  2
+                }
+              }
+            }
+          }
+        }
+      }
+      args:  {
+        id:  11
+        call_expr:  {
+          target:  {
+            id:  10
+            ident_expr:  {
+              name:  "context"
+            }
+          }
+          function:  "sample"
+          args:  {
+            id:  12
+            const_expr:  {
+              double_value:  1
+            }
+          }
+          args:  {
+            id:  13
+            const_expr:  {
+              int64_value:  3
+            }
+          }
+        }
+      }
+    }
+  }
+)pb";
+
+inline constexpr char SampleInvalidMap[] = R"pb(
+  expr:  {
+    id:  2
+    call_expr:  {
+      target:  {
+        id:  1
+        ident_expr:  {
+          name:  "xds"
+        }
+      }
+      function:  "sample"
+      args:  {
+        id:  3
+        const_expr:  {
+          double_value:  0.5
+        }
+      }
+      args:  {
+        id:  4
+        const_expr:  {
+          int64_value:  1
+        }
+      }
+    }
+  }
+)pb";
+
+} // namespace Expr
+} // namespace Common
+} // namespace Filters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ext_proc/matching_utils_test.cc
+++ b/test/extensions/filters/http/ext_proc/matching_utils_test.cc
@@ -50,7 +50,7 @@ TEST_F(ExpressionManagerTest, DuplicateAttributesIgnored) {
   request_headers_.setPath("/foo");
   const auto activation_ptr = Filters::Common::Expr::createActivation(
       &expr_mgr.localInfo(), stream_info_, &request_headers_, &response_headers_,
-      &response_trailers_);
+      &response_trailers_, 42);
 
   auto result = expr_mgr.evaluateRequestAttributes(*activation_ptr);
   EXPECT_EQ(2, result.fields_size());
@@ -74,7 +74,7 @@ TEST_F(ExpressionManagerTest, EmptyExpressionReturnsEmptyStruct) {
   request_headers_.setPath("/foo");
   const auto activation_ptr = Filters::Common::Expr::createActivation(
       &expr_mgr.localInfo(), stream_info_, &request_headers_, &response_headers_,
-      &response_trailers_);
+      &response_trailers_, 42);
 
   EXPECT_EQ(0, expr_mgr.evaluateRequestAttributes(*activation_ptr).fields_size());
 }

--- a/test/extensions/filters/network/generic_proxy/match_test.cc
+++ b/test/extensions/filters/network/generic_proxy/match_test.cc
@@ -19,8 +19,9 @@ TEST(ServiceMatchDataInputTest, ServiceMatchDataInputTest) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   ServiceMatchDataInputFactory factory;
   auto proto_config = factory.createEmptyConfigProto();
-  auto input =
-      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+  auto input = factory.createDataInputFactoryCb(
+      *proto_config, factory_context.messageValidationVisitor(),
+      factory_context.serverFactoryContext().api().randomGenerator())();
 
   FakeStreamCodecFactory::FakeRequest request;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -37,8 +38,9 @@ TEST(HostMatchDataInputTest, HostMatchDataInputTest) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   HostMatchDataInputFactory factory;
   auto proto_config = factory.createEmptyConfigProto();
-  auto input =
-      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+  auto input = factory.createDataInputFactoryCb(
+      *proto_config, factory_context.messageValidationVisitor(),
+      factory_context.serverFactoryContext().api().randomGenerator())();
 
   FakeStreamCodecFactory::FakeRequest request;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -55,8 +57,9 @@ TEST(PathMatchDataInputTest, PathMatchDataInputTest) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   PathMatchDataInputFactory factory;
   auto proto_config = factory.createEmptyConfigProto();
-  auto input =
-      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+  auto input = factory.createDataInputFactoryCb(
+      *proto_config, factory_context.messageValidationVisitor(),
+      factory_context.serverFactoryContext().api().randomGenerator())();
 
   FakeStreamCodecFactory::FakeRequest request;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -73,8 +76,9 @@ TEST(MethodMatchDataInputTest, MethodMatchDataInputTest) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   MethodMatchDataInputFactory factory;
   auto proto_config = factory.createEmptyConfigProto();
-  auto input =
-      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+  auto input = factory.createDataInputFactoryCb(
+      *proto_config, factory_context.messageValidationVisitor(),
+      factory_context.serverFactoryContext().api().randomGenerator())();
 
   FakeStreamCodecFactory::FakeRequest request;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -96,8 +100,9 @@ TEST(PropertyMatchDataInputTest, PropertyMatchDataInputTest) {
 
   typed_proto_config.set_property_name("key_0");
 
-  auto input =
-      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+  auto input = factory.createDataInputFactoryCb(
+      *proto_config, factory_context.messageValidationVisitor(),
+      factory_context.serverFactoryContext().api().randomGenerator())();
 
   FakeStreamCodecFactory::FakeRequest request;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -114,8 +119,9 @@ TEST(RequestMatchDataInputTest, RequestMatchDataInputTest) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   RequestMatchDataInputFactory factory;
   auto proto_config = factory.createEmptyConfigProto();
-  auto input =
-      factory.createDataInputFactoryCb(*proto_config, factory_context.messageValidationVisitor())();
+  auto input = factory.createDataInputFactoryCb(
+      *proto_config, factory_context.messageValidationVisitor(),
+      factory_context.serverFactoryContext().api().randomGenerator())();
 
   EXPECT_EQ(input->dataInputType(),
             "Envoy::Extensions::NetworkFilters::GenericProxy::RequestMatchData");

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.cc
@@ -493,6 +493,27 @@ TEST_F(CelMatcherTest, CelMatcherRequestResponseNotMatchedWithParsedExpr) {
   EXPECT_EQ(result.on_match_, absl::nullopt);
 }
 
+TEST_F(CelMatcherTest, CelMatcherRandomMatched) {
+  auto matcher_tree = buildMatcherTree(SampleCelString);
+
+  EXPECT_CALL(factory_context_.api_.random_, random()).WillOnce(testing::Return(42));
+  const auto result = matcher_tree->match(data_);
+  // The match was complete, match found.
+  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
+  EXPECT_TRUE(result.on_match_.has_value());
+  EXPECT_NE(result.on_match_->action_cb_, nullptr);
+}
+
+TEST_F(CelMatcherTest, CelMatcherRandomNotMatched) {
+  auto matcher_tree = buildMatcherTree(SampleCelString);
+
+  EXPECT_CALL(factory_context_.api_.random_, random()).WillOnce(testing::Return(43));
+  const auto result = matcher_tree->match(data_);
+  // The match was completed, no match found.
+  EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
+  EXPECT_EQ(result.on_match_, absl::nullopt);
+}
+
 TEST_F(CelMatcherTest, NoCelExpression) {
   EXPECT_DEATH(buildMatcherTree(RequestHeaderCelExprString, ExpressionType::NoExpression),
                ".*panic: unset oneof.*");

--- a/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.h
+++ b/test/extensions/matching/input_matchers/cel_matcher/cel_matcher_test.h
@@ -717,6 +717,34 @@ inline constexpr absl::string_view DynamicMetadataCelString = R"pb(
   }
 )pb";
 
+// context.sample(0.5, 0)
+inline constexpr char SampleCelString[] = R"pb(
+  expr: {
+    id: 2
+    call_expr: {
+      target: {
+        id: 1
+        ident_expr: {
+          name: "context"
+        }
+      }
+      function: "sample"
+      args: {
+        id: 3
+        const_expr: {
+          double_value: 0.5
+        }
+      }
+      args: {
+        id: 4
+        const_expr: {
+          int64_value: 1
+        }
+      }
+    }
+  }
+)pb";
+
 } // namespace CelMatcher
 } // namespace InputMatchers
 } // namespace Matching


### PR DESCRIPTION
Commit Message: add random convenience function in CEL expression builder
Additional Description: Add the `random()` function that allows CEL expressions to call the `Random::RandomGenerator::random()` function to generate a random 64-bit unsigned integer
Risk Level: Medium
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #34805 
Fixes istio/istio#50404
