### PR TITLE
http: remove unnecessary filter canonical name

### DIFF
--- a/envoy/http/filter_factory.h
+++ b/envoy/http/filter_factory.h
@@ -31,9 +31,6 @@ struct FilterContext {
   // The name of the filter configuration that used to create related filter factory function.
   // This could be any legitimate non-empty string.
   std::string config_name;
-  // Filter extension qualified name. This is used as a fallback of `config_name`. E.g.,
-  // "envoy.filters.http.buffer" for the HTTP buffer filter.
-  std::string filter_name;
 };
 
 /**

--- a/envoy/http/filter_factory.h
+++ b/envoy/http/filter_factory.h
@@ -25,7 +25,7 @@ using FilterFactoryCb = std::function<void(FilterChainFactoryCallbacks& callback
 
 /**
  * Simple struct of additional contextual information of HTTP filter, e.g. filter config name
- * from configuration, canonical filter name, etc.
+ * from configuration, etc.
  */
 struct FilterContext {
   // The name of the filter configuration that used to create related filter factory function.

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -181,20 +181,14 @@ private:
   const ProtobufTypes::MessagePtr default_configuration_;
 };
 
-// Struct of canonical filter name and HTTP stream filter factory callback.
-struct NamedHttpFilterFactoryCb {
-  // Canonical filter name.
-  std::string name;
-  // Factory function used to create filter instances.
-  Http::FilterFactoryCb factory_cb;
-};
+using HttpFilterFactoryCb = Http::FilterFactoryCb;
 
 // Implementation of a HTTP dynamic filter config provider.
 // NeutralHttpFilterConfigFactory can either be a NamedHttpFilterConfigFactory
 // or an UpstreamHttpFilterConfigFactory.
 template <class FactoryCtx, class NeutralHttpFilterConfigFactory>
 class HttpDynamicFilterConfigProviderImpl
