### PR TITLE
mobile: removing direct response route

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -340,22 +340,13 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   hcm->mutable_stream_idle_timeout()->set_seconds(stream_idle_timeout_seconds_);
   auto* route_config = hcm->mutable_route_config();
   route_config->set_name("api_router");
-  auto* remote_service = route_config->add_virtual_hosts();
-  remote_service->set_name("remote_service");
-  remote_service->add_domains("127.0.0.1");
 
-  auto* route = remote_service->add_routes();
-  route->mutable_match()->set_prefix("/");
-  route->mutable_direct_response()->set_status(404);
-  route->mutable_direct_response()->mutable_body()->set_inline_string("not found");
-  route->add_request_headers_to_remove("x-forwarded-proto");
-  route->add_request_headers_to_remove("x-envoy-mobile-cluster");
   auto* api_service = route_config->add_virtual_hosts();
   api_service->set_name("api");
   api_service->set_include_attempt_count_in_response(true);
   api_service->add_domains("*");
 
-  route = api_service->add_routes();
+  auto* route = api_service->add_routes();
   route->mutable_match()->set_prefix("/");
   route->add_request_headers_to_remove("x-forwarded-proto");
   route->add_request_headers_to_remove("x-envoy-mobile-cluster");

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -1306,33 +1306,6 @@ TEST_P(ClientIntegrationTest, Proxying) {
   ASSERT_EQ(cc_.on_complete_calls_, 2);
 }
 
-TEST_P(ClientIntegrationTest, DirectResponse) {
-  initialize();
-
-  // Override to not validate stream intel.
-  EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
-  stream_callbacks.on_complete_ = [this](envoy_stream_intel, envoy_final_stream_intel final_intel) {
-    cc_.on_complete_received_byte_count_ = final_intel.received_byte_count;
-    cc_.on_complete_calls_++;
-    cc_.terminal_callback_->setReady();
-  };
-
-  default_request_headers_.setHost("127.0.0.1");
-  default_request_headers_.setPath("/");
-
-  stream_ = createNewStream(std::move(stream_callbacks));
-  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
-                       true);
-  terminal_callback_.waitReady();
-  ASSERT_EQ(cc_.status_, "404");
-  ASSERT_EQ(cc_.on_headers_calls_, 1);
-  stream_.reset();
-
-  // Verify the default runtime values.
-  EXPECT_FALSE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_false"));
-  EXPECT_TRUE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_true"));
-}
-
 TEST_P(ClientIntegrationTest, TestRuntimeSet) {
   builder_.addRuntimeGuard("test_feature_true", false);
   builder_.addRuntimeGuard("test_feature_false", true);


### PR DESCRIPTION
Looks like we got rid of all the tests relying on 127.0.0.1 404s.
Risk Level: mobile-only
Testing: CI passes
Docs Changes: n/a
Release Notes: n/a