### PR TITLE
mobile: Add an optional idempotency parameter in sendHeaders

### DIFF
--- a/mobile/examples/java/hello_world/MainActivity.java
+++ b/mobile/examples/java/hello_world/MainActivity.java
@@ -137,7 +137,7 @@ public class MainActivity extends Activity {
           return Unit.INSTANCE;
         })
         .start(Executors.newSingleThreadExecutor())
-        .sendHeaders(requestHeaders, true);
+        .sendHeaders(requestHeaders, /* endStream= */ true, /* idempotent= */ false);
 
     clear_text = !clear_text;
   }

--- a/mobile/library/cc/stream.cc
+++ b/mobile/library/cc/stream.cc
@@ -10,8 +10,8 @@ namespace Platform {
 
 Stream::Stream(InternalEngine* engine, envoy_stream_t handle) : engine_(engine), handle_(handle) {}
 
-Stream& Stream::sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream) {
-  engine_->sendHeaders(handle_, std::move(headers), end_stream);
+Stream& Stream::sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream, bool idempotent) {
+  engine_->sendHeaders(handle_, std::move(headers), end_stream, idempotent);
   return *this;
 }
 

--- a/mobile/library/cc/stream.h
+++ b/mobile/library/cc/stream.h
@@ -21,8 +21,10 @@ public:
    *
    * @param headers the headers to send.
    * @param end_stream indicates whether to close the stream locally after sending this frame.
+   * @param idempotent indicates that the request is idempotent. When idempotent is set to true
+   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
    */
-  Stream& sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream);
+  Stream& sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream, bool idempotent = false);
 
   /**
    * Send data over an open HTTP stream. This method can be invoked multiple times.

--- a/mobile/library/cc/stream.h
+++ b/mobile/library/cc/stream.h
@@ -22,7 +22,8 @@ public:
    * @param headers the headers to send.
    * @param end_stream indicates whether to close the stream locally after sending this frame.
    * @param idempotent indicates that the request is idempotent. When idempotent is set to true
-   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
+   *                   Envoy Mobile will retry on HTTP/3 post-handshake failures. By default, it is
+   *                   set to false.
    */
   Stream& sendHeaders(Http::RequestHeaderMapPtr headers, bool end_stream, bool idempotent = false);
 

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -11,7 +11,6 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "library/common/bridge/utility.h"
-#include "library/common/http/header_utility.h"
 #include "library/common/stream_info/extra_stream_info.h"
 #include "library/common/system/system_helper.h"
 
@@ -552,7 +551,8 @@ void Client::startStream(envoy_stream_t new_stream_handle, EnvoyStreamCallbacks&
   ENVOY_LOG(debug, "[S{}] start stream", new_stream_handle);
 }
 
-void Client::sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, bool end_stream) {
+void Client::sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, bool end_stream,
+                         bool idempotent) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream =
       getStream(stream, GetStreamFilters::AllowOnlyForOpenStreams);
@@ -597,6 +597,12 @@ void Client::sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, boo
   // a request here:
   // https://github.com/envoyproxy/envoy/blob/c9e3b9d2c453c7fe56a0e3615f0c742ac0d5e768/source/common/router/config_impl.cc#L1091-L1096
   headers->setReferenceForwardedProto(Headers::get().SchemeValues.Https);
+  // When the request is idempotent, it is safe to retry.
+  if (idempotent) {
+    // https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on
+    headers->addCopy(Headers::get().EnvoyRetryOn,
+                     Headers::get().EnvoyRetryOnValues.Http3PostConnectFailure);
+  }
   ENVOY_LOG(debug, "[S{}] request headers for stream (end_stream={}):\n{}", stream, end_stream,
             *headers);
   request_decoder->decodeHeaders(std::move(headers), end_stream);

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -79,8 +79,11 @@ public:
    * @param stream the stream to send headers over.
    * @param headers the headers to send.
    * @param end_stream indicates whether to close the stream locally after sending this frame.
+   * @param idempotent indicates that the request is idempotent. When idempotent is set to true
+   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
    */
