### PR TITLE
Made naming of some FilterChainOptions instances more consistent

### DIFF
--- a/envoy/http/filter_factory.h
+++ b/envoy/http/filter_factory.h
@@ -116,7 +116,7 @@ public:
   virtual bool createUpgradeFilterChain(
       absl::string_view upgrade, const UpgradeMap* per_route_upgrade_map,
       FilterChainManager& manager,
-      const Http::FilterChainOptions& option = EmptyFilterChainOptions{}) const PURE;
+      const FilterChainOptions& options = EmptyFilterChainOptions{}) const PURE;
 };
 
 } // namespace Http

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -782,7 +782,7 @@ bool HttpConnectionManagerConfig::createFilterChain(Http::FilterChainManager& ma
 bool HttpConnectionManagerConfig::createUpgradeFilterChain(
     absl::string_view upgrade_type,
     const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
-    Http::FilterChainManager& callbacks, const Http::FilterChainOptions& option) const {
+    Http::FilterChainManager& callbacks, const Http::FilterChainOptions& options) const {
   bool route_enabled = false;
   if (per_route_upgrade_map) {
     auto route_it = findUpgradeBoolCaseInsensitive(*per_route_upgrade_map, upgrade_type);
@@ -807,7 +807,7 @@ bool HttpConnectionManagerConfig::createUpgradeFilterChain(
     filters_to_use = it->second.filter_factories.get();
   }
 
-  Http::FilterChainUtility::createFilterChainForFactories(callbacks, option, *filters_to_use);
+  Http::FilterChainUtility::createFilterChainForFactories(callbacks, options, *filters_to_use);
   return true;
 }
 

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -149,7 +149,7 @@ public:
   bool createUpgradeFilterChain(absl::string_view upgrade_type,
                                 const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
                                 Http::FilterChainManager& manager,
-                                const Http::FilterChainOptions& option) const override;
+                                const Http::FilterChainOptions& options) const override;
 
   // Http::ConnectionManagerConfig
   const Http::RequestIDExtensionSharedPtr& requestIDExtension() override {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -6118,7 +6118,7 @@ TEST_F(ClusterInfoImplTest, FilterChain) {
 
   auto cluster = makeCluster(yaml);
   Http::MockFilterChainManager manager;
-  Http::EmptyFilterChainOptions options;
+  const Http::EmptyFilterChainOptions options;
   EXPECT_FALSE(cluster->info()->createUpgradeFilterChain("foo", nullptr, manager, options));
 
   EXPECT_CALL(manager, applyFilterFactoryCb(_, _));

--- a/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
@@ -186,15 +186,15 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChain) {
   ASSERT_TRUE(creation_status_.ok());
 
   NiceMock<Http::MockFilterChainManager> manager;
-  Http::EmptyFilterChainOptions option;
-  ;
+  Http::EmptyFilterChainOptions options;
+
   // Check the case where WebSockets are configured in the HCM, and no router
   // config is present. We should create an upgrade filter chain for
   // WebSockets.
   {
     EXPECT_CALL(manager.callbacks_, addStreamFilter(_));        // Buffer
     EXPECT_CALL(manager.callbacks_, addStreamDecoderFilter(_)); // Router
-    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, manager, option));
+    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, manager, options));
   }
 
   // Check the case where WebSockets are configured in the HCM, and no router
@@ -202,7 +202,7 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChain) {
   {
     EXPECT_CALL(manager.callbacks_, addStreamFilter(_)).Times(0);
     EXPECT_CALL(manager.callbacks_, addStreamDecoderFilter(_)).Times(0);
-    EXPECT_FALSE(config.createUpgradeFilterChain("foo", nullptr, manager, option));
+    EXPECT_FALSE(config.createUpgradeFilterChain("foo", nullptr, manager, options));
   }
 
   // Now override the HCM with a route-specific disabling of WebSocket to
@@ -210,7 +210,7 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChain) {
   {
     std::map<std::string, bool> upgrade_map;
     upgrade_map.emplace(std::make_pair("WebSocket", false));
-    EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, option));
+    EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, options));
   }
 
   // For paranoia's sake make sure route-specific enabling doesn't break
@@ -220,7 +220,7 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChain) {
     EXPECT_CALL(manager.callbacks_, addStreamDecoderFilter(_)); // Router
     std::map<std::string, bool> upgrade_map;
     upgrade_map.emplace(std::make_pair("WebSocket", true));
-    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, option));
+    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, options));
   }
 }
 
