### PR TITLE
Ensure every instance of StreamFilter and PassThroughFilter to contain only one copy of StreamFilterBase.

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -857,7 +857,7 @@ public:
    * onDestroy() invoked. Filters that cross-register as access log handlers receive log() before
    * onDestroy().
    */
-  virtual void onDestroy() {}
+  virtual void onDestroy() PURE;
 
   /**
    * Called when a match result occurs that isn't handled by the filter manager.

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -857,7 +857,7 @@ public:
    * onDestroy() invoked. Filters that cross-register as access log handlers receive log() before
    * onDestroy().
    */
-  virtual void onDestroy() PURE;
+  virtual void onDestroy() {}
 
   /**
    * Called when a match result occurs that isn't handled by the filter manager.
@@ -901,7 +901,7 @@ public:
 /**
  * Stream decoder filter interface.
  */
-class StreamDecoderFilter : public StreamFilterBase {
+class StreamDecoderFilter : public virtual StreamFilterBase {
 public:
   /**
    * Called with decoded headers, optionally indicating end of stream.
@@ -1117,7 +1117,7 @@ public:
 /**
  * Stream encoder filter interface.
  */
-class StreamEncoderFilter : public StreamFilterBase {
+class StreamEncoderFilter : public virtual StreamFilterBase {
 public:
   /**
    * Called with supported 1xx headers.

--- a/source/extensions/filters/http/common/pass_through_filter.h
+++ b/source/extensions/filters/http/common/pass_through_filter.h
@@ -8,6 +8,9 @@ namespace Http {
 // A decoder filter which passes all data through with Continue status.
 class PassThroughDecoderFilter : public virtual StreamDecoderFilter {
 public:
+  // Http::StreamFilterBase
+  void onDestroy() override {}
+
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     return Http::FilterHeadersStatus::Continue;
@@ -29,6 +32,9 @@ protected:
 // An encoder filter which passes all data through with Continue status.
 class PassThroughEncoderFilter : public virtual StreamEncoderFilter {
 public:
+  // Http::StreamFilterBase
+  void onDestroy() override {}
+
   // Http::StreamEncoderFilter
   Http::Filter1xxHeadersStatus encode1xxHeaders(Http::ResponseHeaderMap&) override {
     return Http::Filter1xxHeadersStatus::Continue;
@@ -56,6 +62,10 @@ protected:
 // A filter which passes all data through with Continue status.
 class PassThroughFilter : public StreamFilter,
                           public PassThroughDecoderFilter,
-                          public PassThroughEncoderFilter {};
+                          public PassThroughEncoderFilter {
+public:
+  // Http::StreamFilterBase
+  void onDestroy() override {}
+};
 } // namespace Http
 } // namespace Envoy

--- a/source/extensions/filters/http/common/pass_through_filter.h
+++ b/source/extensions/filters/http/common/pass_through_filter.h
@@ -8,9 +8,6 @@ namespace Http {
 // A decoder filter which passes all data through with Continue status.
 class PassThroughDecoderFilter : public virtual StreamDecoderFilter {
 public:
-  // Http::StreamFilterBase
-  void onDestroy() override {}
-
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     return Http::FilterHeadersStatus::Continue;
@@ -32,9 +29,6 @@ protected:
 // An encoder filter which passes all data through with Continue status.
 class PassThroughEncoderFilter : public virtual StreamEncoderFilter {
 public:
-  // Http::StreamFilterBase
-  void onDestroy() override {}
-
   // Http::StreamEncoderFilter
   Http::Filter1xxHeadersStatus encode1xxHeaders(Http::ResponseHeaderMap&) override {
     return Http::Filter1xxHeadersStatus::Continue;


### PR DESCRIPTION
Change Stream(Decode|Encode)Filter to inherit from StreamFilterBase virtually.
Move the default implementation of PassThrough(Decoder|Encode)Filter::onDestroy into StreamFilterBase.

Commit Message: Ensure every instance of StreamFilter and PassThroughFilter to contain only one copy of Stream(Decode|Encode)Filter and StreamFilterBase.
Additional Description:
Risk Level: Medium
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