-  void sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, bool end_stream);
+  void sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, bool end_stream,
+                   bool idempotent = false);
 
   /**
    * Notify the stream that the caller is ready to receive more data from the response stream. Only

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -80,7 +80,8 @@ public:
    * @param headers the headers to send.
    * @param end_stream indicates whether to close the stream locally after sending this frame.
    * @param idempotent indicates that the request is idempotent. When idempotent is set to true
-   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
+   *                   Envoy Mobile will retry on HTTP/3 post-handshake failures. By default, it is
+   *                   set to false.
    */
   void sendHeaders(envoy_stream_t stream, RequestHeaderMapPtr headers, bool end_stream,
                    bool idempotent = false);

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -58,10 +58,11 @@ envoy_status_t InternalEngine::startStream(envoy_stream_t stream,
 }
 
 envoy_status_t InternalEngine::sendHeaders(envoy_stream_t stream, Http::RequestHeaderMapPtr headers,
-                                           bool end_stream) {
-  return dispatcher_->post([this, stream, headers = std::move(headers), end_stream]() mutable {
-    http_client_->sendHeaders(stream, std::move(headers), end_stream);
-  });
+                                           bool end_stream, bool idempotent) {
+  return dispatcher_->post(
+      [this, stream, headers = std::move(headers), end_stream, idempotent]() mutable {
+        http_client_->sendHeaders(stream, std::move(headers), end_stream, idempotent);
+      });
   return ENVOY_SUCCESS;
 }
 

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -73,9 +73,11 @@ public:
    * @param stream the stream to send headers over.
    * @param headers the headers to send.
    * @param end_stream indicates whether to close the stream locally after sending this frame.
+   * @param idempotent indicates that the request is idempotent. When idempotent is set to true
+   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
    */
   envoy_status_t sendHeaders(envoy_stream_t stream, Http::RequestHeaderMapPtr headers,
-                             bool end_stream);
+                             bool end_stream, bool idempotent = false);
 
   envoy_status_t readData(envoy_stream_t stream, size_t bytes_to_read);
 

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -74,7 +74,8 @@ public:
    * @param headers the headers to send.
    * @param end_stream indicates whether to close the stream locally after sending this frame.
    * @param idempotent indicates that the request is idempotent. When idempotent is set to true
