### PR TITLE
conn_handler: extend filter status to include StopIterationAndWaitForData

### DIFF
--- a/envoy/network/filter.h
+++ b/envoy/network/filter.h
@@ -37,7 +37,15 @@ enum class FilterStatus {
   // Continue to further filters.
   Continue,
   // Stop executing further filters.
-  StopIteration
+  //
+  // The filter is responsible to continue execution of listener/network filters through
+  // calling continueFilterChain(). This should be used by all StopIteration cases except for
+  // StopIterationAndWaitForData.
+  StopIteration,
+  // Stop executing further filters and wait for data on the wire to continue execution.
+  //
+  // Filter execution will be activated by on_data_cb when data is ready on the wire.
+  StopIterationAndWaitForData
 };
 
 /**

--- a/source/common/listener_manager/active_tcp_socket.cc
+++ b/source/common/listener_manager/active_tcp_socket.cc
@@ -120,7 +120,8 @@ void ActiveTcpSocket::continueFilterChain(bool success) {
 
     for (; iter_ != accept_filters_.end(); iter_++) {
       Network::FilterStatus status = (*iter_)->onAccept(*this);
-      if (status == Network::FilterStatus::StopIteration || status == Network::FilterStatus::StopIterationAndWaitForData) {
+      if (status == Network::FilterStatus::StopIteration ||
+          status == Network::FilterStatus::StopIterationAndWaitForData) {
         // The filter is responsible for calling us again at a later time to continue the filter
         // chain from the next filter.
         if (!socket().ioHandle().isOpen()) {

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -44,7 +44,7 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
     done(true);
     return Network::FilterStatus::Continue;
   case ParseState::Continue:
-    return Network::FilterStatus::StopIteration;
+    return Network::FilterStatus::StopIterationAndWaitForData;
   }
   PANIC_DUE_TO_CORRUPT_ENUM
 }
@@ -62,7 +62,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
   }
 
   cb_ = &cb;
-  return Network::FilterStatus::StopIteration;
+  return Network::FilterStatus::StopIterationAndWaitForData;
 }
 
 ParseState Filter::parseHttpHeader(absl::string_view data) {

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -176,7 +176,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
   ENVOY_LOG(debug, "proxy_protocol: New connection accepted");
   cb_ = &cb;
   // Waiting for data.
-  return Network::FilterStatus::StopIteration;
+  return Network::FilterStatus::StopIterationAndWaitForData;
 }
 
 Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
@@ -204,7 +204,7 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
     cb_->socket().ioHandle().close();
     return Network::FilterStatus::StopIteration;
   case ReadOrParseState::TryAgainLater:
-    return Network::FilterStatus::StopIteration;
+    return Network::FilterStatus::StopIterationAndWaitForData;
   case ReadOrParseState::Done:
     return Network::FilterStatus::Continue;
   }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -106,7 +106,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
   ENVOY_LOG(trace, "tls inspector: new connection accepted");
   cb_ = &cb;
 
-  return Network::FilterStatus::StopIteration;
+  return Network::FilterStatus::StopIterationAndWaitForData;
 }
 
 void Filter::onALPN(const unsigned char* data, unsigned int len) {
@@ -162,11 +162,11 @@ Network::FilterStatus Filter::onData(Network::ListenerFilterBuffer& buffer) {
       return Network::FilterStatus::Continue;
     case ParseState::Continue:
       // Do nothing but wait for the next event.
-      return Network::FilterStatus::StopIteration;
+      return Network::FilterStatus::StopIterationAndWaitForData;
     }
     IS_ENVOY_BUG("unexpected tcp filter parse_state");
   }
-  return Network::FilterStatus::StopIteration;
+  return Network::FilterStatus::StopIterationAndWaitForData;
 }
 
 ParseState Filter::parseClientHello(const void* data, size_t len,

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -115,7 +115,7 @@ public:
     bool got_continue = false;
     EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
     auto accepted = filter_->onAccept(cb_);
-    EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+    EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
     while (!got_continue) {
       ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
       auto status = filter_->onData(*buffer_);
@@ -192,7 +192,7 @@ public:
     bool got_continue = false;
     EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
     auto accepted = filter_->onAccept(cb_);
-    EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+    EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
     while (!got_continue) {
       ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
       auto status = filter_->onData(*buffer_);
@@ -257,7 +257,7 @@ public:
 
     EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
     auto accepted = filter_->onAccept(cb_);
-    EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+    EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
     ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
     auto status = filter_->onData(*buffer_);
     EXPECT_EQ(status, Network::FilterStatus::Continue);
@@ -316,7 +316,7 @@ public:
 #endif
     EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
     auto accepted = filter_->onAccept(cb_);
-    EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+    EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
     ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
     auto status = filter_->onData(*buffer_);
     EXPECT_EQ(status, Network::FilterStatus::Continue);
@@ -466,10 +466,10 @@ TEST_F(HttpInspectorTest, InvalidConnectionPreface) {
 #endif
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   auto accepted = filter_->onAccept(cb_);
-  EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+  EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
   ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
   auto status = filter_->onData(*buffer_);
-  EXPECT_EQ(status, Network::FilterStatus::StopIteration);
+  EXPECT_EQ(status, Network::FilterStatus::StopIterationAndWaitForData);
   EXPECT_EQ(0, cfg_->stats().http_not_found_.value());
 }
 
@@ -570,7 +570,7 @@ TEST_F(HttpInspectorTest, Http1WithLargeRequestLine) {
   const std::vector<absl::string_view> alpn_protos{Http::Utility::AlpnNames::get().Http10};
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
   auto accepted = filter_->onAccept(cb_);
-  EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+  EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
   while (!got_continue) {
     ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
     auto status = filter_->onData(*buffer_);
@@ -624,7 +624,7 @@ TEST_F(HttpInspectorTest, Http1WithLargeHeader) {
   const std::vector<absl::string_view> alpn_protos{Http::Utility::AlpnNames::get().Http10};
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(alpn_protos));
   auto accepted = filter_->onAccept(cb_);
-  EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
+  EXPECT_EQ(accepted, Network::FilterStatus::StopIterationAndWaitForData);
   while (!got_continue) {
     ASSERT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
     auto status = filter_->onData(*buffer_);

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -436,7 +436,7 @@ TEST_P(TlsInspectorTest, EarlyTerminationShouldNotRecordBytesProcessed) {
   // Trigger the event to copy the client hello message into buffer
   EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
   auto state = filter_->onData(*buffer_);
-  EXPECT_EQ(Network::FilterStatus::StopIteration, state);
+  EXPECT_EQ(Network::FilterStatus::StopIterationAndWaitForData, state);
 
   // Terminate early.
   filter_.reset();
@@ -464,14 +464,14 @@ TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoesNotGoBeyondMaxSize) {
   mockSysCallForPeek(client_hello, true);
   EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
   auto state = filter_->onData(*buffer_);
-  EXPECT_EQ(Network::FilterStatus::StopIteration, state);
+  EXPECT_EQ(Network::FilterStatus::StopIterationAndWaitForData, state);
   EXPECT_EQ(2 * initial_buffer_size, filter_->maxReadBytes());
   buffer_->resetCapacity(2 * initial_buffer_size);
 
   mockSysCallForPeek(client_hello, true);
   EXPECT_TRUE(file_event_callback_(Event::FileReadyType::Read).ok());
   state = filter_->onData(*buffer_);
-  EXPECT_EQ(Network::FilterStatus::StopIteration, state);
+  EXPECT_EQ(Network::FilterStatus::StopIterationAndWaitForData, state);
   EXPECT_EQ(max_size, filter_->maxReadBytes());
   buffer_->resetCapacity(max_size);
 

--- a/test/integration/filters/inspect_data_listener_filter.cc
+++ b/test/integration/filters/inspect_data_listener_filter.cc
@@ -30,7 +30,7 @@ public:
     cb_ = &cb;
     if (max_read_bytes_ != 0) {
       ENVOY_LOG_MISC(debug, "in InspectDataListenerFilter::onAccept, expect more data");
-      return Network::FilterStatus::StopIteration;
+      return Network::FilterStatus::StopIterationAndWaitForData;
     }
     if (config_->close_connection_) {
       ENVOY_LOG_MISC(
@@ -64,7 +64,7 @@ public:
                          "in InspectDataListenerFilter::onData, increase max_read_bytes to {} and "
                          "wating for more data.",
                          max_read_bytes_);
-          return Network::FilterStatus::StopIteration;
+          return Network::FilterStatus::StopIterationAndWaitForData;
         }
         ENVOY_LOG_MISC(
             debug,
@@ -75,7 +75,7 @@ public:
       ENVOY_LOG_MISC(
           debug,
           "in InspectDataListenerFilter::onData, waiting for more data and stop the iteration.");
-      return Network::FilterStatus::StopIteration;
+      return Network::FilterStatus::StopIterationAndWaitForData;
     }
   }
 

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -45,7 +45,7 @@ public:
   TestTcpListenerFilter(const uint32_t drain_bytes) : drain_bytes_(drain_bytes) {}
 
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks&) override {
-    return Network::FilterStatus::StopIteration;
+    return Network::FilterStatus::StopIterationAndWaitForData;
   }
 
   Network::FilterStatus onData(Network::ListenerFilterBuffer& buffer) override {

--- a/test/server/active_tcp_listener_test.cc
+++ b/test/server/active_tcp_listener_test.cc
@@ -134,13 +134,34 @@ public:
 };
 
 /**
+ * Filter without buffer returns `Network::FilterStatus::StopIteration`
+ * from `onAccept`, then is recovered and returns success.
+ */
+TEST_F(ActiveTcpListenerTest, ListenerFilterWithoutInspectData) {
+    initializeWithFilter();
+
+    // The filter stops iteration and waits for recovering execution.
+    EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+    EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
+
+    generic_active_listener_->onAcceptWorker(std::move(generic_accepted_socket_), false, true);
+
+    // get the ActiveTcpSocket pointer before unlink() removed from the link-list.
+    ActiveTcpSocket* tcp_socket = generic_active_listener_->sockets().front().get();
+
+    EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(nullptr));
+
+    tcp_socket->continueFilterChain(true);
+}
+
+/**
  * Execute peek data two times, then filter return successful.
  */
 TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectData) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
 
   Event::FileReadyCb file_event_callback;
