### PR TITLE
Bugfix: Flush UdpTunnelUpstreamConnected access log only after receiving valid response headers

### DIFF
--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -922,9 +922,9 @@ bool UdpProxyFilter::TunnelingActiveSession::createConnectionPool() {
     cluster_.cluster_.info()->trafficStats()->upstream_rq_retry_.inc();
   }
 
-  conn_pool_ = conn_pool_factory_->createConnPool(
-      cluster_.cluster_, load_balancer_context_.get(), *cluster_.filter_.config_->tunnelingConfig(),
-      *this, udp_session_info_);
+  conn_pool_ = conn_pool_factory_->createConnPool(cluster_.cluster_, load_balancer_context_.get(),
+                                                  *cluster_.filter_.config_->tunnelingConfig(),
+                                                  *this, udp_session_info_);
 
   if (conn_pool_) {
     connecting_ = true;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -810,12 +810,9 @@ void HttpUpstreamImpl::resetEncoder(Network::ConnectionEvent event, bool by_down
 TunnelingConnectionPoolImpl::TunnelingConnectionPoolImpl(
     Upstream::ThreadLocalCluster& thread_local_cluster, Upstream::LoadBalancerContext* context,
     const UdpTunnelingConfig& tunnel_config, UpstreamTunnelCallbacks& upstream_callbacks,
-    StreamInfo::StreamInfo& downstream_info, bool flush_access_log_on_tunnel_connected,
-    const std::vector<AccessLog::InstanceSharedPtr>& session_access_logs)
+    StreamInfo::StreamInfo& downstream_info)
     : upstream_callbacks_(upstream_callbacks), tunnel_config_(tunnel_config),
-      downstream_info_(downstream_info),
-      flush_access_log_on_tunnel_connected_(flush_access_log_on_tunnel_connected),
-      session_access_logs_(session_access_logs) {
+      downstream_info_(downstream_info) {
   // TODO(ohadvano): support upstream HTTP/3.
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http2;
   conn_pool_data_ =
@@ -864,24 +861,14 @@ void TunnelingConnectionPoolImpl::onPoolReady(Http::RequestEncoder& request_enco
   upstream_->setTunnelCreationCallbacks(*this);
   downstream_info_.upstreamInfo()->setUpstreamHost(upstream_host);
   callbacks_->resetIdleTimer();
-
-  if (flush_access_log_on_tunnel_connected_) {
-    const Formatter::HttpFormatterContext log_context{
-        nullptr, nullptr, nullptr, {}, AccessLog::AccessLogType::UdpTunnelUpstreamConnected};
-    for (const auto& access_log : session_access_logs_) {
-      access_log->log(log_context, downstream_info_);
-    }
-  }
 }
 
 TunnelingConnectionPoolPtr TunnelingConnectionPoolFactory::createConnPool(
     Upstream::ThreadLocalCluster& thread_local_cluster, Upstream::LoadBalancerContext* context,
     const UdpTunnelingConfig& tunnel_config, UpstreamTunnelCallbacks& upstream_callbacks,
-    StreamInfo::StreamInfo& downstream_info, bool flush_access_log_on_tunnel_connected,
-    const std::vector<AccessLog::InstanceSharedPtr>& session_access_logs) const {
+    StreamInfo::StreamInfo& downstream_info) const {
   auto pool = std::make_unique<TunnelingConnectionPoolImpl>(
-      thread_local_cluster, context, tunnel_config, upstream_callbacks, downstream_info,
-      flush_access_log_on_tunnel_connected, session_access_logs);
+      thread_local_cluster, context, tunnel_config, upstream_callbacks, downstream_info);
   return (pool->valid() ? std::move(pool) : nullptr);
 }
 
@@ -937,8 +924,7 @@ bool UdpProxyFilter::TunnelingActiveSession::createConnectionPool() {
 
   conn_pool_ = conn_pool_factory_->createConnPool(
       cluster_.cluster_, load_balancer_context_.get(), *cluster_.filter_.config_->tunnelingConfig(),
-      *this, udp_session_info_, cluster_.filter_.config_->flushAccessLogOnTunnelConnected(),
-      cluster_.filter_.config_->sessionAccessLogs());
+      *this, udp_session_info_);
 
   if (conn_pool_) {
     connecting_ = true;
@@ -993,6 +979,16 @@ void UdpProxyFilter::TunnelingActiveSession::onStreamReady(StreamInfo::StreamInf
   connecting_ = false;
   can_send_upstream_ = true;
   cluster_.cluster_stats_.sess_tunnel_success_.inc();
+
+  if (cluster_.filter_.config_->flushAccessLogOnTunnelConnected()) {
+    fillSessionStreamInfo();
+    const Formatter::HttpFormatterContext log_context{
+        nullptr, nullptr, nullptr, {}, AccessLog::AccessLogType::UdpTunnelUpstreamConnected};
+    for (const auto& access_log : cluster_.filter_.config_->sessionAccessLogs()) {
+      access_log->log(log_context, udp_session_info_);
+    }
+  }
+
   flushBuffer();
 }
 

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -402,9 +402,7 @@ public:
                               Upstream::LoadBalancerContext* context,
                               const UdpTunnelingConfig& tunnel_config,
                               UpstreamTunnelCallbacks& upstream_callbacks,
-                              StreamInfo::StreamInfo& downstream_info,
-                              bool flush_access_log_on_tunnel_connected,
-                              const std::vector<AccessLog::InstanceSharedPtr>& session_access_logs);
+                              StreamInfo::StreamInfo& downstream_info);
   ~TunnelingConnectionPoolImpl() override = default;
 
   bool valid() const { return conn_pool_data_.has_value(); }
@@ -445,8 +443,6 @@ private:
   Http::ConnectionPool::Cancellable* upstream_handle_{};
   const UdpTunnelingConfig& tunnel_config_;
   StreamInfo::StreamInfo& downstream_info_;
-  const bool flush_access_log_on_tunnel_connected_;
-  const std::vector<AccessLog::InstanceSharedPtr>& session_access_logs_;
   Upstream::HostDescriptionConstSharedPtr upstream_host_;
   Ssl::ConnectionInfoConstSharedPtr ssl_info_;
   StreamInfo::StreamInfo* upstream_info_;
@@ -462,17 +458,13 @@ public:
    * @param tunnel_config the tunneling config.
    * @param upstream_callbacks the callbacks to provide to the connection if successfully created.
    * @param stream_info is the downstream session stream info.
-   * @param flush_access_log_on_tunnel_connected indicates whether to flush access log on tunnel
-   * connected.
-   * @param session_access_logs is the list of access logs for the session.
    * @return may be null if pool creation failed.
    */
-  TunnelingConnectionPoolPtr
-  createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
-                 Upstream::LoadBalancerContext* context, const UdpTunnelingConfig& tunnel_config,
-                 UpstreamTunnelCallbacks& upstream_callbacks, StreamInfo::StreamInfo& stream_info,
-                 bool flush_access_log_on_tunnel_connected,
-                 const std::vector<AccessLog::InstanceSharedPtr>& session_access_logs) const;
+  TunnelingConnectionPoolPtr createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
+                                            Upstream::LoadBalancerContext* context,
+                                            const UdpTunnelingConfig& tunnel_config,
+                                            UpstreamTunnelCallbacks& upstream_callbacks,
+                                            StreamInfo::StreamInfo& stream_info) const;
 };
 
 using TunnelingConnectionPoolFactoryPtr = std::unique_ptr<TunnelingConnectionPoolFactory>;

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -1949,9 +1949,8 @@ public:
     header_evaluator_ = Envoy::Router::HeaderParser::configure(headers_to_add).value();
     config_ = std::make_unique<NiceMock<MockUdpTunnelingConfig>>(*header_evaluator_);
     stream_info_.downstream_connection_info_provider_->setConnectionID(0);
