### PR TITLE
grpc: Reword error message for unimplemented response_body

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -314,7 +314,7 @@ Status JsonTranscoderConfig::createMethodInfo(const Protobuf::MethodDescriptor* 
   if (!method_info->response_body_field_path.empty() && !method_info->response_type_is_http_body_) {
     // TODO(euroelessar): Implement https://github.com/envoyproxy/envoy/issues/11136.
     return {StatusCode::kUnimplemented,
-            "Setting \"response_body\" is not supported yet for non-HttpBody fields: " +
+            "Setting \"response_body\" is only supported for fields of type google.api.HttpBody: " +
                 descriptor->full_name()};
   }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: The previous message was confusing for someone unfamiliar with the HttpBody type. Hopefully this makes it easier to understand.
Additional Description: None
Risk Level: LOW
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