@@ -155,7 +176,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectData) {
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_ / 2, Api::IoError::none()))));
   // the filter is looking for more data.
-  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_, Api::IoError::none()))));
@@ -173,7 +194,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataFailedWithPeek) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
   Event::FileReadyCb file_event_callback;
@@ -244,7 +265,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters) {
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
 
   EXPECT_CALL(*inspect_data_filter1, onAccept(_))
-      .WillOnce(Return(Network::FilterStatus::StopIteration));
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   Event::FileReadyCb file_event_callback;
   EXPECT_CALL(io_handle_,
@@ -276,14 +297,14 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters) {
   EXPECT_CALL(*no_inspect_data_filter, onAccept(_))
       .WillOnce(Return(Network::FilterStatus::Continue));
   EXPECT_CALL(*inspect_data_filter2, onAccept(_))
-      .WillOnce(Return(Network::FilterStatus::StopIteration));
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
   EXPECT_CALL(*inspect_data_filter2, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
   EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
   EXPECT_CALL(*inspect_data_filter3, onAccept(_))
-      .WillOnce(Return(Network::FilterStatus::StopIteration));
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
@@ -359,7 +380,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters2) {
       .WillOnce(Return(Network::FilterStatus::Continue));
 
   EXPECT_CALL(*inspect_data_filter1, onAccept(_))
-      .WillOnce(Return(Network::FilterStatus::StopIteration));
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
 
   active_listener->incNumConnections();
@@ -368,14 +389,14 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters2) {
 
   EXPECT_CALL(*inspect_data_filter1, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
   EXPECT_CALL(*inspect_data_filter2, onAccept(_))
-      .WillOnce(Return(Network::FilterStatus::StopIteration));
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
   EXPECT_CALL(*inspect_data_filter2, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
   EXPECT_CALL(*inspect_data_filter3, onAccept(_))
-      .WillOnce(Return(Network::FilterStatus::StopIteration));
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
@@ -387,13 +408,115 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters2) {
 }
 
 /**
+ * Similar to above test, but with no buffer filter recovered by actively calling continueFilterChain().
+ */
+TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters3) {
+    initialize();
+
+    auto inspect_size1 = 128;
+    auto* inspect_data_filter1 = new NiceMock<Network::MockListenerFilter>(inspect_size1);
+    EXPECT_CALL(*inspect_data_filter1, destroy_());
+
+    auto inspect_size2 = 512;
+    auto* inspect_data_filter2 = new NiceMock<Network::MockListenerFilter>(inspect_size2);
+    EXPECT_CALL(*inspect_data_filter2, destroy_());
+
+    auto inspect_size3 = 256;
+    auto* inspect_data_filter3 = new NiceMock<Network::MockListenerFilter>(inspect_size3);
+    EXPECT_CALL(*inspect_data_filter3, destroy_());
+
+    auto* no_inspect_data_filter1 = new NiceMock<Network::MockListenerFilter>();
+    EXPECT_CALL(*no_inspect_data_filter1, destroy_());
+
+    auto* no_inspect_data_filter2 = new NiceMock<Network::MockListenerFilter>();
+    EXPECT_CALL(*no_inspect_data_filter2, destroy_());
+
+    EXPECT_CALL(filter_chain_factory_, createListenerFilterChain(_))
+        .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
+            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{no_inspect_data_filter1});
+            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter1});
+            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter2});
+            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{no_inspect_data_filter2});
+            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter3});
+            return true;
+        }));
+
+    auto listener = std::make_unique<NiceMock<Network::MockListener>>();
+    EXPECT_CALL(*listener, onDestroy());
+    Network::NopConnectionBalancerImpl balancer;
+    Network::Address::InstanceConstSharedPtr address(
+        new Network::Address::Ipv4Instance("127.0.0.1", 10001));
+    auto active_listener = std::make_unique<ActiveTcpListener>(
+        conn_handler_, std::move(listener), address, listener_config_, balancer, runtime_);
+    auto accepted_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+
+    EXPECT_CALL(*accepted_socket, ioHandle()).WillRepeatedly(ReturnRef(io_handle_));
+    EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
+    Event::FileReadyCb file_event_callback;
+
+    EXPECT_CALL(io_handle_,
+                createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
+                                 Event::FileReadyType::Read | Event::FileReadyType::Closed))
+        .WillOnce(SaveArg<1>(&file_event_callback));
+    EXPECT_CALL(io_handle_, recv)
+        .WillOnce([&](void*, size_t size, int) {
+            EXPECT_EQ(128, size);
+            return Api::IoCallUint64Result(128, Api::IoError::none());
+        })
+        .WillOnce([&](void*, size_t size, int) {
+            EXPECT_EQ(512, size);
+            return Api::IoCallUint64Result(512, Api::IoError::none());
+        })
+        .WillOnce([&](void*, size_t size, int) {
+            EXPECT_EQ(512, size);
+            return Api::IoCallUint64Result(512, Api::IoError::none());
+        });
+
+    EXPECT_CALL(*no_inspect_data_filter1, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+
+    active_listener->incNumConnections();
+    // Calling the onAcceptWorker() to create the ActiveTcpSocket.
+    active_listener->onAcceptWorker(std::move(accepted_socket), false, true);
+
+    EXPECT_CALL(*inspect_data_filter1, onAccept(_))
+        .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+    EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
+
+    ActiveTcpSocket* tcp_socket1 = active_listener->sockets().front().get();
+    tcp_socket1->continueFilterChain(true);
+
+    EXPECT_CALL(*inspect_data_filter1, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
+    EXPECT_CALL(*inspect_data_filter2, onAccept(_))
+        .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+    EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
+
+    EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
+
+    EXPECT_CALL(*inspect_data_filter2, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
+    EXPECT_CALL(*no_inspect_data_filter2, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+
+    EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
+
+    EXPECT_CALL(*inspect_data_filter3, onAccept(_))
+        .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+    EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
+
+    tcp_socket1->continueFilterChain(true);
+
+    EXPECT_CALL(*inspect_data_filter3, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
+    EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(nullptr));
+
+    EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
+}
+
+/**
  * Trigger the file closed event.
  */
 TEST_F(ActiveTcpListenerTest, ListenerFilterWithClose) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
   Event::FileReadyCb file_event_callback;
@@ -408,7 +531,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithClose) {
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_ / 2, Api::IoError::none()))));
   // the filter is looking for more data
