### PR TITLE
honor connection_pool_per_downstream_connection in tcp_conn_pool

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -134,6 +134,11 @@ minor_behavior_changes:
 - area: http
   change: |
     Removed runtime guard ``envoy.reloadable_features.refresh_rtt_after_request`` and legacy code path.
+- area: tcp
+  change: |
+    Added support for :ref:`connection_pool_per_downstream_connection
+    <envoy_v3_api_field_config.cluster.v3.Cluster.connection_pool_per_downstream_connection>` flag in tcp connection pool.
+
 - area: http
   change: |
     Changing HTTP/2 semi-colon prefixed headers to being sanitized by Envoy code rather than nghttp2. Should be a functional no-op but

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -138,7 +138,6 @@ minor_behavior_changes:
   change: |
     Added support for :ref:`connection_pool_per_downstream_connection
     <envoy_v3_api_field_config.cluster.v3.Cluster.connection_pool_per_downstream_connection>` flag in tcp connection pool.
-
 - area: http
   change: |
     Changing HTTP/2 semi-colon prefixed headers to being sanitized by Envoy code rather than nghttp2. Should be a functional no-op but

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2132,6 +2132,13 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPoolImpl
     option->hashKey(hash_key);
   }
 
+  // If configured, use the downstream connection id in pool hash key
+  if (cluster_info_->connectionPoolPerDownstreamConnection() && context &&
+      context->downstreamConnection()) {
+    ENVOY_LOG(trace, "honoring connection_pool_per_downstream_connection");
+    context->downstreamConnection()->hashKey(hash_key);
+  }
+
   bool have_transport_socket_options = false;
   if (context != nullptr && context->upstreamTransportSocketOptions() != nullptr) {
     have_transport_socket_options = true;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -6330,7 +6330,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
                                                          Http::Protocol::Http11, &lb_context)));
 }
 
-TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection_TCP) {
+TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection_tcp) {
   const std::string yaml = R"EOF(
   static_resources:
     clusters:
@@ -6365,7 +6365,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection_TCP) {
         .WillOnce(Invoke([i](std::vector<uint8_t>& hash_key) { hash_key.push_back(i); }));
     EXPECT_EQ(conn_pool_vector.back(),
               TcpPoolDataPeer::getPool(cluster_manager_->getThreadLocalCluster("cluster_1")
-                                          ->tcpConnPool(ResourcePriority::Default, &lb_context)));
+                                           ->tcpConnPool(ResourcePriority::Default, &lb_context)));
   }
 
   // Check that the first entry is still in the pool map
@@ -6374,7 +6374,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection_TCP) {
   }));
   EXPECT_EQ(conn_pool_vector.front(),
             TcpPoolDataPeer::getPool(cluster_manager_->getThreadLocalCluster("cluster_1")
-                                        ->tcpConnPool(ResourcePriority::Default, &lb_context)));
+                                         ->tcpConnPool(ResourcePriority::Default, &lb_context)));
 }
 
 TEST_F(ClusterManagerImplTest, CheckActiveStaticCluster) {

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -6330,6 +6330,53 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
                                                          Http::Protocol::Http11, &lb_context)));
 }
 
+TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection_TCP) {
+  const std::string yaml = R"EOF(
+  static_resources:
+    clusters:
+    - name: cluster_1
+      connect_timeout: 0.250s
+      lb_policy: ROUND_ROBIN
+      type: STATIC
+      connection_pool_per_downstream_connection: true
+      load_assignment:
+        cluster_name: cluster_1
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 11001
+  )EOF";
+  create(parseBootstrapFromV3Yaml(yaml));
+  NiceMock<MockLoadBalancerContext> lb_context;
+  NiceMock<Network::MockConnection> downstream_connection;
+  Network::Socket::OptionsSharedPtr options_to_return = nullptr;
+  ON_CALL(lb_context, downstreamConnection()).WillByDefault(Return(&downstream_connection));
+  ON_CALL(downstream_connection, socketOptions()).WillByDefault(ReturnRef(options_to_return));
+
+  std::vector<Tcp::ConnectionPool::MockInstance*> conn_pool_vector;
+  for (size_t i = 0; i < 3; ++i) {
+    conn_pool_vector.push_back(new Tcp::ConnectionPool::MockInstance());
+    EXPECT_CALL(*conn_pool_vector.back(), addIdleCallback(_));
+    EXPECT_CALL(factory_, allocateTcpConnPool_(_)).WillOnce(Return(conn_pool_vector.back()));
+    EXPECT_CALL(downstream_connection, hashKey)
+        .WillOnce(Invoke([i](std::vector<uint8_t>& hash_key) { hash_key.push_back(i); }));
+    EXPECT_EQ(conn_pool_vector.back(),
+              TcpPoolDataPeer::getPool(cluster_manager_->getThreadLocalCluster("cluster_1")
+                                          ->tcpConnPool(ResourcePriority::Default, &lb_context)));
+  }
+
+  // Check that the first entry is still in the pool map
+  EXPECT_CALL(downstream_connection, hashKey).WillOnce(Invoke([](std::vector<uint8_t>& hash_key) {
+    hash_key.push_back(0);
+  }));
+  EXPECT_EQ(conn_pool_vector.front(),
+            TcpPoolDataPeer::getPool(cluster_manager_->getThreadLocalCluster("cluster_1")
+                                        ->tcpConnPool(ResourcePriority::Default, &lb_context)));
+}
+
 TEST_F(ClusterManagerImplTest, CheckActiveStaticCluster) {
   const std::string yaml = R"EOF(
   static_resources:


### PR DESCRIPTION
Commit Message: this flag is already supported by httpConnPool. Adding to tcpConnPool as well so that thrift_proxy etc can use this feature.
Risk Level: low
Fixes https://github.com/envoyproxy/envoy/issues/34762