### PR TITLE
Revert "ext_proc: observability mode part 4: Implement the deferred c…

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -257,6 +257,7 @@ message ExternalProcessor {
   RouteCacheAction route_cache_action = 18
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
 
+  // [#not-implemented-hide:]
   // Specifies the deferred closure timeout for gRPC stream that connects to external processor. Currently, the deferred stream closure
   // is only used in :ref:`observability_mode <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.observability_mode>`.
   // In observability mode, gRPC streams may be held open to the external processor longer than the lifetime of the regular client to

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -184,10 +184,8 @@ FilterConfig::FilterConfig(
     Server::Configuration::CommonFactoryContext& context)
     : failure_mode_allow_(config.failure_mode_allow()),
       observability_mode_(config.observability_mode()),
-      route_cache_action_(config.route_cache_action()),
-      deferred_close_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, deferred_close_timeout,
-                                                         DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS)),
-      message_timeout_(message_timeout), max_message_timeout_ms_(max_message_timeout_ms),
+      route_cache_action_(config.route_cache_action()), message_timeout_(message_timeout),
+      max_message_timeout_ms_(max_message_timeout_ms),
       stats_(generateStats(stats_prefix, config.stat_prefix(), scope)),
       processing_mode_(config.processing_mode()),
       mutation_checker_(config.mutation_rules(), context.regexEngine()),
@@ -358,8 +356,7 @@ Filter::StreamOpenState Filter::openStream() {
 
     // TODO(tyxia) Switch to address of stream
     stream_ = config_->threadLocalStreamManager().store(decoder_callbacks_->streamId(),
-                                                        std::move(stream_object), config_->stats(),
-                                                        config_->deferredCloseTimeout());
+                                                        std::move(stream_object), config_->stats());
     // For custom access logging purposes. Applicable only for Envoy gRPC as Google gRPC does not
     // have a proper implementation of streamInfo.
     if (grpc_service_.has_envoy_grpc() && logging_info_ != nullptr) {
@@ -1381,7 +1378,7 @@ void DeferredDeletableStream::deferredClose(Envoy::Event::Dispatcher& dispatcher
                                             uint64_t stream_id) {
   derferred_close_timer =
       dispatcher.createTimer([this, stream_id] { closeStreamOnTimer(stream_id); });
-  derferred_close_timer->enableTimer(std::chrono::milliseconds(deferred_close_timeout));
+  derferred_close_timer->enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 std::string responseCaseToString(const ProcessingResponse::ResponseCase response_case) {

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -45,7 +45,7 @@ using envoy::service::ext_proc::v3::ImmediateResponse;
 using envoy::service::ext_proc::v3::ProcessingRequest;
 using envoy::service::ext_proc::v3::ProcessingResponse;
 using envoy::service::ext_proc::v3::TrailersResponse;
-using Extensions::HttpFilters::ExternalProcessing::DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS;
+using Extensions::HttpFilters::ExternalProcessing::DEFAULT_CLOSE_TIMEOUT_MS;
 using Extensions::HttpFilters::ExternalProcessing::HasNoHeader;
 using Extensions::HttpFilters::ExternalProcessing::HeaderProtosEqual;
 using Extensions::HttpFilters::ExternalProcessing::makeHeaderValue;
@@ -4161,7 +4161,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithHeader) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithBody) {
@@ -4204,7 +4204,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithBody) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithWrongBodyMode) {
@@ -4222,7 +4222,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithWrongBodyMode) {
   handleUpstreamRequest();
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithTrailer) {
@@ -4254,13 +4254,11 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithTrailer) {
   verifyDownstreamResponse(*response, 200);
   EXPECT_THAT(*(response->trailers()), HasNoHeader("x-modified-trailers"));
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequest) {
   proto_config_.set_observability_mode(true);
-  uint32_t deferred_close_timeout_ms = 1000;
-  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms / 1000);
 
   proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
   proto_config_.mutable_processing_mode()->set_request_trailer_mode(ProcessingMode::SEND);
@@ -4278,13 +4276,11 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullRequest) {
   handleUpstreamRequest();
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(deferred_close_timeout_ms));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
   proto_config_.set_observability_mode(true);
-  uint32_t deferred_close_timeout_ms = 1000;
-  proto_config_.mutable_deferred_close_timeout()->set_seconds(deferred_close_timeout_ms / 1000);
 
   proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SKIP);
   proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
@@ -4302,7 +4298,7 @@ TEST_P(ExtProcIntegrationTest, ObservabilityModeWithFullResponse) {
 
   verifyDownstreamResponse(*response, 200);
 
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(deferred_close_timeout_ms));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, ObservabilityModeWithLogging) {
@@ -4396,6 +4392,9 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersUpstreamObservabilityMode) {
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  // EXPECT_THAT(upstream_request_->headers(), HasNoHeader("x-remove-this"));
+  // EXPECT_THAT(upstream_request_->headers(), HasNoHeader("x-new-header", "new"));
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(100, true);
@@ -4497,7 +4496,7 @@ TEST_P(ExtProcIntegrationTest, InvalidServerOnResponseInObservabilityMode) {
   handleUpstreamRequest();
   EXPECT_FALSE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, processor_connection_,
                                                          std::chrono::milliseconds(25000)));
-  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS));
+  timeSystem().advanceTimeWaitImpl(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS));
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstream) {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -4104,7 +4104,7 @@ TEST_F(HttpFilterTest, HeaderProcessingInObservabilityMode) {
   // Deferred close timer is expected to be enabled by `DeferredDeletableStream`'s deferredClose(),
   // which is triggered by filter onDestroy() function below.
   EXPECT_CALL(*deferred_close_timer_,
-              enableTimer(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS), _));
+              enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS), _));
   filter_->onDestroy();
   deferred_close_timer_->invokeCallback();
 
@@ -4192,7 +4192,7 @@ TEST_F(HttpFilterTest, StreamingBodiesInObservabilityMode) {
   // Deferred close timer is expected to be enabled by `DeferredDeletableStream`'s deferredClose(),
   // which is triggered by filter onDestroy() function.
   EXPECT_CALL(*deferred_close_timer_,
-              enableTimer(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS), _));
+              enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS), _));
   filter_->onDestroy();
   deferred_close_timer_->invokeCallback();
 
@@ -4240,7 +4240,7 @@ TEST_F(HttpFilterTest, StreamingAllDataInObservabilityMode) {
   // Deferred close timer is expected to be enabled by `DeferredDeletableStream`'s deferredClose(),
   // which is triggered by filter onDestroy() function.
   EXPECT_CALL(*deferred_close_timer_,
-              enableTimer(std::chrono::milliseconds(DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS), _));
+              enableTimer(std::chrono::milliseconds(DEFAULT_CLOSE_TIMEOUT_MS), _));
   filter_->onDestroy();
   deferred_close_timer_->invokeCallback();
 


### PR DESCRIPTION
…losure timeout.  (#35084)"

This reverts commit 10ac2b65b3a1306db60c49d979c4cea5bc7848c7.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
