### PR TITLE
Fix #24466 and #24735: make HTTP/2 and HTTP/3 codecs send 400 for headers/tailers with underscores (if configured to reject)

### DIFF
--- a/api/envoy/extensions/http/header_validators/envoy_default/v3/header_validator.proto
+++ b/api/envoy/extensions/http/header_validators/envoy_default/v3/header_validator.proto
@@ -38,8 +38,7 @@ message HeaderValidatorConfig {
     // Allow headers with underscores. This is the default behavior.
     ALLOW = 0;
 
-    // Reject client request. HTTP/1 requests are rejected with the 400 status. HTTP/2 requests
-    // end with the stream reset. The
+    // Reject client request. All HTTP/1, HTTP/2 and HTTP/3 requests are rejected with the 400 status. The
     // :ref:`httpN.requests_rejected_with_underscores_in_headers <config_http_conn_man_stats_per_codec>` counter
     // is incremented for each rejected request.
     REJECT_REQUEST = 1;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1121,19 +1121,13 @@ bool ConnectionManagerImpl::ActiveStream::validateTrailers(RequestTrailerMap& tr
     failure_details = std::string(transformation_result.details());
   }
 
-  Code response_code = Code::BadRequest;
   absl::optional<Grpc::Status::GrpcStatus> grpc_status;
   if (Grpc::Common::hasGrpcContentType(*request_headers_)) {
     grpc_status = Grpc::Status::WellKnownGrpcStatus::Internal;
   }
 
-  // TODO(#24735): Harmonize H/2 and H/3 behavior with H/1
-  if (connection_manager_.codec_->protocol() < Protocol::Http2) {
-    sendLocalReply(response_code, "", nullptr, grpc_status, failure_details);
-  } else {
-    filter_manager_.streamInfo().setResponseCodeDetails(failure_details);
-    resetStream();
-  }
+  sendLocalReply(Code::BadRequest, "", nullptr, grpc_status, failure_details);
+
   if (!response_encoder_->streamErrorOnInvalidHttpMessage()) {
     connection_manager_.handleCodecError(failure_details);
   }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -418,10 +418,8 @@ private:
     // Note: this method is a noop unless ENVOY_ENABLE_UHV is defined
     // Call header validator extension to validate the request trailer map after it was
     // deserialized. If the trailer map failed validation, this method does the following:
-    // 1. For H/1 it sends 400 response and returns false.
-    // 2. For H/2 and H/3 it resets the stream (without error response). Issue #24735 is filed to
-    //    harmonize this behavior with H/1.
-    // 3. If the `stream_error_on_invalid_http_message` is set to `false` (it is by default) in the
+    // 1. For H/1, H2, and H3, it sends 400 response and returns false.
+    // 2. If the `stream_error_on_invalid_http_message` is set to `false` (it is by default) in the
     // HTTP connection manager configuration, then the entire connection is closed.
     bool validateTrailers(RequestTrailerMap& trailers);
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -68,7 +68,7 @@ public:
   const absl::string_view outbound_frame_flood = "http2.outbound_frames_flood";
   // Envoy detected an inbound HTTP/2 frame flood.
   const absl::string_view inbound_empty_frame_flood = "http2.inbound_empty_frames_flood";
-  // Envoy was configured to drop requests with header keys beginning with underscores.
+  // Envoy was configured to drop requests with header keys containing underscores.
   const absl::string_view invalid_underscore = "http2.unexpected_underscore";
   // The peer refused the stream.
   const absl::string_view remote_refused = "http2.remote_refuse";
@@ -2350,7 +2350,7 @@ absl::optional<int> ServerConnectionImpl::checkHeaderNameForUnderscores(
     ENVOY_CONN_LOG(debug, "Rejecting request due to header name with underscores: {}", connection_,
                    header_name);
     stats_.incRequestsRejectedWithUnderscoresInHeaders();
-    return ERR_TEMPORAL_CALLBACK_FAILURE;
+    return absl::nullopt;
   }
 #else
   // Workaround for gcc not understanding [[maybe_unused]] for class members.

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -3819,7 +3819,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp2) {
 }
 
 TEST_F(HttpConnectionManagerImplTest, HeaderValidatorFailTrailersTransformationBeforeResponse) {
-  codec_->protocol_ = Protocol::Http2;
+  codec_->protocol_ = Protocol::Http11;
   setup();
   expectUhvTrailerCheck(HeaderValidator::ValidationResult(
                             HeaderValidator::ValidationResult::Action::Reject, "bad_trailer_map"),

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -3812,6 +3812,31 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp2) {
     return Http::okStatus();
   }));
 
