### PR TITLE
UDP Tunneling: Fix crashes in UDP proxy

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -840,6 +840,8 @@ void TunnelingConnectionPoolImpl::onPoolFailure(Http::ConnectionPool::PoolFailur
                                                 absl::string_view failure_reason,
                                                 Upstream::HostDescriptionConstSharedPtr host) {
   upstream_handle_ = nullptr;
+  // Writing to downstream_info_ before calling onStreamFailure, as the session could be potentially
+  // removed by onStreamFailure, which will cause downstream_info_ to be freed.
   downstream_info_.upstreamInfo()->setUpstreamHost(host);
   downstream_info_.upstreamInfo()->setUpstreamTransportFailureReason(failure_reason);
   callbacks_->onStreamFailure(reason, failure_reason, host);

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -795,14 +795,14 @@ void HttpUpstreamImpl::resetEncoder(Network::ConnectionEvent event, bool by_down
 
   request_encoder_ = nullptr;
 
-  // If we did not receive a valid CONNECT response yet we treat this as a pool
-  // failure, otherwise we forward the event downstream.
-  if (tunnel_creation_callbacks_.has_value()) {
-    tunnel_creation_callbacks_.value().get().onStreamFailure();
-    return;
-  }
-
   if (!by_downstream) {
+    // If we did not receive a valid CONNECT response yet we treat this as a pool
+    // failure, otherwise we forward the event downstream.
+    if (tunnel_creation_callbacks_.has_value()) {
+      tunnel_creation_callbacks_.value().get().onStreamFailure();
+      return;
+    }
+
     upstream_callbacks_.onUpstreamEvent(event);
   }
 }
@@ -840,9 +840,9 @@ void TunnelingConnectionPoolImpl::onPoolFailure(Http::ConnectionPool::PoolFailur
                                                 absl::string_view failure_reason,
                                                 Upstream::HostDescriptionConstSharedPtr host) {
   upstream_handle_ = nullptr;
-  callbacks_->onStreamFailure(reason, failure_reason, host);
   downstream_info_.upstreamInfo()->setUpstreamHost(host);
   downstream_info_.upstreamInfo()->setUpstreamTransportFailureReason(failure_reason);
+  callbacks_->onStreamFailure(reason, failure_reason, host);
 }
 
 void TunnelingConnectionPoolImpl::onPoolReady(Http::RequestEncoder& request_encoder,
@@ -861,6 +861,7 @@ void TunnelingConnectionPoolImpl::onPoolReady(Http::RequestEncoder& request_enco
   upstream_->setRequestEncoder(request_encoder, is_ssl);
   upstream_->setTunnelCreationCallbacks(*this);
   downstream_info_.upstreamInfo()->setUpstreamHost(upstream_host);
+  callbacks_->resetIdleTimer();
 
   if (flush_access_log_on_tunnel_connected_) {
     const Formatter::HttpFormatterContext log_context{
@@ -1084,7 +1085,13 @@ void UdpProxyFilter::TunnelingActiveSession::onIdleTimer() {
             addresses_.local_->asStringView());
   udp_session_info_.setResponseFlag(StreamInfo::CoreResponseFlag::StreamIdleTimeout);
   cluster_.filter_.config_->stats().idle_timeout_.inc();
-  upstream_->onDownstreamEvent(Network::ConnectionEvent::LocalClose);
+
+  if (upstream_) {
+    upstream_->onDownstreamEvent(Network::ConnectionEvent::LocalClose);
+  } else if (conn_pool_) {
+    conn_pool_->onDownstreamEvent(Network::ConnectionEvent::LocalClose);
+  }
+
   cluster_.removeSession(this);
 }
 

--- a/test/extensions/filters/udp/udp_proxy/mocks.h
+++ b/test/extensions/filters/udp/udp_proxy/mocks.h
@@ -105,6 +105,7 @@ public:
   MOCK_METHOD(void, onStreamFailure,
               (ConnectionPool::PoolFailureReason reason, absl::string_view failure_reason,
                Upstream::HostDescriptionConstSharedPtr host));
+  MOCK_METHOD(void, resetIdleTimer, ());
 };
 
 } // namespace SessionFilters

--- a/test/extensions/filters/udp/udp_proxy/session_filters/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/BUILD
@@ -34,6 +34,7 @@ envoy_cc_test_library(
     deps = [
         ":drainer_filter_proto_cc_proto",
         "//envoy/registry",
+        "//source/common/router:string_accessor_lib",
         "//source/extensions/filters/udp/udp_proxy/session_filters:factory_base_lib",
         "//source/extensions/filters/udp/udp_proxy/session_filters:filter_interface",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h
@@ -36,7 +36,7 @@ public:
   void onSessionCompleteInternal() override {
     read_callbacks_->streamInfo().filterState()->setData(
         "test.udp_session.drainer.on_session_complete",
-        std::make_shared<Router::StringAccessorImpl>("session_complete"),
+        std::make_shared<Envoy::Router::StringAccessorImpl>("session_complete"),
         StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection,
         StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   }

--- a/test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h
@@ -3,6 +3,7 @@
 #include "envoy/registry/registry.h"
 
 #include "source/common/config/utility.h"
+#include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/filters/udp/udp_proxy/session_filters/factory_base.h"
 #include "source/extensions/filters/udp/udp_proxy/session_filters/filter.h"
 
@@ -35,7 +36,7 @@ public:
   void onSessionCompleteInternal() override {
     read_callbacks_->streamInfo().filterState()->setData(
         "test.udp_session.drainer.on_session_complete",
-        std::make_shared<Envoy::Router::StringAccessorImpl>("session_complete"),
+        std::make_shared<Router::StringAccessorImpl>("session_complete"),
         StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection,
         StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   }

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -1737,8 +1737,8 @@ TEST_F(HttpUpstreamImplTest, OnResetStream) {
   setup();
   setAndExpectRequestEncoder(expectedHeaders());
 
-  // If the creation callbacks are active will resetting the stream, it means that response
-  // headers were not received, so it's expected to be a failure.
+  // If the creation callbacks are active, it means that response headers were not received,
+  // so it's expected to call onStreamFailure.
   EXPECT_CALL(creation_callbacks_, onStreamFailure());
   upstream_->onResetStream(Http::StreamResetReason::ConnectionTimeout, "reason");
 }
@@ -1747,10 +1747,10 @@ TEST_F(HttpUpstreamImplTest, LocalCloseByDownstreamResetsStream) {
   setup();
   setAndExpectRequestEncoder(expectedHeaders());
 
-  // If the creation callbacks are active will resetting the stream, it means that response
-  // headers were not received, so it's expected to be a failure.
-  EXPECT_CALL(creation_callbacks_, onStreamFailure());
+  // If the creation callbacks are active, it means that response headers were not received,
+  // so it's expected to reset the stream, but not to call onStreamFailure as it's Downstream event.
   EXPECT_CALL(request_encoder_.stream_, resetStream(Http::StreamResetReason::LocalReset));
+  EXPECT_CALL(creation_callbacks_, onStreamFailure()).Times(0);
   upstream_->onDownstreamEvent(Network::ConnectionEvent::LocalClose);
 }
 
@@ -1758,10 +1758,10 @@ TEST_F(HttpUpstreamImplTest, RemoteCloseByDownstreamResetsStream) {
   setup();
   setAndExpectRequestEncoder(expectedHeaders());
 
-  // If the creation callbacks are active will resetting the stream, it means that response
-  // headers were not received, so it's expected to be a failure.
-  EXPECT_CALL(creation_callbacks_, onStreamFailure());
+  // If the creation callbacks are active, it means that response headers were not received,
+  // so it's expected to reset the stream, but not to call onStreamFailure as it's Downstream event.
   EXPECT_CALL(request_encoder_.stream_, resetStream(Http::StreamResetReason::LocalReset));
+  EXPECT_CALL(creation_callbacks_, onStreamFailure()).Times(0);
   upstream_->onDownstreamEvent(Network::ConnectionEvent::RemoteClose);
 }
 
@@ -2006,6 +2006,7 @@ TEST_F(TunnelingConnectionPoolImplTest, PoolReady) {
 
   std::string upstream_host_name = "upstream_host_test";
   EXPECT_CALL(*upstream_host_, hostname()).WillOnce(ReturnRef(upstream_host_name));
+  EXPECT_CALL(stream_callbacks_, resetIdleTimer());
   pool_->onPoolReady(request_encoder_, upstream_host_, stream_info_, absl::nullopt);
   EXPECT_EQ(stream_info_.upstreamInfo()->upstreamHost()->hostname(), upstream_host_name);
 }
@@ -2023,6 +2024,18 @@ TEST_F(TunnelingConnectionPoolImplTest, OnStreamSuccess) {
   createNewStream();
   EXPECT_CALL(stream_callbacks_, onStreamReady(_, _, _, _, _));
   pool_->onStreamSuccess(request_encoder_);
+}
+
+TEST_F(TunnelingConnectionPoolImplTest, onDownstreamEvent) {
+  setup();
+  createNewStream();
+
+  EXPECT_CALL(request_encoder_.stream_, addCallbacks(_));
+  pool_->onPoolReady(request_encoder_, upstream_host_, stream_info_, absl::nullopt);
+
+  EXPECT_CALL(request_encoder_.stream_, removeCallbacks(_));
+  EXPECT_CALL(request_encoder_.stream_, resetStream(Http::StreamResetReason::LocalReset));
+  pool_->onDownstreamEvent(Network::ConnectionEvent::LocalClose);
 }
 
 TEST_F(TunnelingConnectionPoolImplTest, FactoryTest) {

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -2026,7 +2026,7 @@ TEST_F(TunnelingConnectionPoolImplTest, OnStreamSuccess) {
   pool_->onStreamSuccess(request_encoder_);
 }
 
-TEST_F(TunnelingConnectionPoolImplTest, onDownstreamEvent) {
+TEST_F(TunnelingConnectionPoolImplTest, OnDownstreamEvent) {
   setup();
   createNewStream();
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1902,6 +1902,8 @@ envoy_cc_test(
         "//source/extensions/filters/udp/udp_proxy:config",
         "//source/extensions/filters/udp/udp_proxy/session_filters/http_capsule:config",
         "//source/extensions/upstreams/http/udp:config",
+        "//test/extensions/filters/udp/udp_proxy/session_filters:drainer_filter_config_lib",
+        "//test/extensions/filters/udp/udp_proxy/session_filters:drainer_filter_proto_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",


### PR DESCRIPTION
Commit Message: Fix a crash in UDP proxy which happens because of UDP session idle timeout.

Additional Description:
We've observed a crash in envoy that occurs when we get session idle timeout on a session that didn't connect yet to upstream for some reason (for example, this can happen when a filter returns a `StopIteration` in `onNewSession` and the session remains in idle state until the idle timeout).
In this case, "upstream_" will not be initialized and we will get a segment fault because of the following call in `onIdleTimer`:
`upstream_->onDownstreamEvent(Network::ConnectionEvent::LocalClose);`
As a fix for this issue, we're adding the following changes: 
 - Calling `onDownstreamEvent` only if `upstream_` was already initialized.
 - Handling the case when we're already connected to upstream but we still haven't received response headers until the session idle timeout.

Risk Level: low
Testing: unit tests, integration tests
Docs Changes:
Release Notes:
Platform Specific Features:
