### PR TITLE
http: moving HttpServerPropertiesCacheManager from custom singleton

### DIFF
--- a/envoy/http/http_server_properties_cache.h
+++ b/envoy/http/http_server_properties_cache.h
@@ -199,18 +199,5 @@ public:
 
 using HttpServerPropertiesCacheManagerSharedPtr = std::shared_ptr<HttpServerPropertiesCacheManager>;
 
-/**
- * Factory for getting an alternate protocols cache manager.
- */
-class HttpServerPropertiesCacheManagerFactory {
-public:
-  virtual ~HttpServerPropertiesCacheManagerFactory() = default;
-
-  /**
-   * Get the alternate protocols cache manager.
-   */
-  virtual HttpServerPropertiesCacheManagerSharedPtr get() PURE;
-};
-
 } // namespace Http
 } // namespace Envoy

--- a/envoy/server/BUILD
+++ b/envoy/server/BUILD
@@ -181,6 +181,7 @@ envoy_cc_library(
         "//envoy/http:codes_interface",
         "//envoy/http:context_interface",
         "//envoy/http:filter_interface",
+        "//envoy/http:http_server_properties_cache_interface",
         "//envoy/init:manager_interface",
         "//envoy/local_info:local_info_interface",
         "//envoy/network:drain_decision_interface",

--- a/envoy/server/factory_context.h
+++ b/envoy/server/factory_context.h
@@ -13,6 +13,7 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/context.h"
 #include "envoy/http/filter.h"
+#include "envoy/http/http_server_properties_cache.h"
 #include "envoy/init/manager.h"
 #include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
@@ -119,6 +120,11 @@ public:
    * @return Upstream::ClusterManager& singleton for use by the entire server.
    */
   virtual Upstream::ClusterManager& clusterManager() PURE;
+
+  /**
+   * @return const Http::HttpServerPropertiesCacheManager& instance for use by the entire server.
+   */
+  virtual Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() PURE;
 
   /**
    * @return TimeSource& a reference to the time source.

--- a/envoy/server/instance.h
+++ b/envoy/server/instance.h
@@ -13,6 +13,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/grpc/context.h"
 #include "envoy/http/context.h"
+#include "envoy/http/http_server_properties_cache.h"
 #include "envoy/init/manager.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/network/listen_socket.h"
@@ -70,6 +71,11 @@ public:
    * @return const Upstream::ClusterManager& singleton for use by the entire server.
    */
   virtual const Upstream::ClusterManager& clusterManager() const PURE;
+
+  /**
+   * @return const Http::HttpServerPropertiesCacheManager& instance for use by the entire server.
+   */
+  virtual Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() PURE;
 
   /**
    * @return Ssl::ContextManager& singleton for use by the entire server.

--- a/source/common/http/http_server_properties_cache_manager_impl.cc
+++ b/source/common/http/http_server_properties_cache_manager_impl.cc
@@ -13,11 +13,10 @@
 namespace Envoy {
 namespace Http {
 
-SINGLETON_MANAGER_REGISTRATION(alternate_protocols_cache_manager);
-
 HttpServerPropertiesCacheManagerImpl::HttpServerPropertiesCacheManagerImpl(
-    AlternateProtocolsData& data, ThreadLocal::SlotAllocator& tls)
-    : data_(data), slot_(tls) {
+    Server::Configuration::ServerFactoryContext& context,
+    ProtobufMessage::ValidationVisitor& validation_visitor, ThreadLocal::SlotAllocator& tls)
+    : data_(context, validation_visitor), slot_(tls) {
   slot_.set([](Event::Dispatcher& /*dispatcher*/) { return std::make_shared<State>(); });
 }
 
@@ -72,12 +71,6 @@ HttpServerPropertiesCacheSharedPtr HttpServerPropertiesCacheManagerImpl::getCach
 
   (*slot_).caches_.emplace(options.name(), CacheWithOptions{options, new_cache});
   return new_cache;