+  EXPECT_CALL(response_encoder_.stream_, resetStream(_));
+
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+}
+
+TEST_F(HttpConnectionManagerImplTest, HeaderValidatorFailTrailersTransformationBeforeResponse) {
+  codec_->protocol_ = Protocol::Http2;
+  setup();
+  expectUhvTrailerCheck(HeaderValidator::ValidationResult(
+                            HeaderValidator::ValidationResult::Action::Reject, "bad_trailer_map"),
+                        HeaderValidator::TransformationResult::success());
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
+    decoder_ = &conn_manager_->newStream(response_encoder_);
+    RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{
+        {":authority", "host"}, {":path", "/something"}, {":method", "GET"}}};
+    decoder_->decodeHeaders(std::move(headers), false);
+    RequestTrailerMapPtr trailers{
+        new TestRequestTrailerMapImpl{{"trailer1", "value1"}, {"trailer2", "value2"}}};
+    decoder_->decodeTrailers(std::move(trailers));
+    data.drain(4);
+    return Http::okStatus();
+  }));
+
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("400", headers.getStatusValue());

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -3812,31 +3812,6 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp2) {
     return Http::okStatus();
   }));
 
-  EXPECT_CALL(response_encoder_.stream_, resetStream(_));
-
-  Buffer::OwnedImpl fake_input("1234");
-  conn_manager_->onData(fake_input, false);
-}
-
-TEST_F(HttpConnectionManagerImplTest, HeaderValidatorFailTrailersTransformationBeforeResponse) {
-  codec_->protocol_ = Protocol::Http11;
-  setup();
-  expectUhvTrailerCheck(HeaderValidator::ValidationResult(
-                            HeaderValidator::ValidationResult::Action::Reject, "bad_trailer_map"),
-                        HeaderValidator::TransformationResult::success());
-
-  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
-    decoder_ = &conn_manager_->newStream(response_encoder_);
-    RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{
-        {":authority", "host"}, {":path", "/something"}, {":method", "GET"}}};
-    decoder_->decodeHeaders(std::move(headers), false);
-    RequestTrailerMapPtr trailers{
-        new TestRequestTrailerMapImpl{{"trailer1", "value1"}, {"trailer2", "value2"}}};
-    decoder_->decodeTrailers(std::move(trailers));
-    data.drain(4);
-    return Http::okStatus();
-  }));
-
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("400", headers.getStatusValue());
@@ -3977,7 +3952,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectTrailersBeforeRespons
   setup();
   expectUhvTrailerCheck(HeaderValidator::ValidationResult(
                             HeaderValidator::ValidationResult::Action::Reject, "bad_trailer_map"),
-                        HeaderValidator::TransformationResult::success(), false);
+                        HeaderValidator::TransformationResult::success());
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     decoder_ = &conn_manager_->newStream(response_encoder_);
@@ -3991,7 +3966,11 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectTrailersBeforeRespons
     return Http::okStatus();
   }));
 