-    session_access_logs_ = std::make_unique<std::vector<AccessLog::InstanceSharedPtr>>();
     pool_ = std::make_unique<TunnelingConnectionPoolImpl>(
-        cluster_, &context_, *config_, callbacks_, stream_info_, false, *session_access_logs_);
+        cluster_, &context_, *config_, callbacks_, stream_info_);
   }
 
   void createNewStream() { pool_->newStream(stream_callbacks_); }
@@ -1962,7 +1961,6 @@ public:
   std::unique_ptr<NiceMock<MockUdpTunnelingConfig>> config_;
   NiceMock<MockUpstreamTunnelCallbacks> callbacks_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
-  std::unique_ptr<std::vector<AccessLog::InstanceSharedPtr>> session_access_logs_;
   NiceMock<MockHttpStreamCallbacks> stream_callbacks_;
   NiceMock<Http::MockRequestEncoder> request_encoder_;
   std::shared_ptr<NiceMock<Upstream::MockHostDescription>> upstream_host_{
@@ -2042,13 +2040,12 @@ TEST_F(TunnelingConnectionPoolImplTest, FactoryTest) {
   setup();
 
   TunnelingConnectionPoolFactory factory;
-  auto valid_pool = factory.createConnPool(cluster_, &context_, *config_, callbacks_, stream_info_,
-                                           false, *session_access_logs_);
+  auto valid_pool = factory.createConnPool(cluster_, &context_, *config_, callbacks_, stream_info_);
   EXPECT_FALSE(valid_pool == nullptr);
 
   EXPECT_CALL(cluster_, httpConnPool(_, _, _)).WillOnce(Return(absl::nullopt));
   auto invalid_pool = factory.createConnPool(cluster_, &context_, *config_, callbacks_,
-                                             stream_info_, false, *session_access_logs_);
+                                             stream_info_);
   EXPECT_TRUE(invalid_pool == nullptr);
 }
 

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -1949,8 +1949,8 @@ public:
     header_evaluator_ = Envoy::Router::HeaderParser::configure(headers_to_add).value();
     config_ = std::make_unique<NiceMock<MockUdpTunnelingConfig>>(*header_evaluator_);
     stream_info_.downstream_connection_info_provider_->setConnectionID(0);
-    pool_ = std::make_unique<TunnelingConnectionPoolImpl>(
-        cluster_, &context_, *config_, callbacks_, stream_info_);
+    pool_ = std::make_unique<TunnelingConnectionPoolImpl>(cluster_, &context_, *config_, callbacks_,
+                                                          stream_info_);
   }
 
   void createNewStream() { pool_->newStream(stream_callbacks_); }

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -2044,8 +2044,8 @@ TEST_F(TunnelingConnectionPoolImplTest, FactoryTest) {
   EXPECT_FALSE(valid_pool == nullptr);
 
   EXPECT_CALL(cluster_, httpConnPool(_, _, _)).WillOnce(Return(absl::nullopt));
-  auto invalid_pool = factory.createConnPool(cluster_, &context_, *config_, callbacks_,
-                                             stream_info_);
+  auto invalid_pool =
+      factory.createConnPool(cluster_, &context_, *config_, callbacks_, stream_info_);
   EXPECT_TRUE(invalid_pool == nullptr);
 }
 


### PR DESCRIPTION
Commit Message: Flush UdpTunnelUpstreamConnected access log only after receiving valid response headers from upstream
Additional Description:
Risk Level: low
Testing: integration tests
Docs Changes:
Release Notes:
Platform Specific Features: