### PR TITLE
mobile: Add bazel/protoc

### DIFF
--- a/mobile/bazel/protoc/BUILD
+++ b/mobile/bazel/protoc/BUILD
@@ -1,0 +1,1 @@
+licenses(["notice"])  # Apache 2

--- a/mobile/bazel/protoc/BUILD.protoc
+++ b/mobile/bazel/protoc/BUILD.protoc
@@ -1,0 +1,18 @@
+load("@envoy//bazel/protoc:protoc.bzl", "protoc_binary")
+
+protoc_binary(
+    name = "protoc",
+    srcs = select({
+        ":windows": ["bin/protoc.exe"],
+        "//conditions:default": ["bin/protoc"],
+    }),
+    executable = "protoc.exe",
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)

--- a/mobile/bazel/protoc/protoc.bzl
+++ b/mobile/bazel/protoc/protoc.bzl
@@ -1,0 +1,15 @@
+def protoc_binary(name, srcs, executable, **kwargs):
+    """protoc_binary makes a copy of the protoc binary to bazel-bin.
+
+This is a workaround to make sure protoc can be used with attributes
+which don't allow files."""
+
+    native.genrule(
+        name = name,
+        executable = True,
+        srcs = srcs,
+        outs = [executable],
+        cmd_bash = "cp $< $@ && chmod +x $@",
+        cmd_bat = "copy $< $@",
+        **kwargs
+    )


### PR DESCRIPTION
Add `bazel/protoc` into Envoy Mobile similar to https://github.com/envoyproxy/envoy/pull/35412 or else Envoy Mobile will fail to build with error:

```
ERROR: An error occurred during the fetch of repository 'com_google_protobuf_protoc_linux_x86_64':
   Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/bb3efe6b13248f746491cbfc24ae2efe/external/bazel_tools/tools/build_defs/repo/http.bzl", line 142, column 28, in _http_archive_impl
		workspace_and_buildfile(ctx)
	File "/root/.cache/bazel/_bazel_root/bb3efe6b13248f746491cbfc24ae2efe/external/bazel_tools/tools/build_defs/repo/utils.bzl", line 61, column 41, in workspace_and_buildfile
		ctx.file("BUILD.bazel", ctx.read(ctx.attr.build_file))
Error in read: Unable to load package for //bazel/protoc:BUILD.protoc: BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /source/mobile/bazel/protoc
 ```

Risk Level: low
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
