### PR TITLE
mobile: Rewrite JNI cache implementation

### DIFF
--- a/mobile/library/jni/android_jni_utility.cc
+++ b/mobile/library/jni/android_jni_utility.cc
@@ -16,8 +16,8 @@ bool isCleartextPermitted(absl::string_view hostname) {
   JniHelper jni_helper(JniHelper::getThreadLocalEnv());
   LocalRefUniquePtr<jstring> java_host = cppStringToJavaString(jni_helper, std::string(hostname));
   jclass java_android_network_library_class =
-      jni_helper.findClass("io/envoyproxy/envoymobile/utilities/AndroidNetworkLibrary");
-  jmethodID java_is_cleartext_traffic_permitted_method_id = jni_helper.getStaticMethodId(
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/utilities/AndroidNetworkLibrary");
+  jmethodID java_is_cleartext_traffic_permitted_method_id = jni_helper.getStaticMethodIdFromCache(
       java_android_network_library_class, "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
   jboolean result = jni_helper.callStaticBooleanMethod(
       java_android_network_library_class, java_is_cleartext_traffic_permitted_method_id,
@@ -33,9 +33,9 @@ void tagSocket(int ifd, int uid, int tag) {
 #if defined(__ANDROID_API__)
   JniHelper jni_helper(JniHelper::getThreadLocalEnv());
   jclass java_android_network_library_class =
-      jni_helper.findClass("io/envoyproxy/envoymobile/utilities/AndroidNetworkLibrary");
-  jmethodID java_tag_socket_method_id =
-      jni_helper.getStaticMethodId(java_android_network_library_class, "tagSocket", "(III)V");
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/utilities/AndroidNetworkLibrary");
+  jmethodID java_tag_socket_method_id = jni_helper.getStaticMethodIdFromCache(
+      java_android_network_library_class, "tagSocket", "(III)V");
   jni_helper.callStaticVoidMethod(java_android_network_library_class, java_tag_socket_method_id,
                                   ifd, uid, tag);
 #else

--- a/mobile/library/jni/android_network_utility.cc
+++ b/mobile/library/jni/android_network_utility.cc
@@ -35,9 +35,9 @@ enum class CertVerifyStatus : int {
 
 bool jvmCertIsIssuedByKnownRoot(JniHelper& jni_helper, jobject result) {
   jclass jcls_AndroidCertVerifyResult =
-      jni_helper.findClass("io/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult");
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult");
   jmethodID jmid_isIssuedByKnownRoot =
-      jni_helper.getMethodId(jcls_AndroidCertVerifyResult, "isIssuedByKnownRoot", "()Z");
+      jni_helper.getMethodIdFromCache(jcls_AndroidCertVerifyResult, "isIssuedByKnownRoot", "()Z");
   ASSERT(jmid_isIssuedByKnownRoot);
   bool is_issued_by_known_root = jni_helper.callBooleanMethod(result, jmid_isIssuedByKnownRoot);
   return is_issued_by_known_root;
@@ -45,9 +45,9 @@ bool jvmCertIsIssuedByKnownRoot(JniHelper& jni_helper, jobject result) {
 
 CertVerifyStatus jvmCertGetStatus(JniHelper& jni_helper, jobject j_result) {
   jclass jcls_AndroidCertVerifyResult =
-      jni_helper.findClass("io/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult");
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult");
   jmethodID jmid_getStatus =
-      jni_helper.getMethodId(jcls_AndroidCertVerifyResult, "getStatus", "()I");
+      jni_helper.getMethodIdFromCache(jcls_AndroidCertVerifyResult, "getStatus", "()I");
   ASSERT(jmid_getStatus);
   CertVerifyStatus result =
       static_cast<CertVerifyStatus>(jni_helper.callIntMethod(j_result, jmid_getStatus));
@@ -57,9 +57,9 @@ CertVerifyStatus jvmCertGetStatus(JniHelper& jni_helper, jobject j_result) {
 LocalRefUniquePtr<jobjectArray> jvmCertGetCertificateChainEncoded(JniHelper& jni_helper,
                                                                   jobject result) {
   jclass jcls_AndroidCertVerifyResult =
-      jni_helper.findClass("io/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult");
-  jmethodID jmid_getCertificateChainEncoded =
-      jni_helper.getMethodId(jcls_AndroidCertVerifyResult, "getCertificateChainEncoded", "()[[B");
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult");
+  jmethodID jmid_getCertificateChainEncoded = jni_helper.getMethodIdFromCache(
+      jcls_AndroidCertVerifyResult, "getCertificateChainEncoded", "()[[B");
   LocalRefUniquePtr<jobjectArray> certificate_chain =
       jni_helper.callObjectMethod<jobjectArray>(result, jmid_getCertificateChainEncoded);
   return certificate_chain;
@@ -108,8 +108,8 @@ LocalRefUniquePtr<jobject> callJvmVerifyX509CertChain(JniHelper& jni_helper,
                                                       std::string auth_type,
                                                       absl::string_view hostname) {
   jclass jcls_AndroidNetworkLibrary =
-      jni_helper.findClass("io/envoyproxy/envoymobile/utilities/AndroidNetworkLibrary");
-  jmethodID jmid_verifyServerCertificates = jni_helper.getStaticMethodId(
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/utilities/AndroidNetworkLibrary");
+  jmethodID jmid_verifyServerCertificates = jni_helper.getStaticMethodIdFromCache(
       jcls_AndroidNetworkLibrary, "verifyServerCertificates",
       "([[B[B[B)Lio/envoyproxy/envoymobile/utilities/AndroidCertVerifyResult;");
   LocalRefUniquePtr<jobjectArray> chain_byte_array =

--- a/mobile/library/jni/jni_helper.cc
+++ b/mobile/library/jni/jni_helper.cc
@@ -19,44 +19,19 @@ thread_local JNIEnv* jni_env_cache_ = nullptr;
 // `jclass_cache_map` contains `jclass` references that are statically populated. This field is
 // used by `FindClass` to find the `jclass` reference from a given class name.
 absl::flat_hash_map<absl::string_view, jclass> jclass_cache_map;
-// The `jclass_cache_set` is a superset of `jclass_cache_map`. It contains `jclass` objects that are
-// retrieve dynamically via `GetObjectClass`.
-//
-// The `jclass_cache_set` owns the `jclass` global refs, wrapped in `GlobalRefUniquePtr` to allow
-// automatic `GlobalRef` destruction. The other fields, such as `jmethod_id_cache_map`,
-// `static_jmethod_id_cache_map`, `jfield_id_cache_map`, and `static_jfield_id_cache_map` only
-// borrow the `jclass` references.
-//
-// Note: all these fields are `thread_local` to avoid locking.
-thread_local absl::flat_hash_set<GlobalRefUniquePtr<jclass>> jclass_cache_set;
-thread_local absl::flat_hash_map<
+absl::flat_hash_map<
     std::tuple<jclass, absl::string_view /* method */, absl::string_view /* signature */>,
     jmethodID>
     jmethod_id_cache_map;
-thread_local absl::flat_hash_map<
-    std::tuple<jclass, absl::string_view /* method */, absl::string_view>,
-    jmethodID /* signature */>
+absl::flat_hash_map<std::tuple<jclass, absl::string_view /* method */, absl::string_view>,
+                    jmethodID /* signature */>
     static_jmethod_id_cache_map;
-thread_local absl::flat_hash_map<
-    std::tuple<jclass, absl::string_view /* field */, absl::string_view>, jfieldID /* signature */>
+absl::flat_hash_map<std::tuple<jclass, absl::string_view /* field */, absl::string_view>,
+                    jfieldID /* signature */>
     jfield_id_cache_map;
-thread_local absl::flat_hash_map<
-    std::tuple<jclass, absl::string_view /* field */, absl::string_view>, jfieldID /* signature */>
+absl::flat_hash_map<std::tuple<jclass, absl::string_view /* field */, absl::string_view>,
+                    jfieldID /* signature */>
     static_jfield_id_cache_map;
-
-/**
- * This function checks if the `clazz` already exists in the `jclass` `GlobalRef` cache and creates
- * a new `GlobalRef` if it does not already exist. This functions returns the `GlobalRef` of the
- * specified `clazz`.
- */
-jclass addClassToCacheIfNotExist(JNIEnv* env, jclass clazz) {
-  jclass java_class_global_ref = clazz;
-  if (auto it = jclass_cache_set.find(clazz); it == jclass_cache_set.end()) {
-    java_class_global_ref = reinterpret_cast<jclass>(env->NewGlobalRef(clazz));
-    jclass_cache_set.emplace(java_class_global_ref, GlobalRefDeleter());
-  }
-  return java_class_global_ref;
-}
 } // namespace
 
 void GlobalRefDeleter::operator()(jobject object) const {
@@ -99,21 +74,67 @@ void JniHelper::finalize() {
   jfield_id_cache_map.clear();
   static_jfield_id_cache_map.clear();
   jclass_cache_map.clear();
-  for (const auto& clazz : jclass_cache_set) {
-    env->DeleteGlobalRef(clazz.get());
+  for (const auto& [_, clazz] : jclass_cache_map) {
+    env->DeleteGlobalRef(clazz);
   }
-  jclass_cache_set.clear();
 }
 
-void JniHelper::addClassToCache(const char* class_name) {
+void JniHelper::addToCache(absl::string_view class_name, const std::vector<Method>& methods,
+                           const std::vector<Method>& static_methods,
+                           const std::vector<Field>& fields,
+                           const std::vector<Field>& static_fields) {
   JNIEnv* env;
   jint result = getJavaVm()->GetEnv(reinterpret_cast<void**>(&env), getVersion());
   ASSERT(result == JNI_OK, "Unable to get JNIEnv from the JavaVM.");
-  jclass java_class = env->FindClass(class_name);
+  jclass java_class = env->FindClass(class_name.data());
   ASSERT(java_class != nullptr, absl::StrFormat("Unable to find class '%s'.", class_name));
   jclass java_class_global_ref = reinterpret_cast<jclass>(env->NewGlobalRef(java_class));
   jclass_cache_map.emplace(class_name, java_class_global_ref);
-  jclass_cache_set.emplace(java_class_global_ref, GlobalRefDeleter());
+
+  for (const auto& [method_name, signature] : methods) {
+    jmethodID method_id =
+        env->GetMethodID(java_class_global_ref, method_name.data(), signature.data());
+    ASSERT(method_id != nullptr,
+           absl::StrFormat("Unable to find method ID for class '%s', method '%s', signature '%s'.",
+                           class_name, method_name, signature));
+    jmethod_id_cache_map.emplace(std::tuple<jclass, absl::string_view, absl::string_view>(
+                                     java_class_global_ref, method_name, signature),
+                                 method_id);
+  }
+
+  for (const auto& [method_name, signature] : static_methods) {
+    jmethodID method_id =
+        env->GetStaticMethodID(java_class_global_ref, method_name.data(), signature.data());
+    ASSERT(method_id != nullptr,
+           absl::StrFormat(
+               "Unable to find static method ID for class '%s', method '%s', signature '%s'.",
+               class_name, method_name, signature));
+    static_jmethod_id_cache_map.emplace(std::tuple<jclass, absl::string_view, absl::string_view>(
+                                            java_class_global_ref, method_name, signature),
+                                        method_id);
+  }
+
+  for (const auto& [field_name, signature] : fields) {
+    jfieldID field_id = env->GetFieldID(java_class_global_ref, field_name.data(), signature.data());
+    ASSERT(field_id != nullptr,
+           absl::StrFormat("Unable to find field ID for class '%s', field '%s', signature '%s'.",
+                           class_name, field_name, signature));
+    jfield_id_cache_map.emplace(std::tuple<jclass, absl::string_view, absl::string_view>(
+                                    java_class_global_ref, field_name, signature),
+                                field_id);
+  }
+
+  for (const auto& [field_name, signature] : static_fields) {
+    jfieldID field_id =
+        env->GetStaticFieldID(java_class_global_ref, field_name.data(), signature.data());
+    ASSERT(field_id != nullptr,
+           absl::StrFormat(
+               "Unable to find static field ID for class '%s', field '%s', signature '%s'.",
+               class_name, field_name, signature));
+    static_jfield_id_cache_map.emplace(std::tuple<jclass, absl::string_view, absl::string_view>(
+                                           java_class_global_ref, field_name, signature),
+                                       field_id);
+  }
 }
 
 JavaVM* JniHelper::getJavaVm() { return java_vm_cache_.load(std::memory_order_acquire); }
@@ -141,33 +162,45 @@ JNIEnv* JniHelper::getThreadLocalEnv() {
 JNIEnv* JniHelper::getEnv() { return env_; }
 
 jfieldID JniHelper::getFieldId(jclass clazz, const char* name, const char* signature) {
+  jfieldID field_id = env_->GetFieldID(clazz, name, signature);
+  rethrowException();
+  return field_id;
+}
+
+jfieldID JniHelper::getFieldIdFromCache(jclass clazz, const char* name, const char* signature) {
   if (auto it = jfield_id_cache_map.find(
           std::tuple<jclass, absl::string_view, absl::string_view>(clazz, name, signature));
       it != jfield_id_cache_map.end()) {
     return it->second;
   }
-  jfieldID field_id = env_->GetFieldID(clazz, name, signature);
-  jclass clazz_global_ref = addClassToCacheIfNotExist(env_, clazz);
-  jfield_id_cache_map.emplace(
-      std::tuple<jclass, absl::string_view, absl::string_view>(clazz_global_ref, name, signature),
-      field_id);
+  // In the debug mode, the code will fail if the field ID is not in the cache since this is most
+  // likely due to a bug in the code. In the release mode, the code will use the non-caching field
+  // ID.
+  ASSERT(false, absl::StrFormat("Unable to find field ID '%s', signature '%s' from the cache.",
+                                name, signature));
+  return getFieldId(clazz, name, signature);
+}
+
+jfieldID JniHelper::getStaticFieldId(jclass clazz, const char* name, const char* signature) {
+  jfieldID field_id = env_->GetStaticFieldID(clazz, name, signature);
   rethrowException();
   return field_id;
 }
 
-jfieldID JniHelper::getStaticFieldId(jclass clazz, const char* name, const char* signature) {
+jfieldID JniHelper::getStaticFieldIdFromCache(jclass clazz, const char* name,
+                                              const char* signature) {
   if (auto it = static_jfield_id_cache_map.find(
           std::tuple<jclass, absl::string_view, absl::string_view>(clazz, name, signature));
       it != static_jfield_id_cache_map.end()) {
     return it->second;
   }
-  jfieldID field_id = env_->GetStaticFieldID(clazz, name, signature);
-  jclass clazz_global_ref = addClassToCacheIfNotExist(env_, clazz);
-  static_jfield_id_cache_map.emplace(
-      std::tuple<jclass, absl::string_view, absl::string_view>(clazz_global_ref, name, signature),
-      field_id);
-  rethrowException();
-  return field_id;
+  // In the debug mode, the code will fail if the static field ID is not in the cache since this is
+  // most likely due to a bug in the code. In the release mode, the code will use the non-caching
+  // static field ID.
+  ASSERT(false,
+         absl::StrFormat("Unable to find static field ID '%s', signature '%s' from the cache.",
+                         name, signature));
+  return getStaticFieldId(clazz, name, signature);
 }
 
 #define DEFINE_GET_FIELD(JAVA_TYPE, JNI_TYPE)                                                      \
@@ -185,36 +218,48 @@ DEFINE_GET_FIELD(Double, jdouble)
 DEFINE_GET_FIELD(Boolean, jboolean)
 
 jmethodID JniHelper::getMethodId(jclass clazz, const char* name, const char* signature) {
+  jmethodID method_id = env_->GetMethodID(clazz, name, signature);
+  rethrowException();
+  return method_id;
+}
+
+jmethodID JniHelper::getMethodIdFromCache(jclass clazz, const char* name, const char* signature) {
   if (auto it = jmethod_id_cache_map.find(
           std::tuple<jclass, absl::string_view, absl::string_view>(clazz, name, signature));
       it != jmethod_id_cache_map.end()) {
     return it->second;
   }
-  jmethodID method_id = env_->GetMethodID(clazz, name, signature);
-  jclass clazz_global_ref = addClassToCacheIfNotExist(env_, clazz);
-  jmethod_id_cache_map.emplace(
-      std::tuple<jclass, absl::string_view, absl::string_view>(clazz_global_ref, name, signature),
-      method_id);
+  // In the debug mode, the code will fail if the method ID is not in the cache since this is most
+  // likely due to a bug in the code. In the release mode, the code will use the non-caching method
+  // ID.
+  ASSERT(false, absl::StrFormat("Unable to find method ID '%s', signature '%s' from the cache.",
+                                name, signature));
+  return getMethodId(clazz, name, signature);
+}
+
+jmethodID JniHelper::getStaticMethodId(jclass clazz, const char* name, const char* signature) {
+  jmethodID method_id = env_->GetStaticMethodID(clazz, name, signature);
   rethrowException();
   return method_id;
 }
 
-jmethodID JniHelper::getStaticMethodId(jclass clazz, const char* name, const char* signature) {
+jmethodID JniHelper::getStaticMethodIdFromCache(jclass clazz, const char* name,
+                                                const char* signature) {
   if (auto it = static_jmethod_id_cache_map.find(
           std::tuple<jclass, absl::string_view, absl::string_view>(clazz, name, signature));
       it != static_jmethod_id_cache_map.end()) {
     return it->second;
   }
-  jmethodID method_id = env_->GetStaticMethodID(clazz, name, signature);
-  jclass clazz_global_ref = addClassToCacheIfNotExist(env_, clazz);
-  static_jmethod_id_cache_map.emplace(
-      std::tuple<jclass, absl::string_view, absl::string_view>(clazz_global_ref, name, signature),
-      method_id);
-  rethrowException();
-  return method_id;
+  // In the debug mode, the code will fail if the static method ID is not in the cache since this is
+  // most likely due to a bug in the code. In the release mode, the code will use the non-caching
+  // static method ID.
+  ASSERT(false,
+         absl::StrFormat("Unable to find static method ID '%s', signature '%s' from the cache.",
+                         name, signature));
+  return getStaticMethodId(clazz, name, signature);
 }
 
-jclass JniHelper::findClass(const char* class_name) {
+jclass JniHelper::findClassFromCache(const char* class_name) {
   if (auto i = jclass_cache_map.find(class_name); i != jclass_cache_map.end()) {
     return i->second;
   }
@@ -227,7 +272,7 @@ LocalRefUniquePtr<jclass> JniHelper::getObjectClass(jobject object) {
 }
 
 void JniHelper::throwNew(const char* java_class_name, const char* message) {
-  jclass java_class = findClass(java_class_name);
+  jclass java_class = findClassFromCache(java_class_name);
   if (java_class != nullptr) {
     jint error = env_->ThrowNew(java_class, message);
     ASSERT(error == JNI_OK, "Failed calling ThrowNew.");

--- a/mobile/library/jni/jni_utility.cc
+++ b/mobile/library/jni/jni_utility.cc
@@ -11,6 +11,126 @@
 namespace Envoy {
 namespace JNI {
 
+void JniUtility::initCache() {
+  Envoy::JNI::JniHelper::addToCache("java/lang/Object", /* methods= */ {},
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/lang/Integer",
+                                    /* methods= */
+                                    {
+                                        {"<init>", "(I)V"},
+                                        {"intValue", "()I"},
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/lang/ClassLoader", /* methods= */ {},
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/nio/ByteBuffer",
+                                    /* methods= */
+                                    {
+                                        {"array", "()[B"},
+                                        {"isDirect", "()Z"},
+                                    },
+                                    /* static_methods = */
+                                    {
+                                        {"wrap", "([B)Ljava/nio/ByteBuffer;"},
+                                    },
+                                    /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/lang/Throwable",
+                                    /* methods= */
+                                    {
+                                        {"getMessage", "()Ljava/lang/String;"},
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/lang/UnsupportedOperationException",
+                                    /* methods= */ {}, /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("[B", /* methods= */ {}, /* static_methods = */ {},
+                                    /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache(
+      "java/util/LinkedHashMap", /* methods= */
+      {
+          {"<init>", "()V"},
+          {"put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"},
+          {"get", "(Ljava/lang/Object;)Ljava/lang/Object;"},
+      },
+      /* static_methods = */ {}, /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Map", /* methods= */
+                                    {
+                                        {"entrySet", "()Ljava/util/Set;"},
+
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Map$Entry", /* methods= */
+                                    {
+                                        {"getKey", "()Ljava/lang/Object;"},
+                                        {"getValue", "()Ljava/lang/Object;"},
+
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Set", /* methods= */
+                                    {
+                                        {"iterator", "()Ljava/util/Iterator;"},
+
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Iterator", /* methods= */
+                                    {{"hasNext", "()Z"}, {"next", "()Ljava/lang/Object;"}
+
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache(
+      "java/util/HashMap", /* methods= */
+      {{"<init>", "(I)V"}, {"put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"}},
+      /* static_methods = */ {}, /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache(
+      "java/util/List", /* methods= */ {{"size", "()I"}, {"get", "(I)Ljava/lang/Object;"}},
+      /* static_methods = */ {}, /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache(
+      "java/util/ArrayList", /* methods= */ {{"<init>", "()V"}, {"add", "(Ljava/lang/Object;)Z"}},
+      /* static_methods = */ {}, /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel",
+                                    /* methods= */
+                                    {
+                                        {"<init>", "(JJJJ)V"},
+                                        {"getStreamId", "()J"},
+                                        {"getConnectionId", "()J"},
+                                        {"getAttemptCount", "()J"},
+                                        {"getConsumedBytesFromResponse", "()J"},
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel",
+                                    /* methods= */
+                                    {
+                                        {"<init>", "(JJJJJJJJJJJZJJJJ)V"},
+                                        {"getStreamStartMs", "()J"},
+                                        {"getDnsStartMs", "()J"},
+                                        {"getDnsEndMs", "()J"},
+                                        {"getConnectStartMs", "()J"},
+                                        {"getConnectEndMs", "()J"},
+                                        {"getSslStartMs", "()J"},
+                                        {"getSslEndMs", "()J"},
+                                        {"getSendingStartMs", "()J"},
+                                        {"getSendingEndMs", "()J"},
+                                        {"getResponseStartMs", "()J"},
+                                        {"getStreamEndMs", "()J"},
+                                        {"getSocketReused", "()Z"},
+                                        {"getSentByteCount", "()J"},
+                                        {"getReceivedByteCount", "()J"},
+                                        {"getResponseFlags", "()J"},
+                                        {"getUpstreamProtocol", "()J"},
+                                    },
+                                    /* static_methods = */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+}
+
 void jniDeleteGlobalRef(void* context) {
   JNIEnv* env = JniHelper::getThreadLocalEnv();
   jobject ref = static_cast<jobject>(context);
@@ -22,8 +142,8 @@ void jniDeleteConstGlobalRef(const void* context) {
 }
 
 int javaIntegerToCppInt(JniHelper& jni_helper, jobject boxed_integer) {
-  jclass jcls_Integer = jni_helper.findClass("java/lang/Integer");
-  jmethodID jmid_intValue = jni_helper.getMethodId(jcls_Integer, "intValue", "()I");
+  jclass jcls_Integer = jni_helper.findClassFromCache("java/lang/Integer");
+  jmethodID jmid_intValue = jni_helper.getMethodIdFromCache(jcls_Integer, "intValue", "()I");
   return jni_helper.callIntMethod(boxed_integer, jmid_intValue);
 }
 
@@ -99,11 +219,11 @@ envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data) {
   jlong data_length = jni_helper.getDirectBufferCapacity(j_data);
 
   if (data_length < 0) {
-    jclass jcls_ByteBuffer = jni_helper.findClass("java/nio/ByteBuffer");
+    jclass jcls_ByteBuffer = jni_helper.findClassFromCache("java/nio/ByteBuffer");
     // We skip checking hasArray() because only direct ByteBuffers or array-backed ByteBuffers
     // are supported. We will crash here if this is an invalid buffer, but guards may be
     // implemented in the JVM layer.
-    jmethodID jmid_array = jni_helper.getMethodId(jcls_ByteBuffer, "array", "()[B");
+    jmethodID jmid_array = jni_helper.getMethodIdFromCache(jcls_ByteBuffer, "array", "()[B");
     LocalRefUniquePtr<jbyteArray> array =
         jni_helper.callObjectMethod<jbyteArray>(j_data, jmid_array);
     envoy_data native_data = javaByteArrayToEnvoyData(jni_helper, array.get());
@@ -118,11 +238,11 @@ envoy_data javaByteBufferToEnvoyData(JniHelper& jni_helper, jobject j_data, jlon
   uint8_t* direct_address = jni_helper.getDirectBufferAddress<uint8_t*>(j_data);
 
   if (direct_address == nullptr) {
-    jclass jcls_ByteBuffer = jni_helper.findClass("java/nio/ByteBuffer");
+    jclass jcls_ByteBuffer = jni_helper.findClassFromCache("java/nio/ByteBuffer");
     // We skip checking hasArray() because only direct ByteBuffers or array-backed ByteBuffers
     // are supported. We will crash here if this is an invalid buffer, but guards may be
     // implemented in the JVM layer.
-    jmethodID jmid_array = jni_helper.getMethodId(jcls_ByteBuffer, "array", "()[B");
+    jmethodID jmid_array = jni_helper.getMethodIdFromCache(jcls_ByteBuffer, "array", "()[B");
     LocalRefUniquePtr<jbyteArray> array =
         jni_helper.callObjectMethod<jbyteArray>(j_data, jmid_array);
     envoy_data native_data = javaByteArrayToEnvoyData(jni_helper, array.get(), data_length);
@@ -208,7 +328,7 @@ envoy_map javaArrayOfObjectArrayToEnvoyMap(JniHelper& jni_helper, jobjectArray e
 LocalRefUniquePtr<jobjectArray>
 envoyHeadersToJavaArrayOfObjectArray(JniHelper& jni_helper,
                                      const Envoy::Types::ManagedEnvoyHeaders& map) {
-  jclass jcls_byte_array = jni_helper.findClass("java/lang/Object");
+  jclass jcls_byte_array = jni_helper.findClassFromCache("java/lang/Object");
   LocalRefUniquePtr<jobjectArray> javaArray =
       jni_helper.newObjectArray(2 * map.get().length, jcls_byte_array, nullptr);
 
@@ -227,7 +347,7 @@ envoyHeadersToJavaArrayOfObjectArray(JniHelper& jni_helper,
 
 LocalRefUniquePtr<jobjectArray>
 vectorStringToJavaArrayOfByteArray(JniHelper& jni_helper, const std::vector<std::string>& v) {
-  jclass jcls_byte_array = jni_helper.findClass("[B");
+  jclass jcls_byte_array = jni_helper.findClassFromCache("[B");
   LocalRefUniquePtr<jobjectArray> joa =
       jni_helper.newObjectArray(v.size(), jcls_byte_array, nullptr);
 
@@ -339,28 +459,28 @@ absl::flat_hash_map<std::string, std::string> javaMapToCppMap(JniHelper& jni_hel
                                                               jobject java_map) {
   absl::flat_hash_map<std::string, std::string> cpp_map;
 
-  auto java_map_class = jni_helper.getObjectClass(java_map);
+  auto java_map_class = jni_helper.findClassFromCache("java/util/Map");
   auto java_entry_set_method_id =
-      jni_helper.getMethodId(java_map_class.get(), "entrySet", "()Ljava/util/Set;");
+      jni_helper.getMethodIdFromCache(java_map_class, "entrySet", "()Ljava/util/Set;");
   auto java_entry_set_object = jni_helper.callObjectMethod(java_map, java_entry_set_method_id);
 
-  auto java_set_class = jni_helper.getObjectClass(java_entry_set_object.get());
-  jclass java_map_entry_class = jni_helper.findClass("java/util/Map$Entry");
+  auto java_set_class = jni_helper.findClassFromCache("java/util/Set");
+  jclass java_map_entry_class = jni_helper.findClassFromCache("java/util/Map$Entry");
 
   auto java_iterator_method_id =
-      jni_helper.getMethodId(java_set_class.get(), "iterator", "()Ljava/util/Iterator;");
+      jni_helper.getMethodIdFromCache(java_set_class, "iterator", "()Ljava/util/Iterator;");
   auto java_get_key_method_id =
-      jni_helper.getMethodId(java_map_entry_class, "getKey", "()Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_map_entry_class, "getKey", "()Ljava/lang/Object;");
   auto java_get_value_method_id =
-      jni_helper.getMethodId(java_map_entry_class, "getValue", "()Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_map_entry_class, "getValue", "()Ljava/lang/Object;");
 
   auto java_iterator_object =
       jni_helper.callObjectMethod(java_entry_set_object.get(), java_iterator_method_id);
-  auto java_iterator_class = jni_helper.getObjectClass(java_iterator_object.get());
+  auto java_iterator_class = jni_helper.findClassFromCache("java/util/Iterator");
   auto java_has_next_method_id =
-      jni_helper.getMethodId(java_iterator_class.get(), "hasNext", "()Z");
+      jni_helper.getMethodIdFromCache(java_iterator_class, "hasNext", "()Z");
   auto java_next_method_id =
-      jni_helper.getMethodId(java_iterator_class.get(), "next", "()Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_iterator_class, "next", "()Ljava/lang/Object;");
 
   while (jni_helper.callBooleanMethod(java_iterator_object.get(), java_has_next_method_id)) {
     auto java_entry_object =
@@ -381,18 +501,18 @@ absl::flat_hash_map<std::string, std::string> javaMapToCppMap(JniHelper& jni_hel
 LocalRefUniquePtr<jobject> cppHeadersToJavaHeaders(JniHelper& jni_helper,
                                                    const Http::HeaderMap& cpp_headers) {
   // Use LinkedHashMap to preserve the insertion order.
-  jclass java_map_class = jni_helper.findClass("java/util/LinkedHashMap");
-  auto java_map_init_method_id = jni_helper.getMethodId(java_map_class, "<init>", "()V");
-  auto java_map_put_method_id = jni_helper.getMethodId(
+  jclass java_map_class = jni_helper.findClassFromCache("java/util/LinkedHashMap");
+  auto java_map_init_method_id = jni_helper.getMethodIdFromCache(java_map_class, "<init>", "()V");
+  auto java_map_put_method_id = jni_helper.getMethodIdFromCache(
       java_map_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-  auto java_map_get_method_id =
-      jni_helper.getMethodId(java_map_class, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+  auto java_map_get_method_id = jni_helper.getMethodIdFromCache(
+      java_map_class, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
   auto java_map_object = jni_helper.newObject(java_map_class, java_map_init_method_id);
 
-  jclass java_list_class = jni_helper.findClass("java/util/ArrayList");
-  auto java_list_init_method_id = jni_helper.getMethodId(java_list_class, "<init>", "()V");
+  jclass java_list_class = jni_helper.findClassFromCache("java/util/ArrayList");
+  auto java_list_init_method_id = jni_helper.getMethodIdFromCache(java_list_class, "<init>", "()V");
   auto java_list_add_method_id =
-      jni_helper.getMethodId(java_list_class, "add", "(Ljava/lang/Object;)Z");
+      jni_helper.getMethodIdFromCache(java_list_class, "add", "(Ljava/lang/Object;)Z");
 
   cpp_headers.iterate([&](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
     std::string cpp_key = std::string(header.key().getStringView());
@@ -428,33 +548,33 @@ LocalRefUniquePtr<jobject> cppHeadersToJavaHeaders(JniHelper& jni_helper,
 
 void javaHeadersToCppHeaders(JniHelper& jni_helper, jobject java_headers,
                              Http::HeaderMap& cpp_headers) {
-  auto java_map_class = jni_helper.getObjectClass(java_headers);
+  auto java_map_class = jni_helper.findClassFromCache("java/util/Map");
   auto java_entry_set_method_id =
-      jni_helper.getMethodId(java_map_class.get(), "entrySet", "()Ljava/util/Set;");
+      jni_helper.getMethodIdFromCache(java_map_class, "entrySet", "()Ljava/util/Set;");
   auto java_entry_set_object = jni_helper.callObjectMethod(java_headers, java_entry_set_method_id);
 
-  auto java_set_class = jni_helper.getObjectClass(java_entry_set_object.get());
-  jclass java_map_entry_class = jni_helper.findClass("java/util/Map$Entry");
+  auto java_set_class = jni_helper.findClassFromCache("java/util/Set");
+  jclass java_map_entry_class = jni_helper.findClassFromCache("java/util/Map$Entry");
 
   auto java_map_iter_method_id =
-      jni_helper.getMethodId(java_set_class.get(), "iterator", "()Ljava/util/Iterator;");
+      jni_helper.getMethodIdFromCache(java_set_class, "iterator", "()Ljava/util/Iterator;");
   auto java_map_get_key_method_id =
-      jni_helper.getMethodId(java_map_entry_class, "getKey", "()Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_map_entry_class, "getKey", "()Ljava/lang/Object;");
   auto java_map_get_value_method_id =
-      jni_helper.getMethodId(java_map_entry_class, "getValue", "()Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_map_entry_class, "getValue", "()Ljava/lang/Object;");
 
   auto java_iter_object =
       jni_helper.callObjectMethod(java_entry_set_object.get(), java_map_iter_method_id);
-  auto java_iterator_class = jni_helper.getObjectClass(java_iter_object.get());
+  auto java_iterator_class = jni_helper.findClassFromCache("java/util/Iterator");
   auto java_iter_has_next_method_id =
-      jni_helper.getMethodId(java_iterator_class.get(), "hasNext", "()Z");
+      jni_helper.getMethodIdFromCache(java_iterator_class, "hasNext", "()Z");
   auto java_iter_next_method_id =
-      jni_helper.getMethodId(java_iterator_class.get(), "next", "()Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_iterator_class, "next", "()Ljava/lang/Object;");
 
-  jclass java_list_class = jni_helper.findClass("java/util/List");
-  auto java_list_size_method_id = jni_helper.getMethodId(java_list_class, "size", "()I");
+  jclass java_list_class = jni_helper.findClassFromCache("java/util/List");
+  auto java_list_size_method_id = jni_helper.getMethodIdFromCache(java_list_class, "size", "()I");
   auto java_list_get_method_id =
-      jni_helper.getMethodId(java_list_class, "get", "(I)Ljava/lang/Object;");
+      jni_helper.getMethodIdFromCache(java_list_class, "get", "(I)Ljava/lang/Object;");
 
   while (jni_helper.callBooleanMethod(java_iter_object.get(), java_iter_has_next_method_id)) {
     auto java_entry_object =
@@ -481,9 +601,9 @@ void javaHeadersToCppHeaders(JniHelper& jni_helper, jobject java_headers,
 }
 
 bool isJavaDirectByteBuffer(JniHelper& jni_helper, jobject java_byte_buffer) {
-  jclass java_byte_buffer_class = jni_helper.findClass("java/nio/ByteBuffer");
+  jclass java_byte_buffer_class = jni_helper.findClassFromCache("java/nio/ByteBuffer");
   auto java_byte_buffer_is_direct_method_id =
-      jni_helper.getMethodId(java_byte_buffer_class, "isDirect", "()Z");
+      jni_helper.getMethodIdFromCache(java_byte_buffer_class, "isDirect", "()Z");
   return jni_helper.callBooleanMethod(java_byte_buffer, java_byte_buffer_is_direct_method_id);
 }
 
@@ -519,9 +639,9 @@ LocalRefUniquePtr<jobject> cppBufferInstanceToJavaDirectByteBuffer(
 Buffer::InstancePtr javaNonDirectByteBufferToCppBufferInstance(JniHelper& jni_helper,
                                                                jobject java_byte_buffer,
                                                                jlong length) {
-  jclass java_byte_buffer_class = jni_helper.findClass("java/nio/ByteBuffer");
+  jclass java_byte_buffer_class = jni_helper.findClassFromCache("java/nio/ByteBuffer");
   auto java_byte_buffer_array_method_id =
-      jni_helper.getMethodId(java_byte_buffer_class, "array", "()[B");
+      jni_helper.getMethodIdFromCache(java_byte_buffer_class, "array", "()[B");
   auto java_byte_array =
       jni_helper.callObjectMethod<jbyteArray>(java_byte_buffer, java_byte_buffer_array_method_id);
   ASSERT(java_byte_array != nullptr, "The ByteBuffer argument is not a non-direct ByteBuffer.");
@@ -534,9 +654,9 @@ Buffer::InstancePtr javaNonDirectByteBufferToCppBufferInstance(JniHelper& jni_he
 
 LocalRefUniquePtr<jobject> cppBufferInstanceToJavaNonDirectByteBuffer(
     JniHelper& jni_helper, const Buffer::Instance& cpp_buffer_instance, uint64_t length) {
-  jclass java_byte_buffer_class = jni_helper.findClass("java/nio/ByteBuffer");
-  auto java_byte_buffer_wrap_method_id =
-      jni_helper.getStaticMethodId(java_byte_buffer_class, "wrap", "([B)Ljava/nio/ByteBuffer;");
+  jclass java_byte_buffer_class = jni_helper.findClassFromCache("java/nio/ByteBuffer");
+  auto java_byte_buffer_wrap_method_id = jni_helper.getStaticMethodIdFromCache(
+      java_byte_buffer_class, "wrap", "([B)Ljava/nio/ByteBuffer;");
   auto java_byte_array = jni_helper.newByteArray(static_cast<jsize>(cpp_buffer_instance.length()));
   auto java_byte_array_elements = jni_helper.getByteArrayElements(java_byte_array.get(), nullptr);
   cpp_buffer_instance.copyOut(0, length, static_cast<void*>(java_byte_array_elements.get()));
@@ -545,9 +665,9 @@ LocalRefUniquePtr<jobject> cppBufferInstanceToJavaNonDirectByteBuffer(
 }
 
 std::string getJavaExceptionMessage(JniHelper& jni_helper, jthrowable throwable) {
-  jclass java_throwable_class = jni_helper.findClass("java/lang/Throwable");
+  jclass java_throwable_class = jni_helper.findClassFromCache("java/lang/Throwable");
   auto java_get_message_method_id =
-      jni_helper.getMethodId(java_throwable_class, "getMessage", "()Ljava/lang/String;");
+      jni_helper.getMethodIdFromCache(java_throwable_class, "getMessage", "()Ljava/lang/String;");
   auto java_exception_message =
       jni_helper.callObjectMethod<jstring>(throwable, java_get_message_method_id);
   return javaStringToCppString(jni_helper, java_exception_message.get());
@@ -555,19 +675,20 @@ std::string getJavaExceptionMessage(JniHelper& jni_helper, jthrowable throwable)
 
 envoy_stream_intel javaStreamIntelToCppStreamIntel(JniHelper& jni_helper,
                                                    jobject java_stream_intel) {
-  auto java_stream_intel_class = jni_helper.getObjectClass(java_stream_intel);
+  auto java_stream_intel_class =
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel");
   jlong java_stream_id = jni_helper.callLongMethod(
       java_stream_intel,
-      jni_helper.getMethodId(java_stream_intel_class.get(), "getStreamId", "()J"));
+      jni_helper.getMethodIdFromCache(java_stream_intel_class, "getStreamId", "()J"));
   jlong java_connection_id = jni_helper.callLongMethod(
       java_stream_intel,
-      jni_helper.getMethodId(java_stream_intel_class.get(), "getConnectionId", "()J"));
+      jni_helper.getMethodIdFromCache(java_stream_intel_class, "getConnectionId", "()J"));
   jlong java_attempt_count = jni_helper.callLongMethod(
       java_stream_intel,
-      jni_helper.getMethodId(java_stream_intel_class.get(), "getAttemptCount", "()J"));
+      jni_helper.getMethodIdFromCache(java_stream_intel_class, "getAttemptCount", "()J"));
   jlong java_consumed_bytes_from_response = jni_helper.callLongMethod(
-      java_stream_intel,
-      jni_helper.getMethodId(java_stream_intel_class.get(), "getConsumedBytesFromResponse", "()J"));
+      java_stream_intel, jni_helper.getMethodIdFromCache(java_stream_intel_class,
+                                                         "getConsumedBytesFromResponse", "()J"));
 
   return {
       /* stream_id= */ static_cast<int64_t>(java_stream_id),
@@ -580,9 +701,9 @@ envoy_stream_intel javaStreamIntelToCppStreamIntel(JniHelper& jni_helper,
 LocalRefUniquePtr<jobject> cppStreamIntelToJavaStreamIntel(JniHelper& jni_helper,
                                                            const envoy_stream_intel& stream_intel) {
   auto java_stream_intel_class =
-      jni_helper.findClass("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel");
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel");
   auto java_stream_intel_init_method_id =
-      jni_helper.getMethodId(java_stream_intel_class, "<init>", "(JJJJ)V");
+      jni_helper.getMethodIdFromCache(java_stream_intel_class, "<init>", "(JJJJ)V");
   return jni_helper.newObject(java_stream_intel_class, java_stream_intel_init_method_id,
                               static_cast<jlong>(stream_intel.stream_id),
                               static_cast<jlong>(stream_intel.connection_id),
@@ -592,55 +713,56 @@ LocalRefUniquePtr<jobject> cppStreamIntelToJavaStreamIntel(JniHelper& jni_helper
 
 envoy_final_stream_intel
 javaFinalStreamIntelToCppFinalStreamIntel(JniHelper& jni_helper, jobject java_final_stream_intel) {
-  auto java_final_stream_intel_class = jni_helper.getObjectClass(java_final_stream_intel);
+  auto java_final_stream_intel_class =
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");
   jlong java_stream_start_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getStreamStartMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getStreamStartMs", "()J"));
   jlong java_dns_start_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getDnsStartMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getDnsStartMs", "()J"));
   jlong java_dns_end_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getDnsEndMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getDnsEndMs", "()J"));
   jlong java_connect_start_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getConnectStartMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getConnectStartMs", "()J"));
   jlong java_connect_end_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getConnectEndMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getConnectEndMs", "()J"));
   jlong java_ssl_start_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getSslStartMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getSslStartMs", "()J"));
   jlong java_ssl_end_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getSslEndMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getSslEndMs", "()J"));
   jlong java_sending_start_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getSendingStartMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getSendingStartMs", "()J"));
   jlong java_sending_end_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getSendingEndMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getSendingEndMs", "()J"));
   jlong java_response_start_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getResponseStartMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getResponseStartMs", "()J"));
   jlong java_stream_end_ms = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getStreamEndMs", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getStreamEndMs", "()J"));
   jboolean java_socket_reused = jni_helper.callBooleanMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getSocketReused", "()Z"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getSocketReused", "()Z"));
   jlong java_sent_byte_count = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getSentByteCount", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getSentByteCount", "()J"));
   jlong java_received_byte_count = jni_helper.callLongMethod(
-      java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getReceivedByteCount", "()J"));
+      java_final_stream_intel, jni_helper.getMethodIdFromCache(java_final_stream_intel_class,
+                                                               "getReceivedByteCount", "()J"));
   jlong java_response_flags = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getResponseFlags", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getResponseFlags", "()J"));
   jlong java_upstream_protocol = jni_helper.callLongMethod(
       java_final_stream_intel,
-      jni_helper.getMethodId(java_final_stream_intel_class.get(), "getUpstreamProtocol", "()J"));
+      jni_helper.getMethodIdFromCache(java_final_stream_intel_class, "getUpstreamProtocol", "()J"));
 
   return {
       /* stream_start_ms= */ static_cast<int64_t>(java_stream_start_ms),
@@ -666,9 +788,9 @@ LocalRefUniquePtr<jobject>
 cppFinalStreamIntelToJavaFinalStreamIntel(JniHelper& jni_helper,
                                           const envoy_final_stream_intel& final_stream_intel) {
   auto java_final_stream_intel_class =
-      jni_helper.findClass("io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");
-  auto java_final_stream_intel_init_method_id =
-      jni_helper.getMethodId(java_final_stream_intel_class, "<init>", "(JJJJJJJJJJJZJJJJ)V");
+      jni_helper.findClassFromCache("io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");
+  auto java_final_stream_intel_init_method_id = jni_helper.getMethodIdFromCache(
+      java_final_stream_intel_class, "<init>", "(JJJJJJJJJJJZJJJJ)V");
   return jni_helper.newObject(java_final_stream_intel_class, java_final_stream_intel_init_method_id,
                               static_cast<jlong>(final_stream_intel.stream_start_ms),
                               static_cast<jlong>(final_stream_intel.dns_start_ms),

--- a/mobile/library/jni/jni_utility.h
+++ b/mobile/library/jni/jni_utility.h
@@ -16,6 +16,11 @@
 namespace Envoy {
 namespace JNI {
 
+struct JniUtility {
+  /** Initializes the caches for the `JniUtility`. */
+  static void initCache();
+};
+
 void jniDeleteGlobalRef(void* context);
 
 void jniDeleteConstGlobalRef(const void* context);
@@ -109,9 +114,9 @@ LocalRefUniquePtr<jstring> cppStringToJavaString(JniHelper& jni_helper,
 /** Converts from C++'s map-type<std::string, std::string> to Java `HashMap<String, String>`. */
 template <typename MapType>
 LocalRefUniquePtr<jobject> cppMapToJavaMap(JniHelper& jni_helper, const MapType& cpp_map) {
-  jclass java_map_class = jni_helper.findClass("java/util/HashMap");
-  auto java_map_init_method_id = jni_helper.getMethodId(java_map_class, "<init>", "(I)V");
-  auto java_map_put_method_id = jni_helper.getMethodId(
+  jclass java_map_class = jni_helper.findClassFromCache("java/util/HashMap");
+  auto java_map_init_method_id = jni_helper.getMethodIdFromCache(java_map_class, "<init>", "(I)V");
+  auto java_map_put_method_id = jni_helper.getMethodIdFromCache(
       java_map_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
   auto java_map_object =
       jni_helper.newObject(java_map_class, java_map_init_method_id, cpp_map.size());

--- a/mobile/test/java/io/envoyproxy/envoymobile/jni/JniHelperTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/jni/JniHelperTest.java
@@ -18,7 +18,11 @@ public class JniHelperTest {
   // Native methods for testing.
   //================================================================================
   public static native void getFieldId(Class<?> clazz, String name, String signature);
+  public static native void getFieldIdFromCache(String className, String fieldName,
+                                                String signature);
   public static native void getStaticFieldId(Class<?> clazz, String name, String signature);
+  public static native void getStaticFieldIdFromCache(String className, String fieldName,
+                                                      String signature);
   public static native byte getByteField(Class<?> clazz, Object instance, String name,
                                          String signature);
   public static native char getCharField(Class<?> clazz, Object instance, String name,
@@ -38,8 +42,12 @@ public class JniHelperTest {
   public static native Object getObjectField(Class<?> clazz, Object instance, String name,
                                              String signature);
   public static native void getMethodId(Class<?> clazz, String name, String signature);
+  public static native void getMethodIdFromCache(String className, String methodName,
+                                                 String signature);
   public static native void getStaticMethodId(Class<?> clazz, String name, String signature);
-  public static native Class<?> findClass(String className);
+  public static native void getStaticMethodIdFromCache(String className, String methodName,
+                                                       String signature);
+  public static native Class<?> findClassFromCache(String className);
   public static native Class<?> getObjectClass(Object object);
   public static native Object newObject(Class<?> clazz, String name, String signature);
   public static native void throwNew(String className, String message);
@@ -160,21 +168,33 @@ public class JniHelperTest {
   static class Foo {
     private final int field = 1;
     private static int staticField = 2;
+    private static void staticMethod() {}
   }
 
   @Test
   public void testGetFieldId() {
+    getFieldId(Foo.class, "field", "I");
+  }
+
+  @Test
+  public void testGetFieldIdFromCache() {
     // Do it in a loop to test the cache.
     for (int i = 0; i < 10; i++) {
-      getFieldId(Foo.class, "field", "I");
+      getFieldIdFromCache("io/envoyproxy/envoymobile/jni/JniHelperTest$Foo", "field", "I");
     }
   }
 
   @Test
   public void testGetStaticFieldId() {
+    getStaticFieldId(Foo.class, "staticField", "I");
+  }
+
+  @Test
+  public void testGetStaticFieldIdFromCache() {
     // Do it in a loop to test the cache.
     for (int i = 0; i < 10; i++) {
-      getStaticFieldId(Foo.class, "staticField", "I");
+      getStaticFieldIdFromCache("io/envoyproxy/envoymobile/jni/JniHelperTest$Foo", "staticField",
+                                "I");
     }
   }
 
@@ -226,25 +246,36 @@ public class JniHelperTest {
 
   @Test
   public void testGetMethodId() {
+    getMethodId(Foo.class, "<init>", "()V");
+  }
+
+  @Test
+  public void testGetMethodIdFromCache() {
     // Do it in a loop to test the cache.
     for (int i = 0; i < 10; i++) {
-      getMethodId(Foo.class, "<init>", "()V");
+      getMethodIdFromCache("io/envoyproxy/envoymobile/jni/JniHelperTest$Foo", "<init>", "()V");
     }
   }
 
   @Test
   public void testGetStaticMethodId() {
+    getStaticMethodId(Foo.class, "staticMethod", "()V");
+  }
+
+  @Test
+  public void testGetStaticMethodIdFromCache() {
     // Do it in a loop to test the cache.
     for (int i = 0; i < 10; i++) {
-      getStaticMethodId(JniHelperTest.class, "staticVoidMethod", "()V");
+      getStaticMethodIdFromCache("io/envoyproxy/envoymobile/jni/JniHelperTest$Foo", "staticMethod",
+                                 "()V");
     }
   }
 
   @Test
-  public void testFindClass() {
+  public void testFindClassFromCache() {
     // Do it in a loop to test the cache.
     for (int i = 0; i < 10; i++) {
-      assertThat(findClass("java/lang/Exception")).isEqualTo(Exception.class);
+      assertThat(findClassFromCache("java/lang/Exception")).isEqualTo(Exception.class);
     }
   }
 

--- a/mobile/test/jni/jni_helper_test.cc
+++ b/mobile/test/jni/jni_helper_test.cc
@@ -11,8 +11,29 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
-  Envoy::JNI::JniHelper::addClassToCache("java/lang/Exception");
-  Envoy::JNI::JniHelper::addClassToCache("java/lang/RuntimeException");
+  Envoy::JNI::JniHelper::addToCache("java/lang/Exception", /* methods= */ {},
+                                    /* static_methods= */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/lang/RuntimeException", /* methods= */ {},
+                                    /* static_methods= */ {}, /* fields= */ {},
+                                    /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache(
+      "io/envoyproxy/envoymobile/jni/JniHelperTest$Foo", /* methods= */
+      {
+          {"<init>", "()V"},
+      },
+      /* static_methods= */
+      {
+          {"staticMethod", "()V"},
+      },
+      /* fields= */
+      {
+          {"field", "I"},
+      },
+      /* static_fields= */
+      {
+          {"staticField", "I"},
+      });
   return Envoy::JNI::JniHelper::getVersion();
 }
 
@@ -28,12 +49,38 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTe
   jni_helper.getFieldId(clazz, name_ptr.get(), sig_ptr.get());
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getFieldIdFromCache(JNIEnv* env, jclass,
+                                                                     jstring class_name,
+                                                                     jstring field_name,
+                                                                     jstring signature) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  Envoy::JNI::StringUtfUniquePtr class_name_ptr = jni_helper.getStringUtfChars(class_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr field_name_ptr = jni_helper.getStringUtfChars(field_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
+  auto clazz = jni_helper.findClassFromCache(class_name_ptr.get());
+  jni_helper.getFieldIdFromCache(clazz, field_name_ptr.get(), sig_ptr.get());
+}
+
 extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticFieldId(
     JNIEnv* env, jclass, jclass clazz, jstring name, jstring signature) {
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::JNI::StringUtfUniquePtr name_ptr = jni_helper.getStringUtfChars(name, nullptr);
   Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
   jni_helper.getStaticFieldId(clazz, name_ptr.get(), sig_ptr.get());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticFieldIdFromCache(JNIEnv* env, jclass,
+                                                                           jstring class_name,
+                                                                           jstring field_name,
+                                                                           jstring signature) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  Envoy::JNI::StringUtfUniquePtr class_name_ptr = jni_helper.getStringUtfChars(class_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr field_name_ptr = jni_helper.getStringUtfChars(field_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
+  auto clazz = jni_helper.findClassFromCache(class_name_ptr.get());
+  jni_helper.getStaticFieldIdFromCache(clazz, field_name_ptr.get(), sig_ptr.get());
 }
 
 #define DEFINE_JNI_GET_FIELD(JAVA_TYPE, JNI_TYPE)                                                  \
@@ -76,6 +123,20 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTe
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getMethodIdFromCache(JNIEnv* env, jclass,
+                                                                      jstring class_name,
+                                                                      jstring method_name,
+                                                                      jstring signature) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  Envoy::JNI::StringUtfUniquePtr class_name_ptr = jni_helper.getStringUtfChars(class_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr method_name_ptr =
+      jni_helper.getStringUtfChars(method_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
+  auto clazz = jni_helper.findClassFromCache(class_name_ptr.get());
+  jni_helper.getMethodIdFromCache(clazz, method_name_ptr.get(), sig_ptr.get());
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticMethodId(JNIEnv* env, jclass,
                                                                    jclass clazz, jstring name,
                                                                    jstring signature) {
@@ -85,11 +146,26 @@ Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticMethodId(JNIEnv* env, 
   jni_helper.getStaticMethodId(clazz, name_ptr.get(), sig_ptr.get());
 }
 
-extern "C" JNIEXPORT jclass JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_findClass(
-    JNIEnv* env, jclass, jstring class_name) {
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getStaticMethodIdFromCache(JNIEnv* env, jclass,
+                                                                            jstring class_name,
+                                                                            jstring method_name,
+                                                                            jstring signature) {
   Envoy::JNI::JniHelper jni_helper(env);
   Envoy::JNI::StringUtfUniquePtr class_name_ptr = jni_helper.getStringUtfChars(class_name, nullptr);
-  return jni_helper.findClass(class_name_ptr.get());
+  Envoy::JNI::StringUtfUniquePtr method_name_ptr =
+      jni_helper.getStringUtfChars(method_name, nullptr);
+  Envoy::JNI::StringUtfUniquePtr sig_ptr = jni_helper.getStringUtfChars(signature, nullptr);
+  auto clazz = jni_helper.findClassFromCache(class_name_ptr.get());
+  jni_helper.getStaticMethodIdFromCache(clazz, method_name_ptr.get(), sig_ptr.get());
+}
+
+extern "C" JNIEXPORT jclass JNICALL
+Java_io_envoyproxy_envoymobile_jni_JniHelperTest_findClassFromCache(JNIEnv* env, jclass,
+                                                                    jstring class_name) {
+  Envoy::JNI::JniHelper jni_helper(env);
+  Envoy::JNI::StringUtfUniquePtr class_name_ptr = jni_helper.getStringUtfChars(class_name, nullptr);
+  return jni_helper.findClassFromCache(class_name_ptr.get());
 }
 
 extern "C" JNIEXPORT jclass JNICALL Java_io_envoyproxy_envoymobile_jni_JniHelperTest_getObjectClass(

--- a/mobile/test/jni/jni_http_proxy_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_proxy_test_server_factory.cc
@@ -9,9 +9,17 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
-  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
-  Envoy::JNI::JniHelper::addClassToCache(
-      "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
+  Envoy::JNI::JniHelper::addToCache(
+      "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer",
+      /* methods= */
+      {
+          {"<init>", "(JI)V"},
+      },
+      /* static_methods= */ {}, /* fields= */
+      {
+          {"handle", "J"},
+      },
+      /* static_fields= */ {});
   return Envoy::JNI::JniHelper::getVersion();
 }
 
@@ -24,10 +32,10 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_start(J
   Envoy::TestServer* test_server = new Envoy::TestServer();
   test_server->start(static_cast<Envoy::TestServerType>(type), 0);
 
-  jclass java_http_proxy_server_factory_class = jni_helper.findClass(
+  jclass java_http_proxy_server_factory_class = jni_helper.findClassFromCache(
       "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
   auto java_init_method_id =
-      jni_helper.getMethodId(java_http_proxy_server_factory_class, "<init>", "(JI)V");
+      jni_helper.getMethodIdFromCache(java_http_proxy_server_factory_class, "<init>", "(JI)V");
   int port = test_server->getPort();
   return jni_helper
       .newObject(java_http_proxy_server_factory_class, java_init_method_id,
@@ -39,8 +47,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_HttpProxyTestServerFactory_00024HttpProxyTestServer_shutdown(
     JNIEnv* env, jobject instance) {
   Envoy::JNI::JniHelper jni_helper(env);
-  auto java_class = jni_helper.getObjectClass(instance);
-  auto java_handle_field_id = jni_helper.getFieldId(java_class.get(), "handle", "J");
+  auto java_class = jni_helper.findClassFromCache(
+      "io/envoyproxy/envoymobile/engine/testing/HttpProxyTestServerFactory$HttpProxyTestServer");
+  auto java_handle_field_id = jni_helper.getFieldIdFromCache(java_class, "handle", "J");
   jlong java_handle = jni_helper.getLongField(instance, java_handle_field_id);
   Envoy::TestServer* test_server = reinterpret_cast<Envoy::TestServer*>(java_handle);
   test_server->shutdown();

--- a/mobile/test/jni/jni_http_test_server_factory.cc
+++ b/mobile/test/jni/jni_http_test_server_factory.cc
@@ -10,9 +10,47 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
-  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
-  Envoy::JNI::JniHelper::addClassToCache(
-      "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer");
+  Envoy::JNI::JniHelper::addToCache("java/util/Map", /* methods= */
+                                    {
+                                        {"entrySet", "()Ljava/util/Set;"},
+
+                                    },
+                                    /* static_methods = */ {},
+                                    /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Map$Entry", /* methods= */
+                                    {
+                                        {"getKey", "()Ljava/lang/Object;"},
+                                        {"getValue", "()Ljava/lang/Object;"},
+
+                                    },
+                                    /* static_methods = */ {},
+                                    /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Set", /* methods= */
+                                    {
+                                        {"iterator", "()Ljava/util/Iterator;"},
+
+                                    },
+                                    /* static_methods = */ {},
+                                    /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache("java/util/Iterator", /* methods= */
+                                    {
+                                        {"hasNext", "()Z"},
+                                        {"next", "()Ljava/lang/Object;"},
+
+                                    },
+                                    /* static_methods = */ {},
+                                    /* fields= */ {}, /* static_fields= */ {});
+  Envoy::JNI::JniHelper::addToCache(
+      "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer",
+      /* methods= */
+      {
+          {"<init>", "(JLjava/lang/String;ILjava/lang/String;)V"},
+      },
+      /* static_methods= */ {}, /* fields= */
+      {
+          {"handle", "J"},
+      },
+      /* static_fields= */ {});
   return Envoy::JNI::JniHelper::getVersion();
 }
 
@@ -31,10 +69,10 @@ Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_start(
   auto cpp_trailers = Envoy::JNI::javaMapToCppMap(jni_helper, trailers);
   test_server->setResponse(cpp_headers, cpp_body, cpp_trailers);
 
-  jclass java_http_server_factory_class = jni_helper.findClass(
+  jclass java_http_server_factory_class = jni_helper.findClassFromCache(
       "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer");
-  auto java_init_method_id = jni_helper.getMethodId(java_http_server_factory_class, "<init>",
-                                                    "(JLjava/lang/String;ILjava/lang/String;)V");
+  auto java_init_method_id = jni_helper.getMethodIdFromCache(
+      java_http_server_factory_class, "<init>", "(JLjava/lang/String;ILjava/lang/String;)V");
   auto ip_address = Envoy::JNI::cppStringToJavaString(jni_helper, test_server->getIpAddress());
   int port = test_server->getPort();
   auto address = Envoy::JNI::cppStringToJavaString(jni_helper, test_server->getAddress());
@@ -49,8 +87,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_testing_HttpTestServerFactory_00024HttpTestServer_shutdown(
     JNIEnv* env, jobject instance) {
   Envoy::JNI::JniHelper jni_helper(env);
-  auto java_class = jni_helper.getObjectClass(instance);
-  auto java_handle_field_id = jni_helper.getFieldId(java_class.get(), "handle", "J");
+  auto java_class = jni_helper.findClassFromCache(
+      "io/envoyproxy/envoymobile/engine/testing/HttpTestServerFactory$HttpTestServer");
+  auto java_handle_field_id = jni_helper.getFieldIdFromCache(java_class, "handle", "J");
   jlong java_handle = jni_helper.getLongField(instance, java_handle_field_id);
   Envoy::TestServer* test_server = reinterpret_cast<Envoy::TestServer*>(java_handle);
   test_server->shutdown();

--- a/mobile/test/jni/jni_utility_test.cc
+++ b/mobile/test/jni/jni_utility_test.cc
@@ -13,20 +13,7 @@
 
 extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /* reserved */) {
   Envoy::JNI::JniHelper::initialize(vm);
-  Envoy::JNI::JniHelper::addClassToCache("java/lang/Object");
-  Envoy::JNI::JniHelper::addClassToCache("java/lang/Integer");
-  Envoy::JNI::JniHelper::addClassToCache("java/lang/ClassLoader");
-  Envoy::JNI::JniHelper::addClassToCache("java/nio/ByteBuffer");
-  Envoy::JNI::JniHelper::addClassToCache("java/lang/Throwable");
-  Envoy::JNI::JniHelper::addClassToCache("[B");
-  Envoy::JNI::JniHelper::addClassToCache("java/util/Map$Entry");
-  Envoy::JNI::JniHelper::addClassToCache("java/util/LinkedHashMap");
-  Envoy::JNI::JniHelper::addClassToCache("java/util/HashMap");
-  Envoy::JNI::JniHelper::addClassToCache("java/util/List");
-  Envoy::JNI::JniHelper::addClassToCache("java/util/ArrayList");
-  Envoy::JNI::JniHelper::addClassToCache("io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel");
-  Envoy::JNI::JniHelper::addClassToCache(
-      "io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel");
+  Envoy::JNI::JniUtility::initCache();
   return Envoy::JNI::JniHelper::getVersion();
 }
 


### PR DESCRIPTION
This PR rewrites the JNI cache implementation to fix the GlobalRef leak. Prior to this PR, some code would call `getObjectClass` in order to get a `jclass` instance. If the `jclass` was not already in the cache, the code would create a new `GlobalRef` and add it into the cache. Given that there's no guarantee that we will get the same `jclass` instance, the previous code ended up creating a lot of `new GlobalRef` instances due to the cache misses causing a leak. The new implementation updates the code to load the `jclass` from the cache directly via `findClassFromCache` instead of using `getObjectClass`. This guarantees that we will use the same `jclass` instance. The new implementation also changes the cache initialization to be eager instead of lazy, thereby eliminating the need for having `thread_local`, which can help to further reduce the number of `GlobalRef` instances.

Risk Level: medium
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: mobile
