### PR TITLE
add createFilterFactoryFromProtoWithServerContextTyped factory function

### DIFF
--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -20,11 +20,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExtAuthz {
 
-Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
+Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
   const auto filter_config =
       std::make_shared<FilterConfig>(proto_config, context.scope(), stats_prefix, server_context);
   // The callback is created in main thread and executed in worker thread, variables except factory

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -25,7 +25,14 @@ private:
   static constexpr uint64_t DefaultTimeout = 200;
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix,
+                                                              context.serverFactoryContext());
+  }
+
+  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) override;
 
   Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute& proto_config,


### PR DESCRIPTION
Commit Message: add createFilterFactoryFromProtoWithServerContextTyped factory function
Additional Description: Allows ext_authz to be used in ExtensionWithMatcher's per route typed filter config.