-   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
+   *                   Envoy Mobile will retry on HTTP/3 post-handshake failures. By default, it is
+   *                   set to false.
    */
   envoy_status_t sendHeaders(envoy_stream_t stream, Http::RequestHeaderMapPtr headers,
                              bool end_stream, bool idempotent = false);

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -41,7 +41,7 @@ public class EnvoyHTTPStream {
    * @param headers    the headers to send.
    * @param endStream  supplies whether this is headers only.
    * @param idempotent indicates that the request is idempotent. When idempotent is set to true
-   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
+   *                   Envoy Mobile will retry on HTTP/3 post-handshake failures.
    */
   public void sendHeaders(Map<String, List<String>> headers, boolean endStream,
                           boolean idempotent) {

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -38,11 +38,14 @@ public class EnvoyHTTPStream {
    * Send headers over an open HTTP streamHandle. This method can be invoked once
    * and needs to be called before send_data.
    *
-   * @param headers,   the headers to send.
-   * @param endStream, supplies whether this is headers only.
+   * @param headers    the headers to send.
+   * @param endStream  supplies whether this is headers only.
+   * @param idempotent indicates that the request is idempotent. When idempotent is set to true
+   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
    */
-  public void sendHeaders(Map<String, List<String>> headers, boolean endStream) {
-    JniLibrary.sendHeaders(engineHandle, streamHandle, headers, endStream);
+  public void sendHeaders(Map<String, List<String>> headers, boolean endStream,
+                          boolean idempotent) {
+    JniLibrary.sendHeaders(engineHandle, streamHandle, headers, endStream, idempotent);
   }
 
   /**

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -78,7 +78,7 @@ public class JniLibrary {
    * @param headers    the headers to send.
    * @param endStream  supplies whether this is headers only.
    * @param idempotent indicates that the request is idempotent. When idempotent is set to true
-   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
+   *                   Envoy Mobile will retry on HTTP/3 post-handshake failures.
    * @return the resulting status of the operation.
    */
   protected static native int sendHeaders(long engine, long stream,

--- a/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/mobile/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -73,14 +73,17 @@ public class JniLibrary {
    * Send headers over an open HTTP stream. This method can be invoked once and
    * needs to be called before send_data.
    *
-   * @param engine    the stream's associated engine.
-   * @param stream    the stream to send headers over.
-   * @param headers   the headers to send.
-   * @param endStream supplies whether this is headers only.
+   * @param engine     the stream's associated engine.
+   * @param stream     the stream to send headers over.
+   * @param headers    the headers to send.
+   * @param endStream  supplies whether this is headers only.
+   * @param idempotent indicates that the request is idempotent. When idempotent is set to true
+   *                   Envoy Mobile may perform retry on failures. By default, it is set to false.
    * @return the resulting status of the operation.
    */
   protected static native int sendHeaders(long engine, long stream,
-                                          Map<String, List<String>> headers, boolean endStream);
+                                          Map<String, List<String>> headers, boolean endStream,
+                                          boolean idempotent);
 
   /**
    * Send data over an open HTTP stream. This method can be invoked multiple

--- a/mobile/library/java/org/chromium/net/impl/CancelProofEnvoyStream.java
+++ b/mobile/library/java/org/chromium/net/impl/CancelProofEnvoyStream.java
@@ -61,7 +61,7 @@ final class CancelProofEnvoyStream {
     if (returnTrueIfCanceledOrIncreaseConcurrentlyRunningStreamOperations()) {
       return; // Already Cancelled - to late to send something.
     }
-    mStream.sendHeaders(envoyRequestHeaders, endStream);
+    mStream.sendHeaders(envoyRequestHeaders, endStream, /* idempotent= */ false);
     if (decreaseConcurrentlyRunningStreamOperationsAndReturnTrueIfAwaitingCancel()) {
       mStream.cancel(); // Cancel was called previously, so now this is honored.
     }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
@@ -180,7 +180,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
   private String mCurrentUrl;
   private volatile CronvoyUrlResponseInfoImpl mUrlResponseInfo;
   private String mPendingRedirectUrl;
-  private boolean mIempotent;
+  private boolean mIdempotent;
 
   /**
    * @param executor The executor for orchestrating tasks between envoy-mobile callbacks
@@ -211,7 +211,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
     mCurrentUrl = url;
     mUserAgent = userAgent;
     mRequestAnnotations = connectionAnnotations;
-    mIempotent = idempotent;
+    mIdempotent = idempotent;
   }
 
   @Override
@@ -540,7 +540,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
     mCronvoyCallbacks = new CronvoyHttpCallbacks();
     mStream.set(mRequestContext.getEnvoyEngine().startStream(mCronvoyCallbacks,
                                                              /* explicitFlowControl= */ true));
-    mStream.get().sendHeaders(envoyRequestHeaders, mUploadDataStream == null, mIempotent);
+    mStream.get().sendHeaders(envoyRequestHeaders, mUploadDataStream == null, mIdempotent);
     if (mUploadDataStream != null && mUrlChain.size() == 1) {
       mUploadDataStream.initializeWithRequest();
     }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequest.java
@@ -180,6 +180,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
   private String mCurrentUrl;
   private volatile CronvoyUrlResponseInfoImpl mUrlResponseInfo;
   private String mPendingRedirectUrl;
+  private boolean mIempotent;
 
   /**
    * @param executor The executor for orchestrating tasks between envoy-mobile callbacks
@@ -188,7 +189,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
                     Executor executor, String userAgent, boolean allowDirectExecutor,
                     Collection<Object> connectionAnnotations, boolean trafficStatsTagSet,
                     int trafficStatsTag, boolean trafficStatsUidSet, int trafficStatsUid,
-                    RequestFinishedInfo.Listener requestFinishedListener) {
+                    RequestFinishedInfo.Listener requestFinishedListener, boolean idempotent) {
     if (url == null) {
       throw new NullPointerException("URL is required");
     }
@@ -210,6 +211,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
     mCurrentUrl = url;
     mUserAgent = userAgent;
     mRequestAnnotations = connectionAnnotations;
+    mIempotent = idempotent;
   }
 
   @Override
@@ -538,7 +540,7 @@ public final class CronvoyUrlRequest extends CronvoyUrlRequestBase {
     mCronvoyCallbacks = new CronvoyHttpCallbacks();
     mStream.set(mRequestContext.getEnvoyEngine().startStream(mCronvoyCallbacks,
                                                              /* explicitFlowControl= */ true));
