### PR TITLE
Make incompatible command-line args an error

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,6 +5,10 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: command line options
+  change: |
+    :option:`--enable-fine-grain-logging` and :option:`--component-log-level` were incompatible in that one
+    would make the other ineffective. Setting both options at once is now an error, to reduce potential confusion.
 - area: tcp
   change: |
     Added support for :ref:`connection_pool_per_downstream_connection

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -109,6 +109,7 @@ following are the command line options that Envoy supports.
   never set this option. For example, if you want ``upstream`` component to run at ``debug`` level and
   ``connection`` component to run at ``trace`` level, you should pass ``upstream:debug,connection:trace`` to
   this flag. See ``ALL_LOGGER_IDS`` in :repo:`/source/common/common/logger.h` for a list of components.
+  This option is incompatible with :option:`--enable-fine-grain-logging`.
 
 .. option:: --cpuset-threads
 
@@ -193,7 +194,7 @@ following are the command line options that Envoy supports.
   interface. If enabled, main log macros including ``ENVOY_LOG``, ``ENVOY_CONN_LOG``, ``ENVOY_STREAM_LOG`` and
   ``ENVOY_FLUSH_LOG`` will use a per-file logger, and the usage doesn't need ``Envoy::Logger::Loggable`` any
   more. The administration interface usage is similar. Please see :ref:`Administration interface
-  <operations_admin_interface>` for more detail.
+  <operations_admin_interface>` for more detail. This option is incompatible with :option:`--component-log-level`.
 
 .. option:: --socket-path <path string>
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -214,7 +214,12 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   log_format_ = log_format.getValue();
   log_format_set_ = log_format.isSet();
   log_format_escaped_ = log_format_escaped.getValue();
+
   enable_fine_grain_logging_ = enable_fine_grain_logging.getValue();
+  if (enable_fine_grain_logging_ && !component_log_level.getValue().empty()) {
+    throw MalformedArgvException(
+        std::string{"error: --component-log-level will not work with --enable-fine-grain-logging"});
+  }
 
   parseComponentLogLevels(component_log_level.getValue());
 

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -218,7 +218,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   enable_fine_grain_logging_ = enable_fine_grain_logging.getValue();
   if (enable_fine_grain_logging_ && !component_log_level.getValue().empty()) {
     throw MalformedArgvException(
-        std::string{"error: --component-log-level will not work with --enable-fine-grain-logging"});
+        "error: --component-log-level will not work with --enable-fine-grain-logging");
   }
 
   parseComponentLogLevels(component_log_level.getValue());


### PR DESCRIPTION
Commit Message: Make incompatible command-line args an error
Additional Description: Per #35073, `--enable-fine-grain-logging` and `--component-log-level` don't make sense at the same time, one of them will be overridden by the other in a way that can be surprising for the user. This PR makes it an error to apply both, so the user is not surprised by not getting the logs they expected at runtime.
Risk Level: Small. May make existing command-lines with ineffective options fail.
Testing: Added coverage.
Docs Changes: Updated command-line options docs.
Release Notes: Yes, under minor behavior changes.
Platform Specific Features: n/a
