### PR TITLE
http2: fixing QUICHE includes

### DIFF
--- a/source/common/http/http2/metadata_encoder.h
+++ b/source/common/http/http2/metadata_encoder.h
@@ -12,7 +12,7 @@
 #include "source/common/common/logger.h"
 
 #include "quiche/http2/adapter/data_source.h"
-#include "quiche/spdy/core/hpack/hpack_encoder.h"
+#include "quiche/http2/hpack/hpack_encoder.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -5,7 +5,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/http/http3_status_tracker_impl.h"
 
-#include "quiche/spdy/core/spdy_alt_svc_wire_format.h"
+#include "quiche/http2/core/spdy_alt_svc_wire_format.h"
 #include "re2/re2.h"
 
 namespace Envoy {

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -11,9 +11,9 @@
 #include "source/common/quic/envoy_quic_utils.h"
 #include "source/common/runtime/runtime_features.h"
 
+#include "quiche/common/http/http_header_block.h"
 #include "quiche/quic/core/http/quic_header_list.h"
 #include "quiche/quic/core/quic_session.h"
-#include "quiche/spdy/core/http2_header_block.h"
 
 namespace Envoy {
 namespace Quic {
@@ -55,7 +55,7 @@ Http::Status EnvoyQuicClientStream::encodeHeaders(const Http::RequestHeaderMap& 
 
   local_end_stream_ = end_stream;
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);
-  spdy::Http2HeaderBlock spdy_headers;
+  quiche::HttpHeaderBlock spdy_headers;
 #ifndef ENVOY_ENABLE_UHV
   // Extended CONNECT to H/1 upgrade transformation has moved to UHV
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_http3_header_normalisation") &&

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -15,9 +15,9 @@
 #include "source/common/quic/quic_stats_gatherer.h"
 #include "source/common/runtime/runtime_features.h"
 
+#include "quiche/common/http/http_header_block.h"
 #include "quiche/quic/core/http/quic_header_list.h"
 #include "quiche/quic/core/quic_session.h"
-#include "quiche/spdy/core/http2_header_block.h"
 #include "quiche_platform_impl/quiche_mem_slice_impl.h"
 
 namespace Envoy {

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -56,8 +56,8 @@ quic::QuicSocketAddress envoyIpAddressToQuicSocketAddress(const Network::Address
   return quic::QuicSocketAddress(ss);
 }
 
-spdy::Http2HeaderBlock envoyHeadersToHttp2HeaderBlock(const Http::HeaderMap& headers) {
-  spdy::Http2HeaderBlock header_block;
+quiche::HttpHeaderBlock envoyHeadersToHttp2HeaderBlock(const Http::HeaderMap& headers) {
+  quiche::HttpHeaderBlock header_block;
   headers.iterate([&header_block](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
     // The key-value pairs are copied.
     header_block.AppendValueOrAddHeader(header.key().getStringView(),

--- a/source/common/quic/envoy_quic_utils.h
+++ b/source/common/quic/envoy_quic_utils.h
@@ -101,9 +101,10 @@ quicHeadersToEnvoyHeaders(const quic::QuicHeaderList& header_list, HeaderValidat
 
 template <class T>
 std::unique_ptr<T>
-http2HeaderBlockToEnvoyTrailers(const quiche::HttpHeaderBlock& header_block, uint32_t max_headers_kb,
-                                uint32_t max_headers_allowed, HeaderValidator& validator,
-                                absl::string_view& details, quic::QuicRstStreamErrorCode& rst) {
+http2HeaderBlockToEnvoyTrailers(const quiche::HttpHeaderBlock& header_block,
+                                uint32_t max_headers_kb, uint32_t max_headers_allowed,
+                                HeaderValidator& validator, absl::string_view& details,
+                                quic::QuicRstStreamErrorCode& rst) {
   auto headers = T::create(max_headers_kb, max_headers_allowed);
   if (header_block.size() > max_headers_allowed) {
     details = Http3ResponseCodeDetailValues::too_many_trailers;

--- a/source/common/quic/envoy_quic_utils.h
+++ b/source/common/quic/envoy_quic_utils.h
@@ -12,13 +12,13 @@
 #include "source/common/quic/quic_io_handle_wrapper.h"
 
 #include "openssl/ssl.h"
+#include "quiche/common/http/http_header_block.h"
 #include "quiche/quic/core/http/quic_header_list.h"
 #include "quiche/quic/core/quic_config.h"
 #include "quiche/quic/core/quic_error_codes.h"
 #include "quiche/quic/core/quic_types.h"
 #include "quiche/quic/platform/api/quic_ip_address.h"
 #include "quiche/quic/platform/api/quic_socket_address.h"
-#include "quiche/spdy/core/http2_header_block.h"
 
 namespace Envoy {
 namespace Quic {
@@ -101,7 +101,7 @@ quicHeadersToEnvoyHeaders(const quic::QuicHeaderList& header_list, HeaderValidat
 
 template <class T>
 std::unique_ptr<T>
-http2HeaderBlockToEnvoyTrailers(const spdy::Http2HeaderBlock& header_block, uint32_t max_headers_kb,
+http2HeaderBlockToEnvoyTrailers(const quiche::HttpHeaderBlock& header_block, uint32_t max_headers_kb,
                                 uint32_t max_headers_allowed, HeaderValidator& validator,
                                 absl::string_view& details, quic::QuicRstStreamErrorCode& rst) {
   auto headers = T::create(max_headers_kb, max_headers_allowed);
@@ -138,7 +138,7 @@ http2HeaderBlockToEnvoyTrailers(const spdy::Http2HeaderBlock& header_block, uint
   return headers;
 }
 
-spdy::Http2HeaderBlock envoyHeadersToHttp2HeaderBlock(const Http::HeaderMap& headers);
+quiche::HttpHeaderBlock envoyHeadersToHttp2HeaderBlock(const Http::HeaderMap& headers);
 
 // Called when Envoy wants to reset the underlying QUIC stream.
 quic::QuicRstStreamErrorCode envoyResetReasonToQuicRstError(Http::StreamResetReason reason);

--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -6,7 +6,7 @@
 
 #include "source/common/common/hex.h"
 
-#include "quiche/spdy/core/hpack/hpack_encoder.h"
+#include "quiche/http2/hpack/hpack_encoder.h"
 
 namespace {
 


### PR DESCRIPTION
Updates Envoy code that depends on QUICHE HTTP/2 libraries to reference the new location of some header files.

Commit Message: fixes QUICHE HTTP/2 includes
Additional Description:
Risk Level: low
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
