### PR TITLE
test_utils: add config modifier for UDP proxy

### DIFF
--- a/test/config/BUILD
+++ b/test/config/BUILD
@@ -37,6 +37,7 @@ envoy_cc_test_library(
         "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/upstream_codec/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/udp/udp_proxy/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/upstreams/http/v3:pkg_cc_proto",


### PR DESCRIPTION
Additional Description: Adding ``addConfigModifier`` testing utility for UdpProxy configurations. This will be used in a separate PR, but wanted to separate this to another so it's easier to review
Risk Level: low
Testing: none
Docs Changes: none
Release Notes: none
Platform Specific Features: none