-    : public DynamicFilterConfigProviderImpl<NamedHttpFilterFactoryCb> {
+    : public DynamicFilterConfigProviderImpl<HttpFilterFactoryCb> {
 public:
   HttpDynamicFilterConfigProviderImpl(
       FilterConfigSubscriptionSharedPtr& subscription,
@@ -219,14 +213,11 @@ public:
   }
 
 private:
-  absl::StatusOr<NamedHttpFilterFactoryCb>
+  absl::StatusOr<HttpFilterFactoryCb>
   instantiateFilterFactory(const Protobuf::Message& message) const override {
     auto* factory = Registry::FactoryRegistry<NeutralHttpFilterConfigFactory>::getFactoryByType(
         message.GetTypeName());
-    absl::StatusOr<Http::FilterFactoryCb> error_or_factory =
-        factory->createFilterFactoryFromProto(message, getStatPrefix(), factory_context_);
-    RETURN_IF_NOT_OK_REF(error_or_factory.status());
-    return NamedHttpFilterFactoryCb{factory->name(), error_or_factory.value()};
+    return factory->createFilterFactoryFromProto(message, getStatPrefix(), factory_context_);
   }
 
   Server::Configuration::ServerFactoryContext& server_context_;
@@ -651,7 +642,7 @@ protected:
 // HTTP filter
 class HttpFilterConfigProviderManagerImpl
     : public FilterConfigProviderManagerImpl<
-          Server::Configuration::NamedHttpFilterConfigFactory, NamedHttpFilterFactoryCb,
+          Server::Configuration::NamedHttpFilterConfigFactory, HttpFilterFactoryCb,
           Server::Configuration::FactoryContext,
           HttpDynamicFilterConfigProviderImpl<
               Server::Configuration::FactoryContext,
@@ -679,7 +670,7 @@ protected:
 // HTTP filter
 class UpstreamHttpFilterConfigProviderManagerImpl
     : public FilterConfigProviderManagerImpl<
-          Server::Configuration::UpstreamHttpFilterConfigFactory, NamedHttpFilterFactoryCb,
+          Server::Configuration::UpstreamHttpFilterConfigFactory, HttpFilterFactoryCb,
           Server::Configuration::UpstreamFactoryContext,
           HttpDynamicFilterConfigProviderImpl<
               Server::Configuration::UpstreamFactoryContext,

--- a/source/common/http/filter_chain_helper.cc
+++ b/source/common/http/filter_chain_helper.cc
@@ -27,9 +27,7 @@ void FilterChainUtility::createFilterChainForFactories(
 
     auto config = filter_config_provider.provider->config();
     if (config.has_value()) {
-      Filter::NamedHttpFilterFactoryCb& factory_cb = config.value().get();
-      manager.applyFilterFactoryCb({filter_config_provider.provider->name(), factory_cb.name},
-                                   factory_cb.factory_cb);
+      manager.applyFilterFactoryCb({filter_config_provider.provider->name()}, config.ref());
       continue;
     }
 

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -16,10 +16,10 @@ namespace Envoy {
 namespace Http {
 
 using DownstreamFilterConfigProviderManager =
-    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
+    Filter::FilterConfigProviderManager<Filter::HttpFilterFactoryCb,
                                         Server::Configuration::FactoryContext>;
 using UpstreamFilterConfigProviderManager =
-    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
+    Filter::FilterConfigProviderManager<Filter::HttpFilterFactoryCb,
                                         Server::Configuration::UpstreamFactoryContext>;
 
 // Allows graceful handling of missing configuration for ECDS.
@@ -42,7 +42,7 @@ static Http::FilterFactoryCb MissingConfigFilterFactory =
 class FilterChainUtility : Logger::Loggable<Logger::Id::config> {
 public:
   struct FilterFactoryProvider {
-    Filter::FilterConfigProviderPtr<Filter::NamedHttpFilterFactoryCb> provider;
+    Filter::FilterConfigProviderPtr<Filter::HttpFilterFactoryCb> provider;
     // If true, this filter is disabled by default and must be explicitly enabled by
     // route configuration.
     bool disabled{};
@@ -70,7 +70,7 @@ class FilterChainHelper : Logger::Loggable<Logger::Id::config> {
 public:
   using FilterFactoriesList = FilterChainUtility::FilterFactoriesList;
   using FilterConfigProviderManager =
-      Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb, FilterCtx>;
+      Filter::FilterConfigProviderManager<Filter::HttpFilterFactoryCb, FilterCtx>;
 
   FilterChainHelper(FilterConfigProviderManager& filter_config_provider_manager,
                     Server::Configuration::ServerFactoryContext& server_context,

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -146,14 +146,13 @@ private:
     if (!callback_or_error.status().ok()) {
       return callback_or_error.status();
     }
-    Http::FilterFactoryCb callback = callback_or_error.value();
     dependency_manager.registerFilter(factory->name(), *factory->dependencies());
     const bool is_terminal = factory->isTerminalFilterByProto(*message, server_context_);
     RETURN_IF_NOT_OK(Config::Utility::validateTerminalFilters(proto_config.name(), factory->name(),
                                                               filter_chain_type, is_terminal,
                                                               last_filter_in_current_config));
     auto filter_config_provider = filter_config_provider_manager_.createStaticFilterConfigProvider(
-        {factory->name(), callback}, proto_config.name());
+        callback_or_error.value(), proto_config.name());
 #ifdef ENVOY_ENABLE_YAML
     ENVOY_LOG(debug, "      name: {}", filter_config_provider->name());
     ENVOY_LOG(debug, "    config: {}",

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -80,14 +80,11 @@ private:
             return nullptr;
           }
 
-          auto config_value = provider->config();
-          if (config_value.has_value()) {
-            auto factory_cb = config_value.value().get().factory_cb;
-            return std::make_unique<ExecuteFilterAction>(factory_cb, n);
+          if (auto config_value = provider->config(); config_value.has_value()) {
+            return std::make_unique<ExecuteFilterAction>(config_value.ref(), n);
           }
           // There is no dynamic config available. Apply missing config filter.
-          auto factory_cb = Envoy::Http::MissingConfigFilterFactory;
-          return std::make_unique<ExecuteFilterAction>(factory_cb, n);
+          return std::make_unique<ExecuteFilterAction>(Envoy::Http::MissingConfigFilterFactory, n);
         };
   }
 

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -11,8 +11,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Composite {
 
-using HttpExtensionConfigProviderSharedPtr = std::shared_ptr<
-    Config::DynamicExtensionConfigProvider<Envoy::Filter::NamedHttpFilterFactoryCb>>;
+using HttpExtensionConfigProviderSharedPtr =
+    std::shared_ptr<Config::DynamicExtensionConfigProvider<Envoy::Filter::HttpFilterFactoryCb>>;
 
 class ExecuteFilterAction
     : public Matcher::ActionBase<

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -44,7 +44,7 @@ namespace NetworkFilters {
 namespace HttpConnectionManager {
 
 using FilterConfigProviderManager =
-    Filter::FilterConfigProviderManager<Filter::NamedHttpFilterFactoryCb,
+    Filter::FilterConfigProviderManager<Filter::HttpFilterFactoryCb,
                                         Server::Configuration::FactoryContext>;
 
 /**

--- a/test/common/filter/config_discovery_impl_test.cc
+++ b/test/common/filter/config_discovery_impl_test.cc
@@ -275,7 +275,7 @@ public:
 // HTTP filter test
 class HttpFilterConfigDiscoveryImplTest
     : public FilterConfigDiscoveryImplTest<
-          NamedHttpFilterFactoryCb, Server::Configuration::FactoryContext,
+          HttpFilterFactoryCb, Server::Configuration::FactoryContext,
           HttpFilterConfigProviderManagerImpl, TestHttpFilterFactory,
           Server::Configuration::NamedHttpFilterConfigFactory,
           Server::Configuration::MockFactoryContext> {
@@ -292,7 +292,7 @@ public:
 // Upstream HTTP filter test
 class HttpUpstreamFilterConfigDiscoveryImplTest
     : public FilterConfigDiscoveryImplTest<
-          NamedHttpFilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
+          HttpFilterFactoryCb, Server::Configuration::UpstreamFactoryContext,
           UpstreamHttpFilterConfigProviderManagerImpl, TestHttpFilterFactory,
           Server::Configuration::UpstreamHttpFilterConfigFactory,
           Server::Configuration::MockUpstreamFactoryContext> {

--- a/test/common/http/filter_chain_helper_test.cc
+++ b/test/common/http/filter_chain_helper_test.cc
@@ -28,10 +28,8 @@ TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabled) {
 
   for (const auto& name : {"filter_0", "filter_1", "filter_2"}) {
     auto provider =
-        std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::NamedHttpFilterFactoryCb>>(
-            Filter::NamedHttpFilterFactoryCb{"filter_type_name",
-                                             [](FilterChainFactoryCallbacks&) {}},
-            name);
+        std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::HttpFilterFactoryCb>>(
+            [](FilterChainFactoryCallbacks&) {}, name);
     filter_factories.push_back({std::move(provider), false});
   }
 
@@ -61,10 +59,8 @@ TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabledAndDe
 
   for (const auto& name : {"filter_0", "filter_1", "filter_2"}) {
     auto provider =
-        std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::NamedHttpFilterFactoryCb>>(
-            Filter::NamedHttpFilterFactoryCb{"filter_type_name",
-                                             [](FilterChainFactoryCallbacks&) {}},
-            name);
+        std::make_unique<Filter::StaticFilterConfigProviderImpl<Filter::HttpFilterFactoryCb>>(
+            [](FilterChainFactoryCallbacks&) {}, name);
     filter_factories.push_back({std::move(provider), true});
   }
 

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -168,7 +168,7 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringDecodingGrpcClassiciation) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto factory = createDecoderFilterFactoryCb(filter);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, factory);
+        manager.applyFilterFactoryCb({"configName1"}, factory);
         return true;
       }));
 
@@ -222,10 +222,10 @@ TEST_F(FilterManagerTest, SendLocalReplyDuringEncodingGrpcClassiciation) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
 
         auto stream_factory = createStreamFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, stream_factory);
+        manager.applyFilterFactoryCb({"configName2"}, stream_factory);
         return true;
       }));
 
@@ -272,11 +272,11 @@ TEST_F(FilterManagerTest, OnLocalReply) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
         auto stream_factory = createStreamFilterFactoryCb(stream_filter);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, stream_factory);
+        manager.applyFilterFactoryCb({"configName2"}, stream_factory);
         auto encoder_factory = createEncoderFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({"configName3", "filterName3"}, encoder_factory);
+        manager.applyFilterFactoryCb({"configName3"}, encoder_factory);
         return true;
       }));
 
@@ -335,11 +335,11 @@ TEST_F(FilterManagerTest, MultipleOnLocalReply) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
         auto stream_factory = createStreamFilterFactoryCb(stream_filter);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, stream_factory);
+        manager.applyFilterFactoryCb({"configName2"}, stream_factory);
         auto encoder_factory = createEncoderFilterFactoryCb(encoder_filter);
-        manager.applyFilterFactoryCb({"configName3", "filterName3"}, encoder_factory);
+        manager.applyFilterFactoryCb({"configName3"}, encoder_factory);
         return true;
       }));
 
@@ -437,7 +437,7 @@ TEST_F(FilterManagerTest, GetRouteLevelFilterConfig) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"custom-name", "filter-name"}, decoder_factory);
+        manager.applyFilterFactoryCb({"custom-name"}, decoder_factory);
         return true;
       }));
   filter_manager_->createFilterChain();
@@ -491,7 +491,7 @@ TEST_F(FilterManagerTest, GetRouteLevelFilterConfigForNullRoute) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createDecoderFilterFactoryCb(decoder_filter);
-        manager.applyFilterFactoryCb({"custom-name", "filter-name"}, decoder_factory);
+        manager.applyFilterFactoryCb({"custom-name"}, decoder_factory);
         return true;
       }));
   filter_manager_->createFilterChain();
@@ -523,9 +523,9 @@ TEST_F(FilterManagerTest, MetadataContinueAll) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
         decoder_factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName2"}, decoder_factory);
         return true;
       }));
   filter_manager_->createFilterChain();
@@ -595,9 +595,9 @@ TEST_F(FilterManagerTest, DecodeMetadataSendsLocalReply) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, factory);
+        manager.applyFilterFactoryCb({"configName1"}, factory);
         factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, factory);
+        manager.applyFilterFactoryCb({"configName2"}, factory);
         return true;
       }));
   filter_manager_->createFilterChain();
@@ -642,9 +642,9 @@ TEST_F(FilterManagerTest, MetadataContinueAllFollowedByHeadersLocalReply) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto decoder_factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName1"}, decoder_factory);
         decoder_factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, decoder_factory);
+        manager.applyFilterFactoryCb({"configName2"}, decoder_factory);
         return true;
       }));
   filter_manager_->createFilterChain();
@@ -682,9 +682,9 @@ TEST_F(FilterManagerTest, EncodeMetadataSendsLocalReply) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, factory);
+        manager.applyFilterFactoryCb({"configName1"}, factory);
         factory = createStreamFilterFactoryCb(filter_2);
-        manager.applyFilterFactoryCb({"configName2", "filterName2"}, factory);
+        manager.applyFilterFactoryCb({"configName2"}, factory);
         return true;
       }));
   filter_manager_->createFilterChain();
@@ -721,7 +721,7 @@ TEST_F(FilterManagerTest, IdleTimerResets) {
   EXPECT_CALL(filter_factory_, createFilterChain(_))
       .WillRepeatedly(Invoke([&](FilterChainManager& manager) -> bool {
         auto factory = createStreamFilterFactoryCb(filter_1);
-        manager.applyFilterFactoryCb({"configName1", "filterName1"}, factory);
+        manager.applyFilterFactoryCb({"configName1"}, factory);
         return true;
       }));
   filter_manager_->createFilterChain();


### PR DESCRIPTION
Commit Message: http: remove unnecessary filter canonical name
Additional Description:

This the `filter_name` field is unnecessary after #35331.

Risk Level: low.
Testing: n/a.
Docs Changes:  n/a.
Release Notes: n/a.