-  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
@@ -425,7 +548,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterCloseSockets) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   bool is_open = true;
 
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Invoke([&is_open]() { return is_open; }));
@@ -441,7 +564,7 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterCloseSockets) {
   // the filter is looking for more data
   EXPECT_CALL(*filter_, onData(_)).WillOnce(Invoke([&is_open]() {
     is_open = false;
-    return Network::FilterStatus::StopIteration;
+    return Network::FilterStatus::StopIterationAndWaitForData;
   }));
 
   generic_active_listener_->onAcceptWorker(std::move(generic_accepted_socket_), false, true);
@@ -454,7 +577,7 @@ TEST_F(ActiveTcpListenerTest, PopulateSNIWhenActiveTcpSocketTimeout) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
 
   Event::FileReadyCb file_event_callback;
@@ -473,7 +596,7 @@ TEST_F(ActiveTcpListenerTest, PopulateSNIWhenActiveTcpSocketTimeout) {
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_ / 2, Api::IoError::none()))));
   // the filter is looking for more data.
-  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 

--- a/test/server/active_tcp_listener_test.cc
+++ b/test/server/active_tcp_listener_test.cc
@@ -138,20 +138,20 @@ public:
  * from `onAccept`, then is recovered and returns success.
  */
 TEST_F(ActiveTcpListenerTest, ListenerFilterWithoutInspectData) {
-    initializeWithFilter();
+  initializeWithFilter();
 
-    // The filter stops iteration and waits for recovering execution.
-    EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
-    EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
+  // The filter stops iteration and waits for recovering execution.
+  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
 
-    generic_active_listener_->onAcceptWorker(std::move(generic_accepted_socket_), false, true);
+  generic_active_listener_->onAcceptWorker(std::move(generic_accepted_socket_), false, true);
 
-    // get the ActiveTcpSocket pointer before unlink() removed from the link-list.
-    ActiveTcpSocket* tcp_socket = generic_active_listener_->sockets().front().get();
+  // get the ActiveTcpSocket pointer before unlink() removed from the link-list.
+  ActiveTcpSocket* tcp_socket = generic_active_listener_->sockets().front().get();
 
-    EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(nullptr));
 
