### PR TITLE
local rate limit: fix a bug where the x-ratelimit-* headers is added by default

### DIFF
--- a/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/http/local_ratelimit/local_ratelimit.cc
@@ -179,7 +179,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
 Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers, bool) {
   // We can never assume the decodeHeaders() was called before encodeHeaders().
-  if (token_bucket_context_.has_value()) {
+  if (used_config_->enableXRateLimitHeaders() && token_bucket_context_.has_value()) {
     headers.addReferenceKey(
         HttpFilters::Common::RateLimit::XRateLimitHeaders::get().XRateLimitLimit,
         token_bucket_context_->maxTokens());

--- a/test/extensions/filters/http/local_ratelimit/filter_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/filter_test.cc
@@ -719,6 +719,28 @@ TEST_F(DescriptorFilterTest, RouteDescriptorRequestRatelimitedXRateLimitHeaders)
   EXPECT_EQ(1U, findCounter("test.http_local_rate_limit.rate_limited"));
 }
 
+TEST_F(DescriptorFilterTest, RouteDescriptorRequestRatelimitedWithoutXRateLimitHeaders) {
+  setUpTest(fmt::format(descriptor_config_yaml, "0", "\"OFF\"", "0", "0"));
+
+  EXPECT_CALL(decoder_callbacks_.route_->route_entry_.rate_limit_policy_,
+              getApplicableRateLimit(0));
+
+  EXPECT_CALL(route_rate_limit_, populateLocalDescriptors(_, _, _, _))
+      .WillOnce(testing::SetArgReferee<0>(descriptor_));
+
+  auto request_headers = Http::TestRequestHeaderMapImpl();
+  auto response_headers = Http::TestResponseHeaderMapImpl();
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+  EXPECT_TRUE(response_headers.get(Http::LowerCaseString("x-ratelimit-limit")).empty());
+  EXPECT_TRUE(response_headers.get(Http::LowerCaseString("x-ratelimit-remaining")).empty());
+  EXPECT_EQ(1U, findCounter("test.http_local_rate_limit.enabled"));
+  EXPECT_EQ(1U, findCounter("test.http_local_rate_limit.enforced"));
+  EXPECT_EQ(1U, findCounter("test.http_local_rate_limit.rate_limited"));
+}
+
 TEST_F(DescriptorFilterTest,
        RouteDescriptorRequestRatelimitedXRateLimitHeadersWithTimerTokenBucket) {
   TestScopedRuntime runtime;


### PR DESCRIPTION
Commit Message: local rate limit: fix a bug where the x-ratelimit-* headers is added by default
Additional Description:

#35112 introduce a bug where the x-ratelimit-* headers will be added by default. See #35245 for more detail.

This PR fix it and add a unit test to ensue we won't regression.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a. No stable version contains this bug. So, I didn't add the change log.
Platform Specific Features: n/a.