### PR TITLE
Fix extension monitor name

### DIFF
--- a/api/envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto
+++ b/api/envoy/extensions/resource_monitors/downstream_connections/v3/downstream_connections.proto
@@ -12,7 +12,7 @@ option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/res
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Downstream connections]
-// [#extension: envoy.resource_monitors.downstream_connections]
+// [#extension: envoy.resource_monitors.global_downstream_max_connections]
 
 // The downstream connections resource monitor tracks the global number of open downstream connections.
 message DownstreamConnectionsConfig {

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -240,7 +240,7 @@ EXTENSIONS = {
 
     "envoy.resource_monitors.fixed_heap":               "//source/extensions/resource_monitors/fixed_heap:config",
     "envoy.resource_monitors.injected_resource":        "//source/extensions/resource_monitors/injected_resource:config",
-    "envoy.resource_monitors.downstream_connections":   "//source/extensions/resource_monitors/downstream_connections:config",
+    "envoy.resource_monitors.global_downstream_max_connections":   "//source/extensions/resource_monitors/downstream_connections:config",
 
     #
     # Stat sinks

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1070,7 +1070,7 @@ envoy.request_id.uuid:
   status: stable
   type_urls:
   - envoy.extensions.request_id.uuid.v3.UuidRequestIdConfig
-envoy.resource_monitors.downstream_connections:
+envoy.resource_monitors.global_downstream_max_connections:
   categories:
   - envoy.resource_monitors
   security_posture: data_plane_agnostic

--- a/source/extensions/resource_monitors/downstream_connections/config.h
+++ b/source/extensions/resource_monitors/downstream_connections/config.h
@@ -17,7 +17,7 @@ class ActiveDownstreamConnectionsMonitorFactory
               DownstreamConnectionsConfig> {
 public:
   ActiveDownstreamConnectionsMonitorFactory()
-      : ProactiveFactoryBase("envoy.resource_monitors.downstream_connections") {}
+      : ProactiveFactoryBase("envoy.resource_monitors.global_downstream_max_connections") {}
 
 private:
   Server::ProactiveResourceMonitorPtr createProactiveResourceMonitorFromProtoTyped(

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -931,9 +931,11 @@ RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatch
   // If there is no global limit to the number of active connections, warn on startup.
   if (!overload_manager.getThreadLocalOverloadState().isResourceMonitorEnabled(
           Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections)) {
-    ENVOY_LOG(warn, "There is no configured limit to the number of allowed active downstream "
-                    "connections. Configure a "
-                    "limit in `envoy.resource_monitors.global_downstream_max_connections` resource monitor.");
+    ENVOY_LOG(
+        warn,
+        "There is no configured limit to the number of allowed active downstream "
+        "connections. Configure a "
+        "limit in `envoy.resource_monitors.global_downstream_max_connections` resource monitor.");
   }
 
   // Register for cluster manager init notification. We don't start serving worker traffic until

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -838,7 +838,7 @@ void InstanceBase::onRuntimeReady() {
   if (runtime().snapshot().get(Runtime::Keys::GlobalMaxCxRuntimeKey)) {
     ENVOY_LOG(warn,
               "Usage of the deprecated runtime key {}, consider switching to "
-              "`envoy.resource_monitors.downstream_connections` instead."
+              "`envoy.resource_monitors.global_downstream_max_connections` instead."
               "This runtime key will be removed in future.",
               Runtime::Keys::GlobalMaxCxRuntimeKey);
   }
@@ -933,7 +933,7 @@ RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatch
           Server::OverloadProactiveResourceName::GlobalDownstreamMaxConnections)) {
     ENVOY_LOG(warn, "There is no configured limit to the number of allowed active downstream "
                     "connections. Configure a "
-                    "limit in `envoy.resource_monitors.downstream_connections` resource monitor.");
+                    "limit in `envoy.resource_monitors.global_downstream_max_connections` resource monitor.");
   }
 
   // Register for cluster manager init notification. We don't start serving worker traffic until

--- a/test/extensions/resource_monitors/downstream_connections/BUILD
+++ b/test/extensions/resource_monitors/downstream_connections/BUILD
@@ -15,7 +15,7 @@ envoy_package()
 envoy_extension_cc_test(
     name = "downstream_connections_monitor_test",
     srcs = ["downstream_connections_monitor_test.cc"],
-    extension_names = ["envoy.resource_monitors.downstream_connections"],
+    extension_names = ["envoy.resource_monitors.global_downstream_max_connections"],
     external_deps = ["abseil_optional"],
     deps = [
         "//source/extensions/resource_monitors/downstream_connections:downstream_connections_monitor",
@@ -26,7 +26,7 @@ envoy_extension_cc_test(
 envoy_extension_cc_test(
     name = "config_test",
     srcs = ["config_test.cc"],
-    extension_names = ["envoy.resource_monitors.downstream_connections"],
+    extension_names = ["envoy.resource_monitors.global_downstream_max_connections"],
     deps = [
         "//envoy/registry",
         "//source/extensions/resource_monitors/downstream_connections:config",

--- a/test/extensions/resource_monitors/downstream_connections/config_test.cc
+++ b/test/extensions/resource_monitors/downstream_connections/config_test.cc
@@ -20,9 +20,9 @@ namespace {
 TEST(ActiveDownstreamConnectionsMonitorFactoryTest, CreateMonitorInvalidConfig) {
   auto factory =
       Registry::FactoryRegistry<Server::Configuration::ProactiveResourceMonitorFactory>::getFactory(
-          "envoy.resource_monitors.downstream_connections");
+          "envoy.resource_monitors.global_downstream_max_connections");
   ASSERT_NE(factory, nullptr);
-  EXPECT_EQ("envoy.resource_monitors.downstream_connections", factory->name());
+  EXPECT_EQ("envoy.resource_monitors.global_downstream_max_connections", factory->name());
 
   envoy::extensions::resource_monitors::downstream_connections::v3::DownstreamConnectionsConfig
       config;
@@ -42,9 +42,9 @@ TEST(ActiveDownstreamConnectionsMonitorFactoryTest, CreateMonitorInvalidConfig) 
 TEST(ActiveDownstreamConnectionsMonitorFactoryTest, CreateCustomMonitor) {
   auto factory =
       Registry::FactoryRegistry<Server::Configuration::ProactiveResourceMonitorFactory>::getFactory(
-          "envoy.resource_monitors.downstream_connections");
+          "envoy.resource_monitors.global_downstream_max_connections");
   ASSERT_NE(factory, nullptr);
-  EXPECT_EQ("envoy.resource_monitors.downstream_connections", factory->name());
+  EXPECT_EQ("envoy.resource_monitors.global_downstream_max_connections", factory->name());
 
   envoy::extensions::resource_monitors::downstream_connections::v3::DownstreamConnectionsConfig
       config;
@@ -61,7 +61,7 @@ TEST(ActiveDownstreamConnectionsMonitorFactoryTest, CreateCustomMonitor) {
 TEST(ActiveDownstreamConnectionsMonitorFactoryTest, CreateDefaultMonitor) {
   auto factory =
       Registry::FactoryRegistry<Server::Configuration::ProactiveResourceMonitorFactory>::getFactory(
-          "envoy.resource_monitors.downstream_connections");
+          "envoy.resource_monitors.global_downstream_max_connections");
   ASSERT_NE(factory, nullptr);
 
   Event::MockDispatcher dispatcher;

--- a/test/integration/cx_limit_integration_test.cc
+++ b/test/integration/cx_limit_integration_test.cc
@@ -143,7 +143,7 @@ TEST_P(ConnectionLimitIntegrationTest, TestDeprecationWarningForGlobalCxRuntimeL
   };
   const std::string log_line =
       "Usage of the deprecated runtime key overload.global_downstream_max_connections, "
-      "consider switching to `envoy.resource_monitors.downstream_connections` instead."
+      "consider switching to `envoy.resource_monitors.global_downstream_max_connections` instead."
       "This runtime key will be removed in future.";
   EXPECT_LOG_CONTAINS("warn", log_line, { init_func(); });
 }
@@ -154,7 +154,7 @@ TEST_P(ConnectionLimitIntegrationTest, TestEmptyGlobalCxRuntimeLimit) {
   const std::string log_line =
       "There is no configured limit to the number of allowed active downstream connections. "
       "Configure a "
-      "limit in `envoy.resource_monitors.downstream_connections` resource monitor.";
+      "limit in `envoy.resource_monitors.global_downstream_max_connections` resource monitor.";
   EXPECT_LOG_CONTAINS("warn", log_line, { initialize(); });
 }
 


### PR DESCRIPTION
Commit Message: Fix extension name in docs to match the actual implementation. Currently user docs (`envoy.resource_monitors.downstream_connections`) and implementation (`envoy.resource_monitors.global_downstream_max_connections`) don't match in terms of monitor name. Another approach would be to fix the name in the implementation and leave extension name in the docs as it is, but it would affect users who already figured out the correct full name of extension. Since the extension has already been promoted to stable the second approach may be more correct?

Additional Description:
Risk Level:
Testing: Done
Docs Changes: Done
Release Notes:
Platform Specific Features:
Fixes #34932