-    tcp_socket->continueFilterChain(true);
+  tcp_socket->continueFilterChain(true);
 }
 
 /**
@@ -161,7 +161,8 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectData) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
 
   Event::FileReadyCb file_event_callback;
@@ -176,7 +177,8 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectData) {
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_ / 2, Api::IoError::none()))));
   // the filter is looking for more data.
-  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onData(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_, Api::IoError::none()))));
@@ -194,7 +196,8 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataFailedWithPeek) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
   Event::FileReadyCb file_event_callback;
@@ -408,105 +411,108 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters2) {
 }
 
 /**
- * Similar to above test, but with no buffer filter recovered by actively calling continueFilterChain().
+ * Similar to above test, but with no buffer filter recovered by actively calling
+ * continueFilterChain().
  */
 TEST_F(ActiveTcpListenerTest, ListenerFilterWithInspectDataMultipleFilters3) {
-    initialize();
+  initialize();
 
-    auto inspect_size1 = 128;
-    auto* inspect_data_filter1 = new NiceMock<Network::MockListenerFilter>(inspect_size1);
-    EXPECT_CALL(*inspect_data_filter1, destroy_());
+  auto inspect_size1 = 128;
+  auto* inspect_data_filter1 = new NiceMock<Network::MockListenerFilter>(inspect_size1);
+  EXPECT_CALL(*inspect_data_filter1, destroy_());
 
-    auto inspect_size2 = 512;
-    auto* inspect_data_filter2 = new NiceMock<Network::MockListenerFilter>(inspect_size2);
-    EXPECT_CALL(*inspect_data_filter2, destroy_());
+  auto inspect_size2 = 512;
+  auto* inspect_data_filter2 = new NiceMock<Network::MockListenerFilter>(inspect_size2);
+  EXPECT_CALL(*inspect_data_filter2, destroy_());
 
-    auto inspect_size3 = 256;
-    auto* inspect_data_filter3 = new NiceMock<Network::MockListenerFilter>(inspect_size3);
-    EXPECT_CALL(*inspect_data_filter3, destroy_());
+  auto inspect_size3 = 256;
+  auto* inspect_data_filter3 = new NiceMock<Network::MockListenerFilter>(inspect_size3);
+  EXPECT_CALL(*inspect_data_filter3, destroy_());
 
-    auto* no_inspect_data_filter1 = new NiceMock<Network::MockListenerFilter>();
-    EXPECT_CALL(*no_inspect_data_filter1, destroy_());
+  auto* no_inspect_data_filter1 = new NiceMock<Network::MockListenerFilter>();
+  EXPECT_CALL(*no_inspect_data_filter1, destroy_());
 
-    auto* no_inspect_data_filter2 = new NiceMock<Network::MockListenerFilter>();
-    EXPECT_CALL(*no_inspect_data_filter2, destroy_());
+  auto* no_inspect_data_filter2 = new NiceMock<Network::MockListenerFilter>();
+  EXPECT_CALL(*no_inspect_data_filter2, destroy_());
 
-    EXPECT_CALL(filter_chain_factory_, createListenerFilterChain(_))
-        .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
-            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{no_inspect_data_filter1});
-            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter1});
-            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter2});
-            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{no_inspect_data_filter2});
-            manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter3});
-            return true;
-        }));
+  EXPECT_CALL(filter_chain_factory_, createListenerFilterChain(_))
+      .WillRepeatedly(Invoke([&](Network::ListenerFilterManager& manager) -> bool {
+        manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{no_inspect_data_filter1});
+        manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter1});
+        manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter2});
+        manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{no_inspect_data_filter2});
+        manager.addAcceptFilter(nullptr, Network::ListenerFilterPtr{inspect_data_filter3});
+        return true;
+      }));
 
