### PR TITLE
dns: Create new field for delayed DNS resolution

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -45,7 +45,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 58]
+// [#next-free-field: 59]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -157,6 +157,15 @@ message Cluster {
 
     // Use HTTP1.1 or HTTP2, depending on which one is used on the downstream connection.
     USE_DOWNSTREAM_PROTOCOL = 1;
+  }
+
+  // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>` for an explanation of each type.
+  enum OnDemandDNSMode {
+    // On-demand DNS resolution is disabled.
+    DISABLED = 0;
+
+    // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>` for an explanation of this type.
+    DELAYED = 1;
   }
 
   // TransportSocketMatch specifies what transport socket config will be used
@@ -1015,6 +1024,18 @@ message Cluster {
   // When ``typed_dns_resolver_config`` is missing, the default behavior is in place.
   // [#extension-category: envoy.network.dns_resolver]
   core.v3.TypedExtensionConfig typed_dns_resolver_config = 55;
+
+  // Optionally configures on-demand DNS resolution configuration. Note that this field controls the behavior of the cluster,
+  // not the DNS resolver itself
+  // (use :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`for those use-cases).
+  // At present there are 2 modes: DISABLED and DELAYED. DISABLED mode persists the background, asynchronous DNS resolution
+  // behavior that, at time of writing, is the default for STRICT_DNS and LOGICAL_DNS clusters. DELAYED mode will delay
+  // async DNS resolution until the first connection is made to the cluster in question. Once DNS resolution is complete, async
+  // resolution will continue periodically in the background as usual. Note that the latency of the DNS resolution will affect
+  // the first connection's RTT. Consequently, failure to resolve DNS before the connection's idle timeout will result in a connection reset.
+  // This mode is useful for scenarios where large numbers of clusters must be sent to Envoy for config practicality reasons,
+  // but traffic distribution is not uniform across all clusters.
+  OnDemandDNSMode on_demand_dns_mode = 58;
 
   // Optional configuration for having cluster readiness block on warm-up. Currently, only applicable for
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -750,8 +750,7 @@ message Cluster {
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
-  // Refer to :ref:`delayed_dns <envoy_v3_api_field_config.cluster.v3.Cluster.delayed_dns>`
-  // for more information.
+  // [#not-implemented-hide:]
   message DelayedDns {
   }
 
@@ -1022,7 +1021,7 @@ message Cluster {
   core.v3.TypedExtensionConfig typed_dns_resolver_config = 55;
 
   // [#not-implemented-hide:]
-  // Optionally configures on-demand DNS resolution configuration. Note that this field controls the behavior of the cluster,
+  // Configures on-demand DNS resolution configuration. Note that this field controls the behavior of the cluster,
   // not the DNS resolver itself (use
   // :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`
   // for those use-cases). At present there are 2 modes: DISABLED and DELAYED. DISABLED mode persists the background,

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -159,17 +159,6 @@ message Cluster {
     USE_DOWNSTREAM_PROTOCOL = 1;
   }
 
-  // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>`
-  // for an explanation of each type.
-  enum OnDemandDNSMode {
-    // On-demand DNS resolution is disabled.
-    DISABLED = 0;
-
-    // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>`
-    // for an explanation of this type.
-    DELAYED = 1;
-  }
-
   // TransportSocketMatch specifies what transport socket config will be used
   // when the match conditions are satisfied.
   message TransportSocketMatch {
@@ -761,6 +750,11 @@ message Cluster {
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
+  // Refer to :ref:`delayed_dns <envoy_v3_api_field_config.cluster.v3.Cluster.delayed_dns>`
+  // for more information.
+  message DelayedDns {
+  }
+
   reserved 12, 15, 7, 11, 35;
 
   reserved "hosts", "tls_context", "extension_protocol_options";
@@ -1027,6 +1021,7 @@ message Cluster {
   // [#extension-category: envoy.network.dns_resolver]
   core.v3.TypedExtensionConfig typed_dns_resolver_config = 55;
 
+  // [#not-implemented-hide:]
   // Optionally configures on-demand DNS resolution configuration. Note that this field controls the behavior of the cluster,
   // not the DNS resolver itself (use
   // :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`
@@ -1034,10 +1029,10 @@ message Cluster {
   // asynchronous DNS resolution behavior that, at time of writing, is the default for STRICT_DNS and LOGICAL_DNS clusters.
   // DELAYED mode will delay async DNS resolution until the first connection is made to the cluster in question.
   // Once DNS resolution is complete, async resolution will continue periodically in the background as usual. Note that the latency of
-  // the DNS resolution will affect the first connection's RTT. Consequently, failure to resolve DNS before the connection's idle timeout
+  // the DNS resolution will affect the first connection's RTT. Consequently, failure to resolve DNS before the connect timeout
   // will result in a connection reset. This mode is useful for scenarios where large numbers of clusters must be sent to Envoy for config
   // practicality reasons, but traffic distribution is not uniform across all clusters.
-  OnDemandDNSMode on_demand_dns_mode = 58;
+  DelayedDns delayed_dns = 58;
 
   // Optional configuration for having cluster readiness block on warm-up. Currently, only applicable for
   // :ref:`STRICT_DNS<envoy_v3_api_enum_value_config.cluster.v3.Cluster.DiscoveryType.STRICT_DNS>`,

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -159,12 +159,14 @@ message Cluster {
     USE_DOWNSTREAM_PROTOCOL = 1;
   }
 
-  // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>` for an explanation of each type.
+  // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>`
+  // for an explanation of each type.
   enum OnDemandDNSMode {
     // On-demand DNS resolution is disabled.
     DISABLED = 0;
 
-    // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>` for an explanation of this type.
+    // Refer to :ref:`on_demand_dns_mode <envoy_v3_api_field_config.cluster.v3.Cluster.on_demand_dns_mode>`
+    // for an explanation of this type.
     DELAYED = 1;
   }
 
@@ -1026,15 +1028,15 @@ message Cluster {
   core.v3.TypedExtensionConfig typed_dns_resolver_config = 55;
 
   // Optionally configures on-demand DNS resolution configuration. Note that this field controls the behavior of the cluster,
-  // not the DNS resolver itself
-  // (use :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`for those use-cases).
-  // At present there are 2 modes: DISABLED and DELAYED. DISABLED mode persists the background, asynchronous DNS resolution
-  // behavior that, at time of writing, is the default for STRICT_DNS and LOGICAL_DNS clusters. DELAYED mode will delay
-  // async DNS resolution until the first connection is made to the cluster in question. Once DNS resolution is complete, async
-  // resolution will continue periodically in the background as usual. Note that the latency of the DNS resolution will affect
-  // the first connection's RTT. Consequently, failure to resolve DNS before the connection's idle timeout will result in a connection reset.
-  // This mode is useful for scenarios where large numbers of clusters must be sent to Envoy for config practicality reasons,
-  // but traffic distribution is not uniform across all clusters.
+  // not the DNS resolver itself (use
+  // :ref:`typed_dns_resolver_config <envoy_v3_api_field_config.cluster.v3.Cluster.typed_dns_resolver_config>`
+  // for those use-cases). At present there are 2 modes: DISABLED and DELAYED. DISABLED mode persists the background,
+  // asynchronous DNS resolution behavior that, at time of writing, is the default for STRICT_DNS and LOGICAL_DNS clusters.
+  // DELAYED mode will delay async DNS resolution until the first connection is made to the cluster in question.
+  // Once DNS resolution is complete, async resolution will continue periodically in the background as usual. Note that the latency of
+  // the DNS resolution will affect the first connection's RTT. Consequently, failure to resolve DNS before the connection's idle timeout
+  // will result in a connection reset. This mode is useful for scenarios where large numbers of clusters must be sent to Envoy for config
+  // practicality reasons, but traffic distribution is not uniform across all clusters.
   OnDemandDNSMode on_demand_dns_mode = 58;
 
   // Optional configuration for having cluster readiness block on warm-up. Currently, only applicable for


### PR DESCRIPTION
Part of #20562
Commit Message: Create new field for on-demand DNS resolution
Additional Description: This is the first step in providing a sort of on-demand DNS resolution for Envoy. I chose a cluster-level enum field over changes in dns_resolution configuration because the enqueueing behavior of the async DNS requests seem to be a property of the cluster and not any specific DNS resolver (e.g. c-ares). In general, I'm looking to get a thumbs up on the API design before diving into the implementation.
Risk Level: Low
Testing:
Docs Changes: Should be autogenerated from the proto.
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
