### PR TITLE
build: Updates Go to 1.22.5

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -18,7 +18,7 @@ load("@rules_rust//rust:defs.bzl", "rust_common")
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
 
 # go version for rules_go
-GO_VERSION = "1.20"
+GO_VERSION = "1.22.5"
 
 JQ_VERSION = "1.7"
 YQ_VERSION = "4.24.4"


### PR DESCRIPTION

Commit Message: build: Updates Go to 1.22.5
Additional Description:
Go 1.20 has already reached EOF a few months ago.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
