### PR TITLE
Add checks during ORCA header parsing to catch error cases gracefully handled by util method.

### DIFF
--- a/source/common/orca/orca_parser.cc
+++ b/source/common/orca/orca_parser.cc
@@ -29,7 +29,14 @@ absl::StatusOr<OrcaLoadReport> parseOrcaLoadReportHeaders(const HeaderMap& heade
   // Binary protobuf format.
   if (const auto header_bin = headers.get(endpointLoadMetricsHeaderBin()); !header_bin.empty()) {
     const auto header_value = header_bin[0]->value().getStringView();
+    if (header_value.empty()) {
+      return absl::InvalidArgumentError("ORCA binary header value is empty");
+    }
     const std::string decoded_value = Envoy::Base64::decode(header_value);
+    if (decoded_value.empty()) {
+      return absl::InvalidArgumentError(
+          fmt::format("unable to decode ORCA binary header value: {}", header_value));
+    }
     if (!load_report.ParseFromString(decoded_value)) {
       return absl::InvalidArgumentError(
           fmt::format("unable to parse binaryheader to OrcaLoadReport: {}", header_value));

--- a/test/common/orca/orca_parser_test.cc
+++ b/test/common/orca/orca_parser_test.cc
@@ -67,6 +67,23 @@ TEST(OrcaParserUtilTest, InvalidBinaryHeader) {
                   testing::HasSubstr("unable to parse binaryheader to OrcaLoadReport")));
 }
 
+TEST(OrcaParserUtilTest, BinaryHeaderPopulatedWithReadableString) {
+  Http::TestRequestHeaderMapImpl headers{
+      {std::string(kEndpointLoadMetricsHeaderBin), "not-a-valid-binary-proto"}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr(
+                      "unable to decode ORCA binary header value: not-a-valid-binary-proto")));
+}
+
+TEST(OrcaParserUtilTest, EmptyBinaryHeader) {
+  Http::TestRequestHeaderMapImpl headers{{std::string(kEndpointLoadMetricsHeaderBin), ""}};
+  EXPECT_THAT(parseOrcaLoadReportHeaders(headers),
+              StatusHelpers::HasStatus(absl::StatusCode::kInvalidArgument,
+                                       testing::HasSubstr("ORCA binary header value is empty")));
+}
+
 } // namespace
 } // namespace Orca
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Add checks during ORCA header parsing to catch error cases gracefully handled by util method.
Additional Description: Add checks during ORCA header parsing to catch error cases gracefully handled by util method. ORCA parsing introduced in https://github.com/envoyproxy/envoy/pull/35422
https://github.com/envoyproxy/envoy/issues/6614
[Using ORCA load reports in Envoy](https://docs.google.com/document/d/1gb_2pcNnEzTgo1EJ6w1Ol7O-EH-O_Ysu5o215N9MTAg/edit#heading=h.bi4e79pb39fe)
Risk Level: Low
Testing: See included unit tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

CC @efimki @adisuissa @wbpcode