### PR TITLE
Filter state: Add missing api to get filterstate format working

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -53,7 +53,7 @@ def envoy_copts(repository, test = False):
                # Bazel adds an implicit -DNDEBUG for opt targets.
                repository + "//bazel:opt_build": [] if test else ["-ggdb3"],
                repository + "//bazel:fastbuild_build": [],
-               repository + "//bazel:dbg_build": ["-g"],
+               repository + "//bazel:dbg_build": ["-ggdb3"],
                repository + "//bazel:windows_opt_build": [] if test else ["-Z7"],
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -53,7 +53,7 @@ def envoy_copts(repository, test = False):
                # Bazel adds an implicit -DNDEBUG for opt targets.
                repository + "//bazel:opt_build": [] if test else ["-ggdb3"],
                repository + "//bazel:fastbuild_build": [],
-               repository + "//bazel:dbg_build": ["-ggdb3"],
+               repository + "//bazel:dbg_build": ["-g"],
                repository + "//bazel:windows_opt_build": [] if test else ["-Z7"],
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],

--- a/source/common/network/upstream_server_name.h
+++ b/source/common/network/upstream_server_name.h
@@ -16,6 +16,7 @@ class UpstreamServerName : public StreamInfo::FilterState::Object {
 public:
   UpstreamServerName(absl::string_view server_name) : server_name_(server_name) {}
   const std::string& value() const { return server_name_; }
+  absl::optional<std::string> serializeAsString() const override { return server_name_; }
   static const std::string& key();
 
 private:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Filter state: Add missing api to get filterstate format working
Additional Description:
Consider the case where filter state is being set using the `set_filter_state` filter:
```
- name: "envoy.filters.http.set_filter_state"
            typed_config:
              "@type": "type.googleapis.com/envoy.extensions.filters.http.set_filter_state.v3.Config"
              on_request_headers:
              - object_key: "envoy.network.upstream_server_name"
                format_string:
                  text_format_source:
                    inline_string: "%REQ(:AUTHORITY)%"
                shared_with_upstream: "TRANSITIVE"
```
Now if one try to use the value from the filter state, for example in the tunneling config hostname:
```
- name: encap
    internal_listener: {}
    filter_chains:
    - filters:
      - name: tcp
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
          stat_prefix: tcp_stats
          cluster: cluster_0
          tunneling_config:
            hostname: "%FILTER_STATE(envoy.network.upstream_server_name:PLAIN)%"
```
Then filter state formatter fails to find the value because [here](https://github.com/envoyproxy/envoy/blob/main/source/common/formatter/stream_info_formatter.cc#L239), it invokes `serializeAsString()` on the stored filter state object, which is `UpstreamServerName` instance in this case and it is missing this function.

I think similar change would be required for other well-known name objects as well like Upstream subject alt names and alpn application protocols.

 related #30674  
