### PR TITLE
oauth: ability to specify SameSite cookie attribute value

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -32,7 +32,8 @@ message CookieSettings {
     STRICT = 3;
   }
 
-  // The value used for the SameSite cookie attribute. Defaults to SAME_SITE.
+  // The value used for the SameSite cookie attribute. Defaults to DISABLED which does not add the
+  // SameSite attribute.
   SameSiteValues same_site_attribute_value = 1;
 }
 

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -24,6 +24,18 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.http.oauth2]
 //
 
+message CookieSettings {
+  enum SameSiteValues {
+    DISABLED = 0;
+    NONE = 1;
+    LAX = 2;
+    STRICT = 3;
+  }
+
+  // The value used for the SameSite cookie attribute. Defaults to SAME_SITE.
+  SameSiteValues same_site_attribute_value = 1;
+}
+
 message OAuth2Credentials {
   // [#next-free-field: 6]
   message CookieNames {
@@ -74,7 +86,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -161,6 +173,9 @@ message OAuth2Config {
   // will still process incoming ID Tokens as part of the HMAC if they are there. This is to ensure compatibility while switching this setting on. Future
   // sessions would not set the IdToken cookie header.
   bool disable_id_token_set_cookie = 17;
+
+  // Controls for attributes that can be set on the cookies.
+  CookieSettings cookie_settings = 18;
 }
 
 // Filter config.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -93,5 +93,9 @@ new_features:
     <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.custom_tls_certificate_selector>`
     to allow overriding TLS certificate selection behavior.
     An extension can select certificate base on the incoming SNI, in both sync and async mode.
+- area: oauth
+  change: |
+    Add ability to configure SameSite attribute for OAuth cookies using :ref:`same_site_attribute_value
+    <envoy_v3_api_field_extensions.filters.http.oauth2.v3.CookieSettings.same_site_attribute_value>`.
 
 deprecated:

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -143,7 +143,7 @@ public:
   const CookieNames& cookieNames() const { return cookie_names_; }
   const AuthType& authType() const { return auth_type_; }
   bool useRefreshToken() const { return use_refresh_token_; }
-  std::string sameSiteAttribute() { return same_site_attribute_; }
+  std::string cookieSuffix() { return cookie_suffix_; }
   std::chrono::seconds defaultExpiresIn() const { return default_expires_in_; }
   std::chrono::seconds defaultRefreshTokenExpiresIn() const {
     return default_refresh_token_expires_in_;
@@ -170,8 +170,7 @@ private:
   const std::vector<Http::HeaderUtility::HeaderData> deny_redirect_header_matchers_;
   const CookieNames cookie_names_;
   const AuthType auth_type_;
-  // const SameSiteAttribute same_site_attribute_;
-  const std::string same_site_attribute_;
+  const std::string cookie_suffix_;
   const std::chrono::seconds default_expires_in_;
   const std::chrono::seconds default_refresh_token_expires_in_;
   const bool forward_bearer_token_ : 1;
@@ -303,6 +302,12 @@ private:
                                        const std::chrono::seconds& expires_in) const;
   void addResponseCookies(Http::ResponseHeaderMap& headers, const std::string& encoded_token) const;
   const std::string& bearerPrefix() const;
+  std::string buildRefreshTokenCookie(absl::string_view cookie_name,
+                                      absl::string_view cookie_suffix) const;
+  std::string buildIdTokenCookie(absl::string_view cookie_name,
+                                 absl::string_view cookie_suffix) const;
+  std::string buildTokenCookie(absl::string_view cookie_name, absl::string_view token,
+                               absl::string_view expires_in, absl::string_view cookie_suffix) const;
 };
 
 } // namespace Oauth2

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -143,6 +143,7 @@ public:
   const CookieNames& cookieNames() const { return cookie_names_; }
   const AuthType& authType() const { return auth_type_; }
   bool useRefreshToken() const { return use_refresh_token_; }
+  std::string sameSiteAttribute() { return same_site_attribute_; }
   std::chrono::seconds defaultExpiresIn() const { return default_expires_in_; }
   std::chrono::seconds defaultRefreshTokenExpiresIn() const {
     return default_refresh_token_expires_in_;
@@ -169,6 +170,8 @@ private:
   const std::vector<Http::HeaderUtility::HeaderData> deny_redirect_header_matchers_;
   const CookieNames cookie_names_;
   const AuthType auth_type_;
+  // const SameSiteAttribute same_site_attribute_;
+  const std::string same_site_attribute_;
   const std::chrono::seconds default_expires_in_;
   const std::chrono::seconds default_refresh_token_expires_in_;
   const bool forward_bearer_token_ : 1;

--- a/source/extensions/filters/http/oauth2/oauth.h
+++ b/source/extensions/filters/http/oauth2/oauth.h
@@ -38,6 +38,8 @@ public:
  */
 enum class AuthType { UrlEncodedBody, BasicAuth };
 
+enum class SameSiteAttribute { Disabled, None, Lax, Strict };
+
 } // namespace Oauth2
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
Commit Message: oauth: ability to specify SameSite cookie attribute value
Additional Description: The `SameSite` attribute has three different values to allow control over whether the cookies get shared same-site/cross-site. It's optional so there's also a `Disabled` option which excludes the SameSite attribute. This is the default setting so existing deployments are not modified in any way, but now operators can enable SameSite.
Risk Level: Low
Testing: unit
Docs Changes: proto is documented
Release Notes: changelog entry added
