### PR TITLE
docs: move note about health checking to more relevant section in outlier.rst

### DIFF
--- a/docs/root/intro/arch_overview/upstream/outlier.rst
+++ b/docs/root/intro/arch_overview/upstream/outlier.rst
@@ -87,6 +87,18 @@ ejection algorithm works as follows:
    been satisfied. Generally, outlier detection is used alongside :ref:`active health checking
    <arch_overview_health_checking>` for a comprehensive health checking solution.
 
+.. note::
+
+  If :ref:`active health checking <arch_overview_health_checking>` is also configured, a successful active health check unejects the host and
+  clears all outlier detection counters. If the host has not reached :ref:`unhealthy_threshold<envoy_v3_api_field_config.core.v3.HealthCheck.unhealthy_threshold>`
+  failed health checks yet, a single successful health check will uneject the host. If the FAILED_ACTIVE_HC health flag is set for the host,
+  :ref:`healthy_threshold<envoy_v3_api_field_config.core.v3.HealthCheck.healthy_threshold>` consecutive successful health checks
+  will uneject the host (and clear the FAILED_ACTIVE_HC flag).
+  If your active health check is not validating data plane traffic then in situations where
+  active health checking passes but the traffic is failing, the endpoint will be unejected prematurely. To disable this option then set
+  :ref:`outlier_detection.successful_active_health_check_uneject_host<envoy_v3_api_field_config.cluster.v3.OutlierDetection.successful_active_health_check_uneject_host>`
+  configuration flag to ``false``.
+
 Detection types
 ---------------
 
@@ -199,19 +211,6 @@ gRPC
 ----------------------
 
 For gRPC requests, the outlier detection will use the HTTP status mapped from the `grpc-status <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses>`_ response header.
-
-
-.. note::
-
-  If :ref:`active health checking <arch_overview_health_checking>` is also configured, a successful active health check unejects the host and
-  clears all outlier detection counters. If the host has not reached :ref:`unhealthy_threshold<envoy_v3_api_field_config.core.v3.HealthCheck.unhealthy_threshold>`
-  failed health checks yet, a single successful health check will uneject the host. If the FAILED_ACTIVE_HC health flag is set for the host,
-  :ref:`healthy_threshold<envoy_v3_api_field_config.core.v3.HealthCheck.healthy_threshold>` consecutive successful health checks
-  will uneject the host (and clear the FAILED_ACTIVE_HC flag).
-  If your active health check is not validating data plane traffic then in situations where
-  active health checking passes but the traffic is failing, the endpoint will be unejected prematurely. To disable this option then set
-  :ref:`outlier_detection.successful_active_health_check_uneject_host<envoy_v3_api_field_config.cluster.v3.OutlierDetection.successful_active_health_check_uneject_host>`
-  configuration flag to ``false``.
 
 .. _arch_overview_outlier_detection_logging:
 


### PR DESCRIPTION
Commit Message: Moving the note about active health checking unejecting nodes in the outlier detection docs to more relevant section where Ejection algorithm is described. Currently it sits under gRPC giving it false impression that it is only relevant to gRPC which is wrong.
Additional Description: 
Risk Level: Low
Testing: none
Docs Changes: outlier_detection
Release Notes: none
Platform Specific Features: none