### PR TITLE
rlqs: Add support for expired assignment 

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/client_impl.cc
@@ -91,7 +91,6 @@ void RateLimitClientImpl::onReceiveMessage(RateLimitQuotaResponsePtr&& response)
                 response->ShortDebugString());
     } else {
       quota_buckets_[bucket_id]->bucket_action = action;
-      // TODO(tyxia) Handle expired assignment via `assignment_time_to_live`.
       if (quota_buckets_[bucket_id]->bucket_action.has_quota_assignment_action()) {
         auto rate_limit_strategy = quota_buckets_[bucket_id]
                                        ->bucket_action.quota_assignment_action()

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -47,7 +47,7 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
     return sendImmediateReport(bucket_id, match_action);
   } else {
     // Found the cached bucket entry.
-    return processCachedBucket(bucket_id);
+    return processCachedBucket(bucket_id, match_action);
   }
 }
 
@@ -128,6 +128,9 @@ void RateLimitQuotaFilter::createNewBucket(const BucketId& bucket_id,
 
   // Set up the bucket id.
   new_bucket->bucket_id = bucket_id;
+  // Set up the first time assignment time.
+  new_bucket->first_assignment_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        time_source_.monotonicTime().time_since_epoch());
   // Set up the quota usage.
   QuotaUsage quota_usage;
   quota_usage.last_report = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -211,8 +214,40 @@ RateLimitQuotaFilter::sendImmediateReport(const size_t bucket_id,
   }
 }
 