-    mStream.get().sendHeaders(envoyRequestHeaders, mUploadDataStream == null);
+    mStream.get().sendHeaders(envoyRequestHeaders, mUploadDataStream == null, mIempotent);
     if (mUploadDataStream != null && mUrlChain.size() == 1) {
       mUploadDataStream.initializeWithRequest();
     }

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
@@ -132,7 +132,8 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
       checkHaveAdapter();
       return new CronvoyUrlRequest(this, url, callback, executor, mUserAgent, allowDirectExecutor,
                                    requestAnnotations, trafficStatsTagSet, trafficStatsTag,
-                                   trafficStatsUidSet, trafficStatsUid, requestFinishedListener);
+                                   trafficStatsUidSet, trafficStatsUid, requestFinishedListener,
+                                   idempotency == 1);
     }
   }
 

--- a/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
+++ b/mobile/library/java/org/chromium/net/impl/CronvoyUrlRequestContext.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.chromium.net.BidirectionalStream;
 import org.chromium.net.ExperimentalBidirectionalStream;
+import org.chromium.net.ExperimentalUrlRequest;
 import org.chromium.net.NetworkQualityRttListener;
 import org.chromium.net.NetworkQualityThroughputListener;
 import org.chromium.net.RequestFinishedInfo;
@@ -133,7 +134,7 @@ public final class CronvoyUrlRequestContext extends CronvoyEngineBase {
       return new CronvoyUrlRequest(this, url, callback, executor, mUserAgent, allowDirectExecutor,
                                    requestAnnotations, trafficStatsTagSet, trafficStatsTag,
                                    trafficStatsUidSet, trafficStatsUid, requestFinishedListener,
-                                   idempotency == 1);
+                                   idempotency == ExperimentalUrlRequest.Builder.IDEMPOTENT);
     }
   }
 

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -1017,12 +1017,13 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
     JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobject headers,
