### PR TITLE
aws: fix test flake when no IMDS can be found

### DIFF
--- a/source/extensions/common/aws/metadata_fetcher.cc
+++ b/source/extensions/common/aws/metadata_fetcher.cc
@@ -52,6 +52,12 @@ public:
     ASSERT(!request_);
     complete_ = false;
     receiver_ = makeOptRef(receiver);
+
+    // Stop processing if we are shutting down
+    if (cm_.isShutdown()) {
+      return;
+    }
+
     const auto thread_local_cluster = cm_.getThreadLocalCluster(cluster_name_);
     if (thread_local_cluster == nullptr) {
       ENVOY_LOG(error, "{} AWS Metadata failed: [cluster = {}] not found", __func__, cluster_name_);

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
@@ -446,6 +446,7 @@ TEST_F(InitializeFilterTest, TestWithTwoClustersRouteLevelAndStandard) {
 }
 
 TEST_F(InitializeFilterTest, TestWithTwoClustersStandardInstanceProfile) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
   dnsSetup();
   // Web Identity Credentials, Container Credentials and Instance Profile Credentials
   TestEnvironment::setEnvVar("AWS_WEB_IDENTITY_TOKEN_FILE", "/path/to/web_token", 1);

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_integration_test.cc
@@ -446,7 +446,6 @@ TEST_F(InitializeFilterTest, TestWithTwoClustersRouteLevelAndStandard) {
 }
 
 TEST_F(InitializeFilterTest, TestWithTwoClustersStandardInstanceProfile) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
   dnsSetup();
   // Web Identity Credentials, Container Credentials and Instance Profile Credentials
   TestEnvironment::setEnvVar("AWS_WEB_IDENTITY_TOKEN_FILE", "/path/to/web_token", 1);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: aws: fix test flake when no IMDS can be found
Additional Description: Lack of IMDS (169.254.169.254 address) can cause a race condition and crash during testing due to the shutdown of cluster manager. This scenario should not occur normally, as cluster manager will still exist and the lack of IMDS is handled gracefully.
Risk Level: Low
Testing: N/A
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