@@ -237,23 +237,23 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChainHCMDisabled) {
   ASSERT_TRUE(creation_status_.ok());
 
   NiceMock<Http::MockFilterChainManager> manager;
-  Http::EmptyFilterChainOptions option;
+  Http::EmptyFilterChainOptions options;
 
   // Check the case where WebSockets are off in the HCM, and no router config is present.
-  { EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, manager, option)); }
+  { EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, manager, options)); }
 
   // Check the case where WebSockets are off in the HCM and in router config.
   {
     std::map<std::string, bool> upgrade_map;
     upgrade_map.emplace(std::make_pair("WebSocket", false));
-    EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, option));
+    EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, options));
   }
 
   // With a route-specific enabling for WebSocket, WebSocket should work.
   {
     std::map<std::string, bool> upgrade_map;
     upgrade_map.emplace(std::make_pair("WebSocket", true));
-    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, option));
+    EXPECT_TRUE(config.createUpgradeFilterChain("WEBSOCKET", &upgrade_map, manager, options));
   }
 
   // With only a route-config we should do what the route config says.
@@ -261,9 +261,9 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChainHCMDisabled) {
     std::map<std::string, bool> upgrade_map;
     upgrade_map.emplace(std::make_pair("foo", true));
     upgrade_map.emplace(std::make_pair("bar", false));
-    EXPECT_TRUE(config.createUpgradeFilterChain("foo", &upgrade_map, manager, option));
-    EXPECT_FALSE(config.createUpgradeFilterChain("bar", &upgrade_map, manager, option));
-    EXPECT_FALSE(config.createUpgradeFilterChain("eep", &upgrade_map, manager, option));
+    EXPECT_TRUE(config.createUpgradeFilterChain("foo", &upgrade_map, manager, options));
+    EXPECT_FALSE(config.createUpgradeFilterChain("bar", &upgrade_map, manager, options));
+    EXPECT_FALSE(config.createUpgradeFilterChain("eep", &upgrade_map, manager, options));
   }
 }
 
@@ -294,7 +294,7 @@ TEST_F(FilterChainTest, CreateCustomUpgradeFilterChain) {
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
 
-  Http::EmptyFilterChainOptions option;
+  Http::EmptyFilterChainOptions options;
 
   {
     NiceMock<Http::MockFilterChainManager> manager;
@@ -306,14 +306,14 @@ TEST_F(FilterChainTest, CreateCustomUpgradeFilterChain) {
   {
     NiceMock<Http::MockFilterChainManager> manager;
     EXPECT_CALL(manager.callbacks_, addStreamDecoderFilter(_));
-    EXPECT_TRUE(config.createUpgradeFilterChain("websocket", nullptr, manager, option));
+    EXPECT_TRUE(config.createUpgradeFilterChain("websocket", nullptr, manager, options));
   }
 
   {
     NiceMock<Http::MockFilterChainManager> manager;
     EXPECT_CALL(manager.callbacks_, addStreamDecoderFilter(_));
     EXPECT_CALL(manager.callbacks_, addStreamFilter(_)).Times(2); // Buffer
-    EXPECT_TRUE(config.createUpgradeFilterChain("Foo", nullptr, manager, option));
+    EXPECT_TRUE(config.createUpgradeFilterChain("Foo", nullptr, manager, options));
   }
 }
 

--- a/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_filter_chain_test.cc
@@ -186,7 +186,7 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChain) {
   ASSERT_TRUE(creation_status_.ok());
 
   NiceMock<Http::MockFilterChainManager> manager;
-  Http::EmptyFilterChainOptions options;
+  const Http::EmptyFilterChainOptions options;
 
   // Check the case where WebSockets are configured in the HCM, and no router
   // config is present. We should create an upgrade filter chain for
@@ -237,7 +237,7 @@ TEST_F(FilterChainTest, CreateUpgradeFilterChainHCMDisabled) {
   ASSERT_TRUE(creation_status_.ok());
 
   NiceMock<Http::MockFilterChainManager> manager;
-  Http::EmptyFilterChainOptions options;
+  const Http::EmptyFilterChainOptions options;
 
   // Check the case where WebSockets are off in the HCM, and no router config is present.
   { EXPECT_FALSE(config.createUpgradeFilterChain("WEBSOCKET", nullptr, manager, options)); }
@@ -294,7 +294,7 @@ TEST_F(FilterChainTest, CreateCustomUpgradeFilterChain) {
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
 
-  Http::EmptyFilterChainOptions options;
+  const Http::EmptyFilterChainOptions options;
 
   {
     NiceMock<Http::MockFilterChainManager> manager;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -209,7 +209,7 @@ public:
   MOCK_METHOD(bool, createFilterChain, (FilterChainManager & manager), (const));
   MOCK_METHOD(bool, createUpgradeFilterChain,
               (absl::string_view upgrade_type, const FilterChainFactory::UpgradeMap* upgrade_map,
-               FilterChainManager& manager, const Http::FilterChainOptions&),
+               FilterChainManager& manager, const FilterChainOptions&),
               (const));
 };
 


### PR DESCRIPTION
Commit Message: Made naming of some FilterChainOptions instances more consistent
Additional Description: This PR brings cosmetic changes discussed in https://github.com/envoyproxy/envoy/pull/35292#discussion_r1693184337
Risk Level: Low
Testing: Not required
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
