### PR TITLE
c-ares: Add c-ares status in the DNS response details

### DIFF
--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -214,11 +214,9 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
     }
   }
 
-  status = ARES_EBADNAME;
   if (status == ARES_SUCCESS) {
     pending_response_.status_ = ResolutionStatus::Success;
     pending_response_.details_ = absl::StrCat("cares_success:", ares_strerror(status));
-    std::cerr << "RESPONSE DETAILS: " << pending_response_.details_ << "\n";
 
     if (addrinfo != nullptr && addrinfo->nodes != nullptr) {
       bool can_process_v4 =

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -214,9 +214,11 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
     }
   }
 
+  status = ARES_EBADNAME;
   if (status == ARES_SUCCESS) {
     pending_response_.status_ = ResolutionStatus::Success;
-    pending_response_.details_ = absl::StrCat("cares_success: ", ares_strerror(status));
+    pending_response_.details_ = absl::StrCat("cares_success:", ares_strerror(status));
+    std::cerr << "RESPONSE DETAILS: " << pending_response_.details_ << "\n";
 
     if (addrinfo != nullptr && addrinfo->nodes != nullptr) {
       bool can_process_v4 =
@@ -265,10 +267,10 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
     // Treat `ARES_ENODATA` or `ARES_ENOTFOUND` here as success to populate back the
     // "empty records" response.
     pending_response_.status_ = ResolutionStatus::Success;
-    pending_response_.details_ = absl::StrCat("cares_norecords: ", ares_strerror(status));
+    pending_response_.details_ = absl::StrCat("cares_norecords:", ares_strerror(status));
     ASSERT(addrinfo == nullptr);
   } else {
-    pending_response_.details_ = absl::StrCat("cares_failure: ", ares_strerror(status));
+    pending_response_.details_ = absl::StrCat("cares_failure:", ares_strerror(status));
   }
 
   if (timeouts > 0) {

--- a/source/extensions/network/dns_resolver/cares/dns_impl.cc
+++ b/source/extensions/network/dns_resolver/cares/dns_impl.cc
@@ -216,7 +216,7 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
 
   if (status == ARES_SUCCESS) {
     pending_response_.status_ = ResolutionStatus::Success;
-    pending_response_.details_ = "cares_success";
+    pending_response_.details_ = absl::StrCat("cares_success: ", ares_strerror(status));
 
     if (addrinfo != nullptr && addrinfo->nodes != nullptr) {
       bool can_process_v4 =
@@ -265,10 +265,10 @@ void DnsResolverImpl::AddrInfoPendingResolution::onAresGetAddrInfoCallback(
     // Treat `ARES_ENODATA` or `ARES_ENOTFOUND` here as success to populate back the
     // "empty records" response.
     pending_response_.status_ = ResolutionStatus::Success;
-    pending_response_.details_ = "cares_norecords";
+    pending_response_.details_ = absl::StrCat("cares_norecords: ", ares_strerror(status));
     ASSERT(addrinfo == nullptr);
   } else {
-    pending_response_.details_ = "cares_failure";
+    pending_response_.details_ = absl::StrCat("cares_failure: ", ares_strerror(status));
   }
 
   if (timeouts > 0) {

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -291,14 +291,16 @@ typed_config:
     auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_EQ("503", response->headers().getStatusValue());
-    EXPECT_THAT(waitForAccessLog(access_log_name_),
-                HasSubstr("dns_resolution_failure{cares_norecords:Domain_name_not_found}"));
+    std::string access_log = waitForAccessLog(access_log_name_);
+    EXPECT_THAT(access_log, HasSubstr("dns_resolution_failure"));
+    EXPECT_FALSE(StringUtil::hasEmptySpace(access_log));
 
     response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_EQ("503", response->headers().getStatusValue());
-    EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
-                HasSubstr("dns_resolution_failure{cares_norecords:Domain_name_not_found}"));
+    access_log = waitForAccessLog(access_log_name_, 1);
+    EXPECT_THAT(access_log, HasSubstr("dns_resolution_failure"));
+    EXPECT_FALSE(StringUtil::hasEmptySpace(access_log));
   }
 
   void multipleRequestsMaybeReresolve(bool reresolve) {
@@ -530,12 +532,16 @@ TEST_P(ProxyFilterIntegrationTest, RequestWithUnknownDomainAndNoCaching) {
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("dns_resolution_failure"));
+  std::string access_log = waitForAccessLog(access_log_name_);
+  EXPECT_THAT(access_log, HasSubstr("dns_resolution_failure"));
+  EXPECT_FALSE(StringUtil::hasEmptySpace(access_log));
 
   response = codec_client_->makeHeaderOnlyRequest(request_headers);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("503", response->headers().getStatusValue());
-  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("dns_resolution_failure"));
+  access_log = waitForAccessLog(access_log_name_, 1);
+  EXPECT_THAT(access_log, HasSubstr("dns_resolution_failure"));
+  EXPECT_FALSE(StringUtil::hasEmptySpace(access_log));
 }
 
 // Verify that after we populate the cache and reload the cluster we reattach to the cache with

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -291,12 +291,14 @@ typed_config:
     auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_EQ("503", response->headers().getStatusValue());
-    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("dns_resolution_failure"));
+    EXPECT_THAT(waitForAccessLog(access_log_name_),
+                HasSubstr("dns_resolution_failure{cares_norecords:Domain_name_not_found}"));
 
     response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
     ASSERT_TRUE(response->waitForEndStream());
     EXPECT_EQ("503", response->headers().getStatusValue());
-    EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("dns_resolution_failure"));
+    EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
+                HasSubstr("dns_resolution_failure{cares_norecords:Domain_name_not_found}"));
   }
 
   void multipleRequestsMaybeReresolve(bool reresolve) {


### PR DESCRIPTION
Similar to the `getaddrinfo` implementation, this PR adds the c-ares human readable status in the DNS response details.

Risk Level: low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a