### PR TITLE
ext_proc: flow control in observability mode

### DIFF
--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -62,9 +62,9 @@ void ExternalProcessorStreamImpl::send(envoy::service::ext_proc::v3::ProcessingR
 bool ExternalProcessorStreamImpl::close() {
   if (!stream_closed_) {
     ENVOY_LOG(debug, "Closing gRPC stream");
-    if (grpc_side_stream_flow_control_ && !watermark_callbacks_removed_) {
+    // Unregister the watermark callbacks, if any exist.
+    if (grpc_side_stream_flow_control_ && callbacks_.has_value()) {
       stream_.removeWatermarkCallbacks();
-      watermark_callbacks_removed_ = true;
     }
     stream_.closeStream();
     stream_closed_ = true;

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -62,8 +62,9 @@ void ExternalProcessorStreamImpl::send(envoy::service::ext_proc::v3::ProcessingR
 bool ExternalProcessorStreamImpl::close() {
   if (!stream_closed_) {
     ENVOY_LOG(debug, "Closing gRPC stream");
-    if (grpc_side_stream_flow_control_) {
+    if (grpc_side_stream_flow_control_ && !watermark_callbacks_removed_) {
       stream_.removeWatermarkCallbacks();
+      watermark_callbacks_removed_ = true;
     }
     stream_.closeStream();
     stream_closed_ = true;

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -62,7 +62,7 @@ void ExternalProcessorStreamImpl::send(envoy::service::ext_proc::v3::ProcessingR
 bool ExternalProcessorStreamImpl::close() {
   if (!stream_closed_) {
     ENVOY_LOG(debug, "Closing gRPC stream");
-    // Unregister the watermark callbacks, if any exist.
+    // Unregister the watermark callbacks, if any exist (e.g., filter is not destroyed yet)
     if (grpc_side_stream_flow_control_ && callbacks_.has_value()) {
       stream_.removeWatermarkCallbacks();
     }

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -60,10 +60,8 @@ public:
 
     // Unregister the watermark callbacks(if any) to prevent access of filter callbacks after
     // the filter object is destroyed.
-    if (grpc_side_stream_flow_control_) {
-      if (!stream_closed_) {
-        stream_.removeWatermarkCallbacks();
-      }
+    if (grpc_side_stream_flow_control_ && !stream_closed_) {
+      stream_.removeWatermarkCallbacks();
     }
   }
 

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -61,7 +61,7 @@ public:
     // Unregister the watermark callbacks(if any) to prevent access of filter callbacks after
     // the filter object is destroyed.
     if (grpc_side_stream_flow_control_) {
-      if (stream_ != nullptr) {
+      if (!stream_closed_) {
         stream_.removeWatermarkCallbacks();
       }
     }

--- a/source/extensions/filters/http/ext_proc/client_impl.h
+++ b/source/extensions/filters/http/ext_proc/client_impl.h
@@ -60,10 +60,9 @@ public:
 
     // Unregister the watermark callbacks(if any) to prevent access of filter callbacks after
     // the filter object is destroyed.
-    if (grpc_side_stream_flow_control_ && !watermark_callbacks_removed_) {
+    if (grpc_side_stream_flow_control_) {
       if (stream_ != nullptr) {
         stream_.removeWatermarkCallbacks();
-        watermark_callbacks_removed_ = true;
       }
     }
   }
@@ -96,8 +95,6 @@ private:
   Grpc::AsyncStream<ProcessingRequest> stream_;
   Http::AsyncClient::ParentContext grpc_context_;
   bool stream_closed_ = false;
-  // Boolean flag to prevent double removal of the watermark callbacks.
-  bool watermark_callbacks_removed_ = false;
   // Boolean flag initiated by runtime flag.
   const bool grpc_side_stream_flow_control_;
 };

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -396,15 +396,18 @@ void Filter::onDestroy() {
   decoding_state_.stopMessageTimer();
   encoding_state_.stopMessageTimer();
 
-  if (stream_ != nullptr) {
-    stream_->notifyFilterDestroy();
-  }
-
   if (config_->observabilityMode()) {
     // In observability mode where the main stream processing and side stream processing are
     // asynchronous, it is possible that filter instance is destroyed before the side stream request
     // arrives at ext_proc server. In order to prevent the data loss in this case, side stream
     // closure is deferred upon filter destruction with a timer.
+
+    // First, release the referenced filter resource.
+    if (stream_ != nullptr) {
+      stream_->notifyFilterDestroy();
+    }
+
+    // Second, perform stream deferred closure.
     deferredCloseStream();
   } else {
     // Perform immediate close on the stream otherwise.

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -647,7 +647,7 @@ protected:
     verifyDownstreamResponse(*response, 200);
   }
 
-  void testSidestreamPushbackDownstream(bool check_downstream_flow_control) {
+  void testSidestreamPushbackDownstream(uint32_t body_size, bool check_downstream_flow_control) {
     config_helper_.setBufferLimits(1024, 1024);
 
     proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SKIP);
@@ -656,7 +656,7 @@ protected:
     initializeConfig();
     HttpIntegrationTest::initialize();
 
-    std::string body_str = std::string(1030, 'a');
+    std::string body_str = std::string(body_size, 'a');
     auto response = sendDownstreamRequestWithBody(body_str, absl::nullopt);
 
     bool end_stream = false;
@@ -4536,7 +4536,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstream) {
     return;
   }
 
-  testSidestreamPushbackDownstream(true);
+  testSidestreamPushbackDownstream(16 * 1024, true);
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamObservabilityMode) {
@@ -4545,7 +4545,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamObservabilityMode) {
   }
 
   proto_config_.set_observability_mode(true);
-  testSidestreamPushbackDownstream(true);
+  testSidestreamPushbackDownstream(16 * 1024, true);
 }
 
 TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamRuntimeDisable) {
@@ -4556,7 +4556,7 @@ TEST_P(ExtProcIntegrationTest, SidestreamPushbackDownstreamRuntimeDisable) {
   scoped_runtime_.mergeValues(
       {{"envoy.reloadable_features.grpc_side_stream_flow_control", "false"}});
 
-  testSidestreamPushbackDownstream(false);
+  testSidestreamPushbackDownstream(1030, false);
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: This PR is split from https://github.com/envoyproxy/envoy/pull/35077. The change is specifically needed for ext_proc's observability mode where the stream is deferred closed upon filter destruction (i.e., stream outlives the filter object)

Risk Level: Low, existing runtime guard and observability mode only
Testing: e2e test and load test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A


