### PR TITLE
[bp/1.31] c-ares gRPC library: fix a bug impacting gRPC's use of c-ares (#35487)

### DIFF
--- a/bazel/foreign_cc/cares.patch
+++ b/bazel/foreign_cc/cares.patch
@@ -1,0 +1,58 @@
+From a070d7835d667b2fae5266fe1b790677dae47d25 Mon Sep 17 00:00:00 2001
+From: Brad House <brad@brad-house.com>
+Date: Thu, 12 Oct 2023 09:29:14 -0400
+Subject: [PATCH] Socket callbacks were passed SOCK_STREAM instead of
+ SOCK_DGRAM on udp
+
+A regression was introduced in 1.20.0 that would pass SOCK_STREAM on udp
+connections due to code refactoring.  If a client application validated this
+data, it could cause issues as seen in gRPC.
+
+Fixes Issue: #571
+Fix By: Brad House (@bradh352)
+---
+ src/lib/ares_process.c | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/src/lib/ares_process.c b/src/lib/ares_process.c
+index ca597db7ad..2f8e4de30d 100644
+--- a/src/lib/ares_process.c
++++ b/src/lib/ares_process.c
+@@ -1065,6 +1065,7 @@ static ares_status_t open_socket(ares_channel channel,
+   unsigned short port;
+   struct server_connection *conn;
+   ares__llist_node_t *node;
++  int type = is_tcp?SOCK_STREAM:SOCK_DGRAM;
+
+   if (is_tcp) {
+     port = aresx_sitous(server->addr.tcp_port?
+@@ -1098,8 +1099,7 @@ static ares_status_t open_socket(ares_channel channel,
+   }
+
+   /* Acquire a socket. */
+-  s = ares__open_socket(channel, server->addr.family,
+-                        is_tcp?SOCK_STREAM:SOCK_DGRAM, 0);
++  s = ares__open_socket(channel, server->addr.family, type, 0);
+   if (s == ARES_SOCKET_BAD)
+     return ARES_ECONNREFUSED;
+
+@@ -1129,8 +1129,7 @@ static ares_status_t open_socket(ares_channel channel,
+ #endif
+
+   if (channel->sock_config_cb) {
+-    int err = channel->sock_config_cb(s, SOCK_STREAM,
+-                                      channel->sock_config_cb_data);
++    int err = channel->sock_config_cb(s, type, channel->sock_config_cb_data);
+     if (err < 0) {
+       ares__close_socket(channel, s);
+       return ARES_ECONNREFUSED;
+@@ -1148,8 +1147,7 @@ static ares_status_t open_socket(ares_channel channel,
+   }
+
+   if (channel->sock_create_cb) {
+-    int err = channel->sock_create_cb(s, SOCK_STREAM,
+-                                      channel->sock_create_cb_data);
++    int err = channel->sock_create_cb(s, type, channel->sock_create_cb_data);
+     if (err < 0) {
+       ares__close_socket(channel, s);
+       return ARES_ECONNREFUSED;

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -448,6 +448,11 @@ def _com_github_c_ares_c_ares():
     external_http_archive(
         name = "com_github_c_ares_c_ares",
         build_file_content = BUILD_ALL_CONTENT,
+        # Patch c-ares library aith commit
+        # https://github.com/c-ares/c-ares/commit/a070d7835d667b2fae5266fe1b790677dae47d25
+        # This commit fixes an issue when the gRPC library attempts to resolve a domain name.
+        patches = ["@envoy//bazel/foreign_cc:cares.patch"],
+        patch_args = ["-p1"],
     )
     native.bind(
         name = "ares",

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,9 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: c-ares
+  change: |
+    Applying a C-ares patch to fix DNS resoultion by the Google gRPC library.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`


### PR DESCRIPTION
Commit Message:
v1.31 backport of [3f6a8c0](https://github.com/envoyproxy/envoy/commit/3f6a8c0f95a014550d1d8df5c849df36f9078b96).

Additional Description:
When a GoogleGrpc service is configured with a domain name and using C-Ares as a resolver results in an immediate disconnect.
The fix (https://github.com/c-ares/c-ares/commit/a070d7835d667b2fae5266fe1b790677dae47d25) is being imported as a patch until c-ares can be upgraded.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
