### PR TITLE
Reduce Cluster memory utilization by avoiding optional HappyEyeballsConfig overhead

### DIFF
--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -1229,11 +1229,10 @@ public:
   virtual Http::ClientHeaderValidatorPtr makeHeaderValidator(Http::Protocol protocol) const PURE;
 
   /**
-   * @return absl::optional<const envoy::config::cluster::v3::Cluster::HappyEyeballsConfig>
+   * @return OptRef<const envoy::config::cluster::v3::Cluster::HappyEyeballsConfig>
    * an optional value of the configuration for happy eyeballs for this cluster.
    */
-  virtual const absl::optional<
-      envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+  virtual OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
   happyEyeballsConfig() const PURE;
 
 protected:

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1010,9 +1010,12 @@ public:
   Http::Http3::CodecStats& http3CodecStats() const override;
   Http::ClientHeaderValidatorPtr makeHeaderValidator(Http::Protocol protocol) const override;
 
-  const absl::optional<envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+  OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
   happyEyeballsConfig() const override {
-    return happy_eyeballs_config_;
+    if (happy_eyeballs_config_ == nullptr) {
+      return absl::nullopt;
+    }
+    return *happy_eyeballs_config_;
   }
 
 protected:
@@ -1101,6 +1104,8 @@ private:
   mutable Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   mutable Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
   UpstreamFactoryContextImpl upstream_context_;
+  std::unique_ptr<envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
+      happy_eyeballs_config_;
 
   // Keep small values like bools and enums at the end of the class to reduce
   // overhead via alignment
@@ -1115,8 +1120,6 @@ private:
   // true iff the cluster proto specified upstream http filters.
   bool has_configured_http_filters_ : 1;
   const bool per_endpoint_stats_ : 1;
-  const absl::optional<envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
-      happy_eyeballs_config_;
 };
 
 /**

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1761,8 +1761,7 @@ TEST_F(HostImplTest, CreateConnectionHappyEyeballsWithConfig) {
   config.set_first_address_family_version(
       envoy::config::cluster::v3::UpstreamConnectionOptions::V4);
   config.mutable_first_address_family_count()->set_value(2);
-  EXPECT_CALL(*(cluster.info_), happyEyeballsConfig())
-      .WillRepeatedly(Return(absl::make_optional(config)));
+  EXPECT_CALL(*(cluster.info_), happyEyeballsConfig()).WillRepeatedly(Return(config));
 
   envoy::config::core::v3::Metadata metadata;
   Config::Metadata::mutableMetadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
@@ -3724,9 +3723,9 @@ TEST_F(StaticClusterImplTest, HappyEyeballsConfig) {
   uint32_t expected_count(1);
   expected_config.mutable_first_address_family_count()->set_value(expected_count);
   EXPECT_TRUE(cluster->info()->happyEyeballsConfig().has_value());
-  EXPECT_EQ(cluster->info()->happyEyeballsConfig().value().first_address_family_version(),
+  EXPECT_EQ(cluster->info()->happyEyeballsConfig()->first_address_family_version(),
             envoy::config::cluster::v3::UpstreamConnectionOptions::V4);
-  EXPECT_EQ(cluster->info()->happyEyeballsConfig().value().first_address_family_count().value(),
+  EXPECT_EQ(cluster->info()->happyEyeballsConfig()->first_address_family_count().value(),
             expected_count);
 }
 

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -169,9 +169,9 @@ public:
                Http::FilterChainManager& manager),
               (const));
   MOCK_METHOD(Http::ClientHeaderValidatorPtr, makeHeaderValidator, (Http::Protocol), (const));
-  MOCK_METHOD(const absl::optional<
-                  envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>,
-              happyEyeballsConfig, (), (const));
+  MOCK_METHOD(
+      OptRef<const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>,
+      happyEyeballsConfig, (), (const));
   ::Envoy::Http::HeaderValidatorStats& codecStats(Http::Protocol protocol) const;
   Http::Http1::CodecStats& http1CodecStats() const override;
   Http::Http2::CodecStats& http2CodecStats() const override;


### PR DESCRIPTION
This PR switches the optional\<T\> to OptRef backed by  unique_ptr and also fixes class alignment optimization by moving HappyEyeballsConfig above booleans.

This is a step towards more memory efficient config data structures. Issue #24154.

Signed-off-by: Yury Kats <ykats@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