-  EXPECT_CALL(response_encoder_.stream_, resetStream(_));
+  EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
+      .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
+        EXPECT_EQ("400", headers.getStatusValue());
+        EXPECT_EQ("bad_trailer_map", decoder_->streamInfo().responseCodeDetails().value());
+      }));
 
   Buffer::OwnedImpl fake_input("1234");
   conn_manager_->onData(fake_input, false);

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1470,7 +1470,7 @@ TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreAreDropped) {
 
 // Ensures that request with header names containing the underscore character are rejected
 // when the option is set to reject request.
-TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreCauseRequestRejected) {
+TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreAreRejected) {
   headers_with_underscores_action_ = envoy::config::core::v3::HttpProtocolOptions::REJECT_REQUEST;
   initialize();
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1470,7 +1470,7 @@ TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreAreDropped) {
 
 // Ensures that request with header names containing the underscore character are rejected
 // when the option is set to reject request.
-TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreAreRejected) {
+TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreCauseRequestRejected) {
   headers_with_underscores_action_ = envoy::config::core::v3::HttpProtocolOptions::REJECT_REQUEST;
   initialize();
 

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -64,7 +64,8 @@ namespace {
 // the MockRequestDecoder::decodeHeaders() method. With UHV enabled it invokes UHV's
 // validateRequestHeaderMap() method. This will validate and apply transformations expected by the
 // test, before passing it to the base class MockRequestDecoder::decodeHeaders() method. If UHV
-// validation fails it calls the `sendLocalReply` on the decoder, indicating validation error.
+// validation fails it calls the `sendLocalReply` on the decoder and sends 400,
+// indicating a validation error.
 class MockRequestDecoderShimWithUhv : public Http::MockRequestDecoder {
 public:
   MockRequestDecoderShimWithUhv() = default;

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2865,7 +2865,7 @@ TEST_P(Http2CodecImplTest, HeaderNameWithUnderscoreAreRejected) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   request_headers.addCopy("bad_header", "something");
-
+  EXPECT_CALL(request_decoder_, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _));
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
   driveToCompletion();

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2865,6 +2865,7 @@ TEST_P(Http2CodecImplTest, HeaderNameWithUnderscoreAreRejected) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   request_headers.addCopy("bad_header", "something");
+
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
   driveToCompletion();

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -64,10 +64,7 @@ namespace {
 // the MockRequestDecoder::decodeHeaders() method. With UHV enabled it invokes UHV's
 // validateRequestHeaderMap() method. This will validate and apply transformations expected by the
 // test, before passing it to the base class MockRequestDecoder::decodeHeaders() method. If UHV
-// validation fails it calls the `sendLocalReply` on the decoder, indicating validation error. This
-// class also handles behavior specific to the H/2 codec, where it resets requests with headers
-// containing underscores (when configured), instead of sending 400. See
-// https://github.com/envoyproxy/envoy/issues/24466
+// validation fails it calls the `sendLocalReply` on the decoder, indicating validation error.
 class MockRequestDecoderShimWithUhv : public Http::MockRequestDecoder {
 public:
   MockRequestDecoderShimWithUhv() = default;
@@ -94,11 +91,8 @@ public:
         }
         failure_details = transformation_result.details();
       }
-      if (failure_details != UhvResponseCodeDetail::get().InvalidUnderscore) {
-        sendLocalReply(Http::Code::BadRequest, Http::CodeUtility::toString(Http::Code::BadRequest),
-                       nullptr, absl::nullopt, failure_details);
-      }
-      response_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
+      sendLocalReply(Http::Code::BadRequest, Http::CodeUtility::toString(Http::Code::BadRequest),
+                      nullptr, absl::nullopt, failure_details);
       // These tests assume that connection is not closed on protocol errors
     } else {
       MockRequestDecoder::decodeHeaders(std::move(headers), end_stream);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2865,8 +2865,8 @@ TEST_P(Http2CodecImplTest, HeaderNameWithUnderscoreAreRejected) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   request_headers.addCopy("bad_header", "something");
-
-  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
+  EXPECT_CALL(request_decoder_, sendLocalReply(Http::Code::BadRequest, _, _, _, _));
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(0);
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
   driveToCompletion();
   EXPECT_EQ(

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2865,7 +2865,7 @@ TEST_P(Http2CodecImplTest, HeaderNameWithUnderscoreAreRejected) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   request_headers.addCopy("bad_header", "something");
-  EXPECT_CALL(request_decoder_, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, _));
+
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
   driveToCompletion();

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -92,7 +92,7 @@ public:
         failure_details = transformation_result.details();
       }
       sendLocalReply(Http::Code::BadRequest, Http::CodeUtility::toString(Http::Code::BadRequest),
-                      nullptr, absl::nullopt, failure_details);
+                     nullptr, absl::nullopt, failure_details);
       // These tests assume that connection is not closed on protocol errors
     } else {
       MockRequestDecoder::decodeHeaders(std::move(headers), end_stream);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2865,8 +2865,7 @@ TEST_P(Http2CodecImplTest, HeaderNameWithUnderscoreAreRejected) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   request_headers.addCopy("bad_header", "something");
-  EXPECT_CALL(request_decoder_, sendLocalReply(Http::Code::BadRequest, _, _, _, _));
-  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(0);
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
   driveToCompletion();
   EXPECT_EQ(

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -438,6 +438,15 @@ TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderMapEmptyGenericName) {
                              UhvResponseCodeDetail::get().EmptyHeaderName);
 }
 
