### PR TITLE
quic: deprecate `envoy.reloadable_features.quic_fix_filter_manager_uaf`

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -84,6 +84,9 @@ removed_config_or_runtime:
 - area: stateful_session
   change: |
     Removed ``envoy.reloadable_features.stateful_session_encode_ttl_in_cookie`` runtime flag and legacy code paths.
+- area: quic
+  change: |
+    Removed ``envoy.reloadable_features.quic_fix_filter_manager_uaf`` runtime flag and legacy code paths.
 - area: udp
   change: |
     Removed ``envoy.restart_features.udp_read_normalize_addresses`` runtime flag and legacy code paths.

--- a/source/common/quic/envoy_quic_dispatcher.cc
+++ b/source/common/quic/envoy_quic_dispatcher.cc
@@ -188,10 +188,12 @@ void EnvoyQuicDispatcher::closeConnectionsWithFilterChain(
       connection.close(Network::ConnectionCloseType::NoFlush);
     }
     ASSERT(connections_by_filter_chain_.find(filter_chain) == connections_by_filter_chain_.end());
-    // Explicitly destroy closed sessions in the current call stack. Because upon
-    // returning the filter chain configs will be destroyed, and no longer safe to be accessed.
-    // If any filters access those configs during destruction, it'll be use-after-free
-    DeleteSessions();
+    if (num_connections > 0) {
+      // Explicitly destroy closed sessions in the current call stack. Because upon
+      // returning the filter chain configs will be destroyed, and no longer safe to be accessed.
+      // If any filters access those configs during destruction, it'll be use-after-free
+      DeleteSessions();
+    }
   }
 }
 

--- a/source/common/quic/envoy_quic_dispatcher.cc
+++ b/source/common/quic/envoy_quic_dispatcher.cc
@@ -181,26 +181,17 @@ void EnvoyQuicDispatcher::closeConnectionsWithFilterChain(
     // Retain the number of connections in the list early because closing the connection will change
     // the size.
     const size_t num_connections = connections.size();
-    bool delete_sessions_immediately = false;
     for (size_t i = 0; i < num_connections; ++i) {
       Network::Connection& connection = connections.front().get();
       // This will remove the connection from the list. And the last removal will remove connections
       // from the map as well.
       connection.close(Network::ConnectionCloseType::NoFlush);
-      if (!delete_sessions_immediately &&
-          dynamic_cast<QuicFilterManagerConnectionImpl&>(connection).fixQuicLifetimeIssues()) {
-        // If `envoy.reloadable_features.quic_fix_filter_manager_uaf` is true, the closed sessions
-        // need to be deleted right away to consistently handle quic lifetimes. Because upon
-        // returning the filter chain configs will be destroyed, and no longer safe to be accessed.
-        // If any filters access those configs during destruction, it'll be use-after-free
-        delete_sessions_immediately = true;
-      }
     }
     ASSERT(connections_by_filter_chain_.find(filter_chain) == connections_by_filter_chain_.end());
-    if (delete_sessions_immediately) {
-      // Explicitly destroy closed sessions in the current call stack.
-      DeleteSessions();
-    }
+    // Explicitly destroy closed sessions in the current call stack. Because upon
+    // returning the filter chain configs will be destroyed, and no longer safe to be accessed.
+    // If any filters access those configs during destruction, it'll be use-after-free
+    DeleteSessions();
   }
 }
 

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -28,8 +28,6 @@ QuicFilterManagerConnectionImpl::QuicFilterManagerConnectionImpl(
   network_connection_->connectionSocket()->connectionInfoProvider().setConnectionID(id());
   network_connection_->connectionSocket()->connectionInfoProvider().setSslConnection(
       Ssl::ConnectionInfoConstSharedPtr(quic_ssl_info_));
-  fix_quic_lifetime_issues_ =
-      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_fix_filter_manager_uaf");
 }
 
 void QuicFilterManagerConnectionImpl::addWriteFilter(Network::WriteFilterSharedPtr filter) {
@@ -182,9 +180,6 @@ void QuicFilterManagerConnectionImpl::onConnectionCloseEvent(
     network_connection_ = nullptr;
   }
 
-  if (!fix_quic_lifetime_issues_) {
-    filter_manager_ = nullptr;
-  }
   if (!codec_stats_.has_value()) {
     // The connection was closed before it could be used. Stats are not recorded.
     return;

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -171,8 +171,6 @@ public:
     max_headers_count_ = max_headers_count;
   }
 
-  bool fixQuicLifetimeIssues() const { return fix_quic_lifetime_issues_; }
-
 protected:
   // Propagate connection close to network_connection_callbacks_.
   void onConnectionCloseEvent(const quic::QuicConnectionCloseFrame& frame,
@@ -226,7 +224,6 @@ private:
   EnvoyQuicSimulatedWatermarkBuffer write_buffer_watermark_simulation_;
   Buffer::OwnedImpl empty_buffer_;
   absl::optional<Network::ConnectionCloseType> close_type_during_initialize_;
-  bool fix_quic_lifetime_issues_{false};
 };
 
 } // namespace Quic

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -72,7 +72,6 @@ RUNTIME_GUARD(envoy_reloadable_features_original_dst_rely_on_idle_timeout);
 RUNTIME_GUARD(envoy_reloadable_features_process_ext_authz_grpc_error_codes_as_errors);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_104);
 RUNTIME_GUARD(envoy_reloadable_features_proxy_status_mapping_more_core_response_flags);
-RUNTIME_GUARD(envoy_reloadable_features_quic_fix_filter_manager_uaf);
 RUNTIME_GUARD(envoy_reloadable_features_quic_receive_ecn);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year. Confirm with
 // @danzh2010 or @RyanTheOptimist before removing.

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -381,7 +381,6 @@ TEST_P(OverloadScaledTimerIntegrationTest, HTTP3CloseIdleHttpConnectionsDuringHa
     return;
   }
   TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_fix_filter_manager_uaf", "true"}});
 
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto* proof_source_config = bootstrap.mutable_static_resources()


### PR DESCRIPTION
Commit Message: deprecate `envoy.reloadable_features.quic_fix_filter_manager_uaf` and update change log

Risk Level: low
Testing: existing tests
Docs Changes: N/A
Release Notes: Yes
Platform Specific Features: N/A
Fixes #35373