### PR TITLE
opentelemetry: add the option to discard buffer response body for http async exporter

### DIFF
--- a/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
@@ -61,10 +61,11 @@ bool OpenTelemetryHttpTraceExporter::log(const ExportTraceServiceRequest& reques
   }
   message->body().add(request_body);
 
-  const auto options = Http::AsyncClient::RequestOptions().setTimeout(
-      std::chrono::milliseconds(
-          DurationUtil::durationToMilliseconds(http_service_.http_uri().timeout()))
-          .setDiscardResponseBody(true););
+  const auto options =
+      Http::AsyncClient::RequestOptions()
+          .setTimeout(std::chrono::milliseconds(
+              DurationUtil::durationToMilliseconds(http_service_.http_uri().timeout())))
+          .setDiscardResponseBody(true);
 
   Http::AsyncClient::Request* in_flight_request =
       thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);

--- a/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
+++ b/source/extensions/tracers/opentelemetry/http_trace_exporter.cc
@@ -61,8 +61,10 @@ bool OpenTelemetryHttpTraceExporter::log(const ExportTraceServiceRequest& reques
   }
   message->body().add(request_body);
 
-  const auto options = Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(
-      DurationUtil::durationToMilliseconds(http_service_.http_uri().timeout())));
+  const auto options = Http::AsyncClient::RequestOptions().setTimeout(
+      std::chrono::milliseconds(
+          DurationUtil::durationToMilliseconds(http_service_.http_uri().timeout()))
+          .setDiscardResponseBody(true););
 
   Http::AsyncClient::Request* in_flight_request =
       thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);

--- a/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
+++ b/test/extensions/tracers/opentelemetry/http_trace_exporter_test.cc
@@ -70,9 +70,11 @@ TEST_F(OpenTelemetryHttpTraceExporterTest, CreateExporterAndExportSpan) {
   Http::MockAsyncClientRequest request(&cluster_manager_.thread_local_cluster_.async_client_);
   Http::AsyncClient::Callbacks* callback;
 
-  EXPECT_CALL(
-      cluster_manager_.thread_local_cluster_.async_client_,
-      send_(_, _, Http::AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(250))))
+  EXPECT_CALL(cluster_manager_.thread_local_cluster_.async_client_,
+              send_(_, _,
+                    Http::AsyncClient::RequestOptions()
+                        .setTimeout(std::chrono::milliseconds(250))
+                        .setDiscardResponseBody(true)))
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& callbacks,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: opentelemetry: add the option to discard buffer response body for http async exporter
Additional Description: only the response code is used for logging purpose.
Risk Level: low
Testing: unit test
Docs Changes:
Release Notes:
