### PR TITLE
jwt: fix claim to header example doc

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -358,8 +358,8 @@ message JwtProvider {
   // .. code-block:: yaml
   //
   //   claim_to_headers:
-  //     - name: x-jwt-claim-nested-claim
-  //       claim: claim.nested.key
+  //     - header_name: x-jwt-claim-nested-claim
+  //       claim_name: claim.nested.key
   //
   // This header is only reserved for jwt claim; any other value will be overwritten.
   repeated JwtClaimToHeader claim_to_headers = 15;

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -358,6 +358,9 @@ message JwtProvider {
   // .. literalinclude:: /_configs/repo/jwt_authn.yaml
   //    :language: yaml
   //    :lines: 44-48
+  //    :linenos
+  //    :lineno-start: 44
+  //    :caption: :download:`jwt_authn.yaml </_configs/repo/jwt_authn.yaml>`
   //
   // This header is only reserved for jwt claim; any other value will be overwritten.
   repeated JwtClaimToHeader claim_to_headers = 15;

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -355,11 +355,9 @@ message JwtProvider {
   // Specify the claim name you want to copy in which HTTP header. For examples, following config:
   // The claim must be of type; string, int, double, bool. Array type claims are not supported
   //
-  // .. code-block:: yaml
-  //
-  //   claim_to_headers:
-  //     - header_name: x-jwt-claim-nested-claim
-  //       claim_name: claim.nested.key
+  // .. literalinclude:: /_configs/repo/jwt_authn.yaml
+  //    :language: yaml
+  //    :lines: 44-48
   //
   // This header is only reserved for jwt claim; any other value will be overwritten.
   repeated JwtClaimToHeader claim_to_headers = 15;

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -358,7 +358,7 @@ message JwtProvider {
   // .. literalinclude:: /_configs/repo/jwt_authn.yaml
   //    :language: yaml
   //    :lines: 44-48
-  //    :linenos
+  //    :linenos:
   //    :lineno-start: 44
   //    :caption: :download:`jwt_authn.yaml </_configs/repo/jwt_authn.yaml>`
   //

--- a/configs/jwt_authn.yaml
+++ b/configs/jwt_authn.yaml
@@ -74,9 +74,13 @@ static_resources:
     type: STRICT_DNS
     connect_timeout: 2s
     lb_policy: ROUND_ROBIN
-    http2_protocol_options: {}
-    upstream_http_protocol_options:
-      auto_sni: true
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        upstream_http_protocol_options:
+          auto_sni: true
+        auto_config:
+          http2_protocol_options: {}
     load_assignment:
       cluster_name: www.googleapis.com
       endpoints:

--- a/configs/jwt_authn.yaml
+++ b/configs/jwt_authn.yaml
@@ -1,0 +1,93 @@
+# An example config to validate JWT tokens issued by Firebase.
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: default
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                direct_response:
+                  status: 200
+                  body:
+                    inline_string: "OK"
+          http_filters:
+          - name: envoy.extensions.filters.http.jwt_authn
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+              providers:
+                firebase:
+                  claim_to_headers:
+                  - claim_name: user_id
+                    header_name: x-firebase-uid
+                  - claim_name: firebase.sign_in_provider
+                    header_name: x-firebase-provider
+                  issuer: https://securetoken.google.com/example.com:example-project-1234567890
+                  audiences:
+                  - example.com:example-project-1234567890
+                  remoteJwks:
+                    httpUri:
+                      uri: https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com
+                      cluster: www.googleapis.com
+                      timeout: 1s
+                    async_fetch:
+                      fast_listener: false
+                    retry_policy:
+                      num_retries: 10
+                  forward: true
+                  jwt_cache_config:
+                    jwt_cache_size: 1024
+              rules:
+              - match:
+                  prefix: "/"
+                requires:
+                  provider_name: firebase
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: www.googleapis.com
+    type: STRICT_DNS
+    connect_timeout: 2s
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    upstream_http_protocol_options:
+      auto_sni: true
+    load_assignment:
+      cluster_name: www.googleapis.com
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: www.googleapis.com
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        sni: www.googleapis.com

--- a/tools/spelling/check_spelling_pedantic.py
+++ b/tools/spelling/check_spelling_pedantic.py
@@ -690,7 +690,8 @@ def extract_comments(lines):
                     break
 
                 n += 1
-        elif text.strip().startswith(RST_CODE_BLOCK) or text.strip().startswith(RST_LITERAL_INCLUDE):
+        elif text.strip().startswith(RST_CODE_BLOCK) or text.strip().startswith(
+                RST_LITERAL_INCLUDE):
             # Start of a code block.
             indent = len(INDENT.search(text).group(1))
             last_line = comments[n].line

--- a/tools/spelling/check_spelling_pedantic.py
+++ b/tools/spelling/check_spelling_pedantic.py
@@ -106,6 +106,9 @@ RST_LITERAL = re.compile(r'``.*``')
 # RST code block marker.
 RST_CODE_BLOCK = '.. code-block::'
 
+# RST literal include.
+RST_LITERAL_INCLUDE = '.. literalinclude::'
+
 # Path names.
 ABSPATH = re.compile(r'(?:\s|^)((/[A-Za-z0-9_.*-]+)+)(?:\s|$)')
 FILEREF = re.compile(r'(?:\s|^)([A-Za-z0-9_./-]+\.(cc|js|h|py|sh))(?:\s|$)')
@@ -649,7 +652,7 @@ def extract_comments(lines):
             comments.append(Comment(line=line_idx, col=col, text=text, last_on_line=last_on_line))
 
     # Handle control statements and filter out comments that are part of
-    # RST code block directives.
+    # RST code block and literal include directives.
     result = []
     n = 0
     nc = len(comments)
@@ -687,7 +690,7 @@ def extract_comments(lines):
                     break
 
                 n += 1
-        elif text.strip().startswith(RST_CODE_BLOCK):
+        elif text.strip().startswith(RST_CODE_BLOCK) or text.strip().startswith(RST_LITERAL_INCLUDE):
             # Start of a code block.
             indent = len(INDENT.search(text).group(1))
             last_line = comments[n].line


### PR DESCRIPTION

Commit Message: jwt: fix claim to header example doc
Additional Description: The example is not [correct](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/jwt_authn/v3/config.proto#extensions-filters-http-jwt-authn-v3-jwtclaimtoheader), got bitten by copy/paste.
Risk Level: Low