### PR TITLE
backports/1.29: backporting PR#32093 cookie session: support 0 ttl

### DIFF
--- a/api/envoy/type/http/v3/cookie.proto
+++ b/api/envoy/type/http/v3/cookie.proto
@@ -22,7 +22,7 @@ message Cookie {
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // Duration of cookie. This will be used to set the expiry time of a new cookie when it is
-  // generated. Set this to 0 to use a session cookie.
+  // generated. Set this to 0s to use a session cookie and disable cookie expiration.
   google.protobuf.Duration ttl = 2 [(validate.rules).duration = {gte {}}];
 
   // Path of cookie. This will be used to set the path of a new cookie when it is generated.

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: stateful_session
+  change: |
+    Support 0 TTL for proto-encoded cookies, which disables cookie expiration by Envoy.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/test/extensions/http/stateful_session/cookie/cookie_test.cc
+++ b/test/extensions/http/stateful_session/cookie/cookie_test.cc
@@ -52,7 +52,7 @@ TEST(CookieBasedSessionStateFactoryTest, SessionStateTest) {
       if (use_proto) {
         envoy::Cookie cookie;
         cookie.set_address("1.2.3.4:80");
-        cookie.set_expires(1000);
+        // The expiration field is not set in the cookie because TTL is 0 in the config.
         cookie.SerializeToString(&cookie_content);
       } else {
         cookie_content = "1.2.3.4:80";
@@ -176,13 +176,13 @@ TEST(CookieBasedSessionStateFactoryTest, SessionStateProtoCookie) {
   EXPECT_EQ(absl::nullopt, session_state->upstreamAddress());
 
   // PROTO format - no "expired field"
-  cookie.set_expires(0);
+  cookie.clear_expires();
   cookie.SerializeToString(&cookie_content);
   request_headers = {{":path", "/path"},
                      {"cookie", "override_host=" + Envoy::Base64::encode(cookie_content.c_str(),
                                                                          cookie_content.length())}};
   session_state = factory.create(request_headers);
-  EXPECT_EQ(absl::nullopt, session_state->upstreamAddress());
+  EXPECT_EQ("2.3.4.5:80", session_state->upstreamAddress().value());
 
   // PROTO format - pass incorrect format.
   // The content should be treated as "old" style encoding.


### PR DESCRIPTION
backporting #32093

related PR: https://github.com/envoyproxy/envoy/pull/35480