### PR TITLE
server: fixed crash in server properties cache

### DIFF
--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -234,7 +234,9 @@ HttpServerPropertiesCacheImpl::addOriginData(const Origin& origin, OriginData&& 
   ASSERT(protocols_.find(origin) == protocols_.end());
   while (protocols_.size() >= max_entries_) {
     auto iter = protocols_.begin();
-    key_value_store_->remove(originToString(iter->first));
+    if (key_value_store_) {
+      key_value_store_->remove(originToString(iter->first));
+    }
     protocols_.erase(iter);
   }
   protocols_[origin] = std::move(origin_data);


### PR DESCRIPTION
Commit Message:
fix for crash in server properties cache
Additional Description:
Reported the crash to envoy-security@googlegroups.com and got green light to proceed in public. The issue is that key_value_store_ used in cache may be NULL, so it should be checked before each use.
Risk Level: Low
Testing: Converted to parameterized tests to run each test with valid and NULL key_value_store_.
Docs Changes: No
Release Notes: No