### PR TITLE
MSAN: fix issue in tracer test filter

### DIFF
--- a/test/extensions/filters/http/ext_proc/tracer_test_filter.cc
+++ b/test/extensions/filters/http/ext_proc/tracer_test_filter.cc
@@ -33,7 +33,7 @@ public:
   Span(const std::string& operation_name, ExpectedSpansSharedPtr& expected_spans)
       : operation_name_(operation_name), expected_spans_(expected_spans){};
 
-  ~Span() {
+  ~Span() override {
     EXPECT_TRUE(finished_) << fmt::format("span not finished in operation: {}", operation_name_);
     for (auto& expect_span : *expected_spans_) {
       if (expect_span.operation_name != operation_name_) {
@@ -56,40 +56,42 @@ public:
     }
   }
 
-  void setTag(absl::string_view name, absl::string_view value) {
-    tags_.insert_or_assign(name.data(), value.data());
+  void setTag(absl::string_view name, absl::string_view value) override {
+    tags_.insert_or_assign(std::string(name), std::string(value));
   }
-  void setOperation(absl::string_view operation_name) { operation_name_ = operation_name; }
-  void setSampled(bool do_sample) { sampled_ = do_sample; }
 
-  void injectContext(Tracing::TraceContext& trace_context, const Tracing::UpstreamContext&) {
+  void setOperation(absl::string_view operation_name) override { operation_name_ = operation_name; }
+  void setSampled(bool do_sample) override { sampled_ = do_sample; }
+
+  void injectContext(Tracing::TraceContext& trace_context,
+                     const Tracing::UpstreamContext&) override {
     std::string traceparent_header_value = "1";
     traceParentHeader().setRefKey(trace_context, traceparent_header_value);
     context_injected_ = true;
   }
-  void setBaggage(absl::string_view, absl::string_view) { /* not implemented */
+  void setBaggage(absl::string_view, absl::string_view) override { /* not implemented */
   }
-  void log(SystemTime, const std::string&) { /* not implemented */
+  void log(SystemTime, const std::string&) override { /* not implemented */
   }
-  std::string getBaggage(absl::string_view) {
+  std::string getBaggage(absl::string_view) override {
     /* not implemented */
     return EMPTY_STRING;
   };
-  std::string getTraceId() const {
+  std::string getTraceId() const override {
     /* not implemented */
     return EMPTY_STRING;
   };
-  std::string getSpanId() const {
+  std::string getSpanId() const override {
     /* not implemented */
     return EMPTY_STRING;
   };
 
   Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& operation_name,
-                              SystemTime) {
+                              SystemTime) override {
     return std::make_unique<Span>(operation_name, expected_spans_);
   }
 
-  void finishSpan() { finished_ = true; }
+  void finishSpan() override { finished_ = true; }
 
 private:
   std::string operation_name_;
@@ -106,7 +108,7 @@ public:
   Driver(const test::integration::filters::TracerTestConfig& test_config,
          Server::Configuration::CommonFactoryContext&)
       : expected_spans_(std::make_shared<std::vector<ExpectedSpan>>()) {
-    for (auto expected_span : test_config.expect_spans()) {
+    for (const auto& expected_span : test_config.expect_spans()) {
       ExpectedSpan span;
       span.operation_name = expected_span.operation_name();
       span.sampled = expected_span.sampled();
@@ -123,7 +125,7 @@ public:
     return std::make_unique<Span>(operation_name, expected_spans_);
   };
 
-  ~Driver() {
+  ~Driver() override {
     for (auto& span : *expected_spans_) {
       EXPECT_TRUE(span.tested) << fmt::format("missing span with operation '{}'",
                                               span.operation_name);


### PR DESCRIPTION
Commit Message: MSAN: fix issue in tracer test filter
Additional Description:  also fix other clang complains "clang: 'setOperation' overrides a member function but is not marked 'override'"
Risk Level: Low
Fixes https://github.com/envoyproxy/envoy/issues/35630