### PR TITLE
ci: enables clippy and rustfmt in compile-time-options build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,11 +60,11 @@ test --experimental_ui_max_stdouterr_bytes=11712829 #default 1048576
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation
 
-# Enable auto code formatting and linting during build for Rust source code.
-build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build --output_groups=+clippy_checks
-build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build --output_groups=+rustfmt_checks
+# Enable auto rustfmt and clippy during build time of Rust source code.
+build:linux --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build:linux --output_groups=+clippy_checks
+build:linux --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build:linux --output_groups=+rustfmt_checks
 
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)

--- a/.bazelrc
+++ b/.bazelrc
@@ -351,6 +351,12 @@ build:remote-clang-cl --config=remote-windows
 build:remote-clang-cl --config=clang-cl
 build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
+# Enable auto rustfmt and clippy during build time of Rust source code.
+build:rust-format --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build:rust-format --output_groups=+clippy_checks
+build:rust-format --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build:rust-format --output_groups=+rustfmt_checks
+
 ## Compile-time-options testing
 # Right now, none of the available compile-time options conflict with each other. If this
 # changes, this build type may need to be broken up.
@@ -369,11 +375,7 @@ build:compile-time-options --config=libc++20
 build:compile-time-options --test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true
 build:compile-time-options --@envoy//bazel:http3=False
 build:compile-time-options --@envoy//source/extensions/filters/http/kill_request:enabled
-# Enable auto rustfmt and clippy during build time of Rust source code.
-build:compile-time-options --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build:compile-time-options --output_groups=+clippy_checks
-build:compile-time-options --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build:compile-time-options --output_groups=+rustfmt_checks
+build:compile-time-options --config=rust-format
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8

--- a/.bazelrc
+++ b/.bazelrc
@@ -60,12 +60,6 @@ test --experimental_ui_max_stdouterr_bytes=11712829 #default 1048576
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation
 
-# Enable auto rustfmt and clippy during build time of Rust source code.
-build:linux --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
-build:linux --output_groups=+clippy_checks
-build:linux --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
-build:linux --output_groups=+rustfmt_checks
-
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fdebug-types-section
@@ -375,6 +369,11 @@ build:compile-time-options --config=libc++20
 build:compile-time-options --test_env=ENVOY_HAS_EXTRA_EXTENSIONS=true
 build:compile-time-options --@envoy//bazel:http3=False
 build:compile-time-options --@envoy//source/extensions/filters/http/kill_request:enabled
+# Enable auto rustfmt and clippy during build time of Rust source code.
+build:compile-time-options --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build:compile-time-options --output_groups=+clippy_checks
+build:compile-time-options --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build:compile-time-options --output_groups=+rustfmt_checks
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8

--- a/.bazelrc
+++ b/.bazelrc
@@ -60,6 +60,12 @@ test --experimental_ui_max_stdouterr_bytes=11712829 #default 1048576
 # Allow tags to influence execution requirements
 common --experimental_allow_tags_propagation
 
+# Enable auto code formatting and linting during build for Rust source code.
+build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build --output_groups=+clippy_checks
+build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build --output_groups=+rustfmt_checks
+
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fdebug-types-section


### PR DESCRIPTION
Commit Message: ci: enables clippy and rustfmt in compile-time-options build
Additional Description:
With the dynamic module features being developed, enabling the standard
formatter and linter for Rust source code should be setup.
This commit enables clippy and rustfmt checks that run during the build time.

Risk Level: None
Testing:  N/A
Docs Changes: N/A
Release Notes:  N/A
Platform Specific Features:  N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
