### PR TITLE
filter_state: add new envoy.hashable_string object factory

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -208,5 +208,10 @@ new_features:
   change: |
     Added :ref:`delay_deny <envoy_v3_api_msg_extensions.filters.network.rbac.v3.RBAC>` to support deny connection after
     the configured duration.
+- area: filter state
+  change: |
+    Added a special generic string object factory with hashing interface in filter state with key ``envoy.hashable_string``
+    which is to be used when unique upstream connection needs to be picked based on the hash of the value of filter state being shared.
+    See :ref:`the well-known filter state keys <well_known_filter_state>` for more detail.
 
 deprecated:

--- a/docs/root/configuration/advanced/well_known_filter_state.rst
+++ b/docs/root/configuration/advanced/well_known_filter_state.rst
@@ -63,6 +63,10 @@ The following lists the filter state object keys used by the Envoy extensions:
   A special generic string object factory, to be used as a :ref:`factory lookup key
   <envoy_v3_api_field_extensions.filters.common.set_filter_state.v3.FilterStateValue.factory_key>`.
 
+``envoy.hashable_string``
+  A special generic string object factory similar to ``envoy.string`` which implements hashing interface, to be used
+  when unique upstream connection needs to be picked based on the hash of the value of filter state being shared.
+
 ``envoy.tcp_proxy.per_connection_idle_timeout_ms``
   :ref:`TCP proxy idle timeout duration
   <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.idle_timeout>` override on a per-connection

--- a/source/extensions/filters/common/set_filter_state/BUILD
+++ b/source/extensions/filters/common/set_filter_state/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     srcs = ["filter_config.cc"],
     hdrs = ["filter_config.h"],
     deps = [
+        "//envoy/common:hashable_interface",
         "//envoy/formatter:substitution_formatter_interface",
         "//envoy/registry",
         "//envoy/stream_info:filter_state_interface",

--- a/source/extensions/filters/common/set_filter_state/filter_config.cc
+++ b/source/extensions/filters/common/set_filter_state/filter_config.cc
@@ -22,6 +22,17 @@ public:
 
 REGISTER_FACTORY(GenericStringObjectFactory, StreamInfo::FilterState::ObjectFactory);
 
+class HashableStringObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "envoy.hashable_string"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    return std::make_unique<HashableStringObject>(data);
+  }
+};
+
+REGISTER_FACTORY(HashableStringObjectFactory, StreamInfo::FilterState::ObjectFactory);
+
 std::vector<Value>
 Config::parse(const Protobuf::RepeatedPtrField<FilterStateValueProto>& proto_values,
               Server::Configuration::GenericFactoryContext& context) const {


### PR DESCRIPTION
### Background

**See:** https://github.com/envoyproxy/envoy/issues/35711

### Changes

This PR adds a new generic string object factory with hashing interface in filter state with key `envoy.hashable_string` which could be used when unique upstream connection needs to be picked based on the hash of the value of filter state being shared.

---
**Commit Message:** filter_state: add new envoy.hashable_string object factory.
**Additional Description:** See Background Section.
**Risk Level:** Low
**Testing:** Unit Tests
**Docs Changes:** Added the description of the new object factory.
**Release Notes:** Added
**Platform Specific Features:** N/A

**Signed-off-by:** Rohit Agrawal <rohit.agrawal@databricks.com>