### PR TITLE
mobile: Load envoy_repo in the WORKSPACE

### DIFF
--- a/mobile/WORKSPACE
+++ b/mobile/WORKSPACE
@@ -46,6 +46,10 @@ load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
 
 envoy_api_dependencies()
 
+load("@envoy//bazel:repo.bzl", "envoy_repo")
+
+envoy_repo()
+
 load("@envoy//bazel:repositories.bzl", "envoy_dependencies")
 
 envoy_dependencies()


### PR DESCRIPTION
This is to fix this error.

```
ERROR: Skipping '@envoy//tools/code_format:check_format': error loading package '@envoy//tools/code_format': Unable to find package for @envoy_repo//:path.bzl: The repository '@envoy_repo' could not be resolved: Repository '@envoy_repo' is not defined.
```

Risk Level: low
Testing: `tools/check_format.sh fix`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a