### PR TITLE
Added utility methods to parse ORCA response headers from backends.

### DIFF
--- a/source/common/orca/BUILD
+++ b/source/common/orca/BUILD
@@ -13,14 +13,12 @@ envoy_cc_library(
     srcs = ["orca_parser.cc"],
     hdrs = ["orca_parser.h"],
     external_deps = [
-        "abseil_flat_hash_set",
         "abseil_status",
         "abseil_strings",
         "abseil_statusor",
         "fmtlib",
     ],
     deps = [
-        "//envoy/common:exception_lib",
         "//envoy/http:header_map_interface",
         "//source/common/common:base64_lib",
         "//source/common/http:header_utility_lib",

--- a/source/common/orca/BUILD
+++ b/source/common/orca/BUILD
@@ -1,0 +1,30 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_library(
+    name = "orca_parser",
+    srcs = ["orca_parser.cc"],
+    hdrs = ["orca_parser.h"],
+    external_deps = [
+        "abseil_flat_hash_set",
+        "abseil_status",
+        "abseil_strings",
+        "abseil_statusor",
+        "fmtlib",
+    ],
+    deps = [
+        "//envoy/common:exception_lib",
+        "//envoy/http:header_map_interface",
+        "//source/common/common:base64_lib",
+        "//source/common/http:header_utility_lib",
+        "//source/common/protobuf:utility_lib_header",
+        "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
+    ],
+)

--- a/source/common/orca/BUILD
+++ b/source/common/orca/BUILD
@@ -13,7 +13,6 @@ envoy_cc_library(
     srcs = ["orca_parser.cc"],
     hdrs = ["orca_parser.h"],
     external_deps = [
-        "abseil_status",
         "abseil_strings",
         "abseil_statusor",
         "fmtlib",
@@ -21,8 +20,6 @@ envoy_cc_library(
     deps = [
         "//envoy/http:header_map_interface",
         "//source/common/common:base64_lib",
-        "//source/common/http:header_utility_lib",
-        "//source/common/protobuf:utility_lib_header",
         "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -43,6 +43,7 @@ absl::Status tryCopyNamedMetricToOrcaLoadReport(absl::string_view metric_name, d
 
 std::vector<absl::string_view> parseCommaDelimitedHeader(const HeaderMap::GetResult& entry) {
   const std::vector<absl::string_view> values;
+  values.reserve(entry.size());
   for (size_t i = 0; i < entry.size(); ++i) {
     std::vector<absl::string_view> tokens =
         Envoy::Http::HeaderUtility::parseCommaDelimitedHeader(entry[i]->value().getStringView());

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -10,18 +10,24 @@
 #include "absl/strings/string_view.h"
 
 using ::Envoy::Http::HeaderMap;
-using ::Envoy::Http::LowerCaseString;
 using xds::data::orca::v3::OrcaLoadReport;
 
 namespace Envoy {
 namespace Orca {
 
+namespace {
+
+const Http::LowerCaseString& endpointLoadMetricsHeaderBin() {
+  CONSTRUCT_ON_FIRST_USE(Http::LowerCaseString, kEndpointLoadMetricsHeaderBin);
+}
+
+} // namespace
+
 absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& headers) {
   OrcaLoadReport load_report;
 
   // Binary protobuf format.
-  if (const auto header_bin = headers.get(LowerCaseString(kEndpointLoadMetricsHeaderBin));
-      !header_bin.empty()) {
+  if (const auto header_bin = headers.get(endpointLoadMetricsHeaderBin()); !header_bin.empty()) {
     const auto header_value = header_bin[0]->value().getStringView();
     const std::string decoded_value = Envoy::Base64::decode(header_value);
     if (!load_report.ParseFromString(decoded_value)) {

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -42,7 +42,7 @@ absl::Status tryCopyNamedMetricToOrcaLoadReport(absl::string_view metric_name, d
 }
 
 std::vector<absl::string_view> parseCommaDelimitedHeader(const HeaderMap::GetResult& entry) {
-  const std::vector<absl::string_view> values;
+  std::vector<absl::string_view> values;
   values.reserve(entry.size());
   for (size_t i = 0; i < entry.size(); ++i) {
     std::vector<absl::string_view> tokens =

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -1,0 +1,181 @@
+#include "source/common/orca/orca_parser.h"
+
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/common/exception.h"
+#include "envoy/http/header_map.h"
+
+#include "source/common/common/base64.h"
+#include "source/common/common/fmt.h"
+#include "source/common/http/header_utility.h"
+#include "source/common/protobuf/utility.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+
+using ::Envoy::Http::HeaderMap;
+using xds::data::orca::v3::OrcaLoadReport;
+
+namespace Envoy {
+namespace Orca {
+
+namespace {
+
+absl::Status tryCopyNamedMetricToOrcaLoadReport(absl::string_view metric_name, double metric_value,
+                                                OrcaLoadReport& orca_load_report) {
+  if (metric_name.empty()) {
+    return absl::InvalidArgumentError("named metric key is empty.");
+  }
+
+  orca_load_report.mutable_named_metrics()->insert({std::string(metric_name), metric_value});
+  return absl::OkStatus();
+}
+
+std::vector<absl::string_view> parseCommaDelimitedHeader(const HeaderMap::GetResult& entry) {
+  std::vector<absl::string_view> values;
+  for (size_t i = 0; i < entry.size(); ++i) {
+    std::vector<absl::string_view> tokens =
+        Envoy::Http::HeaderUtility::parseCommaDelimitedHeader(entry[i]->value().getStringView());
+    values.insert(values.end(), tokens.begin(), tokens.end());
+  }
+  return values;
+}
+
+absl::Status tryCopyMetricToOrcaLoadReport(absl::string_view metric_name,
+                                           absl::string_view metric_value,
+                                           OrcaLoadReport& orca_load_report) {
+  if (metric_name.empty()) {
+    return absl::InvalidArgumentError("metric names cannot be empty strings");
+  }
+
+  if (metric_value.empty()) {
+    return absl::InvalidArgumentError("metric values cannot be empty strings");
+  }
+
+  double value;
+  if (!absl::SimpleAtod(metric_value, &value)) {
+    return absl::InvalidArgumentError(fmt::format(
+        "unable to parse custom backend load metric value({}): {}", metric_name, metric_value));
+  }
+
+  if (std::isnan(value)) {
+    return absl::InvalidArgumentError(
+        fmt::format("custom backend load metric value({}) cannot be NaN.", metric_name));
+  }
+
+  if (std::isinf(value)) {
+    return absl::InvalidArgumentError(
+        fmt::format("custom backend load metric value({}) cannot be infinity.", metric_name));
+  }
+
+  if (absl::StartsWith(metric_name, kNamedMetricsFieldPrefix)) {
+    auto metric_name_without_prefix = absl::StripPrefix(metric_name, kNamedMetricsFieldPrefix);
+    return tryCopyNamedMetricToOrcaLoadReport(metric_name_without_prefix, value, orca_load_report);
+  }
+
+  if (metric_name == kCpuUtilizationField) {
+    orca_load_report.set_cpu_utilization(value);
+  } else if (metric_name == kMemUtilizationField) {
+    orca_load_report.set_mem_utilization(value);
+  } else if (metric_name == kApplicationUtilizationField) {
+    orca_load_report.set_application_utilization(value);
+  } else if (metric_name == kEpsField) {
+    orca_load_report.set_eps(value);
+  } else if (metric_name == kRpsFractionalField) {
+    orca_load_report.set_rps_fractional(value);
+  } else {
+    return absl::InvalidArgumentError(absl::StrCat("unsupported metric name: ", metric_name));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status tryParseNativeHttpEncoded(const HeaderMap::GetResult& header,
+                                       OrcaLoadReport& orca_load_report) {
+  if (header.empty()) {
+    return absl::InvalidArgumentError("header is empty.");
+  }
+
+  const std::vector<absl::string_view> values = parseCommaDelimitedHeader(header);
+
+  // Check for duplicate metric names here because OrcaLoadReport fields are not
+  // marked as optional and therefore don't differentiate between unset and
+  // default values.
+  absl::flat_hash_set<absl::string_view> metric_names;
+  for (const auto value : values) {
+    std::pair<absl::string_view, absl::string_view> entry =
+        absl::StrSplit(value, absl::MaxSplits(':', 1), absl::SkipWhitespace());
+    if (metric_names.contains(entry.first)) {
+      return absl::AlreadyExistsError(
+          absl::StrCat(kEndpointLoadMetricsHeader, " contains duplicate metric: ", entry.first));
+    }
+    RETURN_IF_NOT_OK(tryCopyMetricToOrcaLoadReport(entry.first, entry.second, orca_load_report));
+    metric_names.insert(entry.first);
+  }
+  return absl::OkStatus();
+}
+
+} // namespace
+
+absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& headers) {
+  OrcaLoadReport load_report;
+
+  const auto load_metrics_native_http =
+      headers.get(Envoy::Http::LowerCaseString(kEndpointLoadMetricsHeader));
+  const auto load_metrics_json =
+      headers.get(Envoy::Http::LowerCaseString(kEndpointLoadMetricsHeaderJson));
+  const auto load_metrics_bin =
+      headers.get(Envoy::Http::LowerCaseString(kEndpointLoadMetricsHeaderBin));
+
+  if (load_metrics_native_http.empty() && load_metrics_json.empty() && load_metrics_bin.empty()) {
+    return absl::NotFoundError("no ORCA data sent from the backend");
+  }
+
+  if ((!load_metrics_native_http.empty() && !load_metrics_json.empty()) ||
+      (!load_metrics_native_http.empty() && !load_metrics_bin.empty()) ||
+      (!load_metrics_json.empty() && !load_metrics_bin.empty())) {
+    // If more than one ORCA header format is found, we will be
+    // unable to determine which header to use.
+    return absl::InvalidArgumentError("more than one ORCA header found");
+  }
+
+  // Native HTTP format.
+  if (!load_metrics_native_http.empty()) {
+    RETURN_IF_NOT_OK(tryParseNativeHttpEncoded(load_metrics_native_http, load_report));
+  }
+
+  // JSON format.
+  if (!load_metrics_json.empty()) {
+#if defined(ENVOY_ENABLE_FULL_PROTOS) && defined(ENVOY_ENABLE_YAML)
+    bool has_unknown_field = false;
+    std::string json_string = std::string(load_metrics_json[0]->value().getStringView());
+    RETURN_IF_ERROR(
+        Envoy::MessageUtil::loadFromJsonNoThrow(json_string, load_report, has_unknown_field));
+#else
+    IS_ENVOY_BUG("JSON formatted ORCA header support not implemented for this build");
+#endif // !ENVOY_ENABLE_FULL_PROTOS || !ENVOY_ENABLE_YAML
+  }
+
+  // Binary protobuf format.
+  if (!load_metrics_bin.empty()) {
+    auto header_value = load_metrics_bin[0]->value().getStringView();
+    std::string decoded_value = Envoy::Base64::decode(header_value);
+    if (!load_report.ParseFromString(decoded_value)) {
+      return absl::InvalidArgumentError(
+          fmt::format("unable to parse binaryheader to OrcaLoadReport: {}", header_value));
+    }
+  }
+  return load_report;
+}
+
+} // namespace Orca
+} // namespace Envoy

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -6,10 +6,7 @@
 
 #include "source/common/common/base64.h"
 #include "source/common/common/fmt.h"
-#include "source/common/http/header_utility.h"
-#include "source/common/protobuf/utility.h"
 
-#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 using ::Envoy::Http::HeaderMap;

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -42,7 +42,7 @@ absl::Status tryCopyNamedMetricToOrcaLoadReport(absl::string_view metric_name, d
 }
 
 std::vector<absl::string_view> parseCommaDelimitedHeader(const HeaderMap::GetResult& entry) {
-  std::vector<absl::string_view> values;
+  const std::vector<absl::string_view> values;
   for (size_t i = 0; i < entry.size(); ++i) {
     std::vector<absl::string_view> tokens =
         Envoy::Http::HeaderUtility::parseCommaDelimitedHeader(entry[i]->value().getStringView());
@@ -101,10 +101,6 @@ absl::Status tryCopyMetricToOrcaLoadReport(absl::string_view metric_name,
 
 absl::Status tryParseNativeHttpEncoded(const HeaderMap::GetResult& header,
                                        OrcaLoadReport& orca_load_report) {
-  if (header.empty()) {
-    return absl::InvalidArgumentError("header is empty.");
-  }
-
   const std::vector<absl::string_view> values = parseCommaDelimitedHeader(header);
 
   // Check for duplicate metric names here because OrcaLoadReport fields are not
@@ -157,7 +153,7 @@ absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& heade
   if (!load_metrics_json.empty()) {
 #if defined(ENVOY_ENABLE_FULL_PROTOS) && defined(ENVOY_ENABLE_YAML)
     bool has_unknown_field = false;
-    std::string json_string = std::string(load_metrics_json[0]->value().getStringView());
+    const std::string json_string = std::string(load_metrics_json[0]->value().getStringView());
     RETURN_IF_ERROR(
         Envoy::MessageUtil::loadFromJsonNoThrow(json_string, load_report, has_unknown_field));
 #else
@@ -167,8 +163,8 @@ absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& heade
 
   // Binary protobuf format.
   if (!load_metrics_bin.empty()) {
-    auto header_value = load_metrics_bin[0]->value().getStringView();
-    std::string decoded_value = Envoy::Base64::decode(header_value);
+    const auto header_value = load_metrics_bin[0]->value().getStringView();
+    const std::string decoded_value = Envoy::Base64::decode(header_value);
     if (!load_report.ParseFromString(decoded_value)) {
       return absl::InvalidArgumentError(
           fmt::format("unable to parse binaryheader to OrcaLoadReport: {}", header_value));

--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -1,12 +1,7 @@
 #include "source/common/orca/orca_parser.h"
 
-#include <cmath>
-#include <cstddef>
 #include <string>
-#include <utility>
-#include <vector>
 
-#include "envoy/common/exception.h"
 #include "envoy/http/header_map.h"
 
 #include "source/common/common/base64.h"
@@ -14,14 +9,8 @@
 #include "source/common/http/header_utility.h"
 #include "source/common/protobuf/utility.h"
 
-#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
-#include "absl/strings/match.h"
-#include "absl/strings/numbers.h"
-#include "absl/strings/str_cat.h"
-#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
-#include "absl/strings/strip.h"
 
 using ::Envoy::Http::HeaderMap;
 using ::Envoy::Http::LowerCaseString;
@@ -29,100 +18,6 @@ using xds::data::orca::v3::OrcaLoadReport;
 
 namespace Envoy {
 namespace Orca {
-
-namespace {
-
-absl::Status tryCopyNamedMetricToOrcaLoadReport(absl::string_view metric_name, double metric_value,
-                                                OrcaLoadReport& orca_load_report) {
-  if (metric_name.empty()) {
-    return absl::InvalidArgumentError("named metric key is empty.");
-  }
-
-  orca_load_report.mutable_named_metrics()->insert({std::string(metric_name), metric_value});
-  return absl::OkStatus();
-}
-
-std::vector<absl::string_view> parseCommaDelimitedHeader(const HeaderMap::GetResult& entry) {
-  std::vector<absl::string_view> values;
-  values.reserve(entry.size());
-  for (size_t i = 0; i < entry.size(); ++i) {
-    std::vector<absl::string_view> tokens =
-        Envoy::Http::HeaderUtility::parseCommaDelimitedHeader(entry[i]->value().getStringView());
-    values.insert(values.end(), tokens.begin(), tokens.end());
-  }
-  return values;
-}
-
-absl::Status tryCopyMetricToOrcaLoadReport(absl::string_view metric_name,
-                                           absl::string_view metric_value,
-                                           OrcaLoadReport& orca_load_report) {
-  if (metric_name.empty()) {
-    return absl::InvalidArgumentError("metric names cannot be empty strings");
-  }
-
-  if (metric_value.empty()) {
-    return absl::InvalidArgumentError("metric values cannot be empty strings");
-  }
-
-  double value;
-  if (!absl::SimpleAtod(metric_value, &value)) {
-    return absl::InvalidArgumentError(fmt::format(
-        "unable to parse custom backend load metric value({}): {}", metric_name, metric_value));
-  }
-
-  if (std::isnan(value)) {
-    return absl::InvalidArgumentError(
-        fmt::format("custom backend load metric value({}) cannot be NaN.", metric_name));
-  }
-
-  if (std::isinf(value)) {
-    return absl::InvalidArgumentError(
-        fmt::format("custom backend load metric value({}) cannot be infinity.", metric_name));
-  }
-
-  if (absl::StartsWith(metric_name, kNamedMetricsFieldPrefix)) {
-    auto metric_name_without_prefix = absl::StripPrefix(metric_name, kNamedMetricsFieldPrefix);
-    return tryCopyNamedMetricToOrcaLoadReport(metric_name_without_prefix, value, orca_load_report);
-  }
-
-  if (metric_name == kCpuUtilizationField) {
-    orca_load_report.set_cpu_utilization(value);
-  } else if (metric_name == kMemUtilizationField) {
-    orca_load_report.set_mem_utilization(value);
-  } else if (metric_name == kApplicationUtilizationField) {
-    orca_load_report.set_application_utilization(value);
-  } else if (metric_name == kEpsField) {
-    orca_load_report.set_eps(value);
-  } else if (metric_name == kRpsFractionalField) {
-    orca_load_report.set_rps_fractional(value);
-  } else {
-    return absl::InvalidArgumentError(absl::StrCat("unsupported metric name: ", metric_name));
-  }
-  return absl::OkStatus();
-}
-
-absl::Status tryParseNativeHttpEncoded(const HeaderMap::GetResult& header,
-                                       OrcaLoadReport& orca_load_report) {
-  const std::vector<absl::string_view> values = parseCommaDelimitedHeader(header);
-
-  // Check for duplicate metric names here because OrcaLoadReport fields are not
-  // marked as optional and therefore don't differentiate between unset and
-  // default values.
-  absl::flat_hash_set<absl::string_view> metric_names;
-  for (const auto value : values) {
-    std::pair<absl::string_view, absl::string_view> entry =
-        absl::StrSplit(value, absl::MaxSplits(':', 1), absl::SkipWhitespace());
-    if (metric_names.contains(entry.first)) {
-      return absl::AlreadyExistsError(
-          absl::StrCat(kEndpointLoadMetricsHeader, " contains duplicate metric: ", entry.first));
-    }
-    RETURN_IF_NOT_OK(tryCopyMetricToOrcaLoadReport(entry.first, entry.second, orca_load_report));
-    metric_names.insert(entry.first);
-  }
-  return absl::OkStatus();
-}
-
-} // namespace
 
 absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& headers) {
   OrcaLoadReport load_report;
@@ -136,22 +31,6 @@ absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& heade
       return absl::InvalidArgumentError(
           fmt::format("unable to parse binaryheader to OrcaLoadReport: {}", header_value));
     }
-  } else if (const auto header_native_http =
-                 headers.get(LowerCaseString(kEndpointLoadMetricsHeader));
-             !header_native_http.empty()) {
-    // Native HTTP format.
-    RETURN_IF_NOT_OK(tryParseNativeHttpEncoded(header_native_http, load_report));
-  } else if (const auto header_json = headers.get(LowerCaseString(kEndpointLoadMetricsHeaderJson));
-             !header_json.empty()) {
-    // JSON format.
-#if defined(ENVOY_ENABLE_FULL_PROTOS) && defined(ENVOY_ENABLE_YAML)
-    bool has_unknown_field = false;
-    const std::string json_string = std::string(header_json[0]->value().getStringView());
-    RETURN_IF_ERROR(
-        Envoy::MessageUtil::loadFromJsonNoThrow(json_string, load_report, has_unknown_field));
-#else
-    IS_ENVOY_BUG("JSON formatted ORCA header support not implemented for this build");
-#endif // !ENVOY_ENABLE_FULL_PROTOS || !ENVOY_ENABLE_YAML
   } else {
     return absl::NotFoundError("no ORCA data sent from the backend");
   }

--- a/source/common/orca/orca_parser.h
+++ b/source/common/orca/orca_parser.h
@@ -9,17 +9,17 @@ namespace Envoy {
 namespace Orca {
 
 // Headers used to send ORCA load metrics from the backend.
-static constexpr char kEndpointLoadMetricsHeader[] = "endpoint-load-metrics";
-static constexpr char kEndpointLoadMetricsHeaderBin[] = "endpoint-load-metrics-bin";
-static constexpr char kEndpointLoadMetricsHeaderJson[] = "endpoint-load-metrics-json";
+static constexpr absl::string_view kEndpointLoadMetricsHeader = "endpoint-load-metrics";
+static constexpr absl::string_view kEndpointLoadMetricsHeaderBin = "endpoint-load-metrics-bin";
+static constexpr absl::string_view kEndpointLoadMetricsHeaderJson = "endpoint-load-metrics-json";
 // The following fields are the names of the metrics tracked in the ORCA load
 // report proto.
-static constexpr char kApplicationUtilizationField[] = "application_utilization";
-static constexpr char kCpuUtilizationField[] = "cpu_utilization";
-static constexpr char kMemUtilizationField[] = "mem_utilization";
-static constexpr char kEpsField[] = "eps";
-static constexpr char kRpsFractionalField[] = "rps_fractional";
-static constexpr char kNamedMetricsFieldPrefix[] = "named_metrics.";
+static constexpr absl::string_view kApplicationUtilizationField = "application_utilization";
+static constexpr absl::string_view kCpuUtilizationField = "cpu_utilization";
+static constexpr absl::string_view kMemUtilizationField = "mem_utilization";
+static constexpr absl::string_view kEpsField = "eps";
+static constexpr absl::string_view kRpsFractionalField = "rps_fractional";
+static constexpr absl::string_view kNamedMetricsFieldPrefix = "named_metrics.";
 
 // Parses ORCA load metrics from a header map into an OrcaLoadReport proto.
 // Supports native HTTP, JSON and serialized binary formats.

--- a/source/common/orca/orca_parser.h
+++ b/source/common/orca/orca_parser.h
@@ -8,21 +8,11 @@
 namespace Envoy {
 namespace Orca {
 
-// Headers used to send ORCA load metrics from the backend.
-static constexpr absl::string_view kEndpointLoadMetricsHeader = "endpoint-load-metrics";
+// Header used to send ORCA load metrics from the backend.
 static constexpr absl::string_view kEndpointLoadMetricsHeaderBin = "endpoint-load-metrics-bin";
-static constexpr absl::string_view kEndpointLoadMetricsHeaderJson = "endpoint-load-metrics-json";
-// The following fields are the names of the metrics tracked in the ORCA load
-// report proto.
-static constexpr absl::string_view kApplicationUtilizationField = "application_utilization";
-static constexpr absl::string_view kCpuUtilizationField = "cpu_utilization";
-static constexpr absl::string_view kMemUtilizationField = "mem_utilization";
-static constexpr absl::string_view kEpsField = "eps";
-static constexpr absl::string_view kRpsFractionalField = "rps_fractional";
-static constexpr absl::string_view kNamedMetricsFieldPrefix = "named_metrics.";
 
 // Parses ORCA load metrics from a header map into an OrcaLoadReport proto.
-// Supports native HTTP, JSON and serialized binary formats.
+// Supports serialized binary formats.
 absl::StatusOr<xds::data::orca::v3::OrcaLoadReport>
 parseOrcaLoadReportHeaders(const Envoy::Http::HeaderMap& headers);
 } // namespace Orca

--- a/source/common/orca/orca_parser.h
+++ b/source/common/orca/orca_parser.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "envoy/http/header_map.h"
+
+#include "absl/status/statusor.h"
+#include "xds/data/orca/v3/orca_load_report.pb.h"
+
+namespace Envoy {
+namespace Orca {
+
+// Headers used to send ORCA load metrics from the backend.
+static constexpr char kEndpointLoadMetricsHeader[] = "endpoint-load-metrics";
+static constexpr char kEndpointLoadMetricsHeaderBin[] = "endpoint-load-metrics-bin";
+static constexpr char kEndpointLoadMetricsHeaderJson[] = "endpoint-load-metrics-json";
+// The following fields are the names of the metrics tracked in the ORCA load
+// report proto.
+static constexpr char kApplicationUtilizationField[] = "application_utilization";
+static constexpr char kCpuUtilizationField[] = "cpu_utilization";
+static constexpr char kMemUtilizationField[] = "mem_utilization";
+static constexpr char kEpsField[] = "eps";
+static constexpr char kRpsFractionalField[] = "rps_fractional";
+static constexpr char kNamedMetricsFieldPrefix[] = "named_metrics.";
+
+// Parses ORCA load metrics from a header map into an OrcaLoadReport proto.
+// Supports native HTTP, JSON and serialized binary formats.
+absl::StatusOr<xds::data::orca::v3::OrcaLoadReport>
+parseOrcaLoadReportHeaders(const Envoy::Http::HeaderMap& headers);
+} // namespace Orca
+} // namespace Envoy

--- a/test/common/orca/BUILD
+++ b/test/common/orca/BUILD
@@ -1,0 +1,26 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "orca_parser_test",
+    srcs = ["orca_parser_test.cc"],
+    external_deps = [
+        "abseil_status",
+        "abseil_strings",
+        "fmtlib",
+    ],
+    deps = [
+        "//source/common/common:base64_lib",
+        "//source/common/orca:orca_parser",
+        "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
+        "@com_github_cncf_xds//xds/data/orca/v3:pkg_cc_proto",
+    ],
+)

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -7,7 +7,6 @@
 #include "test/test_common/utility.h"
 
 #include "absl/status/status.h"
-#include "absl/strings/str_cat.h"
 #include "xds/data/orca/v3/orca_load_report.pb.h"
 
 namespace Envoy {

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -124,9 +124,10 @@ TEST(OrcaParserUtilTest, JsonHeaderIncorrectFieldType) {
 }
 
 TEST(OrcaParserUtilTest, BinaryHeader) {
-  auto orca_load_report_serialized_string = ExampleOrcaLoadReport().SerializeAsString();
-  auto orca_load_report_header_bin = Envoy::Base64::encode(
-      orca_load_report_serialized_string.c_str(), orca_load_report_serialized_string.length());
+  std::string proto_string =
+      TestUtility::getProtobufBinaryStringFromMessage(ExampleOrcaLoadReport());
+  auto orca_load_report_header_bin =
+      Envoy::Base64::encode(proto_string.c_str(), proto_string.length());
   Http::TestRequestHeaderMapImpl headers{
       {kEndpointLoadMetricsHeaderBin, orca_load_report_header_bin}};
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
@@ -134,10 +135,11 @@ TEST(OrcaParserUtilTest, BinaryHeader) {
 }
 
 TEST(OrcaParserUtilTest, InvalidBinaryHeader) {
-  auto orca_load_report_serialized_string = ExampleOrcaLoadReport().SerializeAsString();
+  std::string proto_string =
+      TestUtility::getProtobufBinaryStringFromMessage(ExampleOrcaLoadReport());
   // Force a bad base64 encoding by shortening the length of the output.
-  auto orca_load_report_header_bin = Envoy::Base64::encode(
-      orca_load_report_serialized_string.c_str(), orca_load_report_serialized_string.length() / 2);
+  auto orca_load_report_header_bin =
+      Envoy::Base64::encode(proto_string.c_str(), proto_string.length() / 2);
   Http::TestRequestHeaderMapImpl headers{
       {kEndpointLoadMetricsHeaderBin, orca_load_report_header_bin}};
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -14,7 +14,7 @@ namespace Orca {
 namespace {
 
 // Returns an example OrcaLoadReport proto with all fields populated.
-static xds::data::orca::v3::OrcaLoadReport ExampleOrcaLoadReport() {
+static xds::data::orca::v3::OrcaLoadReport exampleOrcaLoadReport() {
   xds::data::orca::v3::OrcaLoadReport orca_load_report;
   orca_load_report.set_cpu_utilization(0.7);
   orca_load_report.set_application_utilization(0.8);
@@ -44,18 +44,18 @@ TEST(OrcaParserUtilTest, MissingOrcaHeaders) {
 
 TEST(OrcaParserUtilTest, BinaryHeader) {
   const std::string proto_string =
-      TestUtility::getProtobufBinaryStringFromMessage(ExampleOrcaLoadReport());
+      TestUtility::getProtobufBinaryStringFromMessage(exampleOrcaLoadReport());
   const auto orca_load_report_header_bin =
       Envoy::Base64::encode(proto_string.c_str(), proto_string.length());
   Http::TestRequestHeaderMapImpl headers{
       {std::string(kEndpointLoadMetricsHeaderBin), orca_load_report_header_bin}};
   EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+              StatusHelpers::IsOkAndHolds(ProtoEq(exampleOrcaLoadReport())));
 }
 
 TEST(OrcaParserUtilTest, InvalidBinaryHeader) {
   const std::string proto_string =
-      TestUtility::getProtobufBinaryStringFromMessage(ExampleOrcaLoadReport());
+      TestUtility::getProtobufBinaryStringFromMessage(exampleOrcaLoadReport());
   // Force a bad base64 encoding by shortening the length of the output.
   const auto orca_load_report_header_bin =
       Envoy::Base64::encode(proto_string.c_str(), proto_string.length() / 2);

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -1,4 +1,4 @@
-#include <limits>
+#include <string>
 
 #include "source/common/common/base64.h"
 #include "source/common/orca/orca_parser.h"
@@ -43,123 +43,6 @@ TEST(OrcaParserUtilTest, MissingOrcaHeaders) {
               StatusHelpers::HasStatus(absl::NotFoundError("no ORCA data sent from the backend")));
 }
 
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeader) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader),
-       "cpu_utilization:0.7,application_utilization:0.8,mem_utilization:0.9,"
-       "rps_fractional:1000,eps:2,"
-       "named_metrics.foo:123,named_metrics.bar:0.2"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderIncorrectFieldType) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:\"0.7\""}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(
-                  absl::InvalidArgumentError("unable to parse custom backend load metric "
-                                             "value(cpu_utilization): \"0.7\"")));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderNanMetricValue) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader),
-       absl::StrCat("cpu_utilization:", std::numeric_limits<double>::quiet_NaN())}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::InvalidArgumentError(
-                  "custom backend load metric value(cpu_utilization) cannot be NaN.")));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderInfinityMetricValue) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader),
-       absl::StrCat("cpu_utilization:", std::numeric_limits<double>::infinity())}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::InvalidArgumentError(
-                  "custom backend load metric value(cpu_utilization) cannot be "
-                  "infinity.")));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsDuplicateMetric) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:0.7,cpu_utilization:0.8"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::AlreadyExistsError(absl::StrCat(
-                  kEndpointLoadMetricsHeader, " contains duplicate metric: cpu_utilization"))));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderUnsupportedMetric) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:0.7,unsupported_metric:0.8"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(
-                  absl::InvalidArgumentError("unsupported metric name: unsupported_metric")));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsDuplicateNamedMetric) {
-  Http::TestRequestHeaderMapImpl headers{{std::string(kEndpointLoadMetricsHeader),
-                                          "named_metrics.foo:123,named_metrics.duplicate:123,"
-                                          "named_metrics.duplicate:0.2"}};
-  EXPECT_THAT(
-      parseOrcaLoadReportHeaders(headers),
-      StatusHelpers::HasStatus(absl::AlreadyExistsError(absl::StrCat(
-          kEndpointLoadMetricsHeader, " contains duplicate metric: named_metrics.duplicate"))));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsEmptyNamedMetricKey) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader), "named_metrics.:123"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::InvalidArgumentError("named metric key is empty.")));
-}
-
-TEST(OrcaParserUtilTest, InvalidNativeHttpEncodedHeader) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader), "not-a-list-of-key-value-pairs"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(
-                  absl::InvalidArgumentError("metric values cannot be empty strings")));
-}
-
-TEST(OrcaParserUtilTest, JsonHeader) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeaderJson),
-       "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
-       "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2, "
-       "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
-}
-
-TEST(OrcaParserUtilTest, InvalidJsonHeader) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeaderJson), "not-a-valid-json-string"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
-                                       testing::HasSubstr("invalid JSON")));
-}
-
-TEST(OrcaParserUtilTest, JsonHeaderUnknownField) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeaderJson),
-       "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
-       "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2,  "
-       "\"unknown_field\": 2,"
-       "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
-                                       testing::HasSubstr("invalid JSON")));
-}
-
-TEST(OrcaParserUtilTest, JsonHeaderIncorrectFieldType) {
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeaderJson), "{\"cpu_utilization\": \"0.7\""}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
-                                       testing::HasSubstr("invalid JSON")));
-}
-
 TEST(OrcaParserUtilTest, BinaryHeader) {
   const std::string proto_string =
       TestUtility::getProtobufBinaryStringFromMessage(ExampleOrcaLoadReport());
@@ -183,33 +66,6 @@ TEST(OrcaParserUtilTest, InvalidBinaryHeader) {
               StatusHelpers::HasStatus(
                   absl::StatusCode::kInvalidArgument,
                   testing::HasSubstr("unable to parse binaryheader to OrcaLoadReport")));
-}
-
-TEST(OrcaParserUtilTest, BinHeaderPrecedence) {
-  // Verifies that the order of precedence (binary proto over native http
-  // format) is observed when multiple ORCA headers are sent from the backend.
-  const std::string proto_string =
-      TestUtility::getProtobufBinaryStringFromMessage(ExampleOrcaLoadReport());
-  const auto orca_load_report_header_bin =
-      Envoy::Base64::encode(proto_string.c_str(), proto_string.length());
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader), "cpu_utilization:0.7"},
-      {std::string(kEndpointLoadMetricsHeaderBin), orca_load_report_header_bin}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
-}
-
-TEST(OrcaParserUtilTest, NativeHttpHeaderPrecedence) {
-  // Verifies that the order of precedence (native http over JSON format) is
-  // observed when multiple ORCA headers are sent from the backend.
-  Http::TestRequestHeaderMapImpl headers{
-      {std::string(kEndpointLoadMetricsHeader),
-       "cpu_utilization:0.7,application_utilization:0.8,mem_utilization:0.9,"
-       "rps_fractional:1000,eps:2,"
-       "named_metrics.foo:123,named_metrics.bar:0.2"},
-      {std::string(kEndpointLoadMetricsHeaderJson), "{\"cpu_utilization\": 0.7}"}};
-  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
-              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
 }
 
 } // namespace

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -1,0 +1,151 @@
+#include "source/common/common/base64.h"
+#include "source/common/orca/orca_parser.h"
+
+#include "test/test_common/status_utility.h"
+#include "test/test_common/utility.h"
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "xds/data/orca/v3/orca_load_report.pb.h"
+
+namespace Envoy {
+namespace Orca {
+namespace {
+
+// Returns an example OrcaLoadReport proto with all fields populated.
+static xds::data::orca::v3::OrcaLoadReport ExampleOrcaLoadReport() {
+  xds::data::orca::v3::OrcaLoadReport orca_load_report;
+  orca_load_report.set_cpu_utilization(0.7);
+  orca_load_report.set_application_utilization(0.8);
+  orca_load_report.set_mem_utilization(0.9);
+  orca_load_report.set_eps(2);
+  orca_load_report.set_rps_fractional(1000);
+  orca_load_report.mutable_named_metrics()->insert({"foo", 123});
+  orca_load_report.mutable_named_metrics()->insert({"bar", 0.2});
+  return orca_load_report;
+}
+
+TEST(OrcaParserUtilTest, EmptyHeaders) {
+  Http::TestRequestHeaderMapImpl headers{};
+  // parseOrcaLoadReport returns error when no ORCA data is sent from
+  // the backend.
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::NotFoundError("no ORCA data sent from the backend")));
+}
+
+TEST(OrcaParserUtilTest, MissingOrcaHeaders) {
+  Http::TestRequestHeaderMapImpl headers{{"wrong-header", "wrong-value"}};
+  // parseOrcaLoadReport returns error when no ORCA data is sent from
+  // the backend.
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::NotFoundError("no ORCA data sent from the backend")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeader,
+       "cpu_utilization:0.7,application_utilization:0.8,mem_utilization:0.9,"
+       "rps_fractional:1000,eps:2,"
+       "named_metrics.foo:123,named_metrics.bar:0.2"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderIncorrectFieldType) {
+  Http::TestRequestHeaderMapImpl headers{{kEndpointLoadMetricsHeader, "cpu_utilization:\"0.7\""}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::InvalidArgumentError("unable to parse custom backend load metric "
+                                             "value(cpu_utilization): \"0.7\"")));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsDuplicateMetric) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeader, "cpu_utilization:0.7,cpu_utilization:0.8"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::AlreadyExistsError(absl::StrCat(
+                  kEndpointLoadMetricsHeader, " contains duplicate metric: cpu_utilization"))));
+}
+
+TEST(OrcaParserUtilTest, NativeHttpEncodedHeaderContainsDuplicateNamedMetric) {
+  Http::TestRequestHeaderMapImpl headers{{kEndpointLoadMetricsHeader,
+                                          "named_metrics.foo:123,named_metrics.duplicate:123,"
+                                          "named_metrics.duplicate:0.2"}};
+  EXPECT_THAT(
+      parseOrcaLoadReportHeaders(headers),
+      StatusHelpers::HasStatus(absl::AlreadyExistsError(absl::StrCat(
+          kEndpointLoadMetricsHeader, " contains duplicate metric: named_metrics.duplicate"))));
+}
+
+TEST(OrcaParserUtilTest, InvalidNativeHttpEncodedHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeader, "not-a-list-of-key-value-pairs"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::InvalidArgumentError("metric values cannot be empty strings")));
+}
+
+TEST(OrcaParserUtilTest, JsonHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeaderJson,
+       "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
+       "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2, "
+       "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+}
+
+TEST(OrcaParserUtilTest, InvalidJsonHeader) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeaderJson, "not-a-valid-json-string"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("invalid JSON")));
+}
+
+TEST(OrcaParserUtilTest, JsonHeaderUnknownField) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeaderJson,
+       "{\"cpu_utilization\": 0.7, \"application_utilization\": 0.8, "
+       "\"mem_utilization\": 0.9, \"rps_fractional\": 1000, \"eps\": 2,  "
+       "\"unknown_field\": 2,"
+       "\"named_metrics\": {\"foo\": 123,\"bar\": 0.2}}"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("invalid JSON")));
+}
+
+TEST(OrcaParserUtilTest, JsonHeaderIncorrectFieldType) {
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeaderJson, "{\"cpu_utilization\": \"0.7\""}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("invalid JSON")));
+}
+
+TEST(OrcaParserUtilTest, BinaryHeader) {
+  auto orca_load_report_serialized_string = ExampleOrcaLoadReport().SerializeAsString();
+  auto orca_load_report_header_bin = Envoy::Base64::encode(
+      orca_load_report_serialized_string.c_str(), orca_load_report_serialized_string.length());
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeaderBin, orca_load_report_header_bin}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::IsOkAndHolds(ProtoEq(ExampleOrcaLoadReport())));
+}
+
+TEST(OrcaParserUtilTest, InvalidBinaryHeader) {
+  auto orca_load_report_serialized_string = ExampleOrcaLoadReport().SerializeAsString();
+  // Force a bad base64 encoding by shortening the length of the output.
+  auto orca_load_report_header_bin = Envoy::Base64::encode(
+      orca_load_report_serialized_string.c_str(), orca_load_report_serialized_string.length() / 2);
+  Http::TestRequestHeaderMapImpl headers{
+      {kEndpointLoadMetricsHeaderBin, orca_load_report_header_bin}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr("unable to parse binaryheader to OrcaLoadReport")));
+}
+
+} // namespace
+} // namespace Orca
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: Add utility methods to parse ORCA response headers from backends.
Additional Description: Add utility methods to parse ORCA response headers from backends. `parseOrcaLoadReportHeaders` will be called from the `RouterFilter`.
[Open Request Cost Aggregation (ORCA) Design Proposal](https://github.com/envoyproxy/envoy/issues/6614)
[Using ORCA load reports in Envoy](https://docs.google.com/document/d/1gb_2pcNnEzTgo1EJ6w1Ol7O-EH-O_Ysu5o215N9MTAg/edit#heading=h.bi4e79pb39fe)
Risk Level: Low
Testing: See included unit tests.
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: JSON formatted header not supported on Envoy Mobile

CC @efimki @AndresGuedez 