-    auto listener = std::make_unique<NiceMock<Network::MockListener>>();
-    EXPECT_CALL(*listener, onDestroy());
-    Network::NopConnectionBalancerImpl balancer;
-    Network::Address::InstanceConstSharedPtr address(
-        new Network::Address::Ipv4Instance("127.0.0.1", 10001));
-    auto active_listener = std::make_unique<ActiveTcpListener>(
-        conn_handler_, std::move(listener), address, listener_config_, balancer, runtime_);
-    auto accepted_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  auto listener = std::make_unique<NiceMock<Network::MockListener>>();
+  EXPECT_CALL(*listener, onDestroy());
+  Network::NopConnectionBalancerImpl balancer;
+  Network::Address::InstanceConstSharedPtr address(
+      new Network::Address::Ipv4Instance("127.0.0.1", 10001));
+  auto active_listener = std::make_unique<ActiveTcpListener>(
+      conn_handler_, std::move(listener), address, listener_config_, balancer, runtime_);
+  auto accepted_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
 
-    EXPECT_CALL(*accepted_socket, ioHandle()).WillRepeatedly(ReturnRef(io_handle_));
-    EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
-    Event::FileReadyCb file_event_callback;
+  EXPECT_CALL(*accepted_socket, ioHandle()).WillRepeatedly(ReturnRef(io_handle_));
+  EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
+  Event::FileReadyCb file_event_callback;
 
