### PR TITLE
envoy: cleaning up formatter use for Envoy Mobile

### DIFF
--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -194,8 +194,7 @@ GrpcStatusFormatter::Format GrpcStatusFormatter::parseFormat(absl::string_view f
     return GrpcStatusFormatter::Number;
   }
 
-  throwEnvoyExceptionOrPanic(
-      "GrpcStatusFormatter only supports CAMEL_STRING, SNAKE_STRING or NUMBER.");
+  throw EnvoyException("GrpcStatusFormatter only supports CAMEL_STRING, SNAKE_STRING or NUMBER.");
 }
 
 GrpcStatusFormatter::GrpcStatusFormatter(const std::string& main_header,

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -164,7 +164,7 @@ FilterStateFormatter::create(const std::string& format, const absl::optional<siz
 
   SubstitutionFormatUtils::parseSubcommand(format, ':', key, serialize_type, field_name);
   if (key.empty()) {
-    throwEnvoyExceptionOrPanic("Invalid filter state configuration, key cannot be empty.");
+    throw EnvoyException("Invalid filter state configuration, key cannot be empty.");
   }
 
   if (serialize_type.empty()) {
@@ -172,12 +172,12 @@ FilterStateFormatter::create(const std::string& format, const absl::optional<siz
   }
   if (serialize_type != PLAIN_SERIALIZATION && serialize_type != TYPED_SERIALIZATION &&
       serialize_type != FIELD_SERIALIZATION) {
-    throwEnvoyExceptionOrPanic("Invalid filter state serialize type, only "
-                               "support PLAIN/TYPED/FIELD.");
+    throw EnvoyException("Invalid filter state serialize type, only "
+                         "support PLAIN/TYPED/FIELD.");
   }
   if ((serialize_type == FIELD_SERIALIZATION) ^ !field_name.empty()) {
-    throwEnvoyExceptionOrPanic("Invalid filter state serialize type, FIELD "
-                               "should be used with the field name.");
+    throw EnvoyException("Invalid filter state serialize type, FIELD "
+                         "should be used with the field name.");
   }
 
   const bool serialize_as_string = serialize_type == PLAIN_SERIALIZATION;
@@ -423,8 +423,7 @@ CommonDurationFormatter::create(absl::string_view sub_command) {
   absl::InlinedVector<absl::string_view, 3> parsed_sub_commands = absl::StrSplit(sub_command, ':');
 
   if (parsed_sub_commands.size() < 2 || parsed_sub_commands.size() > 3) {
-    throwEnvoyExceptionOrPanic(
-        fmt::format("Invalid common duration configuration: {}.", sub_command));
+    throw EnvoyException(fmt::format("Invalid common duration configuration: {}.", sub_command));
   }
 
   absl::string_view start = parsed_sub_commands[0];
@@ -442,8 +441,7 @@ CommonDurationFormatter::create(absl::string_view sub_command) {
     } else if (precision_str == NanosecondsPrecision) {
       precision = DurationPrecision::Nanoseconds;
     } else {
-      throwEnvoyExceptionOrPanic(
-          fmt::format("Invalid common duration precision: {}.", precision_str));
+      throw EnvoyException(fmt::format("Invalid common duration precision: {}.", precision_str));
     }
   }
 
@@ -555,7 +553,7 @@ SystemTimeFormatter::SystemTimeFormatter(const std::string& format, TimeFieldExt
   // Validate the input specifier here. The formatted string may be destined for a header, and
   // should not contain invalid characters {NUL, LR, CF}.
   if (std::regex_search(format, getSystemTimeFormatNewlinePattern())) {
-    throwEnvoyExceptionOrPanic("Invalid header configuration. Format string contains newline.");
+    throw EnvoyException("Invalid header configuration. Format string contains newline.");
   }
 }
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -347,7 +347,7 @@ envoy_cc_test_binary(
         "abseil_symbolize",
     ],
     deps = [
-        "//source/common/formatter:formatter_extension_lib",
+        ":common_extensions_lib",
         "//source/common/http:rds_lib",
         "//source/exe:envoy_main_common_with_core_extensions_lib",
         "//source/exe:platform_impl_lib",
@@ -370,7 +370,7 @@ envoy_cc_test_binary(
     ],
     linkstatic = envoy_select_linkstatic(),
     deps = [
-        "//source/common/formatter:formatter_extension_lib",
+        ":common_extensions_lib",
         "//source/exe:main_common_lib",
         "//source/exe:platform_impl_lib",
         "//source/exe:process_wide_lib",
@@ -1119,6 +1119,7 @@ envoy_cc_test_library(
 envoy_cc_test_library(
     name = "common_extensions_lib",
     deps = [
+        "//source/common/formatter:formatter_extension_lib",
         "//source/common/http:rds_lib",
         "//source/common/router:scoped_rds_lib",
         "//source/extensions/clusters/eds:eds_lib",
@@ -1149,7 +1150,6 @@ envoy_cc_test_library(
         ":utility_lib",
         "//source/common/common:thread_lib",
         "//source/common/config:api_version_lib",
-        "//source/common/formatter:formatter_extension_lib",
         "//source/common/tls:context_config_lib",
         "//source/common/tls:context_lib",
         "//source/common/tls:ssl_socket_lib",


### PR DESCRIPTION
formatter code was removed from the E-M build but still included in E-M tests so still had to use the OrPanic macros.
Fixed by removing it from the E-M tests as well.

Risk Level: n/a
Testing: CI
Docs Changes: n/a
Release Notes: n/a