### PR TITLE
bazel/protoc: Patch protoc setup to workaround removal

### DIFF
--- a/bazel/protoc/BUILD
+++ b/bazel/protoc/BUILD
@@ -1,0 +1,1 @@
+licenses(["notice"])  # Apache 2

--- a/bazel/protoc/BUILD.protoc
+++ b/bazel/protoc/BUILD.protoc
@@ -1,0 +1,18 @@
+load("@envoy//bazel/protoc:protoc.bzl", "protoc_binary")
+
+protoc_binary(
+    name = "protoc",
+    srcs = select({
+        ":windows": ["bin/protoc.exe"],
+        "//conditions:default": ["bin/protoc"],
+    }),
+    executable = "protoc.exe",
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)

--- a/bazel/protoc/protoc.bzl
+++ b/bazel/protoc/protoc.bzl
@@ -1,0 +1,15 @@
+def protoc_binary(name, srcs, executable, **kwargs):
+    """protoc_binary makes a copy of the protoc binary to bazel-bin.
+
+This is a workaround to make sure protoc can be used with attributes
+which don't allow files."""
+
+    native.genrule(
+        name = name,
+        executable = True,
+        srcs = srcs,
+        outs = [executable],
+        cmd_bash = "cp $< $@ && chmod +x $@",
+        cmd_bat = "copy $< $@",
+        **kwargs
+    )

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -992,7 +992,7 @@ def _com_google_protobuf():
         # instead.
         external_http_archive(
             "com_google_protobuf_protoc_%s" % platform,
-            build_file = "@rules_proto//proto/private:BUILD.protoc",
+            build_file = "//bazel/protoc:BUILD.protoc",
         )
 
     external_http_archive(

--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -25,6 +25,7 @@ sed -e "s|{ENVOY_SRCDIR}|${ENVOY_SRCDIR}|" "${ENVOY_SRCDIR}"/ci/WORKSPACE.filter
 mkdir -p "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel
 ln -sf "${ENVOY_SRCDIR}"/bazel/get_workspace_status "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
 ln -sf "${ENVOY_SRCDIR}"/bazel/platform_mappings "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
+cp -a "${ENVOY_SRCDIR}"/bazel/protoc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/bazel/
 cp -f "${ENVOY_SRCDIR}"/.bazelrc "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/
 rm -f "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/.bazelversion
 cp -f "${ENVOY_SRCDIR}"/.bazelversion "${ENVOY_FILTER_EXAMPLE_SRCDIR}"/


### PR DESCRIPTION
Our current implementation to use precompiled `protoc` patches protobuf with some of the rules from `rules_proto`

Those rules have now been completely removed in latest versions.

There is a bzlmod-only resolution for this here https://registry.bazel.build/modules/toolchains_protoc, but that doesnt help us until we have finally transitioned to bzlmod

this pr works around these issues by reviving the removed files here, which should unblock updates of several of our deps


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
