### PR TITLE
ext_proc: Fix the flaky test

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1599,8 +1599,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeadersAndTrailersOnResponse) {
 // Test the filter using the default configuration by connecting to
 // an ext_proc server that tries to modify the trailers incorrectly
 // according to the header mutation rules.
-// TODO(tyxia): re-enable this test (see https://github.com/envoyproxy/envoy/issues/35281)
-TEST_P(ExtProcIntegrationTest, DISABLED_GetAndSetTrailersIncorrectlyOnResponse) {
+TEST_P(ExtProcIntegrationTest, GetAndSetTrailersIncorrectlyOnResponse) {
   proto_config_.mutable_processing_mode()->set_response_trailer_mode(ProcessingMode::SEND);
   proto_config_.mutable_mutation_rules()->mutable_disallow_all()->set_value(true);
   proto_config_.mutable_mutation_rules()->mutable_disallow_is_error()->set_value(true);
@@ -1620,6 +1619,7 @@ TEST_P(ExtProcIntegrationTest, DISABLED_GetAndSetTrailersIncorrectlyOnResponse) 
       });
 
   if (Runtime::runtimeFeatureEnabled(Runtime::defer_processing_backedup_streams)) {
+    timeSystem().advanceTimeWait(TestUtility::DefaultTimeout);
     // We get a reset since we've received some of the response already.
     ASSERT_TRUE(response->waitForReset());
   } else {

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -1619,6 +1619,7 @@ TEST_P(ExtProcIntegrationTest, GetAndSetTrailersIncorrectlyOnResponse) {
       });
 
   if (Runtime::runtimeFeatureEnabled(Runtime::defer_processing_backedup_streams)) {
+    // Advance time by `DefaultTimeout` which is default timeout used in waitForReset() below.
     timeSystem().advanceTimeWait(TestUtility::DefaultTimeout);
     // We get a reset since we've received some of the response already.
     ASSERT_TRUE(response->waitForReset());


### PR DESCRIPTION
Use simulate time.
Test with --runs_per_test=5000 (I can only reproduce this flakiness with 5000)