-    EXPECT_CALL(io_handle_,
-                createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
-                                 Event::FileReadyType::Read | Event::FileReadyType::Closed))
-        .WillOnce(SaveArg<1>(&file_event_callback));
-    EXPECT_CALL(io_handle_, recv)
-        .WillOnce([&](void*, size_t size, int) {
-            EXPECT_EQ(128, size);
-            return Api::IoCallUint64Result(128, Api::IoError::none());
-        })
-        .WillOnce([&](void*, size_t size, int) {
-            EXPECT_EQ(512, size);
-            return Api::IoCallUint64Result(512, Api::IoError::none());
-        })
-        .WillOnce([&](void*, size_t size, int) {
-            EXPECT_EQ(512, size);
-            return Api::IoCallUint64Result(512, Api::IoError::none());
-        });
+  EXPECT_CALL(io_handle_,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
+                               Event::FileReadyType::Read | Event::FileReadyType::Closed))
+      .WillOnce(SaveArg<1>(&file_event_callback));
+  EXPECT_CALL(io_handle_, recv)
+      .WillOnce([&](void*, size_t size, int) {
+        EXPECT_EQ(128, size);
+        return Api::IoCallUint64Result(128, Api::IoError::none());
+      })
+      .WillOnce([&](void*, size_t size, int) {
+        EXPECT_EQ(512, size);
+        return Api::IoCallUint64Result(512, Api::IoError::none());
+      })
+      .WillOnce([&](void*, size_t size, int) {
+        EXPECT_EQ(512, size);
+        return Api::IoCallUint64Result(512, Api::IoError::none());
+      });
 