-    jboolean end_stream) {
+    jboolean end_stream, jboolean idempotent) {
   Envoy::JNI::JniHelper jni_helper(env);
   auto cpp_headers = Envoy::Http::Utility::createRequestHeaderMapPtr();
   Envoy::JNI::javaHeadersToCppHeaders(jni_helper, headers, *cpp_headers);
   return reinterpret_cast<Envoy::InternalEngine*>(engine_handle)
-      ->sendHeaders(static_cast<envoy_stream_t>(stream_handle), std::move(cpp_headers), end_stream);
+      ->sendHeaders(static_cast<envoy_stream_t>(stream_handle), std::move(cpp_headers), end_stream,
+                    idempotent);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
@@ -17,10 +17,16 @@ open class Stream(
    *
    * @param headers Headers to send over the stream.
    * @param endStream Whether this is a headers-only request.
+   * @param idempotent indicates that the request is idempotent. When idempotent is set to true
+   *   Envoy Mobile may perform retry on failures. By default, it is set to false.
    * @return This stream, for chaining syntax.
    */
-  open fun sendHeaders(headers: RequestHeaders, endStream: Boolean): Stream {
-    underlyingStream.sendHeaders(headers.caseSensitiveHeaders(), endStream)
+  open fun sendHeaders(
+    headers: RequestHeaders,
+    endStream: Boolean,
+    idempotent: Boolean = false
+  ): Stream {
+    underlyingStream.sendHeaders(headers.caseSensitiveHeaders(), endStream, idempotent)
     return this
   }
 

--- a/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
+++ b/mobile/library/kotlin/io/envoyproxy/envoymobile/Stream.kt
@@ -18,7 +18,7 @@ open class Stream(
    * @param headers Headers to send over the stream.
    * @param endStream Whether this is a headers-only request.
    * @param idempotent indicates that the request is idempotent. When idempotent is set to true
-   *   Envoy Mobile may perform retry on failures. By default, it is set to false.
+   *   Envoy Mobile will retry on HTTP/3 post-handshake failures. By default, it is set to false.
    * @return This stream, for chaining syntax.
    */
   open fun sendHeaders(

--- a/mobile/test/java/integration/AndroidEngineExplicitFlowTest.java
+++ b/mobile/test/java/integration/AndroidEngineExplicitFlowTest.java
@@ -585,7 +585,8 @@ public class AndroidEngineExplicitFlowTest {
             .start(requestScenario.useDirectExecutor ? Runnable::run
                                                      : Executors.newSingleThreadExecutor());
     streamRef.set(stream); // Set before sending headers to avoid race conditions.
-    stream.sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
+    stream.sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody(),
+                       /* idempotent= */ false);
     if (requestScenario.hasBody()) {
       // The first "send" is assumes that the window is available - API contract.
       onSendWindowAvailable(requestScenario, streamRef.get(), chunkIterator, response.get());

--- a/mobile/test/java/integration/AndroidEngineFlowTest.java
+++ b/mobile/test/java/integration/AndroidEngineFlowTest.java
@@ -305,7 +305,8 @@ public class AndroidEngineFlowTest {
                           return null;
                         })
                         .start(Executors.newSingleThreadExecutor())
-                        .sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
+                        .sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody(),
+                                     /* idempotent= */ false);
     if (requestScenario.cancelBeforeSendingRequestBody) {
       stream.cancel();
     } else {

--- a/mobile/test/java/integration/AndroidEngineSocketTagTest.java
+++ b/mobile/test/java/integration/AndroidEngineSocketTagTest.java
@@ -142,7 +142,8 @@ public class AndroidEngineSocketTagTest {
             .start(requestScenario.useDirectExecutor ? Runnable::run
                                                      : Executors.newSingleThreadExecutor());
     streamRef.set(stream); // Set before sending headers to avoid race conditions.
-    stream.sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
+    stream.sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody(),
+                       /* idempotent= */ false);
     latch.await();
     response.get().throwAssertionErrorIfAny();
     return response.get();

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -122,7 +122,8 @@ public class QuicTestServerTest {
                           return null;
                         })
                         .start(Executors.newSingleThreadExecutor())
-                        .sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
+                        .sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody(),
+                                     /* idempotent= */ false);
     requestScenario.getBodyChunks().forEach(stream::sendData);
     requestScenario.getClosingBodyChunk().ifPresent(stream::close);
     latch.await();

--- a/mobile/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
+++ b/mobile/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
@@ -358,7 +358,8 @@ public class CancelProofEnvoyStreamTest {
     private MockedStream() { super(0, 0, null, false); }
 
     @Override
-    public void sendHeaders(Map<String, List<String>> headers, boolean endStream) {
+    public void sendHeaders(Map<String, List<String>> headers, boolean endStream,
+                            boolean idempotent) {
       mSendHeadersInvocationCount.incrementAndGet();
       mStartLatch.countDown();
       mSendHeadersBlock.block();

--- a/mobile/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
+++ b/mobile/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
@@ -105,7 +105,7 @@ public class AndroidEnvoyExplicitH2FlowTest {
               return null;
             })
             .start(Runnable::run) // direct executor - all the logic runs on the EM Network Thread.
-            .sendHeaders(requestHeaders, false));
+            .sendHeaders(requestHeaders, /* endStream= */ false, /* idempotent= */ false));
     ByteBuffer bf = ByteBuffer.allocateDirect(1);
     bf.put((byte)'a');
     stream.get().sendData(bf);

--- a/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/mobile/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -132,7 +132,7 @@ public class Http2TestServerTest {
         })
         .setOnCancel((ignored) -> { throw new AssertionError("Unexpected OnCancel called."); })
         .start(Executors.newSingleThreadExecutor())
-        .sendHeaders(requestScenario.getHeaders(), false);
+        .sendHeaders(requestScenario.getHeaders(), /* endStream= */ false, /* idempotent= */ false);
 
     latch.await();
     assertNotNull(response.get().getEnvoyError());
@@ -169,7 +169,7 @@ public class Http2TestServerTest {
         })
         .setOnCancel((ignored) -> { throw new AssertionError("Unexpected OnCancel called."); })
         .start(Executors.newSingleThreadExecutor())
-        .sendHeaders(requestScenario.getHeaders(), false);
+        .sendHeaders(requestScenario.getHeaders(), /* endStream= */ false, /* idempotent= */ false);
 
     latch.await();
     assertNotNull(response.get().getEnvoyError());
@@ -220,7 +220,8 @@ public class Http2TestServerTest {
           return null;
         })
         .start(Executors.newSingleThreadExecutor())