+TEST_F(Http2HeaderValidatorTest, ValidateRequestTrailersAllowUnderscoreHeadersByDefault) {
+  TestRequestTrailerMapImpl trailers{{"trailer1", "value1"}, {"x_foo", "bar"}};
+  auto uhv = createH2ServerUhv(empty_config);
+
+  EXPECT_ACCEPT(uhv->validateRequestTrailers(trailers));
+  EXPECT_ACCEPT(uhv->transformRequestTrailers(trailers));
+  EXPECT_EQ(trailers, TestRequestTrailerMapImpl({{"trailer1", "value1"}, {"x_foo", "bar"}}));
+}
+
 TEST_F(Http2HeaderValidatorTest, ValidateGenericHeaderNameRejectConnectionHeaders) {
   std::string connection_headers[] = {"transfer-encoding", "connection", "keep-alive", "upgrade",
                                       "proxy-connection"};

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1850,7 +1850,8 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   }
-  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
+  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new
+  // Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
@@ -1884,7 +1885,8 @@ TEST_P(DownstreamProtocolIntegrationTest, TrailerWithUnderscoresCauseRequestReje
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   }
-  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
+  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new
+  // Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1850,8 +1850,6 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   }
-  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new
-  // Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1857,7 +1857,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
     ASSERT_TRUE(response->reset());
     EXPECT_EQ((downstream_protocol_ == Http::CodecType::HTTP3
                    ? Http::StreamResetReason::ProtocolError
-                   : Http::StreamResetReason::RemoteReset),
+                   : Http::StreamResetReason::ConnectionTermination),
               response->resetReason());
   }
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
@@ -1898,7 +1898,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TrailerWithUnderscoresCauseRequestReje
     ASSERT_TRUE(response->reset());
     EXPECT_EQ((downstream_protocol_ == Http::CodecType::HTTP3
                    ? Http::StreamResetReason::ProtocolError
-                   : Http::StreamResetReason::RemoteReset),
+                   : Http::StreamResetReason::ConnectionTermination),
               response->resetReason());
   }
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1849,9 +1849,12 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
+    ASSERT_TRUE(response->complete());
+    EXPECT_EQ("400", response->headers().getStatusValue());
+  } else {
+    ASSERT_TRUE(!response->complete());
+    codec_client_->close();
   }
-  ASSERT_TRUE(response->complete());
-  EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
 }
 
@@ -1882,9 +1885,12 @@ TEST_P(DownstreamProtocolIntegrationTest, TrailerWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
+    ASSERT_TRUE(response->complete());
+    EXPECT_EQ("400", response->headers().getStatusValue());
+  } else {
+    ASSERT_TRUE(!response->complete());
+    codec_client_->close();
   }
-  ASSERT_TRUE(response->complete());
-  EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1849,12 +1849,10 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
-    ASSERT_TRUE(response->complete());
-    EXPECT_EQ("400", response->headers().getStatusValue());
-  } else {
-    ASSERT_TRUE(!response->complete());
-    codec_client_->close();
   }
+  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
 }
 
@@ -1885,12 +1883,10 @@ TEST_P(DownstreamProtocolIntegrationTest, TrailerWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
-    ASSERT_TRUE(response->complete());
-    EXPECT_EQ("400", response->headers().getStatusValue());
-  } else {
-    ASSERT_TRUE(!response->complete());
-    codec_client_->close();
   }
+  // response->decodeHeaders(Http::ResponseHeaderMapPtr(new Http::TestResponseHeaderMapImpl{{":status", "400"}}), true);
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1849,8 +1849,6 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
-  } else {
-    ASSERT_TRUE(response->waitForEndStream());
   }
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());
@@ -1884,8 +1882,6 @@ TEST_P(DownstreamProtocolIntegrationTest, TrailerWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
-  } else {
-    ASSERT_TRUE(response->waitForEndStream());
   }
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1849,17 +1849,11 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
 
   if (downstream_protocol_ == Http::CodecType::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
-    ASSERT_TRUE(response->complete());
-    EXPECT_EQ("400", response->headers().getStatusValue());
   } else {
-    ASSERT_TRUE(response->waitForReset());
-    codec_client_->close();
-    ASSERT_TRUE(response->reset());
-    EXPECT_EQ((downstream_protocol_ == Http::CodecType::HTTP3
-                   ? Http::StreamResetReason::ProtocolError
-                   : Http::StreamResetReason::RemoteReset),
-              response->resetReason());
+    ASSERT_TRUE(response->waitForEndStream());
   }
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
 }
 
@@ -1888,7 +1882,11 @@ TEST_P(DownstreamProtocolIntegrationTest, TrailerWithUnderscoresCauseRequestReje
       *request_encoder_,
       Http::TestRequestTrailerMapImpl{{"trailer1", "value1"}, {"trailer_2", "value2"}});
 
-  ASSERT_TRUE(codec_client_->waitForDisconnect());
+  if (downstream_protocol_ == Http::CodecType::HTTP1) {
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+  } else {
+    ASSERT_TRUE(response->waitForEndStream());
+  }
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));


### PR DESCRIPTION
Commit Message: Fix #24466 and #24735: make HTTP/2 and HTTP/3 codecs send 400 for headers/tailers with underscores (if configured to reject)
Additional Description: If Envoy is configured to reject requests with underscores in header/tailer keys, the HTTP/2 and HTTP/3 codecs will return 400 (like HTTP/1).
Risk Level: Low
Testing: Unit tests
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes #Issue: #24466 and #24735
