### PR TITLE
Update function parameter in grpc_json_transcoder

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -63,7 +63,7 @@ bool HttpBodyUtils::parseMessageByFieldPath(
 }
 
 void HttpBodyUtils::appendHttpBodyEnvelope(
-    Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
+    Buffer::Instance& output, const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
     std::string content_type, uint64_t content_length, const UnknownQueryParams& unknown_params) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded for wire format.

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
@@ -18,7 +18,7 @@ public:
                                       const std::vector<const ProtobufWkt::Field*>& field_path,
                                       Protobuf::Message* message);
   static void appendHttpBodyEnvelope(
-      Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
+      Buffer::Instance& output, const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
       std::string content_type, uint64_t content_length,
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownQueryParams&
           unknown_params);

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
@@ -18,7 +18,8 @@ public:
                                       const std::vector<const ProtobufWkt::Field*>& field_path,
                                       Protobuf::Message* message);
   static void appendHttpBodyEnvelope(
-      Buffer::Instance& output, const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
+      Buffer::Instance& output,
+      const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
       std::string content_type, uint64_t content_length,
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownQueryParams&
           unknown_params);

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -381,7 +381,6 @@ replacements:
     # Well-known types should be referenced from the ProtobufWkt namespace.
     "Protobuf::Any": "ProtobufWkt::Any"
     "Protobuf::Empty": "ProtobufWkt::Empty"
-    "Protobuf::Field": "ProtobufWkt::Field"
     "Protobuf::ListValue": "ProtobufWkt::ListValue"
     "Protobuf::NULL_VALUE": "ProtobufWkt::NULL_VALUE"
     "Protobuf::StringValue": "ProtobufWkt::StringValue"

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -381,6 +381,7 @@ replacements:
     # Well-known types should be referenced from the ProtobufWkt namespace.
     "Protobuf::Any": "ProtobufWkt::Any"
     "Protobuf::Empty": "ProtobufWkt::Empty"
+    "Protobuf::Field": "ProtobufWkt::Field"
     "Protobuf::ListValue": "ProtobufWkt::ListValue"
     "Protobuf::NULL_VALUE": "ProtobufWkt::NULL_VALUE"
     "Protobuf::StringValue": "ProtobufWkt::StringValue"


### PR DESCRIPTION
Commit Message: Use `ProtobufWkt::Field` instead of `Protobuf::Field` in grpc_json_transcoder to fix build issues.
Additional Description:
Risk Level: Low
Testing: `bazelisk test //test/extensions/filters/http/grpc_json_transcoder/...`
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
