### PR TITLE
[cache_filter] Determine end_stream later

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -550,10 +550,12 @@ void CacheFilter::handleCacheHitWithRangeRequest() {
   insert_status_ = InsertStatus::NoInsertCacheHit;
 
   lookup_result_->headers_->setStatus(static_cast<uint64_t>(Envoy::Http::Code::PartialContent));
-  lookup_result_->headers_->addCopy(Envoy::Http::Headers::get().ContentRange,
-                                    absl::StrCat("bytes ", ranges[0].begin(), "-",
-                                                 ranges[0].end() - 1, "/",
-                                                 lookup_result_->content_length_.value()));
+  lookup_result_->headers_->addCopy(
+      Envoy::Http::Headers::get().ContentRange,
+      absl::StrCat("bytes ", ranges[0].begin(), "-", ranges[0].end() - 1, "/",
+                   lookup_result_->content_length_.has_value()
+                       ? absl::StrCat(lookup_result_->content_length_.value())
+                       : "*"));
   // We serve only the desired range, so adjust the length
   // accordingly.
   lookup_result_->setContentLength(ranges[0].length());

--- a/source/extensions/filters/http/cache/cache_filter.h
+++ b/source/extensions/filters/http/cache/cache_filter.h
@@ -93,12 +93,12 @@ private:
   void getTrailers();
 
   // Callbacks for HttpCache to call when headers/body/trailers are ready.
-  void onHeaders(LookupResult&& result, Http::RequestHeaderMap& request_headers);
-  void onBody(Buffer::InstancePtr&& body);
+  void onHeaders(LookupResult&& result, Http::RequestHeaderMap& request_headers, bool end_stream);
+  void onBody(Buffer::InstancePtr&& bod, bool end_stream);
   void onTrailers(Http::ResponseTrailerMapPtr&& trailers);
 
   // Set required state in the CacheFilter for handling a cache hit.
-  void handleCacheHit();
+  void handleCacheHit(bool end_stream_after_headers);
 
   // Set up the required state in the CacheFilter for handling a range
   // request.
@@ -128,7 +128,7 @@ private:
   // Adds a cache lookup result to the response encoding stream.
   // Can be called during decoding if a valid cache hit is found,
   // or during encoding if a cache entry was validated successfully.
-  void encodeCachedResponse();
+  void encodeCachedResponse(bool end_stream_after_headers);
 
   // Precondition: finished adding a response from cache to the response encoding stream.
   // Updates filter_state_ and continues the encoding stream if necessary.
@@ -156,10 +156,6 @@ private:
   std::vector<AdjustedByteRange> remaining_ranges_;
 
   const std::shared_ptr<const CacheFilterConfig> config_;
-
-  // True if the response has trailers.
-  // TODO(toddmgreer): cache trailers.
-  bool response_has_trailers_ = false;
 
   // True if a request allows cache inserts according to:
   // https://httpwg.org/specs/rfc7234.html#response.cacheability

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -130,8 +130,8 @@ bool LookupRequest::requiresValidation(const Http::ResponseHeaderMap& response_h
 }
 
 LookupResult LookupRequest::makeLookupResult(Http::ResponseHeaderMapPtr&& response_headers,
-                                             ResponseMetadata&& metadata, uint64_t content_length,
-                                             bool has_trailers) const {
+                                             ResponseMetadata&& metadata,
+                                             uint64_t content_length) const {
   // TODO(toddmgreer): Implement all HTTP caching semantics.
   ASSERT(response_headers);
   LookupResult result;
@@ -147,7 +147,6 @@ LookupResult LookupRequest::makeLookupResult(Http::ResponseHeaderMapPtr&& respon
   result.headers_ = std::move(response_headers);
   result.content_length_ = content_length;
   result.range_details_ = RangeUtils::createRangeDetails(requestHeaders(), content_length);
-  result.has_trailers_ = has_trailers;
 
   return result;
 }

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -131,7 +131,7 @@ bool LookupRequest::requiresValidation(const Http::ResponseHeaderMap& response_h
 
 LookupResult LookupRequest::makeLookupResult(Http::ResponseHeaderMapPtr&& response_headers,
                                              ResponseMetadata&& metadata,
-                                             uint64_t content_length) const {
+                                             absl::optional<uint64_t> content_length) const {
   // TODO(toddmgreer): Implement all HTTP caching semantics.
   ASSERT(response_headers);
   LookupResult result;
@@ -145,8 +145,20 @@ LookupResult LookupRequest::makeLookupResult(Http::ResponseHeaderMapPtr&& respon
                                    ? CacheEntryStatus::RequiresValidation
                                    : CacheEntryStatus::Ok;
   result.headers_ = std::move(response_headers);
-  result.content_length_ = content_length;
-  result.range_details_ = RangeUtils::createRangeDetails(requestHeaders(), content_length);
+  if (content_length.has_value()) {
+    result.content_length_ = content_length;
+  } else {
+    absl::string_view content_length_header = result.headers_->getContentLengthValue();
+    int64_t length_from_header;
+    if (!content_length_header.empty() &&
+        absl::SimpleAtoi(content_length_header, &length_from_header)) {
+      result.content_length_ = length_from_header;
+    }
+  }
+  if (result.content_length_.has_value()) {
+    result.range_details_ =
+        RangeUtils::createRangeDetails(requestHeaders(), result.content_length_.value());
+  }
 
   return result;
 }

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -197,8 +197,8 @@ public:
   // requests may be unable to receive a response until the content-length is
   // known to exceed the end of the requested range. In this case a cache
   // implementation should wait until that is known before calling the callback,
-  // and must pass headers with a 416 Range Not Satisfiable response if the request
-  // is invalid.
+  // and must pass a LookupResult with range_details_->satisfiable_ = false
+  // if the request is invalid.
   virtual void getHeaders(LookupHeadersCallback&& cb) PURE;
 
   // Reads the next fragment from the cache, calling cb when the fragment is ready.

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -211,7 +211,14 @@ public:
   // A request may have a range that exceeds the size of the content, in support
   // of a "shared stream" cache entry, where the request may not know the size of
   // the content in advance. In this case the cache should call cb with
-  // end_stream=true when the end of the body is reached.
+  // end_stream=true when the end of the body is reached, if there are no trailers.
+  //
+  // If there are trailers *and* the size of the content was not known when the
+  // LookupContext was created, the cache should pass a null buffer pointer to the
+  // LookupBodyCallback (when getBody is called with a range starting beyond the
+  // end of the actual content-length) to indicate that no more body is available
+  // and the filter should request trailers. It is invalid to pass a null buffer
+  // pointer other than in this case.
   //
   // If a cache happens to load data in fragments of a set size, it may be
   // efficient to respond with fewer than the requested number of bytes. For

--- a/source/extensions/filters/http/cache/range_utils.h
+++ b/source/extensions/filters/http/cache/range_utils.h
@@ -71,7 +71,16 @@ public:
     ASSERT(first < last, "Illegal byte range.");
   }
   uint64_t begin() const { return first_; }
+
   // Unlike RawByteRange, end() is one past the index of the last offset.
+  //
+  // std::numeric_limits<uint64_t>::max() is a special case that may (and most
+  // likely does) indicate that the range was filled in automatically and the
+  // content-length was unknown at that time. In this case it is allowable for
+  // a cache to pass a null body pointer to the LookupBodyCallback to indicate
+  // that no more body is available and the filter should request trailers.
+  // (If there is no trailer, end_stream should have already been passed with
+  // the final body chunk, meaning a null body pointer should not be necessary.)
   uint64_t end() const { return last_; }
   uint64_t length() const { return last_ - first_; }
   void trimFront(uint64_t n) {

--- a/source/extensions/filters/http/cache/range_utils.h
+++ b/source/extensions/filters/http/cache/range_utils.h
@@ -74,13 +74,8 @@ public:
 
   // Unlike RawByteRange, end() is one past the index of the last offset.
   //
-  // std::numeric_limits<uint64_t>::max() is a special case that may (and most
-  // likely does) indicate that the range was filled in automatically and the
-  // content-length was unknown at that time. In this case it is allowable for
-  // a cache to pass a null body pointer to the LookupBodyCallback to indicate
-  // that no more body is available and the filter should request trailers.
-  // (If there is no trailer, end_stream should have already been passed with
-  // the final body chunk, meaning a null body pointer should not be necessary.)
+  // If end() == std::numeric_limits<uint64_t>::max(), the cache doesn't yet
+  // know the response body's length.
   uint64_t end() const { return last_; }
   uint64_t length() const { return last_ - first_; }
   void trimFront(uint64_t n) {

--- a/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
@@ -41,14 +41,15 @@ public:
     body_ = std::move(entry.body_);
     trailers_ = std::move(entry.trailers_);
     cb(entry.response_headers_ ? request_.makeLookupResult(std::move(entry.response_headers_),
-                                                           std::move(entry.metadata_), body_.size(),
-                                                           trailers_ != nullptr)
-                               : LookupResult{});
+                                                           std::move(entry.metadata_), body_.size())
+                               : LookupResult{},
+       body_.empty() && trailers_ == nullptr);
   }
 
   void getBody(const AdjustedByteRange& range, LookupBodyCallback&& cb) override {
     ASSERT(range.end() <= body_.length(), "Attempt to read past end of body.");
-    cb(std::make_unique<Buffer::OwnedImpl>(&body_[range.begin()], range.length()));
+    cb(std::make_unique<Buffer::OwnedImpl>(&body_[range.begin()], range.length()),
+       trailers_ == nullptr && range.end() == body_.length());
   }
 
   // The cache must call cb with the cached trailers.

--- a/test/extensions/filters/http/cache/http_cache_implementation_test_common.h
+++ b/test/extensions/filters/http/cache/http_cache_implementation_test_common.h
@@ -71,9 +71,11 @@ protected:
                       const Http::TestResponseHeaderMapImpl& headers, const absl::string_view body,
                       std::chrono::milliseconds timeout = std::chrono::seconds(1));
 
-  Http::ResponseHeaderMapPtr getHeaders(LookupContext& context);
+  // Returns the headers and a bool for end_stream.
+  std::pair<Http::ResponseHeaderMapPtr, bool> getHeaders(LookupContext& context);
 
-  std::string getBody(LookupContext& context, uint64_t start, uint64_t end);
+  // Returns a body chunk and a bool for end_stream.
+  std::pair<std::string, bool> getBody(LookupContext& context, uint64_t start, uint64_t end);
 
   Http::TestResponseTrailerMapImpl getTrailers(LookupContext& context);
 
@@ -94,6 +96,7 @@ protected:
   std::unique_ptr<HttpCacheTestDelegate> delegate_;
   VaryAllowList vary_allow_list_;
   LookupResult lookup_result_;
+  bool lookup_end_stream_after_headers_;
   Http::TestRequestHeaderMapImpl request_headers_;
   Event::SimulatedTimeSystem time_system_;
   Event::MockDispatcher dispatcher_;

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -174,12 +174,12 @@ public:
 
 LookupResult makeLookupResult(const LookupRequest& lookup_request,
                               const Http::TestResponseHeaderMapImpl& response_headers,
-                              uint64_t content_length = 0, bool has_trailers = false) {
+                              uint64_t content_length = 0) {
   // For the purpose of the test, set the response_time to the date header value.
   ResponseMetadata metadata = {CacheHeadersUtils::httpTime(response_headers.Date())};
   return lookup_request.makeLookupResult(
       std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers), std::move(metadata),
-      content_length, has_trailers);
+      content_length);
 }
 
 INSTANTIATE_TEST_SUITE_P(ResultMatchesExpectation, LookupRequestTest,
@@ -202,7 +202,6 @@ TEST_P(LookupRequestTest, ResultWithoutBodyMatchesExpectation) {
   EXPECT_THAT(*lookup_response.headers_,
               HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_EQ(lookup_response.content_length_, 0);
-  EXPECT_FALSE(lookup_response.has_trailers_);
 }
 
 TEST_P(LookupRequestTest, ResultWithBodyMatchesExpectation) {
@@ -223,7 +222,6 @@ TEST_P(LookupRequestTest, ResultWithBodyMatchesExpectation) {
   EXPECT_THAT(*lookup_response.headers_,
               HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_EQ(lookup_response.content_length_, content_length);
-  EXPECT_FALSE(lookup_response.has_trailers_);
 }
 
 TEST_F(LookupRequestTest, ExpiredViaFallbackheader) {
@@ -346,7 +344,7 @@ TEST_P(LookupRequestTest, ResultWithBodyAndTrailersMatchesExpectation) {
        {"date", formatter_.fromTime(response_date)}});
   const uint64_t content_length = 5;
   const LookupResult lookup_response =
-      makeLookupResult(lookup_request, response_headers, content_length, /*has_trailers=*/true);
+      makeLookupResult(lookup_request, response_headers, content_length);
 
   EXPECT_EQ(GetParam().expected_cache_entry_status, lookup_response.cache_entry_status_);
   ASSERT_TRUE(lookup_response.headers_ != nullptr);
@@ -355,7 +353,6 @@ TEST_P(LookupRequestTest, ResultWithBodyAndTrailersMatchesExpectation) {
   EXPECT_THAT(*lookup_response.headers_,
               HeaderHasValueRef(Http::CustomHeaders::get().Age, GetParam().expected_age));
   EXPECT_EQ(lookup_response.content_length_, content_length);
-  EXPECT_TRUE(lookup_response.has_trailers_);
 }
 
 TEST_F(LookupRequestTest, HttpScheme) {


### PR DESCRIPTION
Commit Message: [cache_filter] Determine end_stream later
Additional Description: Currently the cache filter is incompatible with streaming a result at the same time as populating it, because the lookup requires foreknowledge of whether the entry will have trailers or not, which isn't known until the end of the request (a `Trailers` header is a hint but not a guarantee). This change makes it so the end_stream value from the cache acts more like the way it does for every other stream, so no foreknowledge is required. Plus similar changes for content-length being potentially unknown under the same circumstances.
Risk Level: Some risk to changing behavior of a filter still tagged WIP.
Testing: Existing tests provide coverage, and are updated to verify the new value. Additional tests for content-length handling especially around range requests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
