### PR TITLE
mobile: Update Android proxy tests to not use mocks

### DIFF
--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPRequestUsingProxyTest.kt
@@ -20,8 +20,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 //                                               ┌──────────────────┐
 //                                               │   Envoy Proxy    │
@@ -55,18 +55,20 @@ class ProxyInfoIntentPerformHTTPRequestUsingProxyTest {
 
   @Test
   fun `performs an HTTP request through a proxy`() {
-    val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
-    val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
-    Mockito.doReturn(connectivityManager)
-      .`when`(context)
-      .getSystemService(Context.CONNECTIVITY_SERVICE)
-    Mockito.`when`(connectivityManager.defaultProxy)
-      .thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port))
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val connectivityManager =
+      context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    connectivityManager.bindProcessToNetwork(connectivityManager.activeNetwork)
+    shadowOf(connectivityManager)
+      .setProxyForNetwork(
+        connectivityManager.activeNetwork,
+        ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port)
+      )
 
     val onEngineRunningLatch = CountDownLatch(1)
-    val onRespondeHeadersLatch = CountDownLatch(1)
+    val onResponseHeadersLatch = CountDownLatch(1)
 
-    context.sendStickyBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
+    context.sendBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
 
     val builder = AndroidEngineBuilder(context)
     val engine =
@@ -96,13 +98,13 @@ class ProxyInfoIntentPerformHTTPRequestUsingProxyTest {
         val status = responseHeaders.httpStatus ?: 0L
         assertThat(status).isEqualTo(301)
         assertThat(responseHeaders.value("x-proxy-response")).isEqualTo(listOf("true"))
-        onRespondeHeadersLatch.countDown()
+        onResponseHeadersLatch.countDown()
       }
       .start(Executors.newSingleThreadExecutor())
       .sendHeaders(requestHeaders, true)
 
-    onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)
-    assertThat(onRespondeHeadersLatch.count).isEqualTo(0)
+    onResponseHeadersLatch.await(15, TimeUnit.SECONDS)
+    assertThat(onResponseHeadersLatch.count).isEqualTo(0)
 
     engine.terminate()
   }

--- a/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
+++ b/mobile/test/kotlin/integration/proxying/ProxyInfoIntentPerformHTTPSRequestUsingProxyTest.kt
@@ -21,8 +21,8 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 
 //                                                ┌──────────────────┐
 //                                                │   Envoy Proxy    │
@@ -57,18 +57,20 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
   @Ignore("https://github.com/envoyproxy/envoy/issues/33014")
   @Test
   fun `performs an HTTPs request through a proxy`() {
-    val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
-    val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
-    Mockito.doReturn(connectivityManager)
-      .`when`(context)
-      .getSystemService(Context.CONNECTIVITY_SERVICE)
-    Mockito.`when`(connectivityManager.defaultProxy)
-      .thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port))
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val connectivityManager =
+      context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    connectivityManager.bindProcessToNetwork(connectivityManager.activeNetwork)
+    Shadows.shadowOf(connectivityManager)
+      .setProxyForNetwork(
+        connectivityManager.activeNetwork,
+        ProxyInfo.buildDirectProxy("127.0.0.1", httpProxyTestServer.port)
+      )
 
     val onEngineRunningLatch = CountDownLatch(1)
-    val onRespondeHeadersLatch = CountDownLatch(1)
+    val onResponseHeadersLatch = CountDownLatch(1)
 
-    context.sendStickyBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
+    context.sendBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
 
     val builder = AndroidEngineBuilder(context)
     val engine =
@@ -98,13 +100,13 @@ class ProxyInfoIntentPerformHTTPSRequestUsingProxyTest {
         val status = responseHeaders.httpStatus ?: 0L
         assertThat(status).isEqualTo(200)
         assertThat(responseHeaders.value("x-response-header-that-should-be-stripped")).isNull()
-        onRespondeHeadersLatch.countDown()
+        onResponseHeadersLatch.countDown()
       }
       .start(Executors.newSingleThreadExecutor())
       .sendHeaders(requestHeaders, true)
 
-    onRespondeHeadersLatch.await(15, TimeUnit.SECONDS)
-    assertThat(onRespondeHeadersLatch.count).isEqualTo(0)
+    onResponseHeadersLatch.await(15, TimeUnit.SECONDS)
+    assertThat(onResponseHeadersLatch.count).isEqualTo(0)
 
     engine.terminate()
   }


### PR DESCRIPTION
This PR updates the Android proxy tests to not use mocks, which have been causing an issue for me when running the tests locally due to the bytecode mismatch. Using a real object with `shadowOf` is also the recommended approach. This PR also updates the tests to not use a deprecated `sendStickyBroadcast` method.

Risk Level: low (tests only)
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
