### PR TITLE
vpp/build: Minor fix for cmake build

### DIFF
--- a/contrib/vcl/source/BUILD
+++ b/contrib/vcl/source/BUILD
@@ -57,7 +57,7 @@ envoy_cmake(
     postfix_script = """
         mkdir -p $INSTALLDIR/lib/external $INSTALLDIR/include/external \
         && find . -name "*.a" | xargs -I{} cp -a {} $INSTALLDIR/lib/ \
-        && find . -name "*.h" | xargs -I{} cp -a {} $INSTALLDIR/include
+        && find . -name "*.h" ! -name config.h | xargs -I{} cp -a {} $INSTALLDIR/include
     """,
     tags = [
         "cpu:16",


### PR DESCRIPTION
There are multiple files named config.h and in some build environments it causes the build postscript to fail

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
