### PR TITLE
backport to rel1.28: Fix crash in server properties cache.

### DIFF
--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -234,7 +234,9 @@ HttpServerPropertiesCacheImpl::addOriginData(const Origin& origin, OriginData&& 
   ASSERT(protocols_.find(origin) == protocols_.end());
   while (protocols_.size() >= max_entries_) {
     auto iter = protocols_.begin();
-    key_value_store_->remove(originToString(iter->first));
+    if (key_value_store_) {
+      key_value_store_->remove(originToString(iter->first));
+    }
     protocols_.erase(iter);
   }
   protocols_[origin] = std::move(origin_data);


### PR DESCRIPTION
Commit Message:
backport https://github.com/envoyproxy/envoy/pull/35268 to rel1.28
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:

