### PR TITLE
test: update a broken test due to PRs race

### DIFF
--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -490,7 +490,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainConnectionUponCompletionVsOnDrainTime
   Event::MockTimer* connection_duration_timer = setUpTimer();
   EXPECT_CALL(*connection_duration_timer, enableTimer(_, _));
   // Set up connection.
-  setup(false, "");
+  setup();
 
   // Create a filter so we can encode responses.
   MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();


### PR DESCRIPTION
Commit Message: test: update a broken test due to PRs race
Additional Description:
PR #35568 used an old `setup()` method call which was modified by PR #35209 that was merged just before it, causing a build failure.
This PR update the test and fixes the build failure.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A