### PR TITLE
grpc_field_extraction: fix empty ListValue indication

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_field_extraction/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_field_extraction/v3/config.proto
@@ -66,7 +66,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // 1. the extracted field names/values will be wrapped in be ``field<StringValue
 // or MapValue>`` -> ``values<ListValue of StringValue or StructValue>``, which will be added in the dynamic ``metadata<google.protobuf.Struct>``.
 //
-// 2. if the field value is empty, an empty ``<ListValue>`` will be set.
+// 2. if the field value is empty, an empty ``Value`` will be set.
 //
 // Performance
 // -----------


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->


ProtobufWkt::Value is introduced by #35162

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
