### PR TITLE
mobile: Add onError callback in the swift_async_await test app

### DIFF
--- a/mobile/examples/swift/async_await/ContentView.swift
+++ b/mobile/examples/swift/async_await/ContentView.swift
@@ -89,6 +89,15 @@ private extension StreamClient {
 
                 logger("Upload failed.\nHeaders: \(headerMessage)")
             }
+            .setOnError { error, _ in
+                let message: String
+                if let attemptCount = error.attemptCount {
+                    message = "Failed after \(attemptCount) attempt(s) with error: \(error.message)"
+                } else {
+                    message = "Failed with error: \(error.message)"
+                }
+                logger(message)
+            }
             .start(queue: .networking)
 
         let headers = RequestHeadersBuilder(method: .post, scheme: "https",


### PR DESCRIPTION
With the `onError` callback it'll be impossible to debug any error related to the test app.

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
