### PR TITLE
xDS: enable envoy.restart_features.use_eds_cache_for_ads by default

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -15,6 +15,15 @@ behavior_changes:
     HttpConnectionManager to close the connection itself.  Defaults to off ("unsafe" -- check
     \#34356) and is configurable via :ref:`http1_safe_max_connection_duration
     <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.http1_safe_max_connection_duration>`.
+- area: eds
+  change: |
+    Enabling caching caching of EDS assignments when used with ADS by default (introduced in Envoy v1.28).
+    Prior to this change, Envoy required that EDS assignments were sent after an EDS cluster was updated.
+    If no EDS assignment was received for the cluster, it ended up with an empty assignment.
+    Following this change, after a cluster update, Envoy waits for an EDS assignment until
+    :ref:`initial_fetch_timeout <envoy_v3_api_field_config.core.v3.ConfigSource.initial_fetch_timeout>` times out, and will then apply
+    the cached assignment and finish updating the warmed cluster. This change temporarily disabled by setting
+    the runtime flag ``envoy.restart_features.use_eds_cache_for_ads`` to ``false``.
 - area: stats scoped_rds
   change: |
     Added new tag extraction so that scoped rds stats have their :ref:'scope_route_config_name

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -98,6 +98,7 @@ RUNTIME_GUARD(envoy_reloadable_features_xdstp_path_avoid_colon_encoding);
 RUNTIME_GUARD(envoy_restart_features_allow_client_socket_creation_failure);
 RUNTIME_GUARD(envoy_restart_features_allow_slot_destroy_on_worker_threads);
 RUNTIME_GUARD(envoy_restart_features_quic_handle_certs_with_shared_tls_code);
+RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 RUNTIME_GUARD(envoy_restart_features_use_fast_protobuf_hash);
 
 // Begin false flags. Most of them should come with a TODO to flip true.
@@ -127,8 +128,6 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_quic_reject_all);
 // remove the feature flag and remove code path that relies on old technique to fetch credentials
 // via libcurl and remove the bazel steps to pull and test the curl dependency.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_use_http_client_to_fetch_aws_credentials);
-// TODO(adisuissa): enable by default once this is tested in prod.
-FALSE_RUNTIME_GUARD(envoy_restart_features_use_eds_cache_for_ads);
 // TODO(#10646) change to true when UHV is sufficiently tested
 // For more information about Universal Header Validation, please see
 // https://github.com/envoyproxy/envoy/issues/10646


### PR DESCRIPTION
Commit Message: xDS: enable envoy.restart_features.use_eds_cache_for_ads by default
Additional Description:
Reverts #32767 (re-enables #32604) after a bug was fixed and this has been running in prod for a few months.

Caching of EDS responses was added in https://github.com/envoyproxy/envoy/pull/28273 and we have been using it internally.
This PR flips the runtime guard to be true by default.
This solves the issue of not receiving EDS assignments after receiving a cluster update (in a CDS response).

Risk Level: medium - may impact memory, but should not impact data-plane/config-plane behavior
Testing: updated in previous PRs
Docs Changes: updated in previous PRs
Release Notes: Added
Platform Specific Features: N/A