### PR TITLE
xds-failover: docs

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -201,6 +201,10 @@ new_features:
   change: |
     Prefer using IPv6 address when addresses from both families are available.
     Can be reverted by setting ``envoy.reloadable_features.prefer_ipv6_dns_on_macos`` to false.
+- area: config
+  change: |
+    Introducing :ref:`xDS-Failover supporti <config_overview_xds_failover>`. This is under testing
+    at the moment, and can be enable by setting ``envoy.restart_features.xds_failover_support`` to true.
 - area: grpc_field_extraction
   change: |
     Added ``map<string, string>`` support: Target fields of type ``map<string, string>`` can be extracted and added to dynamic metadata.

--- a/docs/root/configuration/overview/mgmt_server.rst
+++ b/docs/root/configuration/overview/mgmt_server.rst
@@ -62,4 +62,4 @@ The following statistics are generated for all subscriptions.
  update_time, Gauge, Timestamp of the last successful API fetch attempt as milliseconds since the epoch. Refreshed even after a trivial configuration reload that contained no configuration changes.
  version, Gauge, Hash of the contents from the last successful API fetch
  version_text, TextReadout, The version text from the last successful API fetch
- control_plane.connected_state, Gauge, A boolean (1 for connected and 0 for disconnected) that indicates the current connection state with management server
+ control_plane.connected_state, Gauge, Indicates which management server Envoy is currently connected to. 0 - disconnected, 1 - the primary (first) server, 2 - the failover (second) server (if configured).

--- a/docs/root/intro/arch_overview/operations/dynamic_configuration.rst
+++ b/docs/root/intro/arch_overview/operations/dynamic_configuration.rst
@@ -130,6 +130,9 @@ different types reach Envoy, there is aggregated xDS, a single gRPC service that
 resource types in a single gRPC stream. (ADS is only supported by gRPC).
 :ref:`More details about ADS <config_overview_ads>`.
 
+Envoy also supports a failover ADS config source. See
+:ref:`xDS-Failover support <config_overview_xds_failover>` for more details.
+
 .. _arch_overview_dynamic_config_delta:
 
 Delta gRPC xDS


### PR DESCRIPTION
Commit Message: xds-failover: docs
Additional Description:
Adding the documentation around the xDS-Failover feature.
Almost the last part of the work described in: #28099.
Describes the work done in #34215, #35591, #35691, and #35692

Risk Level: low - docs only
Testing: N/A - docs
Docs Changes: Added.
Release Notes: Added.
Platform Specific Features: N/A
Runtime guard: This is runtime guarded by `envoy.restart_features.xds_failover_support` that is currently false by default.