-Http::FilterHeadersStatus RateLimitQuotaFilter::processCachedBucket(size_t bucket_id) {
-  // First, get the quota assignment (if exists) from the cached bucket action.
+Http::FilterHeadersStatus
+RateLimitQuotaFilter::processCachedBucket(size_t bucket_id,
+                                          const RateLimitOnMatchAction& match_action) {
+  // First, Check if assignment has expired nor not.
+  auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      time_source_.monotonicTime().time_since_epoch());
+  auto assignment_time_elapsed = Protobuf::util::TimeUtil::NanosecondsToDuration(
+      (now - quota_buckets_[bucket_id]->first_assignment_time).count());
+
+  if (assignment_time_elapsed > quota_buckets_[bucket_id]
+                                    ->bucket_action.quota_assignment_action()
+                                    .assignment_time_to_live()) {
+    // If expired, remove the cache entry.
+    quota_buckets_.erase(bucket_id);
+
+    // Default strategy is fail-Open (i.e., allow_all).
+    auto ret_status = Envoy::Http::FilterHeadersStatus::Continue;
+    // Check the expired assignment behavior if configured.
+    // Note, only fail-open and fail-close is supported, more advanced expired assignment can be
+    // supported as needed.
+    if (match_action.bucketSettings().has_expired_assignment_behavior()) {
+      if (match_action.bucketSettings()
+              .expired_assignment_behavior()
+              .fallback_rate_limit()
+              .blanket_rule() == envoy::type::v3::RateLimitStrategy::DENY_ALL) {
+        sendDenyResponse();
+        ret_status = Envoy::Http::FilterHeadersStatus::StopIteration;
+      }
+    }
+
+    return ret_status;
+  }
+
+  // Second, get the quota assignment (if exists) from the cached bucket action.
   if (quota_buckets_[bucket_id]->bucket_action.has_quota_assignment_action()) {
     auto rate_limit_strategy =
         quota_buckets_[bucket_id]->bucket_action.quota_assignment_action().rate_limit_strategy();

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -217,7 +217,7 @@ RateLimitQuotaFilter::sendImmediateReport(const size_t bucket_id,
 Http::FilterHeadersStatus
 RateLimitQuotaFilter::processCachedBucket(size_t bucket_id,
                                           const RateLimitOnMatchAction& match_action) {
-  // First, Check if assignment has expired nor not.
+  // First, check if assignment has expired nor not.
   auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(
       time_source_.monotonicTime().time_since_epoch());
   auto assignment_time_elapsed = Protobuf::util::TimeUtil::NanosecondsToDuration(
@@ -232,7 +232,7 @@ RateLimitQuotaFilter::processCachedBucket(size_t bucket_id,
     // Default strategy is fail-Open (i.e., allow_all).
     auto ret_status = Envoy::Http::FilterHeadersStatus::Continue;
     // Check the expired assignment behavior if configured.
-    // Note, only fail-open and fail-close is supported, more advanced expired assignment can be
+    // Note, only fail-open and fail-close are supported, more advanced expired assignment can be
     // supported as needed.
     if (match_action.bucketSettings().has_expired_assignment_behavior()) {
       if (match_action.bucketSettings()

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -130,9 +130,6 @@ void RateLimitQuotaFilter::createNewBucket(const BucketId& bucket_id,
   new_bucket->bucket_id = bucket_id;
   // Set up the first time assignment time.
   new_bucket->first_assignment_time = time_source_.monotonicTime();
-
-  std::chrono::duration_cast<std::chrono::nanoseconds>(
-      time_source_.monotonicTime().time_since_epoch());
   // Set up the quota usage.
   QuotaUsage quota_usage;
   quota_usage.last_report = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -130,7 +130,7 @@ void RateLimitQuotaFilter::createNewBucket(const BucketId& bucket_id,
   new_bucket->bucket_id = bucket_id;
   // Set up the first time assignment time.
   new_bucket->first_assignment_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        time_source_.monotonicTime().time_since_epoch());
+      time_source_.monotonicTime().time_since_epoch());
   // Set up the quota usage.
   QuotaUsage quota_usage;
   quota_usage.last_report = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -129,7 +129,9 @@ void RateLimitQuotaFilter::createNewBucket(const BucketId& bucket_id,
   // Set up the bucket id.
   new_bucket->bucket_id = bucket_id;
   // Set up the first time assignment time.
-  new_bucket->first_assignment_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+  new_bucket->first_assignment_time = time_source_.monotonicTime();
+
+  std::chrono::duration_cast<std::chrono::nanoseconds>(
       time_source_.monotonicTime().time_since_epoch());
   // Set up the quota usage.
   QuotaUsage quota_usage;
@@ -221,8 +223,9 @@ RateLimitQuotaFilter::processCachedBucket(size_t bucket_id,
   auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(
       time_source_.monotonicTime().time_since_epoch());
   auto assignment_time_elapsed = Protobuf::util::TimeUtil::NanosecondsToDuration(
-      (now - quota_buckets_[bucket_id]->first_assignment_time).count());
-
+      (now - std::chrono::duration_cast<std::chrono::nanoseconds>(
+                 quota_buckets_[bucket_id]->first_assignment_time.time_since_epoch()))
+          .count());
   if (assignment_time_elapsed > quota_buckets_[bucket_id]
                                     ->bucket_action.quota_assignment_action()
                                     .assignment_time_to_live()) {

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -93,7 +93,8 @@ private:
   Http::FilterHeadersStatus sendImmediateReport(const size_t bucket_id,
                                                 const RateLimitOnMatchAction& match_action);
 
-  Http::FilterHeadersStatus processCachedBucket(size_t bucket_id, const RateLimitOnMatchAction& match_action);
+  Http::FilterHeadersStatus processCachedBucket(size_t bucket_id,
+                                                const RateLimitOnMatchAction& match_action);
   // TODO(tyxia) Build the customized response based on `DenyResponseSettings`.
   void sendDenyResponse() {
     callbacks_->sendLocalReply(Envoy::Http::Code::TooManyRequests, "", nullptr, absl::nullopt, "");

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -30,8 +30,6 @@ namespace RateLimitQuota {
 using ::envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse;
 using QuotaAssignmentAction = ::envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse::
     BucketAction::QuotaAssignmentAction;
-using DenyResponseSettings = ::envoy::extensions::filters::http::rate_limit_quota::v3::
-    RateLimitQuotaBucketSettings::DenyResponseSettings;
 
 /**
  * Possible async results for a limit call.

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -30,6 +30,8 @@ namespace RateLimitQuota {
 using ::envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse;
 using QuotaAssignmentAction = ::envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse::
     BucketAction::QuotaAssignmentAction;
+using DenyResponseSettings = ::envoy::extensions::filters::http::rate_limit_quota::v3::
+    RateLimitQuotaBucketSettings::DenyResponseSettings;
 
 /**
  * Possible async results for a limit call.
@@ -93,7 +95,7 @@ private:
   Http::FilterHeadersStatus sendImmediateReport(const size_t bucket_id,
                                                 const RateLimitOnMatchAction& match_action);
 
-  Http::FilterHeadersStatus processCachedBucket(size_t bucket_id);
+  Http::FilterHeadersStatus processCachedBucket(size_t bucket_id, const RateLimitOnMatchAction& match_action);
   // TODO(tyxia) Build the customized response based on `DenyResponseSettings`.
   void sendDenyResponse() {
     callbacks_->sendLocalReply(Envoy::Http::Code::TooManyRequests, "", nullptr, absl::nullopt, "");

--- a/source/extensions/filters/http/rate_limit_quota/quota_bucket_cache.h
+++ b/source/extensions/filters/http/rate_limit_quota/quota_bucket_cache.h
@@ -46,6 +46,8 @@ struct Bucket {
   QuotaUsage quota_usage;
   // Rate limiter based on token bucket algorithm.
   TokenBucketPtr token_bucket_limiter;
+  // First assignment time.
+  std::chrono::nanoseconds first_assignment_time = {};
 };
 
 using BucketsCache = absl::flat_hash_map<size_t, std::unique_ptr<Bucket>>;

--- a/source/extensions/filters/http/rate_limit_quota/quota_bucket_cache.h
+++ b/source/extensions/filters/http/rate_limit_quota/quota_bucket_cache.h
@@ -47,7 +47,7 @@ struct Bucket {
   // Rate limiter based on token bucket algorithm.
   TokenBucketPtr token_bucket_limiter;
   // First assignment time.
-  std::chrono::nanoseconds first_assignment_time = {};
+  Envoy::MonotonicTime first_assignment_time = {};
 };
 
 using BucketsCache = absl::flat_hash_map<size_t, std::unique_ptr<Bucket>>;

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -28,6 +28,7 @@ enum class BlanketRule {
 struct ConfigOption {
   bool valid_rlqs_server = true;
   BlanketRule no_assignment_blanket_rule = BlanketRule::NOT_SPECIFIED;
+  BlanketRule expired_assignment_blanket_rule = BlanketRule::NOT_SPECIFIED;
 };
 
 // These tests exercise the rate limit quota filter through Envoy's integration test
@@ -82,19 +83,19 @@ protected:
       xds::type::matcher::v3::Matcher matcher;
       TestUtility::loadFromYaml(std::string(ValidMatcherConfig), matcher);
 
+      auto* mutable_config = matcher.mutable_matcher_list()
+                                 ->mutable_matchers(0)
+                                 ->mutable_on_match()
+                                 ->mutable_action()
+                                 ->mutable_typed_config();
+      ASSERT_TRUE(mutable_config->Is<::envoy::extensions::filters::http::rate_limit_quota::v3::
+                                         RateLimitQuotaBucketSettings>());
+
+      auto mutable_bucket_settings = MessageUtil::anyConvert<
+          ::envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaBucketSettings>(
+          *mutable_config);
       // Configure the no_assignment behavior.
       if (config_option.no_assignment_blanket_rule != BlanketRule::NOT_SPECIFIED) {
-        auto* mutable_config = matcher.mutable_matcher_list()
-                                   ->mutable_matchers(0)
-                                   ->mutable_on_match()
-                                   ->mutable_action()
-                                   ->mutable_typed_config();
-        ASSERT_TRUE(mutable_config->Is<::envoy::extensions::filters::http::rate_limit_quota::v3::
-                                           RateLimitQuotaBucketSettings>());
-
-        auto mutable_bucket_settings = MessageUtil::anyConvert<
-            ::envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaBucketSettings>(
-            *mutable_config);
         if (config_option.no_assignment_blanket_rule == BlanketRule::ALLOW_ALL) {
           mutable_bucket_settings.mutable_no_assignment_behavior()
               ->mutable_fallback_rate_limit()
@@ -104,9 +105,21 @@ protected:
               ->mutable_fallback_rate_limit()
               ->set_blanket_rule(envoy::type::v3::RateLimitStrategy::DENY_ALL);
         }
-        mutable_config->PackFrom(mutable_bucket_settings);
       }
 
+      if (config_option.expired_assignment_blanket_rule != BlanketRule::NOT_SPECIFIED) {
+        if (config_option.expired_assignment_blanket_rule == BlanketRule::ALLOW_ALL) {
+          mutable_bucket_settings.mutable_expired_assignment_behavior()
+              ->mutable_fallback_rate_limit()
+              ->set_blanket_rule(envoy::type::v3::RateLimitStrategy::ALLOW_ALL);
+        } else if (config_option.expired_assignment_blanket_rule == BlanketRule::DENY_ALL) {
+          mutable_bucket_settings.mutable_expired_assignment_behavior()
+              ->mutable_fallback_rate_limit()
+              ->set_blanket_rule(envoy::type::v3::RateLimitStrategy::DENY_ALL);
+        }
+      }
+
+      mutable_config->PackFrom(mutable_bucket_settings);
       proto_config_.mutable_bucket_matchers()->MergeFrom(matcher);
 
       // Construct a configuration proto for our filter and then re-write it
@@ -772,6 +785,148 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiRequestWithTokenBucket) {
     }
 
     cleanUp();
+  }
+}
+
+TEST_P(RateLimitQuotaIntegrationTest, MultiSameRequestWithExpiredAssignmentDeny) {
+  ConfigOption option;
+  option.expired_assignment_blanket_rule = BlanketRule::DENY_ALL;
+  initializeConfig(option);
+  HttpIntegrationTest::initialize();
+  absl::flat_hash_map<std::string, std::string> custom_headers = {{"environment", "staging"},
+                                                                  {"group", "envoy"}};
+  for (int i = 0; i < 2; ++i) {
+    // Advance the time to make cached assignment expired.
+    if (i == 1) {
+      simTime().advanceTimeWait(std::chrono::milliseconds(12 * 1000));
+    }
+    // Send downstream client request to upstream.
+    sendClientRequest(&custom_headers);
+
+    // 2nd downstream client request will not trigger the reports to RLQS server since it is
+    // same as first request, which will find the entry in the cache.
+    if (i == 0) {
+      // Start the gRPC stream to RLQS server.
+      ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, rlqs_connection_));
+      ASSERT_TRUE(rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
+
+      envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports reports;
+      ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
+      rlqs_stream_->startGrpcStream();
+
+      // Build the response.
+      envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse rlqs_response;
+      absl::flat_hash_map<std::string, std::string> custom_headers_cpy = custom_headers;
+      custom_headers_cpy.insert({"name", "prod"});
+      auto* bucket_action = rlqs_response.add_bucket_action();
+
+      for (const auto& [key, value] : custom_headers_cpy) {
+        (*bucket_action->mutable_bucket_id()->mutable_bucket()).insert({key, value});
+        auto* quota_assignment = bucket_action->mutable_quota_assignment_action();
+        quota_assignment->mutable_assignment_time_to_live()->set_seconds(10);
+        auto* strategy = quota_assignment->mutable_rate_limit_strategy();
+        strategy->set_blanket_rule(envoy::type::v3::RateLimitStrategy::ALLOW_ALL);
+      }
+
+      // Send the response from RLQS server.
+      rlqs_stream_->sendGrpcMessage(rlqs_response);
+    }
+
+    // 2nd request is throttled because the assignment has expired and
+    // expired assignment behavior is DENY_ALL.
+    if (i == 1) {
+      ASSERT_TRUE(response_->waitForEndStream());
+      EXPECT_TRUE(response_->complete());
+      EXPECT_EQ(response_->headers().getStatusValue(), "429");
+    } else {
+      // Handle the request received by upstream.
+      ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+      ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+      ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+      upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+      upstream_request_->encodeData(100, true);
+
+      // Verify the response to downstream.
+      ASSERT_TRUE(response_->waitForEndStream());
+      EXPECT_TRUE(response_->complete());
+      EXPECT_EQ(response_->headers().getStatusValue(), "200");
+    }
+
+    cleanUp();
+  }
+}
+
+TEST_P(RateLimitQuotaIntegrationTest, MultiSameRequestWithExpiredAssignmentAllow) {
+  ConfigOption option;
+  option.expired_assignment_blanket_rule = BlanketRule::ALLOW_ALL;
+  initializeConfig(option);
+  HttpIntegrationTest::initialize();
+  absl::flat_hash_map<std::string, std::string> custom_headers = {{"environment", "staging"},
+                                                                  {"group", "envoy"}};
+  for (int i = 0; i < 3; ++i) {
+    // Advance the time to make cached assignment expired.
+    if (i == 1) {
+      simTime().advanceTimeWait(std::chrono::milliseconds(3 * 1000));
+    }
+    // Send downstream client request to upstream.
+    sendClientRequest(&custom_headers);
+
+    // 2nd downstream client request will not trigger the reports to RLQS server since it is
+    // same as first request, which will find the entry in the cache.
+    if (i != 1) {
+      // 1st request will start the gRPC stream.
+      if (i == 0) {
+        // Start the gRPC stream to RLQS server on the first request.
+        ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(
+            *dispatcher_, rlqs_connection_));
+        ASSERT_TRUE(
+            rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
+
+        envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports
+            reports;
+        ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
+        rlqs_stream_->startGrpcStream();
+      } else {
+        // 3rd request won't start gRPC stream again since it is kept open.
+        envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports
+            reports;
+        ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
+      }
+
+      // Build the response.
+      envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse rlqs_response;
+      absl::flat_hash_map<std::string, std::string> custom_headers_cpy = custom_headers;
+      custom_headers_cpy.insert({"name", "prod"});
+      auto* bucket_action = rlqs_response.add_bucket_action();
+
+      for (const auto& [key, value] : custom_headers_cpy) {
+        (*bucket_action->mutable_bucket_id()->mutable_bucket()).insert({key, value});
+        auto* quota_assignment = bucket_action->mutable_quota_assignment_action();
+        quota_assignment->mutable_assignment_time_to_live()->set_seconds(2);
+        auto* strategy = quota_assignment->mutable_rate_limit_strategy();
+        strategy->set_blanket_rule(envoy::type::v3::RateLimitStrategy::ALLOW_ALL);
+      }
+
+      // Send the response from RLQS server.
+      rlqs_stream_->sendGrpcMessage(rlqs_response);
+    }
+
+    // Even though assignment was expired on 2nd request, the request is still allowed because the
+    // expired assignment behavior is ALLOW_ALL.
+    ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+    ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+    ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+    upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    upstream_request_->encodeData(100, true);
+
+    // Verify the response to downstream.
+    ASSERT_TRUE(response_->waitForEndStream());
+    EXPECT_TRUE(response_->complete());
+    EXPECT_EQ(response_->headers().getStatusValue(), "200");
+
+    // Clean up the upstream and downstream resource but keep the gRPC connection to RLQS server
+    // open.
+    cleanupUpstreamAndDownstream();
   }
 }
 

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -840,7 +840,8 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiSameRequestWithExpiredAssignmentDeny)
       EXPECT_EQ(response_->headers().getStatusValue(), "429");
     } else {
       // Handle the request received by upstream.
-      ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+      ASSERT_TRUE(
+          fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
       ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
       ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
       upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
@@ -877,19 +878,15 @@ TEST_P(RateLimitQuotaIntegrationTest, MultiSameRequestWithExpiredAssignmentAllow
       // 1st request will start the gRPC stream.
       if (i == 0) {
         // Start the gRPC stream to RLQS server on the first request.
-        ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(
-            *dispatcher_, rlqs_connection_));
-        ASSERT_TRUE(
-            rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
+        ASSERT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, rlqs_connection_));
+        ASSERT_TRUE(rlqs_connection_->waitForNewStream(*dispatcher_, rlqs_stream_));
 
-        envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports
-            reports;
+        envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports reports;
         ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
         rlqs_stream_->startGrpcStream();
       } else {
         // 3rd request won't start gRPC stream again since it is kept open.
-        envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports
-            reports;
+        envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports reports;
         ASSERT_TRUE(rlqs_stream_->waitForGrpcMessage(*dispatcher_, reports));
       }
 


### PR DESCRIPTION
Add support for expired assignment. Currently supported expired assignment behavior: Fail-open or Fail close.