### PR TITLE
Fix flaky geoip test

### DIFF
--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -653,8 +653,7 @@ TEST_P(MmdbReloadImplTest, MmdbNotReloadedRuntimeFeatureDisabled) {
   TestScopedRuntime scoped_runtime_;
   scoped_runtime_.mergeValues({{"envoy.reloadable_features.mmdb_files_reload_enabled", "false"}});
   MmdbReloadTestCase test_case = GetParam();
-  auto cb_added_opt = absl::make_optional<ConditionalInitializer>();
-  initializeProvider(test_case.yaml_config_, cb_added_opt);
+  initializeProvider(test_case.yaml_config_, cb_added_nullopt);
   Network::Address::InstanceConstSharedPtr remote_address =
       Network::Utility::parseInternetAddressNoThrow(test_case.ip_);
   Geolocation::LookupRequest lookup_rq{std::move(remote_address)};


### PR DESCRIPTION
On some runs mmdb_reload custom thread is not starting until tests ends which results in segfaults in the test. Addding cond var to await in the test for when mmdb reload thread has populated the callbacks.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #35829
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