-    EXPECT_CALL(*no_inspect_data_filter1, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*no_inspect_data_filter1, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIteration));
 
-    active_listener->incNumConnections();
-    // Calling the onAcceptWorker() to create the ActiveTcpSocket.
-    active_listener->onAcceptWorker(std::move(accepted_socket), false, true);
+  active_listener->incNumConnections();
+  // Calling the onAcceptWorker() to create the ActiveTcpSocket.
+  active_listener->onAcceptWorker(std::move(accepted_socket), false, true);
 
-    EXPECT_CALL(*inspect_data_filter1, onAccept(_))
-        .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
-    EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
+  EXPECT_CALL(*inspect_data_filter1, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
 
-    ActiveTcpSocket* tcp_socket1 = active_listener->sockets().front().get();
-    tcp_socket1->continueFilterChain(true);
+  ActiveTcpSocket* tcp_socket1 = active_listener->sockets().front().get();
+  tcp_socket1->continueFilterChain(true);
 
-    EXPECT_CALL(*inspect_data_filter1, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
-    EXPECT_CALL(*inspect_data_filter2, onAccept(_))
-        .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
-    EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
+  EXPECT_CALL(*inspect_data_filter1, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
+  EXPECT_CALL(*inspect_data_filter2, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
 
-    EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
+  EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
-    EXPECT_CALL(*inspect_data_filter2, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
-    EXPECT_CALL(*no_inspect_data_filter2, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIteration));
+  EXPECT_CALL(*inspect_data_filter2, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
+  EXPECT_CALL(*no_inspect_data_filter2, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIteration));
 
-    EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
+  EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
-    EXPECT_CALL(*inspect_data_filter3, onAccept(_))
-        .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
-    EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
+  EXPECT_CALL(*inspect_data_filter3, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Read));
 
-    tcp_socket1->continueFilterChain(true);
+  tcp_socket1->continueFilterChain(true);
 
-    EXPECT_CALL(*inspect_data_filter3, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
-    EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(nullptr));
+  EXPECT_CALL(*inspect_data_filter3, onData(_)).WillOnce(Return(Network::FilterStatus::Continue));
+  EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(nullptr));
 
-    EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
+  EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 }
 
 /**
@@ -516,7 +522,8 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithClose) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
   Event::FileReadyCb file_event_callback;
@@ -531,7 +538,8 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterWithClose) {
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_ / 2, Api::IoError::none()))));
   // the filter is looking for more data
-  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onData(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
@@ -548,7 +556,8 @@ TEST_F(ActiveTcpListenerTest, ListenerFilterCloseSockets) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   bool is_open = true;
 
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Invoke([&is_open]() { return is_open; }));
@@ -577,7 +586,8 @@ TEST_F(ActiveTcpListenerTest, PopulateSNIWhenActiveTcpSocketTimeout) {
   initializeWithInspectFilter();
 
   // The filter stop the filter iteration and waiting for the data.
-  EXPECT_CALL(*filter_, onAccept(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onAccept(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
   EXPECT_CALL(io_handle_, isOpen()).WillRepeatedly(Return(true));
 
   Event::FileReadyCb file_event_callback;
@@ -596,7 +606,8 @@ TEST_F(ActiveTcpListenerTest, PopulateSNIWhenActiveTcpSocketTimeout) {
   EXPECT_CALL(io_handle_, recv)
       .WillOnce(Return(ByMove(Api::IoCallUint64Result(inspect_size_ / 2, Api::IoError::none()))));
   // the filter is looking for more data.
-  EXPECT_CALL(*filter_, onData(_)).WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
+  EXPECT_CALL(*filter_, onData(_))
+      .WillOnce(Return(Network::FilterStatus::StopIterationAndWaitForData));
 
   EXPECT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -1994,7 +1994,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
       }));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
-        return Network::FilterStatus::StopIteration;
+        return Network::FilterStatus::StopIterationAndWaitForData;
       }));
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   Network::MockIoHandle io_handle;
@@ -2048,7 +2048,7 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
   std::string data = "test";
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
-        return Network::FilterStatus::StopIteration;
+        return Network::FilterStatus::StopIterationAndWaitForData;
       }));
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   Network::IoSocketHandleImpl io_handle{42};
@@ -2107,7 +2107,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
-        return Network::FilterStatus::StopIteration;
+        return Network::FilterStatus::StopIterationAndWaitForData;
       }));
   Network::MockIoHandle io_handle;
   EXPECT_CALL(*accepted_socket, ioHandle()).WillOnce(ReturnRef(io_handle));
@@ -2168,7 +2168,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
       }));
   EXPECT_CALL(*test_filter, onAccept(_))
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
-        return Network::FilterStatus::StopIteration;
+        return Network::FilterStatus::StopIterationAndWaitForData;
       }));
   Network::MockIoHandle io_handle;
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();


### PR DESCRIPTION

Commit Message: extend filter status to include StopIterationAndWaitForData
Additional Description: For listener/network filters, currently there are 2 filter status, `Continue` and `StopIteration` respectively.
And especially for listener filters, a `ListenerFilterBufferImpl` is shared by all listener filters which need to read data on the wire. So there are several cases can be covered as below by adding a new filter status StopIterationAndWaitForData.

- `Continue`: Filter continues to execute
- `StopIteration`: Filter which is not interested in data on the wire, stops executing and waits for callback to recover execution
- `StopIterationAndWaitForData`: Filter needs to read data and share `ListenerFilterBufferImpl`

Risk Level: low
Testing: unit test and manual test
Docs Changes:
Release Notes: N/A
Platform Specific Features: N/A
Fixes #35079
