### PR TITLE
mobile: Remove toBridge from Envoy::Http::Client

### DIFF
--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -199,9 +199,9 @@ private:
           (remote_end_stream_received_ && !remote_end_stream_forwarded_ && !response_trailers_));
     }
 
-    void sendDataToBridge(Buffer::Instance& data, bool end_stream);
-    void sendTrailersToBridge(const ResponseTrailerMap& trailers);
-    void sendErrorToBridge();
+    void sendData(Buffer::Instance& data, bool end_stream);
+    void sendTrailers(const ResponseTrailerMap& trailers);
+    void sendError();
     envoy_stream_intel streamIntel();
     envoy_final_stream_intel& finalStreamIntel();
 


### PR DESCRIPTION
`Envoy::Http::Client` no longer uses C wrapper types, so the `toBridge` name no longer makes sense.

Risk Level: low (rename only)
Testing: CI
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
