### PR TITLE
Support multiple ADS configuration to allow distinct control-planes to serve parts of the configuration

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -67,7 +67,7 @@ message Bootstrap {
     repeated envoy.extensions.transport_sockets.tls.v3.Secret secrets = 3;
   }
 
-  // [#next-free-field: 7]
+  // [#next-free-field: 8]
   message DynamicResources {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v2.Bootstrap.DynamicResources";
@@ -96,9 +96,18 @@ message Bootstrap {
     // <envoy_v3_api_field_config.core.v3.ApiConfigSource.api_type>` :ref:`GRPC
     // <envoy_v3_api_enum_value_config.core.v3.ApiConfigSource.ApiType.GRPC>`. Only
     // :ref:`ConfigSources <envoy_v3_api_msg_config.core.v3.ConfigSource>` that have
-    // the :ref:`ads <envoy_v3_api_field_config.core.v3.ConfigSource.ads>` field set will be
-    // streamed on the ADS channel.
+    // the :ref:`ads <envoy_v3_api_field_config.core.v3.ConfigSource.ads>` field set
+    // with no explicit instance name will be streamed on this ADS channel.
     core.v3.ApiConfigSource ads_config = 3;
+
+    // Additional :ref:`ADS <config_overview_ads>` sources may be optionally
+    // specified. This must have :ref:`api_type
+    // <envoy_v3_api_field_config.core.v3.ApiConfigSource.api_type>` :ref:`GRPC
+    // <envoy_v3_api_enum_value_config.core.v3.ApiConfigSource.ApiType.GRPC>`. Only
+    // :ref:`ConfigSources <envoy_v3_api_msg_config.core.v3.ConfigSource>` that have
+    // the :ref:`ads <envoy_v3_api_field_config.core.v3.ConfigSource.ads>` field set and explicitly
+    // referring to the provided name will be streamed on those ADS channel.
+    map<string, core.v3.ApiConfigSource> additional_ads_configs = 7;
   }
 
   message ApplicationLogConfig {

--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -126,6 +126,11 @@ message ApiConfigSource {
 message AggregatedConfigSource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.AggregatedConfigSource";
+
+  // Use the specified ads instance instead of the default one from the bootstrap configuration,
+  // as specified in :ref:`api_type_field_config.bootstrap.v3.DynamicResources.additional_ads_configs>`.
+  // By default the main instance set at :ref:`api_type_field_config.bootstrap.v3.DynamicResources.ads_config>` is used.
+  string instance = 1;
 }
 
 // [#not-implemented-hide:]

--- a/envoy/config/grpc_mux.h
+++ b/envoy/config/grpc_mux.h
@@ -15,6 +15,7 @@ namespace Envoy {
 namespace Config {
 
 using ScopedResume = std::unique_ptr<Cleanup>;
+using ScopedResumes = std::unique_ptr<std::vector<ScopedResume>>;
 /**
  * All control plane related stats. @see stats_macros.h
  */

--- a/source/common/config/subscription_factory_impl.h
+++ b/source/common/config/subscription_factory_impl.h
@@ -30,6 +30,7 @@ public:
       const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
       Stats::Scope& scope, SubscriptionCallbacks& callbacks,
       OpaqueResourceDecoderSharedPtr resource_decoder, const SubscriptionOptions& options) override;
+      
   absl::StatusOr<SubscriptionPtr>
   collectionSubscriptionFromUrl(const xds::core::v3::ResourceLocator& collection_locator,
                                 const envoy::config::core::v3::ConfigSource& config,

--- a/source/common/listener_manager/lds_api.cc
+++ b/source/common/listener_manager/lds_api.cc
@@ -49,14 +49,11 @@ absl::Status
 LdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                            const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                            const std::string& system_version_info) {
-  Config::ScopedResume maybe_resume_rds_sds;
-  if (cm_.adsMux()) {
-    const std::vector<std::string> paused_xds_types{
-        Config::getTypeUrl<envoy::config::route::v3::RouteConfiguration>(),
-        Config::getTypeUrl<envoy::config::route::v3::ScopedRouteConfiguration>(),
-        Config::getTypeUrl<envoy::extensions::transport_sockets::tls::v3::Secret>()};
-    maybe_resume_rds_sds = cm_.adsMux()->pause(paused_xds_types);
-  }
+  const std::vector<std::string> paused_xds_types{
+      Config::getTypeUrl<envoy::config::route::v3::RouteConfiguration>(),
+      Config::getTypeUrl<envoy::config::route::v3::ScopedRouteConfiguration>(),
+      Config::getTypeUrl<envoy::extensions::transport_sockets::tls::v3::Secret>()};
+  auto maybe_resume_rds_sds = cm_.pauseAdsMuxes(paused_xds_types);
 
   bool any_applied = false;
   listener_manager_.beginListenerUpdate();

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -18,15 +18,12 @@ std::vector<std::string>
 CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_resources,
                              const Protobuf::RepeatedPtrField<std::string>& removed_resources,
                              const std::string& system_version_info) {
-  Config::ScopedResume maybe_resume_eds_leds_sds;
-  if (cm_.adsMux()) {
-    // A cluster update pauses sending EDS and LEDS requests.
-    const std::vector<std::string> paused_xds_types{
-        Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>(),
-        Config::getTypeUrl<envoy::config::endpoint::v3::LbEndpoint>(),
-        Config::getTypeUrl<envoy::extensions::transport_sockets::tls::v3::Secret>()};
-    maybe_resume_eds_leds_sds = cm_.adsMux()->pause(paused_xds_types);
-  }
+  // A cluster update pauses sending EDS and LEDS requests.
+  const std::vector<std::string> paused_xds_types{
+      Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>(),
+      Config::getTypeUrl<envoy::config::endpoint::v3::LbEndpoint>(),
+      Config::getTypeUrl<envoy::extensions::transport_sockets::tls::v3::Secret>()};
+  auto maybe_resume_eds_leds_sds = cm_.pauseAdsMuxes(paused_xds_types);
 
   ENVOY_LOG(info, "{}: add {} cluster(s), remove {} cluster(s)", name_, added_resources.size(),
             removed_resources.size());

--- a/source/extensions/config_subscription/grpc/grpc_collection_subscription_factory.cc
+++ b/source/extensions/config_subscription/grpc/grpc_collection_subscription_factory.cc
@@ -53,8 +53,9 @@ SubscriptionPtr DeltaGrpcCollectionConfigSubscriptionFactory::create(
 
 SubscriptionPtr AggregatedGrpcCollectionConfigSubscriptionFactory::create(
     ConfigSubscriptionFactory::SubscriptionData& data) {
+  auto instance = data.config_.ads().instance();
   return std::make_unique<GrpcCollectionSubscriptionImpl>(
-      data.collection_locator_.value(), data.cm_.adsMux(), data.callbacks_, data.resource_decoder_,
+      data.collection_locator_.value(), data.cm_.adsMux(instance), data.callbacks_, data.resource_decoder_,
       data.stats_, data.dispatcher_, Utility::configSourceInitialFetchTimeout(data.config_),
       /*is_aggregated=*/true, data.options_);
 }
@@ -63,8 +64,9 @@ SubscriptionPtr
 AdsCollectionConfigSubscriptionFactory::create(ConfigSubscriptionFactory::SubscriptionData& data) {
   // All Envoy collections currently are xDS resource graph roots and require node context
   // parameters.
+  auto instance = data.config_.ads().instance();
   return std::make_unique<GrpcCollectionSubscriptionImpl>(
-      data.collection_locator_.value(), data.cm_.adsMux(), data.callbacks_, data.resource_decoder_,
+      data.collection_locator_.value(), data.cm_.adsMux(instance), data.callbacks_, data.resource_decoder_,
       data.stats_, data.dispatcher_, Utility::configSourceInitialFetchTimeout(data.config_), true,
       data.options_);
 }

--- a/source/extensions/config_subscription/grpc/grpc_subscription_factory.cc
+++ b/source/extensions/config_subscription/grpc/grpc_subscription_factory.cc
@@ -50,7 +50,7 @@ GrpcConfigSubscriptionFactory::create(ConfigSubscriptionFactory::SubscriptionDat
 
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.unified_mux")) {
     mux = std::make_shared<Config::XdsMux::GrpcMuxSotw>(
-        grpc_mux_context, api_config_source.set_node_on_first_message_only());
+        std::move(grpc_mux_context), api_config_source.set_node_on_first_message_only());
   } else {
     mux = std::make_shared<Config::GrpcMuxImpl>(grpc_mux_context,
                                                 api_config_source.set_node_on_first_message_only());
@@ -99,7 +99,7 @@ DeltaGrpcConfigSubscriptionFactory::create(ConfigSubscriptionFactory::Subscripti
 
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.unified_mux")) {
     mux = std::make_shared<Config::XdsMux::GrpcMuxDelta>(
-        grpc_mux_context, api_config_source.set_node_on_first_message_only());
+        std::move(grpc_mux_context), api_config_source.set_node_on_first_message_only());
   } else {
     mux = std::make_shared<Config::NewGrpcMuxImpl>(grpc_mux_context);
   }
@@ -111,8 +111,9 @@ DeltaGrpcConfigSubscriptionFactory::create(ConfigSubscriptionFactory::Subscripti
 
 SubscriptionPtr
 AdsConfigSubscriptionFactory::create(ConfigSubscriptionFactory::SubscriptionData& data) {
+  std::string ads_instance = data.config_.ads().instance();
   return std::make_unique<GrpcSubscriptionImpl>(
-      data.cm_.adsMux(), data.callbacks_, data.resource_decoder_, data.stats_, data.type_url_,
+      data.cm_.adsMux(ads_instance), data.callbacks_, data.resource_decoder_, data.stats_, data.type_url_,
       data.dispatcher_, Utility::configSourceInitialFetchTimeout(data.config_), true,
       data.options_);
 }

--- a/source/extensions/config_subscription/grpc/xds_mux/grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/xds_mux/grpc_mux_impl.h
@@ -60,7 +60,7 @@ class GrpcMuxImpl : public GrpcStreamCallbacks<RS>,
                     public ShutdownableMux,
                     Logger::Loggable<Logger::Id::config> {
 public:
-  GrpcMuxImpl(std::unique_ptr<F> subscription_state_factory, GrpcMuxContext& grpc_mux_context,
+  GrpcMuxImpl(std::unique_ptr<F> subscription_state_factory, GrpcMuxContext&& grpc_mux_context,
               bool skip_subsequent_node);
 
   ~GrpcMuxImpl() override;
@@ -237,7 +237,7 @@ class GrpcMuxDelta : public GrpcMuxImpl<DeltaSubscriptionState, DeltaSubscriptio
                                         envoy::service::discovery::v3::DeltaDiscoveryRequest,
                                         envoy::service::discovery::v3::DeltaDiscoveryResponse> {
 public:
-  GrpcMuxDelta(GrpcMuxContext& grpc_mux_context, bool skip_subsequent_node);
+  GrpcMuxDelta(GrpcMuxContext&& grpc_mux_context, bool skip_subsequent_node);
 
   // GrpcStreamCallbacks
   void requestOnDemandUpdate(const std::string& type_url,
@@ -248,7 +248,7 @@ class GrpcMuxSotw : public GrpcMuxImpl<SotwSubscriptionState, SotwSubscriptionSt
                                        envoy::service::discovery::v3::DiscoveryRequest,
                                        envoy::service::discovery::v3::DiscoveryResponse> {
 public:
-  GrpcMuxSotw(GrpcMuxContext& grpc_mux_context, bool skip_subsequent_node);
+  GrpcMuxSotw(GrpcMuxContext&& grpc_mux_context, bool skip_subsequent_node);
 
   // GrpcStreamCallbacks
   void requestOnDemandUpdate(const std::string&, const absl::flat_hash_set<std::string>&) override {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -954,10 +954,7 @@ RunHelper::RunHelper(Instance& instance, const Options& options, Event::Dispatch
     // Pause RDS to ensure that we don't send any requests until we've
     // subscribed to all the RDS resources. The subscriptions happen in the init callbacks,
     // so we pause RDS until we've completed all the callbacks.
-    Config::ScopedResume maybe_resume_rds;
-    if (cm.adsMux()) {
-      maybe_resume_rds = cm.adsMux()->pause(type_url);
-    }
+    auto maybe_resume_rds = cm.pauseAdsMuxes(type_url);
 
     ENVOY_LOG(info, "all clusters initialized. initializing init manager");
     init_manager.initialize(init_watcher_);

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -75,7 +75,7 @@ public:
         /*eds_resources_cache_=*/nullptr};
 
     if (should_use_unified_) {
-      mux_ = std::make_shared<Config::XdsMux::GrpcMuxSotw>(grpc_mux_context, true);
+      mux_ = std::make_shared<Config::XdsMux::GrpcMuxSotw>(std::move(grpc_mux_context), true);
     } else {
       mux_ = std::make_shared<Config::GrpcMuxImpl>(grpc_mux_context, true);
     }

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -334,7 +334,7 @@ dynamic_scoped_route_configs:
 class ScopedRdsTest : public ScopedRoutesTestBase {
 protected:
   void setup() {
-    ON_CALL(server_factory_context_.cluster_manager_, adsMux())
+    ON_CALL(server_factory_context_.cluster_manager_, adsMux(_))
         .WillByDefault(Return(std::make_shared<::Envoy::Config::NullGrpcMuxImpl>()));
 
     InSequence s;

--- a/test/extensions/clusters/eds/eds_speed_test.cc
+++ b/test/extensions/clusters/eds/eds_speed_test.cc
@@ -69,7 +69,7 @@ public:
         /*target_xds_authority_=*/"",
         /*eds_resources_cache_=*/nullptr};
     if (use_unified_mux_) {
-      grpc_mux_ = std::make_shared<Config::XdsMux::GrpcMuxSotw>(grpc_mux_context, true);
+      grpc_mux_ = std::make_shared<Config::XdsMux::GrpcMuxSotw>(std::move(grpc_mux_context), true);
     } else {
       grpc_mux_ = std::make_shared<Config::GrpcMuxImpl>(grpc_mux_context, true);
     }

--- a/test/extensions/config_subscription/common/subscription_factory_impl_test.cc
+++ b/test/extensions/config_subscription/common/subscription_factory_impl_test.cc
@@ -541,7 +541,7 @@ TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux, GrpcCollectionAggregatedSubscr
   primary_clusters.insert("static_cluster");
   EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
   auto ads_mux = std::make_shared<NiceMock<MockGrpcMux>>();
-  EXPECT_CALL(cm_, adsMux()).WillOnce(Return(ads_mux));
+  EXPECT_CALL(cm_, adsMux(_)).WillOnce(Return(ads_mux));
   EXPECT_CALL(dispatcher_, createTimer_(_));
   // onConfigUpdateFailed() should not be called for gRPC stream connection failure
   EXPECT_CALL(callbacks_, onConfigUpdateFailed(_, _)).Times(0);
@@ -566,7 +566,7 @@ TEST_P(SubscriptionFactoryTestUnifiedOrLegacyMux, GrpcCollectionAggregatedSotwSu
   const std::string xds_url = "xdstp://foo/envoy.config.endpoint.v3.ClusterLoadAssignment/bar";
 
   GrpcMuxSharedPtr ads_mux = std::make_shared<NiceMock<MockGrpcMux>>();
-  EXPECT_CALL(cm_, adsMux()).WillOnce(Return(ads_mux));
+  EXPECT_CALL(cm_, adsMux(_)).WillOnce(Return(ads_mux));
   EXPECT_CALL(dispatcher_, createTimer_(_));
   collectionSubscriptionFromUrl(xds_url, config)->start({});
 }

--- a/test/extensions/config_subscription/grpc/delta_subscription_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/delta_subscription_impl_test.cc
@@ -169,7 +169,7 @@ TEST_P(DeltaSubscriptionNoGrpcStreamTest, NoGrpcStream) {
       /*target_xds_authority_=*/"",
       /*eds_resources_cache_=*/nullptr};
   if (GetParam() == LegacyOrUnified::Unified) {
-    xds_context = std::make_shared<Config::XdsMux::GrpcMuxDelta>(grpc_mux_context, false);
+    xds_context = std::make_shared<Config::XdsMux::GrpcMuxDelta>(std::move(grpc_mux_context), false);
   } else {
     xds_context = std::make_shared<NewGrpcMuxImpl>(grpc_mux_context);
   }

--- a/test/extensions/config_subscription/grpc/delta_subscription_test_harness.h
+++ b/test/extensions/config_subscription/grpc/delta_subscription_test_harness.h
@@ -65,7 +65,7 @@ public:
         /*target_xds_authority_=*/"",
         /*eds_resources_cache_=*/nullptr};
     if (should_use_unified_) {
-      xds_context_ = std::make_shared<Config::XdsMux::GrpcMuxDelta>(grpc_mux_context, false);
+      xds_context_ = std::make_shared<Config::XdsMux::GrpcMuxDelta>(std::move(grpc_mux_context), false);
     } else {
       xds_context_ = std::make_shared<NewGrpcMuxImpl>(grpc_mux_context);
     }

--- a/test/extensions/config_subscription/grpc/new_grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/new_grpc_mux_impl_test.cc
@@ -88,7 +88,7 @@ public:
         /*target_xds_authority_=*/"",
         /*eds_resources_cache_=*/std::unique_ptr<MockEdsResourcesCache>(eds_resources_cache_)};
     if (isUnifiedMuxTest()) {
-      grpc_mux_ = std::make_unique<XdsMux::GrpcMuxDelta>(grpc_mux_context, false);
+      grpc_mux_ = std::make_unique<XdsMux::GrpcMuxDelta>(std::move(grpc_mux_context), false);
       return;
     }
     grpc_mux_ = std::make_unique<NewGrpcMuxImpl>(grpc_mux_context);

--- a/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
@@ -87,7 +87,7 @@ public:
             random_),
         /*target_xds_authority_=*/"",
         /*eds_resources_cache_=*/std::unique_ptr<MockEdsResourcesCache>(eds_resources_cache_)};
-    grpc_mux_ = std::make_unique<XdsMux::GrpcMuxSotw>(grpc_mux_context, true);
+    grpc_mux_ = std::make_unique<XdsMux::GrpcMuxSotw>(std::move(grpc_mux_context), true);
   }
 
   void expectSendMessage(const std::string& type_url,
@@ -941,7 +941,7 @@ TEST_P(GrpcMuxImplTest, BadLocalInfoEmptyClusterName) {
       /*target_xds_authority_=*/"",
       /*eds_resources_cache_=*/nullptr};
   EXPECT_THROW_WITH_MESSAGE(
-      XdsMux::GrpcMuxSotw(grpc_mux_context, true), EnvoyException,
+      XdsMux::GrpcMuxSotw(std::move(grpc_mux_context), true), EnvoyException,
       "ads: node 'id' and 'cluster' are required. Set it either in 'node' config or via "
       "--service-node and --service-cluster options.");
 }
@@ -967,7 +967,7 @@ TEST_P(GrpcMuxImplTest, BadLocalInfoEmptyNodeName) {
       /*target_xds_authority_=*/"",
       /*eds_resources_cache_=*/nullptr};
   EXPECT_THROW_WITH_MESSAGE(
-      XdsMux::GrpcMuxSotw(grpc_mux_context, true), EnvoyException,
+      XdsMux::GrpcMuxSotw(std::move(grpc_mux_context), true), EnvoyException,
       "ads: node 'id' and 'cluster' are required. Set it either in 'node' config or via "
       "--service-node and --service-cluster options.");
 }
@@ -1093,7 +1093,7 @@ TEST_P(GrpcMuxImplTest, AllMuxesStateTest) {
           SubscriptionFactory::RetryInitialDelayMs, SubscriptionFactory::RetryMaxDelayMs, random_),
       /*target_xds_authority_=*/"",
       /*eds_resources_cache_=*/nullptr};
-  auto grpc_mux_1 = std::make_unique<XdsMux::GrpcMuxSotw>(grpc_mux_context, true);
+  auto grpc_mux_1 = std::make_unique<XdsMux::GrpcMuxSotw>(std::move(grpc_mux_context), true);
   Config::XdsMux::GrpcMuxSotw::shutdownAll();
 
   EXPECT_TRUE(grpc_mux_->isShutdown());

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -22,7 +22,8 @@ MockClusterManager::MockClusterManager()
       cluster_request_response_size_stat_names_(*symbol_table_),
       cluster_timeout_budget_stat_names_(*symbol_table_) {
   ON_CALL(*this, bindConfig()).WillByDefault(ReturnRef(bind_config_));
-  ON_CALL(*this, adsMux()).WillByDefault(Return(ads_mux_));
+  ON_CALL(*this, adsMux(testing::Eq(absl::string_view()))).WillByDefault(Return(ads_mux_));
+  ON_CALL(*this, adsMux(_)).WillByDefault(Invoke([this](absl::string_view instance){ return additional_ads_muxes_[instance]; } ));
   ON_CALL(*this, grpcAsyncClientManager()).WillByDefault(ReturnRef(async_client_manager_));
   ON_CALL(*this, localClusterName()).WillByDefault((ReturnRef(local_cluster_name_)));
   ON_CALL(*this, subscriptionFactory()).WillByDefault(ReturnRef(subscription_factory_));

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -52,7 +52,9 @@ public:
   MOCK_METHOD(void, shutdown, ());
   MOCK_METHOD(bool, isShutdown, ());
   MOCK_METHOD(const absl::optional<envoy::config::core::v3::BindConfig>&, bindConfig, (), (const));
-  MOCK_METHOD(Config::GrpcMuxSharedPtr, adsMux, ());
+  MOCK_METHOD(Config::GrpcMuxSharedPtr, adsMux, (absl::string_view), (const));
+  MOCK_METHOD(Config::ScopedResumes, pauseAdsMuxes, (const std::string&), (const));
+  MOCK_METHOD(Config::ScopedResumes, pauseAdsMuxes, (const std::vector<std::string>&), (const));
   MOCK_METHOD(Grpc::AsyncClientManager&, grpcAsyncClientManager, ());
   MOCK_METHOD(const std::string, versionInfo, (), (const));
   MOCK_METHOD(const absl::optional<std::string>&, localClusterName, (), (const));
@@ -100,6 +102,7 @@ public:
   NiceMock<MockThreadLocalCluster> thread_local_cluster_;
   absl::optional<envoy::config::core::v3::BindConfig> bind_config_;
   std::shared_ptr<NiceMock<Config::MockGrpcMux>> ads_mux_;
+  absl::flat_hash_map<std::string, std::shared_ptr<NiceMock<Config::MockGrpcMux>>> additional_ads_muxes_;
   NiceMock<Grpc::MockAsyncClientManager> async_client_manager_;
   absl::optional<std::string> local_cluster_name_;
   NiceMock<MockClusterManagerFactory> cluster_manager_factory_;


### PR DESCRIPTION
- Commit Message: Support multiple ADS configuration to allow distinct control-planes to serve parts of the configuration
- Additional Description: 
In order to allow multiplexing of watches for distinct control-planes from the main ADS provider, add support for addtional control-plane instances to be considered as ADS providers. Those instances can be referenced within the configuration of other `config_sources` through a new `ads: instance:` field. By default ADS behavior is unchanged.
Those additional instances are configured in the initial bootstrapping configuration and inherit the same constraints (e.g. only depending on primary clusters). Those could potentially be relaxed to allow depending on secondary clusters loaded through the primary ADS instance, but this would make the change much more complex for unclear benefit. 
- Risk Level: medium. No functional change without opt-in. 
- Testing:
- Docs Changes:
- Release Notes:
  - Support additional ADS instances, allowing multiplexing resource watches to distinct control-planes from the original ones.
- Fixes #35483
- [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md)
