### PR TITLE
Fix file_system_buffer's adherence to continueEncoding API

### DIFF
--- a/source/extensions/filters/http/file_system_buffer/filter.cc
+++ b/source/extensions/filters/http/file_system_buffer/filter.cc
@@ -67,13 +67,8 @@ Http::FilterHeadersStatus FileSystemBufferFilter::decodeHeaders(Http::RequestHea
   // the memory limit, once in our own buffer and once in the outgoing buffer. (Plus overflow
   // because the limit isn't hard.)
   request_callbacks_->setDecoderBufferLimit(request_state_.config_->memoryBufferBytesLimit());
-  // If we're going to buffer everything, don't even start sending the data until we're ready.
-  if (request_state_.injecting_content_length_header_ ||
-      request_state_.config_->behavior().alwaysFullyBuffer()) {
-    request_headers_ = &headers;
-    return Http::FilterHeadersStatus::StopIteration;
-  }
-  return Http::FilterHeadersStatus::Continue;
+  request_headers_ = &headers;
+  return Http::FilterHeadersStatus::StopIteration;
 }
 
 Http::FilterHeadersStatus FileSystemBufferFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
@@ -100,13 +95,8 @@ Http::FilterHeadersStatus FileSystemBufferFilter::encodeHeaders(Http::ResponseHe
   // the memory limit, once in our own buffer and once in the outgoing buffer. (Plus overflow
   // because the limit isn't hard.)
   response_callbacks_->setEncoderBufferLimit(response_state_.config_->memoryBufferBytesLimit());
-  // If we're going to buffer everything, don't even start sending the data until we're ready.
-  if (response_state_.injecting_content_length_header_ ||
-      response_state_.config_->behavior().alwaysFullyBuffer()) {
-    response_headers_ = &headers;
-    return Http::FilterHeadersStatus::StopIteration;
-  }
-  return Http::FilterHeadersStatus::Continue;
+  response_headers_ = &headers;
+  return Http::FilterHeadersStatus::StopIteration;
 }
 
 void FileSystemBufferFilter::onAboveWriteBufferHighWatermark() {

--- a/test/extensions/filters/http/file_system_buffer/filter_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/filter_test.cc
@@ -270,7 +270,8 @@ TEST_F(FileSystemBufferFilterTest, DoesNotBufferRequestWhenContentLengthPresent)
         inject_content_length_if_necessary: {}
   )");
   request_headers_.setContentLength(6);
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
   Buffer::OwnedImpl data1("hello");
   Buffer::OwnedImpl data2(" banana");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data1, false));
@@ -290,7 +291,8 @@ TEST_F(FileSystemBufferFilterTest, DoesNotBufferResponseWhenContentLengthPresent
         inject_content_length_if_necessary: {}
   )");
   response_headers_.setContentLength(6);
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers_, false));
   Buffer::OwnedImpl data1("hello");
   Buffer::OwnedImpl data2(" banana");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(data1, false));
@@ -312,7 +314,8 @@ constexpr int outerWatermarkAfterIntercepting() {
 
 TEST_F(FileSystemBufferFilterTest, BuffersResponseWhenDownstreamIsSlow) {
   createFilterFromYaml(minimal_config);
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers_, false));
   Buffer::OwnedImpl data1("hello");
   Buffer::OwnedImpl data2(" banana");
   sendResponseHighWatermark();
@@ -340,7 +343,8 @@ TEST_F(FileSystemBufferFilterTest,
     response:
       memory_buffer_bytes_limit: 6
   )");
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers_, false));
   Buffer::OwnedImpl data1("hello ");
   Buffer::OwnedImpl data2("wor");
   Buffer::OwnedImpl data3("ld");
@@ -441,7 +445,8 @@ TEST_F(FileSystemBufferFilterTest, ResponseSlowsWhenTotalBufferSizeExceededAndSt
       memory_buffer_bytes_limit: 10
       storage_buffer_bytes_limit: 0
   )");
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers_, false));
   sendResponseHighWatermark();
   Buffer::OwnedImpl data1("hello ");
   Buffer::OwnedImpl data2("wor");
@@ -475,7 +480,8 @@ TEST_F(FileSystemBufferFilterTest, ResponseSlowsWhenDiskWriteTakesTooLongAndWate
       memory_buffer_bytes_limit: 10
       storage_buffer_queue_high_watermark_bytes: 10
   )");
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->encodeHeaders(response_headers_, false));
   // Stream recipient says stop sending right away.
   sendResponseHighWatermark();
   Buffer::OwnedImpl data1("hello worm");


### PR DESCRIPTION
Commit Message: Fix file_system_buffer's adherence to continueEncoding API
Additional Description: According to the API, `continueEncoding` and `continueDecoding` should not be called after headers replied with anything other than `StopIteration`. This change makes it so if the stream is going to buffer, headers always return `StopIteration`.
Risk Level: Some from leaving it as-is, some from changing it.
Testing: Modified some tests. Integration tests still pass as before.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
