### PR TITLE
[mobile]Initialize booleans in Apple proxy resolvers

### DIFF
--- a/mobile/library/common/network/apple_proxy_resolver.h
+++ b/mobile/library/common/network/apple_proxy_resolver.h
@@ -50,7 +50,7 @@ private:
   std::unique_ptr<ApplePacProxyResolver> pac_proxy_resolver_;
   absl::optional<SystemProxySettings> proxy_settings_;
   absl::Mutex mutex_;
-  bool started_;
+  bool started_ = false;
 };
 
 } // namespace Network

--- a/mobile/library/common/network/apple_system_proxy_settings_monitor.h
+++ b/mobile/library/common/network/apple_system_proxy_settings_monitor.h
@@ -42,7 +42,7 @@ private:
 
   dispatch_source_t source_;
   dispatch_queue_t queue_;
-  bool started_;
+  bool started_ = false;
   SystemProxySettingsReadCallback proxy_settings_read_callback_;
 };
 


### PR DESCRIPTION
Commit Message: Initialize booleans in Apple proxy resolvers
Additional Description: This fixes issue where the resolver thinks it's already started and system proxy setting is not read.
Risk Level: Low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