-        .sendHeaders(requestScenario.getHeaders(), /* hasRequestBody= */ false);
+        .sendHeaders(requestScenario.getHeaders(), /* hasRequestBody= */ false,
+                     /* idempotent= */ false);
 
     latch.await();
     response.get().throwAssertionErrorIfAny();

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
@@ -11,7 +11,11 @@ import java.nio.ByteBuffer
  */
 class MockEnvoyHTTPStream(val callbacks: EnvoyHTTPCallbacks, val explicitFlowControl: Boolean) :
   EnvoyHTTPStream(0, 0, callbacks, explicitFlowControl) {
-  override fun sendHeaders(headers: MutableMap<String, MutableList<String>>?, endStream: Boolean) {}
+  override fun sendHeaders(
+    headers: MutableMap<String, MutableList<String>>?,
+    endStream: Boolean,
+    idempotent: Boolean
+  ) {}
 
   override fun sendData(data: ByteBuffer?, endStream: Boolean) {}
 

--- a/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
+++ b/mobile/test/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
@@ -24,7 +24,9 @@ class MockStream(underlyingStream: MockEnvoyHTTPStream) :
     EnvoyFinalStreamIntel(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, 0, 0, 0, 0)
 
   /** Closure that will be called when request headers are sent. */
-  var onRequestHeaders: ((headers: RequestHeaders, endStream: Boolean) -> Unit)? = null
+  var onRequestHeaders:
+    ((headers: RequestHeaders, endStream: Boolean, idempotent: Boolean) -> Unit)? =
+    null
   /** Closure that will be called when request data is sent. */
   var onRequestData: ((data: ByteBuffer, endStream: Boolean) -> Unit)? = null
   /** Closure that will be called when request trailers are sent. */
@@ -32,8 +34,12 @@ class MockStream(underlyingStream: MockEnvoyHTTPStream) :
   /** Closure that will be called when the stream is canceled by the client. */
   var onCancel: (() -> Unit)? = null
 
-  override fun sendHeaders(headers: RequestHeaders, endStream: Boolean): Stream {
-    onRequestHeaders?.invoke(headers, endStream)
+  override fun sendHeaders(
+    headers: RequestHeaders,
+    endStream: Boolean,
+    idempotent: Boolean
+  ): Stream {
+    onRequestHeaders?.invoke(headers, endStream, idempotent)
     return this
   }
 


### PR DESCRIPTION
This PR adds an optional parameter to indicate whether a request is an idempotent in the `sendHeaders`. This can be useful to automatically add a retry policy, such as `http3-post-connect-failure` when the `idempotent` flag is set. This makes the Envoy Mobile API similar to Cronet API. The Cronvoy implementation has also been updated to respect the `idempotency` flag.

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
