### PR TITLE
update ip tagging filter to emit tags to a custom header

### DIFF
--- a/api/envoy/extensions/filters/http/ip_tagging/v3/ip_tagging.proto
+++ b/api/envoy/extensions/filters/http/ip_tagging/v3/ip_tagging.proto
@@ -18,6 +18,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // IP tagging :ref:`configuration overview <config_http_filters_ip_tagging>`.
 // [#extension: envoy.filters.http.ip_tagging]
 
+// [#next-free-field: 6]
 message IPTagging {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ip_tagging.v2.IPTagging";
@@ -59,4 +60,7 @@ message IPTagging {
   // Tracked by issue https://github.com/envoyproxy/envoy/issues/2695]
   // The set of IP tags for the filter.
   repeated IPTag ip_tags = 4 [(validate.rules).repeated = {min_items: 1}];
+
+  // Custom header to emit tag.
+  string custom_header = 5;
 }

--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
@@ -37,6 +37,7 @@ public:
 
   Runtime::Loader& runtime() { return runtime_; }
   FilterRequestType requestType() const { return request_type_; }
+  const Http::LowerCaseString& customHeader() const { return custom_header_; }
   const Network::LcTrie::LcTrie<std::string>& trie() const { return *trie_; }
 
   void incHit(absl::string_view tag) {
@@ -63,6 +64,7 @@ private:
   void incCounter(Stats::StatName name);
 
   const FilterRequestType request_type_;
+  const Http::LowerCaseString custom_header_;
   Stats::Scope& scope_;
   Runtime::Loader& runtime_;
   Stats::StatNameSetPtr stat_name_set_;


### PR DESCRIPTION

Commit Message:
Additional Description: currently the tags are set to a fixed header, it's better to allow tags in a custom header.
Risk Level: low
Testing: unit test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
