### PR TITLE
tls: fix openssl 509 null chain malloc leak

### DIFF
--- a/test/common/tls/utility_test.cc
+++ b/test/common/tls/utility_test.cc
@@ -223,11 +223,12 @@ TEST(UtilityTest, TestMapX509Stack) {
   auto func = [](X509& cert) -> std::string { return Utility::getSubjectFromCertificate(cert); };
   EXPECT_EQ(expected_subject, Utility::mapX509Stack(*cert_chain, func));
 
-  EXPECT_ENVOY_BUG(Utility::mapX509Stack(*sk_X509_new_null(), func), "x509 stack is empty or NULL");
+  bssl::UniquePtr<STACK_OF(X509)> empty_chain(sk_X509_new_null());
+  EXPECT_ENVOY_BUG(Utility::mapX509Stack(*empty_chain, func), "x509 stack is empty or NULL");
   EXPECT_ENVOY_BUG(Utility::mapX509Stack(*cert_chain, nullptr), "field_extractor is nullptr");
-  bssl::UniquePtr<STACK_OF(X509)> fakeCertChain(sk_X509_new_null());
-  sk_X509_push(fakeCertChain.get(), nullptr);
-  EXPECT_EQ(std::vector<std::string>{""}, Utility::mapX509Stack(*fakeCertChain, func));
+  bssl::UniquePtr<STACK_OF(X509)> fake_cert_chain(sk_X509_new_null());
+  sk_X509_push(fake_cert_chain.get(), nullptr);
+  EXPECT_EQ(std::vector<std::string>{""}, Utility::mapX509Stack(*fake_cert_chain, func));
 }
 
 } // namespace


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Introduced from https://github.com/envoyproxy/envoy/pull/35513

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
