### PR TITLE
report imcomplete metadata in complete events for thrift_to_metadata filter

### DIFF
--- a/source/extensions/filters/http/thrift_to_metadata/filter.cc
+++ b/source/extensions/filters/http/thrift_to_metadata/filter.cc
@@ -182,19 +182,17 @@ Http::FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_strea
                                       : Http::FilterDataStatus::StopIterationAndBuffer;
 }
 
-Http::FilterTrailersStatus Filter::decodeTrailers(Http::RequestTrailerMap&) {
+void Filter::decodeComplete() {
   if (!config_->shouldParseRequestMetadata() || request_processing_finished_) {
-    return Http::FilterTrailersStatus::Continue;
+    return;
   }
 
   ENVOY_LOG(trace,
-            "thrift to metadata filter decodeTrailers: handle incomplete request thrift message");
+            "thrift to metadata filter decodeComplete: handle incomplete request thrift message");
 
   // Handle incomplete request thrift message while we reach here.
   handleAllOnMissing(config_->requestRules(), *decoder_callbacks_, request_processing_finished_);
   config_->rqstats().invalid_thrift_body_.inc();
-
-  return Http::FilterTrailersStatus::Continue;
 }
 
 Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers, bool end_stream) {
@@ -246,19 +244,17 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_strea
                                        : Http::FilterDataStatus::StopIterationAndBuffer;
 }
 
-Http::FilterTrailersStatus Filter::encodeTrailers(Http::ResponseTrailerMap&) {
+void Filter::encodeComplete() {
   if (!config_->shouldParseResponseMetadata() || response_processing_finished_) {
-    return Http::FilterTrailersStatus::Continue;
+    return;
   }
 
   ENVOY_LOG(trace,
-            "thrift to metadata filter encodeTrailers: handle incomplete response thrift message");
+            "thrift to metadata filter encodeComplete: handle incomplete response thrift message");
 
   // Handle incomplete response thrift message while we reach here.
   handleAllOnMissing(config_->responseRules(), *encoder_callbacks_, response_processing_finished_);
   config_->respstats().invalid_thrift_body_.inc();
-
-  return Http::FilterTrailersStatus::Continue;
 }
 
 bool Filter::processData(Buffer::Instance& incoming_data, Buffer::Instance& buffer,

--- a/source/extensions/filters/http/thrift_to_metadata/filter.h
+++ b/source/extensions/filters/http/thrift_to_metadata/filter.h
@@ -181,11 +181,11 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
-  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
+  void decodeComplete() override;
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
                                           bool end_stream) override;
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
-  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& trailers) override;
+  void encodeComplete() override;
 
   // PassThroughDecoderEventHandler
   FilterStatus messageBegin(MessageMetadataSharedPtr metadata) override;


### PR DESCRIPTION
Commit Message:
We notice some http rq/resp with no `end_stream` filter events nor trailers event, which breaks the original assumption.
Hence, move checks to `decodeComplete` and `encodeComplete`

Additional Description:
Risk Level: low
Testing: new unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