-}
-
-HttpServerPropertiesCacheManagerSharedPtr HttpServerPropertiesCacheManagerFactoryImpl::get() {
-  return singleton_manager_.getTyped<HttpServerPropertiesCacheManager>(
-      SINGLETON_MANAGER_REGISTERED_NAME(alternate_protocols_cache_manager),
-      [this] { return std::make_shared<HttpServerPropertiesCacheManagerImpl>(data_, tls_); });
 }
 
 } // namespace Http

--- a/source/common/http/http_server_properties_cache_manager_impl.h
+++ b/source/common/http/http_server_properties_cache_manager_impl.h
@@ -27,7 +27,8 @@ struct AlternateProtocolsData {
 class HttpServerPropertiesCacheManagerImpl : public HttpServerPropertiesCacheManager,
                                              public Singleton::Instance {
 public:
-  HttpServerPropertiesCacheManagerImpl(AlternateProtocolsData& data,
+  HttpServerPropertiesCacheManagerImpl(Server::Configuration::ServerFactoryContext& context,
+                                       ProtobufMessage::ValidationVisitor& validation_visitor,
                                        ThreadLocal::SlotAllocator& tls);
 
   // HttpServerPropertiesCacheManager
@@ -52,25 +53,10 @@ private:
     absl::flat_hash_map<std::string, CacheWithOptions> caches_;
   };
 
-  AlternateProtocolsData& data_;
+  AlternateProtocolsData data_;
 
   // Thread local state for the cache.
   ThreadLocal::TypedSlot<State> slot_;
-};
-
-class HttpServerPropertiesCacheManagerFactoryImpl : public HttpServerPropertiesCacheManagerFactory {
-public:
-  HttpServerPropertiesCacheManagerFactoryImpl(Singleton::Manager& singleton_manager,
-                                              ThreadLocal::SlotAllocator& tls,
-                                              AlternateProtocolsData data)
-      : singleton_manager_(singleton_manager), tls_(tls), data_(data) {}
-
-  HttpServerPropertiesCacheManagerSharedPtr get() override;
-
-private:
-  Singleton::Manager& singleton_manager_;
-  ThreadLocal::SlotAllocator& tls_;
-  AlternateProtocolsData data_;
 };
 
 } // namespace Http

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2215,8 +2215,8 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
   Http::HttpServerPropertiesCacheSharedPtr alternate_protocols_cache;
   if (alternate_protocol_options.has_value()) {
     // If there is configuration for an alternate protocols cache, always create one.
-    alternate_protocols_cache = alternate_protocols_cache_manager_->getCache(
-        alternate_protocol_options.value(), dispatcher);
+    alternate_protocols_cache =
+        alternate_protocols_cache_manager_.getCache(alternate_protocol_options.value(), dispatcher);
   } else if (!alternate_protocol_options.has_value() &&
              (protocols.size() == 2 ||
               (protocols.size() == 1 && protocols[0] == Http::Protocol::Http2))) {
@@ -2227,7 +2227,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     envoy::config::core::v3::AlternateProtocolsCacheOptions default_options;
     default_options.set_name(host->cluster().name());
     alternate_protocols_cache =
-        alternate_protocols_cache_manager_->getCache(default_options, dispatcher);
+        alternate_protocols_cache_manager_.getCache(default_options, dispatcher);
   }
 
   absl::optional<Http::HttpServerPropertiesCache::Origin> origin =
@@ -2259,7 +2259,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
       envoy::config::core::v3::AlternateProtocolsCacheOptions default_options;
       default_options.set_name(host->cluster().name());
       alternate_protocols_cache =
-          alternate_protocols_cache_manager_->getCache(default_options, dispatcher);
+          alternate_protocols_cache_manager_.getCache(default_options, dispatcher);
     }
 
     ASSERT(contains(protocols, {Http::Protocol::Http11, Http::Protocol::Http2}));

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -61,9 +61,7 @@ public:
       : context_(context), stats_(stats), tls_(tls), http_context_(http_context),
         dns_resolver_fn_(dns_resolver_fn), ssl_context_manager_(ssl_context_manager),
         secret_manager_(secret_manager), quic_stat_names_(quic_stat_names),
-        alternate_protocols_cache_manager_factory_(context.singletonManager(), tls,
-                                                   {context, context.messageValidationVisitor()}),
-        alternate_protocols_cache_manager_(alternate_protocols_cache_manager_factory_.get()),
+        alternate_protocols_cache_manager_(context.httpServerPropertiesCacheManager()),
         server_(server) {}
 
   // Upstream::ClusterManagerFactory
@@ -104,8 +102,7 @@ protected:
   Ssl::ContextManager& ssl_context_manager_;
   Secret::SecretManager& secret_manager_;
   Quic::QuicStatNames& quic_stat_names_;
-  Http::HttpServerPropertiesCacheManagerFactoryImpl alternate_protocols_cache_manager_factory_;
-  Http::HttpServerPropertiesCacheManagerSharedPtr alternate_protocols_cache_manager_;
+  Http::HttpServerPropertiesCacheManager& alternate_protocols_cache_manager_;
   Server::Instance& server_;
 };
 

--- a/source/extensions/filters/http/alternate_protocols_cache/config.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.cc
@@ -18,11 +18,8 @@ Http::FilterFactoryCb AlternateProtocolsCacheFilterFactory::createFilterFactoryF
 
   auto& server_context = context.serverFactoryContext();
 
-  Http::HttpServerPropertiesCacheManagerFactoryImpl alternate_protocol_cache_manager_factory(
-      server_context.singletonManager(), server_context.threadLocal(),
-      {context.serverFactoryContext(), context.messageValidationVisitor()});
   FilterConfigSharedPtr filter_config(
-      std::make_shared<FilterConfig>(proto_config, alternate_protocol_cache_manager_factory,
+      std::make_shared<FilterConfig>(proto_config, context.httpServerPropertiesCacheManager(),
                                      server_context.mainThreadDispatcher().timeSource()));
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/alternate_protocols_cache/config.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.cc
@@ -18,9 +18,9 @@ Http::FilterFactoryCb AlternateProtocolsCacheFilterFactory::createFilterFactoryF
 
   auto& server_context = context.serverFactoryContext();
 
-  FilterConfigSharedPtr filter_config(
-      std::make_shared<FilterConfig>(proto_config, context.httpServerPropertiesCacheManager(),
-                                     server_context.mainThreadDispatcher().timeSource()));
+  FilterConfigSharedPtr filter_config(std::make_shared<FilterConfig>(
+      proto_config, context.serverFactoryContext().httpServerPropertiesCacheManager(),
+      server_context.mainThreadDispatcher().timeSource()));
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamEncoderFilter(

--- a/source/extensions/filters/http/alternate_protocols_cache/filter.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.cc
@@ -19,7 +19,7 @@ using CustomClusterType = envoy::config::cluster::v3::Cluster::CustomClusterType
 
 FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig& config,
-    HttpServerPropertiesCacheManager& cache_manager, TimeSource& time_source)
+    Http::HttpServerPropertiesCacheManager& cache_manager, TimeSource& time_source)
     : alternate_protocol_cache_manager_(cache_manager), time_source_(time_source) {
   if (config.has_alternate_protocols_cache_options()) {
     ENVOY_LOG_MISC(warn, "Using deprecated and ignored alternate_protocols_cache_options in "
@@ -40,7 +40,7 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
   Http::HttpServerPropertiesCacheSharedPtr cache;
   auto info = encoder_callbacks_->streamInfo().upstreamClusterInfo();
   if (info && (*info)->alternateProtocolsCacheOptions()) {
-    cache = config_->alternateProtocolCacheManager()->getCache(
+    cache = config_->alternateProtocolCacheManager().getCache(
         *((*info)->alternateProtocolsCacheOptions()), dispatcher_);
   }
   if (!cache) {

--- a/source/extensions/filters/http/alternate_protocols_cache/filter.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.cc
@@ -19,10 +19,8 @@ using CustomClusterType = envoy::config::cluster::v3::Cluster::CustomClusterType
 
 FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig& config,
-    Http::HttpServerPropertiesCacheManagerFactory& alternate_protocol_cache_manager_factory,
-    TimeSource& time_source)
-    : alternate_protocol_cache_manager_(alternate_protocol_cache_manager_factory.get()),
-      time_source_(time_source) {
+    HttpServerPropertiesCacheManager& cache_manager, TimeSource& time_source)
+    : alternate_protocol_cache_manager_(cache_manager), time_source_(time_source) {
   if (config.has_alternate_protocols_cache_options()) {
     ENVOY_LOG_MISC(warn, "Using deprecated and ignored alternate_protocols_cache_options in "
                          "alternate_protocols_cache config.");

--- a/source/extensions/filters/http/alternate_protocols_cache/filter.h
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.h
@@ -16,19 +16,17 @@ namespace AlternateProtocolsCache {
  */
 class FilterConfig {
 public:
-  FilterConfig(
-      const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
-          proto_config,
-      Http::HttpServerPropertiesCacheManagerFactory& alternate_protocol_cache_manager_factory,
-      TimeSource& time_source);
+  FilterConfig(const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
+                   proto_config,
+               HttpServerPropertiesCacheManager& cache_manager, TimeSource& time_source);
 
   TimeSource& timeSource() { return time_source_; }
-  const Http::HttpServerPropertiesCacheManagerSharedPtr alternateProtocolCacheManager() {
+  const Http::HttpServerPropertiesCacheManager& alternateProtocolCacheManager() {
     return alternate_protocol_cache_manager_;
   }
 
 private:
-  const Http::HttpServerPropertiesCacheManagerSharedPtr alternate_protocol_cache_manager_;
+  const Http::HttpServerPropertiesCacheManager& alternate_protocol_cache_manager_;
   TimeSource& time_source_;
 };
 

--- a/source/extensions/filters/http/alternate_protocols_cache/filter.h
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.h
@@ -18,15 +18,15 @@ class FilterConfig {
 public:
   FilterConfig(const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
                    proto_config,
-               HttpServerPropertiesCacheManager& cache_manager, TimeSource& time_source);
+               Http::HttpServerPropertiesCacheManager& cache_manager, TimeSource& time_source);
 
   TimeSource& timeSource() { return time_source_; }
-  const Http::HttpServerPropertiesCacheManager& alternateProtocolCacheManager() {
+  Http::HttpServerPropertiesCacheManager& alternateProtocolCacheManager() {
     return alternate_protocol_cache_manager_;
   }
 
 private:
-  const Http::HttpServerPropertiesCacheManager& alternate_protocol_cache_manager_;
+  Http::HttpServerPropertiesCacheManager& alternate_protocol_cache_manager_;
   TimeSource& time_source_;
 };
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -139,6 +139,11 @@ void ValidationInstance::initialize(const Options& options,
   ssl_context_manager_ =
       std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(server_contexts_);
 
+  http_server_properties_cache_manager_ =
+      std::make_unique<Http::HttpServerPropertiesCacheManagerImpl>(
+          serverFactoryContext(), messageValidationContext().staticValidationVisitor(),
+          thread_local_);
+
   cluster_manager_factory_ = std::make_unique<Upstream::ValidationClusterManagerFactory>(
       server_contexts_, stats(), threadLocal(), http_context_,
       [this]() -> Network::DnsResolverSharedPtr { return this->dnsResolver(); },

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -80,6 +80,9 @@ public:
   const Upstream::ClusterManager& clusterManager() const override {
     return *config_.clusterManager();
   }
+  Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() override {
+    return *http_server_properties_cache_manager_;
+  }
   Ssl::ContextManager& sslContextManager() override { return *ssl_context_manager_; }
   Event::Dispatcher& dispatcher() override { return *dispatcher_; }
   Network::DnsResolverSharedPtr dnsResolver() override;
@@ -179,6 +182,7 @@ private:
   Configuration::MainImpl config_;
   LocalInfo::LocalInfoPtr local_info_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
+  std::unique_ptr<Http::HttpServerPropertiesCacheManager> http_server_properties_cache_manager_;
   std::unique_ptr<Upstream::ValidationClusterManagerFactory> cluster_manager_factory_;
   std::unique_ptr<ListenerManager> listener_manager_;
   std::unique_ptr<OverloadManager> overload_manager_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -740,6 +740,11 @@ absl::Status InstanceBase::initializeOrThrow(Network::Address::InstanceConstShar
   ssl_context_manager_ =
       std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(server_contexts_);
 
+  http_server_properties_cache_manager_ =
+      std::make_unique<Http::HttpServerPropertiesCacheManagerImpl>(
+          serverFactoryContext(), messageValidationContext().staticValidationVisitor(),
+          thread_local_);
+
   cluster_manager_factory_ = std::make_unique<Upstream::ProdClusterManagerFactory>(
       serverFactoryContext(), stats_store_, thread_local_, http_context_,
       [this]() -> Network::DnsResolverSharedPtr { return this->getOrCreateDnsResolver(); },

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -178,6 +178,9 @@ public:
 
   // Configuration::ServerFactoryContext
   Upstream::ClusterManager& clusterManager() override { return server_.clusterManager(); }
+  Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() override {
+    return server_.httpServerPropertiesCacheManager();
+  }
   Event::Dispatcher& mainThreadDispatcher() override { return server_.dispatcher(); }
   const Server::Options& options() override { return server_.options(); }
   const LocalInfo::LocalInfo& localInfo() const override { return server_.localInfo(); }
@@ -264,6 +267,9 @@ public:
   Api::Api& api() override { return *api_; }
   Upstream::ClusterManager& clusterManager() override;
   const Upstream::ClusterManager& clusterManager() const override;
+  Http::HttpServerPropertiesCacheManager& httpServerPropertiesCacheManager() override {
+    return *http_server_properties_cache_manager_;
+  }
   Ssl::ContextManager& sslContextManager() override { return *ssl_context_manager_; }
   Event::Dispatcher& dispatcher() override { return *dispatcher_; }
   Network::DnsResolverSharedPtr dnsResolver() override { return dns_resolver_; }
@@ -408,6 +414,7 @@ private:
   std::unique_ptr<OverloadManager> overload_manager_;
   std::unique_ptr<OverloadManager> null_overload_manager_;
   std::vector<BootstrapExtensionPtr> bootstrap_extensions_;
+  std::unique_ptr<Http::HttpServerPropertiesCacheManager> http_server_properties_cache_manager_;
   Envoy::MutexTracer* mutex_tracer_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/test/common/http/http_server_properties_cache_manager_test.cc
+++ b/test/common/http/http_server_properties_cache_manager_test.cc
@@ -23,17 +23,13 @@ public:
     options2_.mutable_max_entries()->set_value(max_entries2_);
   }
   void initialize() {
-    AlternateProtocolsData data(context_.server_factory_context_,
-                                context_.messageValidationVisitor());
-    factory_ = std::make_unique<Http::HttpServerPropertiesCacheManagerFactoryImpl>(
-        singleton_manager_, tls_, data);
-    manager_ = factory_->get();
+    manager_ = std::make_unique<HttpServerPropertiesCacheManagerImpl>(
+        context_.server_factory_context_, context_.messageValidationVisitor(), tls_);
   }
 
   Singleton::ManagerImpl singleton_manager_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   testing::NiceMock<ThreadLocal::MockInstance> tls_;
-  std::unique_ptr<Http::HttpServerPropertiesCacheManagerFactoryImpl> factory_;
   HttpServerPropertiesCacheManagerSharedPtr manager_;
   const std::string name1_ = "name1";
   const std::string name2_ = "name2";
@@ -44,13 +40,6 @@ public:
   envoy::config::core::v3::AlternateProtocolsCacheOptions options1_;
   envoy::config::core::v3::AlternateProtocolsCacheOptions options2_;
 };
-
-TEST_F(HttpServerPropertiesCacheManagerTest, FactoryGet) {
-  initialize();
-
-  EXPECT_NE(nullptr, manager_);
-  EXPECT_EQ(manager_, factory_->get());
-}
 
 TEST_F(HttpServerPropertiesCacheManagerTest, GetCache) {
   initialize();

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_test.cc
@@ -27,23 +27,19 @@ public:
   }
 
   void initialize(bool populate_config) {
-    EXPECT_CALL(alternate_protocols_cache_manager_factory_, get())
-        .WillOnce(Return(alternate_protocols_cache_manager_));
-
     envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig proto_config;
     if (populate_config) {
       EXPECT_CALL(*alternate_protocols_cache_manager_, getCache(_, _))
           .Times(testing::AnyNumber())
           .WillOnce(Return(alternate_protocols_cache_));
     }
-    filter_config_ = std::make_shared<FilterConfig>(
-        proto_config, alternate_protocols_cache_manager_factory_, simTime());
+    filter_config_ = std::make_shared<FilterConfig>(proto_config,
+                                                    *alternate_protocols_cache_manager_, simTime());
     filter_ = std::make_unique<Filter>(filter_config_, dispatcher_);
     filter_->setEncoderFilterCallbacks(callbacks_);
   }
 
   Event::MockDispatcher dispatcher_;
-  Http::MockHttpServerPropertiesCacheManagerFactory alternate_protocols_cache_manager_factory_;
   std::shared_ptr<Http::MockHttpServerPropertiesCacheManager> alternate_protocols_cache_manager_;
   std::shared_ptr<Http::MockHttpServerPropertiesCache> alternate_protocols_cache_;
   FilterConfigSharedPtr filter_config_;

--- a/test/extensions/key_value/file_based/alternate_protocols_cache_impl_test.cc
+++ b/test/extensions/key_value/file_based/alternate_protocols_cache_impl_test.cc
@@ -20,16 +20,12 @@ public:
     options_.mutable_max_entries()->set_value(10);
   }
   void initialize() {
-    Http::AlternateProtocolsData data{context_.server_factory_context_,
-                                      context_.messageValidationVisitor()};
-    factory_ = std::make_unique<Http::HttpServerPropertiesCacheManagerFactoryImpl>(
-        singleton_manager_, tls_, data);
-    manager_ = factory_->get();
+    manager_ = std::make_unique<Http::HttpServerPropertiesCacheManagerImpl>(
+        context_.server_factory_context_, context_.messageValidationVisitor(), tls_);
   }
   Singleton::ManagerImpl singleton_manager_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
   testing::NiceMock<ThreadLocal::MockInstance> tls_;
-  std::unique_ptr<Http::HttpServerPropertiesCacheManagerFactoryImpl> factory_;
   Http::HttpServerPropertiesCacheManagerSharedPtr manager_;
   envoy::config::core::v3::AlternateProtocolsCacheOptions options_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/mocks/http/http_server_properties_cache.cc
+++ b/test/mocks/http/http_server_properties_cache.cc
@@ -7,8 +7,5 @@ MockHttpServerPropertiesCache::~MockHttpServerPropertiesCache() = default;
 
 MockHttpServerPropertiesCacheManager::~MockHttpServerPropertiesCacheManager() = default;
 
-MockHttpServerPropertiesCacheManagerFactory::~MockHttpServerPropertiesCacheManagerFactory() =
-    default;
-
 } // namespace Http
 } // namespace Envoy

--- a/test/mocks/http/http_server_properties_cache.h
+++ b/test/mocks/http/http_server_properties_cache.h
@@ -32,12 +32,5 @@ public:
                Event::Dispatcher& dispatcher));
 };
 
-class MockHttpServerPropertiesCacheManagerFactory : public HttpServerPropertiesCacheManagerFactory {
-public:
-  ~MockHttpServerPropertiesCacheManagerFactory() override;
-
-  MOCK_METHOD(HttpServerPropertiesCacheManagerSharedPtr, get, ());
-};
-
 } // namespace Http
 } // namespace Envoy

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -220,6 +220,7 @@ envoy_cc_mock(
         "//test/mocks/access_log:access_log_mocks",
         "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/http:http_server_properties_cache_mocks",
         "//test/mocks/init:init_mocks",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -31,6 +31,8 @@ MockInstance::MockInstance()
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
   ON_CALL(*this, admin()).WillByDefault(Return(OptRef<Server::Admin>{admin_}));
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
+  ON_CALL(*this, httpServerPropertiesCacheManager())
+      .WillByDefault(ReturnRef(http_server_properties_cache_manager_));
   ON_CALL(*this, sslContextManager()).WillByDefault(ReturnRef(ssl_context_manager_));
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
   ON_CALL(*this, runtime()).WillByDefault(ReturnRef(runtime_loader_));

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -22,6 +22,7 @@ public:
   MOCK_METHOD(Api::Api&, api, ());
   MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
   MOCK_METHOD(const Upstream::ClusterManager&, clusterManager, (), (const));
+  MOCK_METHOD(Http::HttpServerPropertiesCacheManager&, httpServerPropertiesCacheManager, ());
   MOCK_METHOD(Ssl::ContextManager&, sslContextManager, ());
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(Network::DnsResolverSharedPtr, dnsResolver, ());

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -2,6 +2,7 @@
 
 #include "envoy/server/instance.h"
 
+#include "test/mocks/http/http_server_properties_cache.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/server/transport_socket_factory_context.h"
 
@@ -80,6 +81,8 @@ public:
   Event::GlobalTimeSystem time_system_;
   std::unique_ptr<Secret::SecretManager> secret_manager_;
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
+  testing::NiceMock<Http::MockHttpServerPropertiesCacheManager>
+      http_server_properties_cache_manager_;
   Thread::MutexBasicLockable access_log_lock_;
   testing::NiceMock<Runtime::MockLoader> runtime_loader_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/mocks/server/server_factory_context.cc
+++ b/test/mocks/server/server_factory_context.cc
@@ -11,6 +11,8 @@ MockServerFactoryContext::MockServerFactoryContext()
     : singleton_manager_(new Singleton::ManagerImpl()), http_context_(store_.symbolTable()),
       grpc_context_(store_.symbolTable()), router_context_(store_.symbolTable()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
+  ON_CALL(*this, httpServerPropertiesCacheManager())
+      .WillByDefault(ReturnRef(http_server_properties_cache_manager_));
   ON_CALL(*this, mainThreadDispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
   ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -56,6 +56,7 @@ public:
   ~MockServerFactoryContext() override;
 
   MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
+  MOCK_METHOD(Http::HttpServerPropertiesCacheManager&, httpServerPropertiesCacheManager, ());
   MOCK_METHOD(Event::Dispatcher&, mainThreadDispatcher, ());
   MOCK_METHOD(const Server::Options&, options, ());
   MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());
@@ -137,6 +138,7 @@ public:
   ~StatelessMockServerFactoryContext() override = default;
 
   MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
+  MOCK_METHOD(Http::HttpServerPropertiesCacheManager&, httpServerPropertiesCacheManager, ());
   MOCK_METHOD(Event::Dispatcher&, mainThreadDispatcher, ());
   MOCK_METHOD(const Server::Options&, options, ());
   MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -12,6 +12,7 @@
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/http_server_properties_cache.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/init/mocks.h"
 #include "test/mocks/local_info/mocks.h"
@@ -100,6 +101,8 @@ public:
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
   testing::NiceMock<Init::MockManager> init_manager_;
   testing::NiceMock<MockServerLifecycleNotifier> lifecycle_notifier_;
+  testing::NiceMock<Http::MockHttpServerPropertiesCacheManager>
+      http_server_properties_cache_manager_;
 
   Singleton::ManagerPtr singleton_manager_;
   testing::NiceMock<MockAdmin> admin_;


### PR DESCRIPTION
HttpServerPropertiesCacheManager was created in a weird way using the singleton manager and creating at whichever call site instantiated it first.  Changing to be a proper server-wide manager as most managers are.

Risk Level: low
Testing: updated tests
Docs Changes: n/a
Release Notes: n/a