### PR TITLE
api: add fields for propagation of ORCA to LRS

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -45,7 +45,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 57]
+// [#next-free-field: 58]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -1150,6 +1150,22 @@ message Cluster {
   // maybe by allowing LRS to go on the ADS stream, or maybe by moving some of the negotiation
   // from the LRS stream here.]
   core.v3.ConfigSource lrs_server = 42;
+
+  // [#not-implemented-hide:]
+  // A list of metric names from ORCA load reports to propagate to LRS.
+  //
+  // For map fields in the ORCA proto, the string will be of the form ``<map_field_name>.<map_key>``.
+  // For example, the string ``named_metrics.foo`` will mean to look for the key ``foo`` in the ORCA
+  // ``named_metrics`` field.
+  //
+  // The special map key ``*`` means to report all entries in the map (e.g., ``named_metrics.*`` means to
+  // report all entries in the ORCA named_metrics field). Note that this should be used only with trusted
+  // backends.
+  //
+  // The metric names in LRS will follow the same semantics as this field. In other words, if this field
+  // contains ``named_metrics.foo``, then the LRS load report will include the data with that same string
+  // as the key.
+  repeated string lrs_report_endpoint_metric = 57;
 
   // If track_timeout_budgets is true, the :ref:`timeout budget histograms
   // <config_cluster_manager_cluster_stats_timeout_budgets>` will be published for each

--- a/api/envoy/config/endpoint/v3/load_report.proto
+++ b/api/envoy/config/endpoint/v3/load_report.proto
@@ -75,11 +75,20 @@ message UpstreamLocalityStats {
   // [#not-implemented-hide:]
   uint64 total_fail_connections = 11 [(xds.annotations.v3.field_status).work_in_progress = true];
 
-  // Stats for multi-dimensional load balancing.
-  // These typically come from endpoint metrics reported via ORCA.
+  // CPU utilization stats for multi-dimensional load balancing.
+  // This typically comes from endpoint metrics reported via ORCA.
   UnnamedEndpointLoadMetricStats cpu_utilization = 12;
+
+  // Memory utilization for multi-dimensional load balancing.
+  // This typically comes from endpoint metrics reported via ORCA.
   UnnamedEndpointLoadMetricStats mem_utilization = 13;
+
+  // Blended application-defined utilization for multi-dimensional load balancing.
+  // This typically comes from endpoint metrics reported via ORCA.
   UnnamedEndpointLoadMetricStats application_utilization = 14;
+
+  // Named stats for multi-dimensional load balancing.
+  // These typically come from endpoint metrics reported via ORCA.
   repeated EndpointLoadMetricStats load_metric_stats = 5;
 
   // Endpoint granularity stats information for this locality. This information

--- a/api/envoy/config/endpoint/v3/load_report.proto
+++ b/api/envoy/config/endpoint/v3/load_report.proto
@@ -25,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // These are stats Envoy reports to the management server at a frequency defined by
 // :ref:`LoadStatsResponse.load_reporting_interval<envoy_v3_api_field_service.load_stats.v3.LoadStatsResponse.load_reporting_interval>`.
 // Stats per upstream region/zone and optionally per subzone.
-// [#next-free-field: 12]
+// [#next-free-field: 15]
 message UpstreamLocalityStats {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.endpoint.UpstreamLocalityStats";
@@ -76,6 +76,10 @@ message UpstreamLocalityStats {
   uint64 total_fail_connections = 11 [(xds.annotations.v3.field_status).work_in_progress = true];
 
   // Stats for multi-dimensional load balancing.
+  // These typically come from endpoint metrics reported via ORCA.
+  UnnamedEndpointLoadMetricStats cpu_utilization = 12;
+  UnnamedEndpointLoadMetricStats mem_utilization = 13;
+  UnnamedEndpointLoadMetricStats application_utilization = 14;
   repeated EndpointLoadMetricStats load_metric_stats = 5;
 
   // Endpoint granularity stats information for this locality. This information
@@ -143,6 +147,16 @@ message EndpointLoadMetricStats {
   // Sum of metric values across all calls that finished with this metric for
   // load_reporting_interval.
   double total_metric_value = 3;
+}
+
+// Same as EndpointLoadMetricStats, except without the metric_name field.
+message UnnamedEndpointLoadMetricStats {
+  // Number of calls that finished and included this metric.
+  uint64 num_requests_finished_with_metric = 1;
+
+  // Sum of metric values across all calls that finished with this metric for
+  // load_reporting_interval.
+  double total_metric_value = 2;
 }
 
 // Per cluster load stats. Envoy reports these stats a management server in a


### PR DESCRIPTION
Commit Message: api: add fields for propagation of ORCA to LRS
Additional Description: Add fields in CDS to control which ORCA fields get propagated to LRS.  Also add fields in LRS for top-level ORCA metrics, to avoid having to encode the field name in LRS for these common cases.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @efimki @andresguedez @ejona86 @dfawley @vishalpowar 